### PR TITLE
i18n: import translations from tc/

### DIFF
--- a/lighthouse-core/lib/i18n/locales/ar-XB.json
+++ b/lighthouse-core/lib/i18n/locales/ar-XB.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "‏‮Access‬‏ ‏‮keys‬‏ ‏‮let‬‏ ‏‮users‬‏ ‏‮quickly‬‏ ‏‮focus‬‏ ‏‮a‬‏ ‏‮part‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮page‬‏. ‏‮For‬‏ ‏‮proper‬‏ ‏‮navigation‬‏, ‏‮each‬‏ ‏‮access‬‏ ‏‮key‬‏ ‏‮must‬‏ ‏‮be‬‏ ‏‮unique‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮accesskeys‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Access‬‏ ‏‮keys‬‏ ‏‮let‬‏ ‏‮users‬‏ ‏‮quickly‬‏ ‏‮focus‬‏ ‏‮a‬‏ ‏‮part‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮page‬‏. ‏‮For‬‏ ‏‮proper‬‏ ‏‮navigation‬‏, ‏‮each‬‏ ‏‮access‬‏ ‏‮key‬‏ ‏‮must‬‏ ‏‮be‬‏ ‏‮unique‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "`[‏‮accesskey‬‏]` ‏‮values‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮unique‬‏"
+    "message": "`[accesskey]` ‏‮values‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮unique‬‏"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "`[‏‮accesskey‬‏]` ‏‮values‬‏ ‏‮are‬‏ ‏‮unique‬‏"
+    "message": "`[accesskey]` ‏‮values‬‏ ‏‮are‬‏ ‏‮unique‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "‏‮Each‬‏ ‏‮ARIA‬‏ `‏‮role‬‏` ‏‮supports‬‏ ‏‮a‬‏ ‏‮specific‬‏ ‏‮subset‬‏ ‏‮of‬‏ `‏‮aria‬‏-*` ‏‮attributes‬‏. ‏‮Mismatching‬‏ ‏‮these‬‏ ‏‮invalidates‬‏ ‏‮the‬‏ `‏‮aria‬‏-*` ‏‮attributes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮aria‬‏-‏‮allowed‬‏-‏‮attr‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Each‬‏ ‏‮ARIA‬‏ `role` ‏‮supports‬‏ ‏‮a‬‏ ‏‮specific‬‏ ‏‮subset‬‏ ‏‮of‬‏ `aria-*` ‏‮attributes‬‏. ‏‮Mismatching‬‏ ‏‮these‬‏ ‏‮invalidates‬‏ ‏‮the‬‏ `aria-*` ‏‮attributes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "`[‏‮aria‬‏-*]` ‏‮attributes‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮match‬‏ ‏‮their‬‏ ‏‮roles‬‏"
+    "message": "`[aria-*]` ‏‮attributes‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮match‬‏ ‏‮their‬‏ ‏‮roles‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "`[‏‮aria‬‏-*]` ‏‮attributes‬‏ ‏‮match‬‏ ‏‮their‬‏ ‏‮roles‬‏"
+    "message": "`[aria-*]` ‏‮attributes‬‏ ‏‮match‬‏ ‏‮their‬‏ ‏‮roles‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "‏‮Some‬‏ ‏‮ARIA‬‏ ‏‮roles‬‏ ‏‮have‬‏ ‏‮required‬‏ ‏‮attributes‬‏ ‏‮that‬‏ ‏‮describe‬‏ ‏‮the‬‏ ‏‮state‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮element‬‏ ‏‮to‬‏ ‏‮screen‬‏ ‏‮readers‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮aria‬‏-‏‮required‬‏-‏‮attr‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Some‬‏ ‏‮ARIA‬‏ ‏‮roles‬‏ ‏‮have‬‏ ‏‮required‬‏ ‏‮attributes‬‏ ‏‮that‬‏ ‏‮describe‬‏ ‏‮the‬‏ ‏‮state‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮element‬‏ ‏‮to‬‏ ‏‮screen‬‏ ‏‮readers‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "`[‏‮role‬‏]`‏‮s‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮all‬‏ ‏‮required‬‏ `[‏‮aria‬‏-*]` ‏‮attributes‬‏"
+    "message": "`[role]`‏‮s‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮all‬‏ ‏‮required‬‏ `[aria-*]` ‏‮attributes‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "`[‏‮role‬‏]`‏‮s‬‏ ‏‮have‬‏ ‏‮all‬‏ ‏‮required‬‏ `[‏‮aria‬‏-*]` ‏‮attributes‬‏"
+    "message": "`[role]`‏‮s‬‏ ‏‮have‬‏ ‏‮all‬‏ ‏‮required‬‏ `[aria-*]` ‏‮attributes‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "‏‮Some‬‏ ‏‮ARIA‬‏ ‏‮parent‬‏ ‏‮roles‬‏ ‏‮must‬‏ ‏‮contain‬‏ ‏‮specific‬‏ ‏‮child‬‏ ‏‮roles‬‏ ‏‮to‬‏ ‏‮perform‬‏ ‏‮their‬‏ ‏‮intended‬‏ ‏‮accessibility‬‏ ‏‮functions‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮aria‬‏-‏‮required‬‏-‏‮children‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Some‬‏ ‏‮ARIA‬‏ ‏‮parent‬‏ ‏‮roles‬‏ ‏‮must‬‏ ‏‮contain‬‏ ‏‮specific‬‏ ‏‮child‬‏ ‏‮roles‬‏ ‏‮to‬‏ ‏‮perform‬‏ ‏‮their‬‏ ‏‮intended‬‏ ‏‮accessibility‬‏ ‏‮functions‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "‏‮Elements‬‏ ‏‮with‬‏ `[‏‮role‬‏]` ‏‮that‬‏ ‏‮require‬‏ ‏‮specific‬‏ ‏‮children‬‏ `[‏‮role‬‏]`‏‮s‬‏, ‏‮are‬‏ ‏‮missing‬‏."
+    "message": "‏‮Elements‬‏ ‏‮with‬‏ `[role]` ‏‮that‬‏ ‏‮require‬‏ ‏‮specific‬‏ ‏‮children‬‏ `[role]`‏‮s‬‏, ‏‮are‬‏ ‏‮missing‬‏."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "‏‮Elements‬‏ ‏‮with‬‏ `[‏‮role‬‏]` ‏‮that‬‏ ‏‮require‬‏ ‏‮specific‬‏ ‏‮children‬‏ `[‏‮role‬‏]`‏‮s‬‏, ‏‮are‬‏ ‏‮present‬‏"
+    "message": "‏‮Elements‬‏ ‏‮with‬‏ `[role]` ‏‮that‬‏ ‏‮require‬‏ ‏‮specific‬‏ ‏‮children‬‏ `[role]`‏‮s‬‏, ‏‮are‬‏ ‏‮present‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "‏‮Some‬‏ ‏‮ARIA‬‏ ‏‮child‬‏ ‏‮roles‬‏ ‏‮must‬‏ ‏‮be‬‏ ‏‮contained‬‏ ‏‮by‬‏ ‏‮specific‬‏ ‏‮parent‬‏ ‏‮roles‬‏ ‏‮to‬‏ ‏‮properly‬‏ ‏‮perform‬‏ ‏‮their‬‏ ‏‮intended‬‏ ‏‮accessibility‬‏ ‏‮functions‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮aria‬‏-‏‮required‬‏-‏‮parent‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Some‬‏ ‏‮ARIA‬‏ ‏‮child‬‏ ‏‮roles‬‏ ‏‮must‬‏ ‏‮be‬‏ ‏‮contained‬‏ ‏‮by‬‏ ‏‮specific‬‏ ‏‮parent‬‏ ‏‮roles‬‏ ‏‮to‬‏ ‏‮properly‬‏ ‏‮perform‬‏ ‏‮their‬‏ ‏‮intended‬‏ ‏‮accessibility‬‏ ‏‮functions‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "`[‏‮role‬‏]`‏‮s‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮contained‬‏ ‏‮by‬‏ ‏‮their‬‏ ‏‮required‬‏ ‏‮parent‬‏ ‏‮element‬‏"
+    "message": "`[role]`‏‮s‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮contained‬‏ ‏‮by‬‏ ‏‮their‬‏ ‏‮required‬‏ ‏‮parent‬‏ ‏‮element‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "`[‏‮role‬‏]`‏‮s‬‏ ‏‮are‬‏ ‏‮contained‬‏ ‏‮by‬‏ ‏‮their‬‏ ‏‮required‬‏ ‏‮parent‬‏ ‏‮element‬‏"
+    "message": "`[role]`‏‮s‬‏ ‏‮are‬‏ ‏‮contained‬‏ ‏‮by‬‏ ‏‮their‬‏ ‏‮required‬‏ ‏‮parent‬‏ ‏‮element‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "‏‮ARIA‬‏ ‏‮roles‬‏ ‏‮must‬‏ ‏‮have‬‏ ‏‮valid‬‏ ‏‮values‬‏ ‏‮in‬‏ ‏‮order‬‏ ‏‮to‬‏ ‏‮perform‬‏ ‏‮their‬‏ ‏‮intended‬‏ ‏‮accessibility‬‏ ‏‮functions‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮aria‬‏-‏‮roles‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮ARIA‬‏ ‏‮roles‬‏ ‏‮must‬‏ ‏‮have‬‏ ‏‮valid‬‏ ‏‮values‬‏ ‏‮in‬‏ ‏‮order‬‏ ‏‮to‬‏ ‏‮perform‬‏ ‏‮their‬‏ ‏‮intended‬‏ ‏‮accessibility‬‏ ‏‮functions‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "`[‏‮role‬‏]` ‏‮values‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮valid‬‏"
+    "message": "`[role]` ‏‮values‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮valid‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "`[‏‮role‬‏]` ‏‮values‬‏ ‏‮are‬‏ ‏‮valid‬‏"
+    "message": "`[role]` ‏‮values‬‏ ‏‮are‬‏ ‏‮valid‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "‏‮Assistive‬‏ ‏‮technologies‬‏, ‏‮like‬‏ ‏‮screen‬‏ ‏‮readers‬‏, ‏‮can‬‏'‏‮t‬‏ ‏‮interpret‬‏ ‏‮ARIA‬‏ ‏‮attributes‬‏ ‏‮with‬‏ ‏‮invalid‬‏ ‏‮values‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮aria‬‏-‏‮valid‬‏-‏‮attr‬‏-‏‮value‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Assistive‬‏ ‏‮technologies‬‏, ‏‮like‬‏ ‏‮screen‬‏ ‏‮readers‬‏, ‏‮can‬‏'‏‮t‬‏ ‏‮interpret‬‏ ‏‮ARIA‬‏ ‏‮attributes‬‏ ‏‮with‬‏ ‏‮invalid‬‏ ‏‮values‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "`[‏‮aria‬‏-*]` ‏‮attributes‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮valid‬‏ ‏‮values‬‏"
+    "message": "`[aria-*]` ‏‮attributes‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮valid‬‏ ‏‮values‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "`[‏‮aria‬‏-*]` ‏‮attributes‬‏ ‏‮have‬‏ ‏‮valid‬‏ ‏‮values‬‏"
+    "message": "`[aria-*]` ‏‮attributes‬‏ ‏‮have‬‏ ‏‮valid‬‏ ‏‮values‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "‏‮Assistive‬‏ ‏‮technologies‬‏, ‏‮like‬‏ ‏‮screen‬‏ ‏‮readers‬‏, ‏‮can‬‏'‏‮t‬‏ ‏‮interpret‬‏ ‏‮ARIA‬‏ ‏‮attributes‬‏ ‏‮with‬‏ ‏‮invalid‬‏ ‏‮names‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮aria‬‏-‏‮valid‬‏-‏‮attr‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Assistive‬‏ ‏‮technologies‬‏, ‏‮like‬‏ ‏‮screen‬‏ ‏‮readers‬‏, ‏‮can‬‏'‏‮t‬‏ ‏‮interpret‬‏ ‏‮ARIA‬‏ ‏‮attributes‬‏ ‏‮with‬‏ ‏‮invalid‬‏ ‏‮names‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "`[‏‮aria‬‏-*]` ‏‮attributes‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮valid‬‏ ‏‮or‬‏ ‏‮misspelled‬‏"
+    "message": "`[aria-*]` ‏‮attributes‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮valid‬‏ ‏‮or‬‏ ‏‮misspelled‬‏"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "`[‏‮aria‬‏-*]` ‏‮attributes‬‏ ‏‮are‬‏ ‏‮valid‬‏ ‏‮and‬‏ ‏‮not‬‏ ‏‮misspelled‬‏"
+    "message": "`[aria-*]` ‏‮attributes‬‏ ‏‮are‬‏ ‏‮valid‬‏ ‏‮and‬‏ ‏‮not‬‏ ‏‮misspelled‬‏"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "‏‮Captions‬‏ ‏‮make‬‏ ‏‮audio‬‏ ‏‮elements‬‏ ‏‮usable‬‏ ‏‮for‬‏ ‏‮deaf‬‏ ‏‮or‬‏ ‏‮hearing‬‏-‏‮impaired‬‏ ‏‮users‬‏, ‏‮providing‬‏ ‏‮critical‬‏ ‏‮information‬‏ ‏‮such‬‏ ‏‮as‬‏ ‏‮who‬‏ ‏‮is‬‏ ‏‮talking‬‏, ‏‮what‬‏ ‏‮they‬‏'‏‮re‬‏ ‏‮saying‬‏, ‏‮and‬‏ ‏‮other‬‏ ‏‮non‬‏-‏‮speech‬‏ ‏‮information‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮audio‬‏-‏‮caption‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Captions‬‏ ‏‮make‬‏ ‏‮audio‬‏ ‏‮elements‬‏ ‏‮usable‬‏ ‏‮for‬‏ ‏‮deaf‬‏ ‏‮or‬‏ ‏‮hearing‬‏-‏‮impaired‬‏ ‏‮users‬‏, ‏‮providing‬‏ ‏‮critical‬‏ ‏‮information‬‏ ‏‮such‬‏ ‏‮as‬‏ ‏‮who‬‏ ‏‮is‬‏ ‏‮talking‬‏, ‏‮what‬‏ ‏‮they‬‏'‏‮re‬‏ ‏‮saying‬‏, ‏‮and‬‏ ‏‮other‬‏ ‏‮non‬‏-‏‮speech‬‏ ‏‮information‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "`<audio>` ‏‮elements‬‏ ‏‮are‬‏ ‏‮missing‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[‏‮kind‬‏=\"‏‮captions‬‏\"]`."
+    "message": "`<audio>` ‏‮elements‬‏ ‏‮are‬‏ ‏‮missing‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "`<audio>` ‏‮elements‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[‏‮kind‬‏=\"‏‮captions‬‏\"]`"
+    "message": "`<audio>` ‏‮elements‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "‏‮Failing‬‏ ‏‮Elements‬‏"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "‏‮When‬‏ ‏‮a‬‏ ‏‮button‬‏ ‏‮doesn‬‏'‏‮t‬‏ ‏‮have‬‏ ‏‮an‬‏ ‏‮accessible‬‏ ‏‮name‬‏, ‏‮screen‬‏ ‏‮readers‬‏ ‏‮announce‬‏ ‏‮it‬‏ ‏‮as‬‏ \"‏‮button‬‏\", ‏‮making‬‏ ‏‮it‬‏ ‏‮unusable‬‏ ‏‮for‬‏ ‏‮users‬‏ ‏‮who‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮screen‬‏ ‏‮readers‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮button‬‏-‏‮name‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮When‬‏ ‏‮a‬‏ ‏‮button‬‏ ‏‮doesn‬‏'‏‮t‬‏ ‏‮have‬‏ ‏‮an‬‏ ‏‮accessible‬‏ ‏‮name‬‏, ‏‮screen‬‏ ‏‮readers‬‏ ‏‮announce‬‏ ‏‮it‬‏ ‏‮as‬‏ \"‏‮button‬‏\", ‏‮making‬‏ ‏‮it‬‏ ‏‮unusable‬‏ ‏‮for‬‏ ‏‮users‬‏ ‏‮who‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮screen‬‏ ‏‮readers‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "‏‮Buttons‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮an‬‏ ‏‮accessible‬‏ ‏‮name‬‏"
@@ -93,7 +93,7 @@
     "message": "‏‮Buttons‬‏ ‏‮have‬‏ ‏‮an‬‏ ‏‮accessible‬‏ ‏‮name‬‏"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "‏‮Adding‬‏ ‏‮ways‬‏ ‏‮to‬‏ ‏‮bypass‬‏ ‏‮repetitive‬‏ ‏‮content‬‏ ‏‮lets‬‏ ‏‮keyboard‬‏ ‏‮users‬‏ ‏‮navigate‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮more‬‏ ‏‮efficiently‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮bypass‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Adding‬‏ ‏‮ways‬‏ ‏‮to‬‏ ‏‮bypass‬‏ ‏‮repetitive‬‏ ‏‮content‬‏ ‏‮lets‬‏ ‏‮keyboard‬‏ ‏‮users‬‏ ‏‮navigate‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮more‬‏ ‏‮efficiently‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "‏‮The‬‏ ‏‮page‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮contain‬‏ ‏‮a‬‏ ‏‮heading‬‏, ‏‮skip‬‏ ‏‮link‬‏, ‏‮or‬‏ ‏‮landmark‬‏ ‏‮region‬‏"
@@ -102,7 +102,7 @@
     "message": "‏‮The‬‏ ‏‮page‬‏ ‏‮contains‬‏ ‏‮a‬‏ ‏‮heading‬‏, ‏‮skip‬‏ ‏‮link‬‏, ‏‮or‬‏ ‏‮landmark‬‏ ‏‮region‬‏"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "‏‮Low‬‏-‏‮contrast‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮difficult‬‏ ‏‮or‬‏ ‏‮impossible‬‏ ‏‮for‬‏ ‏‮many‬‏ ‏‮users‬‏ ‏‮to‬‏ ‏‮read‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮color‬‏-‏‮contrast‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Low‬‏-‏‮contrast‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮difficult‬‏ ‏‮or‬‏ ‏‮impossible‬‏ ‏‮for‬‏ ‏‮many‬‏ ‏‮users‬‏ ‏‮to‬‏ ‏‮read‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "‏‮Background‬‏ ‏‮and‬‏ ‏‮foreground‬‏ ‏‮colors‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮sufficient‬‏ ‏‮contrast‬‏ ‏‮ratio‬‏."
@@ -111,16 +111,16 @@
     "message": "‏‮Background‬‏ ‏‮and‬‏ ‏‮foreground‬‏ ‏‮colors‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮sufficient‬‏ ‏‮contrast‬‏ ‏‮ratio‬‏"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "‏‮When‬‏ ‏‮definition‬‏ ‏‮lists‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮properly‬‏ ‏‮marked‬‏ ‏‮up‬‏, ‏‮screen‬‏ ‏‮readers‬‏ ‏‮may‬‏ ‏‮produce‬‏ ‏‮confusing‬‏ ‏‮or‬‏ ‏‮inaccurate‬‏ ‏‮output‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮definition‬‏-‏‮list‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮When‬‏ ‏‮definition‬‏ ‏‮lists‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮properly‬‏ ‏‮marked‬‏ ‏‮up‬‏, ‏‮screen‬‏ ‏‮readers‬‏ ‏‮may‬‏ ‏‮produce‬‏ ‏‮confusing‬‏ ‏‮or‬‏ ‏‮inaccurate‬‏ ‏‮output‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "`<dl>`'‏‮s‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮contain‬‏ ‏‮only‬‏ ‏‮properly‬‏-‏‮ordered‬‏ `<dt>` ‏‮and‬‏ `<dd>` ‏‮groups‬‏, `<script>` ‏‮or‬‏ `<‏‮template‬‏>` ‏‮elements‬‏."
+    "message": "`<dl>`'‏‮s‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮contain‬‏ ‏‮only‬‏ ‏‮properly‬‏-‏‮ordered‬‏ `<dt>` ‏‮and‬‏ `<dd>` ‏‮groups‬‏, `<script>` ‏‮or‬‏ `<template>` ‏‮elements‬‏."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "`<dl>`'‏‮s‬‏ ‏‮contain‬‏ ‏‮only‬‏ ‏‮properly‬‏-‏‮ordered‬‏ `<dt>` ‏‮and‬‏ `<dd>` ‏‮groups‬‏, `<script>` ‏‮or‬‏ `<‏‮template‬‏>` ‏‮elements‬‏."
+    "message": "`<dl>`'‏‮s‬‏ ‏‮contain‬‏ ‏‮only‬‏ ‏‮properly‬‏-‏‮ordered‬‏ `<dt>` ‏‮and‬‏ `<dd>` ‏‮groups‬‏, `<script>` ‏‮or‬‏ `<template>` ‏‮elements‬‏."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "‏‮Definition‬‏ ‏‮list‬‏ ‏‮items‬‏ (`<dt>` ‏‮and‬‏ `<dd>`) ‏‮must‬‏ ‏‮be‬‏ ‏‮wrapped‬‏ ‏‮in‬‏ ‏‮a‬‏ ‏‮parent‬‏ `<dl>` ‏‮element‬‏ ‏‮to‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮screen‬‏ ‏‮readers‬‏ ‏‮can‬‏ ‏‮properly‬‏ ‏‮announce‬‏ ‏‮them‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮dlitem‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Definition‬‏ ‏‮list‬‏ ‏‮items‬‏ (`<dt>` ‏‮and‬‏ `<dd>`) ‏‮must‬‏ ‏‮be‬‏ ‏‮wrapped‬‏ ‏‮in‬‏ ‏‮a‬‏ ‏‮parent‬‏ `<dl>` ‏‮element‬‏ ‏‮to‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮screen‬‏ ‏‮readers‬‏ ‏‮can‬‏ ‏‮properly‬‏ ‏‮announce‬‏ ‏‮them‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
     "message": "‏‮Definition‬‏ ‏‮list‬‏ ‏‮items‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮wrapped‬‏ ‏‮in‬‏ `<dl>` ‏‮elements‬‏"
@@ -129,7 +129,7 @@
     "message": "‏‮Definition‬‏ ‏‮list‬‏ ‏‮items‬‏ ‏‮are‬‏ ‏‮wrapped‬‏ ‏‮in‬‏ `<dl>` ‏‮elements‬‏"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "‏‮The‬‏ ‏‮title‬‏ ‏‮gives‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏ ‏‮an‬‏ ‏‮overview‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮page‬‏, ‏‮and‬‏ ‏‮search‬‏ ‏‮engine‬‏ ‏‮users‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮it‬‏ ‏‮heavily‬‏ ‏‮to‬‏ ‏‮determine‬‏ ‏‮if‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮is‬‏ ‏‮relevant‬‏ ‏‮to‬‏ ‏‮their‬‏ ‏‮search‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮title‬‏)."
+    "message": "‏‮The‬‏ ‏‮title‬‏ ‏‮gives‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏ ‏‮an‬‏ ‏‮overview‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮page‬‏, ‏‮and‬‏ ‏‮search‬‏ ‏‮engine‬‏ ‏‮users‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮it‬‏ ‏‮heavily‬‏ ‏‮to‬‏ ‏‮determine‬‏ ‏‮if‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮is‬‏ ‏‮relevant‬‏ ‏‮to‬‏ ‏‮their‬‏ ‏‮search‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "‏‮Document‬‏ ‏‮doesn‬‏'‏‮t‬‏ ‏‮have‬‏ ‏‮a‬‏ `<title>` ‏‮element‬‏"
@@ -138,16 +138,16 @@
     "message": "‏‮Document‬‏ ‏‮has‬‏ ‏‮a‬‏ `<title>` ‏‮element‬‏"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "‏‮The‬‏ ‏‮value‬‏ ‏‮of‬‏ ‏‮an‬‏ ‏‮id‬‏ ‏‮attribute‬‏ ‏‮must‬‏ ‏‮be‬‏ ‏‮unique‬‏ ‏‮to‬‏ ‏‮prevent‬‏ ‏‮other‬‏ ‏‮instances‬‏ ‏‮from‬‏ ‏‮being‬‏ ‏‮overlooked‬‏ ‏‮by‬‏ ‏‮assistive‬‏ ‏‮technologies‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮duplicate‬‏-‏‮id‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮The‬‏ ‏‮value‬‏ ‏‮of‬‏ ‏‮an‬‏ ‏‮id‬‏ ‏‮attribute‬‏ ‏‮must‬‏ ‏‮be‬‏ ‏‮unique‬‏ ‏‮to‬‏ ‏‮prevent‬‏ ‏‮other‬‏ ‏‮instances‬‏ ‏‮from‬‏ ‏‮being‬‏ ‏‮overlooked‬‏ ‏‮by‬‏ ‏‮assistive‬‏ ‏‮technologies‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "`[‏‮id‬‏]` ‏‮attributes‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮unique‬‏"
+    "message": "`[id]` ‏‮attributes‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮unique‬‏"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "`[‏‮id‬‏]` ‏‮attributes‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮are‬‏ ‏‮unique‬‏"
+    "message": "`[id]` ‏‮attributes‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮are‬‏ ‏‮unique‬‏"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "‏‮Screen‬‏ ‏‮reader‬‏ ‏‮users‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮frame‬‏ ‏‮titles‬‏ ‏‮to‬‏ ‏‮describe‬‏ ‏‮the‬‏ ‏‮contents‬‏ ‏‮of‬‏ ‏‮frames‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮frame‬‏-‏‮title‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Screen‬‏ ‏‮reader‬‏ ‏‮users‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮frame‬‏ ‏‮titles‬‏ ‏‮to‬‏ ‏‮describe‬‏ ‏‮the‬‏ ‏‮contents‬‏ ‏‮of‬‏ ‏‮frames‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "`<frame>` ‏‮or‬‏ `<iframe>` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮title‬‏"
@@ -156,43 +156,43 @@
     "message": "`<frame>` ‏‮or‬‏ `<iframe>` ‏‮elements‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮title‬‏"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "‏‮If‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮doesn‬‏'‏‮t‬‏ ‏‮specify‬‏ ‏‮a‬‏ ‏‮lang‬‏ ‏‮attribute‬‏, ‏‮a‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮assumes‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮is‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮default‬‏ ‏‮language‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮user‬‏ ‏‮chose‬‏ ‏‮when‬‏ ‏‮setting‬‏ ‏‮up‬‏ ‏‮the‬‏ ‏‮screen‬‏ ‏‮reader‬‏. ‏‮If‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮isn‬‏'‏‮t‬‏ ‏‮actually‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮default‬‏ ‏‮language‬‏, ‏‮then‬‏ ‏‮the‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮might‬‏ ‏‮not‬‏ ‏‮announce‬‏ ‏‮the‬‏ ‏‮page‬‏'‏‮s‬‏ ‏‮text‬‏ ‏‮correctly‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮html‬‏-‏‮has‬‏-‏‮lang‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮If‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮doesn‬‏'‏‮t‬‏ ‏‮specify‬‏ ‏‮a‬‏ ‏‮lang‬‏ ‏‮attribute‬‏, ‏‮a‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮assumes‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮is‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮default‬‏ ‏‮language‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮user‬‏ ‏‮chose‬‏ ‏‮when‬‏ ‏‮setting‬‏ ‏‮up‬‏ ‏‮the‬‏ ‏‮screen‬‏ ‏‮reader‬‏. ‏‮If‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮isn‬‏'‏‮t‬‏ ‏‮actually‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮default‬‏ ‏‮language‬‏, ‏‮then‬‏ ‏‮the‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮might‬‏ ‏‮not‬‏ ‏‮announce‬‏ ‏‮the‬‏ ‏‮page‬‏'‏‮s‬‏ ‏‮text‬‏ ‏‮correctly‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "`<html>` ‏‮element‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ `[‏‮lang‬‏]` ‏‮attribute‬‏"
+    "message": "`<html>` ‏‮element‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ `[lang]` ‏‮attribute‬‏"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "`<html>` ‏‮element‬‏ ‏‮has‬‏ ‏‮a‬‏ `[‏‮lang‬‏]` ‏‮attribute‬‏"
+    "message": "`<html>` ‏‮element‬‏ ‏‮has‬‏ ‏‮a‬‏ `[lang]` ‏‮attribute‬‏"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "‏‮Specifying‬‏ ‏‮a‬‏ ‏‮valid‬‏ [‏‮BCP‬‏ 47 ‏‮language‬‏](‏‮https‬‏://‏‮www‬‏.‏‮w‬‏3.‏‮org‬‏/‏‮International‬‏/‏‮questions‬‏/‏‮qa‬‏-‏‮choosing‬‏-‏‮language‬‏-‏‮tags‬‏#‏‮question‬‏) ‏‮helps‬‏ ‏‮screen‬‏ ‏‮readers‬‏ ‏‮announce‬‏ ‏‮text‬‏ ‏‮properly‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮valid‬‏-‏‮lang‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Specifying‬‏ ‏‮a‬‏ ‏‮valid‬‏ [‏‮BCP‬‏ 47 ‏‮language‬‏](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ‏‮helps‬‏ ‏‮screen‬‏ ‏‮readers‬‏ ‏‮announce‬‏ ‏‮text‬‏ ‏‮properly‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "`<html>` ‏‮element‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮value‬‏ ‏‮for‬‏ ‏‮its‬‏ `[‏‮lang‬‏]` ‏‮attribute‬‏."
+    "message": "`<html>` ‏‮element‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮value‬‏ ‏‮for‬‏ ‏‮its‬‏ `[lang]` ‏‮attribute‬‏."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "`<html>` ‏‮element‬‏ ‏‮has‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮value‬‏ ‏‮for‬‏ ‏‮its‬‏ `[‏‮lang‬‏]` ‏‮attribute‬‏"
+    "message": "`<html>` ‏‮element‬‏ ‏‮has‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮value‬‏ ‏‮for‬‏ ‏‮its‬‏ `[lang]` ‏‮attribute‬‏"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "‏‮Informative‬‏ ‏‮elements‬‏ ‏‮should‬‏ ‏‮aim‬‏ ‏‮for‬‏ ‏‮short‬‏, ‏‮descriptive‬‏ ‏‮alternate‬‏ ‏‮text‬‏. ‏‮Decorative‬‏ ‏‮elements‬‏ ‏‮can‬‏ ‏‮be‬‏ ‏‮ignored‬‏ ‏‮with‬‏ ‏‮an‬‏ ‏‮empty‬‏ ‏‮alt‬‏ ‏‮attribute‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮image‬‏-‏‮alt‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Informative‬‏ ‏‮elements‬‏ ‏‮should‬‏ ‏‮aim‬‏ ‏‮for‬‏ ‏‮short‬‏, ‏‮descriptive‬‏ ‏‮alternate‬‏ ‏‮text‬‏. ‏‮Decorative‬‏ ‏‮elements‬‏ ‏‮can‬‏ ‏‮be‬‏ ‏‮ignored‬‏ ‏‮with‬‏ ‏‮an‬‏ ‏‮empty‬‏ ‏‮alt‬‏ ‏‮attribute‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "‏‮Image‬‏ ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ `[‏‮alt‬‏]` ‏‮attributes‬‏"
+    "message": "‏‮Image‬‏ ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ `[alt]` ‏‮attributes‬‏"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "‏‮Image‬‏ ‏‮elements‬‏ ‏‮have‬‏ `[‏‮alt‬‏]` ‏‮attributes‬‏"
+    "message": "‏‮Image‬‏ ‏‮elements‬‏ ‏‮have‬‏ `[alt]` ‏‮attributes‬‏"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "‏‮When‬‏ ‏‮an‬‏ ‏‮image‬‏ ‏‮is‬‏ ‏‮being‬‏ ‏‮used‬‏ ‏‮as‬‏ ‏‮an‬‏ `<input>` ‏‮button‬‏, ‏‮providing‬‏ ‏‮alternative‬‏ ‏‮text‬‏ ‏‮can‬‏ ‏‮help‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏ ‏‮understand‬‏ ‏‮the‬‏ ‏‮purpose‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮button‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮input‬‏-‏‮image‬‏-‏‮alt‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮When‬‏ ‏‮an‬‏ ‏‮image‬‏ ‏‮is‬‏ ‏‮being‬‏ ‏‮used‬‏ ‏‮as‬‏ ‏‮an‬‏ `<input>` ‏‮button‬‏, ‏‮providing‬‏ ‏‮alternative‬‏ ‏‮text‬‏ ‏‮can‬‏ ‏‮help‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏ ‏‮understand‬‏ ‏‮the‬‏ ‏‮purpose‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮button‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "`<input type=\"image\">` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ `[‏‮alt‬‏]` ‏‮text‬‏"
+    "message": "`<input type=\"image\">` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ `[alt]` ‏‮text‬‏"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "`<input type=\"image\">` ‏‮elements‬‏ ‏‮have‬‏ `[‏‮alt‬‏]` ‏‮text‬‏"
+    "message": "`<input type=\"image\">` ‏‮elements‬‏ ‏‮have‬‏ `[alt]` ‏‮text‬‏"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "‏‮Labels‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮form‬‏ ‏‮controls‬‏ ‏‮are‬‏ ‏‮announced‬‏ ‏‮properly‬‏ ‏‮by‬‏ ‏‮assistive‬‏ ‏‮technologies‬‏, ‏‮like‬‏ ‏‮screen‬‏ ‏‮readers‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮label‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Labels‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮form‬‏ ‏‮controls‬‏ ‏‮are‬‏ ‏‮announced‬‏ ‏‮properly‬‏ ‏‮by‬‏ ‏‮assistive‬‏ ‏‮technologies‬‏, ‏‮like‬‏ ‏‮screen‬‏ ‏‮readers‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "‏‮Form‬‏ ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮associated‬‏ ‏‮labels‬‏"
@@ -201,16 +201,16 @@
     "message": "‏‮Form‬‏ ‏‮elements‬‏ ‏‮have‬‏ ‏‮associated‬‏ ‏‮labels‬‏"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "‏‮A‬‏ ‏‮table‬‏ ‏‮being‬‏ ‏‮used‬‏ ‏‮for‬‏ ‏‮layout‬‏ ‏‮purposes‬‏ ‏‮should‬‏ ‏‮not‬‏ ‏‮include‬‏ ‏‮data‬‏ ‏‮elements‬‏, ‏‮such‬‏ ‏‮as‬‏ ‏‮the‬‏ ‏‮th‬‏ ‏‮or‬‏ ‏‮caption‬‏ ‏‮elements‬‏ ‏‮or‬‏ ‏‮the‬‏ ‏‮summary‬‏ ‏‮attribute‬‏, ‏‮because‬‏ ‏‮this‬‏ ‏‮can‬‏ ‏‮create‬‏ ‏‮a‬‏ ‏‮confusing‬‏ ‏‮experience‬‏ ‏‮for‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮layout‬‏-‏‮table‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮A‬‏ ‏‮table‬‏ ‏‮being‬‏ ‏‮used‬‏ ‏‮for‬‏ ‏‮layout‬‏ ‏‮purposes‬‏ ‏‮should‬‏ ‏‮not‬‏ ‏‮include‬‏ ‏‮data‬‏ ‏‮elements‬‏, ‏‮such‬‏ ‏‮as‬‏ ‏‮the‬‏ ‏‮th‬‏ ‏‮or‬‏ ‏‮caption‬‏ ‏‮elements‬‏ ‏‮or‬‏ ‏‮the‬‏ ‏‮summary‬‏ ‏‮attribute‬‏, ‏‮because‬‏ ‏‮this‬‏ ‏‮can‬‏ ‏‮create‬‏ ‏‮a‬‏ ‏‮confusing‬‏ ‏‮experience‬‏ ‏‮for‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "‏‮Presentational‬‏ `<table>` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮avoid‬‏ ‏‮using‬‏ `<th>`, `<caption>` ‏‮or‬‏ ‏‮the‬‏ `[‏‮summary‬‏]` ‏‮attribute‬‏."
+    "message": "‏‮Presentational‬‏ `<table>` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮avoid‬‏ ‏‮using‬‏ `<th>`, `<caption>` ‏‮or‬‏ ‏‮the‬‏ `[summary]` ‏‮attribute‬‏."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "‏‮Presentational‬‏ `<table>` ‏‮elements‬‏ ‏‮avoid‬‏ ‏‮using‬‏ `<th>`, `<caption>` ‏‮or‬‏ ‏‮the‬‏ `[‏‮summary‬‏]` ‏‮attribute‬‏."
+    "message": "‏‮Presentational‬‏ `<table>` ‏‮elements‬‏ ‏‮avoid‬‏ ‏‮using‬‏ `<th>`, `<caption>` ‏‮or‬‏ ‏‮the‬‏ `[summary]` ‏‮attribute‬‏."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "‏‮Link‬‏ ‏‮text‬‏ (‏‮and‬‏ ‏‮alternate‬‏ ‏‮text‬‏ ‏‮for‬‏ ‏‮images‬‏, ‏‮when‬‏ ‏‮used‬‏ ‏‮as‬‏ ‏‮links‬‏) ‏‮that‬‏ ‏‮is‬‏ ‏‮discernible‬‏, ‏‮unique‬‏, ‏‮and‬‏ ‏‮focusable‬‏ ‏‮improves‬‏ ‏‮the‬‏ ‏‮navigation‬‏ ‏‮experience‬‏ ‏‮for‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮link‬‏-‏‮name‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Link‬‏ ‏‮text‬‏ (‏‮and‬‏ ‏‮alternate‬‏ ‏‮text‬‏ ‏‮for‬‏ ‏‮images‬‏, ‏‮when‬‏ ‏‮used‬‏ ‏‮as‬‏ ‏‮links‬‏) ‏‮that‬‏ ‏‮is‬‏ ‏‮discernible‬‏, ‏‮unique‬‏, ‏‮and‬‏ ‏‮focusable‬‏ ‏‮improves‬‏ ‏‮the‬‏ ‏‮navigation‬‏ ‏‮experience‬‏ ‏‮for‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "‏‮Links‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮discernible‬‏ ‏‮name‬‏"
@@ -219,16 +219,16 @@
     "message": "‏‮Links‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮discernible‬‏ ‏‮name‬‏"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮specific‬‏ ‏‮way‬‏ ‏‮of‬‏ ‏‮announcing‬‏ ‏‮lists‬‏. ‏‮Ensuring‬‏ ‏‮proper‬‏ ‏‮list‬‏ ‏‮structure‬‏ ‏‮aids‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮output‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮list‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮specific‬‏ ‏‮way‬‏ ‏‮of‬‏ ‏‮announcing‬‏ ‏‮lists‬‏. ‏‮Ensuring‬‏ ‏‮proper‬‏ ‏‮list‬‏ ‏‮structure‬‏ ‏‮aids‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮output‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "‏‮Lists‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮contain‬‏ ‏‮only‬‏ `<li>` ‏‮elements‬‏ ‏‮and‬‏ ‏‮script‬‏ ‏‮supporting‬‏ ‏‮elements‬‏ (`<script>` ‏‮and‬‏ `<‏‮template‬‏>`)."
+    "message": "‏‮Lists‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮contain‬‏ ‏‮only‬‏ `<li>` ‏‮elements‬‏ ‏‮and‬‏ ‏‮script‬‏ ‏‮supporting‬‏ ‏‮elements‬‏ (`<script>` ‏‮and‬‏ `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "‏‮Lists‬‏ ‏‮contain‬‏ ‏‮only‬‏ `<li>` ‏‮elements‬‏ ‏‮and‬‏ ‏‮script‬‏ ‏‮supporting‬‏ ‏‮elements‬‏ (`<script>` ‏‮and‬‏ `<‏‮template‬‏>`)."
+    "message": "‏‮Lists‬‏ ‏‮contain‬‏ ‏‮only‬‏ `<li>` ‏‮elements‬‏ ‏‮and‬‏ ‏‮script‬‏ ‏‮supporting‬‏ ‏‮elements‬‏ (`<script>` ‏‮and‬‏ `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮require‬‏ ‏‮list‬‏ ‏‮items‬‏ (`<li>`) ‏‮to‬‏ ‏‮be‬‏ ‏‮contained‬‏ ‏‮within‬‏ ‏‮a‬‏ ‏‮parent‬‏ `<ul>` ‏‮or‬‏ `<ol>` ‏‮to‬‏ ‏‮be‬‏ ‏‮announced‬‏ ‏‮properly‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮listitem‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮require‬‏ ‏‮list‬‏ ‏‮items‬‏ (`<li>`) ‏‮to‬‏ ‏‮be‬‏ ‏‮contained‬‏ ‏‮within‬‏ ‏‮a‬‏ ‏‮parent‬‏ `<ul>` ‏‮or‬‏ `<ol>` ‏‮to‬‏ ‏‮be‬‏ ‏‮announced‬‏ ‏‮properly‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
     "message": "‏‮List‬‏ ‏‮items‬‏ (`<li>`) ‏‮are‬‏ ‏‮not‬‏ ‏‮contained‬‏ ‏‮within‬‏ `<ul>` ‏‮or‬‏ `<ol>` ‏‮parent‬‏ ‏‮elements‬‏."
@@ -237,7 +237,7 @@
     "message": "‏‮List‬‏ ‏‮items‬‏ (`<li>`) ‏‮are‬‏ ‏‮contained‬‏ ‏‮within‬‏ `<ul>` ‏‮or‬‏ `<ol>` ‏‮parent‬‏ ‏‮elements‬‏"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "‏‮Users‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮expect‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮to‬‏ ‏‮refresh‬‏ ‏‮automatically‬‏, ‏‮and‬‏ ‏‮doing‬‏ ‏‮so‬‏ ‏‮will‬‏ ‏‮move‬‏ ‏‮focus‬‏ ‏‮back‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮top‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮page‬‏. ‏‮This‬‏ ‏‮may‬‏ ‏‮create‬‏ ‏‮a‬‏ ‏‮frustrating‬‏ ‏‮or‬‏ ‏‮confusing‬‏ ‏‮experience‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮meta‬‏-‏‮refresh‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Users‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮expect‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮to‬‏ ‏‮refresh‬‏ ‏‮automatically‬‏, ‏‮and‬‏ ‏‮doing‬‏ ‏‮so‬‏ ‏‮will‬‏ ‏‮move‬‏ ‏‮focus‬‏ ‏‮back‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮top‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮page‬‏. ‏‮This‬‏ ‏‮may‬‏ ‏‮create‬‏ ‏‮a‬‏ ‏‮frustrating‬‏ ‏‮or‬‏ ‏‮confusing‬‏ ‏‮experience‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
     "message": "‏‮The‬‏ ‏‮document‬‏ ‏‮uses‬‏ `<meta http-equiv=\"refresh\">`"
@@ -246,76 +246,88 @@
     "message": "‏‮The‬‏ ‏‮document‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮use‬‏ `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "‏‮Disabling‬‏ ‏‮zooming‬‏ ‏‮is‬‏ ‏‮problematic‬‏ ‏‮for‬‏ ‏‮users‬‏ ‏‮with‬‏ ‏‮low‬‏ ‏‮vision‬‏ ‏‮who‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮screen‬‏ ‏‮magnification‬‏ ‏‮to‬‏ ‏‮properly‬‏ ‏‮see‬‏ ‏‮the‬‏ ‏‮contents‬‏ ‏‮of‬‏ ‏‮a‬‏ ‏‮web‬‏ ‏‮page‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮meta‬‏-‏‮viewport‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Disabling‬‏ ‏‮zooming‬‏ ‏‮is‬‏ ‏‮problematic‬‏ ‏‮for‬‏ ‏‮users‬‏ ‏‮with‬‏ ‏‮low‬‏ ‏‮vision‬‏ ‏‮who‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮screen‬‏ ‏‮magnification‬‏ ‏‮to‬‏ ‏‮properly‬‏ ‏‮see‬‏ ‏‮the‬‏ ‏‮contents‬‏ ‏‮of‬‏ ‏‮a‬‏ ‏‮web‬‏ ‏‮page‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "`[‏‮user‬‏-‏‮scalable‬‏=\"‏‮no‬‏\"]` ‏‮is‬‏ ‏‮used‬‏ ‏‮in‬‏ ‏‮the‬‏ `<meta name=\"viewport\">` ‏‮element‬‏ ‏‮or‬‏ ‏‮the‬‏ `[‏‮maximum‬‏-‏‮scale‬‏]` ‏‮attribute‬‏ ‏‮is‬‏ ‏‮less‬‏ ‏‮than‬‏ 5."
+    "message": "`[user-scalable=\"no\"]` ‏‮is‬‏ ‏‮used‬‏ ‏‮in‬‏ ‏‮the‬‏ `<meta name=\"viewport\">` ‏‮element‬‏ ‏‮or‬‏ ‏‮the‬‏ `[maximum-scale]` ‏‮attribute‬‏ ‏‮is‬‏ ‏‮less‬‏ ‏‮than‬‏ 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "`[‏‮user‬‏-‏‮scalable‬‏=\"‏‮no‬‏\"]` ‏‮is‬‏ ‏‮not‬‏ ‏‮used‬‏ ‏‮in‬‏ ‏‮the‬‏ `<meta name=\"viewport\">` ‏‮element‬‏ ‏‮and‬‏ ‏‮the‬‏ `[‏‮maximum‬‏-‏‮scale‬‏]` ‏‮attribute‬‏ ‏‮is‬‏ ‏‮not‬‏ ‏‮less‬‏ ‏‮than‬‏ 5."
+    "message": "`[user-scalable=\"no\"]` ‏‮is‬‏ ‏‮not‬‏ ‏‮used‬‏ ‏‮in‬‏ ‏‮the‬‏ `<meta name=\"viewport\">` ‏‮element‬‏ ‏‮and‬‏ ‏‮the‬‏ `[maximum-scale]` ‏‮attribute‬‏ ‏‮is‬‏ ‏‮not‬‏ ‏‮less‬‏ ‏‮than‬‏ 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮cannot‬‏ ‏‮translate‬‏ ‏‮non‬‏-‏‮text‬‏ ‏‮content‬‏. ‏‮Adding‬‏ ‏‮alt‬‏ ‏‮text‬‏ ‏‮to‬‏ `<object>` ‏‮elements‬‏ ‏‮helps‬‏ ‏‮screen‬‏ ‏‮readers‬‏ ‏‮convey‬‏ ‏‮meaning‬‏ ‏‮to‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮object‬‏-‏‮alt‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮cannot‬‏ ‏‮translate‬‏ ‏‮non‬‏-‏‮text‬‏ ‏‮content‬‏. ‏‮Adding‬‏ ‏‮alt‬‏ ‏‮text‬‏ ‏‮to‬‏ `<object>` ‏‮elements‬‏ ‏‮helps‬‏ ‏‮screen‬‏ ‏‮readers‬‏ ‏‮convey‬‏ ‏‮meaning‬‏ ‏‮to‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "`<object>` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ `[‏‮alt‬‏]` ‏‮text‬‏"
+    "message": "`<object>` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ `[alt]` ‏‮text‬‏"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "`<object>` ‏‮elements‬‏ ‏‮have‬‏ `[‏‮alt‬‏]` ‏‮text‬‏"
+    "message": "`<object>` ‏‮elements‬‏ ‏‮have‬‏ `[alt]` ‏‮text‬‏"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "‏‮A‬‏ ‏‮value‬‏ ‏‮greater‬‏ ‏‮than‬‏ 0 ‏‮implies‬‏ ‏‮an‬‏ ‏‮explicit‬‏ ‏‮navigation‬‏ ‏‮ordering‬‏. ‏‮Although‬‏ ‏‮technically‬‏ ‏‮valid‬‏, ‏‮this‬‏ ‏‮often‬‏ ‏‮creates‬‏ ‏‮frustrating‬‏ ‏‮experiences‬‏ ‏‮for‬‏ ‏‮users‬‏ ‏‮who‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮assistive‬‏ ‏‮technologies‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮tabindex‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮A‬‏ ‏‮value‬‏ ‏‮greater‬‏ ‏‮than‬‏ 0 ‏‮implies‬‏ ‏‮an‬‏ ‏‮explicit‬‏ ‏‮navigation‬‏ ‏‮ordering‬‏. ‏‮Although‬‏ ‏‮technically‬‏ ‏‮valid‬‏, ‏‮this‬‏ ‏‮often‬‏ ‏‮creates‬‏ ‏‮frustrating‬‏ ‏‮experiences‬‏ ‏‮for‬‏ ‏‮users‬‏ ‏‮who‬‏ ‏‮rely‬‏ ‏‮on‬‏ ‏‮assistive‬‏ ‏‮technologies‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "‏‮Some‬‏ ‏‮elements‬‏ ‏‮have‬‏ ‏‮a‬‏ `[‏‮tabindex‬‏]` ‏‮value‬‏ ‏‮greater‬‏ ‏‮than‬‏ 0"
+    "message": "‏‮Some‬‏ ‏‮elements‬‏ ‏‮have‬‏ ‏‮a‬‏ `[tabindex]` ‏‮value‬‏ ‏‮greater‬‏ ‏‮than‬‏ 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "‏‮No‬‏ ‏‮element‬‏ ‏‮has‬‏ ‏‮a‬‏ `[‏‮tabindex‬‏]` ‏‮value‬‏ ‏‮greater‬‏ ‏‮than‬‏ 0"
+    "message": "‏‮No‬‏ ‏‮element‬‏ ‏‮has‬‏ ‏‮a‬‏ `[tabindex]` ‏‮value‬‏ ‏‮greater‬‏ ‏‮than‬‏ 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮have‬‏ ‏‮features‬‏ ‏‮to‬‏ ‏‮make‬‏ ‏‮navigating‬‏ ‏‮tables‬‏ ‏‮easier‬‏. ‏‮Ensuring‬‏ `<td>` ‏‮cells‬‏ ‏‮using‬‏ ‏‮the‬‏ `[‏‮headers‬‏]` ‏‮attribute‬‏ ‏‮only‬‏ ‏‮refer‬‏ ‏‮to‬‏ ‏‮other‬‏ ‏‮cells‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮same‬‏ ‏‮table‬‏ ‏‮may‬‏ ‏‮improve‬‏ ‏‮the‬‏ ‏‮experience‬‏ ‏‮for‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮td‬‏-‏‮headers‬‏-‏‮attr‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮have‬‏ ‏‮features‬‏ ‏‮to‬‏ ‏‮make‬‏ ‏‮navigating‬‏ ‏‮tables‬‏ ‏‮easier‬‏. ‏‮Ensuring‬‏ `<td>` ‏‮cells‬‏ ‏‮using‬‏ ‏‮the‬‏ `[headers]` ‏‮attribute‬‏ ‏‮only‬‏ ‏‮refer‬‏ ‏‮to‬‏ ‏‮other‬‏ ‏‮cells‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮same‬‏ ‏‮table‬‏ ‏‮may‬‏ ‏‮improve‬‏ ‏‮the‬‏ ‏‮experience‬‏ ‏‮for‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "‏‮Cells‬‏ ‏‮in‬‏ ‏‮a‬‏ `<table>` ‏‮element‬‏ ‏‮that‬‏ ‏‮use‬‏ ‏‮the‬‏ `[‏‮headers‬‏]` ‏‮attribute‬‏ ‏‮refers‬‏ ‏‮to‬‏ ‏‮other‬‏ ‏‮cells‬‏ ‏‮of‬‏ ‏‮that‬‏ ‏‮same‬‏ ‏‮table‬‏."
+    "message": "‏‮Cells‬‏ ‏‮in‬‏ ‏‮a‬‏ `<table>` ‏‮element‬‏ ‏‮that‬‏ ‏‮use‬‏ ‏‮the‬‏ `[headers]` ‏‮attribute‬‏ ‏‮refers‬‏ ‏‮to‬‏ ‏‮other‬‏ ‏‮cells‬‏ ‏‮of‬‏ ‏‮that‬‏ ‏‮same‬‏ ‏‮table‬‏."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "‏‮Cells‬‏ ‏‮in‬‏ ‏‮a‬‏ `<table>` ‏‮element‬‏ ‏‮that‬‏ ‏‮use‬‏ ‏‮the‬‏ `[‏‮headers‬‏]` ‏‮attribute‬‏ ‏‮only‬‏ ‏‮refer‬‏ ‏‮to‬‏ ‏‮other‬‏ ‏‮cells‬‏ ‏‮of‬‏ ‏‮that‬‏ ‏‮same‬‏ ‏‮table‬‏."
+    "message": "‏‮Cells‬‏ ‏‮in‬‏ ‏‮a‬‏ `<table>` ‏‮element‬‏ ‏‮that‬‏ ‏‮use‬‏ ‏‮the‬‏ `[headers]` ‏‮attribute‬‏ ‏‮only‬‏ ‏‮refer‬‏ ‏‮to‬‏ ‏‮other‬‏ ‏‮cells‬‏ ‏‮of‬‏ ‏‮that‬‏ ‏‮same‬‏ ‏‮table‬‏."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮have‬‏ ‏‮features‬‏ ‏‮to‬‏ ‏‮make‬‏ ‏‮navigating‬‏ ‏‮tables‬‏ ‏‮easier‬‏. ‏‮Ensuring‬‏ ‏‮table‬‏ ‏‮headers‬‏ ‏‮always‬‏ ‏‮refer‬‏ ‏‮to‬‏ ‏‮some‬‏ ‏‮set‬‏ ‏‮of‬‏ ‏‮cells‬‏ ‏‮may‬‏ ‏‮improve‬‏ ‏‮the‬‏ ‏‮experience‬‏ ‏‮for‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮th‬‏-‏‮has‬‏-‏‮data‬‏-‏‮cells‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Screen‬‏ ‏‮readers‬‏ ‏‮have‬‏ ‏‮features‬‏ ‏‮to‬‏ ‏‮make‬‏ ‏‮navigating‬‏ ‏‮tables‬‏ ‏‮easier‬‏. ‏‮Ensuring‬‏ ‏‮table‬‏ ‏‮headers‬‏ ‏‮always‬‏ ‏‮refer‬‏ ‏‮to‬‏ ‏‮some‬‏ ‏‮set‬‏ ‏‮of‬‏ ‏‮cells‬‏ ‏‮may‬‏ ‏‮improve‬‏ ‏‮the‬‏ ‏‮experience‬‏ ‏‮for‬‏ ‏‮screen‬‏ ‏‮reader‬‏ ‏‮users‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "`<th>` ‏‮elements‬‏ ‏‮and‬‏ ‏‮elements‬‏ ‏‮with‬‏ `[‏‮role‬‏=\"‏‮columnheader‬‏\"/\"‏‮rowheader‬‏\"]` ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮data‬‏ ‏‮cells‬‏ ‏‮they‬‏ ‏‮describe‬‏."
+    "message": "`<th>` ‏‮elements‬‏ ‏‮and‬‏ ‏‮elements‬‏ ‏‮with‬‏ `[role=\"columnheader\"/\"rowheader\"]` ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮data‬‏ ‏‮cells‬‏ ‏‮they‬‏ ‏‮describe‬‏."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "`<th>` ‏‮elements‬‏ ‏‮and‬‏ ‏‮elements‬‏ ‏‮with‬‏ `[‏‮role‬‏=\"‏‮columnheader‬‏\"/\"‏‮rowheader‬‏\"]` ‏‮have‬‏ ‏‮data‬‏ ‏‮cells‬‏ ‏‮they‬‏ ‏‮describe‬‏."
+    "message": "`<th>` ‏‮elements‬‏ ‏‮and‬‏ ‏‮elements‬‏ ‏‮with‬‏ `[role=\"columnheader\"/\"rowheader\"]` ‏‮have‬‏ ‏‮data‬‏ ‏‮cells‬‏ ‏‮they‬‏ ‏‮describe‬‏."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "‏‮Specifying‬‏ ‏‮a‬‏ ‏‮valid‬‏ [‏‮BCP‬‏ 47 ‏‮language‬‏](‏‮https‬‏://‏‮www‬‏.‏‮w‬‏3.‏‮org‬‏/‏‮International‬‏/‏‮questions‬‏/‏‮qa‬‏-‏‮choosing‬‏-‏‮language‬‏-‏‮tags‬‏#‏‮question‬‏) ‏‮on‬‏ ‏‮elements‬‏ ‏‮helps‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮pronounced‬‏ ‏‮correctly‬‏ ‏‮by‬‏ ‏‮a‬‏ ‏‮screen‬‏ ‏‮reader‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮valid‬‏-‏‮lang‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Specifying‬‏ ‏‮a‬‏ ‏‮valid‬‏ [‏‮BCP‬‏ 47 ‏‮language‬‏](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ‏‮on‬‏ ‏‮elements‬‏ ‏‮helps‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮pronounced‬‏ ‏‮correctly‬‏ ‏‮by‬‏ ‏‮a‬‏ ‏‮screen‬‏ ‏‮reader‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "`[‏‮lang‬‏]` ‏‮attributes‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮value‬‏"
+    "message": "`[lang]` ‏‮attributes‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮value‬‏"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "`[‏‮lang‬‏]` ‏‮attributes‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮value‬‏"
+    "message": "`[lang]` ‏‮attributes‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮value‬‏"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "‏‮When‬‏ ‏‮a‬‏ ‏‮video‬‏ ‏‮provides‬‏ ‏‮a‬‏ ‏‮caption‬‏ ‏‮it‬‏ ‏‮is‬‏ ‏‮easier‬‏ ‏‮for‬‏ ‏‮deaf‬‏ ‏‮and‬‏ ‏‮hearing‬‏ ‏‮impaired‬‏ ‏‮users‬‏ ‏‮to‬‏ ‏‮access‬‏ ‏‮its‬‏ ‏‮information‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮video‬‏-‏‮caption‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮When‬‏ ‏‮a‬‏ ‏‮video‬‏ ‏‮provides‬‏ ‏‮a‬‏ ‏‮caption‬‏ ‏‮it‬‏ ‏‮is‬‏ ‏‮easier‬‏ ‏‮for‬‏ ‏‮deaf‬‏ ‏‮and‬‏ ‏‮hearing‬‏ ‏‮impaired‬‏ ‏‮users‬‏ ‏‮to‬‏ ‏‮access‬‏ ‏‮its‬‏ ‏‮information‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "`<video>` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[‏‮kind‬‏=\"‏‮captions‬‏\"]`."
+    "message": "`<video>` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "`<video>` ‏‮elements‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[‏‮kind‬‏=\"‏‮captions‬‏\"]`"
+    "message": "`<video>` ‏‮elements‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "‏‮Audio‬‏ ‏‮descriptions‬‏ ‏‮provide‬‏ ‏‮relevant‬‏ ‏‮information‬‏ ‏‮for‬‏ ‏‮videos‬‏ ‏‮that‬‏ ‏‮dialogue‬‏ ‏‮cannot‬‏, ‏‮such‬‏ ‏‮as‬‏ ‏‮facial‬‏ ‏‮expressions‬‏ ‏‮and‬‏ ‏‮scenes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮dequeuniversity‬‏.‏‮com‬‏/‏‮rules‬‏/‏‮axe‬‏/3.1/‏‮video‬‏-‏‮description‬‏?‏‮application‬‏=‏‮lighthouse‬‏)."
+    "message": "‏‮Audio‬‏ ‏‮descriptions‬‏ ‏‮provide‬‏ ‏‮relevant‬‏ ‏‮information‬‏ ‏‮for‬‏ ‏‮videos‬‏ ‏‮that‬‏ ‏‮dialogue‬‏ ‏‮cannot‬‏, ‏‮such‬‏ ‏‮as‬‏ ‏‮facial‬‏ ‏‮expressions‬‏ ‏‮and‬‏ ‏‮scenes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "`<video>` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[‏‮kind‬‏=\"‏‮description‬‏\"]`."
+    "message": "`<video>` ‏‮elements‬‏ ‏‮do‬‏ ‏‮not‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "`<video>` ‏‮elements‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[‏‮kind‬‏=\"‏‮description‬‏\"]`"
+    "message": "`<video>` ‏‮elements‬‏ ‏‮contain‬‏ ‏‮a‬‏ `<track>` ‏‮element‬‏ ‏‮with‬‏ `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "‏‮For‬‏ ‏‮ideal‬‏ ‏‮appearance‬‏ ‏‮on‬‏ ‏‮iOS‬‏ ‏‮when‬‏ ‏‮users‬‏ ‏‮add‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮home‬‏ ‏‮screen‬‏, ‏‮define‬‏ ‏‮an‬‏ ‏‮apple‬‏-‏‮touch‬‏-‏‮icon‬‏. ‏‮It‬‏ ‏‮must‬‏ ‏‮point‬‏ ‏‮to‬‏ ‏‮a‬‏ ‏‮non‬‏-‏‮transparent‬‏ 192‏‮px‬‏ (‏‮or‬‏ 180‏‮px‬‏) ‏‮square‬‏ ‏‮PNG‬‏. [‏‮Learn‬‏ ‏‮More‬‏](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "‏‮Does‬‏ ‏‮not‬‏ ‏‮provide‬‏ ‏‮a‬‏ ‏‮valid‬‏ `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` ‏‮is‬‏ ‏‮out‬‏ ‏‮of‬‏ ‏‮date‬‏; `apple-touch-icon` ‏‮is‬‏ ‏‮preferred‬‏."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "‏‮Provides‬‏ ‏‮a‬‏ ‏‮valid‬‏ `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "‏‮Chrome‬‏ ‏‮extensions‬‏ ‏‮negatively‬‏ ‏‮affected‬‏ ‏‮this‬‏ ‏‮page‬‏'‏‮s‬‏ ‏‮load‬‏ ‏‮performance‬‏. ‏‮Try‬‏ ‏‮auditing‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮in‬‏ ‏‮incognito‬‏ ‏‮mode‬‏ ‏‮or‬‏ ‏‮from‬‏ ‏‮a‬‏ ‏‮Chrome‬‏ ‏‮profile‬‏ ‏‮without‬‏ ‏‮extensions‬‏."
@@ -330,7 +342,7 @@
     "message": "‏‮Total‬‏ ‏‮CPU‬‏ ‏‮Time‬‏"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "‏‮Consider‬‏ ‏‮reducing‬‏ ‏‮the‬‏ ‏‮time‬‏ ‏‮spent‬‏ ‏‮parsing‬‏, ‏‮compiling‬‏, ‏‮and‬‏ ‏‮executing‬‏ ‏‮JS‬‏. ‏‮You‬‏ ‏‮may‬‏ ‏‮find‬‏ ‏‮delivering‬‏ ‏‮smaller‬‏ ‏‮JS‬‏ ‏‮payloads‬‏ ‏‮helps‬‏ ‏‮with‬‏ ‏‮this‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮bootup‬‏)."
+    "message": "‏‮Consider‬‏ ‏‮reducing‬‏ ‏‮the‬‏ ‏‮time‬‏ ‏‮spent‬‏ ‏‮parsing‬‏, ‏‮compiling‬‏, ‏‮and‬‏ ‏‮executing‬‏ ‏‮JS‬‏. ‏‮You‬‏ ‏‮may‬‏ ‏‮find‬‏ ‏‮delivering‬‏ ‏‮smaller‬‏ ‏‮JS‬‏ ‏‮payloads‬‏ ‏‮helps‬‏ ‏‮with‬‏ ‏‮this‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "‏‮Reduce‬‏ ‏‮JavaScript‬‏ ‏‮execution‬‏ ‏‮time‬‏"
@@ -339,28 +351,28 @@
     "message": "‏‮JavaScript‬‏ ‏‮execution‬‏ ‏‮time‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "‏‮Large‬‏ ‏‮GIFs‬‏ ‏‮are‬‏ ‏‮inefficient‬‏ ‏‮for‬‏ ‏‮delivering‬‏ ‏‮animated‬‏ ‏‮content‬‏. ‏‮Consider‬‏ ‏‮using‬‏ ‏‮MPEG‬‏4/‏‮WebM‬‏ ‏‮videos‬‏ ‏‮for‬‏ ‏‮animations‬‏ ‏‮and‬‏ ‏‮PNG‬‏/‏‮WebP‬‏ ‏‮for‬‏ ‏‮static‬‏ ‏‮images‬‏ ‏‮instead‬‏ ‏‮of‬‏ ‏‮GIF‬‏ ‏‮to‬‏ ‏‮save‬‏ ‏‮network‬‏ ‏‮bytes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮fundamentals‬‏/‏‮performance‬‏/‏‮optimizing‬‏-‏‮content‬‏-‏‮efficiency‬‏/‏‮replace‬‏-‏‮animated‬‏-‏‮gifs‬‏-‏‮with‬‏-‏‮video‬‏/)"
+    "message": "‏‮Large‬‏ ‏‮GIFs‬‏ ‏‮are‬‏ ‏‮inefficient‬‏ ‏‮for‬‏ ‏‮delivering‬‏ ‏‮animated‬‏ ‏‮content‬‏. ‏‮Consider‬‏ ‏‮using‬‏ ‏‮MPEG‬‏4/‏‮WebM‬‏ ‏‮videos‬‏ ‏‮for‬‏ ‏‮animations‬‏ ‏‮and‬‏ ‏‮PNG‬‏/‏‮WebP‬‏ ‏‮for‬‏ ‏‮static‬‏ ‏‮images‬‏ ‏‮instead‬‏ ‏‮of‬‏ ‏‮GIF‬‏ ‏‮to‬‏ ‏‮save‬‏ ‏‮network‬‏ ‏‮bytes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "‏‮Use‬‏ ‏‮video‬‏ ‏‮formats‬‏ ‏‮for‬‏ ‏‮animated‬‏ ‏‮content‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "‏‮Consider‬‏ ‏‮lazy‬‏-‏‮loading‬‏ ‏‮offscreen‬‏ ‏‮and‬‏ ‏‮hidden‬‏ ‏‮images‬‏ ‏‮after‬‏ ‏‮all‬‏ ‏‮critical‬‏ ‏‮resources‬‏ ‏‮have‬‏ ‏‮finished‬‏ ‏‮loading‬‏ ‏‮to‬‏ ‏‮lower‬‏ ‏‮time‬‏ ‏‮to‬‏ ‏‮interactive‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮offscreen‬‏-‏‮images‬‏)."
+    "message": "‏‮Consider‬‏ ‏‮lazy‬‏-‏‮loading‬‏ ‏‮offscreen‬‏ ‏‮and‬‏ ‏‮hidden‬‏ ‏‮images‬‏ ‏‮after‬‏ ‏‮all‬‏ ‏‮critical‬‏ ‏‮resources‬‏ ‏‮have‬‏ ‏‮finished‬‏ ‏‮loading‬‏ ‏‮to‬‏ ‏‮lower‬‏ ‏‮time‬‏ ‏‮to‬‏ ‏‮interactive‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "‏‮Defer‬‏ ‏‮offscreen‬‏ ‏‮images‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "‏‮Resources‬‏ ‏‮are‬‏ ‏‮blocking‬‏ ‏‮the‬‏ ‏‮first‬‏ ‏‮paint‬‏ ‏‮of‬‏ ‏‮your‬‏ ‏‮page‬‏. ‏‮Consider‬‏ ‏‮delivering‬‏ ‏‮critical‬‏ ‏‮JS‬‏/‏‮CSS‬‏ ‏‮inline‬‏ ‏‮and‬‏ ‏‮deferring‬‏ ‏‮all‬‏ ‏‮non‬‏-‏‮critical‬‏ ‏‮JS‬‏/‏‮styles‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮blocking‬‏-‏‮resources‬‏)."
+    "message": "‏‮Resources‬‏ ‏‮are‬‏ ‏‮blocking‬‏ ‏‮the‬‏ ‏‮first‬‏ ‏‮paint‬‏ ‏‮of‬‏ ‏‮your‬‏ ‏‮page‬‏. ‏‮Consider‬‏ ‏‮delivering‬‏ ‏‮critical‬‏ ‏‮JS‬‏/‏‮CSS‬‏ ‏‮inline‬‏ ‏‮and‬‏ ‏‮deferring‬‏ ‏‮all‬‏ ‏‮non‬‏-‏‮critical‬‏ ‏‮JS‬‏/‏‮styles‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "‏‮Eliminate‬‏ ‏‮render‬‏-‏‮blocking‬‏ ‏‮resources‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "‏‮Large‬‏ ‏‮network‬‏ ‏‮payloads‬‏ ‏‮cost‬‏ ‏‮users‬‏ ‏‮real‬‏ ‏‮money‬‏ ‏‮and‬‏ ‏‮are‬‏ ‏‮highly‬‏ ‏‮correlated‬‏ ‏‮with‬‏ ‏‮long‬‏ ‏‮load‬‏ ‏‮times‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮network‬‏-‏‮payloads‬‏)."
+    "message": "‏‮Large‬‏ ‏‮network‬‏ ‏‮payloads‬‏ ‏‮cost‬‏ ‏‮users‬‏ ‏‮real‬‏ ‏‮money‬‏ ‏‮and‬‏ ‏‮are‬‏ ‏‮highly‬‏ ‏‮correlated‬‏ ‏‮with‬‏ ‏‮long‬‏ ‏‮load‬‏ ‏‮times‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "‏‮Total‬‏ ‏‮size‬‏ ‏‮was‬‏ {‏‮totalBytes‬‏} ‏‮KB‬‏"
+    "message": "‏‮Total‬‏ ‏‮size‬‏ ‏‮was‬‏ {totalBytes, number, bytes} ‏‮KB‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "‏‮Avoid‬‏ ‏‮enormous‬‏ ‏‮network‬‏ ‏‮payloads‬‏"
@@ -369,19 +381,19 @@
     "message": "‏‮Avoids‬‏ ‏‮enormous‬‏ ‏‮network‬‏ ‏‮payloads‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "‏‮Minifying‬‏ ‏‮CSS‬‏ ‏‮files‬‏ ‏‮can‬‏ ‏‮reduce‬‏ ‏‮network‬‏ ‏‮payload‬‏ ‏‮sizes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮minify‬‏-‏‮css‬‏)."
+    "message": "‏‮Minifying‬‏ ‏‮CSS‬‏ ‏‮files‬‏ ‏‮can‬‏ ‏‮reduce‬‏ ‏‮network‬‏ ‏‮payload‬‏ ‏‮sizes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "‏‮Minify‬‏ ‏‮CSS‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "‏‮Minifying‬‏ ‏‮JavaScript‬‏ ‏‮files‬‏ ‏‮can‬‏ ‏‮reduce‬‏ ‏‮payload‬‏ ‏‮sizes‬‏ ‏‮and‬‏ ‏‮script‬‏ ‏‮parse‬‏ ‏‮time‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮speed‬‏/‏‮docs‬‏/‏‮insights‬‏/‏‮MinifyResources‬‏)."
+    "message": "‏‮Minifying‬‏ ‏‮JavaScript‬‏ ‏‮files‬‏ ‏‮can‬‏ ‏‮reduce‬‏ ‏‮payload‬‏ ‏‮sizes‬‏ ‏‮and‬‏ ‏‮script‬‏ ‏‮parse‬‏ ‏‮time‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "‏‮Minify‬‏ ‏‮JavaScript‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "‏‮Remove‬‏ ‏‮dead‬‏ ‏‮rules‬‏ ‏‮from‬‏ ‏‮stylesheets‬‏ ‏‮and‬‏ ‏‮defer‬‏ ‏‮the‬‏ ‏‮loading‬‏ ‏‮of‬‏ ‏‮CSS‬‏ ‏‮not‬‏ ‏‮used‬‏ ‏‮for‬‏ ‏‮above‬‏-‏‮the‬‏-‏‮fold‬‏ ‏‮content‬‏ ‏‮to‬‏ ‏‮reduce‬‏ ‏‮unnecessary‬‏ ‏‮bytes‬‏ ‏‮consumed‬‏ ‏‮by‬‏ ‏‮network‬‏ ‏‮activity‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮unused‬‏-‏‮css‬‏)."
+    "message": "‏‮Remove‬‏ ‏‮dead‬‏ ‏‮rules‬‏ ‏‮from‬‏ ‏‮stylesheets‬‏ ‏‮and‬‏ ‏‮defer‬‏ ‏‮the‬‏ ‏‮loading‬‏ ‏‮of‬‏ ‏‮CSS‬‏ ‏‮not‬‏ ‏‮used‬‏ ‏‮for‬‏ ‏‮above‬‏-‏‮the‬‏-‏‮fold‬‏ ‏‮content‬‏ ‏‮to‬‏ ‏‮reduce‬‏ ‏‮unnecessary‬‏ ‏‮bytes‬‏ ‏‮consumed‬‏ ‏‮by‬‏ ‏‮network‬‏ ‏‮activity‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "‏‮Remove‬‏ ‏‮unused‬‏ ‏‮CSS‬‏"
@@ -393,7 +405,7 @@
     "message": "‏‮Remove‬‏ ‏‮unused‬‏ ‏‮JavaScript‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "‏‮A‬‏ ‏‮long‬‏ ‏‮cache‬‏ ‏‮lifetime‬‏ ‏‮can‬‏ ‏‮speed‬‏ ‏‮up‬‏ ‏‮repeat‬‏ ‏‮visits‬‏ ‏‮to‬‏ ‏‮your‬‏ ‏‮page‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮cache‬‏-‏‮policy‬‏)."
+    "message": "‏‮A‬‏ ‏‮long‬‏ ‏‮cache‬‏ ‏‮lifetime‬‏ ‏‮can‬‏ ‏‮speed‬‏ ‏‮up‬‏ ‏‮repeat‬‏ ‏‮visits‬‏ ‏‮to‬‏ ‏‮your‬‏ ‏‮page‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 ‏‮resource‬‏ ‏‮found‬‏}zero{# ‏‮resources‬‏ ‏‮found‬‏}two{# ‏‮resources‬‏ ‏‮found‬‏}few{# ‏‮resources‬‏ ‏‮found‬‏}many{# ‏‮resources‬‏ ‏‮found‬‏}other{# ‏‮resources‬‏ ‏‮found‬‏}}"
@@ -405,37 +417,88 @@
     "message": "‏‮Uses‬‏ ‏‮efficient‬‏ ‏‮cache‬‏ ‏‮policy‬‏ ‏‮on‬‏ ‏‮static‬‏ ‏‮assets‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "‏‮Optimized‬‏ ‏‮images‬‏ ‏‮load‬‏ ‏‮faster‬‏ ‏‮and‬‏ ‏‮consume‬‏ ‏‮less‬‏ ‏‮cellular‬‏ ‏‮data‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮optimize‬‏-‏‮images‬‏)."
+    "message": "‏‮Optimized‬‏ ‏‮images‬‏ ‏‮load‬‏ ‏‮faster‬‏ ‏‮and‬‏ ‏‮consume‬‏ ‏‮less‬‏ ‏‮cellular‬‏ ‏‮data‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "‏‮Efficiently‬‏ ‏‮encode‬‏ ‏‮images‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "‏‮Serve‬‏ ‏‮images‬‏ ‏‮that‬‏ ‏‮are‬‏ ‏‮appropriately‬‏-‏‮sized‬‏ ‏‮to‬‏ ‏‮save‬‏ ‏‮cellular‬‏ ‏‮data‬‏ ‏‮and‬‏ ‏‮improve‬‏ ‏‮load‬‏ ‏‮time‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮oversized‬‏-‏‮images‬‏)."
+    "message": "‏‮Serve‬‏ ‏‮images‬‏ ‏‮that‬‏ ‏‮are‬‏ ‏‮appropriately‬‏-‏‮sized‬‏ ‏‮to‬‏ ‏‮save‬‏ ‏‮cellular‬‏ ‏‮data‬‏ ‏‮and‬‏ ‏‮improve‬‏ ‏‮load‬‏ ‏‮time‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "‏‮Properly‬‏ ‏‮size‬‏ ‏‮images‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "‏‮Text‬‏-‏‮based‬‏ ‏‮resources‬‏ ‏‮should‬‏ ‏‮be‬‏ ‏‮served‬‏ ‏‮with‬‏ ‏‮compression‬‏ (‏‮gzip‬‏, ‏‮deflate‬‏ ‏‮or‬‏ ‏‮brotli‬‏) ‏‮to‬‏ ‏‮minimize‬‏ ‏‮total‬‏ ‏‮network‬‏ ‏‮bytes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮text‬‏-‏‮compression‬‏)."
+    "message": "‏‮Text‬‏-‏‮based‬‏ ‏‮resources‬‏ ‏‮should‬‏ ‏‮be‬‏ ‏‮served‬‏ ‏‮with‬‏ ‏‮compression‬‏ (‏‮gzip‬‏, ‏‮deflate‬‏ ‏‮or‬‏ ‏‮brotli‬‏) ‏‮to‬‏ ‏‮minimize‬‏ ‏‮total‬‏ ‏‮network‬‏ ‏‮bytes‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "‏‮Enable‬‏ ‏‮text‬‏ ‏‮compression‬‏"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "‏‮Image‬‏ ‏‮formats‬‏ ‏‮like‬‏ ‏‮JPEG‬‏ 2000, ‏‮JPEG‬‏ ‏‮XR‬‏, ‏‮and‬‏ ‏‮WebP‬‏ ‏‮often‬‏ ‏‮provide‬‏ ‏‮better‬‏ ‏‮compression‬‏ ‏‮than‬‏ ‏‮PNG‬‏ ‏‮or‬‏ ‏‮JPEG‬‏, ‏‮which‬‏ ‏‮means‬‏ ‏‮faster‬‏ ‏‮downloads‬‏ ‏‮and‬‏ ‏‮less‬‏ ‏‮data‬‏ ‏‮consumption‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮webp‬‏)."
+    "message": "‏‮Image‬‏ ‏‮formats‬‏ ‏‮like‬‏ ‏‮JPEG‬‏ 2000, ‏‮JPEG‬‏ ‏‮XR‬‏, ‏‮and‬‏ ‏‮WebP‬‏ ‏‮often‬‏ ‏‮provide‬‏ ‏‮better‬‏ ‏‮compression‬‏ ‏‮than‬‏ ‏‮PNG‬‏ ‏‮or‬‏ ‏‮JPEG‬‏, ‏‮which‬‏ ‏‮means‬‏ ‏‮faster‬‏ ‏‮downloads‬‏ ‏‮and‬‏ ‏‮less‬‏ ‏‮data‬‏ ‏‮consumption‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "‏‮Serve‬‏ ‏‮images‬‏ ‏‮in‬‏ ‏‮next‬‏-‏‮gen‬‏ ‏‮formats‬‏"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "‏‮The‬‏ ‏‮Critical‬‏ ‏‮Request‬‏ ‏‮Chains‬‏ ‏‮below‬‏ ‏‮show‬‏ ‏‮you‬‏ ‏‮what‬‏ ‏‮resources‬‏ ‏‮are‬‏ ‏‮loaded‬‏ ‏‮with‬‏ ‏‮a‬‏ ‏‮high‬‏ ‏‮priority‬‏. ‏‮Consider‬‏ ‏‮reducing‬‏ ‏‮the‬‏ ‏‮length‬‏ ‏‮of‬‏ ‏‮chains‬‏, ‏‮reducing‬‏ ‏‮the‬‏ ‏‮download‬‏ ‏‮size‬‏ ‏‮of‬‏ ‏‮resources‬‏, ‏‮or‬‏ ‏‮deferring‬‏ ‏‮the‬‏ ‏‮download‬‏ ‏‮of‬‏ ‏‮unnecessary‬‏ ‏‮resources‬‏ ‏‮to‬‏ ‏‮improve‬‏ ‏‮page‬‏ ‏‮load‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮critical‬‏-‏‮request‬‏-‏‮chains‬‏)."
+    "message": "‏‮The‬‏ ‏‮Critical‬‏ ‏‮Request‬‏ ‏‮Chains‬‏ ‏‮below‬‏ ‏‮show‬‏ ‏‮you‬‏ ‏‮what‬‏ ‏‮resources‬‏ ‏‮are‬‏ ‏‮loaded‬‏ ‏‮with‬‏ ‏‮a‬‏ ‏‮high‬‏ ‏‮priority‬‏. ‏‮Consider‬‏ ‏‮reducing‬‏ ‏‮the‬‏ ‏‮length‬‏ ‏‮of‬‏ ‏‮chains‬‏, ‏‮reducing‬‏ ‏‮the‬‏ ‏‮download‬‏ ‏‮size‬‏ ‏‮of‬‏ ‏‮resources‬‏, ‏‮or‬‏ ‏‮deferring‬‏ ‏‮the‬‏ ‏‮download‬‏ ‏‮of‬‏ ‏‮unnecessary‬‏ ‏‮resources‬‏ ‏‮to‬‏ ‏‮improve‬‏ ‏‮page‬‏ ‏‮load‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 ‏‮chain‬‏ ‏‮found‬‏}zero{# ‏‮chains‬‏ ‏‮found‬‏}two{# ‏‮chains‬‏ ‏‮found‬‏}few{# ‏‮chains‬‏ ‏‮found‬‏}many{# ‏‮chains‬‏ ‏‮found‬‏}other{# ‏‮chains‬‏ ‏‮found‬‏}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "‏‮Minimize‬‏ ‏‮Critical‬‏ ‏‮Requests‬‏ ‏‮Depth‬‏"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "‏‮Deprecation‬‏ / ‏‮Warning‬‏"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "‏‮Line‬‏"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "‏‮Deprecated‬‏ ‏‮APIs‬‏ ‏‮will‬‏ ‏‮eventually‬‏ ‏‮be‬‏ ‏‮removed‬‏ ‏‮from‬‏ ‏‮the‬‏ ‏‮browser‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 ‏‮warning‬‏ ‏‮found‬‏}zero{# ‏‮warnings‬‏ ‏‮found‬‏}two{# ‏‮warnings‬‏ ‏‮found‬‏}few{# ‏‮warnings‬‏ ‏‮found‬‏}many{# ‏‮warnings‬‏ ‏‮found‬‏}other{# ‏‮warnings‬‏ ‏‮found‬‏}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "‏‮Uses‬‏ ‏‮deprecated‬‏ ‏‮APIs‬‏"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "‏‮Avoids‬‏ ‏‮deprecated‬‏ ‏‮APIs‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "‏‮Application‬‏ ‏‮Cache‬‏ ‏‮is‬‏ ‏‮deprecated‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "‏‮Found‬‏ \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "‏‮Uses‬‏ ‏‮Application‬‏ ‏‮Cache‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "‏‮Avoids‬‏ ‏‮Application‬‏ ‏‮Cache‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "‏‮Specifying‬‏ ‏‮a‬‏ ‏‮doctype‬‏ ‏‮prevents‬‏ ‏‮the‬‏ ‏‮browser‬‏ ‏‮from‬‏ ‏‮switching‬‏ ‏‮to‬‏ ‏‮quirks‬‏-‏‮mode‬‏. ‏‮Read‬‏ ‏‮more‬‏ ‏‮on‬‏ ‏‮the‬‏ [‏‮MDN‬‏ ‏‮Web‬‏ ‏‮Docs‬‏ ‏‮page‬‏](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "‏‮Doctype‬‏ ‏‮name‬‏ ‏‮must‬‏ ‏‮be‬‏ ‏‮the‬‏ ‏‮lowercase‬‏ ‏‮string‬‏ `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "‏‮Document‬‏ ‏‮must‬‏ ‏‮contain‬‏ ‏‮a‬‏ ‏‮doctype‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "‏‮Expected‬‏ ‏‮publicId‬‏ ‏‮to‬‏ ‏‮be‬‏ ‏‮an‬‏ ‏‮empty‬‏ ‏‮string‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "‏‮Expected‬‏ ‏‮systemId‬‏ ‏‮to‬‏ ‏‮be‬‏ ‏‮an‬‏ ‏‮empty‬‏ ‏‮string‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "‏‮Page‬‏ ‏‮lacks‬‏ ‏‮the‬‏ ‏‮HTML‬‏ ‏‮doctype‬‏, ‏‮thus‬‏ ‏‮triggering‬‏ ‏‮quirks‬‏-‏‮mode‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "‏‮Page‬‏ ‏‮has‬‏ ‏‮the‬‏ ‏‮HTML‬‏ ‏‮doctype‬‏"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "‏‮Element‬‏"
@@ -447,7 +510,7 @@
     "message": "‏‮Value‬‏"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "‏‮Browser‬‏ ‏‮engineers‬‏ ‏‮recommend‬‏ ‏‮pages‬‏ ‏‮contain‬‏ ‏‮fewer‬‏ ‏‮than‬‏ ~1,500 ‏‮DOM‬‏ ‏‮elements‬‏. ‏‮The‬‏ ‏‮sweet‬‏ ‏‮spot‬‏ ‏‮is‬‏ ‏‮a‬‏ ‏‮tree‬‏ ‏‮depth‬‏ < 32 ‏‮elements‬‏ ‏‮and‬‏ ‏‮fewer‬‏ ‏‮than‬‏ 60 ‏‮children‬‏/‏‮parent‬‏ ‏‮element‬‏. ‏‮A‬‏ ‏‮large‬‏ ‏‮DOM‬‏ ‏‮can‬‏ ‏‮increase‬‏ ‏‮memory‬‏ ‏‮usage‬‏, ‏‮cause‬‏ ‏‮longer‬‏ [‏‮style‬‏ ‏‮calculations‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮fundamentals‬‏/‏‮performance‬‏/‏‮rendering‬‏/‏‮reduce‬‏-‏‮the‬‏-‏‮scope‬‏-‏‮and‬‏-‏‮complexity‬‏-‏‮of‬‏-‏‮style‬‏-‏‮calculations‬‏), ‏‮and‬‏ ‏‮produce‬‏ ‏‮costly‬‏ [‏‮layout‬‏ ‏‮reflows‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮speed‬‏/‏‮articles‬‏/‏‮reflow‬‏). [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮dom‬‏-‏‮size‬‏)."
+    "message": "‏‮Browser‬‏ ‏‮engineers‬‏ ‏‮recommend‬‏ ‏‮pages‬‏ ‏‮contain‬‏ ‏‮fewer‬‏ ‏‮than‬‏ ~1,500 ‏‮DOM‬‏ ‏‮elements‬‏. ‏‮The‬‏ ‏‮sweet‬‏ ‏‮spot‬‏ ‏‮is‬‏ ‏‮a‬‏ ‏‮tree‬‏ ‏‮depth‬‏ < 32 ‏‮elements‬‏ ‏‮and‬‏ ‏‮fewer‬‏ ‏‮than‬‏ 60 ‏‮children‬‏/‏‮parent‬‏ ‏‮element‬‏. ‏‮A‬‏ ‏‮large‬‏ ‏‮DOM‬‏ ‏‮can‬‏ ‏‮increase‬‏ ‏‮memory‬‏ ‏‮usage‬‏, ‏‮cause‬‏ ‏‮longer‬‏ [‏‮style‬‏ ‏‮calculations‬‏](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), ‏‮and‬‏ ‏‮produce‬‏ ‏‮costly‬‏ [‏‮layout‬‏ ‏‮reflows‬‏](https://developers.google.com/speed/articles/reflow). [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 ‏‮element‬‏}zero{# ‏‮elements‬‏}two{# ‏‮elements‬‏}few{# ‏‮elements‬‏}many{# ‏‮elements‬‏}other{# ‏‮elements‬‏}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "‏‮Avoids‬‏ ‏‮an‬‏ ‏‮excessive‬‏ ‏‮DOM‬‏ ‏‮size‬‏"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "‏‮Rel‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "‏‮Target‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "‏‮Add‬‏ `rel=\"noopener\"` ‏‮or‬‏ `rel=\"noreferrer\"` ‏‮to‬‏ ‏‮any‬‏ ‏‮external‬‏ ‏‮links‬‏ ‏‮to‬‏ ‏‮improve‬‏ ‏‮performance‬‏ ‏‮and‬‏ ‏‮prevent‬‏ ‏‮security‬‏ ‏‮vulnerabilities‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "‏‮Links‬‏ ‏‮to‬‏ ‏‮cross‬‏-‏‮origin‬‏ ‏‮destinations‬‏ ‏‮are‬‏ ‏‮unsafe‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "‏‮Links‬‏ ‏‮to‬‏ ‏‮cross‬‏-‏‮origin‬‏ ‏‮destinations‬‏ ‏‮are‬‏ ‏‮safe‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "‏‮Unable‬‏ ‏‮to‬‏ ‏‮determine‬‏ ‏‮the‬‏ ‏‮destination‬‏ ‏‮for‬‏ ‏‮anchor‬‏ ({anchorHTML}). ‏‮If‬‏ ‏‮not‬‏ ‏‮used‬‏ ‏‮as‬‏ ‏‮a‬‏ ‏‮hyperlink‬‏, ‏‮consider‬‏ ‏‮removing‬‏ ‏‮target‬‏=_‏‮blank‬‏."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "‏‮Users‬‏ ‏‮are‬‏ ‏‮mistrustful‬‏ ‏‮of‬‏ ‏‮or‬‏ ‏‮confused‬‏ ‏‮by‬‏ ‏‮sites‬‏ ‏‮that‬‏ ‏‮request‬‏ ‏‮their‬‏ ‏‮location‬‏ ‏‮without‬‏ ‏‮context‬‏. ‏‮Consider‬‏ ‏‮tying‬‏ ‏‮the‬‏ ‏‮request‬‏ ‏‮to‬‏ ‏‮a‬‏ ‏‮user‬‏ ‏‮action‬‏ ‏‮instead‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "‏‮Requests‬‏ ‏‮the‬‏ ‏‮geolocation‬‏ ‏‮permission‬‏ ‏‮on‬‏ ‏‮page‬‏ ‏‮load‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "‏‮Avoids‬‏ ‏‮requesting‬‏ ‏‮the‬‏ ‏‮geolocation‬‏ ‏‮permission‬‏ ‏‮on‬‏ ‏‮page‬‏ ‏‮load‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "‏‮Version‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "‏‮All‬‏ ‏‮front‬‏-‏‮end‬‏ ‏‮JavaScript‬‏ ‏‮libraries‬‏ ‏‮detected‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "‏‮Detected‬‏ ‏‮JavaScript‬‏ ‏‮libraries‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "‏‮For‬‏ ‏‮users‬‏ ‏‮on‬‏ ‏‮slow‬‏ ‏‮connections‬‏, ‏‮external‬‏ ‏‮scripts‬‏ ‏‮dynamically‬‏ ‏‮injected‬‏ ‏‮via‬‏ `document.write()` ‏‮can‬‏ ‏‮delay‬‏ ‏‮page‬‏ ‏‮load‬‏ ‏‮by‬‏ ‏‮tens‬‏ ‏‮of‬‏ ‏‮seconds‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "‏‮Uses‬‏ `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "‏‮Avoids‬‏ `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "‏‮Highest‬‏ ‏‮Severity‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "‏‮Library‬‏ ‏‮Version‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "‏‮Vulnerability‬‏ ‏‮Count‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "‏‮Some‬‏ ‏‮third‬‏-‏‮party‬‏ ‏‮scripts‬‏ ‏‮may‬‏ ‏‮contain‬‏ ‏‮known‬‏ ‏‮security‬‏ ‏‮vulnerabilities‬‏ ‏‮that‬‏ ‏‮are‬‏ ‏‮easily‬‏ ‏‮identified‬‏ ‏‮and‬‏ ‏‮exploited‬‏ ‏‮by‬‏ ‏‮attackers‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 ‏‮vulnerability‬‏ ‏‮detected‬‏}zero{# ‏‮vulnerabilities‬‏ ‏‮detected‬‏}two{# ‏‮vulnerabilities‬‏ ‏‮detected‬‏}few{# ‏‮vulnerabilities‬‏ ‏‮detected‬‏}many{# ‏‮vulnerabilities‬‏ ‏‮detected‬‏}other{# ‏‮vulnerabilities‬‏ ‏‮detected‬‏}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "‏‮Includes‬‏ ‏‮front‬‏-‏‮end‬‏ ‏‮JavaScript‬‏ ‏‮libraries‬‏ ‏‮with‬‏ ‏‮known‬‏ ‏‮security‬‏ ‏‮vulnerabilities‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "‏‮High‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "‏‮Low‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "‏‮Medium‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "‏‮Avoids‬‏ ‏‮front‬‏-‏‮end‬‏ ‏‮JavaScript‬‏ ‏‮libraries‬‏ ‏‮with‬‏ ‏‮known‬‏ ‏‮security‬‏ ‏‮vulnerabilities‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "‏‮Users‬‏ ‏‮are‬‏ ‏‮mistrustful‬‏ ‏‮of‬‏ ‏‮or‬‏ ‏‮confused‬‏ ‏‮by‬‏ ‏‮sites‬‏ ‏‮that‬‏ ‏‮request‬‏ ‏‮to‬‏ ‏‮send‬‏ ‏‮notifications‬‏ ‏‮without‬‏ ‏‮context‬‏. ‏‮Consider‬‏ ‏‮tying‬‏ ‏‮the‬‏ ‏‮request‬‏ ‏‮to‬‏ ‏‮user‬‏ ‏‮gestures‬‏ ‏‮instead‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "‏‮Requests‬‏ ‏‮the‬‏ ‏‮notification‬‏ ‏‮permission‬‏ ‏‮on‬‏ ‏‮page‬‏ ‏‮load‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "‏‮Avoids‬‏ ‏‮requesting‬‏ ‏‮the‬‏ ‏‮notification‬‏ ‏‮permission‬‏ ‏‮on‬‏ ‏‮page‬‏ ‏‮load‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "‏‮Failing‬‏ ‏‮Elements‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "‏‮Preventing‬‏ ‏‮password‬‏ ‏‮pasting‬‏ ‏‮undermines‬‏ ‏‮good‬‏ ‏‮security‬‏ ‏‮policy‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "‏‮Prevents‬‏ ‏‮users‬‏ ‏‮to‬‏ ‏‮paste‬‏ ‏‮into‬‏ ‏‮password‬‏ ‏‮fields‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "‏‮Allows‬‏ ‏‮users‬‏ ‏‮to‬‏ ‏‮paste‬‏ ‏‮into‬‏ ‏‮password‬‏ ‏‮fields‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "‏‮Protocol‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "‏‮HTTP‬‏/2 ‏‮offers‬‏ ‏‮many‬‏ ‏‮benefits‬‏ ‏‮over‬‏ ‏‮HTTP‬‏/1.1, ‏‮including‬‏ ‏‮binary‬‏ ‏‮headers‬‏, ‏‮multiplexing‬‏, ‏‮and‬‏ ‏‮server‬‏ ‏‮push‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 ‏‮request‬‏ ‏‮not‬‏ ‏‮served‬‏ ‏‮via‬‏ ‏‮HTTP‬‏/2}zero{# ‏‮requests‬‏ ‏‮not‬‏ ‏‮served‬‏ ‏‮via‬‏ ‏‮HTTP‬‏/2}two{# ‏‮requests‬‏ ‏‮not‬‏ ‏‮served‬‏ ‏‮via‬‏ ‏‮HTTP‬‏/2}few{# ‏‮requests‬‏ ‏‮not‬‏ ‏‮served‬‏ ‏‮via‬‏ ‏‮HTTP‬‏/2}many{# ‏‮requests‬‏ ‏‮not‬‏ ‏‮served‬‏ ‏‮via‬‏ ‏‮HTTP‬‏/2}other{# ‏‮requests‬‏ ‏‮not‬‏ ‏‮served‬‏ ‏‮via‬‏ ‏‮HTTP‬‏/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "‏‮Does‬‏ ‏‮not‬‏ ‏‮use‬‏ ‏‮HTTP‬‏/2 ‏‮for‬‏ ‏‮all‬‏ ‏‮of‬‏ ‏‮its‬‏ ‏‮resources‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "‏‮Uses‬‏ ‏‮HTTP‬‏/2 ‏‮for‬‏ ‏‮its‬‏ ‏‮own‬‏ ‏‮resources‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "‏‮Consider‬‏ ‏‮marking‬‏ ‏‮your‬‏ ‏‮touch‬‏ ‏‮and‬‏ ‏‮wheel‬‏ ‏‮event‬‏ ‏‮listeners‬‏ ‏‮as‬‏ `passive` ‏‮to‬‏ ‏‮improve‬‏ ‏‮your‬‏ ‏‮page‬‏'‏‮s‬‏ ‏‮scroll‬‏ ‏‮performance‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "‏‮Does‬‏ ‏‮not‬‏ ‏‮use‬‏ ‏‮passive‬‏ ‏‮listeners‬‏ ‏‮to‬‏ ‏‮improve‬‏ ‏‮scrolling‬‏ ‏‮performance‬‏"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "‏‮Uses‬‏ ‏‮passive‬‏ ‏‮listeners‬‏ ‏‮to‬‏ ‏‮improve‬‏ ‏‮scrolling‬‏ ‏‮performance‬‏"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "‏‮Description‬‏"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "‏‮Errors‬‏ ‏‮logged‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮console‬‏ ‏‮indicate‬‏ ‏‮unresolved‬‏ ‏‮problems‬‏. ‏‮They‬‏ ‏‮can‬‏ ‏‮come‬‏ ‏‮from‬‏ ‏‮network‬‏ ‏‮request‬‏ ‏‮failures‬‏ ‏‮and‬‏ ‏‮other‬‏ ‏‮browser‬‏ ‏‮concerns‬‏."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "‏‮Browser‬‏ ‏‮errors‬‏ ‏‮were‬‏ ‏‮logged‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮console‬‏"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "‏‮No‬‏ ‏‮browser‬‏ ‏‮errors‬‏ ‏‮logged‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮console‬‏"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "‏‮Leverage‬‏ ‏‮the‬‏ ‏‮font‬‏-‏‮display‬‏ ‏‮CSS‬‏ ‏‮feature‬‏ ‏‮to‬‏ ‏‮ensure‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮user‬‏-‏‮visible‬‏ ‏‮while‬‏ ‏‮webfonts‬‏ ‏‮are‬‏ ‏‮loading‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮updates‬‏/2016/02/‏‮font‬‏-‏‮display‬‏)."
+    "message": "‏‮Leverage‬‏ ‏‮the‬‏ ‏‮font‬‏-‏‮display‬‏ ‏‮CSS‬‏ ‏‮feature‬‏ ‏‮to‬‏ ‏‮ensure‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮user‬‏-‏‮visible‬‏ ‏‮while‬‏ ‏‮webfonts‬‏ ‏‮are‬‏ ‏‮loading‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "‏‮Ensure‬‏ ‏‮text‬‏ ‏‮remains‬‏ ‏‮visible‬‏ ‏‮during‬‏ ‏‮webfont‬‏ ‏‮load‬‏"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "‏‮All‬‏ ‏‮text‬‏ ‏‮remains‬‏ ‏‮visible‬‏ ‏‮during‬‏ ‏‮webfont‬‏ ‏‮loads‬‏"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "‏‮Lighthouse‬‏ ‏‮was‬‏ ‏‮unable‬‏ ‏‮to‬‏ ‏‮automatically‬‏ ‏‮check‬‏ ‏‮the‬‏ ‏‮font‬‏-‏‮display‬‏ ‏‮value‬‏ ‏‮for‬‏ ‏‮the‬‏ ‏‮following‬‏ ‏‮URL‬‏: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "‏‮Aspect‬‏ ‏‮Ratio‬‏ (‏‮Actual‬‏)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "‏‮Aspect‬‏ ‏‮Ratio‬‏ (‏‮Displayed‬‏)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "‏‮Image‬‏ ‏‮display‬‏ ‏‮dimensions‬‏ ‏‮should‬‏ ‏‮match‬‏ ‏‮natural‬‏ ‏‮aspect‬‏ ‏‮ratio‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "‏‮Displays‬‏ ‏‮images‬‏ ‏‮with‬‏ ‏‮incorrect‬‏ ‏‮aspect‬‏ ‏‮ratio‬‏"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "‏‮Displays‬‏ ‏‮images‬‏ ‏‮with‬‏ ‏‮correct‬‏ ‏‮aspect‬‏ ‏‮ratio‬‏"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "‏‮Invalid‬‏ ‏‮image‬‏ ‏‮sizing‬‏ ‏‮information‬‏ {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "‏‮Insecure‬‏ ‏‮URL‬‏"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "‏‮All‬‏ ‏‮sites‬‏ ‏‮should‬‏ ‏‮be‬‏ ‏‮protected‬‏ ‏‮with‬‏ ‏‮HTTPS‬‏, ‏‮even‬‏ ‏‮ones‬‏ ‏‮that‬‏ ‏‮don‬‏'‏‮t‬‏ ‏‮handle‬‏ ‏‮sensitive‬‏ ‏‮data‬‏. ‏‮HTTPS‬‏ ‏‮prevents‬‏ ‏‮intruders‬‏ ‏‮from‬‏ ‏‮tampering‬‏ ‏‮with‬‏ ‏‮or‬‏ ‏‮passively‬‏ ‏‮listening‬‏ ‏‮in‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮communications‬‏ ‏‮between‬‏ ‏‮your‬‏ ‏‮app‬‏ ‏‮and‬‏ ‏‮your‬‏ ‏‮users‬‏, ‏‮and‬‏ ‏‮is‬‏ ‏‮a‬‏ ‏‮prerequisite‬‏ ‏‮for‬‏ ‏‮HTTP‬‏/2 ‏‮and‬‏ ‏‮many‬‏ ‏‮new‬‏ ‏‮web‬‏ ‏‮platform‬‏ ‏‮APIs‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 ‏‮insecure‬‏ ‏‮request‬‏ ‏‮found‬‏}zero{# ‏‮insecure‬‏ ‏‮requests‬‏ ‏‮found‬‏}two{# ‏‮insecure‬‏ ‏‮requests‬‏ ‏‮found‬‏}few{# ‏‮insecure‬‏ ‏‮requests‬‏ ‏‮found‬‏}many{# ‏‮insecure‬‏ ‏‮requests‬‏ ‏‮found‬‏}other{# ‏‮insecure‬‏ ‏‮requests‬‏ ‏‮found‬‏}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "‏‮Does‬‏ ‏‮not‬‏ ‏‮use‬‏ ‏‮HTTPS‬‏"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "‏‮Uses‬‏ ‏‮HTTPS‬‏"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "‏‮A‬‏ ‏‮fast‬‏ ‏‮page‬‏ ‏‮load‬‏ ‏‮over‬‏ ‏‮a‬‏ ‏‮cellular‬‏ ‏‮network‬‏ ‏‮ensures‬‏ ‏‮a‬‏ ‏‮good‬‏ ‏‮mobile‬‏ ‏‮user‬‏ ‏‮experience‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮fast‬‏-3‏‮g‬‏)."
+    "message": "‏‮A‬‏ ‏‮fast‬‏ ‏‮page‬‏ ‏‮load‬‏ ‏‮over‬‏ ‏‮a‬‏ ‏‮cellular‬‏ ‏‮network‬‏ ‏‮ensures‬‏ ‏‮a‬‏ ‏‮good‬‏ ‏‮mobile‬‏ ‏‮user‬‏ ‏‮experience‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "‏‮Interactive‬‏ ‏‮at‬‏ {‏‮timeInMsSec‬‏} ‏‮s‬‏"
+    "message": "‏‮Interactive‬‏ ‏‮at‬‏ {timeInMs, number, seconds} ‏‮s‬‏"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "‏‮Interactive‬‏ ‏‮on‬‏ ‏‮simulated‬‏ ‏‮mobile‬‏ ‏‮network‬‏ ‏‮at‬‏ {‏‮timeInMsSec‬‏} ‏‮s‬‏"
+    "message": "‏‮Interactive‬‏ ‏‮on‬‏ ‏‮simulated‬‏ ‏‮mobile‬‏ ‏‮network‬‏ ‏‮at‬‏ {timeInMs, number, seconds} ‏‮s‬‏"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "‏‮Page‬‏ ‏‮load‬‏ ‏‮is‬‏ ‏‮not‬‏ ‏‮fast‬‏ ‏‮enough‬‏ ‏‮on‬‏ ‏‮mobile‬‏ ‏‮networks‬‏"
@@ -504,106 +735,130 @@
     "message": "‏‮Minimizes‬‏ ‏‮main‬‏-‏‮thread‬‏ ‏‮work‬‏"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "‏‮Estimated‬‏ ‏‮Input‬‏ ‏‮Latency‬‏ ‏‮is‬‏ ‏‮an‬‏ ‏‮estimate‬‏ ‏‮of‬‏ ‏‮how‬‏ ‏‮long‬‏ ‏‮your‬‏ ‏‮app‬‏ ‏‮takes‬‏ ‏‮to‬‏ ‏‮respond‬‏ ‏‮to‬‏ ‏‮user‬‏ ‏‮input‬‏, ‏‮in‬‏ ‏‮milliseconds‬‏, ‏‮during‬‏ ‏‮the‬‏ ‏‮busiest‬‏ 5‏‮s‬‏ ‏‮window‬‏ ‏‮of‬‏ ‏‮page‬‏ ‏‮load‬‏. ‏‮If‬‏ ‏‮your‬‏ ‏‮latency‬‏ ‏‮is‬‏ ‏‮higher‬‏ ‏‮than‬‏ 50 ‏‮ms‬‏, ‏‮users‬‏ ‏‮may‬‏ ‏‮perceive‬‏ ‏‮your‬‏ ‏‮app‬‏ ‏‮as‬‏ ‏‮laggy‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮estimated‬‏-‏‮input‬‏-‏‮latency‬‏)."
+    "message": "‏‮Estimated‬‏ ‏‮Input‬‏ ‏‮Latency‬‏ ‏‮is‬‏ ‏‮an‬‏ ‏‮estimate‬‏ ‏‮of‬‏ ‏‮how‬‏ ‏‮long‬‏ ‏‮your‬‏ ‏‮app‬‏ ‏‮takes‬‏ ‏‮to‬‏ ‏‮respond‬‏ ‏‮to‬‏ ‏‮user‬‏ ‏‮input‬‏, ‏‮in‬‏ ‏‮milliseconds‬‏, ‏‮during‬‏ ‏‮the‬‏ ‏‮busiest‬‏ 5‏‮s‬‏ ‏‮window‬‏ ‏‮of‬‏ ‏‮page‬‏ ‏‮load‬‏. ‏‮If‬‏ ‏‮your‬‏ ‏‮latency‬‏ ‏‮is‬‏ ‏‮higher‬‏ ‏‮than‬‏ 50 ‏‮ms‬‏, ‏‮users‬‏ ‏‮may‬‏ ‏‮perceive‬‏ ‏‮your‬‏ ‏‮app‬‏ ‏‮as‬‏ ‏‮laggy‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "‏‮Estimated‬‏ ‏‮Input‬‏ ‏‮Latency‬‏"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "‏‮First‬‏ ‏‮Contentful‬‏ ‏‮Paint‬‏ ‏‮marks‬‏ ‏‮the‬‏ ‏‮time‬‏ ‏‮at‬‏ ‏‮which‬‏ ‏‮the‬‏ ‏‮first‬‏ ‏‮text‬‏ ‏‮or‬‏ ‏‮image‬‏ ‏‮is‬‏ ‏‮painted‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮first‬‏-‏‮contentful‬‏-‏‮paint‬‏)."
+    "message": "‏‮First‬‏ ‏‮Contentful‬‏ ‏‮Paint‬‏ ‏‮marks‬‏ ‏‮the‬‏ ‏‮time‬‏ ‏‮at‬‏ ‏‮which‬‏ ‏‮the‬‏ ‏‮first‬‏ ‏‮text‬‏ ‏‮or‬‏ ‏‮image‬‏ ‏‮is‬‏ ‏‮painted‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "‏‮First‬‏ ‏‮Contentful‬‏ ‏‮Paint‬‏"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "‏‮First‬‏ ‏‮CPU‬‏ ‏‮Idle‬‏ ‏‮marks‬‏ ‏‮the‬‏ ‏‮first‬‏ ‏‮time‬‏ ‏‮at‬‏ ‏‮which‬‏ ‏‮the‬‏ ‏‮page‬‏'‏‮s‬‏ ‏‮main‬‏ ‏‮thread‬‏ ‏‮is‬‏ ‏‮quiet‬‏ ‏‮enough‬‏ ‏‮to‬‏ ‏‮handle‬‏ ‏‮input‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮first‬‏-‏‮interactive‬‏)."
+    "message": "‏‮First‬‏ ‏‮CPU‬‏ ‏‮Idle‬‏ ‏‮marks‬‏ ‏‮the‬‏ ‏‮first‬‏ ‏‮time‬‏ ‏‮at‬‏ ‏‮which‬‏ ‏‮the‬‏ ‏‮page‬‏'‏‮s‬‏ ‏‮main‬‏ ‏‮thread‬‏ ‏‮is‬‏ ‏‮quiet‬‏ ‏‮enough‬‏ ‏‮to‬‏ ‏‮handle‬‏ ‏‮input‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "‏‮First‬‏ ‏‮CPU‬‏ ‏‮Idle‬‏"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "‏‮First‬‏ ‏‮Meaningful‬‏ ‏‮Paint‬‏ ‏‮measures‬‏ ‏‮when‬‏ ‏‮the‬‏ ‏‮primary‬‏ ‏‮content‬‏ ‏‮of‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮is‬‏ ‏‮visible‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮first‬‏-‏‮meaningful‬‏-‏‮paint‬‏)."
+    "message": "‏‮First‬‏ ‏‮Meaningful‬‏ ‏‮Paint‬‏ ‏‮measures‬‏ ‏‮when‬‏ ‏‮the‬‏ ‏‮primary‬‏ ‏‮content‬‏ ‏‮of‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮is‬‏ ‏‮visible‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "‏‮First‬‏ ‏‮Meaningful‬‏ ‏‮Paint‬‏"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "‏‮Time‬‏ ‏‮to‬‏ ‏‮interactive‬‏ ‏‮is‬‏ ‏‮the‬‏ ‏‮amount‬‏ ‏‮of‬‏ ‏‮time‬‏ ‏‮it‬‏ ‏‮takes‬‏ ‏‮for‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮to‬‏ ‏‮become‬‏ ‏‮fully‬‏ ‏‮interactive‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮consistently‬‏-‏‮interactive‬‏)."
+    "message": "‏‮Time‬‏ ‏‮to‬‏ ‏‮interactive‬‏ ‏‮is‬‏ ‏‮the‬‏ ‏‮amount‬‏ ‏‮of‬‏ ‏‮time‬‏ ‏‮it‬‏ ‏‮takes‬‏ ‏‮for‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮to‬‏ ‏‮become‬‏ ‏‮fully‬‏ ‏‮interactive‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "‏‮Time‬‏ ‏‮to‬‏ ‏‮Interactive‬‏"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "‏‮The‬‏ ‏‮potential‬‏ ‏‮First‬‏ ‏‮Input‬‏ ‏‮Delay‬‏ ‏‮that‬‏ ‏‮your‬‏ ‏‮users‬‏ ‏‮could‬‏ ‏‮experience‬‏ ‏‮is‬‏ ‏‮the‬‏ ‏‮duration‬‏, ‏‮in‬‏ ‏‮milliseconds‬‏, ‏‮of‬‏ ‏‮the‬‏ ‏‮longest‬‏ ‏‮task‬‏."
+    "message": "‏‮The‬‏ ‏‮maximum‬‏ ‏‮potential‬‏ ‏‮First‬‏ ‏‮Input‬‏ ‏‮Delay‬‏ ‏‮that‬‏ ‏‮your‬‏ ‏‮users‬‏ ‏‮could‬‏ ‏‮experience‬‏ ‏‮is‬‏ ‏‮the‬‏ ‏‮duration‬‏, ‏‮in‬‏ ‏‮milliseconds‬‏, ‏‮of‬‏ ‏‮the‬‏ ‏‮longest‬‏ ‏‮task‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "‏‮Max‬‏ ‏‮Potential‬‏ ‏‮FID‬‏"
+    "message": "‏‮Max‬‏ ‏‮Potential‬‏ ‏‮First‬‏ ‏‮Input‬‏ ‏‮Delay‬‏"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "‏‮Speed‬‏ ‏‮Index‬‏ ‏‮shows‬‏ ‏‮how‬‏ ‏‮quickly‬‏ ‏‮the‬‏ ‏‮contents‬‏ ‏‮of‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮are‬‏ ‏‮visibly‬‏ ‏‮populated‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮speed‬‏-‏‮index‬‏)."
+    "message": "‏‮Speed‬‏ ‏‮Index‬‏ ‏‮shows‬‏ ‏‮how‬‏ ‏‮quickly‬‏ ‏‮the‬‏ ‏‮contents‬‏ ‏‮of‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮are‬‏ ‏‮visibly‬‏ ‏‮populated‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "‏‮Speed‬‏ ‏‮Index‬‏"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "‏‮Sum‬‏ ‏‮of‬‏ ‏‮all‬‏ ‏‮time‬‏ ‏‮periods‬‏ ‏‮between‬‏ ‏‮FCP‬‏ ‏‮and‬‏ ‏‮Time‬‏ ‏‮to‬‏ ‏‮Interactive‬‏, ‏‮when‬‏ ‏‮task‬‏ ‏‮length‬‏ ‏‮exceeded‬‏ 50‏‮ms‬‏, ‏‮expressed‬‏ ‏‮in‬‏ ‏‮milliseconds‬‏."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "‏‮Total‬‏ ‏‮Blocking‬‏ ‏‮Time‬‏"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "‏‮Network‬‏ ‏‮round‬‏ ‏‮trip‬‏ ‏‮times‬‏ (‏‮RTT‬‏) ‏‮have‬‏ ‏‮a‬‏ ‏‮large‬‏ ‏‮impact‬‏ ‏‮on‬‏ ‏‮performance‬‏. ‏‮If‬‏ ‏‮the‬‏ ‏‮RTT‬‏ ‏‮to‬‏ ‏‮an‬‏ ‏‮origin‬‏ ‏‮is‬‏ ‏‮high‬‏, ‏‮it‬‏'‏‮s‬‏ ‏‮an‬‏ ‏‮indication‬‏ ‏‮that‬‏ ‏‮servers‬‏ ‏‮closer‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮user‬‏ ‏‮could‬‏ ‏‮improve‬‏ ‏‮performance‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮hpbn‬‏.‏‮co‬‏/‏‮primer‬‏-‏‮on‬‏-‏‮latency‬‏-‏‮and‬‏-‏‮bandwidth‬‏/)."
+    "message": "‏‮Network‬‏ ‏‮round‬‏ ‏‮trip‬‏ ‏‮times‬‏ (‏‮RTT‬‏) ‏‮have‬‏ ‏‮a‬‏ ‏‮large‬‏ ‏‮impact‬‏ ‏‮on‬‏ ‏‮performance‬‏. ‏‮If‬‏ ‏‮the‬‏ ‏‮RTT‬‏ ‏‮to‬‏ ‏‮an‬‏ ‏‮origin‬‏ ‏‮is‬‏ ‏‮high‬‏, ‏‮it‬‏'‏‮s‬‏ ‏‮an‬‏ ‏‮indication‬‏ ‏‮that‬‏ ‏‮servers‬‏ ‏‮closer‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮user‬‏ ‏‮could‬‏ ‏‮improve‬‏ ‏‮performance‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "‏‮Network‬‏ ‏‮Round‬‏ ‏‮Trip‬‏ ‏‮Times‬‏"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "‏‮Server‬‏ ‏‮latencies‬‏ ‏‮can‬‏ ‏‮impact‬‏ ‏‮web‬‏ ‏‮performance‬‏. ‏‮If‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮latency‬‏ ‏‮of‬‏ ‏‮an‬‏ ‏‮origin‬‏ ‏‮is‬‏ ‏‮high‬‏, ‏‮it‬‏'‏‮s‬‏ ‏‮an‬‏ ‏‮indication‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮is‬‏ ‏‮overloaded‬‏ ‏‮or‬‏ ‏‮has‬‏ ‏‮poor‬‏ ‏‮backend‬‏ ‏‮performance‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮hpbn‬‏.‏‮co‬‏/‏‮primer‬‏-‏‮on‬‏-‏‮web‬‏-‏‮performance‬‏/#‏‮analyzing‬‏-‏‮the‬‏-‏‮resource‬‏-‏‮waterfall‬‏)."
+    "message": "‏‮Server‬‏ ‏‮latencies‬‏ ‏‮can‬‏ ‏‮impact‬‏ ‏‮web‬‏ ‏‮performance‬‏. ‏‮If‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮latency‬‏ ‏‮of‬‏ ‏‮an‬‏ ‏‮origin‬‏ ‏‮is‬‏ ‏‮high‬‏, ‏‮it‬‏'‏‮s‬‏ ‏‮an‬‏ ‏‮indication‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮is‬‏ ‏‮overloaded‬‏ ‏‮or‬‏ ‏‮has‬‏ ‏‮poor‬‏ ‏‮backend‬‏ ‏‮performance‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "‏‮Server‬‏ ‏‮Backend‬‏ ‏‮Latencies‬‏"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "‏‮Over‬‏ ‏‮Budget‬‏"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "‏‮Keep‬‏ ‏‮the‬‏ ‏‮quantity‬‏ ‏‮and‬‏ ‏‮size‬‏ ‏‮of‬‏ ‏‮network‬‏ ‏‮requests‬‏ ‏‮under‬‏ ‏‮the‬‏ ‏‮targets‬‏ ‏‮set‬‏ ‏‮by‬‏ ‏‮the‬‏ ‏‮provided‬‏ ‏‮performance‬‏ ‏‮budget‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 ‏‮request‬‏}zero{# ‏‮requests‬‏}two{# ‏‮requests‬‏}few{# ‏‮requests‬‏}many{# ‏‮requests‬‏}other{# ‏‮requests‬‏}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "‏‮Performance‬‏ ‏‮budget‬‏"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "‏‮Redirects‬‏ ‏‮introduce‬‏ ‏‮additional‬‏ ‏‮delays‬‏ ‏‮before‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮can‬‏ ‏‮be‬‏ ‏‮loaded‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮redirects‬‏)."
+    "message": "‏‮Redirects‬‏ ‏‮introduce‬‏ ‏‮additional‬‏ ‏‮delays‬‏ ‏‮before‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮can‬‏ ‏‮be‬‏ ‏‮loaded‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "‏‮Avoid‬‏ ‏‮multiple‬‏ ‏‮page‬‏ ‏‮redirects‬‏"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "‏‮To‬‏ ‏‮set‬‏ ‏‮budgets‬‏ ‏‮for‬‏ ‏‮the‬‏ ‏‮quantity‬‏ ‏‮and‬‏ ‏‮size‬‏ ‏‮of‬‏ ‏‮page‬‏ ‏‮resources‬‏, ‏‮add‬‏ ‏‮a‬‏ ‏‮budget‬‏.‏‮json‬‏ ‏‮file‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 ‏‮request‬‏}zero{# ‏‮requests‬‏}two{# ‏‮requests‬‏}few{# ‏‮requests‬‏}many{# ‏‮requests‬‏}other{# ‏‮requests‬‏}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "‏‮Keep‬‏ ‏‮request‬‏ ‏‮counts‬‏ ‏‮low‬‏ ‏‮and‬‏ ‏‮transfer‬‏ ‏‮sizes‬‏ ‏‮small‬‏"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "‏‮Canonical‬‏ ‏‮links‬‏ ‏‮suggest‬‏ ‏‮which‬‏ ‏‮URL‬‏ ‏‮to‬‏ ‏‮show‬‏ ‏‮in‬‏ ‏‮search‬‏ ‏‮results‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮canonical‬‏)."
+    "message": "‏‮Canonical‬‏ ‏‮links‬‏ ‏‮suggest‬‏ ‏‮which‬‏ ‏‮URL‬‏ ‏‮to‬‏ ‏‮show‬‏ ‏‮in‬‏ ‏‮search‬‏ ‏‮results‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "‏‮Multiple‬‏ ‏‮conflicting‬‏ ‏‮URLs‬‏ ({‏‮urlList‬‏})"
+    "message": "‏‮Multiple‬‏ ‏‮conflicting‬‏ ‏‮URLs‬‏ ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "‏‮Points‬‏ ‏‮to‬‏ ‏‮a‬‏ ‏‮different‬‏ ‏‮domain‬‏ ({‏‮url‬‏})"
+    "message": "‏‮Points‬‏ ‏‮to‬‏ ‏‮a‬‏ ‏‮different‬‏ ‏‮domain‬‏ ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "‏‮Invalid‬‏ ‏‮URL‬‏ ({‏‮url‬‏})"
+    "message": "‏‮Invalid‬‏ ‏‮URL‬‏ ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "‏‮Points‬‏ ‏‮to‬‏ ‏‮another‬‏ `‏‮hreflang‬‏` ‏‮location‬‏ ({‏‮url‬‏})"
+    "message": "‏‮Points‬‏ ‏‮to‬‏ ‏‮another‬‏ `hreflang` ‏‮location‬‏ ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "‏‮Relative‬‏ ‏‮URL‬‏ ({‏‮url‬‏})"
+    "message": "‏‮Relative‬‏ ‏‮URL‬‏ ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "‏‮Points‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮domain‬‏'‏‮s‬‏ ‏‮root‬‏ ‏‮URL‬‏ (‏‮the‬‏ ‏‮homepage‬‏), ‏‮instead‬‏ ‏‮of‬‏ ‏‮an‬‏ ‏‮equivalent‬‏ ‏‮page‬‏ ‏‮of‬‏ ‏‮content‬‏"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "‏‮Document‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ `‏‮rel‬‏=‏‮canonical‬‏`"
+    "message": "‏‮Document‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "‏‮Document‬‏ ‏‮has‬‏ ‏‮a‬‏ ‏‮valid‬‏ `‏‮rel‬‏=‏‮canonical‬‏`"
+    "message": "‏‮Document‬‏ ‏‮has‬‏ ‏‮a‬‏ ‏‮valid‬‏ `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "‏‮Font‬‏ ‏‮sizes‬‏ ‏‮less‬‏ ‏‮than‬‏ 12‏‮px‬‏ ‏‮are‬‏ ‏‮too‬‏ ‏‮small‬‏ ‏‮to‬‏ ‏‮be‬‏ ‏‮legible‬‏ ‏‮and‬‏ ‏‮require‬‏ ‏‮mobile‬‏ ‏‮visitors‬‏ ‏‮to‬‏ “‏‮pinch‬‏ ‏‮to‬‏ ‏‮zoom‬‏” ‏‮in‬‏ ‏‮order‬‏ ‏‮to‬‏ ‏‮read‬‏. ‏‮Strive‬‏ ‏‮to‬‏ ‏‮have‬‏ >60% ‏‮of‬‏ ‏‮page‬‏ ‏‮text‬‏ ≥12‏‮px‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮font‬‏-‏‮sizes‬‏)."
+    "message": "‏‮Font‬‏ ‏‮sizes‬‏ ‏‮less‬‏ ‏‮than‬‏ 12‏‮px‬‏ ‏‮are‬‏ ‏‮too‬‏ ‏‮small‬‏ ‏‮to‬‏ ‏‮be‬‏ ‏‮legible‬‏ ‏‮and‬‏ ‏‮require‬‏ ‏‮mobile‬‏ ‏‮visitors‬‏ ‏‮to‬‏ “‏‮pinch‬‏ ‏‮to‬‏ ‏‮zoom‬‏” ‏‮in‬‏ ‏‮order‬‏ ‏‮to‬‏ ‏‮read‬‏. ‏‮Strive‬‏ ‏‮to‬‏ ‏‮have‬‏ >60% ‏‮of‬‏ ‏‮page‬‏ ‏‮text‬‏ ≥12‏‮px‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "{‏‮decimalProportionExtendedPercent‬‏} ‏‮legible‬‏ ‏‮text‬‏"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{‏‮decimalProportionExtendedPercent‬‏} ‏‮of‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮too‬‏ ‏‮small‬‏."
+    "message": "{decimalProportion, number, extendedPercent} ‏‮legible‬‏ ‏‮text‬‏"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "‏‮Text‬‏ ‏‮is‬‏ ‏‮illegible‬‏ ‏‮because‬‏ ‏‮there‬‏'‏‮s‬‏ ‏‮no‬‏ ‏‮viewport‬‏ ‏‮meta‬‏ ‏‮tag‬‏ ‏‮optimized‬‏ ‏‮for‬‏ ‏‮mobile‬‏ ‏‮screens‬‏."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{‏‮decimalProportionExtendedPercent‬‏} ‏‮of‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮too‬‏ ‏‮small‬‏ (‏‮based‬‏ ‏‮on‬‏ {‏‮decimalProportionVisited‬‏} ‏‮sample‬‏)."
+    "message": "{decimalProportion, number, extendedPercent} ‏‮of‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮too‬‏ ‏‮small‬‏ (‏‮based‬‏ ‏‮on‬‏ {decimalProportionVisited, number, extendedPercent} ‏‮sample‬‏)."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "‏‮Document‬‏ ‏‮doesn‬‏'‏‮t‬‏ ‏‮use‬‏ ‏‮legible‬‏ ‏‮font‬‏ ‏‮sizes‬‏"
@@ -612,16 +867,16 @@
     "message": "‏‮Document‬‏ ‏‮uses‬‏ ‏‮legible‬‏ ‏‮font‬‏ ‏‮sizes‬‏"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "‏‮hreflang‬‏ ‏‮links‬‏ ‏‮tell‬‏ ‏‮search‬‏ ‏‮engines‬‏ ‏‮what‬‏ ‏‮version‬‏ ‏‮of‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮they‬‏ ‏‮should‬‏ ‏‮list‬‏ ‏‮in‬‏ ‏‮search‬‏ ‏‮results‬‏ ‏‮for‬‏ ‏‮a‬‏ ‏‮given‬‏ ‏‮language‬‏ ‏‮or‬‏ ‏‮region‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮hreflang‬‏)."
+    "message": "‏‮hreflang‬‏ ‏‮links‬‏ ‏‮tell‬‏ ‏‮search‬‏ ‏‮engines‬‏ ‏‮what‬‏ ‏‮version‬‏ ‏‮of‬‏ ‏‮a‬‏ ‏‮page‬‏ ‏‮they‬‏ ‏‮should‬‏ ‏‮list‬‏ ‏‮in‬‏ ‏‮search‬‏ ‏‮results‬‏ ‏‮for‬‏ ‏‮a‬‏ ‏‮given‬‏ ‏‮language‬‏ ‏‮or‬‏ ‏‮region‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "‏‮Document‬‏ ‏‮doesn‬‏'‏‮t‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ `‏‮hreflang‬‏`"
+    "message": "‏‮Document‬‏ ‏‮doesn‬‏'‏‮t‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "‏‮Document‬‏ ‏‮has‬‏ ‏‮a‬‏ ‏‮valid‬‏ `‏‮hreflang‬‏`"
+    "message": "‏‮Document‬‏ ‏‮has‬‏ ‏‮a‬‏ ‏‮valid‬‏ `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "‏‮Pages‬‏ ‏‮with‬‏ ‏‮unsuccessful‬‏ ‏‮HTTP‬‏ ‏‮status‬‏ ‏‮codes‬‏ ‏‮may‬‏ ‏‮not‬‏ ‏‮be‬‏ ‏‮indexed‬‏ ‏‮properly‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮successful‬‏-‏‮http‬‏-‏‮code‬‏)."
+    "message": "‏‮Pages‬‏ ‏‮with‬‏ ‏‮unsuccessful‬‏ ‏‮HTTP‬‏ ‏‮status‬‏ ‏‮codes‬‏ ‏‮may‬‏ ‏‮not‬‏ ‏‮be‬‏ ‏‮indexed‬‏ ‏‮properly‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "‏‮Page‬‏ ‏‮has‬‏ ‏‮unsuccessful‬‏ ‏‮HTTP‬‏ ‏‮status‬‏ ‏‮code‬‏"
@@ -630,7 +885,7 @@
     "message": "‏‮Page‬‏ ‏‮has‬‏ ‏‮successful‬‏ ‏‮HTTP‬‏ ‏‮status‬‏ ‏‮code‬‏"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "‏‮Search‬‏ ‏‮engines‬‏ ‏‮are‬‏ ‏‮unable‬‏ ‏‮to‬‏ ‏‮include‬‏ ‏‮your‬‏ ‏‮pages‬‏ ‏‮in‬‏ ‏‮search‬‏ ‏‮results‬‏ ‏‮if‬‏ ‏‮they‬‏ ‏‮don‬‏'‏‮t‬‏ ‏‮have‬‏ ‏‮permission‬‏ ‏‮to‬‏ ‏‮crawl‬‏ ‏‮them‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮indexing‬‏)."
+    "message": "‏‮Search‬‏ ‏‮engines‬‏ ‏‮are‬‏ ‏‮unable‬‏ ‏‮to‬‏ ‏‮include‬‏ ‏‮your‬‏ ‏‮pages‬‏ ‏‮in‬‏ ‏‮search‬‏ ‏‮results‬‏ ‏‮if‬‏ ‏‮they‬‏ ‏‮don‬‏'‏‮t‬‏ ‏‮have‬‏ ‏‮permission‬‏ ‏‮to‬‏ ‏‮crawl‬‏ ‏‮them‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "‏‮Page‬‏ ‏‮is‬‏ ‏‮blocked‬‏ ‏‮from‬‏ ‏‮indexing‬‏"
@@ -639,7 +894,7 @@
     "message": "‏‮Page‬‏ ‏‮isn‬‏’‏‮t‬‏ ‏‮blocked‬‏ ‏‮from‬‏ ‏‮indexing‬‏"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "‏‮Descriptive‬‏ ‏‮link‬‏ ‏‮text‬‏ ‏‮helps‬‏ ‏‮search‬‏ ‏‮engines‬‏ ‏‮understand‬‏ ‏‮your‬‏ ‏‮content‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮descriptive‬‏-‏‮link‬‏-‏‮text‬‏)."
+    "message": "‏‮Descriptive‬‏ ‏‮link‬‏ ‏‮text‬‏ ‏‮helps‬‏ ‏‮search‬‏ ‏‮engines‬‏ ‏‮understand‬‏ ‏‮your‬‏ ‏‮content‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 ‏‮link‬‏ ‏‮found‬‏}zero{# ‏‮links‬‏ ‏‮found‬‏}two{# ‏‮links‬‏ ‏‮found‬‏}few{# ‏‮links‬‏ ‏‮found‬‏}many{# ‏‮links‬‏ ‏‮found‬‏}other{# ‏‮links‬‏ ‏‮found‬‏}}"
@@ -651,13 +906,13 @@
     "message": "‏‮Links‬‏ ‏‮have‬‏ ‏‮descriptive‬‏ ‏‮text‬‏"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "‏‮Run‬‏ ‏‮the‬‏ [‏‮Structured‬‏ ‏‮Data‬‏ ‏‮Testing‬‏ ‏‮Tool‬‏](‏‮https‬‏://‏‮search‬‏.‏‮google‬‏.‏‮com‬‏/‏‮structured‬‏-‏‮data‬‏/‏‮testing‬‏-‏‮tool‬‏/) ‏‮and‬‏ ‏‮the‬‏ [‏‮Structured‬‏ ‏‮Data‬‏ ‏‮Linter‬‏](‏‮http‬‏://‏‮linter‬‏.‏‮structured‬‏-‏‮data‬‏.‏‮org‬‏/) ‏‮to‬‏ ‏‮validate‬‏ ‏‮structured‬‏ ‏‮data‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮search‬‏/‏‮docs‬‏/‏‮guides‬‏/‏‮mark‬‏-‏‮up‬‏-‏‮content‬‏)."
+    "message": "‏‮Run‬‏ ‏‮the‬‏ [‏‮Structured‬‏ ‏‮Data‬‏ ‏‮Testing‬‏ ‏‮Tool‬‏](https://search.google.com/structured-data/testing-tool/) ‏‮and‬‏ ‏‮the‬‏ [‏‮Structured‬‏ ‏‮Data‬‏ ‏‮Linter‬‏](http://linter.structured-data.org/) ‏‮to‬‏ ‏‮validate‬‏ ‏‮structured‬‏ ‏‮data‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "‏‮Structured‬‏ ‏‮data‬‏ ‏‮is‬‏ ‏‮valid‬‏"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "‏‮Meta‬‏ ‏‮descriptions‬‏ ‏‮may‬‏ ‏‮be‬‏ ‏‮included‬‏ ‏‮in‬‏ ‏‮search‬‏ ‏‮results‬‏ ‏‮to‬‏ ‏‮concisely‬‏ ‏‮summarize‬‏ ‏‮page‬‏ ‏‮content‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮description‬‏)."
+    "message": "‏‮Meta‬‏ ‏‮descriptions‬‏ ‏‮may‬‏ ‏‮be‬‏ ‏‮included‬‏ ‏‮in‬‏ ‏‮search‬‏ ‏‮results‬‏ ‏‮to‬‏ ‏‮concisely‬‏ ‏‮summarize‬‏ ‏‮page‬‏ ‏‮content‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "‏‮Description‬‏ ‏‮text‬‏ ‏‮is‬‏ ‏‮empty‬‏."
@@ -669,7 +924,7 @@
     "message": "‏‮Document‬‏ ‏‮has‬‏ ‏‮a‬‏ ‏‮meta‬‏ ‏‮description‬‏"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "‏‮Search‬‏ ‏‮engines‬‏ ‏‮can‬‏'‏‮t‬‏ ‏‮index‬‏ ‏‮plugin‬‏ ‏‮content‬‏, ‏‮and‬‏ ‏‮many‬‏ ‏‮devices‬‏ ‏‮restrict‬‏ ‏‮plugins‬‏ ‏‮or‬‏ ‏‮don‬‏'‏‮t‬‏ ‏‮support‬‏ ‏‮them‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮plugins‬‏)."
+    "message": "‏‮Search‬‏ ‏‮engines‬‏ ‏‮can‬‏'‏‮t‬‏ ‏‮index‬‏ ‏‮plugin‬‏ ‏‮content‬‏, ‏‮and‬‏ ‏‮many‬‏ ‏‮devices‬‏ ‏‮restrict‬‏ ‏‮plugins‬‏ ‏‮or‬‏ ‏‮don‬‏'‏‮t‬‏ ‏‮support‬‏ ‏‮them‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "‏‮Document‬‏ ‏‮uses‬‏ ‏‮plugins‬‏"
@@ -681,7 +936,7 @@
     "message": "‏‮If‬‏ ‏‮your‬‏ ‏‮robots‬‏.‏‮txt‬‏ ‏‮file‬‏ ‏‮is‬‏ ‏‮malformed‬‏, ‏‮crawlers‬‏ ‏‮may‬‏ ‏‮not‬‏ ‏‮be‬‏ ‏‮able‬‏ ‏‮to‬‏ ‏‮understand‬‏ ‏‮how‬‏ ‏‮you‬‏ ‏‮want‬‏ ‏‮your‬‏ ‏‮website‬‏ ‏‮to‬‏ ‏‮be‬‏ ‏‮crawled‬‏ ‏‮or‬‏ ‏‮indexed‬‏."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "‏‮request‬‏ ‏‮for‬‏ ‏‮robots‬‏.‏‮txt‬‏ ‏‮returned‬‏ ‏‮HTTP‬‏ ‏‮status‬‏: {‏‮statusCode‬‏}"
+    "message": "‏‮request‬‏ ‏‮for‬‏ ‏‮robots‬‏.‏‮txt‬‏ ‏‮returned‬‏ ‏‮HTTP‬‏ ‏‮status‬‏: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{1 ‏‮error‬‏ ‏‮found‬‏}zero{# ‏‮errors‬‏ ‏‮found‬‏}two{# ‏‮errors‬‏ ‏‮found‬‏}few{# ‏‮errors‬‏ ‏‮found‬‏}many{# ‏‮errors‬‏ ‏‮found‬‏}other{# ‏‮errors‬‏ ‏‮found‬‏}}"
@@ -696,10 +951,10 @@
     "message": "‏‮robots‬‏.‏‮txt‬‏ ‏‮is‬‏ ‏‮valid‬‏"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "‏‮Interactive‬‏ ‏‮elements‬‏ ‏‮like‬‏ ‏‮buttons‬‏ ‏‮and‬‏ ‏‮links‬‏ ‏‮should‬‏ ‏‮be‬‏ ‏‮large‬‏ ‏‮enough‬‏ (48‏‮x‬‏48‏‮px‬‏), ‏‮and‬‏ ‏‮have‬‏ ‏‮enough‬‏ ‏‮space‬‏ ‏‮around‬‏ ‏‮them‬‏, ‏‮to‬‏ ‏‮be‬‏ ‏‮easy‬‏ ‏‮enough‬‏ ‏‮to‬‏ ‏‮tap‬‏ ‏‮without‬‏ ‏‮overlapping‬‏ ‏‮onto‬‏ ‏‮other‬‏ ‏‮elements‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮fundamentals‬‏/‏‮accessibility‬‏/‏‮accessible‬‏-‏‮styles‬‏#‏‮multi‬‏-‏‮device‬‏_‏‮responsive‬‏_‏‮design‬‏)."
+    "message": "‏‮Interactive‬‏ ‏‮elements‬‏ ‏‮like‬‏ ‏‮buttons‬‏ ‏‮and‬‏ ‏‮links‬‏ ‏‮should‬‏ ‏‮be‬‏ ‏‮large‬‏ ‏‮enough‬‏ (48‏‮x‬‏48‏‮px‬‏), ‏‮and‬‏ ‏‮have‬‏ ‏‮enough‬‏ ‏‮space‬‏ ‏‮around‬‏ ‏‮them‬‏, ‏‮to‬‏ ‏‮be‬‏ ‏‮easy‬‏ ‏‮enough‬‏ ‏‮to‬‏ ‏‮tap‬‏ ‏‮without‬‏ ‏‮overlapping‬‏ ‏‮onto‬‏ ‏‮other‬‏ ‏‮elements‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "{‏‮decimalProportionPercent‬‏} ‏‮appropriately‬‏ ‏‮sized‬‏ ‏‮tap‬‏ ‏‮targets‬‏"
+    "message": "{decimalProportion, number, percent} ‏‮appropriately‬‏ ‏‮sized‬‏ ‏‮tap‬‏ ‏‮targets‬‏"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "‏‮Tap‬‏ ‏‮targets‬‏ ‏‮are‬‏ ‏‮too‬‏ ‏‮small‬‏ ‏‮because‬‏ ‏‮there‬‏'‏‮s‬‏ ‏‮no‬‏ ‏‮viewport‬‏ ‏‮meta‬‏ ‏‮tag‬‏ ‏‮optimized‬‏ ‏‮for‬‏ ‏‮mobile‬‏ ‏‮screens‬‏"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "‏‮Overlapping‬‏ ‏‮Target‬‏"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "‏‮Size‬‏"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "‏‮Tap‬‏ ‏‮Target‬‏"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "‏‮Tap‬‏ ‏‮targets‬‏ ‏‮are‬‏ ‏‮sized‬‏ ‏‮appropriately‬‏"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "‏‮Main‬‏ ‏‮Thread‬‏ ‏‮Time‬‏"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "‏‮Third‬‏-‏‮Party‬‏"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "‏‮Third‬‏-‏‮party‬‏ ‏‮code‬‏ ‏‮can‬‏ ‏‮significantly‬‏ ‏‮impact‬‏ ‏‮load‬‏ ‏‮performance‬‏. ‏‮Limit‬‏ ‏‮the‬‏ ‏‮number‬‏ ‏‮of‬‏ ‏‮redundant‬‏ ‏‮third‬‏-‏‮party‬‏ ‏‮providers‬‏ ‏‮and‬‏ ‏‮try‬‏ ‏‮to‬‏ ‏‮load‬‏ ‏‮third‬‏-‏‮party‬‏ ‏‮code‬‏ ‏‮after‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮has‬‏ ‏‮primarily‬‏ ‏‮finished‬‏ ‏‮loading‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 ‏‮Third‬‏-‏‮Party‬‏ ‏‮Found‬‏}zero{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}two{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}few{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}many{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}other{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "‏‮Third‬‏-‏‮Party‬‏ ‏‮Usage‬‏"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "‏‮Time‬‏ ‏‮To‬‏ ‏‮First‬‏ ‏‮Byte‬‏ ‏‮identifies‬‏ ‏‮the‬‏ ‏‮time‬‏ ‏‮at‬‏ ‏‮which‬‏ ‏‮your‬‏ ‏‮server‬‏ ‏‮sends‬‏ ‏‮a‬‏ ‏‮response‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮ttfb‬‏)."
+    "message": "‏‮Time‬‏ ‏‮To‬‏ ‏‮First‬‏ ‏‮Byte‬‏ ‏‮identifies‬‏ ‏‮the‬‏ ‏‮time‬‏ ‏‮at‬‏ ‏‮which‬‏ ‏‮your‬‏ ‏‮server‬‏ ‏‮sends‬‏ ‏‮a‬‏ ‏‮response‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "‏‮Root‬‏ ‏‮document‬‏ ‏‮took‬‏ {‏‮timeInMs‬‏} ‏‮ms‬‏"
+    "message": "‏‮Root‬‏ ‏‮document‬‏ ‏‮took‬‏ {timeInMs, number, milliseconds} ‏‮ms‬‏"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "‏‮Reduce‬‏ ‏‮server‬‏ ‏‮response‬‏ ‏‮times‬‏ (‏‮TTFB‬‏)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "‏‮Duration‬‏"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "‏‮Name‬‏"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "‏‮Start‬‏ ‏‮Time‬‏"
   },
@@ -744,7 +1008,7 @@
     "message": "‏‮Type‬‏"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "‏‮Consider‬‏ ‏‮instrumenting‬‏ ‏‮your‬‏ ‏‮app‬‏ ‏‮with‬‏ ‏‮the‬‏ ‏‮User‬‏ ‏‮Timing‬‏ ‏‮API‬‏ ‏‮to‬‏ ‏‮measure‬‏ ‏‮your‬‏ ‏‮app‬‏'‏‮s‬‏ ‏‮real‬‏-‏‮world‬‏ ‏‮performance‬‏ ‏‮during‬‏ ‏‮key‬‏ ‏‮user‬‏ ‏‮experiences‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮user‬‏-‏‮timing‬‏)."
+    "message": "‏‮Consider‬‏ ‏‮instrumenting‬‏ ‏‮your‬‏ ‏‮app‬‏ ‏‮with‬‏ ‏‮the‬‏ ‏‮User‬‏ ‏‮Timing‬‏ ‏‮API‬‏ ‏‮to‬‏ ‏‮measure‬‏ ‏‮your‬‏ ‏‮app‬‏'‏‮s‬‏ ‏‮real‬‏-‏‮world‬‏ ‏‮performance‬‏ ‏‮during‬‏ ‏‮key‬‏ ‏‮user‬‏ ‏‮experiences‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 ‏‮user‬‏ ‏‮timing‬‏}zero{# ‏‮user‬‏ ‏‮timings‬‏}two{# ‏‮user‬‏ ‏‮timings‬‏}few{# ‏‮user‬‏ ‏‮timings‬‏}many{# ‏‮user‬‏ ‏‮timings‬‏}other{# ‏‮user‬‏ ‏‮timings‬‏}}"
@@ -753,19 +1017,19 @@
     "message": "‏‮User‬‏ ‏‮Timing‬‏ ‏‮marks‬‏ ‏‮and‬‏ ‏‮measures‬‏"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "‏‮A‬‏ ‏‮preconnect‬‏ <link> ‏‮was‬‏ ‏‮found‬‏ ‏‮for‬‏ \"{‏‮securityOrigin‬‏}\" ‏‮but‬‏ ‏‮was‬‏ ‏‮not‬‏ ‏‮used‬‏ ‏‮by‬‏ ‏‮the‬‏ ‏‮browser‬‏. ‏‮Check‬‏ ‏‮that‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮using‬‏ ‏‮the‬‏ `‏‮crossorigin‬‏` ‏‮attribute‬‏ ‏‮properly‬‏."
+    "message": "‏‮A‬‏ ‏‮preconnect‬‏ <link> ‏‮was‬‏ ‏‮found‬‏ ‏‮for‬‏ \"{securityOrigin}\" ‏‮but‬‏ ‏‮was‬‏ ‏‮not‬‏ ‏‮used‬‏ ‏‮by‬‏ ‏‮the‬‏ ‏‮browser‬‏. ‏‮Check‬‏ ‏‮that‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮using‬‏ ‏‮the‬‏ `crossorigin` ‏‮attribute‬‏ ‏‮properly‬‏."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "‏‮Consider‬‏ ‏‮adding‬‏ ‏‮preconnect‬‏ ‏‮or‬‏ ‏‮dns‬‏-‏‮prefetch‬‏ ‏‮resource‬‏ ‏‮hints‬‏ ‏‮to‬‏ ‏‮establish‬‏ ‏‮early‬‏ ‏‮connections‬‏ ‏‮to‬‏ ‏‮important‬‏ ‏‮third‬‏-‏‮party‬‏ ‏‮origins‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮fundamentals‬‏/‏‮performance‬‏/‏‮resource‬‏-‏‮prioritization‬‏#‏‮preconnect‬‏)."
+    "message": "‏‮Consider‬‏ ‏‮adding‬‏ ‏‮preconnect‬‏ ‏‮or‬‏ ‏‮dns‬‏-‏‮prefetch‬‏ ‏‮resource‬‏ ‏‮hints‬‏ ‏‮to‬‏ ‏‮establish‬‏ ‏‮early‬‏ ‏‮connections‬‏ ‏‮to‬‏ ‏‮important‬‏ ‏‮third‬‏-‏‮party‬‏ ‏‮origins‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "‏‮Preconnect‬‏ ‏‮to‬‏ ‏‮required‬‏ ‏‮origins‬‏"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "‏‮A‬‏ ‏‮preload‬‏ <link> ‏‮was‬‏ ‏‮found‬‏ ‏‮for‬‏ \"{‏‮preloadURL‬‏}\" ‏‮but‬‏ ‏‮was‬‏ ‏‮not‬‏ ‏‮used‬‏ ‏‮by‬‏ ‏‮the‬‏ ‏‮browser‬‏. ‏‮Check‬‏ ‏‮that‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮using‬‏ ‏‮the‬‏ `‏‮crossorigin‬‏` ‏‮attribute‬‏ ‏‮properly‬‏."
+    "message": "‏‮A‬‏ ‏‮preload‬‏ <link> ‏‮was‬‏ ‏‮found‬‏ ‏‮for‬‏ \"{preloadURL}\" ‏‮but‬‏ ‏‮was‬‏ ‏‮not‬‏ ‏‮used‬‏ ‏‮by‬‏ ‏‮the‬‏ ‏‮browser‬‏. ‏‮Check‬‏ ‏‮that‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮using‬‏ ‏‮the‬‏ `crossorigin` ‏‮attribute‬‏ ‏‮properly‬‏."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "‏‮Consider‬‏ ‏‮using‬‏ <link rel=preload> ‏‮to‬‏ ‏‮prioritize‬‏ ‏‮fetching‬‏ ‏‮resources‬‏ ‏‮that‬‏ ‏‮are‬‏ ‏‮currently‬‏ ‏‮requested‬‏ ‏‮later‬‏ ‏‮in‬‏ ‏‮page‬‏ ‏‮load‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/‏‮audits‬‏/‏‮preload‬‏)."
+    "message": "‏‮Consider‬‏ ‏‮using‬‏ `<link rel=preload>` ‏‮to‬‏ ‏‮prioritize‬‏ ‏‮fetching‬‏ ‏‮resources‬‏ ‏‮that‬‏ ‏‮are‬‏ ‏‮currently‬‏ ‏‮requested‬‏ ‏‮later‬‏ ‏‮in‬‏ ‏‮page‬‏ ‏‮load‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "‏‮Preload‬‏ ‏‮key‬‏ ‏‮requests‬‏"
@@ -789,10 +1053,10 @@
     "message": "‏‮Best‬‏ ‏‮practices‬‏"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "‏‮These‬‏ ‏‮checks‬‏ ‏‮highlight‬‏ ‏‮opportunities‬‏ ‏‮to‬‏ [‏‮improve‬‏ ‏‮the‬‏ ‏‮accessibility‬‏ ‏‮of‬‏ ‏‮your‬‏ ‏‮web‬‏ ‏‮app‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮fundamentals‬‏/‏‮accessibility‬‏). ‏‮Only‬‏ ‏‮a‬‏ ‏‮subset‬‏ ‏‮of‬‏ ‏‮accessibility‬‏ ‏‮issues‬‏ ‏‮can‬‏ ‏‮be‬‏ ‏‮automatically‬‏ ‏‮detected‬‏ ‏‮so‬‏ ‏‮manual‬‏ ‏‮testing‬‏ ‏‮is‬‏ ‏‮also‬‏ ‏‮encouraged‬‏."
+    "message": "‏‮These‬‏ ‏‮checks‬‏ ‏‮highlight‬‏ ‏‮opportunities‬‏ ‏‮to‬‏ [‏‮improve‬‏ ‏‮the‬‏ ‏‮accessibility‬‏ ‏‮of‬‏ ‏‮your‬‏ ‏‮web‬‏ ‏‮app‬‏](https://developers.google.com/web/fundamentals/accessibility). ‏‮Only‬‏ ‏‮a‬‏ ‏‮subset‬‏ ‏‮of‬‏ ‏‮accessibility‬‏ ‏‮issues‬‏ ‏‮can‬‏ ‏‮be‬‏ ‏‮automatically‬‏ ‏‮detected‬‏ ‏‮so‬‏ ‏‮manual‬‏ ‏‮testing‬‏ ‏‮is‬‏ ‏‮also‬‏ ‏‮encouraged‬‏."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "‏‮These‬‏ ‏‮items‬‏ ‏‮address‬‏ ‏‮areas‬‏ ‏‮which‬‏ ‏‮an‬‏ ‏‮automated‬‏ ‏‮testing‬‏ ‏‮tool‬‏ ‏‮cannot‬‏ ‏‮cover‬‏. ‏‮Learn‬‏ ‏‮more‬‏ ‏‮in‬‏ ‏‮our‬‏ ‏‮guide‬‏ ‏‮on‬‏ [‏‮conducting‬‏ ‏‮an‬‏ ‏‮accessibility‬‏ ‏‮review‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮fundamentals‬‏/‏‮accessibility‬‏/‏‮how‬‏-‏‮to‬‏-‏‮review‬‏)."
+    "message": "‏‮These‬‏ ‏‮items‬‏ ‏‮address‬‏ ‏‮areas‬‏ ‏‮which‬‏ ‏‮an‬‏ ‏‮automated‬‏ ‏‮testing‬‏ ‏‮tool‬‏ ‏‮cannot‬‏ ‏‮cover‬‏. ‏‮Learn‬‏ ‏‮more‬‏ ‏‮in‬‏ ‏‮our‬‏ ‏‮guide‬‏ ‏‮on‬‏ [‏‮conducting‬‏ ‏‮an‬‏ ‏‮accessibility‬‏ ‏‮review‬‏](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "‏‮Accessibility‬‏"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "‏‮Tables‬‏ ‏‮and‬‏ ‏‮lists‬‏"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "‏‮Best‬‏ ‏‮Practices‬‏"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "‏‮Performance‬‏ ‏‮budgets‬‏ ‏‮set‬‏ ‏‮standards‬‏ ‏‮for‬‏ ‏‮the‬‏ ‏‮performance‬‏ ‏‮of‬‏ ‏‮your‬‏ ‏‮site‬‏."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "‏‮Budgets‬‏"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "‏‮More‬‏ ‏‮information‬‏ ‏‮about‬‏ ‏‮the‬‏ ‏‮performance‬‏ ‏‮of‬‏ ‏‮your‬‏ ‏‮application‬‏."
+    "message": "‏‮More‬‏ ‏‮information‬‏ ‏‮about‬‏ ‏‮the‬‏ ‏‮performance‬‏ ‏‮of‬‏ ‏‮your‬‏ ‏‮application‬‏. ‏‮These‬‏ ‏‮numbers‬‏ ‏‮don‬‏'‏‮t‬‏ [‏‮directly‬‏ ‏‮affect‬‏](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) ‏‮the‬‏ ‏‮Performance‬‏ ‏‮score‬‏."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "‏‮Diagnostics‬‏"
@@ -840,7 +1113,7 @@
     "message": "‏‮First‬‏ ‏‮Paint‬‏ ‏‮Improvements‬‏"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "‏‮These‬‏ ‏‮optimizations‬‏ ‏‮can‬‏ ‏‮speed‬‏ ‏‮up‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮load‬‏."
+    "message": "‏‮These‬‏ ‏‮suggestions‬‏ ‏‮can‬‏ ‏‮help‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮load‬‏ ‏‮faster‬‏. ‏‮They‬‏ ‏‮don‬‏'‏‮t‬‏ [‏‮directly‬‏ ‏‮affect‬‏](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) ‏‮the‬‏ ‏‮Performance‬‏ ‏‮score‬‏."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "‏‮Opportunities‬‏"
@@ -867,7 +1140,7 @@
     "message": "‏‮PWA‬‏ ‏‮Optimized‬‏"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "‏‮These‬‏ ‏‮checks‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮is‬‏ ‏‮optimized‬‏ ‏‮for‬‏ ‏‮search‬‏ ‏‮engine‬‏ ‏‮results‬‏ ‏‮ranking‬‏. ‏‮There‬‏ ‏‮are‬‏ ‏‮additional‬‏ ‏‮factors‬‏ ‏‮Lighthouse‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮check‬‏ ‏‮that‬‏ ‏‮may‬‏ ‏‮affect‬‏ ‏‮your‬‏ ‏‮search‬‏ ‏‮ranking‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮support‬‏.‏‮google‬‏.‏‮com‬‏/‏‮webmasters‬‏/‏‮answer‬‏/35769)."
+    "message": "‏‮These‬‏ ‏‮checks‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮is‬‏ ‏‮optimized‬‏ ‏‮for‬‏ ‏‮search‬‏ ‏‮engine‬‏ ‏‮results‬‏ ‏‮ranking‬‏. ‏‮There‬‏ ‏‮are‬‏ ‏‮additional‬‏ ‏‮factors‬‏ ‏‮Lighthouse‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮check‬‏ ‏‮that‬‏ ‏‮may‬‏ ‏‮affect‬‏ ‏‮your‬‏ ‏‮search‬‏ ‏‮ranking‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "‏‮Run‬‏ ‏‮these‬‏ ‏‮additional‬‏ ‏‮validators‬‏ ‏‮on‬‏ ‏‮your‬‏ ‏‮site‬‏ ‏‮to‬‏ ‏‮check‬‏ ‏‮additional‬‏ ‏‮SEO‬‏ ‏‮best‬‏ ‏‮practices‬‏."
@@ -888,7 +1161,7 @@
     "message": "‏‮Crawling‬‏ ‏‮and‬‏ ‏‮Indexing‬‏"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "‏‮Make‬‏ ‏‮sure‬‏ ‏‮your‬‏ ‏‮pages‬‏ ‏‮are‬‏ ‏‮mobile‬‏ ‏‮friendly‬‏ ‏‮so‬‏ ‏‮users‬‏ ‏‮don‬‏’‏‮t‬‏ ‏‮have‬‏ ‏‮to‬‏ ‏‮pinch‬‏ ‏‮or‬‏ ‏‮zoom‬‏ ‏‮in‬‏ ‏‮order‬‏ ‏‮to‬‏ ‏‮read‬‏ ‏‮the‬‏ ‏‮content‬‏ ‏‮pages‬‏. [‏‮Learn‬‏ ‏‮more‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮search‬‏/‏‮mobile‬‏-‏‮sites‬‏/)."
+    "message": "‏‮Make‬‏ ‏‮sure‬‏ ‏‮your‬‏ ‏‮pages‬‏ ‏‮are‬‏ ‏‮mobile‬‏ ‏‮friendly‬‏ ‏‮so‬‏ ‏‮users‬‏ ‏‮don‬‏’‏‮t‬‏ ‏‮have‬‏ ‏‮to‬‏ ‏‮pinch‬‏ ‏‮or‬‏ ‏‮zoom‬‏ ‏‮in‬‏ ‏‮order‬‏ ‏‮to‬‏ ‏‮read‬‏ ‏‮the‬‏ ‏‮content‬‏ ‏‮pages‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "‏‮Mobile‬‏ ‏‮Friendly‬‏"
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "‏‮Cache‬‏ ‏‮TTL‬‏"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "‏‮Location‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "‏‮Name‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "‏‮Requests‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "‏‮Resource‬‏ ‏‮Type‬‏"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "‏‮Size‬‏ (‏‮KB‬‏)"
+    "message": "‏‮Size‬‏"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "‏‮Time‬‏ ‏‮Spent‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "‏‮Transfer‬‏ ‏‮Size‬‏"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "‏‮URL‬‏"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "‏‮Potential‬‏ ‏‮Savings‬‏ (‏‮KB‬‏)"
+    "message": "‏‮Potential‬‏ ‏‮Savings‬‏"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "‏‮Potential‬‏ ‏‮Savings‬‏ (‏‮ms‬‏)"
+    "message": "‏‮Potential‬‏ ‏‮Savings‬‏"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "‏‮Potential‬‏ ‏‮savings‬‏ ‏‮of‬‏ {‏‮wastedBytes‬‏} ‏‮KB‬‏"
+    "message": "‏‮Potential‬‏ ‏‮savings‬‏ ‏‮of‬‏ {wastedBytes, number, bytes} ‏‮KB‬‏"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "‏‮Potential‬‏ ‏‮savings‬‏ ‏‮of‬‏ {‏‮wastedMs‬‏} ‏‮ms‬‏"
+    "message": "‏‮Potential‬‏ ‏‮savings‬‏ ‏‮of‬‏ {wastedMs, number, milliseconds} ‏‮ms‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "‏‮Document‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "‏‮Font‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "‏‮Image‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "‏‮Media‬‏"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{‏‮timeInMs‬‏} ‏‮ms‬‏"
+    "message": "{timeInMs, number, milliseconds} ‏‮ms‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "‏‮Other‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "‏‮Script‬‏"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{‏‮timeInMsSec‬‏} ‏‮s‬‏"
+    "message": "{timeInMs, number, seconds} ‏‮s‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "‏‮Stylesheet‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "‏‮Third‬‏-‏‮party‬‏"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "‏‮Total‬‏"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "‏‮Something‬‏ ‏‮went‬‏ ‏‮wrong‬‏ ‏‮with‬‏ ‏‮recording‬‏ ‏‮the‬‏ ‏‮trace‬‏ ‏‮over‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮load‬‏. ‏‮Please‬‏ ‏‮run‬‏ ‏‮Lighthouse‬‏ ‏‮again‬‏. ({‏‮errorCode‬‏})"
+    "message": "‏‮Something‬‏ ‏‮went‬‏ ‏‮wrong‬‏ ‏‮with‬‏ ‏‮recording‬‏ ‏‮the‬‏ ‏‮trace‬‏ ‏‮over‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮load‬‏. ‏‮Please‬‏ ‏‮run‬‏ ‏‮Lighthouse‬‏ ‏‮again‬‏. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "‏‮Timeout‬‏ ‏‮waiting‬‏ ‏‮for‬‏ ‏‮initial‬‏ ‏‮Debugger‬‏ ‏‮Protocol‬‏ ‏‮connection‬‏."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "‏‮Chrome‬‏ ‏‮didn‬‏'‏‮t‬‏ ‏‮collect‬‏ ‏‮any‬‏ ‏‮screenshots‬‏ ‏‮during‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮load‬‏. ‏‮Please‬‏ ‏‮make‬‏ ‏‮sure‬‏ ‏‮there‬‏ ‏‮is‬‏ ‏‮content‬‏ ‏‮visible‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏, ‏‮and‬‏ ‏‮then‬‏ ‏‮try‬‏ ‏‮re‬‏-‏‮running‬‏ ‏‮Lighthouse‬‏. ({‏‮errorCode‬‏})"
+    "message": "‏‮Chrome‬‏ ‏‮didn‬‏'‏‮t‬‏ ‏‮collect‬‏ ‏‮any‬‏ ‏‮screenshots‬‏ ‏‮during‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮load‬‏. ‏‮Please‬‏ ‏‮make‬‏ ‏‮sure‬‏ ‏‮there‬‏ ‏‮is‬‏ ‏‮content‬‏ ‏‮visible‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏, ‏‮and‬‏ ‏‮then‬‏ ‏‮try‬‏ ‏‮re‬‏-‏‮running‬‏ ‏‮Lighthouse‬‏. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "‏‮DNS‬‏ ‏‮servers‬‏ ‏‮could‬‏ ‏‮not‬‏ ‏‮resolve‬‏ ‏‮the‬‏ ‏‮provided‬‏ ‏‮domain‬‏."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "‏‮Required‬‏ {artifactName} ‏‮gatherer‬‏ ‏‮encountered‬‏ ‏‮an‬‏ ‏‮error‬‏: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "‏‮An‬‏ ‏‮internal‬‏ ‏‮Chrome‬‏ ‏‮error‬‏ ‏‮occurred‬‏. ‏‮Please‬‏ ‏‮restart‬‏ ‏‮Chrome‬‏ ‏‮and‬‏ ‏‮try‬‏ ‏‮re‬‏-‏‮running‬‏ ‏‮Lighthouse‬‏."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "‏‮Required‬‏ {artifactName} ‏‮gatherer‬‏ ‏‮did‬‏ ‏‮not‬‏ ‏‮run‬‏."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "‏‮Lighthouse‬‏ ‏‮was‬‏ ‏‮unable‬‏ ‏‮to‬‏ ‏‮reliably‬‏ ‏‮load‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮you‬‏ ‏‮requested‬‏. ‏‮Make‬‏ ‏‮sure‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮testing‬‏ ‏‮the‬‏ ‏‮correct‬‏ ‏‮URL‬‏ ‏‮and‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮is‬‏ ‏‮properly‬‏ ‏‮responding‬‏ ‏‮to‬‏ ‏‮all‬‏ ‏‮requests‬‏."
@@ -945,19 +1266,22 @@
     "message": "‏‮Lighthouse‬‏ ‏‮was‬‏ ‏‮unable‬‏ ‏‮to‬‏ ‏‮reliably‬‏ ‏‮load‬‏ ‏‮the‬‏ ‏‮URL‬‏ ‏‮you‬‏ ‏‮requested‬‏ ‏‮because‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮stopped‬‏ ‏‮responding‬‏."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "‏‮The‬‏ ‏‮URL‬‏ ‏‮you‬‏ ‏‮have‬‏ ‏‮provided‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮valid‬‏ ‏‮security‬‏ ‏‮credentials‬‏. {‏‮securityMessages‬‏}"
+    "message": "‏‮The‬‏ ‏‮URL‬‏ ‏‮you‬‏ ‏‮have‬‏ ‏‮provided‬‏ ‏‮does‬‏ ‏‮not‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮valid‬‏ ‏‮security‬‏ ‏‮certificate‬‏. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "‏‮Chrome‬‏ ‏‮prevented‬‏ ‏‮page‬‏ ‏‮load‬‏ ‏‮with‬‏ ‏‮an‬‏ ‏‮interstitial‬‏. ‏‮Make‬‏ ‏‮sure‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮testing‬‏ ‏‮the‬‏ ‏‮correct‬‏ ‏‮URL‬‏ ‏‮and‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮is‬‏ ‏‮properly‬‏ ‏‮responding‬‏ ‏‮to‬‏ ‏‮all‬‏ ‏‮requests‬‏."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "‏‮Lighthouse‬‏ ‏‮was‬‏ ‏‮unable‬‏ ‏‮to‬‏ ‏‮reliably‬‏ ‏‮load‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮you‬‏ ‏‮requested‬‏. ‏‮Make‬‏ ‏‮sure‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮testing‬‏ ‏‮the‬‏ ‏‮correct‬‏ ‏‮URL‬‏ ‏‮and‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮is‬‏ ‏‮properly‬‏ ‏‮responding‬‏ ‏‮to‬‏ ‏‮all‬‏ ‏‮requests‬‏. (‏‮Details‬‏: {‏‮errorDetails‬‏})"
+    "message": "‏‮Lighthouse‬‏ ‏‮was‬‏ ‏‮unable‬‏ ‏‮to‬‏ ‏‮reliably‬‏ ‏‮load‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮you‬‏ ‏‮requested‬‏. ‏‮Make‬‏ ‏‮sure‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮testing‬‏ ‏‮the‬‏ ‏‮correct‬‏ ‏‮URL‬‏ ‏‮and‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮is‬‏ ‏‮properly‬‏ ‏‮responding‬‏ ‏‮to‬‏ ‏‮all‬‏ ‏‮requests‬‏. (‏‮Details‬‏: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "‏‮Lighthouse‬‏ ‏‮was‬‏ ‏‮unable‬‏ ‏‮to‬‏ ‏‮reliably‬‏ ‏‮load‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮you‬‏ ‏‮requested‬‏. ‏‮Make‬‏ ‏‮sure‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮testing‬‏ ‏‮the‬‏ ‏‮correct‬‏ ‏‮URL‬‏ ‏‮and‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮is‬‏ ‏‮properly‬‏ ‏‮responding‬‏ ‏‮to‬‏ ‏‮all‬‏ ‏‮requests‬‏. (‏‮Status‬‏ ‏‮code‬‏: {‏‮statusCode‬‏})"
+    "message": "‏‮Lighthouse‬‏ ‏‮was‬‏ ‏‮unable‬‏ ‏‮to‬‏ ‏‮reliably‬‏ ‏‮load‬‏ ‏‮the‬‏ ‏‮page‬‏ ‏‮you‬‏ ‏‮requested‬‏. ‏‮Make‬‏ ‏‮sure‬‏ ‏‮you‬‏ ‏‮are‬‏ ‏‮testing‬‏ ‏‮the‬‏ ‏‮correct‬‏ ‏‮URL‬‏ ‏‮and‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮server‬‏ ‏‮is‬‏ ‏‮properly‬‏ ‏‮responding‬‏ ‏‮to‬‏ ‏‮all‬‏ ‏‮requests‬‏. (‏‮Status‬‏ ‏‮code‬‏: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "‏‮Your‬‏ ‏‮page‬‏ ‏‮took‬‏ ‏‮too‬‏ ‏‮long‬‏ ‏‮to‬‏ ‏‮load‬‏. ‏‮Please‬‏ ‏‮follow‬‏ ‏‮the‬‏ ‏‮opportunities‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮report‬‏ ‏‮to‬‏ ‏‮reduce‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮load‬‏ ‏‮time‬‏, ‏‮and‬‏ ‏‮then‬‏ ‏‮try‬‏ ‏‮re‬‏-‏‮running‬‏ ‏‮Lighthouse‬‏. ({‏‮errorCode‬‏})"
+    "message": "‏‮Your‬‏ ‏‮page‬‏ ‏‮took‬‏ ‏‮too‬‏ ‏‮long‬‏ ‏‮to‬‏ ‏‮load‬‏. ‏‮Please‬‏ ‏‮follow‬‏ ‏‮the‬‏ ‏‮opportunities‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮report‬‏ ‏‮to‬‏ ‏‮reduce‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮load‬‏ ‏‮time‬‏, ‏‮and‬‏ ‏‮then‬‏ ‏‮try‬‏ ‏‮re‬‏-‏‮running‬‏ ‏‮Lighthouse‬‏. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "‏‮Waiting‬‏ ‏‮for‬‏ ‏‮DevTools‬‏ ‏‮protocol‬‏ ‏‮response‬‏ ‏‮has‬‏ ‏‮exceeded‬‏ ‏‮the‬‏ ‏‮allotted‬‏ ‏‮time‬‏. (‏‮Method‬‏: {‏‮protocolMethod‬‏})"
+    "message": "‏‮Waiting‬‏ ‏‮for‬‏ ‏‮DevTools‬‏ ‏‮protocol‬‏ ‏‮response‬‏ ‏‮has‬‏ ‏‮exceeded‬‏ ‏‮the‬‏ ‏‮allotted‬‏ ‏‮time‬‏. (‏‮Method‬‏: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "‏‮Fetching‬‏ ‏‮resource‬‏ ‏‮content‬‏ ‏‮has‬‏ ‏‮exceeded‬‏ ‏‮the‬‏ ‏‮allotted‬‏ ‏‮time‬‏"
@@ -984,7 +1308,7 @@
     "message": "‏‮Lab‬‏ ‏‮Data‬‏"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[‏‮Lighthouse‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮tools‬‏/‏‮lighthouse‬‏/) ‏‮analysis‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮current‬‏ ‏‮page‬‏ ‏‮on‬‏ ‏‮an‬‏ ‏‮emulated‬‏ ‏‮mobile‬‏ ‏‮network‬‏. ‏‮Values‬‏ ‏‮are‬‏ ‏‮estimated‬‏ ‏‮and‬‏ ‏‮may‬‏ ‏‮vary‬‏."
+    "message": "[‏‮Lighthouse‬‏](https://developers.google.com/web/tools/lighthouse/) ‏‮analysis‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮current‬‏ ‏‮page‬‏ ‏‮on‬‏ ‏‮an‬‏ ‏‮emulated‬‏ ‏‮mobile‬‏ ‏‮network‬‏. ‏‮Values‬‏ ‏‮are‬‏ ‏‮estimated‬‏ ‏‮and‬‏ ‏‮may‬‏ ‏‮vary‬‏."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "‏‮Additional‬‏ ‏‮items‬‏ ‏‮to‬‏ ‏‮manually‬‏ ‏‮check‬‏"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "‏‮Expand‬‏ ‏‮snippet‬‏"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "‏‮Show‬‏ 3‏‮rd‬‏-‏‮party‬‏ ‏‮resources‬‏"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "‏‮There‬‏ ‏‮were‬‏ ‏‮issues‬‏ ‏‮affecting‬‏ ‏‮this‬‏ ‏‮run‬‏ ‏‮of‬‏ ‏‮Lighthouse‬‏:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "‏‮Values‬‏ ‏‮are‬‏ ‏‮estimated‬‏ ‏‮and‬‏ ‏‮may‬‏ ‏‮vary‬‏."
+    "message": "‏‮Values‬‏ ‏‮are‬‏ ‏‮estimated‬‏ ‏‮and‬‏ ‏‮may‬‏ ‏‮vary‬‏. ‏‮The‬‏ ‏‮performance‬‏ ‏‮score‬‏ ‏‮is‬‏ [‏‮based‬‏ ‏‮only‬‏ ‏‮on‬‏ ‏‮these‬‏ ‏‮metrics‬‏](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "‏‮Passed‬‏ ‏‮audits‬‏ ‏‮but‬‏ ‏‮with‬‏ ‏‮warnings‬‏"
@@ -1023,10 +1350,10 @@
     "message": "‏‮Consider‬‏ ‏‮uploading‬‏ ‏‮your‬‏ ‏‮GIF‬‏ ‏‮to‬‏ ‏‮a‬‏ ‏‮service‬‏ ‏‮which‬‏ ‏‮will‬‏ ‏‮make‬‏ ‏‮it‬‏ ‏‮available‬‏ ‏‮to‬‏ ‏‮embed‬‏ ‏‮as‬‏ ‏‮an‬‏ ‏‮HTML‬‏5 ‏‮video‬‏."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "‏‮Install‬‏ ‏‮a‬‏ [‏‮lazy‬‏-‏‮load‬‏ ‏‮WordPress‬‏ ‏‮plugin‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/‏‮search‬‏/‏‮lazy‬‏+‏‮load‬‏/) ‏‮that‬‏ ‏‮provides‬‏ ‏‮the‬‏ ‏‮ability‬‏ ‏‮to‬‏ ‏‮defer‬‏ ‏‮any‬‏ ‏‮offscreen‬‏ ‏‮images‬‏, ‏‮or‬‏ ‏‮switch‬‏ ‏‮to‬‏ ‏‮a‬‏ ‏‮theme‬‏ ‏‮that‬‏ ‏‮provides‬‏ ‏‮that‬‏ ‏‮functionality‬‏. ‏‮Also‬‏ ‏‮consider‬‏ ‏‮using‬‏ [‏‮the‬‏ ‏‮AMP‬‏ ‏‮plugin‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/‏‮amp‬‏/)."
+    "message": "‏‮Install‬‏ ‏‮a‬‏ [‏‮lazy‬‏-‏‮load‬‏ ‏‮WordPress‬‏ ‏‮plugin‬‏](https://wordpress.org/plugins/search/lazy+load/) ‏‮that‬‏ ‏‮provides‬‏ ‏‮the‬‏ ‏‮ability‬‏ ‏‮to‬‏ ‏‮defer‬‏ ‏‮any‬‏ ‏‮offscreen‬‏ ‏‮images‬‏, ‏‮or‬‏ ‏‮switch‬‏ ‏‮to‬‏ ‏‮a‬‏ ‏‮theme‬‏ ‏‮that‬‏ ‏‮provides‬‏ ‏‮that‬‏ ‏‮functionality‬‏. ‏‮Also‬‏ ‏‮consider‬‏ ‏‮using‬‏ [‏‮the‬‏ ‏‮AMP‬‏ ‏‮plugin‬‏](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "‏‮There‬‏ ‏‮are‬‏ ‏‮a‬‏ ‏‮number‬‏ ‏‮of‬‏ ‏‮WordPress‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮can‬‏ ‏‮help‬‏ ‏‮you‬‏ [‏‮inline‬‏ ‏‮critical‬‏ ‏‮assets‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/‏‮search‬‏/‏‮critical‬‏+‏‮css‬‏/) ‏‮or‬‏ [‏‮defer‬‏ ‏‮less‬‏ ‏‮important‬‏ ‏‮resources‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/‏‮search‬‏/‏‮defer‬‏+‏‮css‬‏+‏‮javascript‬‏/). ‏‮Beware‬‏ ‏‮that‬‏ ‏‮optimizations‬‏ ‏‮provided‬‏ ‏‮by‬‏ ‏‮these‬‏ ‏‮plugins‬‏ ‏‮may‬‏ ‏‮break‬‏ ‏‮features‬‏ ‏‮of‬‏ ‏‮your‬‏ ‏‮theme‬‏ ‏‮or‬‏ ‏‮plugins‬‏, ‏‮so‬‏ ‏‮you‬‏ ‏‮will‬‏ ‏‮likely‬‏ ‏‮need‬‏ ‏‮to‬‏ ‏‮make‬‏ ‏‮code‬‏ ‏‮changes‬‏."
+    "message": "‏‮There‬‏ ‏‮are‬‏ ‏‮a‬‏ ‏‮number‬‏ ‏‮of‬‏ ‏‮WordPress‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮can‬‏ ‏‮help‬‏ ‏‮you‬‏ [‏‮inline‬‏ ‏‮critical‬‏ ‏‮assets‬‏](https://wordpress.org/plugins/search/critical+css/) ‏‮or‬‏ [‏‮defer‬‏ ‏‮less‬‏ ‏‮important‬‏ ‏‮resources‬‏](https://wordpress.org/plugins/search/defer+css+javascript/). ‏‮Beware‬‏ ‏‮that‬‏ ‏‮optimizations‬‏ ‏‮provided‬‏ ‏‮by‬‏ ‏‮these‬‏ ‏‮plugins‬‏ ‏‮may‬‏ ‏‮break‬‏ ‏‮features‬‏ ‏‮of‬‏ ‏‮your‬‏ ‏‮theme‬‏ ‏‮or‬‏ ‏‮plugins‬‏, ‏‮so‬‏ ‏‮you‬‏ ‏‮will‬‏ ‏‮likely‬‏ ‏‮need‬‏ ‏‮to‬‏ ‏‮make‬‏ ‏‮code‬‏ ‏‮changes‬‏."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "‏‮Themes‬‏, ‏‮plugins‬‏, ‏‮and‬‏ ‏‮server‬‏ ‏‮specifications‬‏ ‏‮all‬‏ ‏‮contribute‬‏ ‏‮to‬‏ ‏‮server‬‏ ‏‮response‬‏ ‏‮time‬‏. ‏‮Consider‬‏ ‏‮finding‬‏ ‏‮a‬‏ ‏‮more‬‏ ‏‮optimized‬‏ ‏‮theme‬‏, ‏‮carefully‬‏ ‏‮selecting‬‏ ‏‮an‬‏ ‏‮optimization‬‏ ‏‮plugin‬‏, ‏‮and‬‏/‏‮or‬‏ ‏‮upgrading‬‏ ‏‮your‬‏ ‏‮server‬‏."
@@ -1035,30 +1362,30 @@
     "message": "‏‮Consider‬‏ ‏‮showing‬‏ ‏‮excerpts‬‏ ‏‮in‬‏ ‏‮your‬‏ ‏‮post‬‏ ‏‮lists‬‏ (‏‮e‬‏.‏‮g‬‏. ‏‮via‬‏ ‏‮the‬‏ ‏‮more‬‏ ‏‮tag‬‏), ‏‮reducing‬‏ ‏‮the‬‏ ‏‮number‬‏ ‏‮of‬‏ ‏‮posts‬‏ ‏‮shown‬‏ ‏‮on‬‏ ‏‮a‬‏ ‏‮given‬‏ ‏‮page‬‏, ‏‮breaking‬‏ ‏‮your‬‏ ‏‮long‬‏ ‏‮posts‬‏ ‏‮into‬‏ ‏‮multiple‬‏ ‏‮pages‬‏, ‏‮or‬‏ ‏‮using‬‏ ‏‮a‬‏ ‏‮plugin‬‏ ‏‮to‬‏ ‏‮lazy‬‏-‏‮load‬‏ ‏‮comments‬‏."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "‏‮A‬‏ ‏‮number‬‏ ‏‮of‬‏ [‏‮WordPress‬‏ ‏‮plugins‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/‏‮search‬‏/‏‮minify‬‏+‏‮css‬‏/) ‏‮can‬‏ ‏‮speed‬‏ ‏‮up‬‏ ‏‮your‬‏ ‏‮site‬‏ ‏‮by‬‏ ‏‮concatenating‬‏, ‏‮minifying‬‏, ‏‮and‬‏ ‏‮compressing‬‏ ‏‮your‬‏ ‏‮styles‬‏. ‏‮You‬‏ ‏‮may‬‏ ‏‮also‬‏ ‏‮want‬‏ ‏‮to‬‏ ‏‮use‬‏ ‏‮a‬‏ ‏‮build‬‏ ‏‮process‬‏ ‏‮to‬‏ ‏‮do‬‏ ‏‮this‬‏ ‏‮minification‬‏ ‏‮up‬‏-‏‮front‬‏ ‏‮if‬‏ ‏‮possible‬‏."
+    "message": "‏‮A‬‏ ‏‮number‬‏ ‏‮of‬‏ [‏‮WordPress‬‏ ‏‮plugins‬‏](https://wordpress.org/plugins/search/minify+css/) ‏‮can‬‏ ‏‮speed‬‏ ‏‮up‬‏ ‏‮your‬‏ ‏‮site‬‏ ‏‮by‬‏ ‏‮concatenating‬‏, ‏‮minifying‬‏, ‏‮and‬‏ ‏‮compressing‬‏ ‏‮your‬‏ ‏‮styles‬‏. ‏‮You‬‏ ‏‮may‬‏ ‏‮also‬‏ ‏‮want‬‏ ‏‮to‬‏ ‏‮use‬‏ ‏‮a‬‏ ‏‮build‬‏ ‏‮process‬‏ ‏‮to‬‏ ‏‮do‬‏ ‏‮this‬‏ ‏‮minification‬‏ ‏‮up‬‏-‏‮front‬‏ ‏‮if‬‏ ‏‮possible‬‏."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "‏‮A‬‏ ‏‮number‬‏ ‏‮of‬‏ [‏‮WordPress‬‏ ‏‮plugins‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/‏‮search‬‏/‏‮minify‬‏+‏‮javascript‬‏/) ‏‮can‬‏ ‏‮speed‬‏ ‏‮up‬‏ ‏‮your‬‏ ‏‮site‬‏ ‏‮by‬‏ ‏‮concatenating‬‏, ‏‮minifying‬‏, ‏‮and‬‏ ‏‮compressing‬‏ ‏‮your‬‏ ‏‮scripts‬‏. ‏‮You‬‏ ‏‮may‬‏ ‏‮also‬‏ ‏‮want‬‏ ‏‮to‬‏ ‏‮use‬‏ ‏‮a‬‏ ‏‮build‬‏ ‏‮process‬‏ ‏‮to‬‏ ‏‮do‬‏ ‏‮this‬‏ ‏‮minification‬‏ ‏‮up‬‏ ‏‮front‬‏ ‏‮if‬‏ ‏‮possible‬‏."
+    "message": "‏‮A‬‏ ‏‮number‬‏ ‏‮of‬‏ [‏‮WordPress‬‏ ‏‮plugins‬‏](https://wordpress.org/plugins/search/minify+javascript/) ‏‮can‬‏ ‏‮speed‬‏ ‏‮up‬‏ ‏‮your‬‏ ‏‮site‬‏ ‏‮by‬‏ ‏‮concatenating‬‏, ‏‮minifying‬‏, ‏‮and‬‏ ‏‮compressing‬‏ ‏‮your‬‏ ‏‮scripts‬‏. ‏‮You‬‏ ‏‮may‬‏ ‏‮also‬‏ ‏‮want‬‏ ‏‮to‬‏ ‏‮use‬‏ ‏‮a‬‏ ‏‮build‬‏ ‏‮process‬‏ ‏‮to‬‏ ‏‮do‬‏ ‏‮this‬‏ ‏‮minification‬‏ ‏‮up‬‏ ‏‮front‬‏ ‏‮if‬‏ ‏‮possible‬‏."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "‏‮Consider‬‏ ‏‮reducing‬‏, ‏‮or‬‏ ‏‮switching‬‏, ‏‮the‬‏ ‏‮number‬‏ ‏‮of‬‏ [‏‮WordPress‬‏ ‏‮plugins‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/) ‏‮loading‬‏ ‏‮unused‬‏ ‏‮CSS‬‏ ‏‮in‬‏ ‏‮your‬‏ ‏‮page‬‏. ‏‮To‬‏ ‏‮identify‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮are‬‏ ‏‮adding‬‏ ‏‮extraneous‬‏ ‏‮CSS‬‏, ‏‮try‬‏ ‏‮running‬‏ [‏‮code‬‏ ‏‮coverage‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮updates‬‏/2017/04/‏‮devtools‬‏-‏‮release‬‏-‏‮notes‬‏#‏‮coverage‬‏) ‏‮in‬‏ ‏‮Chrome‬‏ ‏‮DevTools‬‏. ‏‮You‬‏ ‏‮can‬‏ ‏‮identify‬‏ ‏‮the‬‏ ‏‮theme‬‏/‏‮plugin‬‏ ‏‮responsible‬‏ ‏‮from‬‏ ‏‮the‬‏ ‏‮URL‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮stylesheet‬‏. ‏‮Look‬‏ ‏‮out‬‏ ‏‮for‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮have‬‏ ‏‮many‬‏ ‏‮stylesheets‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮list‬‏ ‏‮which‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮lot‬‏ ‏‮of‬‏ ‏‮red‬‏ ‏‮in‬‏ ‏‮code‬‏ ‏‮coverage‬‏. ‏‮A‬‏ ‏‮plugin‬‏ ‏‮should‬‏ ‏‮only‬‏ ‏‮enqueue‬‏ ‏‮a‬‏ ‏‮stylesheet‬‏ ‏‮if‬‏ ‏‮it‬‏ ‏‮is‬‏ ‏‮actually‬‏ ‏‮used‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏."
+    "message": "‏‮Consider‬‏ ‏‮reducing‬‏, ‏‮or‬‏ ‏‮switching‬‏, ‏‮the‬‏ ‏‮number‬‏ ‏‮of‬‏ [‏‮WordPress‬‏ ‏‮plugins‬‏](https://wordpress.org/plugins/) ‏‮loading‬‏ ‏‮unused‬‏ ‏‮CSS‬‏ ‏‮in‬‏ ‏‮your‬‏ ‏‮page‬‏. ‏‮To‬‏ ‏‮identify‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮are‬‏ ‏‮adding‬‏ ‏‮extraneous‬‏ ‏‮CSS‬‏, ‏‮try‬‏ ‏‮running‬‏ [‏‮code‬‏ ‏‮coverage‬‏](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) ‏‮in‬‏ ‏‮Chrome‬‏ ‏‮DevTools‬‏. ‏‮You‬‏ ‏‮can‬‏ ‏‮identify‬‏ ‏‮the‬‏ ‏‮theme‬‏/‏‮plugin‬‏ ‏‮responsible‬‏ ‏‮from‬‏ ‏‮the‬‏ ‏‮URL‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮stylesheet‬‏. ‏‮Look‬‏ ‏‮out‬‏ ‏‮for‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮have‬‏ ‏‮many‬‏ ‏‮stylesheets‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮list‬‏ ‏‮which‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮lot‬‏ ‏‮of‬‏ ‏‮red‬‏ ‏‮in‬‏ ‏‮code‬‏ ‏‮coverage‬‏. ‏‮A‬‏ ‏‮plugin‬‏ ‏‮should‬‏ ‏‮only‬‏ ‏‮enqueue‬‏ ‏‮a‬‏ ‏‮stylesheet‬‏ ‏‮if‬‏ ‏‮it‬‏ ‏‮is‬‏ ‏‮actually‬‏ ‏‮used‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "‏‮Consider‬‏ ‏‮reducing‬‏, ‏‮or‬‏ ‏‮switching‬‏, ‏‮the‬‏ ‏‮number‬‏ ‏‮of‬‏ [‏‮WordPress‬‏ ‏‮plugins‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/) ‏‮loading‬‏ ‏‮unused‬‏ ‏‮JavaScript‬‏ ‏‮in‬‏ ‏‮your‬‏ ‏‮page‬‏. ‏‮To‬‏ ‏‮identify‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮are‬‏ ‏‮adding‬‏ ‏‮extraneous‬‏ ‏‮JS‬‏, ‏‮try‬‏ ‏‮running‬‏ [‏‮code‬‏ ‏‮coverage‬‏](‏‮https‬‏://‏‮developers‬‏.‏‮google‬‏.‏‮com‬‏/‏‮web‬‏/‏‮updates‬‏/2017/04/‏‮devtools‬‏-‏‮release‬‏-‏‮notes‬‏#‏‮coverage‬‏) ‏‮in‬‏ ‏‮Chrome‬‏ ‏‮DevTools‬‏. ‏‮You‬‏ ‏‮can‬‏ ‏‮identify‬‏ ‏‮the‬‏ ‏‮theme‬‏/‏‮plugin‬‏ ‏‮responsible‬‏ ‏‮from‬‏ ‏‮the‬‏ ‏‮URL‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮script‬‏. ‏‮Look‬‏ ‏‮out‬‏ ‏‮for‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮have‬‏ ‏‮many‬‏ ‏‮scripts‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮list‬‏ ‏‮which‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮lot‬‏ ‏‮of‬‏ ‏‮red‬‏ ‏‮in‬‏ ‏‮code‬‏ ‏‮coverage‬‏. ‏‮A‬‏ ‏‮plugin‬‏ ‏‮should‬‏ ‏‮only‬‏ ‏‮enqueue‬‏ ‏‮a‬‏ ‏‮script‬‏ ‏‮if‬‏ ‏‮it‬‏ ‏‮is‬‏ ‏‮actually‬‏ ‏‮used‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏."
+    "message": "‏‮Consider‬‏ ‏‮reducing‬‏, ‏‮or‬‏ ‏‮switching‬‏, ‏‮the‬‏ ‏‮number‬‏ ‏‮of‬‏ [‏‮WordPress‬‏ ‏‮plugins‬‏](https://wordpress.org/plugins/) ‏‮loading‬‏ ‏‮unused‬‏ ‏‮JavaScript‬‏ ‏‮in‬‏ ‏‮your‬‏ ‏‮page‬‏. ‏‮To‬‏ ‏‮identify‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮are‬‏ ‏‮adding‬‏ ‏‮extraneous‬‏ ‏‮JS‬‏, ‏‮try‬‏ ‏‮running‬‏ [‏‮code‬‏ ‏‮coverage‬‏](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) ‏‮in‬‏ ‏‮Chrome‬‏ ‏‮DevTools‬‏. ‏‮You‬‏ ‏‮can‬‏ ‏‮identify‬‏ ‏‮the‬‏ ‏‮theme‬‏/‏‮plugin‬‏ ‏‮responsible‬‏ ‏‮from‬‏ ‏‮the‬‏ ‏‮URL‬‏ ‏‮of‬‏ ‏‮the‬‏ ‏‮script‬‏. ‏‮Look‬‏ ‏‮out‬‏ ‏‮for‬‏ ‏‮plugins‬‏ ‏‮that‬‏ ‏‮have‬‏ ‏‮many‬‏ ‏‮scripts‬‏ ‏‮in‬‏ ‏‮the‬‏ ‏‮list‬‏ ‏‮which‬‏ ‏‮have‬‏ ‏‮a‬‏ ‏‮lot‬‏ ‏‮of‬‏ ‏‮red‬‏ ‏‮in‬‏ ‏‮code‬‏ ‏‮coverage‬‏. ‏‮A‬‏ ‏‮plugin‬‏ ‏‮should‬‏ ‏‮only‬‏ ‏‮enqueue‬‏ ‏‮a‬‏ ‏‮script‬‏ ‏‮if‬‏ ‏‮it‬‏ ‏‮is‬‏ ‏‮actually‬‏ ‏‮used‬‏ ‏‮on‬‏ ‏‮the‬‏ ‏‮page‬‏."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "‏‮Read‬‏ ‏‮about‬‏ [‏‮Browser‬‏ ‏‮Caching‬‏ ‏‮in‬‏ ‏‮WordPress‬‏](‏‮https‬‏://‏‮codex‬‏.‏‮wordpress‬‏.‏‮org‬‏/‏‮WordPress‬‏_‏‮Optimization‬‏#‏‮Browser‬‏_‏‮Caching‬‏)."
+    "message": "‏‮Read‬‏ ‏‮about‬‏ [‏‮Browser‬‏ ‏‮Caching‬‏ ‏‮in‬‏ ‏‮WordPress‬‏](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "‏‮Consider‬‏ ‏‮using‬‏ ‏‮an‬‏ [‏‮image‬‏ ‏‮optimization‬‏ ‏‮WordPress‬‏ ‏‮plugin‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/‏‮search‬‏/‏‮optimize‬‏+‏‮images‬‏/) ‏‮that‬‏ ‏‮compresses‬‏ ‏‮your‬‏ ‏‮images‬‏ ‏‮while‬‏ ‏‮retaining‬‏ ‏‮quality‬‏."
+    "message": "‏‮Consider‬‏ ‏‮using‬‏ ‏‮an‬‏ [‏‮image‬‏ ‏‮optimization‬‏ ‏‮WordPress‬‏ ‏‮plugin‬‏](https://wordpress.org/plugins/search/optimize+images/) ‏‮that‬‏ ‏‮compresses‬‏ ‏‮your‬‏ ‏‮images‬‏ ‏‮while‬‏ ‏‮retaining‬‏ ‏‮quality‬‏."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "‏‮Upload‬‏ ‏‮images‬‏ ‏‮directly‬‏ ‏‮through‬‏ ‏‮the‬‏ [‏‮media‬‏ ‏‮library‬‏](‏‮https‬‏://‏‮codex‬‏.‏‮wordpress‬‏.‏‮org‬‏/‏‮Media‬‏_‏‮Library‬‏_‏‮Screen‬‏) ‏‮to‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮required‬‏ ‏‮image‬‏ ‏‮sizes‬‏ ‏‮are‬‏ ‏‮available‬‏, ‏‮and‬‏ ‏‮then‬‏ ‏‮insert‬‏ ‏‮them‬‏ ‏‮from‬‏ ‏‮the‬‏ ‏‮media‬‏ ‏‮library‬‏ ‏‮or‬‏ ‏‮use‬‏ ‏‮the‬‏ ‏‮image‬‏ ‏‮widget‬‏ ‏‮to‬‏ ‏‮ensure‬‏ ‏‮the‬‏ ‏‮optimal‬‏ ‏‮image‬‏ ‏‮sizes‬‏ ‏‮are‬‏ ‏‮used‬‏ (‏‮including‬‏ ‏‮those‬‏ ‏‮for‬‏ ‏‮the‬‏ ‏‮responsive‬‏ ‏‮breakpoints‬‏). ‏‮Avoid‬‏ ‏‮using‬‏ `‏‮Full‬‏ ‏‮Size‬‏` ‏‮images‬‏ ‏‮unless‬‏ ‏‮the‬‏ ‏‮dimensions‬‏ ‏‮are‬‏ ‏‮adequate‬‏ ‏‮for‬‏ ‏‮their‬‏ ‏‮usage‬‏. [‏‮Learn‬‏ ‏‮More‬‏](‏‮https‬‏://‏‮codex‬‏.‏‮wordpress‬‏.‏‮org‬‏/‏‮Inserting‬‏_‏‮Images‬‏_‏‮into‬‏_‏‮Posts‬‏_‏‮and‬‏_‏‮Pages‬‏#‏‮Image‬‏_‏‮Size‬‏)."
+    "message": "‏‮Upload‬‏ ‏‮images‬‏ ‏‮directly‬‏ ‏‮through‬‏ ‏‮the‬‏ [‏‮media‬‏ ‏‮library‬‏](https://codex.wordpress.org/Media_Library_Screen) ‏‮to‬‏ ‏‮ensure‬‏ ‏‮that‬‏ ‏‮the‬‏ ‏‮required‬‏ ‏‮image‬‏ ‏‮sizes‬‏ ‏‮are‬‏ ‏‮available‬‏, ‏‮and‬‏ ‏‮then‬‏ ‏‮insert‬‏ ‏‮them‬‏ ‏‮from‬‏ ‏‮the‬‏ ‏‮media‬‏ ‏‮library‬‏ ‏‮or‬‏ ‏‮use‬‏ ‏‮the‬‏ ‏‮image‬‏ ‏‮widget‬‏ ‏‮to‬‏ ‏‮ensure‬‏ ‏‮the‬‏ ‏‮optimal‬‏ ‏‮image‬‏ ‏‮sizes‬‏ ‏‮are‬‏ ‏‮used‬‏ (‏‮including‬‏ ‏‮those‬‏ ‏‮for‬‏ ‏‮the‬‏ ‏‮responsive‬‏ ‏‮breakpoints‬‏). ‏‮Avoid‬‏ ‏‮using‬‏ `Full Size` ‏‮images‬‏ ‏‮unless‬‏ ‏‮the‬‏ ‏‮dimensions‬‏ ‏‮are‬‏ ‏‮adequate‬‏ ‏‮for‬‏ ‏‮their‬‏ ‏‮usage‬‏. [‏‮Learn‬‏ ‏‮More‬‏](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "‏‮You‬‏ ‏‮can‬‏ ‏‮enable‬‏ ‏‮text‬‏ ‏‮compression‬‏ ‏‮in‬‏ ‏‮your‬‏ ‏‮web‬‏ ‏‮server‬‏ ‏‮configuration‬‏."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "‏‮Consider‬‏ ‏‮using‬‏ ‏‮a‬‏ [‏‮plugin‬‏](‏‮https‬‏://‏‮wordpress‬‏.‏‮org‬‏/‏‮plugins‬‏/‏‮search‬‏/‏‮convert‬‏+‏‮webp‬‏/) ‏‮or‬‏ ‏‮service‬‏ ‏‮that‬‏ ‏‮will‬‏ ‏‮automatically‬‏ ‏‮convert‬‏ ‏‮your‬‏ ‏‮uploaded‬‏ ‏‮images‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮optimal‬‏ ‏‮formats‬‏."
+    "message": "‏‮Consider‬‏ ‏‮using‬‏ ‏‮a‬‏ [‏‮plugin‬‏](https://wordpress.org/plugins/search/convert+webp/) ‏‮or‬‏ ‏‮service‬‏ ‏‮that‬‏ ‏‮will‬‏ ‏‮automatically‬‏ ‏‮convert‬‏ ‏‮your‬‏ ‏‮uploaded‬‏ ‏‮images‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮optimal‬‏ ‏‮formats‬‏."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/ar.json
+++ b/lighthouse-core/lib/i18n/locales/ar.json
@@ -1,6 +1,6 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "تتيح مفاتيح الوصول للمستخدمين التركيز بسرعة على جزء من الصفحة. للانتقال الصحيح، يجب أن يكون كل مفتاح وصول فريدًا. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "تتيح مفاتيح الوصول للمستخدمين التركيز بسرعة على جزء من الصفحة. للانتقال إلى الموضع الصحيح من الصفحة، يجب أن يكون كل مفتاح وصول فريدًا. [مزيد من المعلومات](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
     "message": "قيم `[accesskey]` غير فريدة"
@@ -9,7 +9,7 @@
     "message": "قيم `[accesskey]` فريدة"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "يوفّر كل \"دور\" ARIA مجموعة فرعية محدّدة من سمات `aria-*`. يؤدي عدم تطابق هذه الأدوار إلى إبطال السمات `aria-*`. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "يوفّر كل دور ARIA `role` مجموعة فرعية محددة من سمات `aria-*`. يؤدي عدم تطابق هذه الأدوار إلى إبطال السمات `aria-*`. [مزيد من المعلومات](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
     "message": "عدم تطابق سمات `[aria-*]` مع أدوارها"
@@ -18,25 +18,25 @@
     "message": "مطابقة سمات `[aria-*]` لأدوارها"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "تتطلّب بعض أدوار ARIA تزويد برامج قراءة الشاشة بسمات تصف حالة العنصر. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "تتطلّب بعض أدوار ARIA تزويد برامج قراءة الشاشة بسمات تصف حالة العنصر. [مزيد من المعلومات](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "عدم احتواء `[role]` على جميع سمات `[aria-*]` المطلوبة"
+    "message": "عدم احتواء `[role]` على جميع سمات`[aria-*]` المطلوبة"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
     "message": "احتواء `[role]` على جميع سمات `[aria-*]` المطلوبة"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "يجب أن تحتوي بعض أدوار ARIA الرئيسية على أدوار ثانوية محدّدة لأداء وظائف إمكانية الوصول المقصودة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "يجب أن تحتوي بعض أدوار ARIA الرئيسية على أدوار ثانوية محدّدة لأداء وظائف إمكانية الوصول المقصودة. [مزيد من المعلومات](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "العناصر التي تتضمّن`[role]` والتي تتطلب `[role]` محدّدة للأطفال مفقودة."
+    "message": "العناصر التي تتضمّن `[role]` والتي تتطلب `[role]`محدّدة للأطفال مفقودة."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "العناصر التي تتضمّن`[role]` والتي تتطلب `[role]` محدّدة للأطفال متوفرة"
+    "message": "العناصر التي تتضمن `[role]` والتي تتطلب `[role]` محدّدة للأطفال متوفّرة"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "يجب أن يتم احتواء بعض أدوار ثانوية ARIA ضمن أدوار رئيسية محدّدة لتنفيذ وظائف إمكانية الوصول المقصودة بشكل صحيح. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "يجب أن يتم احتواء بعض أدوار ثانوية ARIA ضمن أدوار رئيسية محدّدة لتنفيذ وظائف إمكانية الوصول المقصودة بشكل صحيح. [مزيد من المعلومات](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
     "message": "عدم تضمين `[role]` من خلال العنصر الرئيسي المطلوب"
@@ -45,46 +45,46 @@
     "message": "تضمين `[role]` من خلال العنصر الرئيسي المطلوب"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "يجب أن تحتوي أدوار ARIA على قيم صالحة لتنفيذ وظائف إمكانية الوصول المقصودة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "يجب أن تحتوي أدوار ARIA على قيم صالحة لتنفيذ وظائف إمكانية الوصول المقصودة. [مزيد من المعلومات](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "قيم `[role]` غير صحيحة"
+    "message": "قيم `[role]` غير صالحة"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "قيم `[role]` صحيحة"
+    "message": "قيم `[role]` صالحة"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "لا يمكن لتقنيات المساعدة، مثل برامج قراءة الشاشة، تفسير سمات ARIA باستخدام قيم غير صحيحة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "لا يمكن لتقنيات المساعدة، مثل برامج قراءة الشاشة، تفسير سمات ARIA باستخدام قيم غير صحيحة. [مزيد من المعلومات](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "عدم احتواء سمات `[aria-*]`على قيم صحيحة"
+    "message": "عدم احتواء سمات `[aria-*]` على قيم صحيحة"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "احتواء سمات `[aria-*]`على قيم صحيحة"
+    "message": "احتواء سمات `[aria-*]` على قيم صالحة"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "لا يمكن لتقنيات المساعدة، مثل برامج قراءة الشاشة، تفسير سمات ARIA بأسماء غير صحيحة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "لا يمكن لتقنيات المساعدة، مثل برامج قراءة الشاشة، تفسير سمات ARIA بأسماء غير صحيحة. [مزيد من المعلومات](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "سمات `[aria-*]` غير صحيحة أو بها خطأ إملائي"
+    "message": "سمات `[aria-*]` غير صالحة أو بها أخطاء إملائية"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "سمات `[aria-*]` صحيحة وليس بها أخطاء إملائية"
+    "message": "سمات `[aria-*]` صالحة وليس بها أخطاء إملائية"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "تسهّل الشروح على الصُم أو الذين يعانون من إعاقة سمعية استخدام العناصر الصوتية والاطّلاع بالتالي على معلومات مهمة، مثل هوية الشخص المتحدث والحوار الذي يدور ومعلومات أخرى بخلاف الكلام. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "تجعل الشروح العناصر الصوتية قابلة للاستخدام للمستخدمين الصُم أو الذين يعانون من إعاقة سمعية، ما يوفّر معلومات مهمة، مثل الشخص المتحدث والحوار الذي يدور ومعلومات أخرى بخلاف الكلام. [مزيد من المعلومات](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "فقدان عناصر `<audio>` عنصر `<track>` يتضمّن `[kind=\"captions\"]`."
+    "message": "فقدان عناصر `<audio>` عنصر `<track>`يتضمن `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "احتواء عناصر `<audio>` على عنصر `<track>` يتضمّن `[kind=\"captions\"]`"
+    "message": "احتواء العناصر `<audio>` على عنصر `<track>` مع `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
-    "message": "العناصر التي تعذّرت"
+    "message": "العناصر التي رسبت في عملية التدقيق"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "في حال كان أحد الأزرار لا يحمل اسمًا يمكن الوصول إليه، تعلن برامج قراءة الشاشة بأنه \"زر\"، ما يجعله غير قابل للاستخدام بالنسبة إلى المستخدمين الذين يعتمدون على برامج قراءة الشاشة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "عند عدم احتواء زر على اسم يمكن الوصول إليه، تعلن برامج قراءة الشاشة بأنه \"زر\"، ما يجعله غير قابل للاستخدام بالنسبة إلى المستخدمين الذين يعتمدون على برامج قراءة الشاشة. [مزيد من المعلومات](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "عدم احتواء الأزرار على اسم يمكن الوصول إليه"
@@ -93,7 +93,7 @@
     "message": "احتواء الأزرار على اسم الوصول"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "تؤدي إضافة طرق لتخطي المحتوى المكرّر إلى السماح لمستخدمي لوحة المفاتيح بالتنقل في الصفحة بكفاءة أكبر. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "تؤدي إضافة طرق لتخطي المحتوى المكرّر إلى السماح لمستخدمي لوحة المفاتيح بالتنقل في الصفحة بكفاءة أكبر. [مزيد من المعلومات](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "عدم احتواء الصفحة على عنوان أو رابط تخطٍ أو منطقة معالم"
@@ -102,7 +102,7 @@
     "message": "احتواء الصفحة على عنوان أو رابط تخطٍ أو منطقة معالم"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "يعتبر العديد من المستخدمين أنّه من الصعب أو المستحيل عليهم قراءة نص منخفض التباين. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "النص منخفض التباين صعب أو مستحيل قراءته بالنسبة إلى العديد من المستخدمين. [مزيد من المعلومات](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "عدم احتواء الخلفية وألوان الخلفية على نسبة تباين كافية"
@@ -111,16 +111,16 @@
     "message": "تمييز الخلفية والألوان الخلفية بنسبة تباين كافية"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "عندما لا يتم ترميز قوائم التعريفات بشكل صحيح، قد تقدم برامج قراءة الشاشة نتائج غير واضحة أو غير دقيقة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "عندما لا يتم ترميز قوائم التعريفات بشكل صحيح، قد تقدم برامج قراءة الشاشة نتائج غير واضحة أو غير دقيقة. [مزيد من المعلومات](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "عدم احتواء `<dl>` على مجموعات `<dt>` و`<dd>` المرتبة بشكلٍ صحيح فقط، أو العناصر `<script>` أو `<template>`."
+    "message": "عدم احتواء `<dl>` على مجموعات `<dt>` و`<dd>` المرتبة بشكلٍ صحيح فقط، أو العناصر `<script>` أو `<template>`"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
     "message": "احتواء `<dl>` على مجموعات `<dt>` و`<dd>` المرتبة بشكلٍ صحيح فقط، أو العناصر `<script>` أو `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "يجب إدراج عناصر قائمة التعريفات (`<dt>` و`<dd>`) في عنصر رئيسي `<dl>` وذلك لضمان إمكانية إعلان برامج قراءة الشاشة عنها بشكل صحيح. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "يجب إدراج عناصر قائمة التعريفات (`<dt>` و`<dd>`) في عنصر رئيسي `<dl>` وذلك لضمان إمكانية إعلان برامج قراءة الشاشة عنها بشكل صحيح. [مزيد من المعلومات](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
     "message": "عدم التفاف عناصر قائمة التعريفات في عناصر `<dl>`"
@@ -129,7 +129,7 @@
     "message": "التفاف عناصر قائمة التعريفات في عناصر `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "يمنح العنوان مستخدمي برامج قراءة الشاشة نظرة عامة على الصفحة، ويعتمد مستخدمو محرك البحث على هذا بشكل كبير لتحديد ما إذا كانت الصفحة ذات صلة ببحثهم أو لا. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "يمنح العنوان مستخدمي برامج قراءة الشاشة نظرة عامة على الصفحة، ويعتمد مستخدمو محرك البحث على هذا بشكل كبير لتحديد ما إذا كانت الصفحة ذات صلة ببحثهم أو لا. [مزيد من المعلومات](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "عدم احتواء المستند على عنصر `<title>`"
@@ -138,7 +138,7 @@
     "message": "احتواء المستند على عنصر `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "يجب أن تكون قيمة سمة رقم التعريف فريدة لكي لا تتغاضى تقنيات المساعدة عن الأمثلة الأخرى. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "يجب أن تكون قيمة سمة رقم التعريف فريدة لكي لا تتغاضى تقنيات المساعدة عن الأمثلة الأخرى. [مزيد من المعلومات](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
     "message": "سمات `[id]` في الصفحة غير فريدة"
@@ -147,16 +147,16 @@
     "message": "سمات `[id]` في الصفحة فريدة"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "يعتمد مستخدمو برامج قراءة الشاشة على عناوين الإطارات لوصف محتوى الإطارات. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "يعتمد مستخدمو برامج قراءة الشاشة على عناوين الإطارات لوصف محتوى الإطارات. [مزيد من المعلومات](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "عدم تضمين عناصر `<frame>` أو`<iframe>` لأي عنوان"
+    "message": "عدم احتواء عناصر `<frame>` أو `<iframe>` على عنوان"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
     "message": "احتواء عناصر `<frame>` أو `<iframe>` على عنوان"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "في حال لم تحدّد الصفحة سمة اللغة، يفترض قارئ الشاشة أن تكون الصفحة باللغة التلقائية التي اختارها المستخدم عند إعداد قارئ الشاشة. في حال لم تكن الصفحة باللغة التلقائية فعليًا، حينئذٍ قد لا يُعلِن قارئ الشاشة عن نص الصفحة بشكل صحيح. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "في حال لم تحدّد الصفحة سمة اللغة، يفترض قارئ الشاشة أن تكون الصفحة باللغة التلقائية التي اختارها المستخدم عند إعداد قارئ الشاشة. في حال لم تكن الصفحة باللغة التلقائية فعليًا، حينئذٍ قد لا يُعلِن قارئ الشاشة عن نص الصفحة بشكل صحيح. [مزيد من المعلومات](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
     "message": "عدم احتواء عنصر `<html>` على سمة `[lang]`"
@@ -165,16 +165,16 @@
     "message": "احتواء عنصر `<html>` على سمة `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "يؤدي تحديد [BCP 47 language] (https://www.w3.org/International/questions/qa-choosing-language-tags#question) صحيحة إلى مساعدة برامج قراءة الشاشة على الإعلان عن النص بشكلٍ صحيح. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "يؤدي تحديد [لغة BCP 47 ](https://www.w3.org/International/questions/qa-choosing-language-tags#question) صحيحة إلى مساعدة برامج قراءة الشاشة على الإعلان عن النص بشكلٍ صحيح. [مزيد من المعلومات](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "عدم احتواء عنصر `<html>` على قيمة صحيحة للسمة `[lang]`."
+    "message": "عدم احتواء العنصر `<html>` على قيمة صالحة للسمة `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
     "message": "احتواء عنصر `<html>` على قيمة صحيحة لسمة `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "يجب أن تتضمن العناصر الإعلامية نصًا بديلاً وصفيًا وقصيرًا. يمكن تجاهل العناصر الزخرفية من خلال استخدام سمة نص بديل فارغة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "يجب أن تهدف العناصر الإعلامية إلى نص وصفي بديل وقصير. يمكن تجاهل العناصر الزخرفية بسمة النص البديل الفارغة. [مزيد من المعلومات](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
     "message": "عدم احتواء عناصر الصور على سمات `[alt]`"
@@ -183,7 +183,7 @@
     "message": "احتواء عناصر الصور على سمات `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "عند استخدام صورة كزر `<input>`، يمكن أن يساعد توفير نص بديل مستخدمي قارئ الشاشة على فهم الغرض من الزر. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "عند استخدام صورة كزر `<input>`، يمكن أن يساعد توفير نص بديل مستخدمي قارئ الشاشة على فهم الغرض من الزر. [مزيد من المعلومات](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "عدم احتواء عناصر `<input type=\"image\">` على نص `[alt]`"
@@ -192,7 +192,7 @@
     "message": "احتواء عناصر `<input type=\"image\">` على نص `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "تضمن التصنيفات الإعلان عن عناصر التحكّم بالنموذج بشكل صحيح من خلال التقنيات المساعدة، مثل برامج قراءة الشاشة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "تضمن التصنيفات الإعلان عن عناصر التحكّم بالنموذج بشكل صحيح من خلال التقنيات المساعدة، مثل برامج قراءة الشاشة. [مزيد من المعلومات](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "عدم احتواء عناصر النموذج على تصنيفات مرتبطة"
@@ -201,16 +201,16 @@
     "message": "احتواء عناصر النموذج على التصنيفات المرتبطة"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "يجب ألا يشتمل الجدول المُستخدم لأغراض التنسيق على عناصر البيانات، مثل عناصر الشرح أو سمة الملخّص، لأن ذلك قد يربك لمستخدمي برامج قراءة الشاشة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "يجب ألا يشتمل الجدول المُستخدم لأغراض التنسيق على عناصر البيانات، مثل عناصر الشرح أو سمة الملخّص، لأن ذلك يمكن أن ينشئ تجربة محيرة لمستخدمي برامج قراءة الشاشة. [مزيد من المعلومات](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "عدم تجنب عناصر `<table>` للعرض التقديمي استخدام `<th>` أو `<caption>` أو السمة `[summary]`."
+    "message": "عدم تجنُّب عناصر `<table>` للعرض التقديمي استخدام `<th>` أو `<caption>` أو السمة `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "تجنُب عناصر `<table>` للعرض التقديمي استخدام `<th>` أو `<caption>` أو السمة `[summary]`."
+    "message": "تجنُّب عناصر `<table>` للعرض التقديمي استخدام `<th>` أو `<caption>` أو السمة `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "يحسّن نص الرابط (والنص البديل للصور، عند استخدامه كروابط) الذي يُعد مميّزًا وفريدًا وقابلاً للتركيز تجربة التنقل لمستخدمي برامج قراءة الشاشة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "يحسّن نص الرابط (والنص البديل للصور، عند استخدامه كروابط) الذي يُعد مميّزًا وفريدًا وقابلاً للتركيز تجربة التنقل لمستخدمي برامج قراءة الشاشة. [مزيد من المعلومات](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "عدم احتواء الروابط على اسم مميّز"
@@ -219,43 +219,43 @@
     "message": "احتواء الروابط على اسم مميز"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "تعتمد برامج قراءة الشاشة على طريقة محدّدة للإعلان عن القوائم. يؤدي ضمان بنية القائمة المناسبة إلى المساعدة على الاستماع إلى قارئ الشاشة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "تعتمد برامج قراءة الشاشة على طريقة محدّدة للإعلان عن القوائم. يؤدي ضمان بنية القائمة المناسبة إلى المساعدة على الاستماع إلى قارئ الشاشة. [مزيد من المعلومات](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "عدم احتواء القوائم على عناصر `<li>` فقط وعناصر دعم النص البرمجي (`<script>` و`<template>`)"
+    "message": "عدم احتواء القوائم على عناصر `<li>` وعناصر دعم النص البرمجي (`<script>` و`<template>`) فقط."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
     "message": "احتواء القوائم على عناصر `<li>` وعناصر دعم النص البرمجي (`<script>` و`<template>`) فقط."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "تتطلّب برامج قراءة الشاشة عناصر قائمة (`<li>`) يجب احتواؤها ضمن عنصر رئيسي `<ul>` أو `<ol>` حتى يتم الإعلان عنها بشكلٍ صحيح. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "تتطلّب برامج قراءة الشاشة عناصر قائمة (`<li>`) يجب احتواؤها ضمن عنصر رئيسي `<ul>` أو `<ol>` حتى يتم الإعلان عنها بشكلٍ صحيح. [مزيد من المعلومات](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "عناصر القائمة (`<li>`) لا تتضمّن العناصر الرئيسية `<ul>` أو `<ol>`"
+    "message": "عدم تضمين عناصر القائمة (`<li>`) في العناصر الرئيسية `<ul>` أو `<ol>`"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
     "message": "تضمين عناصر القائمة (`<li>`) في العناصر الرئيسية `<ul>` أو `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "لا يتوقع المستخدمون إعادة تحميل صفحة تلقائيًا، وسيؤدي ذلك إلى نقل التركيز مرة أخرى إلى أعلى الصفحة. وقد ينشأ عن ذلك تجربة محبطة ومربكة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "لا يتوقع المستخدمون إعادة تحميل صفحة تلقائيًا، وسيؤدي ذلك إلى نقل التركيز مرة أخرى إلى أعلى الصفحة. وقد ينشأ عن ذلك تجربة محبطة ومربكة. [مزيد من المعلومات](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "استخدام المستند مع `<meta http-equiv=\"refresh\">`"
+    "message": "استخدام المستند `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "عدم استخدام المستند مع `<meta http-equiv=\"refresh\">`"
+    "message": "عدم استخدام المستند `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "يمثّل إيقاف التكبير/التصغير مشكلة بالنسبة إلى المستخدمين ضعاف البصر الذين يعتمدون على تكبير الشاشة لمشاهدة محتوى صفحة الويب بشكل صحيح. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "يسبب إيقاف التكبير/التصغير مشكلة بالنسبة إلى المستخدمين ضعاف البصر الذين يعتمدون على تكبير الشاشة لمشاهدة محتوى صفحة الويب بشكل صحيح. [مزيد من المعلومات](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "استخدام `[user-scalable=\"no\"]` في العنصر `<meta name=\"viewport\">` أو السمة `[maximum-scale]` والتي تُعد أقل من 5."
+    "message": "استخدام `[user-scalable=\"no\"]` في العنصر `<meta name=\"viewport\">` أو السمة `[maximum-scale]` تكون أقل من 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
     "message": "عدم استخدام `[user-scalable=\"no\"]` في العنصر `<meta name=\"viewport\">` والسمة `[maximum-scale]` لا تكون أقل من 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "لا يمكن لبرامج قراءة الشاشة ترجمة المحتوى غير النصي. تؤدي إضافة نص بديل إلى عناصر `<object>` إلى مساعدة برامج قراءة الشاشة على نقل المعنى إلى المستخدمين. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "لا يمكن لبرامج قراءة الشاشة ترجمة المحتوى غير النصي. تؤدي إضافة نص بديل إلى عناصر `<object>` إلى مساعدة برامج قراءة الشاشة على نقل المعنى إلى المستخدمين. [مزيد من المعلومات](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "عدم احتواء عناصر `<object>` على نص `[alt]`"
@@ -264,7 +264,7 @@
     "message": "احتواء عناصر `<object>` على نص `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "تشير القيمة الأكبر من 0 إلى وجود طلب تنقل صريح. على الرغم من أن ذلك صحيح تقنيًّا، غالبًا ما يؤدي ذلك إلى إنشاء تجارب محبطة للمستخدمين الذين يعتمدون على التقنيات المساعدة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "تشير القيمة الأكبر من 0 إلى وجود طلب تنقل صريح. على الرغم من أن ذلك صحيح تقنيًّا، غالبًا ما يؤدي ذلك إلى إنشاء تجارب محبطة للمستخدمين الذين يعتمدون على التقنيات المساعدة. [مزيد من المعلومات](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "احتواء بعض العناصر على قيمة `[tabindex]` أكبر من 0"
@@ -273,49 +273,61 @@
     "message": "عدم توفُّر عنصر له قيمة `[tabindex]` أكبر من 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "تحتوي برامج قراءة الشاشة على ميزات لتسهيل التنقل بين الجداول. يمكن تحسين تجربة استخدام برامج قراءة الشاشة من خلال ضمان إشارة الخلايا `<td>` التي تستخدم السمة `[headers]` إلى خلايا أخرى في الجدول نفسه فقط. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "تحتوي برامج قراءة الشاشة على ميزات لتسهيل التنقل بين الجداول. يمكن تحسين تجربة استخدام برامج قراءة الشاشة من خلال ضمان إشارة الخلايا `<td>` التي تستخدم السمة `[headers]` إلى خلايا أخرى في الجدول نفسه فقط. [مزيد من المعلومات](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "الخلايا في العنصر `<table>` التي تستخدم السمة `[headers]` تشير إلى وجود خلايا أخرى لهذا الجدول نفسه."
-  },
-  "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
     "message": "الخلايا الواردة في عنصر `<table>` التي تستخدم السمة `[headers]` تشير فقط إلى خلايا أخرى في الجدول نفسه."
   },
+  "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
+    "message": "تشير الخلايا الموجودة في عنصر `<table>` التي تستخدم السمة `[headers]` إلى خلايا أخرى في الجدول نفسه فقط."
+  },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "تحتوي برامج قراءة الشاشة على ميزات لتسهيل التنقل بين الجداول. ويمكن تحسين تجربة استخدام برامج قراءة الشاشة من خلال الحرص على أن تشير عناوين الجداول دائمًا إلى بعض مجموعات الخلايا. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "تحتوي برامج قراءة الشاشة على ميزات لتسهيل التنقل بين الجداول. قد يؤدي ضمان أن عناوين الجداول تشير دائمًا إلى بعض مجموعات الخلايا إلى تحسين تجربة مستخدمي برامج قراءة الشاشة. [مزيد من المعلومات](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "عدم احتواء عناصر `<th>` وعناصر تتضمّن `[role=\"columnheader\"/\"rowheader\"]` على خلايا البيانات التي يتم وصفها"
+    "message": "عدم احتواء عناصر `<th>` وعناصر `[role=\"columnheader\"/\"rowheader\"]` على خلايا البيانات التي يتم وصفها."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
     "message": "احتواء عناصر `<th>` وعناصر `[role=\"columnheader\"/\"rowheader\"]` على خلايا البيانات التي يتم وصفها"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "يؤدي تحديد [BCP 47 language] (https://www.w3.org/International/questions/qa-choosing-language-tags#question) صحيحة على العناصر إلى المساعدة على ضمان نطق النص بشكلٍ صحيح من خلال قارئ الشاشة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "يؤدي تحديد [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) صحيحة على العناصر إلى المساعدة على ضمان نطق النص بشكلٍ صحيح من خلال قارئ الشاشة. [مزيد من المعلومات](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "عدم احتواء سمات `[lang]` على قيمة صحيحة"
+    "message": "عدم احتواء سمات `[lang]` على قيمة صالحة"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "احتواء سمات `[lang]` على قيمة صحيحة"
+    "message": "احتواء سمات `[lang]` على قيمة صالحة"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "عندما يقدم الفيديو شرحًا، يَسهُل على المستخدمين الصُم والذين يعانون من إعاقة سمعية الوصول إلى معلوماته. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "عندما يقدم الفيديو شرحًا، يَسهُل على المستخدمين الصُم والذين يعانون من إعاقة سمعية الوصول إلى معلوماته. [مزيد من المعلومات](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "عدم احتواء عناصر `<video>` على عنصر `<track>` يتضمّن `[kind=\"captions\"]`."
+    "message": "عدم احتواء عناصر `<video>` على عنصر `<track>` مع `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "احتواء عناصر `<video>` على عنصر `<track>` يتضمّن `[kind=\"captions\"]`"
+    "message": "احتواء العناصر `<video>` على عنصر `<track>` مع `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "توفّر الأوصاف الصوتية معلومات ذات صلة للفيديوهات، لا يمكن توفيرها في الحوار مثل تعبيرات الوجه وأجواء الإضاءة. [مزيد من المعلومات](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "توفّر الأوصاف الصوتية معلومات ذات صلة للفيديوهات التي لا يمكن إجراء الحوار بها، مثل تعبيرات الوجه وأجواء الإضاءة. [مزيد من المعلومات](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "عدم احتواء عناصر `<video>` على عنصر `<track>` يتضمّن `[kind=\"description\"]`"
+    "message": "عدم احتواء عناصر `<video>` على عنصر `<track>` مع `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "احتواء عناصر `<video>` على عنصر `<track>` الذي يتضمّن `[kind=\"description\"]`"
+    "message": "احتواء العناصر `<video>` على عنصر `<track>` مع `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "للحصول على المظهر المثالي على نظام التشغيل iOS عندما يضيف المستخدمون إلى الشاشة الرئيسية، يمكنك تحديد رمز-اللمس-apple. يجب أن يشير إلى 192px غير شفاف (أو 180px) مربع PNG. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "عدم تقديم رمز `apple-touch-icon` صالح"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` هو إصدار قديم، و`apple-touch-icon` مفضل."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "تقديم رمز `apple-touch-icon` صالح"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "أثّرت \"إضافات Chrome\" بشكلٍ سلبي في أداء التحميل لهذه الصفحة. ويمكنك تجربة تدقيق الصفحة في وضع التصفُّح المُتخفّي أو من ملف شخصي على Chrome بدون الإضافات."
@@ -330,7 +342,7 @@
     "message": "الوقت الإجمالي لوحدة المعالجة المركزية"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "يمكنك تقليل الوقت المستغرق في تحليل جافا سكريبت وإنشائه وتنفيذه. قد يتبين لك أن تسليم أحمال جافا سكريبت بحجم أصغر يساعد في ذلك. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "يمكنك تقليل الوقت المستغرق في تحليل جافا سكريبت وإنشائها وتنفيذها. قد يتبين لك أن تسليم أحمال جافا سكريبت بحجم أصغر يساعد على ذلك. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "تقليل وقت تنفيذ جافا سكريبت"
@@ -339,28 +351,28 @@
     "message": "وقت تنفيذ جافا سكريبت"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "لا تكفي ملفات GIF الكبيرة لتسليم محتوى صور متحركة. لذا يمكنك استخدام فيديوهات MPEG4 / WebM للصور المتحركة وملفات PNG / WebP للصور الثابتة بدلاً من ملفات GIF لحفظ وحدات البايت للشبكة. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "ملفات GIF الكبيرة غير كافية لعرض محتوى صور متحركة. يمكنك استخدام فيديوهات MPEG4/WebM للصور المتحركة وملفات PNG/WebP للصور الثابتة بدلاً من ملف GIF لحفظ وحدات البايت للشبكة. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "استخدام تنسيقات الفيديو لمحتوى الصور المتحركة"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "خُذ بعين الاعتبار التحميل البطئ خارج الشاشة والصور المخفية بعد الانتهاء من تحميل جميع الموارد المهمة في وقت أقل تفاعلية. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "يمكنك إجراء تحميل بطيء خارج الشاشة والصور المخفية بعد الانتهاء من تحميل جميع الموارد المهمة في وقت أقل تفاعلية. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "تأجيل الصور خارج الشاشة"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "تحظر الموارد العرض الأول لصفحتك. ويمكنك تسليم تضمين JS / CSS المهم وتأجيل كل الأنماط/جافا سكريبت غير المهمة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "تحظر الموارد سرعة عرض الصفحة لصفحتك. ويمكنك تسليم تضمين جافا سكريبت/CSS المهمة وتأجيل جميع الأنماط/جافا سكريبت غير المهمة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "استبعاد موارد حظر العرض"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "تُكلِّف أحمال الشبكة الكبيرة المستخدمين الكثير من الأموال وترتبط مباشرةً بأوقات التحميل الطويلة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "تُكلِّف أحمال الشبكة الكبيرة المستخدمين الكثير من الأموال وترتبط مباشرةً بأوقات التحميل الطويلة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "كان إجمالي الحجم {totalBytes, number, bytes} كيلوبايت"
+    "message": "كان إجمالي الحجم {totalBytes, number, bytes} كيلوبايت."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "تجنُّب الأحمال الضخمة للشبكة"
@@ -369,19 +381,19 @@
     "message": "تجنُّب الأحمال الضخمة للشبكة"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "يمكن أن يؤدي تصغير ملفات CSS إلى تقليل أحجام حمولة الشبكة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "يمكن أن يؤدي تصغير ملفات CSS إلى تقليل أحجام حمولة الشبكة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "تصغير CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "يمكن أن يؤدي تصغير ملفات جافا سكريبت إلى تقليل أحجام الأحمال ووقت تحليل النص البرمجي. [مزيد من المعلومات](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "يمكن أن يؤدي تصغير ملفات جافا سكريبت إلى تقليل أحجام الأحمال ووقت تحليل النص البرمجي. [مزيد من المعلومات](https://developers.google.com/speed/docs/insights/MinifyResources)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "تصغير جافا سكريبت"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "يمكنك إزالة القواعد الضارة من أوراق الأنماط وتأجيل تحميل خدمة CSS غير المستخدمة في محتوى الجزء المرئي من الصفحة للحد من وحدات البايت غير الضرورية المستهلكة من خلال نشاط الشبكة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "يمكنك إزالة القواعد الضارة من أوراق الأنماط وتأجيل تحميل خدمة CSS غير المستخدمة في محتوى الجزء المرئي من الصفحة للحد من وحدات البايت غير الضرورية المستهلكة من خلال نشاط الشبكة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "إزالة خدمة CSS غير المُستخدَمة"
@@ -393,7 +405,7 @@
     "message": "إزالة جافا سكريبت غير المستخدم"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "يمكن لفترة التخزين المؤقت الطويلة تسريع عملية تكرار الزيارات إلى صفحتك. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "يمكن لفترة التخزين المؤقت الطويلة تسريع عملية تكرار الزيارات إلى صفحتك. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{تم العثور على مورد واحد}zero{تم العثور على # مورد}two{تم العثور على مورديْنِ (#)}few{تم العثور على # موارد}many{تم العثور على # موردًا}other{تم العثور على # مورد}}"
@@ -405,37 +417,88 @@
     "message": "استخدام سياسة ذاكرة التخزين المؤقت الفعالة على الأصول الثابتة"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "يتم تحميل الصور المحسَّنة بشكلٍ أسرع وتستهلك بيانات أقل لشبكة الجوّال. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "يتم تحميل الصور المحسَّنة بشكلٍ أسرع وتستهلك بيانات أقل لشبكة الجوّال. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "تشفير الصور بكفاءة"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "يمكنك عرض صور بحجم مناسب لحفظ بيانات شبكة الجوّال وتحسين وقت التحميل. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "يمكنك عرض صور بحجم مناسب لحفظ بيانات شبكة الجوّال وتحسين وقت التحميل. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "الصور ذات الحجم المناسب"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "يجب عرض الموارد المستندة إلى النص باستخدام الضغط (gzip أو الانكماش أو brotli) لتقليل إجمالي وحدات البايت للشبكة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "يجب عرض الموارد المستندة إلى النص باستخدام الضغط (gzip أو الانكماش أو brotli) لتقليل إجمالي وحدات البايت للشبكة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "تفعيل ضغط النص"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "غالبًا ما توفِّر تنسيقات الصور، مثل JPEG 2000 وJPEG XR وWebP، ضغطًا أفضل من تنسيق PNG أو JPEG، وهذا بدوره يعني تنزيلاً أسرع واستهلاكًا أقل للبيانات. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "غالبًا ما توفِّر تنسيقات الصور، مثل JPEG 2000 وJPEG XR وWebP، ضغطًا أفضل من تنسيق PNG أو JPEG، وهذا يعني تنزيلاً أسرع واستهلاكًا أقل للبيانات. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "عرض الصور بتنسيقات الجيل القادم"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "توضح لك \"سلاسل الطلبات المهمة\" أدناه الموارد التي تم تحميلها بأولوية عالية. ويمكنك تقليل طول السلاسل أو تقليل حجم تنزيل الموارد أو تأجيل تنزيل الموارد غير الضرورية لتحسين تحميل الصفحة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "توضح لك \"سلاسل الطلبات المهمة\" أدناه الموارد التي تم تحميلها بأولوية عالية. ويمكنك تقليل طول السلاسل أو تقليل حجم تنزيل الموارد أو تأجيل تنزيل الموارد غير الضرورية لتحسين تحميل الصفحة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{تم العثور على سلسلة واحدة}zero{تم العثور على # سلسلة}two{تم العثور على سلسلتيْنِ (#)}few{تم العثور على # سلاسل}many{تم العثور على # سلسلةً}other{تم العثور على # سلسلة}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "تقليل عمق الطلبات المهمة"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "إيقاف / تحذير"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "سطر"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "ستتم في النهاية إزالة واجهات برمجة التطبيقات المتوقفة من المتصفح. [مزيد من المعلومات](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{تم العثور على تحذير واحد}zero{تم العثور على # تحذير}two{تم العثور على تحذيرين (#)}few{تم العثور على # تحذيرات}many{تم العثور على # تحذيرًا}other{تم العثور على # تحذير}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "استخدام واجهات برمجة التطبيقات المتوقفة"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "يتجنب واجهات برمجة التطبيقات المتوقفة"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "تم إيقاف ذاكرة التخزين المؤقت للتطبيق. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "تم العثور على \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "استخدام ذاكرة التخزين المؤقت للتطبيق"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "تجنُب ذاكرة التخزين المؤقت للتطبيق"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "يؤدي تحديد DOCTYPE إلى منع المتصفح من التبديل إلى وضع Quirks. تعرّف على مزيد من المعلومات في [صفحة مستندات ويب MDN](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "يجب أن يكون اسم DOCTYPE هو سلسلة الأحرف الصغيرة `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "يجب أن يحتوي المستند على DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "من الممكن أن تكون publicId المتوقعة سلسلة فارغة"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "من الممكن أن تكون systemId المتوقعة سلسلة فارغة"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "تفتقر الصفحة إلى HTML DOCTYPE، مما يؤدي إلى تشغيل وضع Quirks."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "احتواء الصفحة على HTML DOCTYPE"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "العنصر"
@@ -447,7 +510,7 @@
     "message": "القيمة"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "يوصي مهندسو المتصفح بالصفحات التي تحتوي على أقل من ~1500 عنصر DOM. ويمثل أفضل مكان للاستماع إلى مكبِّرات الصوت شبكة عمقها < 32 عنصرًا ولا تزيد عن 60 عنصرًا فرعيًا/رئيسيًا. ويمكن أن يزيد عنصر DOM الكبير من استخدام الذاكرة، ويسبب [عمليات حسابية نمطية] أطول (https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)، وينتج [عمليات إعادة عرض للتنسيق] مُكلفة (https://developers.google.com/speed/articles/reflow). [تعرَّف على مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "ينصح مهندسو المتصفّح بأن تحتوي الصفحات على أقل من ~1500 عنصر DOM. أفضل مكان للاستماع إلى مكبِّرات الصوت هو عمق الشجرة أقل من 32 عنصرًا ولا تزيد عن 60 عنصرًا فرعيًا/رئيسيًا. يمكن أن يزيد حجم DOM الكبير من استخدام الذاكرة، ويتسبب في إجراء [حسابات نمطية](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) أطول، وينتج عنها [عمليات إعادة عرض التنسيق مُكلفة](https://developers.google.com/speed/articles/reflow). [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{عنصر واحد}zero{# عنصر}two{عنصرين (#)}few{# عناصر}many{# عنصرًا}other{# عنصر}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "تجنُب حجم DOM الزائد"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "الاستهداف"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "يمكنك إضافة `rel=\"noopener\"` أو `rel=\"noreferrer\"` إلى أي روابط خارجية لتحسين الأداء ومنع الثغرات الأمنية. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "الروابط إلى وجهات مشتركة المصدر غير آمنة"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "الروابط إلى وجهات مشتركة المصدر آمنة"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "يتعذّر تحديد الوجهة لإعلان ثابت {anchorHTML}). في حال عدم استخدامه كرابط تشعبي، يمكنك إزالة target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "لا يثق المستخدمون في المواقع الإلكترونية التي تطلب مواقعهم الجغرافية بدون سياق أو قد يؤدي ذلك إلى إرباكهم. يمكنك ربط الطلب بإجراء المستخدم بدلاً من ذلك. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "طلب إذن رصد الموقع الجغرافي عند تحميل الصفحة"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "تجنُب طلب إذن رصد الموقع الجغرافي عند تحميل الصفحة"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "الإصدار"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "تم رصد جميع مكتبات الواجهة الأمامية جافا سكريبت في الصفحة."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "مكتبات جافا سكريبت المتوقفة"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "بالنسبة إلى المستخدمين الذين لديهم اتصالات بطيئة، يمكن للبرامج النصية الخارجية التي يتم إدخالها ديناميكيًا عبر `document.write()` تأخير تحميل الصفحة لمدة ثواني متعددة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "استخدامات `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "تجنُب `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "أعلى نسبة خطورة"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "إصدار المكتبة"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "عدد الثغرات"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "قد تحتوي بعض البرامج النصية للجهات الخارجية على ثغرات أمنية معروفة يمكن تحديدها واستغلالها بسهولة من خلال المهاجمين. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{تم رصد ثغرة واحدة}zero{تم رصد # ثغرة}two{تم رصد ثغرتين (#)}few{تم رصد # ثغرات}many{تم رصد # ثغرةً}other{تم رصد # ثغرة}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "تضمين مكتبات الواجهة الأمامية جافا سكريبت ذات الثغرات الأمنية المعروفة"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "مرتفع"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "منخفض"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "متوسط"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "تجنُب مكتبات الواجهة الأمامية جافا سكريبت ذات الثغرات الأمنية المعروفة"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "لا يثق المستخدمون في المواقع الإلكترونية التي تطلب إرسال الإشعارات بدون سياق أو قد يؤدي ذلك إلى إرباكهم. يمكنك ربط الطلب بإيماءات المستخدم بدلاً من ذلك. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "طلب إذن الإشعار عند تحميل الصفحة"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "تجنُّب طلب إذن الإشعار عند تحميل الصفحة"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "العناصر التي تعذّرت"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "يؤدي منع لصق كلمة المرور إلى تفويض سياسة الأمان الجيدة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "منع المستخدمين من اللصق في حقول كلمات المرور"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "السماح للمستخدمين باللصق في حقول كلمات المرور"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "البروتوكول"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "يوفّر HTTP/2 العديد من المزايا على HTTP/1.1، بما في ذلك عناوين البرامج الثنائية والتعدد ودفع الخادم. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{لم يتم عرض طلب واحد عبر HTTP/2}zero{لم يتم عرض # طلب عبر HTTP/2}two{لم يتم عرض طلبين (#) عبر HTTP/2}few{لم يتم عرض # طلبات عبر HTTP/2}many{لم يتم عرض # طلبًا عبر HTTP/2}other{لم يتم عرض # طلب عبر HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "عدم استخدام HTTP/2 لجميع موارده"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "استخدام HTTP/2 لموارده الخاصة"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "يمكنك وضع علامة على أدوات معالجة الأحداث باللمس والعجلة بصفتها `passive` لتحسين أداء التمرير في صفحتك. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "عدم استخدام أدوات معالجة الحدث السلبية لتحسين أداء التمرير"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "استخدام أدوات الحدث معالجة السلبية لتحسين أداء التمرير"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "الوصف"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "تشير الأخطاء التي تم تسجيلها في وحدة التحكُّم إلى مشاكل لم يتم حلها. قد تنتج هذه المشاكل من إخفاقات طلب الشبكة ومشاكل أخرى تتعلق بالمتصفِّح."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "تم تسجيل أخطاء المتصفح في وحدة التحكُّم"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "لم يتم تسجيل أخطاء المتصفح في وحدة التحكُّم"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "يمكنك الاستفادة من ميزة CSS لعرض الخطوط لضمان أن يكون النص مرئيًا للمستخدم أثناء تحميل خطوط موقع ويب. [مزيد من المعلومات](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "يمكنك الاستفادة من ميزة CSS لعرض الخطوط لضمان أن يكون النص مرئيًا للمستخدم أثناء تحميل خطوط موقع ويب. [مزيد من المعلومات](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "التأكد من بقاء النص مرئيًا أثناء تحميل خط موقع ويب"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "تظل جميع النصوص مرئية أثناء تحميل خط موقع ويب"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "لم يتمكّن Lighthouse من التحقّق تلقائيًا من قيمة عرض الخط لعنوان URL التالي: {fontURL}"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "نسبة العرض إلى الارتفاع (الفعلية)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "نسبة العرض إلى الارتفاع (معروضة)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "يجب أن تتوافق أبعاد عرض الصورة مع نسبة العرض إلى الارتفاع الطبيعية. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "عرض الصور مع نسبة العرض إلى الارتفاع غير صحيحة"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "عرض الصور مع نسبة العرض إلى الارتفاع الصحيحة"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "معلومات تغيير حجم الصورة غير صالحة {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "عنوان URL غير آمن"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "يجب حماية جميع المواقع الإلكترونية باستخدام HTTPS، حتى تلك المواقع التي لا تتعامل مع البيانات الحساسة. يمنع HTTPS الدخلاء من العبث بالاتصالات بين تطبيقك والمستخدمين أو الاستماع إليها بشكل سلبي، وهو شرط مسبق لـ HTTP/2 والعديد من واجهات برمجة تطبيقات الأنظمة الأساسية للويب الجديدة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{تم العثور على طلب غير آمن واحد}zero{تم العثور على # طلب غير آمن}two{تم العثور على طلبين غير آمنين (#)}few{تم العثور على # طلبات غير آمنة}many{تم العثور على # طلبًا غير آمن}other{تم العثور على # طلب غير آمن}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "عدم استخدام HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "استخدامات HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "يضمن تحميل الصفحات بشكل سريع عبر شبكة الجوّال جودة تجربة الاستخدام. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "يضمن تحميل الصفحات بشكل سريع عبر شبكة الجوّال جودة تجربة الاستخدام. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "الوقت التفاعلي بالثواني: {timeInMs, number, seconds} "
+    "message": "الوقت التفاعلي {timeInMs, number, seconds} ثانية"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "الوقت التفاعلي على شبكة الجوّال التي تمت محاكاتها لمدة {timeInMs, number, seconds} من الثواني"
+    "message": "الوقت التفاعلي على شبكة الجوّال التي تمت محاكاتها لمدة {timeInMs, number, seconds}  من الثواني"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "تحميل الصفحة على شبكات الجوّال ليس سريعًا بشكلٍ كافٍ"
@@ -504,79 +735,106 @@
     "message": "تقليل سلسلة العمل الرئيسية"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "إن وقت الاستجابة للإدخال المقدر يمثّل تقديرًا لطول المدة التي تستغرقها استجابة تطبيقك لإدخال المستخدم بالمللي ثانية، وذلك أثناء الثواني الخمس الأكثر انشغالاً في فترة تحميل الصفحة. وفي حال دام وقت الاستجابة أكثر من 50 مللي ثانية، يمكن للمستخدمين اعتبار تطبيقك بأنه \"بطيء في التفاعل\". [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "إن وقت الاستجابة للإدخال المقدر هو تقدير لطول المدة التي تستغرقها استجابة تطبيقك لإدخال المستخدم بالمللي ثانية، وذلك أثناء الثواني الخمس الأكثر انشغالاً في فترة تحميل الصفحة. وفي حال كان وقت الاستجابة أكثر من 50 مللي ثانية، يمكن للمستخدمين اعتبار تطبيقك بأنه بطيء في التفاعل. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "وقت الاستجابة المُقدّر للإدخال"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "تحدد \"سرعة عرض المحتوى على الصفحة\" الوقت الذي يُعرَض فيه أول صورة أو نص. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics#first_paint_and_first_contentful_paint)."
+    "message": "تحدد \"سرعة عرض المحتوى على الصفحة\" الوقت الذي يُعرَض فيه أول صورة أو نص. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "First Contentful Paint"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "تشير \"وحدة المعالجة المركزية الأولى الخاملة\" إلى المرة الأولى التي تكون فيها السلسلة الرئيسية للصفحة كافية للتعامل مع الإدخال. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "تشير \"وحدة المعالجة المركزية الأولى الخاملة\" إلى المرة الأولى التي تكون فيها السلسلة الرئيسية للصفحة كافية للتعامل مع الإدخال. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "وحدة المعالجة المركزية الأولى الخاملة"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "يقيس First Meaningful Paint الوقت الذي يكون فيه المحتوى الأساسي لصفحة مرئيًا. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "تقيس \"سرعة عرض أوّل محتوى مفيد على الصفحة\" الوقت الذي يكون فيه المحتوى الأساسي لصفحة مرئيًا. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "First Meaningful Paint"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "وقت التفاعل هو مقدار الوقت المستغرق حتى تصبح الصفحة تفاعلية بالكامل. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "وقت التفاعل هو مقدار الوقت المستغرق حتى تصبح الصفحة تفاعلية بالكامل. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "وقت التفاعل"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "تأخير الإدخال الأول المحتمل الذي قد يواجهه المستخدمون هو المُدة بالمللي ثانية لأطول مهمة."
+    "message": "الحد الأقصى المحتمل من مهلة الاستجابة لأوّل إدخال الذي قد يواجهه المستخدمون هو المُدة بالمللي ثانية لأطول مهمة. [مزيد من المعلومات](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "الحد الأقصى المحتمل من تأخير الإدخال الأول (FID)"
+    "message": "الحد الأقصى المحتمل من مهلة الاستجابة لأوّل إدخال"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "يوضح مؤشر السرعة مدى سرعة تعبئة محتوى الصفحة بشكلٍ واضح. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "يوضح مؤشر السرعة مدى سرعة تعبئة محتوى الصفحة بشكلٍ واضح. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "مؤشر السرعة"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "مجموع جميع الفترات الزمنية بين \"سرعة عرض المحتوى على الصفحة\" و\"وقت التفاعل\"، عندما تتجاوز مدة المهمة 50 مللي ثانية، معبرًا عنها بالمللي ثانية."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "إجمالي حظر الوقت"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "تؤثر مُدد الإرسال والاستقبال للشبكة تأثيرًا كبيرًا في مستوى الأداء. في حال كانت مدة الإرسال والاستقبال كبيرة، يشير ذلك إلى احتمال تحسّن أداء الخوادم الأقرب إلى المستخدم. [مزيد من المعلومات](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "تؤثر مُدد الإرسال والاستقبال للشبكة تأثيرًا كبيرًا في مستوى الأداء. في حال كانت مدة الإرسال والاستقبال كبيرة، يشير ذلك إلى احتمال تحسّن أداء الخوادم الأقرب إلى المستخدم. [مزيد من المعلومات](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "أوقات إرسال واستقبال الشبكة"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "قد تؤثر أوقات استجابة الخادم في أداء الويب. في حال كان وقت استجابة الخادم للأصل طويلاً، هذه إشارة إلى أنه تم تحميل الخادم بشكلٍ زائد أو مستوى أدائه ضعيف في الخلفية. [مزيد من المعلومات](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "قد تؤثر أوقات استجابة الخادم في أداء الويب. في حال كان وقت استجابة الخادم للأصل طويلاً، هذه إشارة إلى أنه تم تحميل الخادم بشكلٍ زائد أو مستوى أدائه ضعيف في الخلفية. [مزيد من المعلومات](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "أوقات الاستجابة لواجهة الخادم الخلفية"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "تجاوز الميزانية"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "يمكنك الحفاظ على كمية طلبات الشبكة وحجمها ضمن الاستهدافات المحدّدة في ميزانية الأداء المقدّمة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{طلب واحد}zero{# طلب}two{طلبان (#)}few{# طلبات}many{# طلبًا}other{# طلب}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "ميزانية الأداء"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "تؤدي عمليات إعادة التوجيه إلى حدوث تأخيرات إضافية قبل أن يتم تحميل الصفحة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "تؤدي عمليات إعادة التوجيه إلى حدوث تأخيرات إضافية قبل أن يتم تحميل الصفحة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "تجنُب عمليات إعادة توجيه الصفحات المتعددة"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "لضبط ميزانيات لكمية موارد الصفحة وحجمها، يمكنك إضافة ملف budget.json. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{طلب واحد}zero{# طلب}two{طلبان (#)}few{# طلبات}many{# طلبًا}other{# طلب}} • {byteCount, number, bytes} كيلوبايت"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "الحفاظ على انخفاض عدد الطلبات ونقل الأحجام الصغيرة"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "تقترح الروابط الأساسية عنوان URL للعرض في نتائج البحث. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "تقترح الروابط الأساسية عنوان URL للعرض في نتائج البحث. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "تتعدّد عناوين URL المتضاربة ({urlList})"
+    "message": "تتعدّد عناوين URL المتضاربة ({urlList})."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "النقاط لنطاق مختلف ({url})"
+    "message": "يشير إلى نطاق مختلف ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "عنوان URL غير صالح ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "النقاط لموقع \"hreflang\" الآخر ({url})"
+    "message": "يشير إلى موقع جغرافي `hreflang` آخر ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "عنوان URL نسبي ({url})"
@@ -585,19 +843,16 @@
     "message": "يشير إلى عنوان URL الجذر للنطاق (الصفحة الرئيسية)، بدلاً من صفحة مكافئة للمحتوى"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "لا يحتوي المستند على سمة `rel=canonical` صالحة"
+    "message": "عدم احتواء المستند على سمة `rel=canonical` صالحة"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "يحتوي المستند على سمة `rel=canonical` صالحة"
+    "message": "احتواء المستند على سمة `rel=canonical` صالحة"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "تُعد أحجام الخطوط الأقل من 12 بكسل صغيرة جدًا بحيث لا يمكن قراءتها بسهولة وتتطلب من مستخدمي الجوّال \"تحريك الإصبعين للتكبير أو التصغير\" من أجل قراءتها. يمكنك بذل قصارى جهدك للحصول على نسبة أكبر من 60% من نص الصفحة بمقدار أكبر من أو يساوي 12 بكسل. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "أحجام الخطوط الأقل من 12 بكسل صغيرة جدًا بحيث لا يمكن قراءتها بسهولة وتتطلب من مستخدمي الجوّال \"تحريك الإصبعين للتكبير أو التصغير\" من أجل قراءتها. يمكنك بذل قصارى جهدك للحصول على نسبة أكبر من 60% من نص الصفحة بمقدار أكبر من أو يساوي 12 بكسل. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "نص {decimalProportion, number, extendedPercent} مقروء"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} من النص صغير جدًا."
+    "message": "نص {decimalProportion, number, extendedPercent} قابل للقراءة"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "النص غير مقروء لأنه لا تتوفّر علامة وصفية لإطار العرض محسنة لشاشات الجوّال."
@@ -612,16 +867,16 @@
     "message": "يستخدم المستند أحجام الخط القابلة للقراءة"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "تخبر روابط hreflang محركات البحث عن إصدار الصفحة الذي يجب إدارجه في نتائج البحث للغة أو منطقة معينة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "تخبر روابط hreflang محركات البحث عن إصدار الصفحة الذي يجب إدراجه في نتائج البحث للغة أو منطقة معينة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "لا يحتوي المستند على سمة \"hreflang\" صالحة"
+    "message": "عدم احتواء المستند على سمة `hreflang` صالحة"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "يحتوي المستند على سمة `hreflang` صالحة"
+    "message": "احتواء المستند على سمة `hreflang` صالحة"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "قد لا تتم فهرسة الصفحات التي تتضمّن رموز حالة HTTP غير صالحة بشكلٍ صحيح. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "قد لا تتم فهرسة الصفحات التي تتضمّن رموز حالة HTTP غير صالحة بشكلٍ صحيح. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "تحتوي الصفحة على رمز حالة HTTP غير صالح"
@@ -630,7 +885,7 @@
     "message": "تحتوي الصفحة على رمز حالة HTTP صالح"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "يتعذّر على محركات البحث تضمين صفحاتك في نتائج البحث في حال عدم حصولها على إذن للزحف إلى هذه الصفحات. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "يتعذّر على محركات البحث تضمين صفحاتك في نتائج البحث في حال عدم حصولها على إذن للزحف إلى هذه الصفحات. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "يتم حظر الصفحة من الفهرسة"
@@ -639,7 +894,7 @@
     "message": "الصفحة ليست محظورة من الفهرسة"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "يساعد نص الرابط الوصفي محركات البحث على فهم المحتوى. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "يساعد نص الرابط الوصفي محركات البحث على فهم المحتوى. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{تم العثور على رابط واحد}zero{تم العثور على # رابط}two{تم العثور على رابطين (#)}few{تم العثور على # روابط}many{تم العثور على # رابطًا}other{تم العثور على # رابط}}"
@@ -651,13 +906,13 @@
     "message": "تحتوي الروابط على نص وصفي"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "تشغيل [أداة اختبار البيانات المنظَّمة](https://search.google.com/structured-data/testing-tool/) و[Linter للبيانات المنظَّمة](http://linter.structured-data.org/) للتحقُّق من البيانات المنظَّمة. [مزيد من المعلومات](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "يمكنك تشغيل [أداة اختبار البيانات المنظَّمة](https://search.google.com/structured-data/testing-tool/) و[Linter للبيانات المنظَّمة](http://linter.structured-data.org/) للتحقُّق من البيانات المنظَّمة. [مزيد من المعلومات](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "البيانات المنظَّمة صالحة"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "قد يتم تضمين الأوصاف التعريفية في نتائج البحث لتلخيص محتوى الصفحة بإيجاز. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "قد يتم تضمين الأوصاف التعريفية في نتائج البحث لتلخيص محتوى الصفحة بإيجاز. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/description)"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "نص الوصف فارغ."
@@ -669,7 +924,7 @@
     "message": "يحتوي المستند على وصف تعريفي"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "لا يمكن لمحركات البحث فهرسة محتوى مكون إضافي وتحظر العديد من الأجهزة استخدام المكونات الإضافية أو لا توفّرها. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "لا يمكن لمحركات البحث فهرسة محتوى مكون إضافي وتحظر العديد من الأجهزة استخدام المكونات الإضافية أو لا توفّرها. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "يستخدم المستند مكونات إضافية"
@@ -681,7 +936,7 @@
     "message": "في حال كان ملف \"robots.txt\" مكتوبًا بصيغة غير صحيحة، يمكن ألا تفهم برامج الزحف كيف تريد أن يتم الزحف إلى موقعك الإلكتروني أو أن تتم فهرسته."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "الطلب لملف \"robots.txt\" عرض حالة HTTP: {statusCode}"
+    "message": "الطلب لملف robots.txt عرض حالة HTTP: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{تم العثور على خطأ واحد}zero{تم العثور على # خطأ}two{تم العثور على خطأين (#)}few{تم العثور على # أخطاء}many{تم العثور على # خطأً}other{تم العثور على # خطأ}}"
@@ -696,7 +951,7 @@
     "message": "ملف \"robots.txt\" صالح"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "يجب أن تكون العناصر التفاعلية، مثل الأزرار والروابط كبيرة بشكلٍ كافٍ (48 × 48 بكسل) وتحيط بها مساحة كافية ليكون من السهل النقر عليها بدون النقر على أي عناصر أخرى. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "يجب أن تكون العناصر التفاعلية، مثل الأزرار والروابط كبيرة بشكلٍ كافٍ (48 × 48 بكسل) وتحيط بها مساحة كافية ليكون من السهل النقر عليها بدون النقر على أي عناصر أخرى. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "تم تحديد حجم {decimalProportion, number, percent} لأهداف النقر بشكلٍ مناسب"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "استهداف متداخِل"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "الحجم"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "هدف النقر"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "يتم تحديد حجم أهداف النقر بشكل مناسب"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "وقت سلسلة المحادثات الأساسية"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "الجهة الخارجية"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "يمكن أن يؤثر رمز الجهة الخارجية بشكل كبير في أداء التحميل. يمكنك تحديد عدد مقدِّمي الخدمة للجهات الخارجية المتكرّرين ومحاولة تحميل رمز الجهة الخارجية بعد انتهاء تحميل صفحتك بشكل أساسي. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{تم العثور على جهة خارجية واحدة}zero{تم العثور على # جهة خارجية}two{تم العثور على جهتين خارجيتين (#)}few{تم العثور على # جهات خارجية}many{تم العثور على # جهة خارجية}other{تم العثور على # جهة خارجية}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "استخدام الجهات الخارجية"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "يحدد \"وقت وصول أول بايت\" الوقت الذي يُرسل فيه الخادم استجابة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "يحدّد \"وقت وصول أول بايت\" الوقت الذي يُرسل فيه الخادم استجابة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "استغرق مستند الجذر {timeInMs, number, milliseconds} مللي ثانية."
+    "message": "استغرق مستند الجذر {timeInMs, number, milliseconds} مللي ثانية"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "تقليل أوقات استجابة الخادم (TTFB)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "المدة"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "الاسم"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "وقت البدء"
   },
@@ -744,7 +1008,7 @@
     "message": "النوع"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "يمكنك توجيه تطبيقك باستخدام \"واجهة برمجة التطبيقات لأوقات المستخدم\" لقياس الأداء الفعلي لتطبيقك أثناء التجارب الأساسية للمستخدمين. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "يمكنك توجيه تطبيقك باستخدام \"واجهة برمجة التطبيقات لأوقات المستخدم\" لقياس الأداء الفعلي العالمي لتطبيقك أثناء التجارب الأساسية للمستخدمين. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{وقت واحد للمستخدم}zero{# وقت للمستخدم}two{وقتا (#) المستخدم}few{# أوقات للمستخدم}many{# وقتًا للمستخدم}other{# وقت للمستخدم}}"
@@ -753,19 +1017,19 @@
     "message": "علامات أوقات المستخدم وقياساتها"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "تم العثور على <link> للربط المسبق لـ \"{securityOrigin}\"، ولكن لم يتم استخدامه من خلال المتصفِّح. يُرجى التحقُّق من استخدام السمة `crossorigin` بشكل صحيح."
+    "message": "تم العثور على <link> للربط المسبق لـ \"{securityOrigin}\"، ولكن لم يتم استخدامه من خلال المتصفح. يُرجى التحقُّق من استخدام السمة `crossorigin` بشكل صحيح."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "يمكنك إضافة الاتصال المسبق أو تعديلات موارد الجلب المسبق لنظام أسماء النطاقات لإنشاء اتصالات مبكرة بأصول مهمة تابعة لجهة خارجية. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "يمكنك إضافة الاتصال المسبق أو تعديلات موارد الجلب المسبق لنظام أسماء النطاقات لإنشاء اتصالات مبكرة بأصول مهمة تابعة لجهة خارجية. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "الاتصال المسبق للأصول المطلوبة"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "تم العثور على <link> للتحميل المسبق لـ \"{preloadURL}\"، ولكن لم يتم استخدامه من خلال المتصفِّح. يُرجى التحقُّق من استخدام السمة `crossorigin` بشكل صحيح."
+    "message": "تم العثور على <link> للتحميل المسبق لـ {preloadURL}، ولكن لم يتم استخدامه من خلال المتصفح. يُرجى التحقُّق من استخدام السمة `crossorigin` بشكل صحيح."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "يمكنك استخدام <link rel = preload> لتحديد أولويات جلب الموارد المطلوبة حاليًا في وقتٍ لاحق في تحميل الصفحة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "يمكنك استخدام `<link rel=preload>` لتحديد أولويات جلب الموارد المطلوبة حاليًا في وقتٍ لاحق في تحميل الصفحة. [مزيد من المعلومات](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "التحميل المسبق للطلبات الأساسية"
@@ -789,10 +1053,10 @@
     "message": "أفضل الممارسات"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "تحدّد عمليات التحقق هذه الفرص التي تتيح [تحسين إمكانية الوصول إلى تطبيق الويب](https://developers.google.com/web/fundamentals/accessibility). يمكن الكشف بشكل تلقائيّ عن مجموعة فرعية من مشاكل إمكانية الوصول فحسب، لذلك يُنصح أيضًا باستخدام الاختبار اليدوي."
+    "message": "تحدّد عمليات التحقق هذه الفرص التي تتيح [لتحسين إمكانية الوصول إلى تطبيق الويب ](https://developers.google.com/web/fundamentals/accessibility). ويمكن تلقائيًا رصد مجموعة فرعية من مشاكل إمكانية الوصول فقط، لذلك يُنصح أيضًا باستخدام الاختبار اليدوي."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "تعالج هذه العناصر المناطق التي يتعذر على أداة الاختبار التلقائية تغطيتها. مزيد من المعلومات في دليلنا حول [إجراء مراجعة إمكانية الوصول](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "تعالج هذه العناصر المناطق التي يتعذر على أداة الاختبار التلقائية تغطيتها. تعرّف على مزيد من المعلومات في دليلنا حول [إجراء مراجعة إمكانية الوصول](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "إمكانية الوصول"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "الجداول والقوائم"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "أفضل الممارسات"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "تضبط ميزانيات الأداء معايير لأداء موقعك الإلكتروني."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "الميزانيات"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "مزيد من المعلومات حول أداء تطبيقك."
+    "message": "مزيد من المعلومات حول أداء تطبيقك. لا تؤثر هذه الأرقام [ بشكل مباشر في ](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) نتيجة الأداء."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "بيانات التشخيص"
@@ -840,7 +1113,7 @@
     "message": "تحسينات العرض الأول"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "يمكن لهذه التحسينات تسريع عملية تحميل الصفحة."
+    "message": "يمكن أن تساعد هذه الاقتراحات على تحميل صفحتك بشكل أسرع. لا تؤثر هذه الاقتراحات [بشكل مباشر](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) في نتيجة الأداء."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "فرص تحسين الأداء"
@@ -867,7 +1140,7 @@
     "message": "تحسين PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "تضمن عمليات التحقُّق هذه تحسين أداء صفحتك لتظهر في ترتيب نتائج مُحرّك البحث. هناك عوامل إضافية لا يتحقّق منها Lighthouse قد تؤثر في ترتيب نتائج البحث. [مزيد من المعلومات](https://support.google.com/webmasters/answer/35769)."
+    "message": "تضمن عمليات التحقُّق هذه تحسين أداء صفحتك لتظهر في ترتيب نتائج مُحرّك البحث. هناك عوامل إضافية لا يتحقّق منها Lighthouse قد تؤثر في ترتيب نتائج البحث. [مزيد من المعلومات](https://support.google.com/webmasters/answer/35769)"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "تشغيل أدوات التحقُّق الإضافية هذه على موقعك الإلكتروني للتحقُّق من أفضل ممارسات تحسين محركات البحث الإضافية."
@@ -888,7 +1161,7 @@
     "message": "الزحف والفهرسة"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "يُرجى التأكُّد من أن صفحاتك متوافقة مع الجوّال، حتى لا يحتاج المستخدمون إلى التصغير أو التكبير من أجل الاطّلاع على صفحات المحتوى. [مزيد من المعلومات](https://developers.google.com/search/mobile-sites/)."
+    "message": "يُرجى التأكُّد من أن صفحاتك متوافقة مع الجوّال، حتى لا يحتاج المستخدمون إلى التصغير أو التكبير من أجل الاطّلاع على صفحات المحتوى. [مزيد من المعلومات](https://developers.google.com/search/mobile-sites/)"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "متوافق مع الجوّال"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "ذاكرة التخزين المؤقت TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "الموقع الجغرافي"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "الاسم"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "الطلبات"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "نوع المورد"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "الحجم (كيلوبايت)"
+    "message": "الحجم"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "الوقت المستغرَق"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "حجم النقل"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "عنوان URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "التوفيرات المحتملة (كيلوبايت)"
+    "message": "التوفيرات المحتملة"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "التوفيرات المحتملة (مللي ثانية)"
+    "message": "التوفيرات المحتملة"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "التوفيرات المحتملة من {wastedBytes, number, bytes} كيلوبايت"
+    "message": "التوفيرات المحتملة من {wastedBytes, number, bytes}  كيلوبايت"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "التوفيرات المحتملة لـ {wastedMs, number, milliseconds} مللي ثانية"
+    "message": "التوفيرات المحتملة من {wastedMs, number, milliseconds} مللي ثانية"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "مستند"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "الخط"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "صورة"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "الوسائط"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds} مللي ثانية"
+    "message": "{timeInMs, number, milliseconds} مللي ثانية"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "غير ذلك"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "نص برمجي"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} ثانية"
+    "message": "{timeInMs, number, seconds} ثانية"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "ورقة الأنماط"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "الجهة الخارجية"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "الإجمالي"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "حدث خطأ أثناء تسجيل التتبع عند تحميل صفحتك. يُرجى تشغيل Lighthouse مرة أخرى. ({errorCode})"
@@ -930,13 +1245,19 @@
     "message": "مهلة انتظار ربط بروتوكول برنامج تصحيح الخلل الأول."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "لم يجمع Chrome أي لقطات شاشة خلال عملية تحميل الصفحة. يُرجى التأكُّد من وجود محتوى مرئي على الصفحة، ثم محاولة إعادة تشغيل Lighthouse. ({errorCode})"
+    "message": "لم يجمع Chrome أي لقطات شاشة خلال عملية تحميل الصفحة. يُرجى التأكُّد من توفّر محتوى مرئي على الصفحة، ثم محاولة إعادة تشغيل Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "تعذّر على خوادم نظام أسماء النطاقات حل مشكلة النطاق المُقدّم."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "واجه المجمِّع {artifactName} المطلوب خطأً: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "حدث خطأ في متصفّح Chrome الداخلي. يُرجى إعادة تشغيل Chrome ومحاولة إعادة تشغيل Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "مطلوب {artifactName} والذي لم يشغّله المجمِّع."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "لم يتمكّن Lighthouse من تحميل الصفحة المطلوبة بشكل موثوق. يمكنك التأكُّد من اختبار عنوان URL الصحيح وأن الخادم يستجيب بشكل صحيح لجميع الطلبات."
@@ -945,7 +1266,10 @@
     "message": "لم يتمكّن Lighthouse من تحميل عنوان URL الذي طلبته بشكل موثوق لأن الصفحة توقفت عن الاستجابة."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "لا يحتوي عنوان URL الذي قدمته على بيانات اعتماد أمان صحيحة. {securityMessages}"
+    "message": "لا يحتوي عنوان URL الذي قدمته على شهادة أمان صالحة. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "منع Chrome تحميل صفحة مع محتوى بيني. يمكنك التأكُّد من اختبار عنوان URL الصحيح وأن الخادم يستجيب بشكل صحيح لجميع الطلبات."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "لم يتمكّن Lighthouse من تحميل الصفحة المطلوبة بشكل موثوق. يمكنك التأكُّد من اختبار عنوان URL الصحيح وأن الخادم يستجيب بشكل صحيح لجميع الطلبات. (التفاصيل: {errorDetails})"
@@ -984,7 +1308,7 @@
     "message": "بيانات المختبَر"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) تحليل الصفحة الحالية على شبكة الجوال في وضع المحاكاة. القيم تقديرية وقابلة للتغير."
+    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) تحليل الصفحة الحالية على شبكة الجوّال في وضع المحاكاة. القيم تقديرية وقابلة للتغيير."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "عناصر إضافية للتحقُّق يدويًا"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "توسيع المقتطف"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "عرض موارد الجهات الخارجية"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "حدثت مشاكل تؤثر في تشغيل Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "القيم تقديرية وقابلة للتغير"
+    "message": "القيم تقديرية وقابلة للتغيير. نتيجة الأداء [مستندة إلى هذه المقاييس فقط](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "عمليات التدقيق التي تم اجتيازها، ولكن تتضمّن التحذيرات"
@@ -1023,10 +1350,10 @@
     "message": "يمكنك تحميل ملف GIF إلى خدمة ستتيح تضمينه باعتباره فيديو HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "يمكنك تثبيت [مكون WordPress الإضافي للتحميل الكسول](https://wordpress.org/plugins/search/lazy+load/) الذي يوفر القدرة على تأجيل أي صور خارج الشاشة، أو التبديل إلى تصميم يوفر هذه القدرة الوظيفية. يمكنك أيضًا استخدام [مكون AMP الإضافي] (https://wordpress.org/plugins/amp/)."
+    "message": "يمكنك تثبيت [مكون WordPress الإضافي للتحميل الكسول](https://wordpress.org/plugins/search/lazy+load/) الذي يوفر القدرة على تأجيل أي صور خارج الشاشة، أو التبديل إلى تصميم يوفِّر هذه القدرة الوظيفية. يمكنك أيضًا استخدام [مكون AMP الإضافي](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "هناك عدد من مكونات WordPress الإضافية التي يمكنها مساعدتك على [تضمين مواد العرض المهمة] (https://wordpress.org/plugins/search/critical+css/) أو [تأجيل موارد أقل أهمية] (https://wordpress.org/plugins/search/defer+css+javascript/). عليك توخي الحذر من أن التحسينات التي توفرها هذه الإضافات قد توقف ميزات التصميم أو المكونات الإضافية، لذلك ستحتاج على الأرجح إلى إجراء تغييرات في الرمز."
+    "message": "هناك عدد من مكونات WordPress الإضافية التي يمكنها مساعدتك على [تضمين مواد العرض المهمة](https://wordpress.org/plugins/search/critical+css/) أو [تأجيل موارد أقل أهمية](https://wordpress.org/plugins/search/defer+css+javascript/). عليك توخي الحذر من أن التحسينات التي توفرها هذه الإضافات قد توقف ميزات التصميم أو المكونات الإضافية، لذلك ستحتاج على الأرجح إلى إجراء تغييرات في الرمز."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "تساهم التصاميم والمكونات الإضافية ومواصفات الخادم في تحسين وقت استجابة الخادم. يمكنك البحث عن تصميم مُحسّن أكثر و/أو اختيار مكون إضافي للتحسين و/أو ترقية الخادم."
@@ -1035,25 +1362,25 @@
     "message": "يمكنك عرض مقتطفات في قوائم مشاركاتك (مثلاً عبر العلامة \"المزيد\")، أو تقليل عدد المشاركات المعروضة في صفحة معينة، أو تقسيم مشاركاتك الطويلة إلى صفحات متعددة، أو استخدام مكون إضافي لتحميل التعليقات ذات التحميل الكسول."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "يمكن لعدد من [مكونات WordPress الإضافية](https://wordpress.org/plugins/search/minify+css/) زيادة سرعة موقعك من خلال ربط الأنماط وتصغيرها وضغطها. يمكنك أيضًا استخدام عملية إنشاء لإزالة البيانات غير الضرورية مقدمًا إذا أمكن ذلك."
+    "message": "يمكن لعدد من [مكونات WordPress الإضافية](https://wordpress.org/plugins/search/minify+css/) زيادة سرعة موقعك الإلكتروني من خلال ربط الأنماط وتصغيرها وضغطها. يمكنك أيضًا استخدام عملية إنشاء لإزالة البيانات غير الضرورية مقدمًا إذا أمكن ذلك."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "يمكن لعدد من [مكونات WordPress الإضافية](https://wordpress.org/plugins/search/minify+javascript/) زيادة سرعة موقعك من خلال ربط النصوص البرمجية وتصغيرها وضغطها. يمكنك أيضًا استخدام عملية إنشاء لإزالة البيانات غير الضرورية مقدمًا إذا أمكن ذلك."
+    "message": "يمكن لعدد من [مكونات WordPress الإضافية ](https://wordpress.org/plugins/search/minify+javascript/) زيادة سرعة موقعك الإلكتروني من خلال ربط النصوص البرمجية وتصغيرها وضغطها. يمكنك أيضًا استخدام عملية إنشاء لإزالة البيانات غير الضرورية مقدمًا إذا أمكن ذلك."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "يمكنك تقليل عدد [مكونات WordPress الإضافية](https://wordpress.org/plugins/) التي تُحمِّل خدمة CSS غير المُستخدَمة في صفحتك أو تبديلها. لتحديد المكونات الإضافية التي تضيف CSS دخيلة، يمكنك محاولة تشغيل [تغطية الرمز](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) في Chrome DevTools. يمكنك تحديد التصميم/المكون الإضافي المسؤول عن عنوان URL لورقة الأنماط. يمكنك البحث عن المكونات الإضافية التي تحتوي على العديد من أوراق الأنماط في القائمة والتي تحتوي على الكثير من اللون الأحمر في تغطية الرمز. يجب أن يدرِج المكون الإضافي ورقة أنماط فقط في حال تم استخدامه في الصفحة سابقًا."
+    "message": "يمكنك تقليل عدد [مكونات WordPress الإضافية](https://wordpress.org/plugins/) التي تُحمِّل خدمة CSS غير المُستخدَمة في صفحتك أو تبديلها. لتحديد المكونات الإضافية التي تضيف CSS دخيلة، يمكنك محاولة تشغيل [تغطية الرمز](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) في Chrome DevTools. يمكنك تحديد التصميم/المكون الإضافي المسؤول عن عنوان URL لورقة الأنماط. يمكنك البحث عن المكونات الإضافية التي تحتوي على العديد من أوراق الأنماط في القائمة والتي تحتوي على الكثير من اللون الأحمر في تغطية الرمز. يجب أن يدرِج المكون الإضافي ورقة أنماط فقط في حال تم استخدامه في الصفحة فعليًا."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "يمكنك تقليل عدد [مكونات WordPress الإضافية](https://wordpress.org/plugins/)التي تُحمِّل JavaScript غير المُستخدَم في صفحتك أو تبديلها. لتحديد المكونات الإضافية التي تضيف JS دخيلة، يمكنك محاولة تشغيل [تغطية الرمز](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) في Chrome DevTools. يمكنك تحديد التصميم/المكون الإضافي المسؤول عن عنوان URL للنص البرمجي. يمكنك البحث عن المكونات الإضافية التي تحتوي على العديد من النصوص البرمجية في القائمة والتي تحتوي على الكثير من اللون الأحمر في تغطية الرمز. يجب أن يدرِج المكون الإضافي نصًا برمجيًا فقط في حال تم استخدامه في الصفحة سابقًا."
+    "message": "يمكنك تقليل عدد [مكونات WordPress الإضافية](https://wordpress.org/plugins/) التي تُحمِّل لغة جافا سكريبت غير المُستخدَمة في صفحتك أو تبديلها. لتحديد المكونات الإضافية التي تضيف JS دخيلة، يمكنك محاولة تشغيل [تغطية الرمز](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) في Chrome DevTools. يمكنك تحديد التصميم/المكون الإضافي المسؤول عن عنوان URL للنص البرمجي. يمكنك البحث عن المكونات الإضافية التي تحتوي على العديد من النصوص البرمجية في القائمة والتي تحتوي على الكثير من اللون الأحمر في تغطية الرمز. يجب أن يدرِج المكون الإضافي نصًا برمجيًا فقط في حال تم استخدامه في الصفحة فعليًا."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "يمكنك الاطِّلاع على [ذاكرة التخزين المؤقت للمتصفح في WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "يمكنك الاطِّلاع على [ذاكرة التخزين المؤقت للمتصفّح في WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "يمكنك استخدام [مكون WordPress الإضافي لتحسين الصورة](https://wordpress.org/plugins/search/optimize+images/) الذي يضغط صورك مع المحافظة على الجودة."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "يمكنك تحميل الصور مباشرةً من خلال [مكتبة الوسائط] (https://codex.wordpress.org/Media_Library_Screen) للتأكد من توفر أحجام الصور المطلوبة، ثم إدراجها من مكتبة الوسائط أو استخدام أداة الصورة لضمان استخدام أفضل حجم للصورة (بما في ذلك تلك الخاصة بنقاط فاصلة متجاوبة). يمكنك تجنب استخدام صور \"بالحجم الكامل\" إلا إذا كانت الأبعاد كافية لاستخدامها. [تعرَّف على مزيد من المعلومات](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "يمكنك تحميل الصور مباشرةً من خلال [مكتبة الوسائط](https://codex.wordpress.org/Media_Library_Screen) للتأكّد من توفّر أحجام الصور المطلوبة، ثم إدراجها من مكتبة الوسائط أو استخدام أداة الصورة لضمان استخدام أفضل حجم للصورة (بما في ذلك تلك الخاصة بنقاط فاصلة متجاوبة). يمكنك تجنب استخدام صور `Full Size` إلا إذا كانت الأبعاد كافية لاستخدامها. [مزيد من المعلومات](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "يمكنك تفعيل ضغط النص في إعداد خادم الويب."

--- a/lighthouse-core/lib/i18n/locales/bg.json
+++ b/lighthouse-core/lib/i18n/locales/bg.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Клавишите за достъп дават възможност на потребителите бързо да преместят фокуса към определена част от страницата. За правилно навигиране всеки клавиш за достъп трябва да е уникален. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Клавишите за достъп дават възможност на потребителите бързо да преместят фокуса към определена част от страницата. За правилно навигиране всеки клавиш за достъп трябва да е уникален. [Научете повече](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Някои стойности на [accesskey] не са уникални"
+    "message": "Някои стойности на `[accesskey]` не са уникални"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Стойностите на [accesskey] са уникални"
+    "message": "Стойностите за `[accesskey]` са уникални"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Всеки елемент role на ARIA поддържа конкретен поднабор от атрибути aria-*. При несъответствие атрибутите aria-* ще станат невалидни. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Всеки елемент ARIA `role` поддържа конкретен поднабор от атрибути `aria-*`. При несъответствие атрибутите `aria-*` ще станат невалидни. [Научете повече](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Някои атрибути [aria-*] не съответстват на ролите си"
+    "message": "Някои атрибути `[aria-*]` не съответстват на ролите си"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Атрибутите [aria-*] съответстват на ролите си"
+    "message": "Атрибутите `[aria-*]` съответстват на ролите си"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Някои роли на ARIA имат задължителни атрибути, от които екранните четци получават описание на състоянието на съответния елемент. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Някои роли на ARIA имат задължителни атрибути, от които екранните четци получават описание на състоянието на съответния елемент. [Научете повече](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Някои елементи [role] нямат всички задължителни атрибути [aria-*]"
+    "message": "Някои елементи `[role]` нямат всички задължителни атрибути `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Елементите [role] имат всички задължителни атрибути [aria-*]"
+    "message": "Елементите `[role]` имат всички задължителни атрибути `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Някои родителски роли на ARIA трябва да съдържат конкретни дъщерни роли, за да изпълняват функциите за достъпност, за които са предназначени. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Някои родителски роли на ARIA трябва да съдържат конкретни дъщерни роли, за да изпълняват функциите за достъпност, за които са предназначени. [Научете повече](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Липсват задължителни дъщерни атрибути [role] за елементи с атрибут [role]."
+    "message": "Липсват задължителни дъщерни атрибути `[role]` за елементи с атрибут `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Елементите с атрибут [role] са обезпечени с необходимите дъщерни елементи [role]"
+    "message": "Елементите с атрибут `[role]`, за които са задължителни конкретни дъщерни елементи `[role]`, са налице"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Някои дъщерни роли на ARIA трябва да се съдържат в конкретни родителски роли, за да изпълняват правилно функциите за достъпност, за които са предназначени. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Някои дъщерни роли на ARIA трябва да се съдържат в конкретни родителски роли, за да изпълняват правилно функциите за достъпност, за които са предназначени. [Научете повече](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Някои елементи [role] не се съдържат в задължителния за тях родителски елемент"
+    "message": "Някои елементи `[role]` не се съдържат в задължителния за тях родителски елемент"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Елементите [role] се съдържат в задължителния за тях родителски елемент"
+    "message": "Елементите `[role]` се съдържат в задължителния за тях родителски елемент"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Ролите на ARIA трябва да имат валидни стойности, за да изпълняват функциите за достъпност, за които са предназначени. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Ролите на ARIA трябва да имат валидни стойности, за да изпълняват функциите за достъпност, за които са предназначени. [Научете повече](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Някои стойности на [role] не са валидни"
+    "message": "Някои стойности на `[role]` не са валидни"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Стойностите на [role] са валидни"
+    "message": "Стойностите на `[role]` са валидни"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Помощните технологии, като например екранни четци, не могат да интерпретират атрибути на ARIA с невалидни стойности. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Помощните технологии, като например екранни четци, не могат да интерпретират атрибути на ARIA с невалидни стойности. [Научете повече](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Някои атрибути [aria-*] нямат валидни стойности"
+    "message": "Някои атрибути `[aria-*]` нямат валидни стойности"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Атрибутите [aria-*] имат валидни стойности"
+    "message": "Атрибутите `[aria-*]` имат валидни стойности"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Помощните технологии, като например екранни четци, не могат да интерпретират атрибути на ARIA с невалидни имена. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Помощните технологии, като например екранни четци, не могат да интерпретират атрибути на ARIA с невалидни имена. [Научете повече](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Някои атрибути [aria-*] не са валидни или са изписани неправилно"
+    "message": "Някои атрибути `[aria-*]` не са валидни или са изписани неправилно"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Атрибутите [aria-*] са валидни и са изписани правилно"
+    "message": "Атрибутите `[aria-*]` са валидни и са изписани правилно"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Надписите правят аудиоелементите използваеми за лицата, лишени от слух, и потребителите със слухови увреждания, като предоставят важна информация, например кой говори и какво казва, както и друга информация, несвързана с речта. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Надписите правят аудиоелементите използваеми за потребителите със слухови увреждания, като предоставят важна информация, например кой говори и какво казва, както и друга информация, несвързана с речта. [Научете повече](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "За някои елементи <audio> липсва елемент <track> с [kind=\"captions\"]."
+    "message": "За някои елементи `<audio>` липсва елемент `<track>` с `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Елементите <audio> съдържат елемент <track> с [kind=\"captions\"]"
+    "message": "Елементите `<audio>` съдържат елемент `<track>` с `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Елементи с грешки"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Когато даден бутон няма достъпно име, той ще бъде прочитан като „бутон“ от екранните четци и съответно ще бъде неизползваем за потребителите им. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Когато даден бутон няма достъпно име, той ще бъде прочитан като „бутон“ от екранните четци и съответно ще бъде неизползваем за потребителите им. [Научете повече](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Бутоните нямат достъпни имена"
@@ -93,7 +93,7 @@
     "message": "Бутоните имат достъпни имена"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Добавянето на начини за заобикаляне на повтарящото се съдържание дава възможност на потребителите, използващи клавиатура, да навигират по-ефективно в страницата. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Добавянето на начини за заобикаляне на повтарящото се съдържание дава възможност на потребителите, използващи клавиатура, да навигират по-ефективно в страницата. [Научете повече](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Страницата не съдържа заглавие, връзка за пропускане или участък с ориентир"
@@ -102,7 +102,7 @@
     "message": "Страницата съдържа заглавие, връзка за пропускане или участък с ориентир"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Четенето на текст с нисък контраст е трудно или невъзможно за много потребители. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Четенето на текст с нисък контраст е трудно или невъзможно за много потребители. [Научете повече](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Коефициентът на контрастност между цветовете на заден и преден план не е достатъчно голям."
@@ -111,88 +111,88 @@
     "message": "Коефициентът на контрастност между цветовете на заден и преден план е достатъчно голям"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Когато списъците с определения не са маркирани правилно, екранните четци може да предоставят объркваща или неточна информация. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Когато списъците с определения не са маркирани правилно, екранните четци може да предоставят объркваща или неточна информация. [Научете повече](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Елементите <dl> не съдържат само правилно подредени групи <dt> и <dd> и елементи <script> или <template>."
+    "message": "Елементите `<dl>` не съдържат само правилно подредени групи `<dt>` и `<dd>` и елементи `<script>` или `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Елементите <dl> съдържат само правилно подредени групи <dt> и <dd> и елементи <script> или <template>."
+    "message": "Елементите `<dl>` съдържат само правилно подредени групи `<dt>` и `<dd>` и елементи `<script>` или `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Списъчните елементи за определение (<dt> и <dd>) трябва да бъдат обвити в родителски елемент <dl>, за да могат да бъдат прочетени правилно от екранните четци. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Списъчните елементи за определение (`<dt>` и `<dd>`) трябва да бъдат обвити в родителски елемент `<dl>`, за да бъдат прочетени правилно от екранните четци. [Научете повече](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Някои списъчни елементи за определение не са обвити в елементи <dl>"
+    "message": "Някои списъчни елементи за определение не са обвити в елементи `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Списъчните елементи за определение са обвити в елементи <dl>"
+    "message": "Списъчните елементи за определение са обвити в елементи `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Заглавието дава възможност на потребителите на екранни четци да добият обща представа за страницата, а потребителите на търсещи машини разчитат на него в голяма степен, за да определят дали страницата е подходяща за търсенето им. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Заглавието дава възможност на потребителите на екранни четци да добият обща представа за страницата, а потребителите на търсещи машини разчитат на него в голяма степен, за да определят дали страницата е подходяща за търсенето им. [Научете повече](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Документът няма елемент <title>"
+    "message": "Документът няма елемент `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Документът има елемент <title>"
+    "message": "Документът има елемент `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Стойността на всеки атрибут за идентификатор трябва да е уникална, за да се предотврати пропускането на други екземпляри от помощните технологии. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Стойността на всеки атрибут id трябва да е уникална, за да се предотврати пропускането на други екземпляри от страна на помощните технологии. [Научете повече](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Някои атрибути [id] на страницата не са уникални"
+    "message": "Някои атрибути `[id]` на страницата не са уникални"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Атрибутите [id] на страницата са уникални"
+    "message": "Атрибутите `[id]` на страницата са уникални"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Потребителите на екранни четци очакват заглавието на рамката да описва съдържанието й. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Потребителите на екранни четци очакват заглавието на рамката да описва съдържанието й. [Научете повече](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Някои елементи <frame> или <iframe> нямат заглавие"
+    "message": "Някои елементи `<frame>` или `<iframe>` нямат заглавие"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Елементите <frame> или <iframe> имат заглавие"
+    "message": "Елементите `<frame>` или `<iframe>` имат заглавие"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Ако за дадена страница не е посочен атрибут lang, екранният четец приема, че тя е написана на стандартния език, който потребителят е избрал при настройването му. Ако страницата всъщност не е на стандартния език, екранният четец може да не прочете текста й правилно. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Ако за дадена страница не е посочен атрибут lang, екранният четец приема, че тя е написана на стандартния език, който потребителят е избрал при настройването му. Ако страницата всъщност не е на стандартния език, екранният четец може да не прочете текста й правилно. [Научете повече](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Елементът <html> няма атрибут [lang]"
+    "message": "Елементът `<html>` няма атрибут `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Елементът <html> има атрибут [lang]"
+    "message": "Елементът `<html>` има атрибут `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Посочването на валиден [език по BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) помага на екранните четци да прочитат текста правилно. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Посочването на валиден [език по BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) помага на екранните четци да четат текста правилно. [Научете повече](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Елементът <html> няма валидна стойност за атрибута [lang]."
+    "message": "Елементът `<html>` няма валидна стойност за атрибута `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Елементът <html> има валидна стойност за атрибута [lang]"
+    "message": "Елементът `<html>` има валидна стойност за атрибута `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Информативните елементи трябва да имат кратък, описателен алтернативен текст. При декоративните елементи атрибутът alt може да бъде оставен без стойност. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Информативните елементи трябва да имат кратък, описателен алтернативен текст. При декоративните елементи атрибутът alt може да бъде оставен без стойност. [Научете повече](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Някои графични елементи нямат атрибути [alt]"
+    "message": "Някои графични елементи нямат атрибути `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Графичните елементи имат атрибути [alt]"
+    "message": "Графичните елементи имат атрибути `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Когато дадено изображение се използва като бутон от типа <input>, предоставянето на алтернативен текст може да помогне на потребителите на екранни четци да разберат за какво служи бутонът. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Когато за бутон от тип `<input>` се използва изображение, предоставянето на алтернативен текст помага на потребителите на екранни четци да разберат за какво служи бутонът. [Научете повече](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Някои елементи <input type=\"image\"> нямат алтернативен текст ([alt])"
+    "message": "Някои елементи `<input type=\"image\">` нямат алтернативен текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Елементите <input type=\"image\"> имат алтернативен текст ([alt])"
+    "message": "Елементите `<input type=\"image\">` имат алтернативен текст (`[alt]`)"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Етикетите дават възможност на помощните технологии, като например екранни четци, да прочитат правилно контролите във формуляри. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Етикетите дават възможност на помощните технологии, като например екранни четци, да четат правилно контролите във формуляри. [Научете повече](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Някои елементи на формуляра нямат свързани етикети"
@@ -201,16 +201,16 @@
     "message": "Елементите на формуляра имат свързани етикети"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Ако дадена таблица се използва само за оформление, тя не трябва да съдържа елементи с данни, като например елементите th или caption или атрибута summary, тъй като това може да създаде объркване за потребителите на екранни четци. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Ако дадена таблица се използва само за оформление, тя не трябва да съдържа елементи с данни, като например елементите th или caption или атрибута summary, тъй като това може да създаде объркване за потребителите на екранни четци. [Научете повече](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Презентационните елементи <table> използват <th>, <caption> или атрибута [summary]."
+    "message": "Презентационните елементи `<table>` използват `<th>`, `<caption>` или атрибута `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Презентационните елементи <table> не използват <th>, <caption> или атрибута [summary]."
+    "message": "Презентационните елементи `<table>` не използват `<th>`, `<caption>` или атрибута `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Текстът на връзките (и алтернативният текст за изображения, който се използва за връзки), който е различим, уникален и дава възможност фокусът да бъде поставен върху него, подобрява навигирането за потребителите на екранни четци. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Текстът на връзките (и алтернативният текст за изображения, когато се използват за връзки), който е различим, уникален и дава възможност фокусът да бъде поставен върху него, подобрява навигирането за потребителите на екранни четци. [Научете повече](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Някои връзки нямат отличително име"
@@ -219,103 +219,115 @@
     "message": "Връзките имат отличителни имена"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Екранните четци съобщават съдържанието на списъците по конкретен начин. Правилното структуриране на списъците улеснява прочитането им от екранните четци. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Екранните четци съобщават съдържанието на списъците по специфичен начин. Правилното структуриране на списъците улеснява четенето им от екранните четци. [Научете повече](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Някои списъци не съдържат само елементи <li> и спомагателни елементи за скриптовете (<script> и <template>)."
+    "message": "Някои списъци не съдържат само елементи `<li>` и елементи за поддръжка на скриптове (`<script>` и `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Списъците съдържат само елементи <li> и спомагателни елементи за скриптовете (<script> и <template>)."
+    "message": "Списъците съдържат само елементи `<li>` и елементи за поддръжка на скриптове (`<script>` и `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Екранните четци изискват списъчните елементи (<li>) да се съдържат в родителски елемент <ul> или <ol>, за да бъдат прочетени правилно. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Екранните четци изискват списъчните елементи (`<li>`) да се съдържат в родителски елемент `<ul>` или `<ol>`, за да бъдат прочетени правилно. [Научете повече](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Някои списъчни елементи (<li>) не се съдържат в родителски елементи <ul> или <ol>."
+    "message": "Някои списъчни елементи (`<li>`) не се съдържат в родителски елементи `<ul>` или `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Списъчните елементи (<li>) се съдържат в родителски елементи <ul> или <ol>"
+    "message": "Списъчните елементи (`<li>`) се съдържат в родителски елементи `<ul>` или `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Потребителите не очакват страницата да се опресни автоматично и ако това се случи, фокусът ще бъде върнат в горната й част. Това може да бъде дразнещо или объркващо за потребителите. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Потребителите не очакват страницата да се опресни автоматично и ако това се случи, фокусът ще бъде върнат в горната й част. Това може да бъде дразнещо или объркващо за потребителите. [Научете повече](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Документът използва <meta http-equiv=\"refresh\">"
+    "message": "Документът използва `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Документът не използва <meta http-equiv=\"refresh\">"
+    "message": "Документът не използва `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Невъзможността за промяна на мащаба създава проблем за потребителите със слабо зрение, които разчитат на увеличението на екрана, за да виждат добре съдържанието на уеб страниците. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Невъзможността за промяна на мащаба създава проблем за потребителите със слабо зрение, които разчитат на увеличението на екрана, за да виждат добре съдържанието на уеб страниците. [Научете повече](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "[user-scalable=\"no\"] се използва в елемента <meta name=\"viewport\"> или стойността на атрибута [maximum-scale] е по-малка от 5."
+    "message": "`[user-scalable=\"no\"]` се използва в елемента `<meta name=\"viewport\">` или стойността на атрибута `[maximum-scale]` е по-малка от 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "[user-scalable=\"no\"] не се използва в елемента <meta name=\"viewport\"> и стойността на атрибута [maximum-scale] не е по-малка от 5."
+    "message": "`[user-scalable=\"no\"]` не се използва в елемента `<meta name=\"viewport\">` и стойността на атрибута `[maximum-scale]` не е по-малка от 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Екранните четци не могат да интерпретират нетекстово съдържание. Добавянето на алтернативен текст към елементите <object> помага на екранните четци да предават смисъла им на потребителите. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Екранните четци не могат да интерпретират нетекстово съдържание. Добавянето на алтернативен текст към елементите `<object>` помага на екранните четци да предават смисъла им на потребителите. [Научете повече](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Някои елементи <object> нямат алтернативен текст ([alt])"
+    "message": "Някои елементи `<object>` нямат алтернативен текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Елементите <object> имат алтернативен текст ([alt])"
+    "message": "Елементите `<object>` имат алтернативен текст (`[alt]`)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Ако стойността е по-голяма от 0, значи се използва изричен ред на навигиране. Въпреки че е технически валидно, това често е дразнещо за потребителите, които разчитат на помощни технологии. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Ако стойността е по-голяма от 0, значи се използва изричен ред на навигиране. Въпреки че е технически валидно, това често създава неудобства за потребителите, които разчитат на помощни технологии. [Научете повече](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Някои елементи имат атрибут [tabindex] със стойност, по-голяма от 0"
+    "message": "Някои елементи имат атрибут `[tabindex]` със стойност, по-голяма от 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Никой от елементите няма атрибут [tabindex] със стойност, по-голяма от 0"
+    "message": "Никой от елементите няма атрибут `[tabindex]` със стойност, по-голяма от 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Екранните четци имат функции за улесняване на навигирането в таблици. Когато клетките от типа <td>, използващи атрибута [headers], са свързани само с други клетки в същата таблица, това може да подобри практическата работа за потребителите на екранни четци. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Екранните четци имат функции за улесняване на навигирането в таблици. Когато клетките от типа `<td>`, използващи атрибута `[headers]`, сочат само към други клетки от същата таблица, това може да подобри практическата работа за потребителите на екранни четци. [Научете повече](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Някои клетки в елемент <table>, които използват атрибута [headers], не са свързани с други клетки от същата таблица."
+    "message": "Някои клетки в елемент `<table>`, които използват атрибута `[headers]`, не сочат към други клетки от същата таблица."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Клетките в елемент <table>, които използват атрибута [headers], са свързани само с други клетки от същата таблица."
+    "message": "Клетките в елемент `<table>`, които използват атрибута `[headers]`, сочат само към други клетки от същата таблица."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Екранните четци имат функции за улесняване на навигирането в таблици. Свързването на всички заглавки в таблицата с набор от клетки може да подобри практическата работа за потребителите на екранни четци. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Екранните четци имат функции за улесняване на навигирането в таблици. Когато всички заглавки в таблицата сочат към някакъв набор от клетки, това може да подобри практическата работа за потребителите на екранни четци. [Научете повече](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Някои елементи <th> и елементи с [role=\"columnheader\"/\"rowheader\"] нямат клетки с данни, за които служат като описание."
+    "message": "Някои елементи `<th>` и елементи с `[role=\"columnheader\"/\"rowheader\"]` нямат клетки с данни, за които служат като описание."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Елементите <th> и елементите с [role=\"columnheader\"/\"rowheader\"] имат клетки с данни, за които служат като описание."
+    "message": "Елементите `<th>` и тези с `[role=\"columnheader\"/\"rowheader\"]` имат клетки с данни, за които служат като описание."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Посочването на валиден [език по BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) за елементите дава възможност на екранните четци да произнасят текста правилно. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Посочването на валиден [език по BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) за елементите дава възможност на екранните четци да произнасят текста правилно. [Научете повече](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Някои атрибути [lang] нямат валидна стойност"
+    "message": "Някои атрибути `[lang]` нямат валидна стойност"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Атрибутите [lang] имат валидна стойност"
+    "message": "Атрибутите `[lang]` имат валидна стойност"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Наличието на надпис за даден видеоклип улеснява достъпа до съответната информация за лицата, лишени от слух, и потребителите със слухови увреждания. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Наличието на надпис за даден видеоклип улеснява достъпа до съответната информация за потребителите със слухови увреждания. [Научете повече](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Някои елементи <video> не съдържат елемент <track> с [kind=\"captions\"]."
+    "message": "Някои елементи `<video>` не съдържат елемент `<track>` с `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Елементите <video> съдържат елемент <track> с [kind=\"captions\"]"
+    "message": "Елементите `<video>` съдържат елемент `<track>` с `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Аудиоописанията предоставят полезна информация за видеоклиповете (например за обстановката и изражението на лицата на героите), която потребителите не биха могли да разберат от диалога. [Научете повече](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Аудиоописанията предоставят полезна информация за видеоклиповете (например за обстановката и изражението на лицата на героите), която потребителите не биха могли да разберат от диалога. [Научете повече](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Някои елементи <video> не съдържат елемент <track> с [kind=\"description\"]."
+    "message": "Някои елементи `<video>` не съдържат елемент `<track>` с `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Елементите <video> съдържат елемент <track> с [kind=\"description\"]"
+    "message": "Елементите `<video>` съдържат елемент `<track>` с `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "За най-добро изобразяване под iOS, когато потребителите добавят към началния екран, дефинирайте атрибут apple-touch-icon. Той трябва да сочи към непрозрачен квадратен PNG файл със страна от 192 (или 180) пиксела. [Научете повече](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Не осигурява валиден атрибут `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Атрибутът `apple-touch-icon-precomposed` не е актуален, препоръчва се `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Съдържа валиден атрибут `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Зареждането на тази страница се забавя от разширения за Chrome. Опитайте да я проверите в режим „инкогнито“ или от потребителски профил в Chrome без инсталирани разширения."
@@ -351,7 +363,7 @@
     "message": "Отложете зареждането на изображенията извън видимата част на екрана"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Ресурси блокират първото изобразяване на страницата ви. Препоръчваме да вградите критичните JS/CSS елементи и да отложите зареждането на всички некритични JS/стилове. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Ресурси блокират първото изобразяване на страницата ви. Препоръчваме да вградите критичните JS/CSS елементи и да отложите зареждането на всички некритични стилове или JS код. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Елиминирайте ресурсите, които блокират изобразяването"
@@ -393,7 +405,7 @@
     "message": "Премахнете неизползвания JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Продължителното съхраняване на кеша може да ускори повторните посещения на страницата ви. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Продължителното съхраняване в кеша може да ускори повторните посещения на страницата ви. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Намерен е 1 ресурс}other{Намерени са # ресурса}}"
@@ -423,7 +435,7 @@
     "message": "Активирайте компресирането на текста"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Графичните формати, като JPEG 2000, JPEG XR и WebP, често осигуряват по-ефективно компресиране от PNG или JPEG. Това означава по-бързо изтегляне и използване на по-малко данни. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Графични формати, като JPEG 2000, JPEG XR и WebP, често осигуряват по-ефективно компресиране от PNG или JPEG. Това означава по-бързо изтегляне и използване на по-малко данни. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Използвайте съвременни формати за показване на изображения"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Намалете дълбочината на критичните заявки"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Оттегляне/предупреждение"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Ред"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Оттеглените приложни програмни интерфейси (API) след време ще бъдат премахнати от браузъра. [Научете повече](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Открито бе 1 предупреждение}other{Открити бяха # предупреждения}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Използва оттеглени приложни програмни интерфейси (API)"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Избягва оттеглени API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Кешът на приложенията е оттеглен. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Намерихме {AppCacheManifest}"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Използва кеша на приложенията"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Избягва кеша на приложенията"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Посочването на doctype не позволява на браузъра да премине в режим на обратна съвместимост. Прочетете повече на [страницата MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Името за doctype трябва да е низът `html` с малки букви"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Документът трябва да съдържа doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "За полето publicId се очакваше да бъде празен низ"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "За полето systemId се очакваше да бъде празен низ"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "На страницата липсва doctype на HTML, което задейства режим на обратна съвместимост"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Страницата съдържа doctype на HTML"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Елемент"
   },
@@ -447,7 +510,7 @@
     "message": "Стойност"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Браузърните инженери препоръчват страниците да съдържат под ~1500 елемента в DOM. Най-добре е йерархичната структура да е с дълбочина под 32 елемента и всеки родителски елемент да има по-малко от 60 дъщерни. Големият размер на DOM може да доведе до използване на повече памет, удължаване на [стиловите изчисления](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) и забавяне поради [преоформяне](https://developers.google.com/speed/articles/reflow). [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Браузърните инженери препоръчват страниците да съдържат под 1500 елемента в DOM. Най-добре е йерархичната структура да не е по-дълбока от 32 нива и всеки родителски елемент да има по-малко от 60 дъщерни. Големият размер на DOM може да доведе до използване на повече памет, удължаване на [стиловите изчисления](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) и забавяне поради [преоформяне](https://developers.google.com/speed/articles/reflow). [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 елемент}other{# елемента}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Не се използва DOM с твърде голям размер"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Target"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Добавете `rel=\"noopener\"` или `rel=\"noreferrer\"` към връзките към външни сайтове, за да подобрите ефективността и да избегнете уязвимости в сигурността. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Връзките към външни дестинации не са безопасни"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Връзките към външни дестинации са безопасни"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Не можахме да определим дестинацията за котвата ({anchorHTML}). Ако не се използва като хипервръзка, бихте могли да премахнете target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Потребителите се объркват или нямат доверие на сайтове, които искат да узнаят местоположението им без контекст. Вместо това бихте могли да обвържете заявката към действие на потребителя. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Иска разрешение за геолокация при зареждането на страницата"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Избягва да иска разрешение за геолокация при зареждането на страницата"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Версия"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Всички библиотеки на JavaScript за предния слой, открити на страницата."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Открити библиотеки на JavaScript"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "За потребителите с бавни връзки външните скриптове, вмъквани динамично чрез `document.write()`, могат да забавят зареждането на страницата с десетки секунди. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Използва `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Избягва `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Най-високо ниво на сериозност"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Версия на библиотеката"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Брой уязвимости"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Някои скриптове на трети страни може да съдържат известни уязвимости в сигурността, които лесно се откриват и използват от атакуващите. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Открита е 1 уязвимост}other{Открити са # уязвимости}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Включва библиотеки на JavaScript за предния слой, съдържащи известни уязвимости в сигурността"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Високо"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Ниско"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Средно"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Избягва библиотеки на JavaScript за предния слой, съдържащи известни уязвимости в сигурността"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Потребителите се объркват или нямат доверие на сайтове, които искат да изпращат известия без контекст. Вместо това бихте могли да обвържете заявката към жестове на потребителя. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Иска разрешение за известяване при зареждането на страницата"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Избягва да иска разрешение за известяване при зареждането на страницата"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Елементи с грешки"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Забраната на поставянето на пароли неутрализира добра практика за сигурност. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Не позволява на потребителите да поставят в полетата за парола"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Разрешава на потребителите да поставят в полетата за парола"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Протокол"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 предлага много предимства спрямо HTTP/1.1, включително заглавки в двоичен формат, мултиплексиране и самостоятелно изпращане на информация от сървъра. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 заявка не е обслужена през HTTP/2}other{# заявки не са обслужени през HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Не използва HTTP/2 за всичките си ресурси"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Използва HTTP/2 за собствените си ресурси"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "За да подобрите ефективността на страницата си при превъртане, бихте могли да означите като `passive` приемателите си на събития, свързани с докосване и с колелцето на мишката. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Не използва пасивни приематели на събития за подобряване на ефективността при превъртане"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Използва пасивни приематели на събития за подобряване на ефективността при превъртане"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Описание"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Грешките, записани в конзолата, показват нерешени проблеми. Може да се дължат на неуспешни заявки за мрежата и други проблеми в браузъра."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "В конзолата бяха записани грешки в браузъра"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "В конзолата не бяха записани грешки в браузъра"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Използвайте функцията font-display на CSS, така че текстът да е видим за потребителите при зареждането на уеб шрифтовете. [Научете повече](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Използвайте функцията font-display на CSS, така че текстът да е видим за потребителите, докато уеб шрифтовете се зареждат. [Научете повече](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Уверете се, че текстът остава видим при зареждането на уеб шрифтовете"
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Целият текст остава видим при зареждането на уеб шрифтовете"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse не успя да провери автоматично стойността на font-display за следния URL адрес: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Съотношение (действително)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Съотношение (показвано)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Размерите за показване на изображението трябва да съответстват на естественото съотношение. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Показва изображения с неправилно съотношение"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Показва изображенията с правилно съотношение"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Информацията за размера на изображението е невалидна: {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Несигурен URL адрес"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Всички сайтове трябва да бъдат защитени с HTTPS, дори онези, които не работят с поверителни данни. HTTPS не позволява на външни лица да променят или подслушват комуникацията между приложението ви и потребителите и е задължително условие за HTTP/2 и множество нови приложни програмни интерфейси (API) за платформи в мрежата. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Установена е 1 незащитена заявка}other{Установени са # незащитени заявки}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Не използва HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Използва HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Бързото зареждане на страниците през мобилни мрежи осигурява добра практическа работа за потребителите на мобилни устройства. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Интерактивност след {timeInMs, number, seconds} сек"
+    "message": "Интерактивна след {timeInMs, number, seconds} сек"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Интерактивност при симулирана мобилна мрежа след {timeInMs, number, seconds} сек"
@@ -504,7 +735,7 @@
     "message": "Работата по основната нишка е сведена до минимум"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Приблизителното забавяне при входящо действие показва приблизително колко време (в милисекунди) е необходимо на приложението ви, за да реагира на входящо потребителско действие по време на най-натоварения 5-секунден период от зареждането на страницата. Ако забавянето е над 50 мсек, приложението ви може да се стори бавно на потребителите. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Приблизителното забавяне при входящо действие показва приблизително колко време (в милисекунди) е необходимо на приложението ви, за да реагира на входящо потребителско действие по време на най-натоварения 5-секунден период от зареждането на страницата. Ако забавянето е над 50 милисекунди, приложението ви може да се стори бавно на потребителите. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Прогнозно забавяне при входящо действие"
@@ -534,10 +765,10 @@
     "message": "Време до интерактивност"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Потенциалното забавяне след първото входящо действие на потребителите е продължителността в милисекунди на най-времеемката задача."
+    "message": "Максималното потенциално забавяне при първото взаимодействие на потребителите е продължителността в милисекунди на най-времеемката задача. [Научете повече](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Макс. потенциално ЗСПВД"
+    "message": "Макс. потенц. забавяне при 1. взаимодействие"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Индексът на скоростта показва колко бързо се постига визуална завършеност на страницата. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
@@ -545,17 +776,35 @@
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Индекс на скоростта"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Сумата от всички интервали от време между FCP и „Време до интерактивност“, когато задачата е траела над 50 мсек, изразена в милисекунди."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Общо време на блокиране"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Времето за осъществяване на двупосочна комуникация в мрежата оказва голямо влияние върху ефективността. Ако двупосочната комуникация с източника отнема дълго време, това означава, че сървърите в близост до потребителя не работят достатъчно ефективно. [Научете повече](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Времето за осъществяване на двупосочна комуникация в мрежата оказва голямо влияние върху ефективността. Ако двупосочната комуникация с източника отнема дълго време, това означава, че разположени по-близо до потребителя сървъри биха подобрили ефективността. [Научете повече](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Време за двупосочна комуникация в мрежата"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Забавянията на сървъра могат да повлияят на ефективността на уебсайта. Наличието на голямо забавяне при източника указва, че сървърът е претоварен или задният слой не работи достатъчно ефективно. [Научете повече](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Забавянията на сървъра могат да повлияят на ефективността на уебсайта. Голямото забавяне при източника указва, че сървърът е претоварен или задният слой не работи достатъчно ефективно. [Научете повече](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Забавяния в задния слой на сървъра"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Надхвърля бюджета"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Поддържайте количеството и обема на мрежовите заявки под целевите стойности в посочения бюджет за ефективността. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 заявка}other{# заявки}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Бюджет за ефективността"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Пренасочванията водят до допълнително забавяне на зареждането на страницата. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
@@ -563,20 +812,29 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Не използвайте пренасочвания през няколко страници"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "За да определите бюджети за количеството и размера на ресурсите на страницата, добавете файл budget.json. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 заявка}other{# заявки}} • {byteCount, number, bytes} КБ"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Поддържайте малък брой заявки и неголям обем на прехвърляните данни"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Каноничните връзки указват кой URL адрес да се показва в резултатите от търсенето. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Няколко несъвместими URL адреса ({urlList})"
+    "message": "Множество несъвместими URL адреси ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Води до друг домейн ({url})"
+    "message": "Сочи към друг домейн ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Невалиден URL адрес ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Води до местоположение с друг атрибут hreflang ({url})"
+    "message": "Сочи към местоположение с друг атрибут `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Относителен URL адрес ({url})"
@@ -585,19 +843,16 @@
     "message": "Води до основния URL адрес (началната страница) на домейна вместо до еквивалентна страница със съдържание"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Документът няма валидна връзка от типа rel=canonical"
+    "message": "Документът няма валидна връзка от тип `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Документът има валидна връзка от типа rel=canonical"
+    "message": "Документът има валиден атрибут `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Шрифтът с размер под 12 пиксела е твърде малък и изисква посетителите, използващи мобилни устройства, да увеличат мащаба с разтваряне на пръсти, за да прочетат текста. Старайте се над 60% от текста на страницата да е с размер поне 12 пиксела. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Шрифтовете с размер под 12 пиксела са твърде малки и се налага посетителите от мобилни устройства да увеличат мащаба с разтваряне на пръсти, за да прочетат текста. Старайте се над 60% от текста на страницата да е с размер поне 12 пиксела. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} от текста е четлив"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} от текста е твърде малък."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Текстът не е четлив, тъй като няма мета маркер viewport, оптимизиран за мобилни екрани."
@@ -615,10 +870,10 @@
     "message": "Връзките от типа hreflang указват на търсещите машини коя версия на страницата да бъде включена в резултатите от търсенето за даден език или регион. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Документът няма валиден атрибут hreflang"
+    "message": "Документът няма валиден атрибут `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Документът има валиден атрибут hreflang"
+    "message": "Документът има валиден атрибут `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Страниците с невалиден HTTP код на състоянието може да не бъдат индексирани правилно. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -651,7 +906,7 @@
     "message": "Текстът на връзките е описателен"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Стартирайте [инструмента за тестване на структурирани данни](https://search.google.com/structured-data/testing-tool/) и [анализатора на структурирани данни](http://linter.structured-data.org/), за да проверите съответните данни. [Научете повече](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Стартирайте [инструмента за тестване на структурирани данни](https://search.google.com/structured-data/testing-tool/) и [анализатора на структурирани данни](http://linter.structured-data.org/), за да проверите структурираните данни. [Научете повече](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Структурираните данни са валидни"
@@ -681,7 +936,7 @@
     "message": "Ако файлът ви robots.txt не е форматиран правилно, роботите може да не могат да разберат как искате да бъде обходен или индексиран уебсайтът ви."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "при заявката за robots.txt се върна следният HTTP код на състоянието: {statusCode}"
+    "message": "при заявката за robots.txt бе върнат следният HTTP код на състоянието: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{Открита е 1 грешка}other{Открити са # грешки}}"
@@ -696,7 +951,7 @@
     "message": "Файлът robots.txt е валиден"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Интерактивните елементи, като бутони и връзки, трябва да са достатъчно големи (48 x 48 пиксела) и с достатъчно пространство около тях, за да се докосват лесно, без да се припокриват с други елементи. [Научете повече](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Интерактивните елементи, като бутони и връзки, трябва да са достатъчно големи (48 x 48 пиксела) и с достатъчно пространство около тях, за да се докосват лесно, без да се застъпват с други елементи. [Научете повече](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} от целевите зони за докосване са оразмерени правилно"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Припокриваща се целева зона"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Размер"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Целева зона за докосване"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Целевите зони за докосване са оразмерени правилно"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Време на основната нишка"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Трета страна"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Кодът от трети страни може сериозно да повлияе върху скоростта на зареждане. Ограничете броя на излишните доставчици трети страни и опитайте да зареждате кода от трети страни, след като основното зареждане на страницата ви е приключило. [Научете повече](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Открит е 1 фрагмент с код от трета страна}other{Открити са # фрагмента с код от трета страна}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Използване на код от трети страни"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Показателят „Време до първия байт“ указва след колко време сървърът изпраща отговор. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "Основният документ отне {timeInMs, number, milliseconds} мсек"
+    "message": "За основния документ бяха необходими {timeInMs, number, milliseconds} мсек"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "Намалете времето за отговор от сървъра (време до първия байт)"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Продължителност"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Име"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Начален час"
@@ -753,19 +1017,19 @@
     "message": "Точки и измервания в разбивката на потребителските времена"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Намерен бе елемент <link> за предварително свързване за {securityOrigin}, който обаче не бе използван от браузъра. Проверете дали използвате правилно атрибута crossorigin."
+    "message": "Намерен бе елемент <link> за предварително свързване за {securityOrigin}, който обаче не бе използван от браузъра. Проверете дали използвате правилно атрибута `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Препоръчваме да добавите подсказки за предварително свързване или предварително извличане на DNS за ресурсите с цел ранно установяване на връзка с важни източници на трети страни. [Научете повече](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Препоръчваме да добавите подсказки за предварително свързване или предварително извличане на DNS за ресурсите с цел ранно установяване на връзка с важни източници от трети страни. [Научете повече](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Осигурете предварително свързване с необходимите източници"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Намерен бе елемент <link> за предварително зареждане за {preloadURL}, който обаче не бе използван от браузъра. Проверете дали използвате правилно атрибута crossorigin."
+    "message": "Намерен бе елемент <link> за предварително зареждане за {preloadURL}, който обаче не бе използван от браузъра. Проверете дали използвате правилно атрибута `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Препоръчваме да използвате <link rel=preload>, за да укажете най-напред да се извличат ресурсите, които понастоящем се заявяват на по-късен етап от зареждането на страницата. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Препоръчваме да използвате `<link rel=preload>`, за да укажете по-ранно извличане на ресурсите, които понастоящем се заявяват на по-късен етап от зареждането на страницата. [Научете повече](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Задайте ключовите заявки да се зареждат предварително"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Таблици и списъци"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Най-добри практики"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Бюджетите за ефективността задават стандарти за ефективността на сайта ви."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Бюджети"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Повече информация за ефективността на приложението ви."
+    "message": "Повече информация за ефективността на приложението ви. Тези стойности не се [отразяват директно](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) върху рейтинга за ефективността."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Диагностика"
@@ -840,7 +1113,7 @@
     "message": "Подобрения, свързани с първото изобразяване"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Тези оптимизации могат да ускорят зареждането на страницата."
+    "message": "Тези предложения може да ускорят зареждането на страницата ви. Те не се [отразяват директно](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) върху рейтинга за ефективността."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Възможности"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Време на валидност на кеша"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Местоположение"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Име"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Заявки"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Тип ресурс"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Размер (КБ)"
+    "message": "Размер"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Прекарано време"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Размер на прехвърлянето"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL адрес"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Потенциална икономия (КБ)"
+    "message": "Потенциална икономия"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Потенциална икономия (мсек)"
+    "message": "Потенциална икономия"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Потенциално спестяване на {wastedBytes, number, bytes} КБ"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Потенциално спестяване на {wastedMs, number, milliseconds} мсек"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Документ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Шрифт"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Изображение"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Мултимедия"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} мсек"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Друго"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Скрипт"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} сек"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Стилов лист"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Трети страни"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Общо"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Нещо се обърка при записването на трасирането за зареждането на страницата ви. Моля, стартирайте отново Lighthouse. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS сървърите не можаха да преобразуват предоставения домейн."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "В задължителния механизъм за събиране на {artifactName} възникна грешка: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Възникна вътрешна грешка в Chrome. Моля, рестартирайте браузъра и опитайте отново да стартирате Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Задължителният механизъм за събиране на {artifactName} не се изпълни."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse не успя надеждно да зареди заявената от вас страница. Уверете се, че тествате точния URL адрес и че сървърът отговаря правилно на всички заявки."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse не успя надеждно да зареди заявения от вас URL адрес, тъй като страницата спря да реагира."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Идентификационните данни за сигурност за предоставения от вас URL адрес не са валидни. {securityMessages}"
+    "message": "Посоченият от вас URL адрес няма валиден сертификат за сигурност. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome не допусна зареждане на страница със заставка. Уверете се, че тествате точния URL адрес и че сървърът отговаря правилно на всички заявки."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse не успя надеждно да зареди заявената от вас страница. Уверете се, че тествате точния URL адрес и че сървърът отговаря правилно на всички заявки. (Подробности: {errorDetails})"
@@ -954,7 +1278,7 @@
     "message": "Lighthouse не успя надеждно да зареди заявената от вас страница. Уверете се, че тествате точния URL адрес и че сървърът отговаря правилно на всички заявки. (Код на състоянието: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Зареждането на страницата отне твърде дълго време. Моля, използвайте посочените в отчета възможности за ускоряване на зареждането й, след което опитайте отново да стартирате Lighthouse. ({errorCode})"
+    "message": "Зареждането на страницата бе твърде бавно. Моля, използвайте посочените в отчета възможности за ускоряване на зареждането ѝ, след което опитайте отново да стартирате Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "Предвиденото време за изчакване на отговор от протокола DevTools бе превишено. (Метод: {protocolMethod})"
@@ -984,7 +1308,7 @@
     "message": "Данни от контролиран тест"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "Анализът с [Lighthouse](https://developers.google.com/web/tools/lighthouse/) на текущата страница бе извършен през емулирана мобилна мрежа. Стойностите са прогнозни и може да варират."
+    "message": "Анализът с [Lighthouse](https://developers.google.com/web/tools/lighthouse/) на текущата страница бе извършен през емулирана мобилна мрежа. Стойностите са приблизителни и може да варират."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Допълнителни елементи, които да проверите ръчно"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Разгъване на фрагмента"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Показване на ресурсите от трети страни"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Възникнаха проблеми при изготвянето на този отчет от Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Стойностите са прогнозни и може да варират."
+    "message": "Стойностите са приблизителни и може да варират. Рейтингът за ефективността [се базира само на тези показатели](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Проверките бяха преминати успешно, но има предупреждения"
@@ -1023,7 +1350,7 @@
     "message": "Добре е да качите GIF файла си в услуга, която ще даде възможност да бъде вграден като видеоклип с HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Инсталирайте [приставка за WordPress за забавено зареждане](https://wordpress.org/plugins/search/lazy+load/), която дава възможност за отлагане на зареждането на изображенията извън видимата част на екрана, или заменете темата с такава, която предоставя тази функционалност. Можете също да използвате [приставката за AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Инсталирайте [приставка за WordPress за забавено зареждане](https://wordpress.org/plugins/search/lazy+load/), която дава възможност за отлагане на зареждането на изображенията извън видимата част на екрана, или преминете към тема с такава функционалност. Можете също да използвате [приставката за AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "Има различни приставки за WordPress, с чиято помощ можете [да вградите важни активи](https://wordpress.org/plugins/search/critical+css/) или [да отложите зареждането на не толкова важни ресурси](https://wordpress.org/plugins/search/defer+css+javascript/). Имайте предвид, че оптимизациите, извършвани чрез тези приставки, може да възпрепятстват работата на функциите на темата ви или други приставки, така че вероятно ще се наложи да промените кода."
@@ -1035,10 +1362,10 @@
     "message": "Обмислете възможността да показвате извадки в списъците си с публикации (напр. чрез маркера more), да намалите броя на публикациите, извеждани на дадена страница, да разделите дългите публикации на няколко страници или да използвате приставка, която да забави зареждането на коментарите."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Има различни [приставки за WordPress](https://wordpress.org/plugins/search/minify+css/), които могат да подобрят скоростта на сайта ви чрез конкатениране, минимизиране и компресиране на стиловете ви. Добре е също при възможност да използвате процес на компилиране, за да извършите това минимизиране предварително."
+    "message": "Има различни [приставки за WordPress](https://wordpress.org/plugins/search/minify+css/), които могат да подобрят скоростта на сайта ви чрез обединяване, минимизиране и компресиране на стиловете. Добре е също при възможност да използвате компилиране, за да извършите това минимизиране предварително."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Има различни [приставки за WordPress](https://wordpress.org/plugins/search/minify+javascript/), които могат да подобрят скоростта на сайта ви чрез конкатениране, минимизиране и компресиране на скриптовете. Добре е също при възможност да използвате процес на компилиране, за да извършите това минимизиране предварително."
+    "message": "Има различни [приставки за WordPress](https://wordpress.org/plugins/search/minify+javascript/), които могат да подобрят скоростта на сайта ви чрез обединяване, минимизиране и компресиране на скриптовете. Добре е също при възможност да използвате компилиране, за да извършите това минимизиране предварително."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
     "message": "Добре е да намалите броя на [приставките за WordPress](https://wordpress.org/plugins/), които зареждат неизползван CSS код в страницата ви, или да ги замените с други. За да откриете приставките, които добавят ненужен CSS код, стартирайте инструмента за [покритие на кода](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) в Chrome DevTools. Можете да намерите проблемната тема/приставка в URL адреса на листа със стилове. Търсете приставки с много листове със стилове в списъка, за които преобладава червеният цвят в диаграмата на инструмента. Даден лист със стилове трябва да бъде поставен в опашката на приставка само ако действително се използва в страницата."
@@ -1047,13 +1374,13 @@
     "message": "Добре е да намалите броя на [приставките за WordPress](https://wordpress.org/plugins/), които зареждат неизползван JavaScript код в страницата ви, или да ги замените с други. За да откриете приставките, които добавят ненужен JS код, стартирайте инструмента за [покритие на кода](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) в Chrome DevTools. Можете да намерите проблемната тема/приставка в URL адреса на скрипта. Търсете приставки с много скриптове в списъка, за които преобладава червеният цвят в диаграмата на инструмента. Даден скрипт трябва да бъде поставен в опашката на приставка само ако действително се използва в страницата."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Прочетете за [кеширането в браузъра чрез WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Прочетете за [кеширането в браузъра при WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "Добре е да използвате [приставка за WordPress за оптимизиране на изображенията](https://wordpress.org/plugins/search/optimize+images/), която компресира графичните ви файлове, като същевременно запазва качеството им."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Качвайте изображенията директно чрез [мултимедийната библиотека](https://codex.wordpress.org/Media_Library_Screen), за да разполагате с графични файлове с необходимите размери, и след това ги вмъквайте от библиотеката или използвайте приспособлението за изображения, така че да се използват файловете с оптимални размери (включително за адаптивните гранични точки). Избягвайте използването на пълноразмерни изображения, освен ако размерите са подходящи за съответното предназначение. [Научете повече](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Качвайте изображенията директно чрез [мултимедийната библиотека](https://codex.wordpress.org/Media_Library_Screen), за да разполагате с графични файлове с необходимите размери, и след това ги вмъквайте от библиотеката или използвайте приспособлението за изображения, така че да се използват файловете с оптимални размери (включително за адаптивните гранични точки). Избягвайте използването на пълноразмерни изображения (`Full Size`), освен ако размерите са подходящи за съответното предназначение. [Научете повече](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Можете да активирате компресирането на текста в конфигурацията на уеб сървъра си."

--- a/lighthouse-core/lib/i18n/locales/ca.json
+++ b/lighthouse-core/lib/i18n/locales/ca.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Les tecles d'accés permeten als usuaris posar el focus ràpidament en una part de la pàgina. Perquè es puguin desplaçar correctament, cada tecla d'accés ha de ser única. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Les tecles d'accés permeten als usuaris posar el focus ràpidament en una part de la pàgina. Perquè es puguin desplaçar correctament, cada tecla d'accés ha de ser única. [Obtén més informació](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Els valors de l'atribut \"[accesskey]\" no són exclusius"
+    "message": "Els valors de l'atribut `[accesskey]` no són únics"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Els valors de l'atribut \"[accesskey]\" són exclusius"
+    "message": "Els valors de l'atribut `[accesskey]` són únics"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Tots els elements \"role\" d'ARIA admeten un subconjunt específic d'atributs \"aria-*\". Si no coincideixen, els atributs \"aria-*\" queden invalidats. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Cada element `role` d'ARIA admet un subconjunt específic d'atributs `aria-*`. Si no coincideixen, els atributs `aria-*` queden invalidats. [Obtén més informació](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Els atributs \"[aria-*]\" no concorden amb les seves funcions"
+    "message": "Els atributs `[aria-*]` no coincideixen amb les seves funcions"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Els atributs \"[aria-*]\" coincideixen amb les seves funcions"
+    "message": "Els atributs `[aria-*]` coincideixen amb les seves funcions"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Algunes funcions d'ARIA tenen atributs obligatoris que descriuen l'estat de l'element als lectors de pantalla. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Algunes funcions d'ARIA tenen atributs obligatoris que descriuen l'estat de l'element als lectors de pantalla. [Obtén més informació](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Els atributs \"[role]\" no tenen tots els atributs \"[aria-*]\" obligatoris"
+    "message": "Els atributs `[role]` no tenen tots els atributs `[aria-*]` obligatoris"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Els atributs \"[role]\" tenen tots els atributs \"[aria-*]\" obligatoris"
+    "message": "Els elements amb l'atribut `[role]` tenen tots els atributs `[aria-*]` obligatoris"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Algunes funcions dels elements d'ARIA superiors han d'incloure funcions concretes dels elements secundaris perquè puguin dur a terme les funcions d'accessibilitat per a què s'han dissenyat. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Algunes funcions dels elements ARIA superiors han d'incloure funcions concretes dels elements secundaris perquè puguin dur a terme les funcions d'accessibilitat per a les quals s'han dissenyat. [Obtén més informació](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Falten elements amb l'atribut \"[role]\" que requereixen determinats atributs \"[role]\" secundaris."
+    "message": "Falten elements amb l'atribut `[role]` que requereixen determinats atributs `[role]` secundaris."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Hi ha elements amb l'atribut \"[role]\" que requereixen determinats atributs \"[role]\" secundaris"
+    "message": "Hi ha elements amb l'atribut `[role]` que requereixen determinats atributs `[role]` secundaris"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Les funcions de determinats elements superiors han d'incloure algunes funcions dels elements d'ARIA secundaris perquè puguin dur a terme les funcions d'accessibilitat per a què s'han dissenyat. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Les funcions de determinats elements superiors han d'incloure algunes funcions dels elements ARIA secundaris perquè puguin dur a terme les funcions d'accessibilitat per a les quals s'han dissenyat. [Obtén més informació](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Els atributs \"[role]\" no s'inclouen a l'element superior obligatori"
+    "message": "Els atributs `[role]` no s'inclouen a l'element superior obligatori"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Els atributs \"[role]\" s'inclouen a l'element superior obligatori"
+    "message": "Els atributs `[role]` s'inclouen a l'element superior obligatori"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Les funcions dels elements d'ARIA han de tenir valors vàlids perquè puguin dur a terme les funcions d'accessibilitat per a què s'han dissenyat. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Les funcions dels elements ARIA han de tenir valors vàlids perquè puguin dur a terme les funcions d'accessibilitat per a les quals s'han dissenyat. [Obtén més informació](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Els valors de l'atribut \"[role]\" no són vàlids"
+    "message": "Els valors de l'atribut `[role]` no són vàlids"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Els valors de l'atribut \"[role]\" són vàlids"
+    "message": "Els valors de l'atribut `[role]` són vàlids"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Les tecnologies d'assistència, com ara els lectors de pantalla, no poden interpretar els atributs d'ARIA que tenen valors que no són vàlids. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Les tecnologies d'assistència, com ara els lectors de pantalla, no poden interpretar els atributs ARIA que tenen valors que no són vàlids. [Obtén més informació](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Els atributs \"[aria-*]\" no tenen valors vàlids"
+    "message": "Els atributs `[aria-*]` no tenen valors vàlids"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Els atributs \"[aria-*]\" tenen valors vàlids"
+    "message": "Els atributs `[aria-*]` tenen valors vàlids"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Les tecnologies d'assistència, com ara els lectors de pantalla, no poden interpretar els atributs d'ARIA que tenen noms que no són vàlids. [Obtén més informació](https://dequeuniversity.com/rules/axe/2.2/aria-valid-attr?application=lighthouse)."
+    "message": "Les tecnologies d'assistència, com ara els lectors de pantalla, no poden interpretar els atributs ARIA que tenen noms que no són vàlids. [Obtén més informació](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Els atributs \"[aria-*]\" no són vàlids o estan mal escrits"
+    "message": "Els atributs `[aria-*]` no són vàlids o estan mal escrits"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Els atributs \"[aria-*]\" són vàlids i estan ben escrits"
+    "message": "Els atributs `[aria-*]` són vàlids i estan ben escrits"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Els subtítols permeten que els usuaris sords o amb discapacitat auditiva utilitzin els elements d'àudio. Així obtenen informació molt important, com ara qui parla, què diu i altres dades no verbals. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Els subtítols permeten que els usuaris sords o amb discapacitat auditiva utilitzin els elements d'àudio. Així obtenen informació essencial, com ara qui parla, què diu i altres dades no verbals. [Obtén més informació](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Als elements \"<audio>\" els falta un element \"<track>\" amb l'atribut \"[kind=\"captions\"]\"."
+    "message": "Als elements `<audio>` els falta un element `<track>` amb `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Els elements \"<audio>\" contenen un element \"<track>\" amb l'atribut \"[kind=\"captions\"]\""
+    "message": "Els elements `<audio>` contenen un element `<track>` amb `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Elements amb errors"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Si un botó no té un nom accessible, els lectors de pantalla el llegeixen com a \"botó\", de manera que queda inservible per als usuaris que depenen d'aquesta tecnologia. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Si un botó no té un nom accessible, els lectors de pantalla el llegeixen com a \"botó\", de manera que queda inservible per als usuaris que depenen d'aquesta tecnologia. [Obtén més informació](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Els botons no tenen un nom accessible"
@@ -93,7 +93,7 @@
     "message": "Els botons tenen noms accessibles"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Si s'afegeixen maneres d'evitar el contingut repetitiu, els usuaris de teclat poden navegar per la pàgina de manera més eficaç. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Si s'afegeixen maneres d'evitar el contingut repetitiu, els usuaris del teclat poden navegar per la pàgina de manera més eficaç. [Obtén més informació](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "La pàgina no conté un encapçalament, un enllaç d'omissió o una regió de referència"
@@ -102,7 +102,7 @@
     "message": "La pàgina conté un encapçalament, un enllaç d'omissió o una regió de referència"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "El text amb contrast baix resulta difícil o impossible de llegir per a molts usuaris. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "El text amb contrast baix resulta difícil o impossible de llegir per a molts usuaris. [Obtén més informació](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "La relació de contrast dels colors de primer i de segon pla no és suficient."
@@ -111,88 +111,88 @@
     "message": "La relació de contrast dels colors de primer i de segon pla és suficient"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Si el marcatge de les llistes de definició no és correcte, és possible que els lectors de pantalla expressin els missatges de manera confusa o inexacta. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Si el marcatge de les llistes de definició no és correcte, és possible que els lectors de pantalla sonin de manera confusa o inexacta. [Obtén més informació](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Els elements \"<dl>\" no contenen només grups de \"<dt>\" i \"<dd>\" ordenats correctament, o bé elements \"<script>\" o \"<template>\"."
+    "message": "Els elements `<dl>` no contenen només grups de `<dt>` i `<dd>` ordenats correctament, o bé elements `<script>` o `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Els elements \"<dl>\" contenen només grups de \"<dt>\" i \"<dd>\" ordenats correctament, o bé elements \"<script>\" o \"<template>\"."
+    "message": "Els elements `<dl>` contenen només grups de `<dt>` i `<dd>` ordenats correctament, o bé elements `<script>` o `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Els elements de la llista de definicions (\"<dt>\" i \"<dd>\") han d'estar tancats dins d'un element \"<dl>\" del nivell superior per garantir que els lectors de pantalla els puguin pronunciar correctament. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Els elements de la llista de definicions (`<dt>` i `<dd>`) han d'estar tancats dins d'un element `<dl>` superior per garantir que els lectors de pantalla els puguin pronunciar correctament. [Obtén més informació](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Els elements de la llista de definicions no estan tancats entre elements \"<dl>\""
+    "message": "Els elements de la llista de definicions estan tancats entre elements `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Els elements de la llista de definicions estan tancats entre elements \"<dl>\""
+    "message": "Els elements de la llista de definicions estan tancats entre elements `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "El títol proporciona als usuaris de lectors de pantalla un resum de la pàgina. A més, els usuaris de motors de cerca hi depenen en gran mesura per determinar si una pàgina és rellevant per a la seva cerca. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "El títol proporciona als usuaris de lectors de pantalla un resum de la pàgina. A més, els usuaris de motors de cerca depenen en gran mesura d'aquest títol per determinar si una pàgina és rellevant per a la seva cerca. [Obtén més informació](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "El document no té cap element \"<title>\""
+    "message": "El document no té cap element `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "El document té un element \"<title>\""
+    "message": "El document té un element `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "El valor d'un atribut d'identificador ha de ser exclusiu per impedir que les tecnologies d'assistència no passin per alt altres instàncies. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "El valor d'un atribut d'identificador ha de ser únic per impedir que les tecnologies d'assistència no passin per alt altres instàncies. [Obtén més informació](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Els atributs \"[id]\" de la pàgina no són exclusius"
+    "message": "Els atributs `[id]` de la pàgina no són únics"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Els atributs \"[id]\" de la pàgina són exclusius"
+    "message": "Els atributs `[id]` de la pàgina són únics"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Els usuaris de lectors de pantalla depenen dels títols dels marcs perquè en descriguin el contingut. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Els usuaris de lectors de pantalla depenen dels títols dels marcs perquè en descriguin el contingut. [Obtén més informació](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Els elements \"<frame>\" o \"<iframe>\" no tenen títol"
+    "message": "Els elements `<frame>` o `<iframe>` no tenen títol"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Els elements \"<frame>\" o \"<iframe>\" tenen títol"
+    "message": "Els elements `<frame>` o `<iframe>` tenen un títol"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Si en una pàgina no s'especifica un atribut d'idioma, els lectors de pantalla suposen que la pàgina està escrita en l'idioma predeterminat que l'usuari ha triat en configurar el lector de pantalla. Si està escrita en un altre idioma, és possible que el lector de pantalla no en llegeixi el text correctament. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Si en una pàgina no s'especifica un atribut d'idioma, els lectors de pantalla suposen que la pàgina està escrita en l'idioma predeterminat que l'usuari ha triat en configurar el lector de pantalla. Si està escrita en un altre idioma, és possible que el lector de pantalla no en llegeixi el text correctament. [Obtén més informació](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "L'element \"<html>\" no té un atribut \"[lang]\""
+    "message": "L'element `<html>` no té un atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "L'element \"<html>\" té un atribut \"[lang]\""
+    "message": "L'element `<html>` té un atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Si especifiques un [idioma vàlid d'acord amb l'estàndard BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), ajudes a fer que els lectors de pantalla pronunciïn el text correctament. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Si especifiques un [idioma vàlid d'acord amb l'estàndard BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), ajudes a fer que els lectors de pantalla pronunciïn el text correctament. [Obtén més informació](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "L'element \"<html>\" no té un valor vàlid per a l'atribut \"[lang]\" corresponent."
+    "message": "L'element `<html>` no té un valor vàlid per a l'atribut `[lang]` corresponent."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "L'element \"<html>\" té un valor vàlid per a l'atribut \"[lang]\" corresponent"
+    "message": "L'element `<html>` té un valor vàlid per a l'atribut `[lang]` corresponent"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Els elements informatius han d'utilitzar text alternatiu que sigui breu i descriptiu. Els elements decoratius es poden ignorar amb un atribut alt buit. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Els elements informatius han d'utilitzar text alternatiu que sigui breu i descriptiu. Els elements decoratius es poden ignorar amb un atribut alt buit. [Obtén més informació](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Els elements d'imatge no tenen atributs \"[alt]\""
+    "message": "Els elements d'imatge no tenen atributs `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Els elements d'imatge tenen atributs \"[alt]\""
+    "message": "Els elements d'imatge tenen atributs `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Si s'utilitza una imatge per al botó \"<input>\", el text alternatiu pot ajudar els usuaris dels lectors de pantalla a entendre la funció del botó. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Si s'utilitza una imatge per al botó `<input>`, el text alternatiu pot ajudar els usuaris dels lectors de pantalla a entendre la funció del botó. [Obtén més informació](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Els elements \"<input type=\"image\">\" no tenen text a l'atribut \"[alt]\""
+    "message": "Els elements `<input type=\"image\">` no tenen text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Els elements \"<input type=\"image\">\" tenen text a l'atribut \"[alt]\""
+    "message": "Els elements `<input type=\"image\">` tenen text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Les etiquetes garanteixen que les tecnologies d'assistència, com ara els lectors de pantalla, puguin llegir correctament els controls dels formularis. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Les etiquetes garanteixen que les tecnologies d'assistència, com ara els lectors de pantalla, puguin llegir correctament els controls dels formularis. [Obtén més informació](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Els elements de formulari no tenen etiquetes associades"
@@ -201,16 +201,16 @@
     "message": "Els elements de formulari tenen etiquetes associades"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Una taula que s'utilitza per al disseny no pot incloure elements de dades, com ara un superíndex, elements de subtítols o l'atribut de resum, ja que es pot crear una experiència confusa per als usuaris de lectors de pantalla. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Una taula que s'utilitza per al disseny no pot incloure elements de dades, com ara un superíndex, elements de subtítols o l'atribut de resum, ja que es pot crear una experiència confusa per als usuaris de lectors de pantalla. [Obtén més informació](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Els elements \"<table>\" per a presentacions no eviten utilitzar \"<th>\", \"<caption>\" ni l'atribut \"[summary]\"."
+    "message": "Els elements `<table>` per a presentacions no eviten utilitzar `<th>`, `<caption>` ni l'atribut `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Els elements \"<table>\" per a presentacions eviten utilitzar \"<th>\", \"<caption>\" o l'atribut \"[summary]\"."
+    "message": "Els elements `<table>` per a presentacions eviten utilitzar `<th>`, `<caption>` o l'atribut `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Si el text dels enllaços (així com el text alternatiu per a les imatges, quan s'utilitzen com enllaços) és discernible, únic i permet que s'hi posi el focus, millora l'experiència de navegació per als usuaris de lectors de pantalla. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Si el text dels enllaços (així com el text alternatiu per a les imatges, quan s'utilitzen com a enllaços) és discernible, únic i permet que s'hi posi el focus, millora l'experiència de navegació dels usuaris de lectors de pantalla. [Obtén més informació](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Els enllaços no tenen noms que es puguin distingir"
@@ -219,103 +219,115 @@
     "message": "Els enllaços tenen noms que es poden distingir"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Els lectors de pantalla tenen una manera específica de llegir les llistes. Estructurar-les correctament millora la manera com els lectors de pantalla expressen els missatges. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Els lectors de pantalla tenen una manera específica de llegir les llistes. Estructurar-les correctament millora la manera com els lectors de pantalla sonen. [Obtén més informació](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Les llistes no contenen només elements \"<li>\" i elements que admeten scripts (\"<script>\" o \"<template>\")."
+    "message": "Les llistes no contenen només elements`<li>` i elements que admeten scripts (`<script>` i `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Les llistes contenen només elements \"<li>\" i elements que admeten scripts (\"<script>\" o \"<template>\")."
+    "message": "Les llistes contenen només elements `<li>` i elements que admeten scripts (`<script>` i `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Els lectors de pantalla requereixen que els elements de llista (\"<li>\") estiguin inclosos dins d'un element \"<ul>\" o \"<ol>\" del nivell superior per poder llegir-los correctament. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Els lectors de pantalla requereixen que els elements de llista (`<li>`) estiguin inclosos dins d'un element `<ul>` o `<ol>` superior per poder llegir-los correctament. [Obtén més informació](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Alguns elements de llista (\"<li>\") no estan inclosos entre elements \"<ul>\" o \"<ol>\" superiors."
+    "message": "Alguns elements de llista (`<li>`) no estan inclosos entre elements `<ul>` o `<ol>` superiors."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Alguns elements de llista (\"<li>\") estan inclosos entre elements \"<ul>\" o \"<ol>\" superiors."
+    "message": "Alguns elements de llista (`<li>`) estan inclosos entre elements `<ul>` o `<ol>` superiors"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Els usuaris no esperen que una pàgina s'actualitzi automàticament. En fer-ho, el focus torna a la part superior de la pàgina i els usuaris es poden sentir frustrats i confosos. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Els usuaris no esperen que una pàgina s'actualitzi automàticament. En fer-ho, el focus torna a la part superior de la pàgina i els usuaris es poden sentir frustrats i confosos. [Obtén més informació](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "El document utilitza \"<meta http-equiv=\"refresh\">\""
+    "message": "El document utilitza la metaetiqueta `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "El document no utilitza \"<meta http-equiv=\"refresh\">\""
+    "message": "El document no utilitza `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Desactivar el zoom pot ser un problema per als usuaris amb visió reduïda que necessiten ampliar la pantalla per veure correctament el contingut d'una pàgina web. [Obtén més informació](https://dequeuniversity.com/rules/axe/2.2/meta-viewport?application=lighthouse)."
+    "message": "Desactivar el zoom pot ser un problema per als usuaris amb visió reduïda que necessiten ampliar la pantalla per veure correctament el contingut d'una pàgina web. [Obtén més informació](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "L'atribut \"[user-scalable=\"no\"]\" s'utilitza a l'element \"<meta name=\"viewport\">\" o l'atribut \"[maximum-scale]\" és inferior a 5."
+    "message": "L'atribut `[user-scalable=\"no\"]` s'utilitza a l'element `<meta name=\"viewport\">` o l'atribut `[maximum-scale]` és inferior a 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "L'atribut \"[user-scalable=\"no\"]\" no s'utilitza a l'element \"<meta name=\"viewport\">\" i \"[maximum-scale]\" no és inferior a 5."
+    "message": "L'atribut `[user-scalable=\"no\"]` no s'utilitza a l'element `<meta name=\"viewport\">` i l'atribut `[maximum-scale]` no és inferior a 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Els lectors de pantalla no poden traduir contingut que no sigui text. Si afegeixes text alternatiu als elements \"<object>\", ajudes els lectors de pantalla a transmetre el significat als usuaris. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Els lectors de pantalla no poden traduir contingut que no sigui text. Si afegeixes text alternatiu als elements `<object>`, ajudes els lectors de pantalla a transmetre el significat als usuaris. [Obtén més informació](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Els elements \"<object>\" no tenen text a l'atribut \"[alt]\""
+    "message": "Els elements `<object>` no tenen text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Els elements \"<object>\" tenen text a l'atribut \"[alt]\""
+    "message": "Els elements `<object>` tenen text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Un valor superior a 0 implica una ordenació explícita de navegació. Tècnicament és vàlid, però sol suposar experiències frustrants per als usuaris que depenen de les tecnologies d'assistència. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Un valor superior a 0 implica una ordenació explícita de navegació. Tècnicament és vàlid, però sol suposar experiències frustrants per als usuaris que depenen de les tecnologies d'assistència. [Obtén més informació](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Alguns elements tenen un valor de \"[tabindex]\" superior a 0"
+    "message": "Alguns elements tenen un valor `[tabindex]` superior a 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Cap element no té un valor de \"[tabindex]\" superior a 0"
+    "message": "Cap element no té un valor `[tabindex]` superior a 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Els lectors de pantalla inclouen funcions perquè sigui més fàcil navegar per les taules. Assegura't que les cel·les \"<td>\" que fan servir l'atribut \"[headers]\" només facin referència a altres cel·les de la mateixa taula. Això pot millorar l'experiència dels usuaris de lectors de pantalla. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Els lectors de pantalla inclouen funcions perquè sigui més fàcil navegar per les taules. Assegura't que les cel·les `<td>` que fan servir l'atribut `[headers]` només facin referència a altres cel·les de la mateixa taula. Això pot millorar l'experiència dels usuaris de lectors de pantalla. [Obtén més informació](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Algunes cel·les d'un element \"<table>\" que fan servir l'atribut \"[headers]\" fan referència a altres cel·les de la mateixa taula."
+    "message": "Algunes cel·les d'un element `<table>` que fan servir l'atribut `[headers]` fan referència a altres cel·les de la mateixa taula."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Algunes cel·les d'un element \"<table>\" que fan servir l'atribut \"[headers]\" només fan referència a altres cel·les de la mateixa taula."
+    "message": "Algunes cel·les d'un element `<table>` que fan servir l'atribut `[headers]` només fan referència a altres cel·les de la mateixa taula."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Els lectors de pantalla inclouen funcions perquè sigui més fàcil navegar per les taules. Assegura't que els encapçalaments de les taules facin sempre referència a un conjunt de cel·les. Això pot millorar l'experiència dels usuaris de lectors de pantalla. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Els lectors de pantalla inclouen funcions perquè sigui més fàcil navegar per les taules. Assegura't que els encapçalaments de les taules facin sempre referència a un conjunt de cel·les. Això pot millorar l'experiència dels usuaris de lectors de pantalla. [Obtén més informació](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Els elements \"<th>\" i els que inclouen l'atribut \"[role=\"columnheader\"/\"rowheader\"]\" no tenen les cel·les de dades que descriuen."
+    "message": "Els elements `<th>` i els que inclouen l'atribut `[role=\"columnheader\"/\"rowheader\"]` no tenen les cel·les de dades que descriuen."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Els elements \"<th>\" i els que inclouen l'atribut \"[role=\"columnheader\"/\"rowheader\"]\" tenen les cel·les de dades que descriuen."
+    "message": "Els elements `<th>` i els que inclouen l'atribut `[role=\"columnheader\"/\"rowheader\"]` tenen les cel·les de dades que descriuen."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Si especifiques un [idioma vàlid d'acord amb l'estàndard BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) als elements, ajudes a fer que els lectors de pantalla pronunciïn el text correctament. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Si especifiques un [idioma vàlid d'acord amb l'estàndard BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) als elements, permets que els lectors de pantalla pronunciïn el text correctament. [Obtén més informació](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Els atributs \"[lang]\" no tenen un valor vàlid"
+    "message": "Els atributs `[lang]` no tenen un valor vàlid"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Els atributs \"[lang]\" tenen un valor vàlid"
+    "message": "Els atributs `[lang]` tenen un valor vàlid"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Si un vídeo ofereix subtítols, permet que els usuaris sords o amb discapacitat auditiva accedeixin a la informació més fàcilment. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Si un vídeo ofereix subtítols, permet que els usuaris sords o amb discapacitat auditiva accedeixin a la informació més fàcilment. [Obtén més informació](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Els elements \"<video>\" no contenen un element \"<track>\" amb l'atribut \"[kind=\"captions\"]\"."
+    "message": "Els elements `<video>` no contenen cap element `<track>` amb `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Els elements \"<video>\" contenen un element \"<track>\" amb l'atribut \"[kind=\"captions\"]\""
+    "message": "Els elements `<video>` contenen un element `<track>` amb `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Les audiodescripcions proporcionen informació rellevant dels vídeos que els diàlegs no poden oferir, com ara les expressions facials i les escenes. [Obtén més informació](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Les audiodescripcions proporcionen informació rellevant dels vídeos que els diàlegs no poden oferir, com ara les expressions facials i les escenes. [Obtén més informació](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Els elements \"<video>\" no contenen un element \"<track>\" amb l'atribut \"[kind=\"description\"]\"."
+    "message": "Els elements `<video>` no contenen cap element `<track>` amb `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Els elements \"<video>\" contenen un element \"<track>\" amb l'atribut \"[kind=\"description\"]\""
+    "message": "Els elements `<video>` contenen un element `<track>` amb `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Perquè l'aspecte del lloc web a iOS sigui l'ideal quan els usuaris l'afegeixin a la pantalla d'inici, defineix un atribut apple-touch-icon. Ha de dirigir a una imatge PNG quadrada de 192 píxels o de 180 píxels que no sigui transparent. [Obtén més informació](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "No conté un atribut `apple-touch-icon` vàlid"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "L'atribut `apple-touch-icon-precomposed` no està actualitzat. És preferible l'atribut `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Proporciona una `apple-touch-icon` vàlida"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Les extensions de Chrome han afectat negativament el rendiment de càrrega de la pàgina. Audita la pàgina en mode d'incògnit o des d'un perfil de Chrome sense extensions."
@@ -330,7 +342,7 @@
     "message": "Temps total de la CPU"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Et recomanem que redueixis el temps dedicat a analitzar, compilar i executar JavaScript. Et pot ajudar utilitzar càrregues útils de JavaScript més petites. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Et recomanem que redueixis el temps dedicat a analitzar, compilar i executar JavaScript. Et pot ajudar utilitzar càrregues útils de JavaScript més petites. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Redueix el temps d'execució de JavaScript"
@@ -339,25 +351,25 @@
     "message": "Temps d'execució de JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Els GIF grans no són eficients a l'hora de publicar contingut animat. Per estalviar bytes de la xarxa, pots substituir-los per vídeos MPEG4/WebM en el cas d'animacions i per PNG/WebP en el cas d'imatges estàtiques. [Més informació] (https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Els GIF grans no són eficients per publicar contingut animat. A fi d'estalviar bytes a la xarxa, pots substituir els GIF per vídeos MPEG4/WebM en el cas de les animacions i per PNG/WebP en el cas de les imatges estàtiques. [Més informació](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Utilitza formats de vídeo per al contingut animat"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Et recomanem que utilitzis la càrrega diferida de les imatges ocultes i que no es mostren a la pantalla un cop s'acabin de carregar tots els recursos crítics a fi de reduir el temps necessari perquè la pàgina sigui interactiva. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Et recomanem que utilitzis la càrrega diferida de les imatges amagades i que no es mostren a la pantalla un cop s'acabin de carregar tots els recursos essencials a fi de reduir el temps necessari perquè la pàgina sigui interactiva. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Ajorna les imatges fora de pantalla"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Els recursos estan bloquejant la primera renderització de la pàgina. Et recomanem que publiquis els fitxers JavaScript o CSS inserits i ajornis tots els estils i els fitxers JavaScript que no siguin crítics. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Els recursos estan bloquejant la primera renderització de la pàgina. Et recomanem que publiquis els fitxers JavaScript o CSS inserits que siguin essencials i ajornis tots els estils i els fitxers JavaScript que no ho siguin. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Elimina els recursos que bloquegen la renderització"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Si la càrrega útil de la xarxa és molt gran, els usuaris consumeixen més dades mòbils i els temps de càrrega són més llargs. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Si la càrrega útil de la xarxa és molt gran, els usuaris consumeixen més dades mòbils i els temps de càrrega són més llargs. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Mida total: {totalBytes, number, bytes} kB"
@@ -369,13 +381,13 @@
     "message": "Evita càrregues útils de xarxa enormes"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Reduir els fitxers CSS pot disminuir les mides de càrrega útil a la xarxa. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Reduir els fitxers CSS pot disminuir les mides de càrrega útil a la xarxa. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Redueix els CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Reduir els fitxers JavaScript pot disminuir les mides de càrrega i els temps d'anàlisi de scripts. [Més informació] (https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Reduir els fitxers JavaScript pot disminuir les mides de càrrega i els temps d'anàlisi de scripts. [Obtén més informació](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Redueix els fitxers JavaScript"
@@ -393,7 +405,7 @@
     "message": "Suprimeix els fitxers JavaScript no utilitzats"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Si la memòria cau té una vida llarga, es poden accelerar les visites repetides a la teva pàgina. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Si la memòria cau té una vida llarga, es poden accelerar les visites repetides a la teva pàgina. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{S'ha trobat 1 recurs}other{S'han trobat # recursos}}"
@@ -405,37 +417,88 @@
     "message": "Utilitza una política de memòria cau eficient per als recursos estàtics"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Les imatges optimitzades es carreguen més ràpidament i utilitzen menys dades mòbils. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Les imatges optimitzades es carreguen més ràpidament i utilitzen menys dades mòbils. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Codifica les imatges amb eficiència"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Publica imatges amb la mida correcta per estalviar dades mòbils i millorar el temps de càrrega. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Publica imatges amb la mida correcta per estalviar dades mòbils i millorar el temps de càrrega. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Adapta la mida de les imatges"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Els recursos basats en text s'han de publicar comprimits (gzip, deflate o brotli) per minimitzar el total de bytes a la xarxa. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Els recursos basats en text s'han de publicar comprimits (gzip, deflate o brotli) per minimitzar el total de bytes a la xarxa. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Activa la compressió de text"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Els formats d'imatge com JPEG 2000, JPEG XR i WebP solen oferir millors resultats de compressió que PNG o JPEG. Això implica baixades més ràpides i menys consum de dades. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Els formats d'imatge com JPEG 2000, JPEG XR i WebP solen oferir millors resultats de compressió que PNG o JPEG. Això implica baixades més ràpides i menys consum de dades. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Publica imatges en format d'última generació"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Les cadenes de sol·licituds crítiques de sota et mostren quins recursos es carreguen amb prioritat alta. Et recomanem que escurcis les cadenes, redueixis la mida de baixada dels recursos o ajornis la baixada de recursos innecessaris per millorar la càrrega de pàgines. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Les cadenes de sol·licituds essencials de sota et mostren quins recursos es carreguen amb prioritat alta. Et recomanem que escurcis les cadenes, redueixis la mida de baixada dels recursos o ajornis la baixada de recursos innecessaris per millorar la càrrega de pàgines. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{S'ha trobat 1 cadena}other{S'han trobat # cadenes}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimitza la profunditat de les sol·licituds crítiques"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Desactivació/advertiment"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Línia"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Les API obsoletes s'acabaran suprimint del navegador. [Obtén més informació](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{S'ha trobat 1 advertiment}other{S'han trobat # advertiments}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Utilitza API obsoletes"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Evita les API obsoletes"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "La memòria cau de l'aplicació està obsoleta. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "S'ha trobat \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Utilitza la memòria cau de l'aplicació"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Evita la memòria cau de l'aplicació"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Especificar un tipus de document impedeix que el navegador canviï a mode Quirks. Obtén més informació a la [pàgina MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "El nom del tipus de document ha de ser la cadena en minúscules `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "El document ha de contenir un tipus de document"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Està previst que el camp publicId sigui una cadena buida"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Està previst que el camp systemId sigui una cadena buida"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "La pàgina no té el tipus de document HTML i, per tant, activa el mode Quirks"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "La pàgina té el tipus de document HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
@@ -447,7 +510,7 @@
     "message": "Valor"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Els enginyers de navegadors recomanen que les pàgines continguin menys d'uns 1.500 elements de DOM. La situació ideal és una profunditat d'arbre inferior a 32 elements i menys de 60 elements superiors o secundaris. Un DOM gran pot augmentar l'ús de la memòria, provocar [càlculs d'estil] més llargs (https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) i produir [reinicis de reflux del disseny] costosos (https://developers.google.com/speed/articles/reflow). [Més informació](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Els enginyers de navegadors recomanen que les pàgines continguin menys d'uns 1.500 elements DOM. La situació ideal és una profunditat d'arbre de menys de 32 elements i de menys de 60 elements superiors o secundaris. Un DOM gran pot augmentar l'ús de la memòria, provocar [càlculs d'estil](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) més llargs i produir [reinicis de reflux del disseny](https://developers.google.com/speed/articles/reflow) costosos. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{Un element}other{# elements}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Evita una mida excessiva de DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Objectiu"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Afegeix `rel=\"noopener\"` o `rel=\"noreferrer\"` a qualsevol enllaç extern per millorar-ne el rendiment i evitar vulnerabilitats de seguretat. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Els enllaços a destinacions de diversos orígens no són segurs"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Els enllaços a destinacions de diversos orígens són segurs"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "No es pot determinar la destinació de l'ancoratge ({anchorHTML}). Si no s'utilitza com a enllaç, et recomanem que suprimeixis target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Els usuaris reaccionen amb desconfiança i desconcert davant dels llocs web que els sol·liciten la ubicació sense context. Et recomanem que vinculis la sol·licitud a una acció de l'usuari. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Sol·licita el permís de geolocalització en carregar la pàgina"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Evita sol·licitar el permís de geolocalització en carregar la pàgina"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versió"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Totes les biblioteques de JavaScript d'interfície detectades a la pàgina."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Biblioteques de JavaScript detectades"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Per als usuaris amb connexions lentes, els scripts externs inserits dinàmicament mitjançant `document.write()` poden retardar la càrrega de la pàgina unes dècimes de segon. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Utilitza `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Evita `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Gravetat més alta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Versió de la biblioteca"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Recompte de vulnerabilitats"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Alguns scripts de tercers poden contenir vulnerabilitats de seguretat que els atacants identifiquen i exploten fàcilment. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{S'ha detectat 1 vulnerabilitat}other{S'han detectat # vulnerabilitats}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Inclou biblioteques de JavaScript d'interfície amb vulnerabilitats de seguretat conegudes"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Alta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Baixa"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Mitjana"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Evita les biblioteques de JavaScript d'interfície amb vulnerabilitats de seguretat conegudes"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Els usuaris reaccionen amb desconfiança i desconcert davant dels llocs web que sol·liciten enviar notificacions sense context. Et recomanem que vinculis la sol·licitud als gestos de l'usuari. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Sol·licita el permís de notificació en carregar la pàgina"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Evita sol·licitar el permís de notificació en carregar la pàgina"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elements amb errors"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Impedir enganxar la contrasenya va en detriment d'una bona política de seguretat. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Evita que els usuaris enganxin contingut als camps de contrasenya"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Permet que els usuaris enganxin contingut als camps de contrasenya"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ofereix molts avantatges respecte a HTTP/1.1, com ara capçaleres binàries, multiplexatge i tramesa automàtica de servidor. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{No s'ha atès 1 sol·licitud mitjançant HTTP/2}other{No s'han atès # sol·licituds mitjançant HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "No utilitza HTTP/2 per a tots els recursos"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Utilitza HTTP/2 per als recursos propis"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Per millorar el rendiment del desplaçament de la pàgina, et recomanem que defineixis els detectors d'esdeveniments de roda de desplaçament com a `passive`. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "No utilitza detectors passius per millorar el rendiment del desplaçament"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Utilitza detectors passius per millorar el rendiment del desplaçament"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Descripció"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Els errors registrats a la consola indiquen problemes pendents de resoldre. Poden provenir d'errors de sol·licitud de la xarxa i d'altres problemes del navegador."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Els errors del navegador s'han registrat a la consola"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "No s'ha registrat cap error del navegador a la consola"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Aprofita la funció CSS que permet mostrar els tipus de lletra per assegurar-te que els usuaris puguin veure el text mentre es carreguen els tipus de lletra per a llocs web. [Més informació] (https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Aprofita la funció CSS que permet mostrar els tipus de lletra per assegurar-te que els usuaris puguin veure el text mentre es carreguen els tipus de lletra per a llocs web. [Obtén més informació](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Assegura't que el text continuï visible durant la càrrega dels tipus de lletra per a llocs web"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Tot el text continua visible durant les càrregues dels tipus de lletra per a llocs web"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse no ha pogut comprovar automàticament el valor que permet mostrar els tipus de lletra de l'URL següent: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Relació d'aspecte (real)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Relació d'aspecte (mostrada)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Les dimensions de visualització de la imatge han de coincidir amb la relació d'aspecte natural. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Mostra les imatges amb una relació d'aspecte incorrecta"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Mostra les imatges amb una relació d'aspecte correcta"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "La informació sobre la mida de la imatge no és vàlida: {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL no segur"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Tots els llocs web haurien d'estar protegits amb HTTPS, fins i tot els que no gestionen dades sensibles. L'HTTPS evita que intrusos manipulin o escoltin passivament les comunicacions entre la teva aplicació i els usuaris, i és un requisit previ per a HTTP/2 i per a moltes API de plataforma web noves. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{S'ha trobat 1 sol·licitud no segura}other{S'han trobat # sol·licituds no segures}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "No utilitza HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Utilitza HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Carregar les pàgines ràpidament mitjançant una xarxa mòbil garanteix una experiència satisfactòria per als usuaris de mòbils. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interactiva al cap de {timeInMs, number, seconds} segons"
+    "message": "Ha tardat {timeInMs, number, seconds} segons a fer-se interactiva"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Interactiva a la xarxa mòbil simulada al cap de {timeInMs, number, seconds} segons"
+    "message": "Ha tardat {timeInMs, number, seconds} segons a fer-se interactiva a la xarxa mòbil"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "La pàgina no es carrega amb prou rapidesa a les xarxes mòbils"
@@ -510,19 +741,19 @@
     "message": "Latència estimada de les accions"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "La primera renderització de contingut marca el moment en què es renderitza el primer text o la primera imatge. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "La mètrica Primera renderització de contingut marca el moment en què es renderitza el primer text o la primera imatge. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Primera renderització de contingut"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "La mètrica Primera inactivitat de la CPU marca el primer moment en què el fil principal de la pàgina està suficientment inactiu per gestionar accions. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "La mètrica Primera inactivitat de la CPU marca el primer moment en què el fil principal de la pàgina està suficientment inactiu per gestionar accions. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Primera inactivitat de la CPU"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "La mètrica Primera renderització significativa mesura el moment en què el contingut principal d'una pàgina està visible. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "La mètrica Primera renderització significativa mesura el moment en què el contingut principal d'una pàgina és visible. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Primera renderització significativa"
@@ -534,70 +765,94 @@
     "message": "Temps fins que és interactiva"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "El possible retard respecte a la primera interacció que els usuaris es poden trobar és la durada, en mil·lisegons, de la tasca més llarga."
+    "message": "El retard potencial màxim respecte a la primera interacció que els usuaris es poden trobar és la durada, en mil·lisegons, de la tasca més llarga. [Obtén més informació](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Màxim retard possible respecte a la primera interacció"
+    "message": "Retard potencial màxim respecte a la primera interacció"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "L'índex de velocitat mostra la rapidesa amb què s'emplena el contingut d'una pàgina. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "L'índex de velocitat mostra la rapidesa amb què s'emplena el contingut d'una pàgina. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Índex de velocitat"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "La suma de tots els períodes de temps entre l'FCP i el Temps fins que és interactiva, quan la llargada de la tasca ha superat els 50 ms, expressada en mil·lisegons."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Durada total del bloqueig"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Els temps d'anada i tornada a la xarxa afecten considerablement el rendiment. Si el temps d'anada i tornada a un origen és llarg, indica que els servidors més a prop de l'usuari podrien millorar el rendiment. [Obtén més informació](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Els temps d'anada i tornada a la xarxa afecten considerablement el rendiment. Si el temps d'anada i tornada a un origen és llarg, indica que els servidors de més a prop de l'usuari podrien millorar el rendiment. [Obtén més informació](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Temps d'anada i tornada a la xarxa"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Les latències del servidor poden afectar el rendiment web. Si són llargues en un origen, indiquen que el servidor està sobrecarregat o té un rendiment dorsal deficient. [Obtén més informació](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Les latències del servidor poden afectar el rendiment web. Si són llargues en un origen, indiquen que el servidor està sobrecarregat o que té un rendiment dorsal deficient. [Obtén més informació](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latències dorsals del servidor"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Per sobre del pressupost"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Manté la quantitat i la mida de les sol·licituds de xarxa ajustades als objectius establerts al pressupost de rendiment que s'ha proporcionat. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 sol·licitud}other{# sol·licituds}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Pressupost de rendiment"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "La mètrica Redireccions introdueix retards addicionals abans de poder carregar la pàgina. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "La mètrica Redireccions introdueix retards addicionals abans de poder carregar la pàgina. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Evita les redireccions múltiples a pàgines"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Per definir els pressupostos de la quantitat i la mida dels recursos de la pàgina, afegeix un fitxer budget.json. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 sol·licitud}other{# sol·licituds}} • {byteCount, number, bytes} kB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Mantén els recomptes de les sol·licituds baixos i les mides de les transferències petites"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Els enllaços canònics suggereixen quins URL s'han de mostrar als resultats de cerca. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Diversos URL en conflicte ({urlList})"
+    "message": "Hi ha diversos URL en conflicte ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Apunta a un altre domini ({url})"
+    "message": "Dirigeix a un altre domini ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "L'URL no és vàlid ({url})"
+    "message": "URL no vàlid ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Apunta a una altra ubicació de l'atribut \"hreflang\" ({url})"
+    "message": "Dirigeix a una altra ubicació de tipus \"`hreflang`\" ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "L'URL és relatiu ({url})"
+    "message": "URL relatiu ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "Apunta a l'URL arrel (la pàgina d'inici) del domini en lloc d'apuntar a una pàgina equivalent de contingut"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "El document no té un valor vàlid per a \"rel=canonical\""
+    "message": "El document no té un valor `rel=canonical` vàlid"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "El document té un valor vàlid per a \"rel=canonical\""
+    "message": "El document té un valor `rel=canonical` vàlid"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Les lletres amb una mida inferior als 12 píxels són massa petites i obliguen els usuaris de mòbils a pinçar la pantalla per apropar-la i poder llegir el text. Intenta que la mida de més del 60% del text de la pàgina sigui igual o superior a 12 píxels. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Les lletres amb una mida inferior als 12 píxels són massa petites i obliguen els usuaris de mòbils a \"pinçar per fer zoom\" a fi d'ampliar el text i poder llegir-lo. Intenta que la mida de més del 60% del text de la pàgina sigui igual o superior a 12 píxels. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "El {decimalProportion, number, extendedPercent} del text és llegible"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "El {decimalProportion, number, extendedPercent} del text és massa petit."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "El text és il·legible perquè no hi ha cap metaetiqueta de finestra gràfica optimitzada per a pantalles de mòbil."
@@ -612,13 +867,13 @@
     "message": "El document utilitza lletres amb mides llegibles"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Els enllaços de tipus \"hreflang\" informen els motors de cerca de quina versió d'una pàgina han d'incloure als resultats de cerca d'un idioma o d'una regió concrets. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Els enllaços de tipus \"hreflang\" informen els motors de cerca de quina versió d'una pàgina han d'incloure als resultats de cerca per a una regió o un idioma concrets. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "El document no té un valor vàlid per a \"hreflang\""
+    "message": "El document no té un valor `hreflang` vàlid"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "El document té un valor vàlid per a \"hreflang\""
+    "message": "El document té un valor `hreflang` vàlid"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "És possible que les pàgines amb codi d'estat HTTP incorrecte no s'indexin correctament. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -651,7 +906,7 @@
     "message": "Els enllaços tenen text descriptiu"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Executa l'[eina de proves de dades estructurades](https://search.google.com/structured-data/testing-tool/) i [l'eina lint de dades estructurades](http://linter.structured-data.org/) per validar aquest tipus de dades. [Obtén més informació](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Executa l'[eina de proves de dades estructurades](https://search.google.com/structured-data/testing-tool/) i l'[eina Structured Data Linter](http://linter.structured-data.org/) per validar aquest tipus de dades. [Obtén més informació](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Les dades estructurades són vàlides"
@@ -681,7 +936,7 @@
     "message": "Si el format del fitxer robots.txt no és correcte, és possible que els rastrejadors no puguin entendre com vols que rastregin o indexin el lloc web."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "La sol·licitud del fitxer robots.txt ha tornat l'estat HTTP {statusCode}"
+    "message": "la sol·licitud del fitxer robots.txt ha tornat l'estat HTTP: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{S'ha trobat 1 error}other{S'han trobat # errors}}"
@@ -696,7 +951,7 @@
     "message": "El fitxer robots.txt és vàlid"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Els elements interactius (com ara els botons i els enllaços) han de ser prou grans (48 x 48 píxels) i han de tenir prou espai al voltant perquè els usuaris els puguin tocar sense que se superposin a altres elements. [Obtén més informació](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Els elements interactius, com ara els botons i els enllaços, han de ser prou grans (48 x 48 píxels) i han de tenir prou espai al voltant perquè els usuaris els puguin tocar sense que se superposin a altres elements. [Obtén més informació](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "El {decimalProportion, number, percent} de les mides dels objectius tàctils és correcte"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Objectiu superposat"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Mida"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Element tàctil"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "La mida dels elements tàctils és correcta"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Durada del fil principal"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Tercers"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "El codi de tercers pot afectar significativament el rendiment de la càrrega. Limita el nombre de proveïdors externs redundants i prova de carregar codi de tercers quan la càrrega principal de la pàgina ha finalitzat. [Obtén més informació](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{S'ha trobat 1 tercer}other{S'han trobat # tercers}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Ús de tercers"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "La mètrica Temps fins al primer byte identifica el moment en què el teu servidor envia una resposta. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "La mètrica Temps fins al primer byte identifica el moment en què el teu servidor envia una resposta. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "El document arrel ha tardat {timeInMs, number, milliseconds} ms"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Durada"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nom"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Hora d'inici"
   },
@@ -744,7 +1008,7 @@
     "message": "Tipus"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Et recomanem que utilitzis l'API Temps d'usuari amb la teva aplicació per mesurar-ne el rendiment al món real durant experiències clau dels usuaris. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Et recomanem que utilitzis l'API Temps d'usuari amb la teva aplicació per mesurar-ne el rendiment al món real durant experiències clau dels usuaris. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 temps d'usuari}other{# temps d'usuari}}"
@@ -753,19 +1017,19 @@
     "message": "Marques i mesures de Temps d'usuari"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "S'ha trobat un element <link> de connexió prèvia per a \"{securityOrigin}\", però el navegador no l'ha utilitzat. Comprova que estiguis utilitzant correctament l'atribut \"crossorigin\"."
+    "message": "S'ha trobat un element <link> de connexió prèvia per a \"{securityOrigin}\", però el navegador no l'ha utilitzat. Comprova que estiguis utilitzant correctament l'atribut `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Et recomanem que afegeixis suggeriments de recursos per connectar-se prèviament o per obtenir el DNS prèviament a fi d'establir connexions anticipades a orígens importants de tercers. [Més informació] (https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Et recomanem que afegeixis suggeriments de recursos per connectar-se prèviament o per obtenir el DNS prèviament a fi d'establir connexions anticipades a orígens importants de tercers. [Obtén més informació](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Connecta't prèviament als orígens necessaris"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "S'ha trobat un element <link> de càrrega prèvia per a \"{preloadURL}\", però el navegador no l'ha utilitzat. Comprova que estiguis utilitzant correctament l'atribut \"crossorigin\"."
+    "message": "S'ha trobat un element <link> de càrrega prèvia per a \"{preloadURL}\", però el navegador no l'ha utilitzat. Comprova que estiguis utilitzant correctament l'atribut `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Et recomanem que utilitzis <link rel=preload> per prioritzar l'obtenció de recursos que en aquests moments se sol·liciten en un moment posterior de la càrrega de pàgines. [Més informació] (https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Et recomanem que utilitzis `<link rel=preload>` per prioritzar l'obtenció de recursos que en aquests moments se sol·liciten en un moment posterior de la càrrega de pàgines. [Obtén més informació](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Carrega prèviament les sol·licituds de clau"
@@ -789,7 +1053,7 @@
     "message": "Pràctiques recomanades"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Aquestes comprovacions destaquen les recomanacions per [millorar l'accessibilitat de l'aplicació web](https://developers.google.com/web/fundamentals/accessibility). Només poden detectar un subconjunt de problemes d'accessibilitat automàticament, de manera que et recomanem que hi facis també proves manuals."
+    "message": "Aquestes comprovacions destaquen les oportunitats per [millorar l'accessibilitat de l'aplicació web](https://developers.google.com/web/fundamentals/accessibility). Només poden detectar un subconjunt de problemes d'accessibilitat automàticament, de manera que et recomanem que també hi facis proves manuals."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "Aquests elements tracten àrees que les eines de proves automatitzades no poden cobrir. Obtén més informació a la nostra guia sobre [com es duen a terme ressenyes d'accessibilitat](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Taules i llistes"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Pràctiques recomanades"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Els pressupostos de rendiment estableixen uns estàndards per al rendiment del teu lloc web."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Pressupostos"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Més informació sobre el rendiment de la teva aplicació."
+    "message": "Més informació sobre el rendiment de la teva aplicació. Aquests números no [afecten directament](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) el resultat del rendiment."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnòstic"
@@ -840,7 +1113,7 @@
     "message": "Millores de la primera renderització"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Aquestes optimitzacions poden accelerar la càrrega de la pàgina."
+    "message": "Aquests suggeriments poden ajudar la pàgina a carregar-se més de pressa. No [afecten directament](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) el resultat del rendiment."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Oportunitats"
@@ -867,7 +1140,7 @@
     "message": "Optimitzat per a PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Aquestes comprovacions garanteixen que la pàgina estigui optimitzada per classificar els resultats del motor de cerca. Hi ha factors addicionals que Lighthouse no comprova i que és possible que afectin la vostra classificació a les cerques. [Obtén més informació](https://support.google.com/webmasters/answer/35769)."
+    "message": "Aquestes comprovacions garanteixen que la pàgina estigui optimitzada per classificar els resultats del motor de cerca. Hi ha factors addicionals que Lighthouse no comprova i que és possible que afectin la teva classificació a les cerques. [Obtén més informació](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Executa aquestes validacions addicionals al lloc web per comprovar les pràctiques addicionals recomanades per a SEO."
@@ -888,7 +1161,7 @@
     "message": "Rastreig i indexació"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Comprova que les pàgines estiguin adaptades per a mòbils, de manera que els usuaris no hagin de pinçar o ampliar les pàgines de contingut per poder-les llegir. [Obtén més informació](https://developers.google.com/search/mobile-sites/)."
+    "message": "Comprova que les pàgines estiguin adaptades per a mòbils, de manera que els usuaris no hagin de pinçar o ampliar les pàgines de contingut per poder llegir-les. [Obtén més informació](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Adaptació per a mòbils"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL de la memòria cau"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Ubicació"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nom"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Sol·licituds"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Tipus de recurs"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Mida (kB)"
+    "message": "Mida"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Temps invertit"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Mida de la transferència"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Possible estalvi (kB)"
+    "message": "Possible estalvi"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Possible estalvi (ms)"
+    "message": "Possible estalvi"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Possible estalvi de {wastedBytes, number, bytes} kB"
@@ -917,26 +1205,59 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Possible estalvi de {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Document"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Tipus de lletra"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Imatge"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Multimèdia"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Altres"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
   },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Full d'estil"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Tercers"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Total"
+  },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "S'ha produït un problema en gravar la traça sobre la càrrega de la pàgina. Torna a executar Lighthouse. ({errorCode})"
+    "message": "Hi ha hagut un problema en gravar la traça sobre la càrrega de la pàgina. Torna a executar Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "S'ha esgotat el temps d'espera de la connexió inicial del protocol de depuració."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome no ha recollit cap captura de pantalla mentre es carregava la pàgina. Comprova que hi hagi contingut visible a la pàgina i, tot seguit, prova d'executar Lighthouse de nou. ({errorCode})"
+    "message": "Chrome no ha recollit cap captura de pantalla mentre es carregava la pàgina. Comprova que hi hagi contingut visible a la pàgina i, a continuació, prova d'executar Lighthouse de nou. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Els servidors DNS no han pogut resoldre el domini proporcionat."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "El recopilador del recurs {artifactName} requerit ha detectat un error: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "S'ha produït un error intern de Chrome. Reinicia el navegador i prova d'executar Lighthouse de nou."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "El recopilador obligatori {artifactName} no s'ha executat."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse no ha pogut carregar de manera fiable la pàgina que has sol·licitat. Assegura't que estiguis fent la prova de l'URL correcte i que el servidor estigui responent correctament a totes les sol·licituds."
@@ -945,7 +1266,10 @@
     "message": "Com que la pàgina ha deixat de respondre, Lighthouse no ha pogut carregar de manera fiable l'URL que has sol·licitat."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "L'URL que has proporcionat no té credencials de seguretat vàlides. {securityMessages}"
+    "message": "L'URL que has proporcionat no té un certificat de seguretat vàlid. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome ha evitat la càrrega de la pàgina amb una pantalla intersticial. Assegura't que estiguis fent la prova de l'URL correcte i que el servidor estigui responent correctament a totes les sol·licituds."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse no ha pogut carregar de manera fiable la pàgina que has sol·licitat. Assegura't que estiguis fent la prova de l'URL correcte i que el servidor estigui responent correctament a totes les sol·licituds. (Detalls: {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Desplega el fragment"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Mostra els recursos de tercers"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Hi ha hagut problemes que afecten aquesta execució de Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Els valors són estimacions i poden variar."
+    "message": "Els valors són estimacions i poden variar. El resultat del rendiment [només es basa en aquestes mètriques](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Auditories aprovades però amb advertiments"
@@ -1026,7 +1353,7 @@
     "message": "Instal·la un [connector de WordPress de càrrega diferida](https://wordpress.org/plugins/search/lazy+load/) que t'ofereixi la possibilitat d'ajornar les imatges fora de pantalla o canviar a un tema que t'ofereixi aquesta funció. També pots fer servir [el connector AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Hi ha diversos connectors de WordPress que et poden ajudar a [inserir recursos crítics](https://wordpress.org/plugins/search/critical+css/) o [ajornar els recursos menys importants](https://wordpress.org/plugins/search/defer+css+javascript/). Tingues en compte que les optimitzacions que proporcionen aquests connectors poden afectar les funcions del tema o dels connectors, de manera que és possible que hagis de fer canvis al codi."
+    "message": "Hi ha diversos connectors de WordPress que et poden ajudar a [inserir recursos essencials](https://wordpress.org/plugins/search/critical+css/) o a [ajornar els recursos menys importants](https://wordpress.org/plugins/search/defer+css+javascript/). Tingues en compte que les optimitzacions que proporcionen aquests connectors poden afectar les funcions del tema o dels connectors, de manera que és possible que hagis de fer canvis al codi."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Els temes, els connectors i les especificacions del servidor contribueixen al temps de resposta del servidor. Pots buscar un tema més optimitzat, seleccionar amb cura un connector d'optimització o actualitzar el servidor."
@@ -1041,10 +1368,10 @@
     "message": "Hi ha diversos [connectors de WordPress](https://wordpress.org/plugins/search/minify+javascript/) que poden accelerar el teu lloc web. Per fer-ho, concatenen, redueixen i comprimeixen els scripts. També et recomanem que utilitzis un procés de compilació per fer aquesta minimització de manera anticipada, si és possible."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Pots reduir o canviar el nombre de [connectors de WordPress](https://wordpress.org/plugins/) que carreguen CSS no utilitzats a la pàgina. Per identificar els connectors que afegeixen CSS externs, intenta executar la [cobertura de codi](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) a Chrome DevTools. Pots identificar el tema o el connector responsable a partir de l'URL del full d'estil. Busca connectors que tinguin molts fulls d'estil a la llista amb molt vermell a la cobertura de codi. Un connector només hauria de tenir un full d'estil a la cua si es fa servir a la pàgina."
+    "message": "Pots reduir o canviar el nombre de [connectors de WordPress](https://wordpress.org/plugins/) que carreguen fitxers CSS no utilitzats a la pàgina. Per identificar els connectors que afegeixen fitxers CSS externs, prova d'executar la [cobertura de codi](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) a Chrome DevTools. Pots identificar el tema o el connector responsable a partir de l'URL del full d'estil. Cerca connectors que tinguin molts fulls d'estil a la llista amb molt vermell a la cobertura de codi. Un connector només hauria de tenir un full d'estil a la cua si es fa servir a la pàgina."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Pots reduir o canviar el nombre de [connectors de WordPress](https://wordpress.org/plugins/) que carreguen JavaScript que no es fa servir a la pàgina. Per identificar els connectors que afegeixen JS externs, intenta executar la [cobertura de codi](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) a Chrome DevTools. Pots identificar el tema o el connector responsable a partir de l'URL de l'script. Busca connectors que tinguin molts scripts a la llista amb molt vermell a la cobertura de codi. Un connector només hauria de tenir un script a la cua si es fa servir a la pàgina."
+    "message": "Pots reduir o canviar el nombre de [connectors de WordPress](https://wordpress.org/plugins/) que carreguen fitxers JavaScript no utilitzats a la pàgina. Per identificar els connectors que afegeixen fitxers JavaScript externs, prova d'executar la [cobertura de codi](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) a Chrome DevTools. Pots identificar el tema o el connector responsable a partir de l'URL de l'script. Cerca connectors que tinguin molts scripts a la llista amb molt vermell a la cobertura de codi. Un connector només hauria de tenir un script a la cua si es fa servir a la pàgina."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Obtén informació sobre la [memòria cau del navegador a WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
@@ -1053,7 +1380,7 @@
     "message": "Pots utilitzar un [connector de WordPress d'optimització d'imatges](https://wordpress.org/plugins/search/optimize+images/) per comprimir les imatges sense perdre qualitat."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Penja imatges directament mitjançant la [biblioteca multimèdia](https://codex.wordpress.org/Media_Library_Screen) per garantir que les mides de la imatge necessàries estiguin disponibles i, tot seguit, insereix-les des de la biblioteca multimèdia o fes servir el widget per garantir que es fan servir les mides de la imatge òptimes (incloses les dels punts de ruptura responsius). Evita fer servir imatges de \"mida completa\", tret que les dimensions siguin les adequades per a l'ús que se'n farà. [Més informació](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Penja imatges directament mitjançant la [biblioteca multimèdia](https://codex.wordpress.org/Media_Library_Screen) per garantir que les mides de la imatge necessàries estiguin disponibles i, a continuació, insereix-les des de la biblioteca multimèdia o fes servir el widget per garantir que es fan servir les mides de la imatge òptimes (incloses les dels punts de ruptura responsius). Evita utilitzar imatges de `Full Size`, tret que les dimensions siguin les adequades per a l'ús que se'n farà. [Obtén més informació](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Pots activar la compressió de text a la configuració del servidor web."

--- a/lighthouse-core/lib/i18n/locales/cs.json
+++ b/lighthouse-core/lib/i18n/locales/cs.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Přístupové klávesy uživatelům umožňují rychleji vybrat část stránky. Aby navigace fungovala správně, musí být každá přístupová klávesa jedinečná. [Další informace](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Přístupové klávesy uživatelům umožňují rychleji vybrat část stránky. Aby navigace fungovala správně, musí být každá přístupová klávesa jedinečná. [Další informace](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Hodnoty atributů [accesskey] nejsou jedinečné"
+    "message": "Hodnoty atributů `[accesskey]` nejsou jedinečné"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Hodnoty atributů [accesskey] jsou jedinečné"
+    "message": "Hodnoty `[accesskey]` jsou unikátní"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Každá role ARIA podporuje konkrétní podmnožinu atributů aria-*. Atributy aria-* použité u nesprávné role nejsou platné. [Další informace](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Každá položka ARIA `role` podporuje konkrétní podmnožinu atributů `aria-*`. Nesprávné přiřazení atributy `aria-*` zneplatní. [Další informace](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Atributy [aria-*] neodpovídají svým rolím"
+    "message": "Atributy `[aria-*]` neodpovídají svým rolím"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Atributy [aria-*] odpovídají příslušným rolím"
+    "message": "Atributy `[aria-*]` odpovídají příslušným rolím"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Některé role ARIA mají povinné atributy, které čtečkám obrazovek popisují stav prvku. [Další informace](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Některé role ARIA mají povinné atributy, které čtečkám obrazovek popisují stav prvku. [Další informace](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Prvky s atributy [role] nemají všechny povinné atributy [aria-*]"
+    "message": "Prvky s atributy `[role]` nemají všechny povinné atributy `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Prvky s atributy [role] mají všechny povinné atributy [aria-*]"
+    "message": "Prvky s atributy `[role]` mají všechny povinné atributy `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Některé nadřazené role ARIA musejí kvůli poskytovaní správných funkcí přístupnosti obsahovat určité podřízené role. [Další informace](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Některé nadřazené role ARIA musejí kvůli poskytovaní správných funkcí přístupnosti obsahovat určité podřízené role. [Další informace](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "V prvcích s atributem [role], které by měly obsahovat podřízené prvky s určitými atributy [role], tyto podřízené prvky chybí."
+    "message": "V prvcích s atributem `[role]`, které by měly obsahovat podřízené prvky s určitými atributy `[role]`, tyto podřízené prvky chybí."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Prvky s atributem [role], které by měly obsahovat podřízené prvky s určitými atributy [role], tyto podřízené prvky obsahují."
+    "message": "Prvky s atributem `[role]`, které by měly obsahovat podřízené prvky s určitými atributy `[role]`, tyto podřízené prvky obsahují"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Aby poskytovaly správné funkce přístupnosti, musejí být některé podřízené role ARIA umístěny v konkrétních nadřazených rolích. [Další informace](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Aby poskytovaly správné funkce přístupnosti, musejí být některé podřízené role ARIA umístěny v konkrétních nadřazených rolích. [Další informace](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Prvky s atributem [role] nejsou umístěny v požadovaném nadřazeném prvku"
+    "message": "Prvky s atributem `[role]` nejsou umístěny v požadovaném nadřazeném prvku"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Prvky s atributy [role] jsou umístěny v požadovaném nadřazeném prvku"
+    "message": "Prvky s atributy `[role]`jsou umístěny v požadovaném nadřazeném prvku"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Aby role ARIA poskytovaly správné funkce přístupnosti, musejí mít platné hodnoty. [Další informace](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Aby role ARIA poskytovaly správné funkce přístupnosti, musejí mít platné hodnoty. [Další informace](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Hodnoty atributů [role] nejsou platné"
+    "message": "Hodnoty atributů `[role]` nejsou platné"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Hodnoty atributů [role] jsou platné"
+    "message": "Hodnoty atributů `[role]` jsou platné"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Asistenční technologie, jako jsou čtečky obrazovek, atributy ARIA s neplatnými hodnotami nedokážou interpretovat. [Další informace](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Asistenční technologie, jako jsou čtečky obrazovek, atributy ARIA s neplatnými hodnotami nedokážou interpretovat. [Další informace](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Atributy [aria-*] nemají platné hodnoty"
+    "message": "Atributy `[aria-*]` nemají platné hodnoty"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Atributy [aria-*] mají platné hodnoty"
+    "message": "Atributy `[aria-*]` mají platné hodnoty"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Asistenční technologie, jako jsou čtečky obrazovek, atributy ARIA s neplatnými názvy nedokážou interpretovat. [Další informace](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Asistenční technologie, jako jsou čtečky obrazovek, atributy ARIA s neplatnými názvy nedokážou interpretovat. [Další informace](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Atributy [aria-*] nejsou platné nebo v nich jsou překlepy"
+    "message": "Atributy `[aria-*]` nejsou platné nebo v nich jsou překlepy"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Atributy [aria-*] jsou platné a nejsou v nich překlepy"
+    "message": "Atributy `[aria-*]` jsou platné a nejsou v nich překlepy"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Titulky umožňují sluchově postiženým uživatelům používat zvukové prvky tím, že jim poskytují kritické informace (například kdo mluví a co říká nebo další informace nesouvisející s řečí). [Další informace](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Titulky umožňují sluchově postiženým uživatelům používat zvukové prvky tím, že jim poskytují kritické informace (například kdo mluví a co říká nebo další informace nesouvisející s řečí). [Další informace](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "V prvcích <audio> chybí prvek <track> s atributem [kind=\"captions\"]."
+    "message": "V prvcích `<audio>` chybí prvek `<track>` s atributem `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Prvky <audio> obsahují prvek <track> s atributem [kind=\"captions\"]"
+    "message": "Prvky `<audio>` obsahují prvek `<track>` s atributem `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Prvky, které neprošly"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Když tlačítko nemá přístupný název, čtečky obrazovek ho oznamují jako „tlačítko“ a pro jejich uživatele je tak v podstatě nepoužitelné. [Další informace](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Když tlačítko nemá přístupný název, čtečky obrazovek ho oznamují jako „tlačítko“ a pro jejich uživatele je tak v podstatě nepoužitelné. [Další informace](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Tlačítka nemají přístupné názvy"
@@ -93,7 +93,7 @@
     "message": "Tlačítka mají přístupné názvy"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Když přidáte možnosti obejití repetitivního obsahu, umožníte tím efektivnější procházení stránky pomocí klávesnice. [Další informace](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Když přidáte možnosti obejití repetitivního obsahu, umožníte tím efektivnější procházení stránky pomocí klávesnice. [Další informace](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Stránka neobsahuje nadpis, odkaz k přeskočení ani orientační bod regionu"
@@ -102,7 +102,7 @@
     "message": "Stránka obsahuje nadpis, odkaz k přeskočení nebo orientační bod regionu"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Text s nízkým kontrastem je pro mnoho uživatelů obtížně čitelný nebo nečitelný. [Další informace](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Text s nízkým kontrastem je pro mnoho uživatelů obtížně čitelný nebo nečitelný. [Další informace](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Barvy pozadí a popředí nemají dostatečný kontrastní poměr."
@@ -111,88 +111,88 @@
     "message": "Barvy pozadí a popředí mají dostatečný kontrastní poměr"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Když seznamy definic nejsou správně označené, čtečky obrazovek mohou generovat matoucí nebo nepřesný výstup. [Další informace](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Když seznamy definic nejsou správně označené, čtečky obrazovek mohou generovat matoucí nebo nepřesný výstup. [Další informace](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Prvky <dl> neobsahují jen správně seřazené skupiny prvků <dt> a <dd> nebo prvky <script> či <template>."
+    "message": "Prvky `<dl>` neobsahují jen správně seřazené skupiny prvků `<dt>` a `<dd>` nebo prvky `<script>` či `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Prvky <dl> obsahují pouze správně seřazené skupiny <dt> a <dd> či prvky <script> nebo <template>."
+    "message": "Prvky `<dl>` neobsahují jen správně seřazené skupiny prvků `<dt>` a `<dd>` nebo prvky `<script>` či `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Aby mohly čtečky obrazovek správně oznamovat položky seznamů definic (<dt> a <dd>), musejí být tyto položky umístěny v nadřazeném prvku <dl>. [Další informace](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Aby mohly čtečky obrazovek správně oznamovat položky seznamů definic (`<dt>` a `<dd>`), musejí být tyto položky umístěny v nadřazeném prvku `<dl>`. [Další informace](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Položky seznamu definic nejsou umístěny v prvcích <dl>"
+    "message": "Položky seznamu definic nejsou umístěny v prvcích `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Položky seznamu definic jsou umístěny v prvcích <dl>"
+    "message": "Položky seznamu definic jsou umístěny v prvcích `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Název (title) uživatelům čteček obrazovek poskytuje souhrnné informace o stránce a uživatelé vyhledávačů se podle něj rozhodují, zda je stránka pro jejich vyhledávání relevantní. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Název (title) uživatelům čteček obrazovek poskytuje souhrnné informace o stránce a uživatelé vyhledávačů se podle něj rozhodují, zda je stránka pro jejich vyhledávání relevantní. [Další informace](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokument neobsahuje prvek <title>"
+    "message": "Dokument neobsahuje prvek `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokument obsahuje prvek <title>"
+    "message": "Dokument obsahuje prvek `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Aby asistenční technologie nepřehlédly další výskyty, hodnota atributu id musí být jedinečná. [Další informace](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Aby asistenční technologie nepřehlédly další výskyty, hodnota atributu id musí být jedinečná. [Další informace](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Atributy [id] na stránce nejsou jedinečné"
+    "message": "Atributy `[id]` na stránce nejsou jedinečné"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Atributy [id] na stránce jsou jedinečné"
+    "message": "Atributy `[id]` na stránce jsou jedinečné"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Čtečky obrazovek obvykle k popisu obsahu rámců používají jejich atributy title. [Další informace](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Čtečky obrazovek obvykle k popisu obsahu rámců používají jejich atributy title. [Další informace](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Prvky <frame> nebo <iframe> nemají atribut title"
+    "message": "Prvky `<frame>` nebo `<iframe>` nemají atribut title"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Prvky <frame> a <iframe> mají atribut title"
+    "message": "Prvky `<frame>` a `<iframe>` mají atribut title"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Pokud stránka neuvádí atribut lang, čtečky obrazovky předpokládají, že je ve výchozím jazyce, který uživatel zvolil při nastavování čtečky obrazovky. Pokud stránka ve skutečnosti ve výchozím jazyce není, čtečka obrazovky text nemusí přečíst správně. [Další informace](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Pokud stránka neuvádí atribut lang, čtečky obrazovky předpokládají, že je ve výchozím jazyce, který uživatel zvolil při nastavování čtečky obrazovky. Pokud stránka ve skutečnosti ve výchozím jazyce není, čtečka obrazovky text nemusí přečíst správně. [Další informace](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Prvek <html> nemá atribut [lang]"
+    "message": "Prvek `<html>` nemá atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Prvek <html> má atribut [lang]"
+    "message": "Prvek `<html>` má atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Zadáním platného [jazyka BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) pomůžete čtečkám obrazovek správně oznamovat text. [Další informace](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Zadáním platného [jazyka BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) pomůžete čtečkám obrazovek správně oznamovat text. [Další informace](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Prvek <html> nemá platnou hodnotu atributu [lang]."
+    "message": "Prvek `<html>` nemá platnou hodnotu atributu `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Prvek <html> má atribut [lang] s platnou hodnotou"
+    "message": "Prvek `<html>` má atribut `[lang]` s platnou hodnotou"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informativní prvky by měly mít krátký, popisný alternativní text. Dekorativní prvky lze ignorovat pomocí prázdného atributu alt. [Další informace](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informativní prvky by měly mít krátký, popisný alternativní text. Dekorativní prvky lze ignorovat pomocí prázdného atributu alt. [Další informace](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Prvky obrázků nemají atributy [alt]"
+    "message": "Prvky obrázků nemají atributy `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Prvky obrázků mají atributy [alt]"
+    "message": "Prvky obrázků mají atributy `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Když je jako tlačítko <input> použit obrázek, uvedení alternativního textu pomůže uživatelům čteček obrazovek porozumět účelu tlačítka. [Další informace](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Když je jako tlačítko `<input>` použit obrázek, uvedení alternativního textu pomůže uživatelům čteček obrazovek porozumět účelu tlačítka. [Další informace](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Prvky <input type=\"image\"> nemají text [alt]"
+    "message": "Prvky `<input type=\"image\">` nemají text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Prvky <input type=\"image\"> mají text [alt]"
+    "message": "Prvky `<input type=\"image\">` mají text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Štítky zajišťují, aby asistenční technologie (například čtečky obrazovek) správně oznamovaly ovládací prvky formulářů. [Další informace](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Štítky zajišťují, aby asistenční technologie (například čtečky obrazovek) správně oznamovaly ovládací prvky formulářů. [Další informace](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "K prvkům formulářů nejsou přidružené štítky"
@@ -201,16 +201,16 @@
     "message": "K prvkům formulářů jsou přidružené štítky"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Tabulka použitá pro účely rozvržení by neměla obsahovat datové prvky, jako jsou prvky th nebo caption ani atribut summary. Pro uživatele čteček obrazovek to může být matoucí. [Další informace](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Tabulka použitá pro účely rozvržení by neměla obsahovat datové prvky, jako jsou prvky th nebo caption ani atribut summary. Pro uživatele čteček obrazovek to může být matoucí. [Další informace](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Prezentační prvky <table> by neměly obsahovat prvky <th> a <caption> ani atribut [summary]."
+    "message": "Prezentační prvky `<table>` obsahují prvky `<th>` či `<caption>` nebo atribut `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Prezentační prvky <table> neobsahují prvky <th> a <caption> ani atribut [summary]."
+    "message": "Prezentační prvky `<table>` neobsahují prvky `<th>` a `<caption>`ani atribut `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Text odkazů (a náhradní text obrázků, když jsou použité jako odkazy), který je rozeznatelný a jedinečný a který lze vybrat, uživatelům čteček obrazovek usnadňuje procházení stránek. [Další informace](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Text odkazů (a náhradní text obrázků, když jsou použité jako odkazy), který je rozeznatelný a jedinečný a který lze vybrat, uživatelům čteček obrazovek usnadňuje procházení stránek. [Další informace](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Odkazy nemají rozeznatelné názvy"
@@ -219,103 +219,115 @@
     "message": "Odkazy mají rozeznatelné názvy"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Čtečky obrazovek oznamují seznamy speciálním způsobem. Použitím správné struktury seznamu pomůžete čtečkám obrazovek s výstupem. [Další informace](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Čtečky obrazovek oznamují seznamy speciálním způsobem. Použitím správné struktury seznamu pomůžete čtečkám obrazovek s výstupem. [Další informace](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Seznamy neobsahují výhradně prvky <li> a prvky, které podporují skripty (<script> a <template>)."
+    "message": "Seznamy neobsahují výhradně prvky `<li>` a prvky, které podporují skripty (`<script>` a `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Seznamy obsahují výhradně prvky <li> a prvky, které podporují skripty (<script> a <template>)."
+    "message": "Seznamy obsahují výhradně prvky `<li>` a prvky, které podporují skripty (`<script>` a `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Aby čtečky obrazovek prvky <ul> a <ol> oznamovaly správně, musejí být tyto prvky umístěny v nadřazených položkách (<li>). [Další informace](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Aby čtečky obrazovek prvky `<li>` a `<ul>` oznamovaly správně, musejí být tyto prvky umístěny v nadřazených položkách (`<ol>`). [Další informace](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Položky seznamů (<li>) nejsou umístěny v nadřazených prvcích <ul> nebo <ol>."
+    "message": "Položky seznamů (`<li>`) nejsou umístěny v nadřazených prvcích `<ul>` nebo `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Položky seznamu (<li>) jsou umístěny v nadřazených prvcích <ul> nebo <ol>"
+    "message": "Položky seznamu (`<li>`) jsou umístěny v nadřazených prvcích `<ul>` nebo `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Uživatelé neočekávají, že se stránka bude automaticky obnovovat. Při automatickém obnovení se prohlížeč vrátí zpět na začátek stránky. Může to vést k nepříjemnému nebo matoucímu chování při procházení. [Další informace](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Uživatelé neočekávají, že se stránka bude automaticky obnovovat. Při automatickém obnovení se prohlížeč vrátí zpět na začátek stránky. Může to vést k nepříjemnému nebo matoucímu chování při procházení. [Další informace](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "V dokumentu je použita metaznačka <meta http-equiv=\"refresh\">"
+    "message": "V dokumentu je použita metaznačka `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "V dokumentu není použita metaznačka <meta http-equiv=\"refresh\">"
+    "message": "V dokumentu není použita metaznačka `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Deaktivace změny velikosti zobrazení je problematická pro slabozraké uživatele, kteří jsou při prohlížení obsahu webové stránky závislí na přiblížení obrazovky. [Další informace](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Deaktivace změny velikosti zobrazení je problematická pro slabozraké uživatele, kteří jsou při prohlížení obsahu webové stránky závislí na přiblížení obrazovky. [Další informace](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "V prvku <meta name=\"viewport\"> je použit atribut [user-scalable=\"no\"] nebo je atribut [maximum-scale] menší než 5."
+    "message": "V prvku `[user-scalable=\"no\"]` je použit atribut `<meta name=\"viewport\">` nebo je atribut `[maximum-scale]` menší než 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "V prvku <meta name=\"viewport\"> není použit atribut [user-scalable=\"no\"] a atribut [maximum-scale] není menší než 5."
+    "message": "V prvku `[user-scalable=\"no\"]` není použit atribut `<meta name=\"viewport\">` a atribut `[maximum-scale]` není menší než 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Čtečky obrazovek nedokážou přeložit obsah jiného typu, než je text. Když k prvkům <object> přidáte alternativní text, čtečky obrazovek uživatelům budou moci sdělit význam. [Další informace](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Čtečky obrazovek nedokážou přeložit obsah jiného typu, než je text. Když k prvkům `<object>` přidáte alternativní text, čtečky obrazovek uživatelům budou moci sdělit význam. [Další informace](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Prvky <object> nemají text [alt]"
+    "message": "Prvky `<object>` nemají text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Prvky <object> mají text [alt]"
+    "message": "Prvky `<object>` mají text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Hodnota větší než 0 naznačuje explicitní řazení navigace. Ačkoli je platná, často vede k chování, které je pro uživatele závislé na asistenčních technologiích nepříjemné. [Další informace](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Hodnota větší než 0 naznačuje explicitní řazení navigace. Ačkoli je platná, často vede k chování, které je pro uživatele závislé na asistenčních technologiích nepříjemné. [Další informace](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Některé prvky mají hodnotu [tabindex] větší než 0"
+    "message": "Některé prvky mají hodnotu `[tabindex]` větší než 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Žádný prvek nemá hodnotu [tabindex] větší než 0"
+    "message": "Žádný prvek nemá hodnotu `[tabindex]` větší než 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Čtečky obrazovek mají funkce, které usnadňují procházení tabulek. Když zajistíte, aby buňky <td> s atributem [headers] odkazovaly pouze na jiné buňky ve stejné tabulce, můžete tím uživatelům čteček obrazovek usnadnit používání. [Další informace](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Čtečky obrazovek mají funkce, které usnadňují procházení tabulek. Když zajistíte, aby buňky `<td>` s atributem `[headers]` odkazovaly pouze na jiné buňky ve stejné tabulce, můžete tím uživatelům čteček obrazovek usnadnit používání. [Další informace](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Buňky v prvku <table>, které mají atribut [headers], odkazují na jiné buňky ve stejné tabulce."
+    "message": "Buňky v prvku `<table>`, které mají atribut `[headers]`, odkazují na jiné buňky ve stejné tabulce."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Buňky v prvku <table>, které mají atribut [headers], odkazují jen na buňky ve stejné tabulce."
+    "message": "Buňky v prvku `<table>`, které mají atribut `[headers]`, odkazují jen na buňky ve stejné tabulce."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Čtečky obrazovek mají funkce, které usnadňují procházení tabulek. Když zajistíte, aby záhlaví tabulek vždy odkazovala na nějakou množinu buněk, bude pro uživatele čteček obrazovek procházení stránky snazší. [Další informace](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Čtečky obrazovek mají funkce, které usnadňují procházení tabulek. Když zajistíte, aby záhlaví tabulek vždy odkazovala na nějakou množinu buněk, bude pro uživatele čteček obrazovek procházení stránky snazší. [Další informace](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Prvky <th> a prvky s atributem [role=\"columnheader\"/\"rowheader\"] nemají datové buňky, které popisují."
+    "message": "Prvky `<th>` a prvky s atributem `[role=\"columnheader\"/\"rowheader\"]` nemají datové buňky, které popisují."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Prvky <th> a prvky s atributem [role=\"columnheader\"/\"rowheader\"] mají datové buňky, které popisují."
+    "message": "Prvky `<th>` a prvky s atributem `[role=\"columnheader\"/\"rowheader\"]` mají datové buňky, které popisují."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Pokud je u prvků uveden platný [jazyk BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) pomůže to zajistit, aby čtečky obrazovek text četly správně. [Další informace](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Pokud je u prvků uveden platný [jazyk BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) pomůže to zajistit, aby čtečky obrazovek text četly správně. [Další informace](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Atributy [lang] nemají platnou hodnotu"
+    "message": "Atributy `[lang]` nemají platnou hodnotu"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Atributy [lang] mají platnou hodnotu"
+    "message": "Atributy `[lang]` mají platnou hodnotu"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Když jsou u videa k dispozici titulky, je pro sluchově postižené uživatele snazší využít informace ve videu. [Další informace](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Když jsou u videa k dispozici titulky, je pro sluchově postižené uživatele snazší využít informace ve videu. [Další informace](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Prvky <video> neobsahují prvek <track> s atributem [kind=\"captions\"]."
+    "message": "Prvky `<video>` neobsahují prvek `<track>` s atributem `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Prvky <video> obsahují prvek <track> s atributem [kind=\"captions\"]"
+    "message": "Prvky `<video>` obsahují prvek `<track>` s atributem `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Zvukové popisy u videí poskytují relevantní informace, které nejsou patrné z dialogů, jako jsou například výrazy v obličejích a popisy scén. [Další informace](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Zvukové popisy u videí poskytují relevantní informace, které nejsou patrné z dialogů, jako jsou například výrazy v obličejích a popisy scén. [Další informace](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Prvky <video> neobsahují prvek <track> s atributem [kind=\"description\"]."
+    "message": "Prvky `<video>` neobsahují prvek `<track>` s atributem `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Prvky <video> obsahují prvek <track> s atributem [kind=\"description\"]"
+    "message": "Prvky `<video>` obsahují prvek `<track>` s atributem `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Pro ideální vzhled po přidání na plochu v systému iOS definujte atribut apple-touch-icon. Musí odkazovat na neprůhledný čtvercový obrázek PNG se stranami o délce 192 px (nebo180 px). [Další informace](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Neobsahuje platný atribut `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Atribut `apple-touch-icon-precomposed` je zastaralý. Je preferován atribut `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Obsahuje platný atribut `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Rychlost načítání této stránky byla negativně ovlivněna rozšířeními pro Chrome. Zkuste stránku zkontrolovat v anonymním režimu nebo profilu Chromu bez rozšíření."
@@ -330,7 +342,7 @@
     "message": "Celková doba využití procesoru"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Pokuste se zkrátit dobu analyzování, kompilování a spouštění JavaScriptu. Mohlo by pomoci odesílat menší soubory JavaScript. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Pokuste se zkrátit dobu analyzování, kompilování a spouštění JavaScriptu. Mohlo by pomoci odesílat menší soubory JavaScript. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Zkraťte dobu provádění JavaScriptu"
@@ -345,19 +357,19 @@
     "message": "Pro animovaný obsah používejte formáty videa"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Zvažte možnost načítat obrázky mimo obrazovku a skryté obrázky „líně“ až po načtení všech kritických zdrojů, abyste zkrátili dobu k dosažení interaktivnosti. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Zvažte možnost načítat obrázky mimo obrazovku a skryté obrázky „líně“ až po načtení všech kritických zdrojů, abyste zkrátili dobu k dosažení interaktivnosti. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Odložte načítání obrázků mimo obrazovku"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "První vykreslení stránky blokují zdroje. Zvažte, zda byste kriticky důležité zdroje JavaScript a CSS nemohli poskytovat přímo v kódu a stahování veškerého nekritického JavaScriptu a stylů odložit. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "První vykreslení stránky blokují zdroje. Zvažte, zda byste kriticky důležité zdroje JavaScript a CSS nemohli poskytovat přímo v kódu a stahování veškerého nekritického JavaScriptu a stylů odložit. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Eliminujte zdroje, které blokují vykreslení"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Přenášení velkého množství dat po síti je pro uživatele finančně nákladné a obvykle vede k pomalému načítání. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Přenášení velkého množství dat po síti je pro uživatele finančně nákladné a obvykle vede k pomalému načítání. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Celková velikost byla {totalBytes, number, bytes} kB"
@@ -369,19 +381,19 @@
     "message": "Nepřenáší enormní množství dat"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Minifikací souborů CSS lze snížit množství přenášených dat. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Minifikací souborů CSS lze snížit množství přenášených dat. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Minifikujte kód CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Minifikací souborů JavaScript lze snížit množství přenášených dat a zrychlit analýzu skriptů. [Další informace](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Minifikací souborů JavaScript lze snížit množství přenášených dat a zrychlit analýzu skriptů. [Další informace](https://developers.google.com/speed/docs/insights/MinifyResources)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Minifikujte JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Odstraňte ze šablon stylů nepoužívaná pravidla a odložte načítání stylů CSS, které se nepoužívají pro obsah nad okrajem, abyste snížili množství nepotřebných dat využívaných síťovou aktivitou. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Odstraňte ze šablon stylů nepoužívaná pravidla a odložte načítání stylů CSS, které se nepoužívají pro obsah zobrazený bez posouvání, abyste snížili množství nepotřebných dat využívaných síťovou aktivitou. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Odstraňte nepoužívané styly CSS"
@@ -393,7 +405,7 @@
     "message": "Odstraňte nepoužívaný JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Dlouhá platnost mezipaměti může zrychlit opakované návštěvy stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Dlouhá platnost mezipaměti může zrychlit opakované návštěvy stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Byl nalezen 1 zdroj}few{Byly nalezeny # zdroje}many{Bylo nalezeno # zdroje}other{Bylo nalezeno # zdrojů}}"
@@ -405,37 +417,88 @@
     "message": "Používá u statických podkladů efektivní zásady pro mezipaměť"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Optimalizované obrázky se načítají rychle a spotřebovávají méně mobilních dat. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Optimalizované obrázky se načítají rychle a spotřebovávají méně mobilních dat. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Používejte efektivní kódování obrázků"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Zobrazujte obrázky s vhodnou velikostí, abyste ušetřili mobilní data a zrychlili načítání. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Zobrazujte obrázky s vhodnou velikostí, abyste ušetřili mobilní data a zrychlili načítání. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Používejte správnou velikost obrázků"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Textové zdroje by se měly odesílat komprimované (gzip, deflate nebo brotli), aby se minimalizovalo množství přenášených dat. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Textové zdroje by se měly odesílat komprimované (gzip, deflate nebo brotli), aby se minimalizovalo množství přenášených dat. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Zapněte kompresi textu"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Formáty obrázků JPEG 2000, JPEG XR a WebP často poskytují lepší kompresi než formáty PNG a JPEG, což znamená rychlejší stahování a menší spotřebu dat. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Formáty obrázků JPEG 2000, JPEG XR a WebP často poskytují lepší kompresi než formáty PNG a JPEG, což znamená rychlejší stahování a menší spotřebu dat. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Zobrazujte obrázky ve formátech nové generace"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Řetězce kritických požadavků níže ukazují, které zdroje se načítají s vysokou prioritou. Zvažte, zda byste načítání stránky nemohli vylepšit tím, že řetězce zkrátíte, zmenšíte zdroje nebo odložíte stahování zdrojů, které nejsou nezbytné. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Řetězce kritických požadavků níže ukazují, které zdroje se načítají s vysokou prioritou. Zvažte, zda byste načítání stránky nemohli vylepšit tím, že řetězce zkrátíte, zmenšíte zdroje nebo odložíte stahování zdrojů, které nejsou nezbytné. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Byl nalezen 1 řetězec}few{Byly nalezeny # řetězce}many{Bylo nalezeno # řetězce}other{Bylo nalezeno # řetězců}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimalizujte hloubku kritických požadavků"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Ukončení podpory / upozornění"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Řádek"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Zastaralá rozhraní API budou z prohlížeče v budoucnu odstraněna. [Další informace](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Bylo nalezeno 1 upozornění}few{Byla nalezena # upozornění}many{Bylo nalezeno # upozornění}other{Bylo nalezeno # upozornění}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Používá zastaralá rozhraní API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Nepoužívá zastaralá rozhraní API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Mezipaměť aplikace je zastaralá technologie. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Nalezeno „{AppCacheManifest}“"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Používá mezipaměť aplikace"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Nepoužívá mezipaměť aplikace"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Zadáním typu dokumentu (DOCTYPE) předejdete přechodu prohlížeče do adaptivního režimu. Další informace naleznete na [stránce webu MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Název typu dokumentu (DOCTYPE) musí být řetězec `html` psaný malými písmeny"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokument musí obsahovat deklaraci typu dokumentu DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "V poli publicId je očekáván prázdný řetězec"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "V poli systemId je očekáván prázdný řetězec"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Na stránce není deklarace typu dokumentu (DOCTYPE) HTML, proto se aktivuje adaptivní režim"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Stránka má deklaraci typu dokumentu (DOCTYPE) HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Prvek"
@@ -447,7 +510,7 @@
     "message": "Hodnota"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Vývojáři prohlížečů doporučují, aby stránky obsahovaly méně než cca. 1 500 prvků modelu DOM. Ideálně by hloubka stromu měla být menší než 32 prvků a každý nadřazený prvek by měl mít méně než 60 podřízených prvků. Velký model DOM může vést k většímu využití paměti, delším [výpočtům stylů](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) a náročným [přeformátováváním rozvržení](https://developers.google.com/speed/articles/reflow). [Další informace](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Vývojáři prohlížečů doporučují, aby stránky obsahovaly méně než cca. 1 500 prvků modelu DOM. Ideálně by hloubka stromu měla být menší než 32 prvků a každý nadřazený prvek by měl mít méně než 60 podřízených prvků. Velký model DOM může vést k většímu využití paměti, delším [výpočtům stylů](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) a náročným [přeformátováváním rozvržení](https://developers.google.com/speed/articles/reflow). [Další informace](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 prvek}few{# prvky}many{# prvku}other{# prvků}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Nepoužívá příliš velký model DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Cíl"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Ke všem externím odkazům přidejte atribut `rel=\"noopener\"` nebo `rel=\"noreferrer\"`. Stránku tím zrychlíte a předejdete ohrožení zabezpečení. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Odkazy na cíle v jiných doménách nejsou bezpečné"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Odkazy na cíle v jiných doménách jsou bezpečné"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Nepodařilo se určit cíl ukotvení ({anchorHTML}). Pokud tento prvek nepoužíváte jako hypertextový odkaz, zvažte odstranění atributu target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Vůči webům, které bez kontextu žádají o polohu, mohou být uživatelé nedůvěřiví nebo z nich mohou být zmateni. Zvažte možnost spojit tuto žádost s akcí uživatele. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Žádá při načtení stránky o oprávnění ke geolokaci"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Nežádá při načtení stránky o oprávnění ke geolokaci"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Verze"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Všechny frontendové javascriptové knihovny zjištěné na stránce."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Byly zjištěny javascriptové knihovny"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "U uživatelů s pomalým připojením mohou externí skripty vkládané metodou zpozdit `document.write()` načtení stránky o desítky sekund. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Používá metodu `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Nepoužívá metodu `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Největší závažnost"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Verze knihovny"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Počet chyb zabezpečení"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Některé skripty třetích stran mohou obsahovat známé chyby zabezpečení, které útočníci mohou snadno odhalit a zneužít. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Byla zjištěna jedna chyba zabezpečení}few{Byly zjištěny # chyby zabezpečení}many{Bylo zjištěno # chyby zabezpečení}other{Bylo zjištěno # chyb zabezpečení}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Zahrnuje frontendové javascriptové knihovny se známými chybami zabezpečení"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Vysoká"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Nízká"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Střední"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Nepoužívá frontendové javascriptové knihovny se známými chybami zabezpečení"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Vůči webům, které bez kontextu žádají o oprávnění odesílat oznámení, mohou být uživatelé nedůvěřiví nebo z nich mohou být zmateni. Zvažte možnost spojit tuto žádost s gesty uživatele. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Žádá při načtení stránky o oprávnění zobrazovat oznámení"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Nežádá při načtení stránky o oprávnění zobrazovat oznámení"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Prvky, které neprošly"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Blokování vkládání hesel je v rozporu s dobrými bezpečnostními zásadami. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Brání uživatelům ve vkládání obsahu do polí pro hesla"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Povoluje uživatelům vkládání obsahu do polí pro hesla"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "Protokol HTTP/2 oproti protokolu HTTP/1.1 nabízí mnoho výhod, včetně binárních záhlaví, multiplexingu a přenášení metodou push ze serveru. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 požadavek nebyl realizován pomocí protokolu HTTP/2}few{# požadavky nebyly realizovány pomocí protokolu HTTP/2}many{# požadavku nebylo realizováno pomocí protokolu HTTP/2}other{# požadavků nebylo realizováno pomocí protokolu HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Nepoužívá pro všechny zdroje protokol HTTP/2"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Pro vlastní zdroje používá protokol HTTP/2"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Zvažte označení posluchačů událostí dotyku a kolečka jako pasivních (`passive`), aby se stránka posouvala plynuleji. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Nepoužívá pasivní posluchače, které zlepšují posouvání"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Používá pasivní posluchače, které zlepšují posouvání"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Popis"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Chyby zaprotokolované do konzole ukazují na nevyřešené problémy. Mohou pocházet ze selhání síťových požadavků nebo jiných problémů v prohlížeči."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Do konzole byly zaprotokolovány chyby prohlížeče"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Do konzole nebyly zaprotokolovány žádné chyby prohlížeče"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Pomocí funkce font-display stylů CSS zajistěte, aby byl text při načítání webfontů viditelný uživatelům. [Další informace](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Pomocí funkce font-display stylů CSS zajistěte, aby byl text při načítání webfontů viditelný uživatelům. [Další informace](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Zajistěte, aby text při načítání webfontů zůstal viditelný"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Při načítání webfontů zůstává veškerý text viditelný"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Nástroj Lighthouse nemohl automaticky zkontrolovat hodnotu font-display pro následující adresu URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Poměr stran (skutečný)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Poměr stran (zobrazený)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Zobrazované rozměry obrázků by měly odpovídat přirozenému poměru stran. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Zobrazuje obrázky s nesprávným poměrem stran"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Zobrazuje obrázky se správným poměrem stran"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Neplatné informace o velikosti obrázku {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Nezabezpečená adresa URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Všechny weby (včetně těch, které nepracují s citlivými daty), by měly být chráněny protokolem HTTPS. Protokol HTTPS útočníkům zabraňuje v manipulaci s komunikací mezi vaší aplikací a uživateli (nebo v jejím pasivním poslechu) a je nezbytný pro HTTP/2 a mnoho nových webových rozhraní API. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Byl nalezen 1 nezabezpečený požadavek}few{Byly nalezeny # nezabezpečené požadavky}many{Bylo nalezeno # nezabezpečeného požadavku}other{Bylo nalezeno # nezabezpečených požadavků}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Nepoužívá protokol HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Používá protokol HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Rychlé načítání stránky přes mobilní síť zajišťuje dobrý dojem pro uživatele mobilních zařízení. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Rychlé načítání stránky přes mobilní síť zajišťuje dobrý dojem pro uživatele mobilních zařízení. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
     "message": "Interaktivní za {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "V simulované mobilní síti je stránka interaktivní za {timeInMs, number, seconds} s"
+    "message": "V simulované mobilní síti je stránka interaktivní za {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Stránka se v mobilních sítích nenačítá dostatečně rychle"
@@ -504,67 +735,94 @@
     "message": "Minimalizuje práci v hlavním podprocesu"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Odhadovaná latence vstupu udává, jak dlouho (v milisekundách) bude aplikaci během nejvytíženějších pěti sekund při načítání stránky odhadem trvat reakce na uživatelský vstup. Pokud je latence větší než 50 ms, mohou uživatelé chování aplikace vnímat jako přerušované. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Odhadovaná latence vstupu udává, jak dlouho (v milisekundách) bude aplikaci během nejvytíženějších pěti sekund při načítání stránky odhadem trvat reakce na uživatelský vstup. Pokud je latence větší než 50 ms, mohou uživatelé chování aplikace vnímat jako přerušované. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Odhadovaná latence vstupu"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "První vykreslení obsahu je okamžik vykreslení prvního textu nebo obrázku. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "První vykreslení obsahu je okamžik vykreslení prvního textu nebo obrázku. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "První vykreslení obsahu"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "První nečinnost procesoru udává čas, kdy je hlavní podproces stránky dostatečně nečinný na to, aby bylo možné zpracovat vstup. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "První nečinnost procesoru udává čas, kdy je hlavní podproces stránky dostatečně nečinný na to, aby bylo možné zpracovat vstup. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "První nečinnost procesoru"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "První smysluplné vykreslení udává, kdy začne být viditelný primární obsah stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "První smysluplné vykreslení udává, kdy začne být viditelný primární obsah stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "První smysluplné vykreslení"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Doba do interaktivity udává, jak dlouho trvá, než stránka začne být plně interaktivní. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Doba do interaktivity udává, jak dlouho trvá, než stránka začne být plně interaktivní. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Doba do interaktivity"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Potenciální prodleva prvního vstupu, kterou by uživatelé mohli pocítit, je trvání nejdelší úlohy (v milisekundách)."
+    "message": "Maximální potenciální prodleva prvního vstupu, kterou by uživatelé mohli pocítit, je trvání nejdelší úlohy (v milisekundách). [Další informace](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Max. potenciální prodleva prvního vstupu"
+    "message": "Maximální potenciální prodleva prvního vstupu"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Index rychlosti ukazuje, jak rychle se viditelně vyplní obsah stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Index rychlosti ukazuje, jak rychle se viditelně vyplní obsah stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Index rychlosti"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Součet všech dob (uvedený v milisekundách) mezi prvním vykreslením obsahu a dobou do interaktivity, u nichž délka úlohy překročila 50 ms."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Celková doba blokování"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Na výkon má velký vliv doba odezvy sítě. Pokud je doba odezvy připojení ke zdroji vysoká, značí to, že by se výkon mohl zlepšit při použití serverů méně vzdálených od uživatele. [Další informace](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Na výkon má velký vliv doba odezvy sítě. Pokud je doba odezvy připojení ke zdroji vysoká, značí to, že by se výkon mohl zlepšit při použití serverů méně vzdálených od uživatele. [Další informace](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Doby odezvy sítě"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Na výkon webu může mít dopad latence serverů. Vysoká latence serveru značí, že je server přetížen nebo že backend není dostatečně výkonný. [Další informace](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Na výkon webu může mít dopad latence serverů. Vysoká latence serveru značí, že je server přetížen nebo že backend není dostatečně výkonný. [Další informace](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latence backendu na serveru"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Nad rozpočet"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Udržujte množství a velikost síťových požadavků pod cílovými hodnotami, které udává poskytnutý rozpočet výkonu. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 požadavek}few{# požadavky}many{# požadavku}other{# požadavků}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Rozpočete výkonu"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Přesměrování způsobují další prodlevy před načtením stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Přesměrování způsobují další prodlevy před načtením stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Nepoužívejte několik přesměrování stránky"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Chcete-li nastavit rozpočet pro množství a velikost zdrojů na stránce, přidejte soubor budget.json. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 požadavek}few{# požadavky}many{# požadavku}other{# požadavků}} • {byteCount, number, bytes} kB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Používejte málo požadavků a malé velikosti přenosů"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Odkazy na kanonické verze slouží jako návrhy, které adresy URL se mají zobrazovat ve výsledcích vyhledávání. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Odkazy na kanonické verze slouží jako návrhy, které adresy URL se mají zobrazovat ve výsledcích vyhledávání. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Několik konfliktních adres URL ({urlList})"
@@ -576,7 +834,7 @@
     "message": "Neplatná adresa URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Odkazuje na jiné umístění hreflang ({url})"
+    "message": "Odkazuje na jiné umístění `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relativní adresa URL ({url})"
@@ -585,19 +843,16 @@
     "message": "Neodkazuje na ekvivalentní obsahovou stránku, ale na kořenovou adresu URL domény (domovskou stránku)"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokument nemá platný atribut rel=canonical"
+    "message": "Dokument nemá platný atribut `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokument má platný atribut rel=canonical"
+    "message": "Dokument má platný odkaz `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Písma menší než 12 px jsou příliš malá na to, aby byla čitelná. Návštěvníci na mobilních zařízeních je kvůli čtení musí zvětšit roztažením prstů. Snažte se, aby více než 60 % textu na stránce mělo velikosti alespoň 12 px. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Písma menší než 12 px jsou příliš malá na to, aby byla čitelná. Návštěvníci na mobilních zařízeních je kvůli čtení musí zvětšit roztažením prstů. Snažte se, aby více než 60 % textu na stránce mělo velikosti alespoň 12 px. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "Podíl čitelného textu: {decimalProportion, number, extendedPercent}"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "Podíl příliš malého textu: {decimalProportion, number, extendedPercent}."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Text není čitelný, protože není k dispozici metaznačka viewport optimalizovaná pro obrazovky mobilních zařízení."
@@ -612,16 +867,16 @@
     "message": "V dokumentu jsou použity čitelné velikosti písma"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Odkazy hreflang sdělují vyhledávačům, kterou verzi stránky mají uvádět ve výsledcích vyhledávání pro určitý jazyk či oblast. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Odkazy hreflang sdělují vyhledávačům, kterou verzi stránky mají uvádět ve výsledcích vyhledávání pro určitý jazyk či oblast. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokument nemá platný atribut hreflang"
+    "message": "Dokument nemá platný atribut `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokument má platný atribut hreflang"
+    "message": "Dokument má platný atribut `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Stránky s neúspěšnými stavovými kódy HTTP nemusejí být správně indexovány. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Stránky s neúspěšnými stavovými kódy HTTP nemusejí být správně indexovány. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "Stránka má neúspěšný stavový kód HTTP"
@@ -630,7 +885,7 @@
     "message": "Stránka má úspěšný stavový kód HTTP"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Pokud vyhledávače nemají oprávnění procházet vaše stránky, nemohou je zahrnout do výsledků vyhledávání. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Pokud vyhledávače nemají oprávnění procházet vaše stránky, nemohou je zahrnout do výsledků vyhledávání. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Indexování stránky je blokováno"
@@ -639,7 +894,7 @@
     "message": "Indexování stránky není blokováno"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Popisný text odkazů pomáhá vyhledávačům porozumět vašemu obsahu. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "Popisný text odkazů pomáhá vyhledávačům porozumět vašemu obsahu. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{Byl nalezen 1 odkaz}few{Byly nalezeny # odkazy}many{Bylo nalezeno # odkazu}other{Bylo nalezeno # odkazů}}"
@@ -651,13 +906,13 @@
     "message": "Odkazy mají popisný text"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Chcete-li ověřit strukturovaná data, spusťte [nástroj na testování strukturovaných dat](https://search.google.com/structured-data/testing-tool/) a [linter strukturovaných dat](http://linter.structured-data.org/). [Další informace](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Chcete-li ověřit strukturovaná data, spusťte [nástroj na testování strukturovaných dat](https://search.google.com/structured-data/testing-tool/) a [linter strukturovaných dat](http://linter.structured-data.org/). [Další informace](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Strukturovaná data jsou platná"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Obsah metaznaček „description“ může být zahrnut ve výsledcích vyhledávání jako stručný souhrn obsahu stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Obsah metaznaček „description“ může být zahrnut ve výsledcích vyhledávání jako stručný souhrn obsahu stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/description)"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Popisný text je prázdný."
@@ -669,7 +924,7 @@
     "message": "Dokument má metaznačku „description“"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Vyhledávače obsah pluginů nedokážou indexovat a na mnoha zařízeních jsou pluginy zakázány nebo nejsou podporovány. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Vyhledávače obsah pluginů nedokážou indexovat a na mnoha zařízeních jsou pluginy zakázány nebo nejsou podporovány. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "Dokument používá pluginy"
@@ -681,7 +936,7 @@
     "message": "Pokud soubor robots.txt nemá správný formát, prohledávače nemusejí být schopné zjistit, jak váš web mají procházet nebo indexovat."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "Na žádost o soubor robots.txt byl vrácen tento stav HTTP: {statusCode}"
+    "message": "Na žádost o soubor robots.txt byl vrácen tento stav HTTP: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{Byla nalezena 1 chyba}few{Byly nalezeny # chyby}many{Bylo nalezeno # chyby}other{Bylo nalezeno # chyb}}"
@@ -696,7 +951,7 @@
     "message": "Soubor robots.txt je platný"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Interaktivní prvky, jako jsou tlačítka a odkazy, by měly být dostatečně velké (48 × 48 px) a mělo by okolo nich být dost místa na to, aby se na ně dalo dostatečně snadno klepnout bez přesahování do dalších prvků. [Další informace](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Interaktivní prvky, jako jsou tlačítka a odkazy, by měly být dostatečně velké (48 × 48 px) a mělo by okolo nich být dost místa na to, aby se na ně dalo dostatečně snadno klepnout bez přesahování do dalších prvků. [Další informace](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "Podíl dostatečně velkých dotykových prvků: {decimalProportion, number, percent}"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Překrývající se cíl"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Velikost"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Dotykový prvek"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Dotykové prvky jsou dostatečně velké"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Doba hlavního podprocesu"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Třetí strana"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Kód třetích stran může mít významný dopad na rychlost načítání. Omezte počet redundantních externích poskytovatelů a snažte se kód třetích stran načítat až poté, co se dokončí načtení vaší stránky. [Další informace](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Byla nalezena 1 třetí strana}few{Byly nalezeny # třetí strany}many{Bylo nalezeno # třetí strany}other{Bylo nalezeno # třetích stran}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Použití zdrojů od třetích stran"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Doba do načtení prvního bajtu udává, jak dlouho vašemu serveru trvá, než odešle odpověď. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "Doba do načtení prvního bajtu udává, jak dlouho vašemu serveru trvá, než odešle odpověď. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Hlavní dokument trval {timeInMs, number, milliseconds} ms"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Trvání"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Název"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Čas zahájení"
   },
@@ -744,7 +1008,7 @@
     "message": "Typ"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Zkuste v aplikaci pomocí rozhraní User Timing API implementovat měření reálného výkonu při událostech zásadních pro uživatelský dojem. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Zkuste v aplikaci pomocí rozhraní User Timing API implementovat měření reálného výkonu při událostech zásadních pro uživatelský dojem. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 časování uživatelů}few{# časování uživatelů}many{# časování uživatelů}other{# časování uživatelů}}"
@@ -753,19 +1017,19 @@
     "message": "Hodnoty časování uživatelů"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Byl nalezen prvek <link> předběžného připojení zdroje {securityOrigin}, ale prohlížeč jej nepoužil. Zkontrolujte, zda správně používáte atribut crossorigin."
+    "message": "Byl nalezen prvek <link> k předběžnému připojení ke zdroji {securityOrigin}, ale prohlížeč jej nepoužil. Zkontrolujte, zda správně používáte atribut `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Zvažte přidání signálů pro předběžné připojení nebo načtení, aby bylo možné včas se připojit k důležitým zdrojům třetích stran. [Další informace](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Zvažte přidání signálů pro předběžné připojení nebo načtení, aby bylo možné včas se připojit k důležitým zdrojům třetích stran. [Další informace](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "K potřebným zdrojům se připojujte předem"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Byl nalezen prvek <link> k předběžnému načtení adresy {preloadURL}, ale prohlížeč jej nepoužil. Zkontrolujte, zda správně používáte atribut crossorigin."
+    "message": "Byl nalezen prvek <link> k předběžnému načtení adresy {preloadURL}, ale prohlížeč jej nepoužil. Zkontrolujte, zda správně používáte atribut `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Zvažte použití značky <link rel=preload> k prioritnímu načtení zdrojů, o které se nyní žádá později během načítání stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Zvažte použití značky `<link rel=preload>` k prioritnímu načtení zdrojů, o které se nyní žádá později během načítání stránky. [Další informace](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Klíčové požadavky načítejte předběžně"
@@ -789,10 +1053,10 @@
     "message": "Rady a tipy pro odpovídání na recenze"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Tyto kontroly odhalují příležitosti ke [zlepšení přístupnosti webové aplikace](https://developers.google.com/web/fundamentals/accessibility). Automaticky lze odhalit jen část problémů s přístupností, proto obsah doporučujeme otestovat i ručně."
+    "message": "Tyto kontroly odhalují příležitosti ke [zlepšení přístupnosti webové aplikace](https://developers.google.com/web/fundamentals/accessibility). Automaticky lze odhalit jen část problémů s přístupností, proto obsah doporučujeme otestovat i ručně."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Tyto položky se týkají oblastí, které v současné době automatické testování nedokáže pokrýt. Další informace najdete v průvodci [provedením kontroly přístupnosti](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Tyto položky se týkají oblastí, které v současné době automatické testování nedokáže pokrýt. Další informace najdete v průvodci [provedením kontroly přístupnosti](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Přístupnost"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabulky a seznamy"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Doporučené postupy"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Výkonové rozpočty nastavují standard pro výkon vašeho webu."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Rozpočty"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Další informace o výkonu vaší aplikace."
+    "message": "Další informace o výkonu vaší aplikace. Tyto hodnoty nemají [přímý vliv](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) na skóre výkonu."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostika"
@@ -840,7 +1113,7 @@
     "message": "Vylepšení prvního vykreslení"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Tyto optimalizace mohou zrychlit načítání vaší stránky."
+    "message": "Tyto návrhy vám mohou pomoci zrychlit načítání stránky. Na skóre výkonu nemají [přímý vliv](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Příležitosti"
@@ -867,7 +1140,7 @@
     "message": "Optimalizováno pro PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Tyto kontroly zajišťují, aby vaše stránka byla optimalizovaná pro hodnocení výsledků ve vyhledávačích. Na hodnocení ve vyhledávání mohou mít vliv i další faktory, které nástroj Lighthouse nekontroluje. [Další informace](https://support.google.com/webmasters/answer/35769)."
+    "message": "Tyto kontroly zajišťují, aby vaše stránka byla optimalizovaná pro hodnocení výsledků ve vyhledávačích. Na hodnocení ve vyhledávání mohou mít vliv i další faktory, které nástroj Lighthouse nekontroluje. [Další informace](https://support.google.com/webmasters/answer/35769)"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Chcete-li zkontrolovat dodržování dalších doporučených postupů pro SEO, spusťte pro svůj web tyto další validátory."
@@ -888,7 +1161,7 @@
     "message": "Procházení a indexování"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Zajistěte, aby stránky byly optimalizovány pro mobily a aby uživatelé nemuseli obsah stránky zvětšovat. [Další informace](https://developers.google.com/search/mobile-sites/)."
+    "message": "Zajistěte, aby stránky byly optimalizovány pro mobily a aby uživatelé nemuseli obsah stránky zvětšovat. [Další informace](https://developers.google.com/search/mobile-sites/)"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Optimalizováno pro mobily"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Hodnota TTL (Time to Live) mezipaměti"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Místo"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Název"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Požadavky"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Typ zdroje"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Velikost (kB)"
+    "message": "Velikost"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Strávený čas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Velikost přenosu"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Možná úspora (kB)"
+    "message": "Možná úspora"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Možná úspora (ms)"
+    "message": "Možná úspora"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Lze uspořit {wastedBytes, number, bytes} kB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Lze uspořit {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Písmo"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Obrázek"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Média"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Jiné"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skript"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Šablona stylů"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Třetí strana"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Celkem"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Při pořizování záznamu trasování během načítání stránky se něco pokazilo. Spusťte nástroj Lighthouse znovu. ({errorCode})"
@@ -930,13 +1245,19 @@
     "message": "Při čekání na počáteční připojení pomocí ladicího protokolu vypršel časový limit."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome při načítání stránky nezískal žádné snímky obrazovky. Zkontrolujte, zda je na stránce vidět nějaký obsah, a poté nástroj Lighthouse zkuste spustit znovu. ({errorCode})"
+    "message": "Chrome při načítání stránky nezískal žádné snímky obrazovky. Zkontrolujte, zda je na stránce vidět nějaký obsah, a poté nástroj Lighthouse zkuste spustit znovu. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Servery DNS zadanou doménu nedokázaly přeložit."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Při získávání povinného zdroje {artifactName} došlo k chybě: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Došlo k interní chybě Chromu. Restartujte Chrome a zkuste nástroj Lighthouse spustit znovu."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Požadovaný shromažďovací nástroj zdroje {artifactName} se nespustil."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Nástroji Lighthouse se požadovanou stránku nepodařilo spolehlivě načíst. Zkontrolujte, zda testujete správnou adresu URL a zda server správně odpovídá na všechny požadavky."
@@ -945,16 +1266,19 @@
     "message": "Nástroj Lighthouse adresu URL nemohl spolehlivě načíst, protože stránka přestala reagovat."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Adresa URL, kterou jste poskytli, nemá platné bezpečnostní identifikační údaje. {securityMessages}"
+    "message": "Adresa URL, kterou jste zadali, nemá platný bezpečnostní certifikát. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome zabránil načtení stránky a zobrazil vsunutou obrazovku. Zkontrolujte, zda testujete správnou adresu URL a zda server správně odpovídá na všechny požadavky."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Nástroji Lighthouse se požadovanou stránku nepodařilo spolehlivě načíst. Zkontrolujte, zda testujete správnou adresu URL a zda server správně odpovídá na všechny požadavky. (Podrobnosti: {errorDetails})"
+    "message": "Nástroji Lighthouse se požadovanou stránku nepodařilo spolehlivě načíst. Zkontrolujte, zda testujete správnou adresu URL a zda server správně odpovídá na všechny požadavky. (Podrobnosti: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Nástroji Lighthouse se požadovanou stránku nepodařilo spolehlivě načíst. Zkontrolujte, zda testujete správnou adresu URL a zda server správně odpovídá na všechny požadavky. (Stavový kód: {statusCode})"
+    "message": "Nástroji Lighthouse se požadovanou stránku nepodařilo spolehlivě načíst. Zkontrolujte, zda testujete správnou adresu URL a zda server správně odpovídá na všechny požadavky. (Stavový kód: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Načtení stránky trvalo příliš dlouho. Podle návrhů v přehledu zkraťte dobu načítání stránky a poté nástroj Lighthouse zkuste spustit znovu. ({errorCode})"
+    "message": "Načtení stránky trvalo příliš dlouho. Podle návrhů v přehledu zkraťte dobu načítání stránky a poté nástroj Lighthouse zkuste spustit znovu. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "Při čekání na odpověď protokolu DevTools byla překročena přidělená doba. (Metoda: {protocolMethod})"
@@ -984,7 +1308,7 @@
     "message": "Laboratorní data"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "Analýza aktuální stránky pomocí nástroje [Lighthouse](https://developers.google.com/web/tools/lighthouse/) v emulované mobilní síti. Hodnoty jsou odhady a mohou se lišit."
+    "message": "Analýza aktuální stránky pomocí nástroje [Lighthouse](https://developers.google.com/web/tools/lighthouse/) v emulované mobilní síti. Hodnoty jsou odhady a mohou se lišit."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Další položky k ruční kontrole"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Rozbalit úryvek"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Zobrazit zdroje třetích stran"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Při tomto spuštění nástroje Lighthouse se vyskytly problémy:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Hodnoty jsou odhady a mohou se lišit."
+    "message": "Hodnoty jsou odhady a mohou se lišit. Skóre výkonu [vychází pouze z těchto metrik](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Úspěšné audity s upozorněními"
@@ -1026,7 +1353,7 @@
     "message": "Nainstalujte [plugin služby WordPress pro líné načítání](https://wordpress.org/plugins/search/lazy+load/), který umožňuje odložit načítání obrázků mimo obrazovku, nebo přejděte na motiv, který tuto funkci poskytuje. Zvažte také použití [pluginu AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "K dispozici je celá řada pluginů služby WordPress, které vám pomohou [vložit kritické podklady přímo do kódu](https://wordpress.org/plugins/search/critical+css/) nebo [odložit načítání méně důležitých zdrojů](https://wordpress.org/plugins/search/defer+css+javascript/). Upozorňujeme, že optimalizace pomocí těchto pluginů může narušit funkčnost vašeho motivu nebo pluginů. V kódu proto pravděpodobně budete muset provést změny."
+    "message": "K dispozici je celá řada pluginů služby WordPress, které vám pomohou [vložit kritické podklady přímo do kódu](https://wordpress.org/plugins/search/critical+css/) nebo [odložit načítání méně důležitých zdrojů](https://wordpress.org/plugins/search/defer+css+javascript/). Upozorňujeme, že optimalizace pomocí těchto pluginů může narušit funkčnost vašeho motivu nebo pluginů. V kódu proto pravděpodobně budete muset provést změny."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Na reakční dobu serveru mají vliv motivy, pluginy a specifikace serverů. Zvažte vyhledání optimalizovaného motivu, pečlivý výběr optimalizačního pluginu či upgradování serveru."
@@ -1035,25 +1362,25 @@
     "message": "Zvažte zobrazování ukázek v seznamech příspěvků (např. prostřednictvím značky k načtení dalšího obsahu), snížení počtu příspěvků zobrazených na jedné stránce, rozdělení dlouhých příspěvků na několik stránek nebo použití pluginu k línému načítání komentářů."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "K dispozici je celá řada [pluginů služby WordPress](https://wordpress.org/plugins/search/minify+css/), které web mohou zrychlit zřetězením, minifikací a komprimací stylů. Pokud je to možné, můžete minifikaci provést také předem pomocí procesu sestavení."
+    "message": "K dispozici je celá řada [pluginů služby WordPress](https://wordpress.org/plugins/search/minify+css/), které web mohou zrychlit zřetězením, minifikací a komprimací stylů. Pokud je to možné, můžete minifikaci provést také předem pomocí procesu sestavení."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "K dispozici je celá řada [pluginů služby WordPress](https://wordpress.org/plugins/search/minify+javascript/), které váš web mohou zrychlit zřetězením, minifikací a zkomprimováním skriptů. Pokud je to možné, můžete minifikaci provést také předem pomocí procesu sestavení."
+    "message": "K dispozici je celá řada [pluginů služby WordPress](https://wordpress.org/plugins/search/minify+javascript/), které váš web mohou zrychlit zřetězením, minifikací a zkomprimováním skriptů. Pokud je to možné, můžete minifikaci provést také předem pomocí procesu sestavení."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Zvažte snížení počtu [pluginů služby WordPress](https://wordpress.org/plugins/), které na stránce načítají nevyužité styly CSS. Pluginy, které přidávají nadbytečné styly CSS, můžete vyhledat pomocí funkce [Coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) v nástrojích pro vývojáře v Chromu. Odpovědný motiv či plugin můžete identifikovat podle adresy URL šablony stylů. Hledejte pluginy, které v seznamu mají mnoho šablon stylů, u nichž je při použití funkce Coverage velké množství kódu označeno červeně. Plugin by měl šablonu stylů do fronty zařadit jen v případě, že je na stránce opravdu použita."
+    "message": "Zvažte snížení počtu [pluginů služby WordPress](https://wordpress.org/plugins/), které na stránce načítají nevyužité styly CSS. Pluginy, které přidávají nadbytečné styly CSS, můžete vyhledat pomocí funkce [Coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) v nástrojích pro vývojáře v Chromu. Odpovědný motiv či plugin můžete identifikovat podle adresy URL šablony stylů. Hledejte pluginy, které v seznamu mají mnoho šablon stylů, u nichž je při použití funkce Coverage velké množství kódu označeno červeně. Plugin by měl šablonu stylů do fronty zařadit jen v případě, že je na stránce opravdu použita."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Zvažte snížení počtu [pluginů služby WordPress](https://wordpress.org/plugins/), které na stránce načítají nepoužívaný kód JavaScript. Pluginy, které přidávají nadbytečný kód JS, můžete vyhledat pomocí funkce [Coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) v nástrojích pro vývojáře v Chromu. Odpovědný motiv či plugin poznáte podle adresy URL skriptu. Hledejte pluginy, které v seznamu mají mnoho skriptů, u nichž je při použití funkce Coverage velké množství kódu označeno červeně. Plugin by měl skript do fronty zařadit jen v případě, že se na stránce opravdu používá."
+    "message": "Zvažte snížení počtu [pluginů služby WordPress](https://wordpress.org/plugins/), které na stránce načítají nepoužívaný kód JavaScript. Pluginy, které přidávají nadbytečný javascriptový kód, můžete vyhledat pomocí funkce [Coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) v nástrojích pro vývojáře v Chromu. Odpovědný motiv či plugin poznáte podle adresy URL skriptu. Hledejte pluginy, které v seznamu mají mnoho skriptů, u nichž je při použití funkce Coverage velké množství kódu označeno červeně. Plugin by měl skript do fronty zařadit jen v případě, že se na stránce opravdu používá."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Přečtěte si o [ukládání do mezipaměti prohlížeče ve službě WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Přečtěte si o [ukládání do mezipaměti prohlížeče ve službě WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "Zvažte použití [pluginu služby WordPress na optimalizaci obrázků](https://wordpress.org/plugins/search/optimize+images/), který obrázky komprimuje, přičemž zachová jejich kvalitu."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Nahrajte obrázky přímo prostřednictvím [mediální knihovny](https://codex.wordpress.org/Media_Library_Screen), abyste zajistili dostupnost potřebných velikostí obrázků, a poté je vložte z mediální knihovny, případně použití optimálních velikostí obrázků zajistěte pomocí widgetu pro obrázky (včetně obrázků pro responzivní dělicí body). Obrázek v plné velikosti používejte pouze v případě, že jsou jejich rozměry adekvátní k použití. [Další informace](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Nahrajte obrázky přímo prostřednictvím [mediální knihovny](https://codex.wordpress.org/Media_Library_Screen), abyste zajistili dostupnost potřebných velikostí obrázků, a poté je vložte z mediální knihovny, případně použití optimálních velikostí obrázků zajistěte pomocí widgetu pro obrázky (včetně obrázků pro responzivní dělicí body). Obrázky v této velikosti: `Full Size` používejte pouze v případě, že jsou jejich rozměry adekvátní k použití. [Další informace](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Můžete v konfiguraci webového serveru zapnout kompresi textu."

--- a/lighthouse-core/lib/i18n/locales/da.json
+++ b/lighthouse-core/lib/i18n/locales/da.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Med adgangsnøgler kan brugerne hurtigt fokusere på dele af siden. Hver nøgle skal være unik for at navigere korrekt. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Med adgangsnøgler kan brugerne hurtigt fokusere på dele af siden. Hver nøgle skal være unik for at navigere korrekt. [Få flere oplysninger](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "\"[accesskey]\"-værdierne er ikke unikke"
+    "message": "`[accesskey]`-værdierne er ikke unikke"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "\"[accesskey]\"-værdierne er unikke"
+    "message": "`[accesskey]`-værdier er unikke"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Hver ARIA-rolle understøtter en bestemt delmængde af \"aria-*\"-attributter. Uoverensstemmelser i disse ugyldiggør \"aria-*\"-attributterne. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Hver ARIA-`role` understøtter en bestemt delmængde af `aria-*`-attributter. Hvis der opstår uoverensstemmelser, gøres `aria-*`-attributterne ugyldige. [Få flere oplysninger](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "\"[aria-*]\"-attributterne stemmer ikke overens med deres roller"
+    "message": "`[aria-*]`-attributterne stemmer ikke overens med deres roller"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "\"[aria-*]\"-attributterne stemmer overens med deres roller"
+    "message": "`[aria-*]`-attributterne stemmer overens med deres roller"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Nogle ARIA-roller har opnået attributter, der beskriver elementets tilstand for skærmlæsere. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Nogle ARIA-roller har obligatoriske attributter, der beskriver elementets tilstand for skærmlæsere. [Få flere oplysninger](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "\"[role]\"-elementerne har ikke alle de påkrævede \"[aria-*]\"-attributter"
+    "message": "`[role]`-elementerne har ikke alle de obligatoriske `[aria-*]`-attributter"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "\"[role]\"-elementerne har alle de påkrævede \"[aria-*]\"-attributter"
+    "message": "`[role]`-elementerne har alle obligatoriske `[aria-*]`-attributter"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Nogle overordnede ARIA-roller skal indeholde bestemte underordnede roller for at udføre deres tilsigtede hjælpefunktioner [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Nogle overordnede ARIA-roller skal indeholde bestemte underordnede roller for at udføre deres tilsigtede hjælpefunktioner [Få flere oplysninger](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Der mangler elementer med \"[role]\", som kræver bestemte underordnede \"[role]\"-elementer."
+    "message": "Der mangler elementer med `[role]`, som kræver bestemte underordnede `[role]`-elementer."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Der er elementer med \"[role]\", som kræver bestemte underordnede \"[role]\"-elementer"
+    "message": "Elementer med `[role]`, som kræver bestemte underordnede `[role]`-elementer, er til stede."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Nogle underordnede ARIA-roller skal indgå i bestemte overordnede roller for korrekt at udføre deres tilsigtede hjælpefunktioner. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Nogle underordnede ARIA-roller skal indgå i bestemte overordnede roller for at udføre deres tilsigtede hjælpefunktioner korrekt. [Få flere oplysninger](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "\"[role]\"-elementerne indgår ikke i deres påkrævede overordnede element"
+    "message": "`[role]`-elementerne indgår ikke i deres påkrævede overordnede element"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "\"[role]\"-elementerne indgår i deres påkrævede overordnede element"
+    "message": "`[role]`-elementerne indgår i deres påkrævede overordnede element"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA-roller skal have gyldige værdier for at udføre deres tilsigtede hjælpefunktioner. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA-roller skal have gyldige værdier for at udføre deres tilsigtede hjælpefunktioner. [Få flere oplysninger](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "\"[role]\"-værdierne er ikke gyldige"
+    "message": "`[role]`-værdierne er ikke gyldige"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "\"[role]\"-værdierne er gyldige"
+    "message": "`[role]`-værdierne er gyldige"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Hjælpeteknologier som f.eks. skærmlæsere kan ikke fortolke ARIA-attributter med ugyldige værdier. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Hjælpeteknologier som f.eks. skærmlæsere kan ikke fortolke ARIA-attributter med ugyldige værdier. [Få flere oplysninger](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "\"[aria-*]\"-attributterne har ikke gyldige værdier"
+    "message": "`[aria-*]`-attributterne har ikke gyldige værdier"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "\"[aria-*]\"-attributterne har gyldige værdier"
+    "message": "`[aria-*]`-attributterne har gyldige værdier"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Hjælpeteknologier som f.eks. skærmlæsere kan ikke fortolke ARIA-attributter med ugyldige navne. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Hjælpeteknologier som f.eks. skærmlæsere kan ikke fortolke ARIA-attributter med ugyldige navne. [Få flere oplysninger](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "\"[aria-*]\"-attributterne er ikke gyldige eller er stavet forkert"
+    "message": "`[aria-*]`-attributterne er ikke gyldige eller er stavet forkert"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "\"[aria-*]\"-attributterne er gyldige og er stavet korrekt"
+    "message": "`[aria-*]`-attributterne er gyldige og er stavet korrekt"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Undertekster hjælper døve og hørehæmmede med at forstå lydelementer, idet de giver vigtige oplysninger som f.eks., hvem der taler, hvad de siger, og andre oplysninger, som ikke er relateret til tale. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Undertekster hjælper døve og hørehæmmede med at forstå lydelementer, idet de giver vigtige oplysninger som f.eks., hvem der taler, hvad de siger, og andre oplysninger, som ikke er relateret til tale. [Få flere oplysninger](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "\"<audio>\"-elementerne mangler et \"<track>\"-element med \"[kind=\"captions\"]\"."
+    "message": "`<audio>`-elementerne mangler et `<track>`-element med `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "\"<audio>\"-elementerne indeholder et \"<track>\"-element med \"[kind=\"captions\"]\""
+    "message": "`<audio>`-elementerne indeholder et `<track>`-element med `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
-    "message": "Mislykkede elementer"
+    "message": "Elementer, der ikke bestod gennemgangen"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Hvis en knap ikke har et tilgængeligt navn, oplæser skærmlæsere knappen som \"knap\", hvilket gør den ubrugelig for brugere, der anvender skærmlæsere. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Hvis en knap ikke har et tilgængeligt navn, oplæser skærmlæsere knappen som \"knap\", hvilket gør den ubrugelig for brugere, der anvender skærmlæsere. [Få flere oplysninger](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Knapperne har ikke et tilgængeligt navn"
@@ -93,7 +93,7 @@
     "message": "Knapperne har et tilgængeligt navn"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Tastaturbrugere kan nemmere finde rundt på siden, når der tilføjes metoder til tilsidesættelse af gentagelser. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Tastaturbrugere kan nemmere finde rundt på siden, når der tilføjes metoder til tilsidesættelse af gentagelser. [Få flere oplysninger](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Siden indeholder hverken en heading, et skip link eller en landmark region"
@@ -102,7 +102,7 @@
     "message": "Siden indeholder en heading, et skip link eller en landmark region"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Tekst med lav kontrast er for mange brugere svær eller umulig at læse. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Tekst med lav kontrast er for mange brugere svær eller umulig at læse. [Få flere oplysninger](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Farverne i baggrunden og forgrunden har ikke nok kontrastforhold."
@@ -111,88 +111,88 @@
     "message": "Farverne i baggrunden og forgrunden har nok kontrastforhold"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Hvis lister over definitioner ikke opmærkes korrekt, kan skærmlæseres oplæsning være forvirrende og forkert. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Hvis lister over definitioner ikke opmærkes korrekt, kan skærmlæseres oplæsning være forvirrende og forkert. [Få flere oplysninger](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "\"<dl>\"-elementerne indeholder ikke udelukkende korrekt organiserede \"<dt>\"- og \"<dd>\"-grupper , \"<script>\" eller \"<template>\"-elementer."
+    "message": "`<dl>`-elementerne indeholder ikke udelukkende korrekt organiserede `<dt>`- og `<dd>`-grupper, `<script>` eller `<template>`-elementer."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "\"<dl>\"-elementerne indeholder kun korrekt organiserede \"<dt>\"- og \"<dd>\"-grupper , \"<script>\" eller \"<template>\"-elementer."
+    "message": "`<dl>`-elementerne indeholder kun korrekt organiserede `<dt>`- og `<dd>`-grupper, `<script>` eller `<template>`-elementer."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Elementer med lister over definitioner (\"<dt>\" og \"<dd>\") skal indkapsles af et overordnet \"<dl>\"-element for at sikre, at skærmlæsere kan oplæse dem korrekt. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Elementer med lister over definitioner (`<dt>` og `<dd>`) skal indkapsles af et overordnet `<dl>`-element for at sikre, at skærmlæsere kan læse dem op korrekt. [Få flere oplysninger](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Elementer med lister over definitioner er ikke indkapslet af \"<dl>\"-elementer"
+    "message": "Elementer med lister over definitioner er ikke indkapslet af `<dl>`-elementer"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Elementer med lister over definitioner er indkapslet af \"<dl>\"-elementer"
+    "message": "Elementer med lister over definitioner er indkapslet af `<dl>`-elementer"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Titlen giver brugere af skærmlæsere et overblik over siden, og brugere af søgemaskiner skal bruge den til at afgøre, om en side er relevant for deres søgning. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Titlen giver brugere af skærmlæsere et overblik over siden, og brugere af søgemaskiner skal bruge den til at afgøre, om en side er relevant for deres søgning. [Få flere oplysninger](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokumentet har ikke et \"<title>\"-element"
+    "message": "Dokumentet har ikke et `<title>`-element"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokumentet har et \"<title>\"-element"
+    "message": "Dokumentet har et `<title>`-element"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Værdien af en id-attribut skal være unik for at forhindre andre forekomster i at blive overset af hjælpeteknologier. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Værdien af en id-attribut skal være unik for at forhindre andre forekomster i at blive overset af hjælpeteknologier. [Få flere oplysninger](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "\"[id]\"-attributterne på siden er ikke unikke"
+    "message": "`[id]`-attributterne på siden er ikke unikke"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "\"[id]\"-attributterne på siden er unikke"
+    "message": "`[id]`-attributterne på siden er unikke"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Brugere af skærmlæsere har brug for skærmtitler, der beskriver indholdet på skærmen. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Brugere af skærmlæsere har brug for skærmtitler, der beskriver indholdet på skærmen. [Få flere oplysninger](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Elementer af typen \"<frame>\" eller \"<iframe>\" har ikke nogen titel"
+    "message": "`<frame>`- eller `<iframe>`-elementerne har ikke en titel"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Elementerne af typen \"<frame>\" eller \"<iframe>\" har en titel"
+    "message": "`<frame>`- eller `<iframe>`-elementerne har en titel"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Hvis siden ikke angiver en \"lang\"-attribut, antager en skærmlæser, at siden vises på det standardsprog, som brugeren valgte ved konfigurationen af sin skærmlæser. Hvis siden ikke vises på standardsproget, oplæser skærmlæseren muligvis ikke teksten på siden korrekt. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Hvis siden ikke angiver en \"lang\"-attribut, antager en skærmlæser, at siden vises på det standardsprog, som brugeren valgte ved konfigurationen af sin skærmlæser. Hvis siden ikke vises på standardsproget, oplæser skærmlæseren muligvis ikke teksten på siden korrekt. [Få flere oplysninger](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "\"<html>\"-elementerne indeholder ikke en \"[lang]\"-attribut"
+    "message": "`<html>`-elementet har ikke en `[lang]`-attribut"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "\"<html>\"-elementerne indeholder en \"[lang]\"-attribut"
+    "message": "`<html>`-elementet har en `[lang]`-attribut"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Hjælp skærmlæsere med at oplæse tekst korrekt ved at angive et gyldigt [BCP 47-sprog](https://www.w3.org/International/questions/qa-choosing-language-tags#question). [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Hjælp skærmlæsere med at oplæse tekst korrekt ved at angive et gyldigt [BCP 47-sprog](https://www.w3.org/International/questions/qa-choosing-language-tags#question). [Få flere oplysninger](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "\"<html>\"-elementerne har ikke en gyldig værdi for attibutten \"[lang]\"."
+    "message": "`<html>`-elementet har ikke en gyldig værdi for sin `[lang]`-attribut."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "\"<html>\"-elementet har en gyldig værdi for \"[lang]\"-attributten"
+    "message": "`<html>`-elementet har en gyldig værdi for `[lang]`-attributten"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informative elementer bør anvende en kort, beskrivende alternativ tekst. Dekorative elementer kan ignoreres med en tom alt-attribut. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informative elementer bør anvende en kort, beskrivende alternativ tekst. Dekorative elementer kan ignoreres med en tom alt-attribut. [Få flere oplysninger](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Billedelementerne har ikke \"[alt]\"-attributter"
+    "message": "Billedelementerne har ikke `[alt]`-attributter"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Billedelementerne indeholder \"[alt]\"-attributter"
+    "message": "Billedelementerne indeholder `[alt]`-attributter"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Når et billede bruges som en \"<input>\"-knap, kan alternativ tekst hjælpe brugere af skærmlæsere med at forstå knappens formål. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Når et billede bruges som en `<input>`-knap, kan alternativ tekst hjælpe brugere af skærmlæsere med at forstå knappens formål. [Få flere oplysninger](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "\"<input type=\"image\">\"-elementerne har ikke nogen \"[alt]\"-tekst"
+    "message": "`<input type=\"image\">`-elementerne har ikke `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "\"<input type=\"image\">\"-elementerne indeholder \"[alt]\"-tekst"
+    "message": "`<input type=\"image\">`-elementerne har `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Etiketter sikrer, at formularstyring oplæses korrekt af hjælpeteknologier som f.eks. skærmlæsere. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Etiketter sikrer, at formularstyring oplæses korrekt af hjælpeteknologier som f.eks. skærmlæsere. [Få flere oplysninger](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Formularelementerne har ikke tilknyttede etiketter"
@@ -201,16 +201,16 @@
     "message": "Formularelementerne har tilknyttede etiketter"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "En tabel, der bruges til layoutformål, bør ikke indeholde dataelementer som f.eks. th- eller tekstelementer eller oversigtsattributten, da dette kan forvirre brugere af skærmlæsere. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "En tabel, der bruges til layoutformål, bør ikke indeholde dataelementer som f.eks. th- eller tekstelementer eller oversigtsattributten, da dette kan forvirre brugere af skærmlæsere. [Få flere oplysninger](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "\"<table>\"-præsentationselementerne undgår ikke at anvende \"<th>\", \"<caption>\" eller attributten \"[summary]\"."
+    "message": "`<table>`-præsentationselementerne undgår ikke at bruge `<th>`, `<caption>` eller attributten `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "\"<table>\"-præsentationselementerne undgår at anvende \"<th>\", \"<caption>\" eller attributten \"[summary]\"."
+    "message": "`<table>`-præsentationselementerne undgår at bruge `<th>`, `<caption>` eller attributten `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Linktekst (og alternativ tekst til billeder, når de bruges som links), der er skelnelig, unik og fokuserbar, gør det nemmere for brugere af skærmlæsere at finde rundt. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Linktekst (og alternativ tekst til billeder, når de bruges som links), der er skelnelig, unik og fokuserbar, gør det nemmere for brugere af skærmlæsere at finde rundt. [Få flere oplysninger](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Linkene har ikke skelnelige navne"
@@ -219,103 +219,115 @@
     "message": "Linkene har skelnelige navne"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Skærmlæsere oplæser lister på en bestemt måde. Du kan forbedre skærmlæsernes output ved at angive en ordentlig listestruktur. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Skærmlæsere oplæser lister på en bestemt måde. Du kan forbedre skærmlæsernes output ved at angive en ordentlig listestruktur. [Få flere oplysninger](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Listerne indeholder ikke kun \"<li>\"-elementer og elementer, der understøtter scripts (\"<script>\" og \"<template>\")."
+    "message": "Listerne indeholder ikke kun `<li>`-elementer og elementer, der understøtter scripts (`<script>` og `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Listerne indeholder kun \"<li>\"-elementer og elementer, der understøtter scripts (\"<script>\" og \"<template>\")."
+    "message": "Listerne indeholder kun `<li>`-elementer og elementer, der understøtter scripts (`<script>` og `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Skærmlæsere kræver, at listeelementer (\"<li>\") indgår i et overordnet \"<ul>\"- eller \"<ol>\"-element for at blive oplæst korrekt. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Skærmlæsere kræver, at listeelementer (`<li>`) indgår i et overordnet `<ul>`- eller `<ol>`-element for at blive oplæst korrekt. [Få flere oplysninger](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Listeelementerne (\"<li>\") indgår ikke i de overordnede \"<ul>\"- eller \"<ol>\"-elementer."
+    "message": "Listeelementerne (`<li>`) indgår ikke i de overordnede `<ul>`- eller `<ol>`-elementer."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Listeelementerne (\"<li>\") indgår i de overordnede \"<ul>\"- eller \"<ol>\"-elementer"
+    "message": "Listeelementerne (`<li>`) indgår i de overordnede `<ul>`- eller `<ol>`-elementer"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Brugerne forventer ikke, at en side opdateres automatisk, og automatisk opdatering flytter fokus tilbage til toppen af siden. Dette kan være frustrerende og forvirrende for brugerne. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Brugere forventer ikke, at en side opdateres automatisk, og automatisk opdatering flytter fokus tilbage til toppen af siden. Dette kan være frustrerende og forvirrende for brugerne. [Få flere oplysninger](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokumentet anvender \"<meta http-equiv=\"refresh\">\""
+    "message": "Dokumentet bruger `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Dokumentet anvender ikke \"<meta http-equiv=\"refresh\">\""
+    "message": "Dokumentet bruger ikke `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Hvis zoom deaktiveres, kan det skabe problemer for svagtseende brugere, der har brug for skærmforstørrelse til at se indholdet på en webside. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Hvis zoom deaktiveres, kan det skabe problemer for svagtseende brugere, der har brug for skærmforstørrelse til at se indholdet på en webside. [Få flere oplysninger](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "\"[user-scalable=\"no\"]\" anvendes i elementet \"<meta name=\"viewport\">\", eller attributten \"[maximum-scale]\" er mindre end 5."
+    "message": "`[user-scalable=\"no\"]` anvendes i elementet `<meta name=\"viewport\">`, eller attributten `[maximum-scale]` er mindre end 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "\"[user-scalable=\"no\"]\" anvendes ikke i elementet \"<meta name=\"viewport\">\", og attributten \"[maximum-scale]\" er ikke mindre end 5."
+    "message": "`[user-scalable=\"no\"]` anvendes ikke i `<meta name=\"viewport\">`-elementet, og attributten `[maximum-scale]` er ikke mindre end 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Skærmlæsere kan ikke oversætte indhold, som ikke er tekst. Du kan hjælpe skærmlæsere med at formidle meningen for brugerne ved at føje alt-tekst til \"<object>\"-elementer. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Skærmlæsere kan ikke oversætte indhold, som ikke er tekst. Du kan føje alternativ tekst til `<object>`-elementer for at hjælpe skærmlæsere med at formidle meningen til brugerne. [Få flere oplysninger](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "\"<object>\"-elementerne har ikke tekst af typen \"[alt]\""
+    "message": "`<object>`-elementerne har ikke `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "\"<object>\"-elementerne indeholder \"[alt]\"-tekst"
+    "message": "`<object>`-elementerne har `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "En værdi over 0 antyder en utvetydig sortering af navigation. Selvom dette teknisk er gyldigt, skaber det ofte en frustrerende oplevelse for brugere, der anvender hjælpeteknologier. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "En værdi over 0 antyder en utvetydig sortering af navigation. Selvom dette teknisk er gyldigt, skaber det ofte en frustrerende oplevelse for brugere, der anvender hjælpeteknologier. [Få flere oplysninger](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Nogle elementer har en \"[tabindex]\"-værdi, som er større end 0"
+    "message": "Nogle elementer har en `[tabindex]`-værdi, som er større end 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Ingen af elementerne har en \"[tabindex]\"-værdi, der overstiger 0"
+    "message": "Ingen af elementerne har en `[tabindex]`-værdi, der overstiger 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Skærmlæsere har funktioner, der gør det nemmere at finde rundt i tabeller. Du kan give brugere af skærmlæsere en bedre oplevelse ved at sikre, at \"<td>\"-celler, der anvender attributten \"[headers]\", kun henviser til andre celler i samme tabel. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Skærmlæsere har funktioner, der gør det nemmere at finde rundt i tabeller. Du kan give brugere af skærmlæsere en bedre oplevelse ved at sikre, at `<td>`-celler, der anvender attributten `[headers]`, kun henviser til andre celler i samme tabel. [Få flere oplysninger](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Celler i et \"<table>\"-element, der anvender attributten \"[headers]\", henviser til andre celler i den samme tabel."
+    "message": "Celler i et `<table>`-element, der anvender attributten `[headers]`, henviser til andre celler i den samme tabel."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Celler i et \"<table>\"-element, der anvender attributten \"[headers]\", henviser kun til andre celler i den samme tabel."
+    "message": "Celler i et `<table>`-element, der anvender attributten `[headers]`, henviser kun til andre celler i den samme tabel."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Skærmlæsere har funktioner, der gør det nemmere at finde rundt i tabeller. Du kan give brugere af skærmlæsere en bedre oplevelse ved at sikre, at tabeloverskrifter altid henviser til nogle cellesæt. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Skærmlæsere har funktioner, der gør det nemmere at finde rundt i tabeller. Du kan give brugere af skærmlæsere en bedre oplevelse ved at sikre, at tabeloverskrifter altid henviser til nogle cellesæt. [Få flere oplysninger](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "\"<th>\"-elementerne og elementerne med \"[role=\"columnheader\"/\"rowheader\"]\" indeholder ikke de dataceller, de beskriver."
+    "message": "`<th>`-elementerne og elementerne med `[role=\"columnheader\"/\"rowheader\"]` indeholder ikke de dataceller, de beskriver."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "\"<th>\"-elementerne og elementerne med \"[role=\"columnheader\"/\"rowheader\"]\" indeholder de dataceller, de beskriver."
+    "message": "`<th>`-elementerne og elementer med `[role=\"columnheader\"/\"rowheader\"]` indeholder de dataceller, de beskriver."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Hjælp med at sikre, at tekst udtales korrekt af skærmlæsere, ved at angive et gyldigt [BCP 47-sprog](https://www.w3.org/International/questions/qa-choosing-language-tags#question) for elementer. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Hjælp med at sikre, at tekst udtales korrekt af skærmlæsere, ved at angive et gyldigt [BCP 47-sprog](https://www.w3.org/International/questions/qa-choosing-language-tags#question) for elementer. [Få flere oplysninger](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "\"[lang]\"-attributterne har ikke en gyldig værdi"
+    "message": "`[lang]`-attributterne har ikke en gyldig værdi"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "\"[lang]\"-attributterne har en gyldig værdi"
+    "message": "`[lang]`-attributterne har en gyldig værdi"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Det er nemmere for døve og hørehæmmede at få adgang til en videos oplysninger, hvis videoen har tilgængelige undertekster. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Det er nemmere for døve og hørehæmmede at få adgang til en videos oplysninger, hvis videoen tilbyder undertekster. [Få flere oplysninger](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "\"<video>\"-elementerne indeholder ikke et \"<track>\"-element med \"[kind=\"captions\"]\"."
+    "message": "`<video>`-elementerne indeholder ikke et `<track>`-element med `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "\"<video>\"-elementerne indeholder et \"<track>\"-element med \"[kind=\"captions\"]\""
+    "message": "`<video>`-elementerne indeholder et `<track>`-element med `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Lydbeskrivelser giver relevante oplysninger om videoer, som ikke fremgår af dialogen, f.eks. ansigtsudtryk og scener. [Få flere oplysninger](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Lydbeskrivelser giver relevante oplysninger om videoer, som ikke fremgår af dialogen, f.eks. ansigtsudtryk og scener. [Få flere oplysninger](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "\"<video>\"-elementerne indeholder ikke et \"<track>\"-element med \"[kind=\"description\"]\"."
+    "message": "`<video>`-elementerne indeholder ikke et `<track>`-element med `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "\"<video>\"-elementerne indeholder et \"<track>\"-element med \"[kind=\"description\"]\""
+    "message": "`<video>`-elementerne indeholder et `<track>`-element med `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Angiv et apple-touch-icon for at optimere iOS-brugerfladen, når brugere føjer indhold til startskærmen. Den skal pege på en ikke-transparent firkantet PNG på 192 px (eller 180 px). [Få flere oplysninger](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Angiver ikke en gyldig `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` er forældet, og `apple-touch-icon` foretrækkes."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Angiver et gyldigt `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome-udvidelser påvirkede denne sides indlæsning negativt. Prøv at revidere siden i inkognitotilstand eller fra en Chrome-profil uden udvidelser."
@@ -339,19 +351,19 @@
     "message": "Udførelsestid for JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Store giffer er ikke tilstrækkelige til at levere animeret indhold. Overvej at bruge MPEG4-/WebM-videoer til animationer og PNG/WebP til statiske billeder i stedet for giffer for at spare netværksbytes. [Få flere oplysninger](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Store giffer er mindre effektive til at levere animeret indhold. Du kan også overveje at bruge MPEG4-/WebM-videoer til animationer og PNG/WebP til statiske billeder i stedet for giffer for at spare netværksbytes. [Få flere oplysninger](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Brug videoformater til animeret indhold"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Overvej at udskyde indlæsningen af skjulte billeder og billeder, der ikke er på skærmen, til efter alle kritiske ressourcer er blevet indlæst for at reducere den tid, der går, inden siden er interaktiv. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Overvej at udskyde indlæsningen af skjulte billeder og billeder, der ikke er på skærmen, til efter alle kritiske ressourcer er blevet indlæst for at reducere den tid, der går, inden siden bliver interaktiv. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Udskyd billeder, der ikke er på skærmen"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Ressourcer blokerer første udfyldning af din side. Overvej at levere kritisk JavaScript/CSS indlejret og udskyde alle ikke-kritiske JavaScript-elementer/typografier. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Ressourcer blokerer for første visning af din side. Overvej at levere kritisk JavaScript/CSS indlejret og udskyde alle ikke-kritiske JavaScript-elementer/typografier. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Fjern ressourcer til blokering af gengivelse"
@@ -429,13 +441,64 @@
     "message": "Vis billeder i formater af næste generation"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Kæderne med kritiske anmodninger nedenfor viser dig, hvilke ressourcer der indlæses med høj prioritet. Du kan også vælge at reducere kædernes længde, så ressourcernes downloadstørrelse bliver mindre, eller at udskyde download af unødvendige ressourcer, så sideindlæsningen forbedres. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Kæderne med kritiske anmodninger nedenfor viser dig, hvilke ressourcer der indlæses med høj prioritet. Overvej at reducere kædernes længde, så ressourcernes downloadstørrelse bliver mindre, eller at udskyde download af unødvendige ressourcer, så sideindlæsningen forbedres. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Der blev fundet 1 kæde}one{Der blev fundet # kæde}other{Der blev fundet # kæder}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimer dybden for kritiske anmodninger"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Udfasning/advarsel"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Linje"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Udfasede API'er fjernes med tiden fra browseren. [Få flere oplysninger](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 advarsel blev fundet}one{# advarsel blev fundet}other{# advarsler blev fundet}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Bruger udfasede API'er"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Undgår udfasede API'er"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Application Cache er udfaset. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" blev fundet"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Bruger Application Cache"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Undgår Application Cache"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Browseren forhindres i at skifte til quirks-tilstand ved at angive en dokumenttype. Få flere oplysninger på [siden MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Navnet på dokumenttypen skal være en `html`-streng med små bogstaver"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokumentet skal indeholde en doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "En tom streng var forventet for publicId"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "En tom streng var forventet for systemId"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Siden mangler dokumenttypen HTML og aktiverer derfor quirks-tilstand"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Siden har dokumenttypen HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
@@ -447,7 +510,7 @@
     "message": "Værdi"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Browserudviklere anbefaler, at sider højst indeholder 1.500 DOM-elementer. Det bedste er en træstrukturdybde med under 32 elementer og færre end 60 underordnede/overordnede elementer. En stor DOM kan øge hukommelsesforbruget, medføre længere [beregninger af typografi](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) og producere dyre [omformateringer af layout](https://developers.google.com/speed/articles/reflow). [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Browserudviklere anbefaler, at sider højst indeholder 1.500 DOM-elementer. Det bedste er en træstrukturdybde med under 32 elementer og færre end 60 underordnede/overordnede elementer. En stor DOM kan øge hukommelsesforbruget, medføre længere [beregninger af typografi](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) og resultere i dyre [omformateringer af layout](https://developers.google.com/speed/articles/reflow). [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 element}one{# element}other{# elementer}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Undgår en overdreven DOM-størrelse"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Mål"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Føj `rel=\"noopener\"` eller `rel=\"noreferrer\"` til alle eksterne links for at forbedre ydeevnen og forhindre sikkerhedssårbarheder. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Links til destinationer af anden oprindelse er ikke sikre"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Links til destinationer af anden oprindelse er sikre"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Destinationen for ankeret ({anchorHTML}) kunne ikke identificeres. Hvis det ikke bruges som hyperlink, bør du overveje at fjerne target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Brugere er mistænksomme over for eller forvirres af websites, der anmoder om deres placering uden sammenhæng. Overvej at knytte anmodningen til en brugerhandling i stedet for. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Anmoder om tilladelse til geoplacering ved indlæsning af siden"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Undgår at anmode om tilladelse til geoplacering ved indlæsning af siden"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Version"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Alle JavaScript-biblioteker i frontend, der registreres på siden."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Registrerede JavaScript-biblioteker"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Eksterne scripts, der indsættes dynamisk via `document.write()`, kan forsinke sideindlæsningen med flere sekunder for brugere med langsomme forbindelser. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Bruger `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Undgår `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Størst omfang"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Biblioteksversion"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Antal sårbarheder"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Nogle scripts fra tredjeparter kan indeholde kendte sikkerhedssårbarheder, som let kan identificeres og udnyttes af hackere. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 sårbarhed blev registreret}one{# sårbarhed blev registreret}other{# sårbarheder blev registreret}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Indeholder JavaScript-biblioteker i frontend med kendte sikkerhedssårbarheder"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Høj"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Lavt"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Middel"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Undgår frontend JavaScript-biblioteker med kendte sikkerhedssårbarheder"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Brugere er mistænksomme over for eller forvirres af websites, der anmoder om at sende notifikationer uden sammenhæng. Overvej at knytte anmodningen til brugerbevægelser i stedet for. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Anmoder om tilladelse til notifikationer ved indlæsning af siden"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Undgår at anmode om tilladelse til notifikationer ved indlæsning af siden"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elementer, der ikke bestod gennemgangen"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "En god sikkerhedspolitik undermineres ved at forhindre indsættelse af adgangskoder. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Forhindrer brugere i at indsætte indhold i adgangskodefelter"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Tillader, at brugere indsætter indhold i adgangskodefelter"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 tilbyder mange fordele i forhold til HTTP/1.1, herunder binære headers, multipleksing og server push. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 anmodning blev ikke leveret via HTTP/2}one{# anmodning blev ikke leveret via HTTP/2}other{# anmodninger blev ikke leveret via HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Anvender ikke HTTP/2 til alle sine ressourcer"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Anvender HTTP/2 til egne ressourcer"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Overvej at markere hændelsesfunktionerne for tryk og hjul som `passive` for at forbedre effektiviteten ved rulning på siden. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Anvender ikke passive hændelsesfunktioner til at forbedre rulning"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Anvender passive hændelsesfunktioner til at forbedre rulning"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Beskrivelse"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Fejl, der er logført i konsollen, angiver uløste problemer. De kan stamme fra mislykkede netværksanmodninger og andre browserproblemer."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Der blev logført browserfejl i konsollen"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Der blev ikke logført nogen browserfejl i konsollen"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Udnyt CSS-funktionen til skrifttypevisning for at sikre dig, at teksten kan ses af brugerne, mens webfonts indlæses. [Få flere oplysninger](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Udnyt CSS-funktionen til skrifttypevisning for at sikre, at teksten kan ses af brugerne, mens webfonts indlæses. [Få flere oplysninger](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Sørg for, at tekst forbliver synlig under indlæsning af webfont"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Al tekst forbliver synlig under indlæsning af webfont"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse kunne ikke automatisk tjekke visningsværdien for skrifttyper for den følgende webadresse: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Billedformat (faktisk)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Billedformat (vist)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Størrelsen for billedvisningen bør matche det naturlige billedformat. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Viser billeder med forkert billedformat"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Viser billeder med korrekt billedformat"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Oplysningerne om billedstørrelse er ikke gyldige {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Usikker webadresse"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Alle websites bør beskyttes med HTTPS, selv websites, der ikke håndterer følsomme oplysninger. HTTPS forhindrer uvedkommende i at manipulere med eller passivt lytte med på kommunikationen mellem din app og dine brugere og er en forudsætning for HTTP/2 og mange nye webplatform-API'er. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 usikker anmodning blev fundet}one{# usikker anmodning blev fundet}other{# usikre anmodninger blev fundet}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Anvender ikke HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Bruger HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Hurtig sideindlæsning via mobilnetværk sikrer en god oplevelse for mobilbrugere. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interaktiv efter {timeInMs, number, seconds} s"
+    "message": "Interaktiv efter {timeInMs, number, seconds} sek."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Interaktiv på simuleret mobilnetværk efter {timeInMs, number, seconds} s"
+    "message": "Interaktiv på simuleret mobilnetværk efter {timeInMs, number, seconds} sek."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Sideindlæsning er ikke hurtig nok på mobilnetværk"
@@ -504,13 +735,13 @@
     "message": "Formindsker primært trådarbejde"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Estimeret inputforsinkelse er et estimat af, hvor længe din app er om at reagere på brugerinput i millisekunder i det travleste femsekundersvindue under en sideindlæsning. Hvis din forsinkelse er længere end 50 ms, kan brugerne opfatte din app som langsom. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Estimeret inputforsinkelse er en anslået værdi af, hvor længe din app er om at reagere på brugerinput i millisekunder i det travleste femsekundersvindue under en sideindlæsning. Hvis din forsinkelse er længere end 50 ms, kan brugerne opfatte din app som langsom. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Estimeret inputforsinkelse"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Første udfyldning af indhold markerer tidspunktet, hvor den første tekst eller det første billede udfyldes. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Første visning af indhold markerer tidspunktet, hvor den første tekst eller det første billede vises. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Første udfyldning af indhold"
@@ -522,28 +753,34 @@
     "message": "Første stillestående CPU"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Første betydningsfulde udfyldning måler, hvornår det primære indhold på en side kan ses. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Første meningsfulde visning måler, hvornår det primære indhold på en side kan ses. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Første betydningsfulde udfyldning"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Tid til interaktiv er den mængde tid, det tager, før siden er helt interaktiv. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Tid inden interaktiv tilstand er den mængde tid, det tager, før siden er helt interaktiv. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Tid inden interaktiv tilstand"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Den potentielle forsinkelse for første input, som dine brugere kan opleve, er varigheden i millisekunder af den længste proces."
+    "message": "Den maksimale potentielle ventetid efter første input, som dine brugere kan opleve, er varigheden i millisekunder af den længste proces. [Få flere oplysninger](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Maks. potentiel forsinkelse for første input"
+    "message": "Maks. potentiel ventetid efter første input"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Hastighedsindekset viser, hvor hurtigt indholdet på en side udfyldes, så det kan ses. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Hastighedsindekset viser, hvor hurtigt indholdet på en side er visuelt udfyldt. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Hastighedsindeks"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Summen af alle tidsrum mellem første visning af indhold og tid inden interaktiv tilstand, når proceslængden overstiger 50 ms, udtrykt i millisekunder."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Samlet blokeringstid"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Netværkets pingtid har stor indflydelse på ydeevnen. Hvis pingtiden til et oprindelsespunkt er lang, er det tegn på, at servere, der er tættere på brugeren, kan forbedre ydeevnen. [Få flere oplysninger](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,17 +794,38 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Forsinkelser for serverens backend"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Over budget"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Sørg for, at antallet af og størrelsen på netværksanmodningerne ikke overskrider målene i det angivne budget for ydeevne. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 anmodning}one{# anmodning}other{# anmodninger}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Budget for ydeevne"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Omdirigeringer medfører yderligere forsinkelser, inden siden kan indlæses. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Undgå mange sideomdirigeringer"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Tilføj en budget.json-fil for at angive budgetter for antallet af og størrelsen på sideressourcer. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 anmodning}one{# anmodning}other{# anmodning}} • {byteCount, number, bytes} kB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Sørg for, at antallet af anmodninger er lavt, og at overførslerne ikke er for store"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Kanoniske links foreslår, hvilken webadresse der skal vises i søgeresultater. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Flere modstridende webadresser ({urlList})"
+    "message": "Flere webadresser ({urlList}) er modstridende"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "Peger på et andet domæne ({url})"
@@ -576,7 +834,7 @@
     "message": "Ugyldig webadresse ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Peger på en anden placering for \"hreflang\" ({url})"
+    "message": "Peger på en anden placering for `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relativ webadresse ({url})"
@@ -585,19 +843,16 @@
     "message": "Peger på domænets rodwebadresse (startsiden) i stedet for en tilsvarende side med indhold"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokumentet har ikke et gyldigt \"rel=canonical\""
+    "message": "Dokumentet har ikke et gyldigt `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokumentet har et gyldigt \"rel=canonical\""
+    "message": "Dokumentet har et gyldigt `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Skriftstørrelser på mindre end 12 pixel er for små til at være læselige og kræver, at mobilbrugere \"kniber fingrene sammen for at zoome\" for at læse teksten. Du bør bestræbe dig på at gøre over 60 % af sideteksten større end eller lig med 12 pixel. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} læselig tekst"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} af teksten er for lille."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Teksten er ulæselig, fordi der ikke er et viewport-metatag, som er optimeret til mobilskærme."
@@ -612,13 +867,13 @@
     "message": "Dokumentet anvender læselige skriftstørrelser"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "hreflang-links fortæller søgemaskiner, hvilken version af en side de skal angive på listen over søgeresultater for et givet sprog eller en given region. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "hreflang-links fortæller søgemaskiner, hvilken version af en side de skal angive på listen over søgeresultater for et vilkårligt sprog eller område. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokumentet har ikke en gyldig \"hreflang\""
+    "message": "Dokumentet har ikke en gyldig `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokumentet har en gyldig \"hreflang\""
+    "message": "Dokumentet har et gyldigt `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Sider med ugyldige HTTP-statuskoder indekseres muligvis ikke korrekt. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Overlappende mål"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Størrelse"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Trykbart element"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Trykbare elementer har en passende størrelse"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Tid for primær tråd"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Tredjepart"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Kode fra tredjeparter kan have en væsentlig indvirkning på indlæsningen. Begræns antallet af overflødige tredjepartsudbydere, og prøv at indlæse kode fra tredjeparter, når indlæsningen af siden næsten er færdig. [Få flere oplysninger](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 tredjepart blev fundet}one{# tredjepart blev fundet}other{# tredjeparter blev fundet}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Tredjepartsbrug"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "TTFB (Time To First Byte) identificerer tidspunktet for, hvornår din server sender et svar. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Varighed"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Navn"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Starttidspunkt"
   },
@@ -744,7 +1008,7 @@
     "message": "Type"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Du kan også vælge at bruge User Timing API som værktøj til din app for at måle appens effektivitet i den virkelige verden i forbindelse med vigtige brugeroplevelser. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Du kan også vælge at bruge User Timing API som værktøj til din app for at måle appens ydeevne i den virkelige verden i forbindelse med vigtige brugeroplevelser. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 brugstid}one{# brugstid}other{# brugstider}}"
@@ -753,7 +1017,7 @@
     "message": "Brugstider markerer og måler"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Der blev fundet et <link>, der kan oprette forbindelse på forhånd for \"{securityOrigin}\", men det blev ikke brugt af browseren. Tjek, at du bruger attributten \"crossorigin\" korrekt."
+    "message": "Der blev fundet et <link>, der kan oprette forbindelse på forhånd for \"{securityOrigin}\", men det blev ikke brugt af browseren. Tjek, at du bruger attributten `crossorigin` korrekt."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Overvej at tilføje ressourcehints til forbindelse på forhånd eller DNS-forudhentning for at oprette tidlige forbindelser til vigtige tredjepartswebsites. [Få flere oplysninger](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Opret forbindelse på forhånd til påkrævede websites"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Der blev fundet <link> til forudindlæsning for \"{preloadURL}\", men det blev ikke brugt af browseren. Tjek, at du bruger attributten \"crossorigin\" korrekt."
+    "message": "Der blev fundet et <link> til forudindlæsning for \"{preloadURL}\", men det blev ikke brugt af browseren. Tjek, at du bruger attributten `crossorigin` korrekt."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Overvej at bruge <link rel=preload> til at prioritere hentning af ressourcer, som der i øjeblikket anmodes om senere i sideindlæsningen. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Overvej at bruge `<link rel=preload>` til at prioritere hentning af ressourcer, der er anmodet om senere i sideindlæsningen. [Få flere oplysninger](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Forudindlæs vigtige anmodninger"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabeller og lister"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Optimale løsninger"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Budgetter for ydeevne angiver standarder for dit websites ydeevne."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budgetter"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Få flere oplysninger om din apps effektivitet."
+    "message": "Få flere oplysninger om din apps ydeevne. Resultatet [påvirkes ikke direkte](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) af disse tal."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostik"
@@ -840,7 +1113,7 @@
     "message": "Forbedringer af første udfyldning"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Disse optimeringer kan gøre din sideindlæsning hurtigere."
+    "message": "Disse forslag kan være med til at forbedre indlæsningstiden for din side. De [berører ikke direkte](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) resultatet."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Muligheder"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Cache-TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Placering"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Navn"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Anmodninger"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Ressourcetype"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Størrelse (kB)"
+    "message": "Størrelse"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Tidsforbrug"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Overførselsstørrelse"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "Webadresse"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potentiel databesparelse (kB)"
+    "message": "Potentiel besparelse"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potentiel tidsbesparelse (ms)"
+    "message": "Potentiel besparelse"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Potentiel databesparelse på {wastedBytes, number, bytes} kB"
+    "message": "Potentiel besparelse på {wastedBytes, number, bytes} kB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "Potentiel tidsbesparelse på {wastedMs, number, milliseconds} ms"
+    "message": "Potentiel besparelse på {wastedMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Skrifttype"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Billede"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Medier"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Andet"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} sek."
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Typografiark"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Tredjepart"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "I alt"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Der opstod en fejl ved registreringen af din sideindlæsning. Kør Lighthouse igen. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS-serverne kunne ikke løse problemet med det angivne domæne."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Der opstod en fejl i den obligatoriske {artifactName}-indsamler: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Der opstod en intern Chrome-fejl. Genstart Chrome, og prøv at køre Lighthouse igen."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Den obligatoriske {artifactName}-indsamler blev ikke kørt."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse kunne ikke indlæse den side, du anmodede om. Sørg for at teste den rigtige webadresse, og tjek, at serveren svarer korrekt på alle anmodninger."
@@ -945,16 +1266,19 @@
     "message": "Lighthouse kunne ikke indlæse den webadresse, du anmodede om, da siden stoppede med at svare."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Den webadresse, du har angivet, har ikke gyldige sikkerhedsoplysninger til login. {securityMessages}"
+    "message": "Den webadresse, du har angivet, har ikke et gyldigt sikkerhedscertifikat. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome forhindrede indlæsning af en side med en mellemliggende annonce. Sørg for, at du tester den rigtige webadresse, og tjek, at serveren svarer korrekt på alle anmodninger."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Lighthouse kunne ikke indlæse den side, du anmodede om. Sørg for at teste den rigtige webadresse, og tjek, at serveren svarer korrekt på alle anmodninger. (Oplysninger: {errorDetails})"
+    "message": "Lighthouse kunne ikke indlæse den side, du anmodede om. Sørg for, at du tester den rigtige webadresse, og tjek, at serveren svarer korrekt på alle anmodninger. (Info: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Lighthouse kunne ikke indlæse den side, du anmodede om. Sørg for at teste den rigtige webadresse, og tjek, at serveren svarer korrekt på alle anmodninger. (Statuskode: {statusCode})"
+    "message": "Lighthouse kunne ikke indlæse den side, du anmodede om. Sørg for, at du tester den rigtige webadresse, og tjek, at serveren svarer korrekt på alle anmodninger. (Statuskode: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Det tog for lang tid at indlæse siden. Følg mulighederne i rapporten for at reducere indlæsningstiden for din side. Prøv derefter at køre Lighthouse igen. ({errorCode})"
+    "message": "Det tog for lang tid at indlæse siden. Benyt mulighederne i rapporten for at reducere indlæsningstiden for din side. Prøv derefter at køre Lighthouse igen. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "DevTools-protokollen har overskredet den tilladte ventetid for svar. (Metode: {protocolMethod})"
@@ -984,7 +1308,7 @@
     "message": "Laboratoriedata"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse]-analyse (https://developers.google.com/web/tools/lighthouse/) af den aktuelle side på et emuleret mobilnetværk. Værdierne er estimater og kan variere."
+    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/)-analyse af den aktuelle side på et emuleret mobilnetværk. Værdierne er estimater og kan variere."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Yderligere elementer, der skal tjekkes manuelt"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Udvid uddrag"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Vis ressourcer fra tredjeparter"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Der blev registreret problemer, som påvirkede denne kørsel af Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Værdierne er estimater og kan variere."
+    "message": "Værdierne er estimater og kan variere. Resultatet er [kun baseret på disse metrics](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Bestod revisioner, men med advarsler"
@@ -1023,7 +1350,7 @@
     "message": "Overvej at uploade din gif til en tjeneste, hvor den kan integreres som en HTML5-video."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Installer et [WordPress-plugin til langsom indlæsning](https://wordpress.org/plugins/search/lazy+load/), der gør det muligt at udskyde eventuelle billeder, som ikke er på skærmen, eller skifte til et tema, der leverer denne funktionalitet. Overvej også at bruge [AMP-pluginnet](https://wordpress.org/plugins/amp/)."
+    "message": "Installer et [WordPress-plugin til udskudt indlæsning](https://wordpress.org/plugins/search/lazy+load/), der gør det muligt at udskyde eventuelle billeder, som ikke er på skærmen, eller skifte til et tema, der leverer denne funktionalitet. Overvej også at bruge [AMP-pluginnet](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "Der er en række WordPress-plugins, som kan hjælpe dig med at [indlejre vigtige aktiver](https://wordpress.org/plugins/search/critical+css/) eller [udskyde mindre vigtige ressourcer](https://wordpress.org/plugins/search/defer+css+javascript/). Vær opmærksom på, at optimeringer via disse plugins kan ødelægge funktioner i dine temaer og plugins. Du bliver derfor sandsynligvis nødt til at foretage kodeændringer."
@@ -1035,10 +1362,10 @@
     "message": "Overvej at vise uddrag på dine opslagslister (f.eks. via tagget Mere), reducere antallet af viste opslag på en given side, opdele dine lange opslag i flere sider eller bruge et plugin til at indlæse kommentarer langsomt."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "En række [WordPress-plugins](https://wordpress.org/plugins/search/minify+css/) kan gøre dit website hurtigere ved at sammenkæde, formindske og komprimere dine typografier. Det kan også være en god idé at bruge en udviklingsproces til at udføre denne formindskelse på forhånd, hvis det er muligt."
+    "message": "En række [WordPress-plugins](https://wordpress.org/plugins/search/minify+css/) kan gøre dit website hurtigere ved at sammenkæde, formindske og komprimere dine typografier. Det kan også være en god idé at bruge en buildproces til at udføre denne formindskelse på forhånd, hvis det er muligt."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "En række [WordPress-plugins](https://wordpress.org/plugins/search/minify+javascript/) kan gøre dit website hurtigere ved at sammenkæde, formindske og komprimere dine scripts. Det kan også være en god idé at bruge en udviklingsproces til at udføre denne formindskelse på forhånd, hvis det er muligt."
+    "message": "En række [WordPress-plugins](https://wordpress.org/plugins/search/minify+javascript/) kan gøre dit website hurtigere ved at sammenkæde, formindske og komprimere dine scripts. Det kan også være en god idé at bruge en buildproces til at udføre denne formindskelse på forhånd, hvis det er muligt."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
     "message": "Overvej at reducere eller ændre antallet af [WordPress-plugins](https://wordpress.org/plugins/), der indlæser ubrugt CSS på din side. Hvis du vil identificere plugins, der tilføjer irrelevant CSS, kan du prøve at køre [kodedækning](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) i Chrome DevTools. Du kan identificere det problematiske tema/plugin via webadressen for typografiarket. Kig efter plugins med mange typografiark på listen, som indeholder meget rødt i kodedækningen. Et plugin bør kun sætte et typografiark i kø, hvis det rent faktisk anvendes på siden."
@@ -1053,7 +1380,7 @@
     "message": "Overvej at bruge et [WordPress-plugin til billedoptimering](https://wordpress.org/plugins/search/optimize+images/), der komprimerer dine billeder uden at gå på kompromis med kvaliteten."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Upload billeder direkte via [mediesamlingen](https://codex.wordpress.org/Media_Library_Screen), så du er sikker på, at de påkrævede billedstørrelser er tilgængelige, og indsæt dem derefter fra mediesamlingen, eller brug billedwidgetten til at sikre, at de optimale billedstørrelser anvendes (inklusive dem til responsive skillepunkter). Undgå at bruge billeder i \"Fuld størrelse\", medmindre dimensionerne er passende til brugen. [Få flere oplysninger](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Upload billeder direkte via [mediesamlingen](https://codex.wordpress.org/Media_Library_Screen) for at sikre, at de påkrævede billedstørrelser er tilgængelige, og indsæt dem derefter fra mediesamlingen, eller brug billedwidgetten til at sikre, at de optimale billedstørrelser anvendes (inklusive dem til responsive skillepunkter). Undgå at bruge billeder i `Full Size`, medmindre dimensionerne er passende til brugen. [Få flere oplysninger](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Du kan aktivere tekstkomprimering ved konfigurationen af din webserver."

--- a/lighthouse-core/lib/i18n/locales/de.json
+++ b/lighthouse-core/lib/i18n/locales/de.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Anhand von Tastenkombinationen können Nutzer schnell einen Bereich der Seite in den Fokus rücken. Damit die Navigation wie vorgesehen funktioniert, muss jede Tastenkombination eindeutig sein. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Anhand von Tastenkombinationen können Nutzer schnell einen Bereich der Seite in den Fokus rücken. Damit die Navigation wie vorgesehen funktioniert, muss jede Tastenkombination eindeutig sein. [Weitere Informationen.](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "[accesskey]-Werte sind nicht eindeutig"
+    "message": "`[accesskey]`-Werte sind nicht eindeutig"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "[accesskey]-Werte sind eindeutig"
+    "message": "`[accesskey]`-Werte sind eindeutig"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Jede ARIA-Rolle unterstützt eine bestimmte Auswahl an \"aria-*\"-Attributen. Im Falle einer fehlerhaften Zuordnung werden die \"aria-*\"-Attribute ungültig. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Jede ARIA-`role` unterstützt eine bestimmte Auswahl an `aria-*`-Attributen. Wenn sie jedoch falsch zugeordnet sind, werden die `aria-*`-Attribute ungültig. [Weitere Informationen.](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "[aria-*]-Attribute stimmen nicht mit ihren Rollen überein"
+    "message": "`[aria-*]`-Attribute stimmen nicht mit ihren Rollen überein"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "[aria-*]-Attribute entsprechen ihren Rollen"
+    "message": "`[aria-*]`-Attribute entsprechen ihren Rollen"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Für einige ARIA-Rollen sind Attribute erforderlich, die Screenreadern den Zustand des Elements beschreiben. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Für einige ARIA-Rollen sind Attribute erforderlich, die Screenreadern den Zustand des Elements beschreiben. [Weitere Informationen.](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "[role]-Elemente weisen nicht alle erforderlichen [aria-*]-Attribute auf"
+    "message": "`[role]`-Elemente weisen nicht alle erforderlichen `[aria-*]`-Attribute auf"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "[role]-Elemente weisen alle erforderlichen [aria-*]-Attribute auf"
+    "message": "`[role]`-Elemente verfügen über alle erforderlichen `[aria-*]`-Attribute"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Einige übergeordnete ARIA-Rollen müssen bestimmte untergeordnete Rollen enthalten, damit sie die beabsichtigten Hilfsfunktionen erfüllen können. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Einige übergeordnete ARIA-Rollen müssen bestimmte untergeordnete Rollen enthalten, damit sie die beabsichtigten Hilfsfunktionen erfüllen können. [Weitere Informationen.](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Elemente mit \"[role]\", die bestimmte untergeordnete Rollen erfordern, fehlen."
+    "message": "Elemente mit `[role]`, die bestimmte untergeordnete `[role]`-Elemente erfordern, fehlen."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Elemente mit \"[role]\", die bestimmte untergeordnete Rollen erfordern, sind vorhanden"
+    "message": "Elemente mit `[role]`, die bestimmte untergeordnete `[role]`-Elemente erfordern, sind vorhanden"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Einige untergeordnete ARIA-Rollen müssen in bestimmten übergeordneten Rollen enthalten sein, damit sie die beabsichtigten Hilfsfunktionen wie vorgesehen erfüllen können. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Einige untergeordnete ARIA-Rollen müssen in bestimmten übergeordneten Rollen enthalten sein, damit sie die beabsichtigten Hilfsfunktionen erfüllen können. [Weitere Informationen.](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "[role]-Elemente sind nicht ihren jeweils erforderlichen übergeordneten Elementen untergeordnet"
+    "message": "`[role]`-Elemente sind nicht ihren jeweils erforderlichen übergeordneten Elementen untergeordnet"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "[role]-Elemente sind ihren jeweils erforderlichen übergeordneten Elementen untergeordnet"
+    "message": "`[role]`-Elemente sind ihren jeweils erforderlichen übergeordneten Elementen untergeordnet"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Für ARIA-Rollen müssen gültige Werte angegeben sein, damit sie die beabsichtigten Hilfsfunktionen erfüllen können. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Für ARIA-Rollen müssen gültige Werte angegeben sein, damit sie die beabsichtigten Hilfsfunktionen erfüllen können. [Weitere Informationen.](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "[role]-Werte sind nicht gültig"
+    "message": "`[role]`-Werte sind ungültig"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "[role]-Werte sind gültig"
+    "message": "`[role]`-Werte sind gültig"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Hilfstechnologien wie Screenreader können ARIA-Attribute mit ungültigen Werten nicht interpretieren. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Hilfstechnologien wie Screenreader können ARIA-Attribute mit ungültigen Werten nicht interpretieren. [Weitere Informationen.](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "[aria-*]-Attribute weisen keine gültigen Werte auf"
+    "message": "`[aria-*]`-Attribute weisen keine gültigen Werte auf"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Für [aria-*]`-Attribute sind gültige Werte angegeben"
+    "message": "`[aria-*]`-Attribute weisen gültige Werte auf"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Hilfstechnologien wie Screenreader können ARIA-Attribute mit ungültigen Namen nicht interpretieren. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Hilfstechnologien wie Screenreader können ARIA-Attribute mit ungültigen Namen nicht interpretieren. [Weitere Informationen.](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "[aria-*]-Attribute sind ungültig oder falsch geschrieben"
+    "message": "`[aria-*]`-Attribute sind ungültig oder falsch geschrieben"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "[aria-*]-Attribute sind gültig und nicht falsch geschrieben"
+    "message": "`[aria-*]`-Attribute sind gültig und richtig geschrieben"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Durch Untertitel sind Audioelemente auch für Gehörlose und Hörgeschädigte nutzbar, da sie wichtige Informationen zur sprechenden Person und zum Inhalt des Gesprächs sowie andere nonverbale Informationen enthalten. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Durch Untertitel sind Audioelemente auch für Gehörlose und Hörgeschädigte nutzbar, da sie wichtige Informationen zur sprechenden Person und zum Inhalt des Gesprächs sowie andere nonverbale Informationen enthalten. [Weitere Informationen.](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Den <audio>-Elementen fehlt ein <track>-Element mit \"[kind=\"captions\"]\"."
+    "message": "Den `<audio>`-Elementen fehlt ein `<track>`-Element mit `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "<audio>-Elemente enthalten ein <track>-Element mit \"[kind=\"captions\"]\""
+    "message": "`<audio>`-Elemente enthalten ein `<track>`-Element mit `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Fehlerhafte Elemente"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Wenn eine Schaltfläche keinen zugänglichen Namen hat, wird sie von Screenreadern als \"Schaltfläche\" angesagt, was sie für Nutzer, die auf Screenreader angewiesen sind, unbrauchbar macht. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Wenn eine Schaltfläche keinen zugänglichen Namen hat, wird sie von Screenreadern als \"Schaltfläche\" angesagt, was sie für Nutzer, die auf Screenreader angewiesen sind, unbrauchbar macht. [Weitere Informationen.](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Schaltflächen haben keinen für Screenreader zugänglichen Namen"
@@ -93,7 +93,7 @@
     "message": "Die Namen der Schaltflächen sind für Screenreader zugänglich"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Wenn Tastaturnutzer sich wiederholende Inhalte überspringen können, sorgt das für eine effizientere Navigation. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Wenn Tastaturnutzer Inhalte umgehen können, die sich wiederholen, sorgt das für eine effizientere Navigation. [Weitere Informationen.](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Die Seite enthält keine Überschrift, keinen Link zum Überspringen und keinen Landmark-Bereich"
@@ -102,7 +102,7 @@
     "message": "Die Seite enthält eine Überschrift, einen Link zum Überspringen oder einen Landmark-Bereich"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Text mit geringem Kontrast ist für viele Nutzer schlecht oder gar nicht lesbar. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Text mit geringem Kontrast ist für viele Nutzer schlecht oder gar nicht lesbar. [Weitere Informationen.](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Das Kontrastverhältnis von Hintergrund- und Vordergrundfarben ist nicht ausreichend."
@@ -111,88 +111,88 @@
     "message": "Das Kontrastverhältnis von Hintergrund- und Vordergrundfarben ist ausreichend"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Wenn Definitionslisten nicht korrekt mit Markup versehen sind, geben Screenreader unter Umständen verwirrende oder falsche Inhalte aus. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Wenn Definitionslisten nicht korrekt mit Markup versehen sind, geben Screenreader unter Umständen verwirrende oder falsche Inhalte aus. [Weitere Informationen.](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "<dl>-Elemente enthalten nicht nur in der richtigen Reihenfolge angeordnete <dt>- und <dd>-Gruppen sowie <script>- oder <template>-Elemente."
+    "message": "`<dl>`-Elemente enthalten nicht nur richtig angeordnete Gruppen aus `<dt>`- und `<dd>`-Elementen, `<script>`- oder `<template>`-Elemente."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "<dl>-Elemente enthalten nur in der richtigen Reihenfolge angeordnete <dt>- und <dd>-Gruppen sowie <script>- oder <template>-Elemente."
+    "message": "Alle Gruppen aus `<dt>`- und `<dd>`-Elementen sowie `<script>`- oder `<template>`-Elemente, die in `<dl>`-Elementen enthalten sind, sind richtig angeordnet."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Definitionslistenelemente (<dt> und <dd>) müssen Teil eines übergeordnetes <dl>-Elements sein, damit sie von Screenreadern richtig angesagt werden können. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Definitionslistenelemente (`<dt>` und `<dd>`) müssen in ein übergeordnetes `<dl>`-Element eingefasst sein, damit sie von Screenreadern richtig angesagt werden können. [Weitere Informationen.](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Definitionslistenelemente sind nicht in <dl>-Elemente eingefasst"
+    "message": "Definitionslistenelemente sind nicht in `<dl>`-Elemente eingefasst"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Definitionslistenelemente sind in <dl>-Elemente eingefasst"
+    "message": "Definitionslistenelemente sind in `<dl>`-Elemente eingefasst"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Anhand des Titels wissen Screenreader-Nutzer, worum es auf der Seite geht, während Nutzer von Suchmaschinen auf der Grundlage des Titels entscheiden, ob eine Seite für ihre Suche relevant ist. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Anhand des Titels wissen Screenreader-Nutzer, worum es auf der Seite geht. Außerdem entscheiden Nutzer von Suchmaschinen auf der Grundlage des Titels, ob eine Seite für ihre Suche relevant ist. [Weitere Informationen.](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokument hat kein <title>-Element"
+    "message": "Dokument hat kein `<title>`-Element"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokument verfügt über ein <title>-Element"
+    "message": "Dokument enthält ein `<title>`-Element"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Der Wert eines ID-Attributs muss eindeutig sein, damit andere Instanzen nicht von Hilfstechnologien übersehen werden. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Der Wert eines ID-Attributs muss eindeutig sein, damit andere Instanzen nicht von Hilfstechnologien übersehen werden. [Weitere Informationen.](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "[id]-Attribute auf der Seite sind nicht eindeutig"
+    "message": "`[id]`-Attribute auf der Seite sind nicht eindeutig"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "[id]-Attribute auf der Seite sind eindeutig"
+    "message": "`[id]`-Attribute auf der Seite sind eindeutig"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Nutzer von Screenreadern sind auf Frametitel angewiesen, die die Frameinhalte beschreiben. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Nutzer von Screenreadern sind auf Frametitel angewiesen, die die Frameinhalte beschreiben. [Weitere Informationen.](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "<frame>- oder <iframe>-Elemente haben keinen Titel"
+    "message": "`<frame>`- oder `<iframe>`-Elemente haben keinen Titel"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Für <frame>- oder <iframe>-Elemente ist ein Titel vorhanden"
+    "message": "`<frame>`- oder `<iframe>`-Elemente verfügen über einen Titel"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Wenn auf einer Seite kein \"lang\"-Attribut angegeben ist, nimmt ein Screenreader an, dass der Text darauf in der Standardsprache ist, die der Nutzer beim Einrichten des Screenreaders ausgewählt hat. Wenn die Sprache aber nicht der Standardsprache entspricht, gibt der Screenreader den Inhalt der Seite möglicherweise falsch aus. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Wenn auf einer Seite kein lang-Attribut angegeben ist, nimmt ein Screenreader an, dass es sich um die Standardsprache handelt, die der Nutzer beim Einrichten des Screenreaders ausgewählt hat. Wenn die Sprache jedoch nicht der Standardsprache entspricht, gibt der Screenreader den Inhalt der Seite möglicherweise falsch aus. [Weitere Informationen.](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Für das <html>-Element ist kein [lang]-Attribut angegeben"
+    "message": "`<html>`-Element enthält kein `[lang]`-Attribut"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Für das <html>-Element ist ein [lang]-Attribut angegeben"
+    "message": "`<html>`-Element hat ein `[lang]`-Attribut"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Durch Angabe einer gültigen [Sprache gemäß BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) kann der Text von einem Screenreader korrekt wiedergegeben werden. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Durch Angabe einer gültigen [Sprache gemäß BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) kann der Text von einem Screenreader korrekt wiedergegeben werden. [Weitere Informationen.](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Für das [lang]-Attribut des <html>-Elements ist kein gültiger Wert angegeben."
+    "message": "`<html>`-Element weist keinen gültigen Wert für sein `[lang]`-Attribut auf."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Für das [lang]-Attribut des <html>-Elements ist ein gültiger Wert angegeben"
+    "message": "Das `<html>`-Element hat einen gültigen Wert für sein `[lang]`-Attribut"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informative Elemente sollten einen kurzen, beschreibenden alternativen Text haben. Dekorative Elemente können mit einem leeren ALT-Attribut ignoriert werden. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informative Elemente sollten einen kurzen, beschreibenden alternativen Text haben. Dekorative Elemente können mit einem leeren ALT-Attribut ignoriert werden. [Weitere Informationen.](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Bildelemente haben keine [alt]-Attribute"
+    "message": "Bildelemente haben keine `[alt]`-Attribute"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Für Bildelemente sind [alt]-Attribute vorhanden"
+    "message": "Bildelemente verfügen über `[alt]`-Attribute"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Wenn ein Bild als <input>-Schaltfläche verwendet wird, kann die Angabe von alternativem Text Screenreader-Nutzern helfen, den Zweck der Schaltfläche besser zu verstehen. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Wenn ein Bild als `<input>`-Schaltfläche verwendet wird, kann die Angabe von alternativem Text Screenreader-Nutzern helfen, den Zweck der Schaltfläche besser zu verstehen. [Weitere Informationen.](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "<input type=\"image\">-Elemente haben keinen [alt]-Text"
+    "message": "`<input type=\"image\">`-Elemente verfügen nicht über `[alt]`-Text"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Für <input type=\"image\">-Elemente ist [alt]-Text vorhanden"
+    "message": "`<input type=\"image\">`-Elemente verfügen über `[alt]`-Text"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Durch Labels wird gewährleistet, dass Steuerelemente für Formulare von Hilfstechnologien wie Screenreadern richtig angesagt werden. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Durch Labels wird gewährleistet, dass Steuerelemente für Formulare von Hilfstechnologien wie Screenreadern richtig angesagt werden. [Weitere Informationen.](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Die Formularelemente sind nicht mit Labels verknüpft"
@@ -201,16 +201,16 @@
     "message": "Formularelemente sind mit Labels verknüpft"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Eine für Layoutzwecke verwendete Tabelle sollte keine Datenelemente wie \"th\"- oder \"caption\"-Elemente oder das \"summary\"-Attribut enthalten, weil dies für Nutzer von Screenreadern verwirrend sein kann. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Eine für Layoutzwecke verwendete Tabelle sollte keine Datenelemente wie \"th\"- bzw. \"caption\"-Elemente oder das \"summary\"-Attribut enthalten, weil dies für Nutzer von Screenreadern verwirrend sein kann. [Weitere Informationen.](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "<table>-Präsentationselemente verhindern nicht die Nutzung von \"<th>\", \"<caption>\" oder des [summary]-Attributs."
+    "message": "`<table>`-Präsentationselemente verwenden `<th>`, `<caption>` oder das `[summary]`-Attribut."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "<table>-Präsentationselemente verhindern die Nutzung von \"<th>\", \"<caption>\" oder des [summary]-Attributs."
+    "message": "`<table>`-Präsentationselemente enthalten keine `<th>`-, `<caption>`- oder `[summary]`-Attribute."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Linktext, der leicht erkennbar, eindeutig und fokussierbar ist, verbessert die Navigation für Screenreader-Nutzer. Dies gilt auch für alternativen Text für Bilder, die als Links verwendet werden. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Linktext, der leicht erkennbar, eindeutig und fokussierbar ist, verbessert die Navigation für Screenreader-Nutzer. Dies gilt auch für alternativen Text für Bilder, die als Links verwendet werden. [Weitere Informationen.](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Links haben keinen leicht erkennbaren Namen"
@@ -219,103 +219,115 @@
     "message": "Links haben einen leicht erkennbaren Namen"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Screenreader sagen Listen auf bestimmte Art und Weise an. Eine korrekte Listenstruktur gewährleistet, dass der Screenreader sie richtig ausgibt. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Screenreader sagen Listen auf bestimmte Art und Weise an. Eine korrekte Listenstruktur gewährleistet, dass der Screenreader sie richtig ausgibt. [Weitere Informationen.](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Listen enthalten nicht nur <li>-Elemente und Elemente zur Skriptunterstützung (\"<script>\" und \"<template>\")."
+    "message": "Listen enthalten nicht nur `<li>`-Elemente und Elemente zur Skriptunterstützung (`<script>` sowie `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Listen enthalten nur <li>-Elemente und Elemente zur Skriptunterstützung (\"<script>\" und \"<template>\")."
+    "message": "Listen enthalten nur `<li>`-Elemente und Elemente zur Skriptunterstützung (`<script>` sowie `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Listenelemente (<li>) müssen sich in einem übergeordneten <ul>- oder <ol>-Element befinden, damit Screenreader sie richtig ansagen können. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Listenelemente (`<li>`) müssen sich in einem übergeordneten `<ul>`- oder `<ol>`-Element befinden, damit Screenreader sie richtig ansagen können. [Weitere Informationen.](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Listenelemente (<li>) befinden sich nicht in übergeordneten <ul>- oder <ol>-Elementen."
+    "message": "Listenelemente (`<li>`) befinden sich nicht in übergeordneten `<ul>`- oder `<ol>`-Elementen."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Listenelemente (<li>) befinden sich in übergeordneten <ul>- oder <ol>-Elementen"
+    "message": "Listenelemente (`<li>`) befinden sich in übergeordneten `<ul>`- oder `<ol>`-Elementen"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Nutzer erwarten nicht, dass eine Seite automatisch aktualisiert wird. Dadurch wird der Fokus wieder auf den Seitenanfang verschoben. Das kann für den Nutzer frustrierend oder verwirrend sein. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Nutzer rechnen nicht damit, dass eine Seite automatisch aktualisiert wird. Außerdem wird dadurch der Fokus wieder auf den Seitenanfang verschoben. Das kann für den Nutzer frustrierend oder verwirrend sein. [Weitere Informationen.](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Das Dokument verwendet \"<meta http-equiv=\"refresh\">\""
+    "message": "Im Dokument wird `<meta http-equiv=\"refresh\">` verwendet"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "\"<meta http-equiv=\"refresh\">\" wird vom Dokument nicht verwendet"
+    "message": "Dieses Dokument verwendet `<meta http-equiv=\"refresh\">` nicht"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Wenn Sie die Zoomfunktion deaktivieren, haben Nutzer mit eingeschränktem Sehvermögen, die auf die Bildschirmvergrößerung angewiesen sind, möglicherweise Probleme dabei, den Inhalt einer Webseite zu sehen. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Wenn Sie die Zoomfunktion deaktivieren, haben Nutzer mit eingeschränktem Sehvermögen, die auf die Bildschirmvergrößerung angewiesen sind, Probleme, den Inhalt einer Webseite zu sehen. [Weitere Informationen.](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "\"[user-scalable=\"no\"]\" wird im <meta name=\"viewport\">-Element verwendet oder das [maximum-scale]-Attribut ist kleiner als 5."
+    "message": "`[user-scalable=\"no\"]` wird im `<meta name=\"viewport\">`-Element verwendet oder das `[maximum-scale]`-Attribut ist kleiner als 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "\"[user-scalable=\"no\"]\" wird nicht im <meta name=\"viewport\">-Element verwendet und das [maximum-scale]-Attribut ist nicht kleiner als 5."
+    "message": "`[user-scalable=\"no\"]` wird nicht im `<meta name=\"viewport\">`-Element verwendet und das `[maximum-scale]`-Attribut ist nicht kleiner als 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Screenreader können lediglich Textinhalte interpretieren. Wenn Sie <object>-Elementen ALT-Text hinzufügen, kann den Nutzern ihre Bedeutung vermittelt werden. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Screenreader können lediglich Textinhalte interpretieren. Wenn Sie `<object>`-Elementen Alt-Text hinzufügen, können Screenreader-Nutzer besser verstehen, was diese Elemente darstellen. [Weitere Informationen.](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "<object>-Elemente haben keinen [alt]-Text"
+    "message": "`<object>`-Elemente verfügen nicht über `[alt]`-Text"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "[alt]-Text ist für <object>-Elemente vorhanden"
+    "message": "`<object>`-Elemente verfügen über `[alt]`-Text"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Ein Wert größer als 0 impliziert eine explizite Navigationsanordnung. Das ist zwar technisch möglich, für Nutzer, die auf Hilfstechnologien angewiesen sind, ist dies jedoch häufig frustrierend. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Ein Wert größer als 0 impliziert eine explizite Navigationsanordnung. Das ist zwar technisch möglich; aber für Nutzer, die auf Hilfstechnologien angewiesen sind, ist dies häufig frustrierend. [Weitere Informationen.](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Der [tabindex]-Wert einiger Elemente ist größer als 0"
+    "message": "Der `[tabindex]`-Wert einiger Elemente ist größer als 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Kein Element hat einen [tabindex]-Wert größer als 0"
+    "message": "Kein Element hat einen `[tabindex]`-Wert größer als 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Screenreader bieten Funktionen, die die Navigation in Tabellen vereinfachen. Wenn Sie dafür sorgen, dass <td>-Zellen, die das [headers]-Attribut verwenden, nur auf andere Zellen in derselben Tabelle verweisen, kann dies für Screenreader-Nutzer hilfreich sein. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Screenreader bieten Funktionen, die die Navigation in Tabellen vereinfachen. Wenn Sie dafür sorgen, dass `<td>`-Zellen, die das `[headers]`-Attribut verwenden, nur auf andere Zellen in derselben Tabelle verweisen, kann dies für Screenreader-Nutzer hilfreich sein. [Weitere Informationen.](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Zellen in einem <table>-Element, das das Attribut \"[headers]\" verwendet, verweisen auf andere Zellen derselben Tabelle."
+    "message": "Zellen in einem `<table>`-Element, die das `[headers]`-Attribut verwenden, verweisen nur auf andere Zellen in derselben Tabelle."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Zellen in einem <table>-Element, die das [headers]-Attribut verwenden, verweisen nur auf andere Zellen in derselben Tabelle."
+    "message": "Zellen in einem `<table>`-Element, die das `[headers]`-Attribut verwenden, verweisen nur auf andere Zellen in derselben Tabelle."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Screenreader bieten Funktionen, die die Navigation in Tabellen vereinfachen. Wenn Sie dafür sorgen, dass Tabellenüberschriften immer auf eine Auswahl von Zellen verweisen, kann dies für Screenreader-Nutzer hilfreich sein. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Screenreader bieten Funktionen, die die Navigation in Tabellen vereinfachen. Wenn Sie dafür sorgen, dass Tabellenüberschriften immer auf eine Auswahl von Zellen verweisen, kann dies für Screenreader-Nutzer hilfreich sein. [Weitere Informationen.](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Für <th>-Elemente und Elemente mit \"[role=\"columnheader\"/\"rowheader\"]\" sind keine Datenzellen vorhanden, die sie beschreiben."
+    "message": "Für `<th>`-Elemente und Elemente mit `[role=\"columnheader\"/\"rowheader\"]` sind keine Datenzellen vorhanden, die sie beschreiben."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Für <th>-Elemente und Elemente mit \"[role=\"columnheader\"/\"rowheader\"]\" sind Datenzellen vorhanden, die sie beschreiben."
+    "message": "Für `<th>`-Elemente und Elemente mit `[role=\"columnheader\"/\"rowheader\"]` sind Datenzellen vorhanden, die sie beschreiben."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Durch Angabe einer gültigen [Sprache gemäß BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) in Elementen wird sichergestellt, dass der Text von einem Screenreader korrekt ausgesprochen wird. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Durch Angabe einer gültigen [Sprache gemäß BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) in Elementen kann der Text von einem Screenreader korrekt ausgesprochen werden. [Weitere Informationen.](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "[lang]-Attribute weisen keinen gültigen Wert auf"
+    "message": "`[lang]`-Attribute weisen keinen gültigen Wert auf"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "[lang]-Attribute weisen einen gültigen Wert auf"
+    "message": "`[lang]`-Attribute weisen einen gültigen Wert auf"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Bei einem Video mit Untertitel können gehörlose und hörgeschädigte Nutzer einfacher auf die zugehörigen Informationen zugreifen. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Wenn ein Video Untertitel enthält, können gehörlose und hörgeschädigte Nutzer die Informationen im Video besser verstehen. [Weitere Informationen.](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "<video>-Elemente enthalten kein <track>-Element mit \"[kind=\"captions\"]\"."
+    "message": "`<video>`-Elemente enthalten kein `<track>`-Element mit `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "<video>-Elemente enthalten ein <track>-Element mit \"[kind=\"captions\"]\""
+    "message": "`<video>`-Elemente enthalten ein `<track>`-Element mit `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Audiobeschreibungen enthalten relevante Informationen für Videos, die aus dem Dialog nicht ersichtlich sind, zum Beispiel Gesichtsausdrücke und Schauplätze. [Weitere Informationen](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Audiobeschreibungen enthalten relevante Informationen für Videos, die aus dem Dialog nicht ersichtlich sind, z. B. Gesichtsausdrücke und Schauplätze. [Weitere Informationen.](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "<video>-Elemente enthalten kein <track>-Element mit \"[kind=\"description\"]\"."
+    "message": "`<video>`-Elemente enthalten kein `<track>`-Element mit `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "<video>-Elemente enthalten ein <track>-Element mit \"[kind=\"description\"]\""
+    "message": "`<video>`-Elemente enthalten ein `<track>`-Element mit `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Definieren Sie ein apple-touch-icon für eine ideale Darstellung unter iOS, wenn Nutzer die Website dem Startbildschirm hinzufügen. Es muss auf eine nicht transparente, quadratische PNG-Datei mit 192 px (oder 180 px) verweisen. [Weitere Informationen.](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Hat kein gültiges `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` ist veraltet; `apple-touch-icon` wird bevorzugt."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Enthält ein gültiges `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome-Erweiterungen haben die Ladegeschwindigkeit dieser Seite beeinträchtigt. Versuchen Sie, die Seite im Inkognito-Modus oder mit einem Chrome-Profil ohne Erweiterungen zu überprüfen."
@@ -330,7 +342,7 @@
     "message": "CPU-Zeit insgesamt"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Versuchen Sie, die Zeit für das Parsen, Kompilieren und Ausführen von JS zu reduzieren. Die Bereitstellung kleinerer JS-Nutzlasten kann dabei helfen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Versuchen Sie, die Zeit für das Parsen, Kompilieren und Ausführen von JavaScript zu reduzieren. Die Bereitstellung kleinerer JS-Nutzlasten kann dabei helfen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Ausführungszeit von JavaScript reduzieren"
@@ -339,25 +351,25 @@
     "message": "JavaScript-Ausführungszeit"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Große GIF-Dateien sind nur bedingt für die Bereitstellung animierter Inhalte geeignet. Sie können statt GIF MPEG4- oder WebM-Videos für Animationen und PNG oder WebP für statische Bilder verwenden und so die Netzwerk-Datenmenge reduzieren. [Weitere Informationen](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Große GIF-Dateien sind nur bedingt für die Auslieferung animierter Inhalte geeignet. Sie können stattdessen MPEG4- oder WebM-Videos für Animationen und PNG oder WebP für statische Bilder verwenden und so die Netzwerk-Datenmenge reduzieren. [Weitere Informationen](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Videoformate für animierte Inhalte verwenden"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Versuchen Sie, nicht sichtbare und versteckte Bilder erst laden zu lassen, nachdem wichtige Ressourcen geladen wurden, um die Zeit bis zur Interaktivität zu reduzieren. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Wenn Sie nicht sichtbare und versteckte Bilder erst laden lassen, nachdem alle wichtigen Ressourcen geladen wurden, können Sie die Zeit bis zur Interaktivität reduzieren. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Nicht sichtbare Bilder aufschieben"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Ressourcen blockieren das erste Zeichnen Ihrer Seite. Versuchen Sie, wichtiges JS und wichtige CSS inline bereitzustellen und alle nicht kritischen JS und Stile aufzuschieben. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Ressourcen blockieren den First Paint Ihrer Seite. Versuchen Sie, wichtiges JS und wichtige CSS inline anzugeben und alle nicht kritischen JS und Stile aufzuschieben. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Ressourcen beseitigen, die das Rendering blockieren"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Große Netzwerknutzlasten kosten Nutzer bares Geld und hängen eng mit langen Ladezeiten zusammen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Große Netzwerknutzlasten kosten Nutzer bares Geld und hängen eng mit langen Ladezeiten zusammen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Die Gesamtgröße war {totalBytes, number, bytes} KB"
@@ -369,19 +381,19 @@
     "message": "Vermeidet sehr große Netzwerknutzlasten"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Durch die Komprimierung von CSS-Dateien kann die Größe von Netzwerknutzlasten reduziert werden. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Durch die Komprimierung von CSS-Dateien können Netzwerknutzlasten verkleinert werden. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "CSS komprimieren"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Durch die Komprimierung von JavaScript-Dateien können Nutzlastgrößen und die Zeit zum Parsen von Skripts reduziert werden. [Weitere Informationen](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Durch die Komprimierung von JavaScript-Dateien können Nutzlastgrößen und die Zeit zum Parsen von Skripts reduziert werden. [Weitere Informationen.](https://developers.google.com/speed/docs/insights/MinifyResources)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "JavaScript komprimieren"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Sie können ungültige Regeln aus Stylesheets entfernen und das Laden von CSS aufschieben, die nicht für ohne Scrollen sichtbare Inhalte verwendet werden, um unnötigen Datenverbrauch durch Netzwerkaktivität zu vermeiden. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Sie können ungültige Regeln aus Stylesheets entfernen und das Laden von CSS aufschieben, die nicht für ohne Scrollen sichtbare Inhalte verwendet werden, um unnötigen Datenverbrauch durch Netzwerkaktivität zu vermeiden. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Nicht verwendete CSS entfernen"
@@ -393,7 +405,7 @@
     "message": "Nicht genutztes JavaScript entfernen"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Eine lange Lebensdauer des Cache kann wiederholte Besuche Ihrer Seite beschleunigen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Eine lange Lebensdauer des Cache kann wiederholte Besuche Ihrer Seite beschleunigen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 Ressource gefunden}other{# Ressourcen gefunden}}"
@@ -405,37 +417,88 @@
     "message": "Verwendet eine effiziente Cache-Richtlinie für statische Inhalte"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Optimierte Bilder werden schneller geladen und verbrauchen weniger mobile Daten. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Optimierte Bilder werden schneller geladen und verbrauchen weniger mobile Daten. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Bilder effizient codieren"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Stellen Sie Bilder bereit, die eine angemessene Größe haben, um mobile Daten zu sparen und die Ladezeit zu verbessern. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
+    "message": "Stellen Sie Bilder bereit, die eine angemessene Größe haben, um mobile Daten zu sparen und die Ladezeit zu verbessern. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Bilder richtig dimensionieren"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Textbasierte Ressourcen sollten mit Komprimierung (gzip, Deflate oder Brotli) bereitgestellt werden, um die Datenmenge im Netzwerk insgesamt zu minimieren. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
+    "message": "Textbasierte Ressourcen sollten mit Komprimierung (gzip, Deflate oder Brotli) ausgeliefert werden, um die Datenmenge im Netzwerk insgesamt zu minimieren. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Textkomprimierung aktivieren"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Bildformate wie JPEG 2000, JPEG XR und WebP bieten oft eine bessere Komprimierung als PNG oder JPEG, was schnellere Downloads und einen geringeren Datenverbrauch ermöglicht. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Bildformate wie JPEG 2000, JPEG XR und WebP bieten oft eine bessere Komprimierung als PNG oder JPEG, was schnellere Downloads und einen geringeren Datenverbrauch ermöglicht. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Bilder in modernen Formaten bereitstellen"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "In den unten aufgeführten Ketten kritischer Anfragen können Sie sehen, welche Ressourcen mit einer hohen Priorität geladen werden. Versuchen Sie, die Ketten zu verkürzen, die Downloadgröße von Ressourcen zu reduzieren oder das Herunterladen unnötiger Ressourcen aufzuschieben, um den Seitenaufbau zu beschleunigen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "In den unten aufgeführten Ketten kritischer Anfragen können Sie sehen, welche Ressourcen mit einer hohen Priorität geladen werden. Versuchen Sie, die Ketten zu verkürzen, die Downloadgröße von Ressourcen zu reduzieren oder das Herunterladen unnötiger Ressourcen aufzuschieben, um den Seitenaufbau zu beschleunigen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 Kette gefunden}other{# Ketten gefunden}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Tiefe kritischer Anforderungen minimieren"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Veraltet/Warnung"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Zeile"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Veraltete APIs werden aus dem Browser entfernt. [Weitere Informationen.](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 Warnung gefunden}other{# Warnungen gefunden}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Verwendet veraltete APIs"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Vermeidet veraltete APIs"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Application Cache ist veraltet. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" gefunden"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Verwendet Application Cache"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Vermeidet Application Cache"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Das Festlegen eines DOCTYPE hindert den Browser daran, zum Quirks-Modus zu wechseln. Weitere Informationen dazu finden Sie auf der [MDN Web Docs-Seite](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "DOCTYPE-Name muss dieser String sein (in Kleinbuchstaben): `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokument muss einen DOCTYPE enthalten"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "PublicId sollte ein leerer String sein"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "SystemId sollte ein leerer String sein"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Seite verfügt nicht über den HTML-DOCTYPE und startet daher den Quirks-Modus"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Seite verfügt über den HTML-DOCTYPE"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
@@ -447,7 +510,7 @@
     "message": "Wert"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Laut der Empfehlung von Browserentwicklern sollten Seiten nicht mehr als ungefähr 1.500 DOM-Elemente enthalten. Die ideale Strukturtiefe liegt bei unter 32 Elementen und weniger als 60 unter- und übergeordneten Elementen. Ein großes DOM kann zu hohem Speicherverbrauch, langwierigen [Stilberechnungen](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) und kostspieligen [dynamischen Umbrüchen im Layout](https://developers.google.com/speed/articles/reflow) führen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Laut der Empfehlung von Browserentwicklern sollten Seiten nicht mehr als ungefähr 1.500 DOM-Elemente enthalten. Die ideale Strukturtiefe liegt bei unter 32 Elementen und weniger als 60 unter- und übergeordneten Elementen. Ein großes DOM kann zu hohem Speicherverbrauch, langwierigen [Stilberechnungen](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) und kostspieligen [dynamischen Umbrüchen im Layout](https://developers.google.com/speed/articles/reflow) führen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 Element}other{# Elemente}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Vermeidet eine übermäßige DOM-Größe"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Ziel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Fügen Sie beliebigen externen Links `rel=\"noopener\"` oder `rel=\"noreferrer\"` hinzu, um die Leistung zu verbessern und Sicherheitslücken zu vermeiden. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Links zu ursprungsübergreifenden Zielen sind unsicher"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Links zu ursprungsübergreifenden Zielen sind sicher"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Ziel für Anker ({anchorHTML}) kann nicht bestimmt werden. Wenn dies nicht als Hyperlink genutzt wird, sollten Sie target=_blank entfernen."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Nutzer sind misstrauisch oder verwirrt, wenn Websites den Standort ohne Begründung anfordern. Versuchen Sie stattdessen, die Anforderung mit einer Nutzeraktion zu verbinden. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Fordert die Berechtigung zur Standortbestimmung beim Seitenaufbau an"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Fordert während des Seitenaufbaus keine Berechtigung zur Standortbestimmung an"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Version"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Alle Front-End-JavaScript-Bibliotheken auf der Seite wurden erkannt."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "JavaScript-Bibliotheken erkannt"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Für Nutzer mit langsamen Verbindungen können externe Skripts, die dynamisch über `document.write()` eingefügt werden, den Seitenaufbau um einige Sekunden verzögern. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Verwendet `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Verwendet kein `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Höchster Schweregrad"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Bibliotheksversion"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Anzahl der Sicherheitslücken"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Einige Skripts von Drittanbietern können bekannte Sicherheitslücken enthalten, die von Angreifern leicht zu identifizieren und zu missbrauchen sind. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 Sicherheitslücke erkannt}other{# Sicherheitslücken erkannt}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Enthält Front-End-JavaScript-Bibliotheken mit bekannten Sicherheitslücken"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Hoch"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Niedrig"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Mittel"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Vermeidet Front-End-JavaScript-Bibliotheken mit bekannten Sicherheitslücken"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Nutzer sind misstrauisch oder verwirrt, wenn Websites die Berechtigung zum Senden von Benachrichtigungen ohne Begründung anfordern. Versuchen Sie stattdessen, die Anforderung mit Touch-Gesten zu verbinden. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Fordert die Benachrichtigungsberechtigung beim Seitenaufbau an"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Fordert während des Seitenaufbaus keine Benachrichtigungsberechtigung an"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Fehlerhafte Elemente"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Das Einfügen von Passwörtern sollte entsprechend guten Sicherheitsrichtlinien zulässig sein. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Hindert Nutzer daran, Inhalte in Passwortfelder einzufügen"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Erlaubt Nutzern, Inhalte in Passwortfelder einzufügen"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokoll"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 bietet gegenüber HTTP/1.1 viele Vorteile, wie z. B. Binärkopfzeilen, Multiplexing und Server-Push. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{Ressourcen für 1 Anfrage nicht über HTTP/2 bereitgestellt}other{Ressourcen für # Anfragen nicht über HTTP/2 bereitgestellt}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Verwendet HTTP/2 nicht für alle Ressourcen"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Verwendet HTTP/2 für eigene Ressourcen"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Wenn Sie Ihre Ereignis-Listener für Tipp- und Mausradbewegungen als `passive` markieren, können Sie damit die Scrollleistung Ihrer Seite verbessern. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Verwendet keine passiven Listener zur Verbesserung der Scrollleistung"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Verwendet passive Listener zur Verbesserung der Scrollleistung"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Beschreibung"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "In der Konsole protokollierte Fehler weisen auf ungelöste Probleme hin. Sie können durch fehlgeschlagene Netzwerkanfragen und andere Browser-Probleme verursacht werden."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Es wurden Browserfehler in der Konsole protokolliert"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Es wurden keine Browserfehler in der Konsole protokolliert"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Sie können Gebrauch von der CSS-Funktion \"font-display\" machen, um sicherzugehen, dass der Text für Nutzer sichtbar ist, während Webfonts geladen werden. [Weitere Informationen](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Verwenden Sie die CSS-Funktion font-display, damit der Text für Nutzer sichtbar ist, während Webfonts geladen werden. [Weitere Informationen.](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Darauf achten, dass der Text während der Webfont-Ladevorgänge sichtbar bleibt"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Der gesamte Text bleibt während der Webfont-Ladevorgänge sichtbar"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Für die folgende URL konnte Lighthouse den Schriftart-Anzeigewert nicht automatisch prüfen: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Seitenverhältnis (Original)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Seitenverhältnis (angezeigt)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Die Bildgröße sollte dem natürlichen Seitenverhältnis entsprechen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Zeigt Bilder mit einem falschen Seitenverhältnis an"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Zeigt Bilder mit einem korrekten Seitenverhältnis an"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Ungültige Informationen zur Bildgröße {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Unsichere URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Alle Websites sollten durch HTTPS geschützt werden – selbst wenn sie keine vertraulichen Daten enthalten. HTTPS verhindert, dass andere Personen die Website manipulieren oder die Kommunikation zwischen Ihrer App und Ihren Nutzern mitverfolgen können. Dieses Protokoll ist eine Voraussetzung für HTTP/2 sowie für viele neue Webplattform-APIs. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 unsichere Anfrage gefunden}other{# unsichere Anfragen gefunden}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Verwendet nicht HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Verwendet HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Ein schneller Seitenaufbau über ein Mobilfunknetz sorgt dafür, dass die Seite für Nutzer auf Mobilgeräten angenehm zu bedienen ist. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Ein schneller Seitenaufbau über ein Mobilfunknetz sorgt dafür, dass die Seite für Nutzer auf Mobilgeräten angenehm zu bedienen ist. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
     "message": "Interaktiv nach {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Interaktiv im simulierten Mobilfunknetz nach {timeInMs, number, seconds} s"
+    "message": "Im simulierten Mobilfunknetz interaktiv nach {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Seitenaufbau in Mobilfunknetzen ist nicht schnell genug"
@@ -504,67 +735,94 @@
     "message": "Minimiert den Aufwand für den Hauptthread"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Bei der geschätzten Eingabelatenz handelt es sich um eine Schätzung dessen, wie viele Millisekunden Ihre App benötigt, um während des 5-s-Fensters mit der stärksten Auslastung beim Seitenaufbau auf Nutzereingaben zu reagieren. Wenn die Latenz bei Ihnen über 50 ms liegt, empfinden Nutzer Ihre App möglicherweise als langsam. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Die geschätzte Eingabelatenz ist eine Schätzung dessen, wie viele Millisekunden Ihre App benötigt, um während des 5-s-Fensters mit der stärksten Auslastung beim Seitenaufbau auf Nutzereingaben zu reagieren. Wenn die Latenz bei Ihnen über 50 ms beträgt, empfinden Nutzer Ihre App möglicherweise als langsam. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Geschätzte Eingabelatenz"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "\"Erste Inhalte gezeichnet\" gibt an, wann der erste Text oder das erste Bild gezeichnet wird. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "First Contentful Paint gibt an, wann der erste Text oder das erste Bild gezeichnet wird. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Erste Inhalte gezeichnet"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "\"Erster CPU-Leerlauf\" gibt den Zeitpunkt an, an dem die Aktivität des Hauptthreads der Seite das erste Mal gering genug ist, um Eingaben zu verarbeiten. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "\"Erster CPU-Leerlauf\" gibt an, wann die Aktivität des Hauptthreads der Seite das erste Mal gering genug ist, um Eingaben zu verarbeiten. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Erster CPU-Leerlauf"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "\"Inhalte weitgehend gezeichnet\" gibt an, wann die Hauptinhalte einer Seite sichtbar sind. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "\"Inhalte weitgehend gezeichnet\" gibt an, wann die Hauptinhalte einer Seite sichtbar sind. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Inhalte weitgehend gezeichnet"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Die Zeit bis Interaktivität entspricht der Zeit, die vergeht, bis die Seite vollständig interaktiv ist. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Die Zeit bis Interaktivität entspricht der Zeit, die vergeht, bis die Seite vollständig interaktiv ist. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Zeit bis Interaktivität"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Die erste Eingabelatenz, die bei Ihren Nutzern auftreten kann, entspricht der Dauer der längsten Aufgabe in Millisekunden."
+    "message": "Der maximale potenzielle First Input Delay, der bei Ihren Nutzern auftreten kann, entspricht der Dauer der längsten Aufgabe in Millisekunden. [Weitere Informationen.](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Maximale potenzielle erste Eingabelatenz"
+    "message": "Maximaler potenzieller First Input Delay"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Der Geschwindigkeitsindex zeigt an, wie schnell die Inhalte einer Seite sichtbar dargestellt werden. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Der Geschwindigkeitsindex gibt an, wie schnell die Inhalte einer Seite sichtbar dargestellt werden. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Geschwindigkeitsindex"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Summe aller Zeiträume (in Millisekunden) zwischen FCP und Zeit bis Interaktivität, wenn die Aufgabendauer 50 ms überschreitet."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Gesamtdauer der Blockierung"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Die Netzwerk-Umlaufzeit (RTT, Round Trip Time) hat großen Einfluss auf die Leistung. Wenn die RTT zu einem Ursprung hoch ausfällt, weist dies darauf hin, dass die Leistung mit Servern, die näher am Nutzer liegen, verbessert werden kann. [Weitere Informationen](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Die Netzwerk-Umlaufzeit (RTT, Round Trip Time) hat großen Einfluss auf die Leistung. Wenn die RTT zu einem Ursprung hoch ausfällt, weist dies darauf hin, dass die Leistung mit Servern verbessert werden kann, die sich näher beim Nutzer befinden. [Weitere Informationen.](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Netzwerk-Umlaufzeit"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Serverlatenzen können sich auf die Leistung im Web auswirken. Wenn die Serverlatenz eines Ursprungs hoch ist, weist dies darauf hin, dass der Server überlastet ist oder eine schlechte Back-End-Leistung bietet. [Weitere Informationen](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Serverlatenzen können die Leistung im Web beeinträchtigen. Wenn die Serverlatenz eines Ursprungs hoch ist, weist dies darauf hin, dass der Server überlastet ist oder eine schlechte Back-End-Leistung bietet. [Weitere Informationen.](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Server-Back-End-Latenzen"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Über dem Budget"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Die Anzahl und Größe der Netzwerkanfragen sollten unter den Zielvorgaben des Leistungsbudgets liegen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 Anfrage}other{# Anfragen}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Leistungsbudget"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Weiterleitungen führen zu zusätzlichen Verzögerungen, bevor die Seite geladen werden kann. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Weiterleitungen führen zu zusätzlichen Verzögerungen, bevor die Seite geladen werden kann. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Mehrere Weiterleitungen auf die Seite vermeiden"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Fügen Sie zum Einrichten von Budgets für die Anzahl und Größe von Seitenressourcen eine budget.json-Datei hinzu. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 Anfrage}other{# Anfragen}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Halten Sie die Anfrageanzahl niedrig und die Übertragungsgröße gering"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Über kanonische Links wird angegeben, welche URL in den Suchergebnissen angezeigt werden soll. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Über kanonische Links wird angegeben, welche URL in den Suchergebnissen angezeigt werden soll. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Mehrere in Konflikt stehende URLs ({urlList})"
@@ -576,7 +834,7 @@
     "message": "Ungültige URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Verweist auf einen anderen \"hreflang\"-Speicherort ({url})"
+    "message": "Verweist auf einen anderen `hreflang`-Speicherort ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relative URL ({url})"
@@ -585,19 +843,16 @@
     "message": "Verweist auf die Stamm-URL (die Startseite) der Domain statt auf eine identische Inhaltsseite"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokument enthält kein gültiges \"rel=canonical\"-Element"
+    "message": "Dokument enthält kein gültiges `rel=canonical`-Element"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokument enthält ein gültiges \"rel=canonical\"-Element"
+    "message": "Dokument enthält ein gültiges `rel=canonical`-Element"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Schriftgrößen von weniger als 12 px sind zu klein und deshalb nicht gut lesbar, sodass Nutzer von Mobilgeräten den Text per Fingerbewegung heranzoomen müssen. Mindestens 60 % des Texts auf der Seite sollten deshalb eine Schriftgröße von mindestens 12 px haben. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Schriftgrößen von weniger als 12 px sind zu klein und deshalb nicht gut lesbar, sodass Nutzer von Mobilgeräten den Text per Fingerbewegung heranzoomen müssen. Mindestens 60 % des Texts auf der Seite sollten deshalb eine Schriftgröße von mindestens 12 px haben. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} gut lesbarer Text"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} des Texts ist zu klein."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Text ist nicht lesbar, weil kein Meta-Tag für den Darstellungsbereich vorhanden ist, das für Bildschirme von Mobilgeräten optimiert ist."
@@ -612,16 +867,16 @@
     "message": "Dokument enthält gut lesbare Schriftgrößen"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Anhand von \"hreflang\"-Links können Suchmaschinen ermitteln, welche Version einer Seite sie in den Suchergebnissen für eine bestimmte Sprache oder Region anzeigen sollen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Anhand von \"hreflang\"-Links können Suchmaschinen ermitteln, welche Version einer Seite sie in den Suchergebnissen für eine bestimmte Sprache oder Region anzeigen sollen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokument enthält kein gültiges \"hreflang\"-Element"
+    "message": "Dokument enthält kein gültiges `hreflang`-Element"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokument enthält ein gültiges \"hreflang\"-Element"
+    "message": "Dokument enthält ein gültiges `hreflang`-Element"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Seiten mit ungültigen HTTP-Statuscodes werden möglicherweise nicht richtig indexiert. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Seiten mit ungültigen HTTP-Statuscodes werden möglicherweise nicht richtig indexiert. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "Seite hat keinen gültigen HTTP-Statuscode"
@@ -630,7 +885,7 @@
     "message": "Seite hat einen gültigen HTTP-Statuscode"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Suchmaschinen können Ihre Seiten nicht in die Suchergebnisse aufnehmen, wenn sie nicht dazu berechtigt sind, sie zu crawlen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Suchmaschinen können Ihre Seiten nicht in die Suchergebnisse aufnehmen, wenn sie nicht dazu berechtigt sind, sie zu crawlen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Seite ist von Indexierung ausgeschlossen"
@@ -639,7 +894,7 @@
     "message": "Seite ist nicht von Indexierung ausgeschlossen"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Mit beschreibendem Linktext können Suchmaschinen Ihre Inhalte besser verstehen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "Mit beschreibendem Linktext können Suchmaschinen Ihre Inhalte besser verstehen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 Link gefunden}other{# Links gefunden}}"
@@ -651,13 +906,13 @@
     "message": "Links haben beschreibenden Text"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Führen Sie das [Testtool für strukturierte Daten](https://search.google.com/structured-data/testing-tool/) und den [Structured Data Linter](http://linter.structured-data.org/) aus, um strukturierte Daten zu validieren. [Weitere Informationen](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Sie können das [Testtool für strukturierte Daten](https://search.google.com/structured-data/testing-tool/) und den [Lint für strukturierte Daten](http://linter.structured-data.org/) ausführen, um strukturierte Daten zu validieren. [Weitere Informationen.](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Strukturierte Daten sind gültig"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Meta-Beschreibungen können in die Suchergebnisse aufgenommen werden, um die Seiteninhalte kurz zusammenzufassen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Meta-Beschreibungen können in die Suchergebnisse aufgenommen werden, um die Seiteninhalte kurz zusammenzufassen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/description)"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Beschreibungstext ist leer."
@@ -669,7 +924,7 @@
     "message": "Dokument enthält eine Meta-Beschreibung"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Suchmaschinen können keine Plug-in-Inhalte indexieren und auf vielen Geräten werden Plug-ins eingeschränkt oder nicht unterstützt. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Suchmaschinen können keine Plug-in-Inhalte indexieren, und auf vielen Geräten werden Plug-ins eingeschränkt oder nicht unterstützt. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "Dokument verwendet Plug-ins"
@@ -696,7 +951,7 @@
     "message": "robots.txt ist gültig"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Interaktive Elemente wie Schaltflächen und Links sollten groß genug sein (48 x 48 px) und genügend Platz um sich herum haben, um einfach angetippt werden zu können. Dabei sollten sie sich aber nicht mit anderen Elementen überschneiden. [Weitere Informationen](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Interaktive Elemente wie Schaltflächen und Links sollten groß genug sein (48 x 48 px) und genügend Platz um sich herum haben, um einfach angetippt werden zu können. Dabei sollten sie sich aber nicht mit anderen Elementen überschneiden. [Weitere Informationen.](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} der Tippziele haben eine passende Größe"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Sich überschneidendes Ziel"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Größe"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Tippziel"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Größe von Tippzielen ist richtig eingestellt"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Dauer des Hauptthreads"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Drittanbieter"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Code von Drittanbietern kann die Ladegeschwindigkeit erheblich beeinträchtigen. Beschränken Sie die Zahl redundanter Drittanbieter und versuchen Sie, solchen Code erst nachträglich zu laden. [Weitere Informationen.](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 Drittanbieter gefunden}other{# Drittanbieter gefunden}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Nutzung von Drittanbieter-Code"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "TTFB (Time To First Byte) erkennt den Zeitpunkt, an dem Ihr Server eine Antwort sendet. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "TTFB (Time To First Byte) erkennt den Zeitpunkt, zu dem Ihr Server eine Antwort sendet. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Stammdokument brauchte {timeInMs, number, milliseconds} ms"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Dauer"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Name"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Beginn"
   },
@@ -744,7 +1008,7 @@
     "message": "Typ"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Sie können die User Timing API in Ihre App integrieren. Damit lässt sich die Leistung Ihrer App in der Praxis messen, beispielsweise während Seitenladevorgängen oder wichtigen Nutzerinteraktionen. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Sie können die User Timing API in Ihre App integrieren. Damit lässt sich die Leistung Ihrer App während wichtiger Nutzerinteraktionen in der Praxis messen. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 Nutzertiming}other{# Nutzertimings}}"
@@ -753,19 +1017,19 @@
     "message": "Markierungen und Messungen für das Nutzertiming"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Für \"{securityOrigin}\" wurde ein <link> zur Vorverbindung gefunden, der jedoch vom Browser nicht verwendet wurde. Überprüfen Sie, ob das crossorigin-Attribut wie vorgesehen verwendet wird."
+    "message": "Für {securityOrigin} wurde ein <link> zur Vorverbindung gefunden, der jedoch vom Browser nicht verwendet wurde. Überprüfen Sie, ob das `crossorigin`-Attribut richtig verwendet wird."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Versuchen Sie, Hinweise auf Ressourcen für eine Vorverbindung oder einen DNS-Vorabruf hinzuzufügen, damit möglichst frühzeitig eine Verbindung zu wichtigen Drittanbieterursprüngen hergestellt wird. [Weitere Informationen](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Wenn Sie Hinweise auf Ressourcen als Vorverbindung oder DNS-Vorabruf hinzufügen, können Sie möglichst frühzeitig eine Verbindung zu wichtigen Drittanbieterursprüngen herstellen. [Weitere Informationen.](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Vorverbindung zu erforderlichen Ursprüngen aufbauen"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Ein <link>-Element zum Vorabladen wurde für \"{preloadURL}\" gefunden, aber nicht vom Browser verwendet. Überprüfen Sie, ob das \"crossorigin\"-Attribut richtig verwendet wird."
+    "message": "Ein <link>-Element zum Vorabladen wurde für {preloadURL} gefunden, aber nicht vom Browser verwendet. Überprüfen Sie, ob das `crossorigin`-Attribut richtig verwendet wird."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Mit <link rel=preload> können Sie das Abrufen von Ressourcen priorisieren, die aktuell später beim Seitenaufbau angefordert werden. [Weitere Informationen](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Mit `<link rel=preload>` können Sie das Abrufen von Ressourcen priorisieren, die derzeit beim Seitenaufbau erst später angefordert werden. [Weitere Informationen.](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Wichtige Anforderungen vorab laden"
@@ -789,7 +1053,7 @@
     "message": "Best Practices"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Mit diesen Prüfungen erfahren Sie, [wie Sie die Barrierefreiheit Ihrer Web-App verbessern](https://developers.google.com/web/fundamentals/accessibility). Nur bestimmte Probleme mit der Barrierefreiheit können durch automatisierte Tests erkannt werden, weshalb es empfehlenswert ist, zusätzlich manuelle Tests durchzuführen."
+    "message": "Mit diesen Prüfungen erfahren Sie, [wie Sie die Barrierefreiheit Ihrer Web-App verbessern](https://developers.google.com/web/fundamentals/accessibility). Nur bestimmte Probleme mit der Barrierefreiheit können durch automatisierte Tests erkannt werden. Deshalb ist es empfehlenswert, zusätzlich manuelle Tests durchzuführen."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "Diese Prüfungen sind für Bereiche vorgesehen, für die automatische Testtools nicht geeignet sind. Weitere Informationen finden Sie in unserem Leitfaden zur [Durchführung einer Prüfung auf Barrierefreiheit](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabellen und Listen"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Best Practices"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Mithilfe von Leistungsbudgets werden Standards für die Leistung Ihrer Website definiert."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budgets"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Weitere Informationen zur Leistung Ihrer App."
+    "message": "Weitere Informationen zur Leistung Ihrer App finden Sie hier. Diese Angaben haben keinen [direkten Einfluss](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) auf die Leistungsbewertung."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnose"
@@ -840,7 +1113,7 @@
     "message": "Verbesserungen beim Zeichnen der ersten Inhalte"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Diese Optimierungen können den Seitenaufbau beschleunigen."
+    "message": "Mithilfe diese Empfehlungen lässt sich die Ladezeit Ihrer Seite möglicherweise verkürzen. Sie haben keinen [direkten Einfluss](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) auf die Leistungsbewertung."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Empfehlungen"
@@ -867,7 +1140,7 @@
     "message": "PWA-optimiert"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Mit diesen Prüfungen ist gewährleistet, dass Ihre Seite für das Ergebnis-Ranking von Suchmaschinen optimiert ist. Darüber hinaus gibt es aber auch noch andere Faktoren, die sich auf das Such-Ranking Ihrer Seite auswirken können und die Lighthouse nicht berücksichtigt. [Weitere Informationen](https://support.google.com/webmasters/answer/35769)."
+    "message": "Mit diesen Prüfungen ist gewährleistet, dass Ihre Seite für das Ergebnis-Ranking von Suchmaschinen optimiert ist. Darüber hinaus gibt es aber auch noch andere Faktoren, die sich auf das Such-Ranking Ihrer Seite auswirken können und die Lighthouse nicht berücksichtigt. [Weitere Informationen.](https://support.google.com/webmasters/answer/35769)"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Sie können diese zusätzlichen Validierungen für Ihre Website ausführen, um weitere Best Practices für die SEO zu prüfen."
@@ -888,7 +1161,7 @@
     "message": "Crawling und Indexierung"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Achten Sie darauf, dass Ihre Seiten für Mobilgeräte optimiert sind, damit Nutzer problemlos Inhalte lesen können, ohne mit den Fingern heranzoomen zu müssen. [Weitere Informationen](https://developers.google.com/search/mobile-sites/)."
+    "message": "Achten Sie darauf, dass Ihre Seiten für Mobilgeräte optimiert sind, damit Nutzer problemlos Inhalte lesen können, ohne mit den Fingern heranzoomen zu müssen. [Weitere Informationen.](https://developers.google.com/search/mobile-sites/)"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Für Mobilgeräte optimiert"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Cache-TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Position"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Name"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Anfragen"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Ressourcentyp"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Größe (KB)"
+    "message": "Größe"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Zeitaufwand"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Übertragungsgröße"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Mögliche Einsparung (KB)"
+    "message": "Mögliche Einsparungen"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Mögliche Einsparung (ms)"
+    "message": "Mögliche Einsparungen"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Mögliche Einsparung von {wastedBytes, number, bytes} ms"
+    "message": "Mögliche Einsparung von {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Mögliche Einsparung von {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Schriftart"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Bild"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Medien"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Sonstige"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skript"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stylesheet"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Drittanbieter"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Gesamt"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Beim Aufzeichnen des Trace über Ihren Seitenaufbau ist ein Problem aufgetreten. Bitte führen Sie Lighthouse noch einmal aus. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Die angegebene Domain konnte von den DNS-Servern nicht aufgelöst werden."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Beim erforderlichen {artifactName}-Gatherer ist ein Fehler aufgetreten: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Ein interner Chrome-Fehler ist aufgetreten. Starten Sie Chrome neu und versuchen Sie anschließend, Lighthouse noch einmal auszuführen."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Erforderlicher {artifactName}-Gatherer wurde nicht ausgeführt."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Die von Ihnen angeforderte Seite konnte von Lighthouse nicht zuverlässig geladen werden. Überprüfen Sie, ob Sie die richtige URL testen und der Server auf alle Anfragen angemessen reagiert."
@@ -945,7 +1266,10 @@
     "message": "Die angeforderte URL konnte von Lighthouse nicht zuverlässig geladen werden, weil die Seite nicht mehr reagiert hat."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Die Sicherheitsinformationen der von Ihnen angegebenen URL sind nicht gültig. {securityMessages}"
+    "message": "Die von Ihnen angegebene URL hat kein gültiges Sicherheitszertifikat. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome hat den Seitenaufbau mit einem Interstitial verhindert. Überprüfen Sie, ob Sie die richtige URL testen und der Server auf alle Anfragen angemessen reagiert."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Die von Ihnen angeforderte Seite konnte von Lighthouse nicht zuverlässig geladen werden. Überprüfen Sie, ob Sie die richtige URL testen und der Server auf alle Anfragen angemessen reagiert. (Details: {errorDetails})"
@@ -954,7 +1278,7 @@
     "message": "Die von Ihnen angeforderte Seite konnte von Lighthouse nicht zuverlässig geladen werden. Überprüfen Sie, ob Sie die richtige URL testen und der Server auf alle Anfragen angemessen reagiert. (Statuscode: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Das Laden Ihrer Seite hat zu lange gedauert. Nutzen Sie die Tipps im Bericht, um die Seitenladezeit zu verringern, und versuchen Sie anschließend, Lighthouse noch einmal auszuführen. ({errorCode})"
+    "message": "Das Laden Ihrer Seite hat zu lange gedauert. Nutzen Sie die Tipps im Bericht, um die Seitenladezeit zu verringern, und versuchen Sie anschließend noch einmal, Lighthouse auszuführen. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "Die maximal zulässige Antwortzeit des DevTools-Protokolls wurde überschritten. (Methode: {protocolMethod})"
@@ -984,7 +1308,7 @@
     "message": "Labdaten"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse-Analyse](https://developers.google.com/web/tools/lighthouse/) der aktuellen Seite in einem emulierten Mobilfunknetz. Die Werte sind Schätzungen und können variieren."
+    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/)-Analyse der aktuellen Seite in einem emulierten Mobilfunknetz. Die Werte sind Schätzungen und können variieren."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Zusätzliche Elemente zur manuellen Überprüfung"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Snippet maximieren"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Drittanbieter-Ressourcen anzeigen"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Einige Probleme haben diese Ausführung von Lighthouse beeinträchtigt:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Die Werte sind geschätzt und können variieren."
+    "message": "Die Werte sind Schätzungen und können variieren. Die Leistungsbewertung [basiert nur auf diesen Messwerten](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Bestandene Prüfungen mit Warnungen"
@@ -1023,7 +1350,7 @@
     "message": "Sie haben die Möglichkeit, Ihr GIF bei einem Dienst hochzuladen, der dafür sorgt, dass es als HTML5-Video eingebettet werden kann."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Sie können ein [Lazy-Loading-Plug-in für WordPress](https://wordpress.org/plugins/search/lazy+load/) installieren, mit dem Sie nicht sichtbare Bilder aufschieben oder zu einem Design wechseln können, das diese Funktion bietet. Sie sollten sich auch überlegen, [das AMP-Plug-in](https://wordpress.org/plugins/amp/) zu verwenden."
+    "message": "Sie können ein [Lazy-Loading-Plug-in für WordPress](https://wordpress.org/plugins/search/lazy+load/) installieren, mit dem Sie nicht sichtbare Bilder aufschieben. Alternativ können Sie auch zu einem Design wechseln, das diese Funktion bietet. Sie sollten sich auch überlegen, [das AMP-Plug-in](https://wordpress.org/plugins/amp/) zu verwenden."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "Es gibt eine Reihe von WordPress-Plug-ins, mit denen Sie [wichtige Assets einbetten](https://wordpress.org/plugins/search/critical+css/) oder [weniger wichtige Ressourcen aufschieben](https://wordpress.org/plugins/search/defer+css+javascript/) können. Beachten Sie, dass über diese Plug-ins bereitgestellte Optimierungen dazu führen können, dass Ihre Designs oder Plug-ins nicht funktionieren. Daher müssen Sie wahrscheinlich Änderungen am Code vornehmen."
@@ -1035,30 +1362,30 @@
     "message": "Sie haben die Möglichkeit, Auszüge in Ihrer Beitragsliste einzublenden (z. B. über das Tag \"Mehr\"), die Anzahl der Beiträge auf einer Seite zu verringern, lange Beiträge auf mehrere Seiten aufzuteilen oder ein Plug-in für das Lazy Loading von Kommentaren zu verwenden."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Ihre Website kann durch eine Reihe von [WordPress-Plug-ins](https://wordpress.org/plugins/search/minify+css/) beschleunigt werden, durch die Ihre Stile verkettet und komprimiert werden. Sofern möglich, können Sie diese Komprimierung auch im Voraus über einen Build-Prozess vornehmen."
+    "message": "Ihre Website lässt sich mit einer Reihe von [WordPress-Plug-ins](https://wordpress.org/plugins/search/minify+css/) beschleunigen, durch die Ihre Stile verkettet und komprimiert werden. Sofern möglich, können Sie diese Komprimierung auch im Voraus über einen Build-Prozess vornehmen."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Ihre Website kann durch eine Reihe von [WordPress-Plug-ins](https://wordpress.org/plugins/search/minify+javascript/) beschleunigt werden, durch die Ihre Skripte verkettet und komprimiert werden. Sofern möglich, können Sie diese Komprimierung auch im Voraus über einen Build-Prozess vornehmen."
+    "message": "Ihre Website lässt sich mit einer Reihe von [WordPress-Plug-ins](https://wordpress.org/plugins/search/minify+javascript/) beschleunigen, durch die Ihre Skripts verkettet und komprimiert werden. Sofern möglich, können Sie diese Komprimierung auch im Voraus über einen Build-Prozess vornehmen."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
     "message": "Prüfen Sie, ob Sie [WordPress-Plug-ins](https://wordpress.org/plugins/), über die nicht verwendete CSS auf Ihre Seite geladen werden, entfernen oder durch alternative Plug-ins ersetzen können. Wenn Sie die Plug-ins ermitteln möchten, über die irrelevante CSS hinzugefügt werden, können Sie das Prüftool zur [Codeabdeckung](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in den Chrome-Entwicklertools verwenden. Das entsprechende Design/Plug-in können Sie anhand der URL des Stylesheets erkennen. Suchen Sie in der Liste nach Plug-ins mit vielen Stylesheets, bei denen im Prüftool zur Codeabdeckung viel nicht verwendeter Code (markiert in Rot) angezeigt wird. Ein Stylesheet sollte nur dann in ein Plug-in aufgenommen werden, wenn es auch tatsächlich auf der Seite verwendet wird."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Prüfen Sie, ob Sie [WordPress-Plug-ins](https://wordpress.org/plugins/), über die nicht verwendetes JavaScript auf Ihre Seite geladen wird, entfernen oder durch alternative Plug-ins ersetzen können. Wenn Sie die Plug-ins ermitteln möchten, über die irrelevante JavaScripts hinzugefügt werden, können Sie das Prüftool zur [Codeabdeckung](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in den Chrome-Entwicklertools verwenden. Das entsprechende Design/Plug-in können Sie anhand der URL des Skripts erkennen. Suchen Sie in der Liste nach Plug-ins mit vielen Skripts, bei denen im Prüftool zur Codeabdeckung viel nicht verwendeter Code (markiert in Rot) angezeigt wird. Ein Skript sollte nur dann in ein Plug-in aufgenommen werden, wenn es auch tatsächlich auf der Seite verwendet wird."
+    "message": "Prüfen Sie, ob Sie [WordPress-Plug-ins](https://wordpress.org/plugins/), über die nicht verwendete JavaScript-Dateien auf Ihre Seite geladen werden, entfernen oder durch alternative Plug-ins ersetzen können. Wenn Sie die Plug-ins ermitteln möchten, über die irrelevante JavaScript-Dateien hinzugefügt werden, können Sie das Prüftool zur [Codeabdeckung](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in den Chrome-Entwicklertools verwenden. Das entsprechende Design/Plug-in können Sie anhand der URL des Skripts erkennen. Suchen Sie in der Liste nach Plug-ins mit vielen Skripts, bei denen im Prüftool zur Codeabdeckung viel nicht verwendeter Code (markiert in Rot) angezeigt wird. Ein Skript sollte nur dann in ein Plug-in aufgenommen werden, wenn es auch tatsächlich auf der Seite verwendet wird."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "[Hier erhalten Sie Informationen zum Browser-Caching in WordPress.](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)"
+    "message": "Hier erhalten Sie Informationen zum [Browser-Caching in WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Sie haben die Möglichkeit, ein [WordPress-Plug-in für die Bildoptimierung](https://wordpress.org/plugins/search/optimize+images/) zu verwenden, durch das Ihre Bilder komprimiert werden, die Qualität jedoch erhalten bleibt."
+    "message": "Sie haben die Möglichkeit, ein [WordPress-Plug-in für die Bildoptimierung](https://wordpress.org/plugins/search/optimize+images/) zu verwenden, durch das Ihre Bilder komprimiert werden, die Qualität jedoch gleich bleibt."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Sie haben die Möglichkeit, Bilder direkt über die [Medienbibliothek](https://codex.wordpress.org/Media_Library_Screen) hochzuladen, damit die erforderlichen Bildgrößen verfügbar sind. Die Bilder können Sie dann aus der Medienbibliothek einfügen oder auch das Bild-Widget nutzen, um dafür zu sorgen, dass die optimalen Bildgrößen verwendet werden (einschließlich derjenigen für die responsiven Haltepunkte). Bilder in Originalgröße sollten nur verwendet werden, wenn die Abmessungen für die entsprechende Nutzung geeignet sind. [Weitere Informationen](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Sie haben die Möglichkeit, Bilder direkt über die [Medienbibliothek](https://codex.wordpress.org/Media_Library_Screen) hochzuladen, damit die erforderlichen Bildgrößen verfügbar sind. Die Bilder können Sie dann aus der Medienbibliothek einfügen oder auch das Bild-Widget nutzen, damit die optimalen Bildgrößen verwendet werden (einschließlich derjenigen für die responsiven Haltepunkte). Bilder in `Full Size` sollten nur verwendet werden, wenn die Abmessungen für die entsprechende Nutzung geeignet sind. [Weitere Informationen.](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Sie können die Textkomprimierung in der Konfiguration Ihres Webservers aktivieren."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Sie haben die Möglichkeit, Ihre hochgeladenen Bilder mithilfe [eines Plug-ins](https://wordpress.org/plugins/search/convert+webp/) oder eines Dienstes automatisch in das optimale Format zu konvertieren."
+    "message": "Sie haben die Möglichkeit, Ihre hochgeladenen Bilder mithilfe eines [Plug-ins](https://wordpress.org/plugins/search/convert+webp/) oder eines Dienstes automatisch in das optimale Format zu konvertieren."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/el.json
+++ b/lighthouse-core/lib/i18n/locales/el.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Τα πλήκτρα πρόσβασης επιτρέπουν στους χρήστες να εστιάσουν γρήγορα σε ένα τμήμα της σελίδας. Για σωστή πλοήγηση, κάθε πλήκτρο πρόσβασης πρέπει να είναι μοναδικό. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Τα πλήκτρα πρόσβασης επιτρέπουν στους χρήστες να εστιάσουν γρήγορα σε ένα τμήμα της σελίδας. Για σωστή πλοήγηση, κάθε πλήκτρο πρόσβασης πρέπει να είναι μοναδικό. [Μάθετε περισσότερα](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Οι τιμές \"[accesskey]\" δεν είναι μοναδικές"
+    "message": "Οι τιμές `[accesskey]` δεν είναι μοναδικές"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Οι τιμές \"[accesskey]\" είναι μοναδικές"
+    "message": "`[accesskey]` τιμές είναι μοναδικές"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Κάθε \"ρόλος\" ARIA υποστηρίζει ένα συγκεκριμένο υποσύνολο χαρακτηριστικών \"aria-*\". Η λανθασμένη αντιστοίχισή τους καθιστά μη έγκυρα τα χαρακτηριστικά \"aria-*\". [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Κάθε στοιχείο ARIA `role` υποστηρίζει ένα συγκεκριμένο υποσύνολο χαρακτηριστικών `aria-*`. Η λανθασμένη αντιστοίχισή τους καθιστά μη έγκυρα τα χαρακτηριστικά `aria-*`. [Μάθετε περισσότερα](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Τα χαρακτηριστικά \"[aria-*]\" δεν αντιστοιχούν στους ρόλους τους"
+    "message": "Τα χαρακτηριστικά `[aria-*]` δεν αντιστοιχούν στους ρόλους τους"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Τα χαρακτηριστικά \"[aria-*]\" αντιστοιχούν στους ρόλους τους"
+    "message": "Τα χαρακτηριστικά `[aria-*]` αντιστοιχούν στους ρόλους τους"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Ορισμένοι ρόλοι ARIA έχουν απαιτούμενα χαρακτηριστικά που περιγράφουν την κατάσταση του στοιχείου στους αναγνώστες οθόνης. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Ορισμένοι ρόλοι ARIA έχουν απαιτούμενα χαρακτηριστικά που περιγράφουν την κατάσταση του στοιχείου στους αναγνώστες οθόνης. [Μάθετε περισσότερα](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Τα \"[role]\" δεν έχουν όλα τα απαιτούμενα χαρακτηριστικά \"[aria-*]\""
+    "message": "Τα στοιχεία `[role]` δεν έχουν όλα τα απαιτούμενα χαρακτηριστικά `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Τα \"[role]\" έχουν όλα τα απαιτούμενα χαρακτηριστικά \"[aria-*]\""
+    "message": "Τα στοιχεία `[role]` έχουν όλα τα απαιτούμενα χαρακτηριστικά `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Ορισμένοι γονικοί ρόλοι ARIA πρέπει να περιέχουν συγκεκριμένους θυγατρικούς ρόλους, για να μπορούν να εκτελέσουν τις προβλεπόμενες λειτουργίες προσβασιμότητας. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Ορισμένοι γονικοί ρόλοι ARIA πρέπει να περιέχουν συγκεκριμένους θυγατρικούς ρόλους, για να μπορούν να εκτελέσουν τις προβλεπόμενες λειτουργίες προσβασιμότητας. [Μάθετε περισσότερα](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Λείπουν στοιχεία με \"[role]\" που απαιτούν συγκεκριμένα θυγατρικά \"[role]\"."
+    "message": "Λείπουν τα στοιχεία με `[role]` που απαιτούν συγκεκριμένα θυγατρικά `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Υπάρχουν στοιχεία με \"[role]\" που απαιτούν συγκεκριμένα θυγατρικά \"[role]\""
+    "message": "Υπάρχουν τα στοιχεία με `[role]` που απαιτούν συγκεκριμένα θυγατρικά `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Ορισμένοι θυγατρικοί ρόλοι ARIA πρέπει να περιέχονται σε συγκεκριμένους γονικούς ρόλους, για να μπορούν να εκτελέσουν σωστά τις προβλεπόμενες λειτουργίες προσβασιμότητας. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Ορισμένοι θυγατρικοί ρόλοι ARIA πρέπει να περιέχονται σε συγκεκριμένους γονικούς ρόλους, για να μπορούν να εκτελέσουν σωστά τις προβλεπόμενες λειτουργίες προσβασιμότητας. [Μάθετε περισσότερα](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Τα \"[role]\" δεν περιέχονται στο απαιτούμενο γονικό στοιχείο τους"
+    "message": "Τα στοιχεία `[role]` δεν περιλαμβάνονται στο απαιτούμενο γονικό στοιχείο τους"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Τα \"[role]\" περιέχονται στο απαιτούμενο γονικό στοιχείο τους"
+    "message": "Τα στοιχεία `[role]` περιλαμβάνονται στο απαιτούμενο γονικό στοιχείο τους"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Οι ρόλοι ARIA πρέπει να έχουν έγκυρες τιμές, για να μπορούν να εκτελέσουν τις προβλεπόμενες λειτουργίες προσβασιμότητας. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Οι ρόλοι ARIA πρέπει να έχουν έγκυρες τιμές, για να μπορούν να εκτελέσουν τις προβλεπόμενες λειτουργίες προσβασιμότητας. [Μάθετε περισσότερα](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Οι τιμές \"[role]\" δεν είναι έγκυρες"
+    "message": "Οι τιμές `[role]` δεν είναι έγκυρες"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Οι τιμές \"[role]\" είναι έγκυρες"
+    "message": "Οι τιμές `[role]` είναι έγκυρες"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Οι τεχνολογίες για άτομα με ειδικές ανάγκες, όπως οι αναγνώστες οθόνης, δεν μπορούν να ερμηνεύσουν τα χαρακτηριστικά ARIA με μη έγκυρες τιμές. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Οι τεχνολογίες υποβοήθησης χρηστών, όπως οι αναγνώστες οθόνης, δεν μπορούν να ερμηνεύσουν τα χαρακτηριστικά ARIA με μη έγκυρες τιμές. [Μάθετε περισσότερα](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Τα χαρακτηριστικά \"[aria-*]\" δεν έχουν έγκυρες τιμές"
+    "message": "Τα χαρακτηριστικά `[aria-*]` δεν έχουν έγκυρες τιμές"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Τα χαρακτηριστικά \"[aria-*]\" έχουν έγκυρες τιμές"
+    "message": "Τα χαρακτηριστικά `[aria-*]` έχουν έγκυρες τιμές"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Οι τεχνολογίες για άτομα με ειδικές ανάγκες, όπως οι αναγνώστες οθόνης, δεν μπορούν να ερμηνεύσουν τα χαρακτηριστικά ARIA με μη έγκυρα ονόματα. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Οι τεχνολογίες υποβοήθησης χρηστών, όπως οι αναγνώστες οθόνης, δεν μπορούν να ερμηνεύσουν τα χαρακτηριστικά ARIA με μη έγκυρα ονόματα. [Μάθετε περισσότερα](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Τα χαρακτηριστικά \"[aria-*]\" δεν είναι έγκυρα ή είναι λάθος γραμμένα"
+    "message": "Τα χαρακτηριστικά `[aria-*]` δεν είναι έγκυρα ή έχουν ορθογραφικά λάθη"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Τα χαρακτηριστικά \"[aria-*]\" είναι έγκυρα και δεν είναι λάθος γραμμένα"
+    "message": "Τα χαρακτηριστικά `[aria-*]` είναι έγκυρα και δεν έχουν ορθογραφικά λάθη"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Οι υπότιτλοι καθιστούν χρησιμοποιήσιμα τα ηχητικά στοιχεία για χρήστες που είναι κωφοί ή έχουν προβλήματα ακοής, παρέχοντας σημαντικές πληροφορίες όπως το ποιος μιλάει, τι λέει και άλλες μη λεκτικές πληροφορίες. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Οι υπότιτλοι καθιστούν τα στοιχεία ήχου προσβάσιμα από τους χρήστες που είναι κωφοί ή έχουν προβλήματα ακοής, καθώς παρέχουν σημαντικές πληροφορίες όπως το ποιος μιλάει, το τι λέει και άλλες μη λεκτικές πληροφορίες. [Μάθετε περισσότερα](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Από τα στοιχεία \"<audio>\" λείπει ένα στοιχείο \"<track>\" με \"[kind=\"captions\"]\"."
+    "message": "Λείπει ένα στοιχείο `<track>` με `[kind=\"captions\"]` από τα στοιχεία `<audio>`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Τα στοιχεία \"<audio>\" περιέχουν ένα στοιχείο \"<track>\" με \"[kind=\"captions\"]\""
+    "message": "Τα στοιχεία `<audio>` περιέχουν ένα στοιχείο `<track>` με `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Στοιχεία που απέτυχαν"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Όταν ένα κουμπί δεν έχει προσβάσιμο όνομα, οι αναγνώστες οθόνης το εκφωνούν ως \"κουμπί\", με αποτέλεσμα να μην είναι χρησιμοποιήσιμο για τους χρήστες που βασίζονται στους αναγνώστες οθόνης. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Όταν ένα κουμπί δεν έχει προσβάσιμο όνομα, οι αναγνώστες οθόνης το εκφωνούν ως \"κουμπί\", με αποτέλεσμα να μην μπορεί να χρησιμοποιηθεί από τους χρήστες που βασίζονται στους αναγνώστες οθόνης. [Μάθετε περισσότερα](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Τα κουμπιά δεν έχουν προσβάσιμο όνομα"
@@ -93,7 +93,7 @@
     "message": "Τα κουμπιά έχουν προσβάσιμο όνομα"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Η προσθήκη τρόπων για παράκαμψη του επαναληπτικού περιεχομένου επιτρέπει στους χρήστες του πληκτρολογίου να πλοηγηθούν πιο αποτελεσματικά στη σελίδα. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Η προσθήκη τρόπων για την παράκαμψη του επαναλαμβανόμενου περιεχομένου επιτρέπει στους χρήστες του πληκτρολογίου να πλοηγούνται πιο αποτελεσματικά στη σελίδα. [Μάθετε περισσότερα](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Η σελίδα δεν περιέχει κεφαλίδα, σύνδεσμο παράβλεψης ή περιοχή ορόσημου"
@@ -102,7 +102,7 @@
     "message": "Η σελίδα περιέχει κεφαλίδα, σύνδεσμο παράβλεψης ή περιοχή ορόσημου"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Ένα κείμενο χαμηλής αντίθεσης δυσκολεύει τους χρήστες ή καθιστά αδύνατη την ανάγνωση. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Ένα κείμενο χαμηλής αντίθεσης είναι δύσκολο ή αδύνατο να αναγνωστεί. [Μάθετε περισσότερα](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Τα χρώματα παρασκηνίου και προσκηνίου δεν έχουν επαρκή αναλογία αντίθεσης."
@@ -111,88 +111,88 @@
     "message": "Τα χρώματα παρασκηνίου και προσκηνίου έχουν επαρκή αναλογία αντίθεσης"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Όταν οι λίστες ορισμών δεν επισημαίνονται σωστά, οι αναγνώστες οθόνης μπορεί να παράγουν συγκεχυμένα ή ανακριβή αποτελέσματα. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Όταν οι λίστες ορισμών δεν επισημαίνονται σωστά, οι αναγνώστες οθόνης μπορεί να παράγουν συγκεχυμένα ή ανακριβή αποτελέσματα. [Μάθετε περισσότερα](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Τα \"<dl>\" δεν περιέχουν μόνο σωστά ταξινομημένες ομάδες \"<dt>\" και \"<dd>\" και στοιχεία \"<script>\" ή \"<template>\"."
+    "message": "Τα στοιχεία `<dl>` δεν περιέχουν μόνο σωστά ταξινομημένες ομάδες `<dt>` και `<dd>` ή στοιχεία `<script>` ή `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Τα \"<dl>\" περιέχουν μόνο σωστά ταξινομημένες ομάδες \"<dt>\" και \"<dd>\" και στοιχεία \"<script>\" ή \"<template>\"."
+    "message": "Τα στοιχεία `<dl>` περιέχουν μόνο σωστά ταξινομημένες ομάδες `<dt>` και `<dd>` ή στοιχεία `<script>` ή `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Τα στοιχεία λίστας ορισμών (\"<dt>\" και \"<dd>\") πρέπει να περιτυλίγονται από ένα γονικό στοιχείο \"<dl>\", ώστε οι αναγνώστες οθόνης να μπορούν να τα εκφωνήσουν σωστά. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Τα στοιχεία λίστας ορισμών (`<dt>` και `<dd>`) πρέπει να περιτυλίγονται σε ένα γονικό στοιχείο `<dl>`, ώστε οι αναγνώστες οθόνης να μπορούν να τα εκφωνήσουν σωστά. [Μάθετε περισσότερα](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Τα στοιχεία της λίστας ορισμών δεν περιτυλίγονται από στοιχεία \"<dl>\""
+    "message": "Τα στοιχεία της λίστας ορισμών δεν περιτυλίγονται σε στοιχεία `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Τα στοιχεία της λίστας ορισμών περιτυλίγονται από στοιχεία \"<dl>\""
+    "message": "Τα στοιχεία της λίστας ορισμών περιτυλίγονται σε στοιχεία `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Για τους χρήστες του αναγνώστη οθόνης, ο τίτλος λειτουργεί ως επισκόπηση της σελίδας, ενώ οι χρήστες της μηχανής αναζήτησης βασίζονται πολύ σε αυτόν προκειμένου να διαπιστώσουν εάν μια σελίδα είναι σχετική με την αναζήτησή τους. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Για τους χρήστες ενός αναγνώστη οθόνης, ο τίτλος λειτουργεί ως επισκόπηση της σελίδας. Για τους χρήστες μιας μηχανής αναζήτησης, ο τίτλος τούς επιτρέπει να αποφασίσουν εάν μια σελίδα είναι σχετική με την αναζήτησή τους. [Μάθετε περισσότερα](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Το έγγραφο δεν έχει στοιχείο \"<title>\""
+    "message": "Το έγγραφο δεν έχει ένα στοιχείο `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Το έγγραφο έχει στοιχείο \"<title>\""
+    "message": "Το έγγραφο έχει ένα στοιχείο `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Η τιμή ενός χαρακτηριστικού αναγνωριστικού πρέπει να είναι μοναδική, ώστε οι τεχνολογίες για άτομα με ειδικές ανάγκες να μην παραβλέπουν τις άλλες παρουσίες. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Η τιμή ενός χαρακτηριστικού αναγνωριστικού (id) πρέπει να είναι μοναδική, ώστε οι τεχνολογίες υποβοήθησης χρηστών να μην παραβλέπουν τις άλλες παρουσίες. [Μάθετε περισσότερα](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Τα χαρακτηριστικά \"[id]\" στη σελίδα δεν είναι μοναδικά"
+    "message": "Τα χαρακτηριστικά `[id]` στη σελίδα δεν είναι μοναδικά"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Τα χαρακτηριστικά \"[id]\" στη σελίδα είναι μοναδικά"
+    "message": "Τα χαρακτηριστικά `[id]` στη σελίδα είναι μοναδικά"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Οι χρήστες του αναγνώστη οθόνης βασίζονται στους τίτλους των πλαισίων για την περιγραφή του περιεχομένου τους. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Οι χρήστες ενός αναγνώστη οθόνης βασίζονται στους τίτλους των πλαισίων για την περιγραφή του περιεχομένου των πλαισίων. [Μάθετε περισσότερα](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Τα στοιχεία \"<frame>\" ή \"<iframe>\" δεν έχουν τίτλο"
+    "message": "Τα στοιχεία `<frame>` ή `<iframe>` δεν έχουν τίτλο"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Τα στοιχεία \"<frame>\" ή \"<iframe>\" έχουν τίτλο"
+    "message": "Τα στοιχεία `<frame>` ή `<iframe>` έχουν έναν τίτλο"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Εάν μια σελίδα δεν προσδιορίζει κάποιο χαρακτηριστικό γλώσσας, ο αναγνώστης οθόνης υποθέτει ότι η σελίδα εμφανίζεται στην προεπιλεγμένη γλώσσα που επέλεξε ο χρήστης κατά τη ρύθμιση του αναγνώστη οθόνης. Εάν η σελίδα δεν εμφανίζεται στην προεπιλεγμένη γλώσσα, τότε ο αναγνώστης οθόνης μπορεί να μην εκφωνήσει σωστά το κείμενο της σελίδας. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Εάν μια σελίδα δεν προσδιορίζει κάποιο χαρακτηριστικό γλώσσας, ο αναγνώστης οθόνης υποθέτει ότι η σελίδα εμφανίζεται στην προεπιλεγμένη γλώσσα που επέλεξε ο χρήστης κατά τη ρύθμιση του αναγνώστη οθόνης. Εάν η σελίδα δεν εμφανίζεται στην προεπιλεγμένη γλώσσα, τότε ο αναγνώστης οθόνης μπορεί να μην εκφωνήσει σωστά το κείμενο της σελίδας. [Μάθετε περισσότερα](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Το στοιχείο \"<html>\" δεν έχει χαρακτηριστικό \"[lang]\""
+    "message": "Το στοιχείο `<html>` δεν έχει ένα χαρακτηριστικό `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Το στοιχείο \"<html>\" έχει ένα χαρακτηριστικό \"[lang]\""
+    "message": "Το στοιχείο `<html>` έχει ένα χαρακτηριστικό `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Ο ορισμός μιας έγκυρης [γλώσσας BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) βοηθά τους αναγνώστες οθόνης να εκφωνήσουν σωστά το κείμενο. [Μάθετε περισότερα](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ο ορισμός μιας έγκυρης [γλώσσας BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) βοηθά τους αναγνώστες οθόνης να εκφωνούν σωστά το κείμενο. [Μάθετε περισσότερα](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Το στοιχείο \"<html>\" δεν έχει έγκυρη τιμή για το χαρακτηριστικό του \"[lang]\"."
+    "message": "Το στοιχείο `<html>` δεν έχει μια έγκυρη τιμή για το χαρακτηριστικό `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Το στοιχείο \"<html>\" έχει έγκυρη τιμή για το χρακτηριστικό του \"[lang]\""
+    "message": "Το στοιχείο `<html>` έχει μια έγκυρη τιμή για το χαρακτηριστικό `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Τα πληροφοριακά στοιχεία πρέπει να στοχεύουν σε σύντομο και περιγραφικό εναλλακτικό κείμενο. Τα διακοσμητικά στοιχεία μπορούν να παραβλεφθούν με ένα κενό χαρακτηριστικό alt. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Τα πληροφοριακά στοιχεία πρέπει να στοχεύουν σε σύντομο και περιγραφικό εναλλακτικό κείμενο. Τα διακοσμητικά στοιχεία μπορούν να παραβλεφθούν με ένα κενό χαρακτηριστικό alt. [Μάθετε περισσότερα](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Τα στοιχεία εικόνας δεν έχουν χαρακτηριστικά \"[alt]\""
+    "message": "Τα στοιχεία εικόνας δεν έχουν χαρακτηριστικά `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Τα στοιχεία εικόνας έχουν χαρακτηριστικά \"[alt]\""
+    "message": "Τα στοιχεία εικόνας έχουν χαρακτηριστικά `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Όταν μια εικόνα χρησιμοποιείται ως κουμπί \"<input>\", η παροχή εναλλακτικού κειμένου μπορεί να βοηθήσει τους χρήστες του αναγνώστη οθόνης να κατανοήσουν τον σκοπό του κουμπιού. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Όταν μια εικόνα χρησιμοποιείται ως κουμπί `<input>`, η παροχή εναλλακτικού κειμένου μπορεί να βοηθήσει τους χρήστες του αναγνώστη οθόνης να κατανοήσουν τον σκοπό του κουμπιού. [Μάθετε περισσότερα](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Τα στοιχεία \"<input type=\"image\">\" δεν έχουν κείμενο \"[alt]\""
+    "message": "Τα στοιχεία `<input type=\"image\">` δεν έχουν κείμενο `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Τα στοιχεία \"<input type=\"image\">\" έχουν κείμενο \"[alt]\""
+    "message": "Τα στοιχεία `<input type=\"image\">` έχουν κείμενο `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Οι ετικέτες διασφαλίζουν ότι οι τεχνολογίες για άτομα με ειδικές ανάγκες, όπως οι αναγνώστες οθόνης, εκφωνούν σωστά τα στοιχεία ελέγχου φορμών. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Οι ετικέτες διασφαλίζουν ότι οι τεχνολογίες υποβοήθησης χρηστών, όπως οι αναγνώστες οθόνης, εκφωνούν σωστά τα στοιχεία ελέγχου φορμών. [Μάθετε περισσότερα](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Τα στοιχεία φρόμας δεν έχουν συσχετισμένες ετικέτες"
@@ -201,16 +201,16 @@
     "message": "Τα στοιχεία φόρμας έχουν συσχετισμένες ετικέτες"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Ένας πίνακας που χρησιμοποιείται για σκοπούς διάταξης δεν πρέπει να περιλαμβάνει στοιχεία δεδομένων, όπως \"th\" ή \"caption\" ή το χαρακτηριστικό \"summary\", επειδή αυτό μπορεί να δημιουργήσει σύγχυση στους χρήστες του αναγνώστη οθόνης. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Ένας πίνακας που χρησιμοποιείται για σκοπούς διάταξης δεν πρέπει να περιλαμβάνει στοιχεία δεδομένων, όπως τα στοιχεία th ή caption ή το χαρακτηριστικό summary, επειδή αυτό μπορεί να προκαλέσει σύγχυση στους χρήστες του αναγνώστη οθόνης. [Μάθετε περισσότερα](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Τα στοιχεία παρουσίασης \"<table>\" δεν αποφεύγουν τη χρήση των χαρακτηριστικών \"<th>\", \"<caption>\" ή \"[summary]\"."
+    "message": "Τα στοιχεία παρουσίασης `<table>` δεν αποφεύγουν τη χρήση των ετικετών `<th>` ή `<caption>` ή του χαρακτηριστικού `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Τα στοιχεία παρουσίασης \"<table>\" αποφεύγουν τη χρήση των χαρακτηριστικών \"<th>\", \"<caption>\" ή \"[summary]\"."
+    "message": "Τα στοιχεία παρουσίασης `<table>` αποφεύγουν τη χρήση των ετικετών `<th>` ή `<caption>` ή του χαρακτηριστικού `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Το κείμενο συνδέσμων (και το εναλλακτικό κείμενο για εικόνες, όταν χρησιμοποιούνται ως σύνδεσμοι) που είναι διακριτό, μοναδικό και έχει δυνατότητα εστίασης βελτιώνει την εμπειρία πλοήγησης για τους χρήστες των αναγνωστών οθόνης. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Το κείμενο συνδέσμων (και το εναλλακτικό κείμενο για εικόνες όταν χρησιμοποιούνται ως σύνδεσμοι) που είναι διακριτό, μοναδικό και έχει δυνατότητα εστίασης βελτιώνει την εμπειρία πλοήγησης για τους χρήστες των αναγνωστών οθόνης. [Μάθετε περισσότερα](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Οι σύνδεσμοι δεν έχουν διακριτό όνομα"
@@ -219,103 +219,115 @@
     "message": "Οι σύνδεσμοι έχουν διακριτό όνομα"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Οι αναγνώστες οθόνης έχουν έναν συγκεκριμένο τρόπο εκφώνησης των λιστών. Μια κατάλληλη δομή λίστας βοηθά τους αναγνώστες οθόνης να παράγουν σωστά αποτελέσματα. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Οι αναγνώστες οθόνης έχουν έναν συγκεκριμένο τρόπο εκφώνησης των λιστών. Η χρήση κατάλληλης δομής για τις λίστες βοηθά στην αποτελεσματικότερη λειτουργία των αναγνωστών οθόνης. [Μάθετε περισσότερα](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Οι λίστες δεν περιέχουν μόνο στοιχεία \"<li>\" και στοιχεία για υποστήριξη σεναρίων (\"<script>\" και \"<template>\")."
+    "message": "Οι λίστες δεν περιέχουν μόνο στοιχεία `<li>` και στοιχεία υποστήριξης σεναρίων (`<script>` και `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Οι λίστες περιέχουν μόνο στοιχεία \"<li>\" και στοιχεία για υποστήριξη σεναρίων (\"<script>\" και \"<template>\")."
+    "message": "Οι λίστες περιέχουν μόνο στοιχεία `<li>` και στοιχεία υποστήριξης σεναρίων (`<script>` και `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Οι αναγνώστες οθόνες απαιτούν τα στοιχεία λίστας (\"<li>\") να περιέχονται σε ένα γονικό \"<ul>\" ή \"<ol>\", για να εκφωνούνται σωστά. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Για τη σωστή εκφώνηση των στοιχείων λίστας (`<li>`) από τους αναγνώστες οθόνης, τα στοιχεία πρέπει να περιέχονται σε ένα γονικό `<ul>` ή `<ol>`. [Μάθετε περισσότερα](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Τα στοιχεία λίστας (\"<li>\") δεν περιέχονται εντός των γονικών στοιχείων \"<ul>\" ή \"<ol>\"."
+    "message": "Τα στοιχεία λίστας (`<li>`) δεν περιλαμβάνονται στα γονικά στοιχεία `<ul>` ή `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Τα στοιχεία λίστας (\"<li>\") περιέχονται εντός των γονικών στοιχείων \"<ul>\" ή \"<ol>\"."
+    "message": "Τα στοιχεία λίστας (`<li>`) περιλαμβάνονται στα γονικά στοιχεία `<ul>` ή `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Οι χρήστες δεν περιμένουν ότι η σελίδα θα ανανεωθεί αυτόματα και ότι η εστίαση θα επιστρέψει στην κορυφή της σελίδας. Αυτό μπορεί να δημιουργήσει δυσαρέσκεια ή σύγχυση. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Οι χρήστες δεν περιμένουν ότι μια σελίδα θα ανανεωθεί αυτόματα και η εστίαση θα επιστρέψει στην κορυφή της σελίδας. Αυτό μπορεί να δημιουργήσει δυσαρέσκεια ή σύγχυση. [Μάθετε περισσότερα](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Το έγγραφο χρησιμοποιεί \"<meta http-equiv=\"refresh\">\""
+    "message": "Το έγγραφο χρησιμοποιεί μια ετικέτα `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Το έγγραφο δεν χρησιμοποιεί \"<meta http-equiv=\"refresh\">\""
+    "message": "Το έγγραφο δεν χρησιμοποιεί `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Η απενεργοποίηση της δυνατότητας εστίασης αποτελεί πρόβλημα για τους χρήστες με περιορισμένη όραση που βασίζονται στη μεγέθυνση οθόνης, προκειμένου να βλέπουν σωστά τα περιεχόμενα μιας ιστοσελίδας. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Η απενεργοποίηση της δυνατότητας εστίασης αποτελεί πρόβλημα για τους χρήστες με περιορισμένη όραση που βασίζονται στη μεγέθυνση οθόνης για να βλέπουν σωστά τα περιεχόμενα μιας ιστοσελίδας. [Μάθετε περισσότερα](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "Το \"[user-scalable=\"no\"]\" χρησιμοποιείται στο στοιχείο \"<meta name=\"viewport\">\" ή το χαρακτηριστικό \"[maximum-scale]\" είναι λιγότερο από 5."
+    "message": "To χαρακτηριστικό `[user-scalable=\"no\"]` χρησιμοποιείται στο στοιχείο `<meta name=\"viewport\">` ή το χαρακτηριστικό `[maximum-scale]` έχει τιμή μικρότερη από 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "Το \"[user-scalable=\"no\"]\" δεν χρησιμοποιείται στο στοιχείο \"<meta name=\"viewport\">\" και το χαρακτηριστικό \"[maximum-scale]\" δεν είναι λιγότερο από 5."
+    "message": "To χαρακτηριστικό `[user-scalable=\"no\"]` δεν χρησιμοποιείται στο στοιχείο `<meta name=\"viewport\">` και το χαρακτηριστικό `[maximum-scale]` δεν έχει τιμή μικρότερη από 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Οι αναγνώστες οθόνης δεν μπορούν να μεταφράσουν περιεχόμενο που δεν είναι κείμενο. Η προσθήκη κειμένου alt σε στοιχεία \"<object>\" βοηθά τους αναγνώστες οθόνης να μεταβιβάσουν το νόημα στους χρήστες. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Οι αναγνώστες οθόνης δεν μπορούν να μεταφράσουν περιεχόμενο που δεν είναι κείμενο. Η προσθήκη εναλλακτικού κειμένου στα στοιχεία `<object>` βοηθά τους αναγνώστες οθόνης να αποδίδουν το νόημα στους χρήστες. [Μάθετε περισσότερα](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Τα στοιχεία \"<object>\" δεν έχουν κείμενο \"[alt]\""
+    "message": "Τα στοιχεία `<object>` δεν έχουν κείμενο `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Τα στοιχεία \"<object>\" έχουν κείμενο \"[alt]\""
+    "message": "Τα στοιχεία `<object>` έχουν κείμενο `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Μια τιμή μεγαλύτερη από 0 υποδηλώνει μια ρητή σειρά πλοήγησης. Αν και αυτό είναι ορθό από τεχνικής άποψης, συχνά δημιουργεί αρνητική εμπειρία στους χρήστες που βασίζονται στις τεχνολογίες για άτομα με ειδικές ανάγκες. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Μια τιμή μεγαλύτερη από 0 υποδηλώνει μια ρητή σειρά πλοήγησης. Εάν και ορθό από τεχνικής άποψης, αυτό συχνά επηρεάζει αρνητικά την εμπειρία των χρηστών που βασίζονται στις τεχνολογίες υποβοήθησης. [Μάθετε περισσότερα](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Ορισμένα στοιχεία έχουν τιμή \"[tabindex]\" μεγαλύτερη από 0"
+    "message": "Ορισμένα στοιχεία έχουν μια τιμή `[tabindex]` μεγαλύτερη από 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Κανένα στοιχείο δεν έχει τιμή \"[tabindex]\" μεγαλύτερη από 0"
+    "message": "Κανένα στοιχείο δεν έχει τιμή `[tabindex]` μεγαλύτερη από 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Οι αναγνώστες οθόνης έχουν λειτουργίες που κάνουν ευκολότερη την πλοήγηση στους πίνακες. Η παραπομπή των κελιών \"<td>\" που χρησιμοποιούν το χαρακτηριστικό \"[headers]\" μόνο σε άλλα κελιά του ίδιου πίνακα μπορεί να βελτιώσει την εμπειρία για τους χρήστες του αναγνώστη οθόνης. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Οι αναγνώστες οθόνης έχουν λειτουργίες που διευκολύνουν την πλοήγηση στους πίνακες. Διασφαλίζοντας ότι τα κελιά `<td>` που χρησιμοποιούν το χαρακτηριστικό `[headers]` παραπέμπουν μόνο σε άλλα κελιά στον ίδιο πίνακα, μπορείτε να βελτιώσετε την εμπειρία των χρηστών των αναγνωστών οθόνης. [Μάθετε περισσότερα](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Τα κελιά σε ένα στοιχείο \"<table>\" που χρησιμοποιούν το χαρακτηριστικό \"[headers]\" παραπέμπουν σε άλλα κελιά του ίδιου πίνακα."
+    "message": "Τα κελιά σε ένα στοιχείο `<table>` που χρησιμοποιούν το χαρακτηριστικό `[headers]` παραπέμπουν σε άλλα κελιά του ίδιου πίνακα."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Κελιά σε ένα στοιχείο \"<table>\" που χρησιμοποιούν το χαρακτηριστικό \"[headers]\" παραπέμπουν μόνο σε άλλα κελιά του ίδιου πίνακα."
+    "message": "Τα κελιά σε ένα στοιχείο `<table>` που χρησιμοποιούν το χαρακτηριστικό `[headers]` παραπέμπουν μόνο σε άλλα κελιά του ίδιου πίνακα."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Οι αναγνώστες οθόνης έχουν λειτουργίες που κάνουν ευκολότερη την πλοήγηση στους πίνακες. Η παραπομπή των κεφαλίδων πίνακα πάντα σε κάποιο σύνολο κελιών μπορεί να βελτιώσει την εμπειρία για τους χρήστες του αναγνώστη οθόνης. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Οι αναγνώστες οθόνης έχουν λειτουργίες που διευκολύνουν την πλοήγηση στους πίνακες. Διασφαλίζοντας ότι οι κεφαλίδες πίνακα παραπέμπουν πάντα σε ένα σύνολο κελιών του πίνακα, μπορείτε να βελτιώσετε την εμπειρία των χρηστών των αναγνωστών οθόνης. [Μάθετε περισσότερα](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Τα στοιχεία \"<th>\" και τα στοιχεία με \"[role=\"columnheader\"/\"rowheader\"]\" δεν έχουν κελιά δεδομένων που περιγράφουν."
+    "message": "Τα στοιχεία `<th>` και τα στοιχεία με `[role=\"columnheader\"/\"rowheader\"]` δεν έχουν τα κελιά δεδομένων που περιγράφουν."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Τα στοιχεία \"<th>\" και τα στοιχεία με \"[role=\"columnheader\"/\"rowheader\"]\" έχουν κελιά δεδομένων που περιγράφουν."
+    "message": "Τα στοιχεία `<th>` και τα στοιχεία με `[role=\"columnheader\"/\"rowheader\"]` έχουν τα κελιά δεδομένων που περιγράφουν."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Ο ορισμός μιας έγκυρης [γλώσσας BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) στα στοιχεία διασφαλίζει ότι ο αναγνώστης οθόνης θα εκφωνήσει σωστά το κείμενο. [Μάθετε περισότερα](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ο ορισμός μιας έγκυρης [γλώσσας BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) στα στοιχεία συμβάλλει στο να διασφαλιστεί ότι ο αναγνώστης οθόνης θα εκφωνήσει σωστά το κείμενο. [Μάθετε περισσότερα](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Τα χαρακτηριστικά \"[lang]\" δεν έχουν έγκυρη τιμή"
+    "message": "Τα χαρακτηριστικά `[lang]` δεν έχουν έγκυρη τιμή"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Τα χαρακτηριστικά \"[lang]\" έχουν έγκυρη τιμή"
+    "message": "Τα χαρακτηριστικά `[lang]` έχουν μια έγκυρη τιμή"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Όταν ένα βίντεο περιέχει υπότιτλο, είναι πιο εύκολο για τους χρήστες που είναι κωφοί ή έχουν προβλήματα ακοής να αποκτήσουν πρόσβαση στις πληροφορίες του. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Όταν ένα βίντεο περιέχει υπότιτλους, διευκολύνεται η πρόσβαση των χρηστών που είναι κωφοί ή έχουν προβλήματα ακοής στις πληροφορίες που περιέχει. [Μάθετε περισσότερα](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Τα στοιχεία \"<video>\" δεν περιέχουν ένα στοιχείο \"<track>\" με \"[kind=\"captions\"]\"."
+    "message": "Τα στοιχεία `<video>` δεν περιέχουν ένα στοιχείο `<track>` με `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Τα στοιχεία \"<video>\" περιέχουν ένα στοιχείο \"<track>\" με \"[kind=\"captions\"]\""
+    "message": "Τα στοιχεία `<video>` περιέχουν ένα στοιχείο `<track>` με `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Οι ηχητικές περιγραφές παρέχουν σχετικές πληροφορίες για βίντεο, τις οποίες δεν μπορεί να παρέχει ο διάλογος, όπως εκφράσεις προσώπου και σκηνές. [Μάθετε περισσότερα](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Οι ηχητικές περιγραφές παρέχουν πληροφορίες για τα βίντεο, οι οποίες δεν μπορούν να αποδοθούν μέσω των διαλόγων, όπως οι εκφράσεις προσώπου και το σκηνικό δράσης. [Μάθετε περισσότερα](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Τα στοιχεία \"<video>\" δεν περιέχουν ένα στοιχείο \"<track>\" με \"[kind=\"description\"]\"."
+    "message": "Τα στοιχεία `<video>` δεν περιέχουν ένα στοιχείο `<track>` με `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Τα στοιχεία \"<video>\" περιέχουν ένα στοιχείο \"<track>\" με \"[kind=\"description\"]\""
+    "message": "Τα στοιχεία `<video>` περιέχουν ένα στοιχείο `<track>` με `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Για την ιδανική εμφάνιση σε ένα περιβάλλον iOS όταν οι χρήστες προσθέτουν στοιχεία στην αρχική οθόνη, ορίστε ένα apple-touch-icon. Το εικονίδιο πρέπει να παραπέμπει σε μια μη διαφανή, τετράγωνη εικόνα PNG 192px (ή 180px). [Μάθετε περισσότερα](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Δεν παρέχει ένα έγκυρο `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Το `apple-touch-icon-precomposed` δεν είναι ενημερωμένο. Συνιστάται η χρήση του `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Παρέχει ένα έγκυρο `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Οι επεκτάσεις του Chrome επηρέασαν αρνητικά την απόδοση φόρτωσης αυτής της σελίδας. Δοκιμάστε να ελέγξετε τη σελίδα σε κατάσταση ανώνυμης περιήγησης ή από ένα προφίλ του Chrome χωρίς επεκτάσεις."
@@ -330,7 +342,7 @@
     "message": "Συνολικός χρόνος CPU"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Εξετάστε το ενδεχόμενο μείωσης του χρόνου ανάλυσης, σύνθεσης και εκτέλεσης JS. Μπορεί να διαπιστώσετε ότι η προβολή μικρότερων φορτίων δεδομένων JS συμβάλλει προς αυτήν την κατεύθυνση. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Εξετάστε το ενδεχόμενο να ελαττώσετε τον χρόνο ανάλυσης, σύνθεσης και εκτέλεσης JS. Μπορεί να διαπιστώσετε ότι η προβολή μικρότερων φορτίων δεδομένων JS συμβάλλει προς αυτή την κατεύθυνση. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Μείωση χρόνου εκτέλεσης JavaScript"
@@ -339,25 +351,25 @@
     "message": "Χρόνος εκτέλεσης JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Οι μεγάλες εικόνες GIF δεν είναι αποδοτικές για την προβολή περιεχομένου κινούμενων εικόνων. Εξετάστε το ενδεχόμενο χρήσης βίντεο MPEG4/WebM για κινούμενες εικόνες και PNG/WebP για στατικές εικόνες αντί για τη χρήση εικόνων GIF, με στόχο την εξοικονόμηση byte δικτύου. [Μάθετε περισσότερα](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Οι μεγάλες εικόνες GIF δεν είναι αποδοτικές για την προβολή περιεχομένου κινούμενων εικόνων. Εξετάστε το ενδεχόμενο, αντί για τη χρήση εικόνων GIF, να χρησιμοποιείτε βίντεο MPEG4/WebM για τις κινούμενες εικόνες και εικόνες PNG/WebP για τις στατικές εικόνες, ώστε να εξοικονομήσετε byte δικτύου. [Μαθετε περισσότερα](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)."
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Χρήση μορφών βίντεο για περιεχόμενο κινούμενων εικόνων"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Εξετάστε τη φόρτωση εικόνων εκτός οθόνης και κρυφών εικόνων με καθυστέρηση μετά την ολοκλήρωση της φόρτωσης όλων των σημαντικών πόρων, προκειμένου να ελαττωθεί ο χρόνος μετάβασης σε κατάσταση αλληλεπίδρασης. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Εξετάστε το ενδεχόμενο αργής φόρτωσης των εικόνων εκτός οθόνης και των κρυφών εικόνων μετά τη φόρτωση όλων των κρίσιμων πόρων. Με αυτό τον τρόπο, μπορεί να ελλατώθεί ο χρόνος μετάβασης σε κατάσταση αλληλεπίδρασης. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Καθυστέρηση φόρτωσης εικόνων εκτός οθόνης"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Υπάρχουν πόροι οι οποίοι αποκλείουν την πρώτη μορφή της σελίδας σας. Εξετάστε το ενδεχόμενο προβολής σημαντικών ενσωματωμένων JS/CSS και καθυστέρησης όλων των μη σημαντικών JS/στυλ. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Υπάρχουν πόροι οι οποίοι αποκλείουν την πρώτη μορφή της σελίδας σας. Εξετάστε το ενδεχόμενο τα κρίσιμα JS/CSS να προβάλλονται ενσωματωμένα και τα μη κρίσιμα JS/στιλ να φορτώνονται αργότερα. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Εξάλειψη πόρων που αποκλείουν την απόδοση"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Τα μεγάλα φορτία δεδομένων δικτύου συνεπάγονται υψηλό χρηματικό κόστος για τους χρήστες και συσχετίζονται σε μεγάλο βαθμό με εκτενείς χρόνους φόρτωσης. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Τα μεγάλα φορτία δικτύου συνεπάγονται οικονομικό κόστος για τους χρήστες και σχετίζονται σε μεγάλο βαθμό με εκτενείς χρόνους φόρτωσης. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Το συνολικό μέγεθος ήταν {totalBytes, number, bytes} KB"
@@ -369,19 +381,19 @@
     "message": "Αποφεύγει τα πολύ μεγάλα φορτία δεδομένων δικτύου"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Με την ελαχιστοποίηση των αρχείων CSS, μπορεί να ελαττωθούν τα μεγέθη φορτίου δεδομένων δικτύου. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "H ελαχιστοποίηση των αρχείων CSS μπορεί να μειώσει τα μεγέθη φορτίων δικτύου. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Ελαχιστοποίηση CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Με την ελαχιστοποίηση των αρχείων JavaScript, μπορεί να μειωθούν τα μεγέθη φορτίου δεδομένων και να ελαττωθεί ο χρόνος ανάλυσης σεναρίου. [Μάθετε περισσότερα](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Η ελαχιστοποίηση των αρχείων JavaScript μπορεί να ελαττώσει το φορτίο, τα μεγέθη και τον χρόνο ανάλυσης σεναρίων. [Μάθετε περισσότερα](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Ελαχιστοποίηση JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Καταργήστε τυχόν ανενεργούς κανόνες από φύλλα στιλ και αναβάλετε τη φόρτωση CSS που δεν χρησιμοποιείται για περιεχόμενο στο επάνω μέρος, για να ελαττώσετε τα περιττά byte που καταναλώνονται από τη δραστηριότητα δικτύου. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Καταργήστε τους ανενεργούς κανόνες από τα φύλλα στιλ και αναβάλετε τη φόρτωση των CSS που δεν χρησιμοποιούνται για το περιεχόμενο στο πάνω μέρος της σελίδας, για να ελαττώσετε τα περιττά byte που καταναλώνονται από τη δραστηριότητα δικτύου. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Κατάργηση CSS που δεν χρησιμοποιείται"
@@ -411,31 +423,82 @@
     "message": "Αποδοτική κωδικοποίηση εικόνων"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Προβάλετε εικόνες κατάλληλου μεγέθους, για την εξοικονόμηση δεδομένων κινητής τηλεφωνίας και τη βελτίωση του χρόνου φόρτωσης. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Συνιστάται η προβολή εικόνων κατάλληλου μεγέθους για την εξοικονόμηση δεδομένων κινητής τηλεφωνίας και τη βελτίωση του χρόνου φόρτωσης. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Κατάλληλη προσαρμογή μεγέθους εικόνων"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Οι πόροι που βασίζονται σε κείμενο θα πρέπει να προβάλλονται με συμπίεση (gzip, deflate ή brotli), προκειμένου να ελαχιστοποιούνται τα byte δικτύου. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Η προβολή των βασιζόμενων σε κείμενο πόρων πρέπει να γίνεται με συμπίεση (gzip, deflate ή brotli), ώστε να ελαχιστοποιείται ο συνολικός όγκος byte δικτύου. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Ενεργοποίηση συμπίεσης κειμένου"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Οι μορφές εικόνας όπως JPEG 2000, JPEG XR και WebP συχνά παρέχουν καλύτερη συμπίεση από ό,τι οι μορφές PNG και JPEG. Αυτό σημαίνει γρηγορότερες λήψεις και μικρότερη κατανάλωση δεδομένων. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Οι μορφές εικόνας JPEG 2000, JPEG XR και WebP συχνά παρέχουν καλύτερη συμπίεση από ό,τι οι μορφές PNG και JPEG. Αυτό σημαίνει γρηγορότερες λήψεις και μικρότερη κατανάλωση δεδομένων. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Προβολή εικόνων σε μορφές επόμενης γενιάς"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Οι Αλυσίδες κρίσιμων αιτημάτων που ακολουθούν δείχνουν τους πόρους που φορτώνονται με υψηλή προτεραιότητα. Εξετάστε το ενδεχόμενο μείωσης του μεγέθους των αλυσίδων, μείωσης του μεγέθους λήψης πόρων ή καθυστέρησης της λήψης μη απαραίτητων πόρων, για τη βελτίωση της φόρτωσης σελίδας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Στις ακόλουθες αλυσίδες κρίσιμων αιτημάτων φαίνεται ποιοι πόροι φορτώνονται με υψηλή προτεραιότητα. Για τη βελτίωση της φόρτωσης των σελίδων, εξετάστε το ενδεχόμενο μείωσης του μεγέθους των αλυσίδων, μείωσης του μεγέθους λήψης πόρων ή καθυστέρησης λήψης των μη απαραίτητων πόρων. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Βρέθηκε 1 αλυσίδα}other{Βρέθηκαν # αλυσίδες}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Ελαχιστοποίηση βάθους κρίσιμων αιτημάτων"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Κατάργηση / Προειδοποίηση"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Γραμμή"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Τα καταργημένα API θα αφαιρεθούν κάποια στιγμή από το πρόγραμμα περιήγησης. [Μάθετε περισσότερα](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Βρέθηκε 1 προειδοποίηση}other{Βρέθηκαν # προειδοποιήσεις}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Χρησιμοποιεί καταργημένα API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Αποφυγή καταργημένων API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Η κρυφή μνήμη εφαρμογής έχει καταργηθεί. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Βρέθηκε \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Χρησιμοποιεί προσωρινή μνήμη εφαρμογής"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Αποφυγή προσωρινής μνήμης εφαρμογής"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Ο ορισμός ενός τύπου εγγράφου (doctype) εμποδίζει τη μετάβαση του προγράμματος περιήγησης στη λειτουργία ιδιαιτεροτήτων (quirks-mode). Διαβάστε περισσότερα σχετικά με τη [σελίδα MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Το όνομα τύπου εγγράφου (doctype) πρέπει να είναι μια συμβολοσειρά `html` με πεζούς χαρακτήρες."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Το έγγραφο πρέπει να περιέχει έναν τύπο εγγράφου (doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Το αναγνωριστικό publicId αναμενόταν να είναι μια κενή συμβολοσειρά"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Το αναγνωριστικό systemId αναμενόταν να είναι μια κενή συμβολοσειρά"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Από τη σελίδα λείπει ο τύπος εγγράφου (doctype) HTML, με αποτέλεσμα να ενεργοποιείται η λειτουργία ιδιαιτεροτήτων (quirks-mode)."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Η σελίδα έχει τύπο εγγράφου (doctype) HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Στοιχείο"
@@ -447,7 +510,7 @@
     "message": "Τιμή"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Οι μηχανικοί προγραμμάτων περιήγησης συνιστούν να περιέχουν οι σελίδες λιγότερα από ~1.500 στοιχεία DOM. Το ιδανικό είναι ένα βάθος δέντρου με < 32 στοιχεία και λιγότερα από 60 θυγατρικά/γονικά στοιχεία. Ένα μεγάλο DOM μπορεί να αυξήσει τη χρήση της μνήμης, να προκαλέσει μεγαλύτερης διάρκειας [υπολογισμούς στιλ](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) και να δημιουργήσει υψηλού κόστους [επαναλήψεις ροής διάταξης](https://developers.google.com/speed/articles/reflow). [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Οι μηχανικοί προγραμμάτων περιήγησης συνιστούν οι σελίδες να περιέχουν λιγότερα από 1.500 στοιχεία DOM. Το ιδανικό είναι μια δενδρική δομή με βάθος έως 32 στοιχεία και λιγότερα από 60 θυγατρικά/γονικά στοιχεία. Ένα μεγάλο DOM μπορεί να αυξήσει τη χρήση της μνήμης, να προκαλέσει [υπολογισμούς στιλ](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) μεγαλύτερης διάρκειας και να δημιουργήσει [ανανεώσεις ροών διάταξης](https://developers.google.com/speed/articles/reflow) υψηλού κόστους. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 στοιχείο}other{# στοιχεία}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Αποφεύγει τα υπερβολικά μεγάλα μεγέθη DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Στόχος"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Προσθέστε ένα στοιχείο `rel=\"noopener\"` ή `rel=\"noreferrer\"` στους εξωτερικούς συνδέσμους για να βελτιώσετε την απόδοση και να αποφύγετε τις ευπάθειες ασφάλειας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Οι σύνδεσμοι με προορισμούς διασταυρούμενων προελεύσεων δεν είναι ασφαλείς"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Οι σύνδεσμοι με προορισμούς διασταυρούμενων προελεύσεων είναι ασφαλείς"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Δεν ήταν δυνατός ο προσδιορισμός του προορισμού για την αγκύρωση ({anchorHTML}). Εάν δεν χρησιμοποιείται ως υπερσύνδεσμος, εξετάστε το ενδεχόμενο να καταργήσετε το χαρακτηριστικό target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Οι ιστότοποι που απαιτούν τη γνωστοποίηση τοποθεσίας χωρίς προφανή αιτία προκαλούν σύγχυση ή φαίνονται ύποπτοι στους χρήστες. Συνιστάται τα αιτήματα να συνδέονται με τις ενέργειες των χρηστών. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Αίτημα για άδεια εντοπισμού γεωγραφικής τοποθεσίας κατά τη φόρτωση σελίδων"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Αποφυγή αιτήματος για άδεια εντοπισμού γεωγραφικής τοποθεσίας κατά τη φόρτωση σελίδων"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Έκδοση"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Όλες οι βιβλιοθήκες JavaScript διεπαφής εντοπίστηκαν στη σελίδα."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Εντοπίστηκαν βιβλιοθήκες JavaScript"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Για τους χρήστες με αργές συνδέσεις, η δυναμική ενσωμάτωση εξωτερικών σεναρίων μέσω `document.write()` μπορεί να καθυστερήσει τη φόρτωση των σελίδων για δεκάδες δευτερόλεπτα. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Χρησιμοποιεί `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Αποφυγή `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Υψηλότερη σοβαρότητα"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Έκδοση βιβλιοθήκης"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Πλήθος ευπαθειών"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Ορισμένα σενάρια τρίτων μπορεί να έχουν γνωστές ευπάθειες ασφάλειας τις οποίες μπορούν εύκολα να εντοπίσουν και να εκμεταλλευτούν οι επίδοξοι εισβολείς. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Εντοπίστηκε 1 ευπάθεια}other{Εντοπίστηκαν # ευπάθειες}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Συμπερίληψη βιβλιοθηκών JavaScript διεπαφής με γνωστές ευπάθειες ασφάλειας"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Υψηλή"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Χαμηλή"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Μέτρια"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Αποφυγή όλων των βιβλιοθηκών JavaScript διεπαφής με γνωστές ευπάθειες ασφάλειας"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Οι ιστότοποι που απαιτούν την αποστολή ειδοποιήσεων χωρίς προφανή αιτία προκαλούν σύγχυση ή φαίνονται ύποπτοι στους χρήστες. Συνιστάται τα αιτήματα να συνδέονται με τις κινήσεις των χρηστών. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Αίτημα για άδεια ειδοποίησης κατά τη φόρτωση σελίδων"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Αποφυγή αιτήματος για άδεια ειδοποίησης κατά τη φόρτωση σελίδων"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Στοιχεία που απέτυχαν"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Η απαγόρευση της επικόλλησης κωδικών πρόσβασης υπονομεύει την ορθή πολιτική ασφάλειας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Εμποδίζει την επικόλληση στα πεδία κωδικών πρόσβασης από τους χρήστες"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Επιτρέπει την επικόλληση στα πεδία κωδικών πρόσβασης από τους χρήστες"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Πρωτόκολλο"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "Το HTTP/2 παρέχει περισσότερα πλεονεκτήματα σε σχέση με το HTTP/1.1, όπως οι δυαδικές κεφαλίδες, η πολυπλεξία και η λειτουργία αποστολής push από διακομιστή. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 αίτημα δεν εξυπηρετήθηκε μεσω HTTP/2}other{# αιτήματα δεν εξυπηρετήθηκαν μέσω HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Δεν χρησιμοποιεί HTTP/2 για όλους τους πόρους της"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Χρησιμοποιεί HTTP/2 για τους πόρους της"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Εξετάστε το ενδεχόμενο να επισημάνετε τις λειτουργίες επεξεργασίας συμβάντων αφής και χρήσης τροχού κύλισης ως `passive` για να βελτιώσετε την απόδοση κύλισης της σελίδας σας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Δεν χρησιμοποιεί παθητικές λειτουργίες επεξεργασίας συμβάντων για τη βελτίωση της απόδοσης κύλισης"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Χρησιμοποιεί παθητικές λειτουργίες επεξεργασίας συμβάντων για τη βελτίωση της απόδοσης κύλισης"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Περιγραφή"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Τα καταγεγραμμένα στην κονσόλα σφάλματα υποδεικνύουν ότι υπάρχουν προβλήματα που δεν έχουν επιλυθεί. Μπορεί να σχετίζονται με σφάλματα αιτημάτων δικτύου ή με άλλα ζητήματα του προγράμματος περιήγησης."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Έχουν καταγραφεί σφάλματα προγράμματος περιήγησης στην κονσόλα"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Δεν έχουν καταγραφεί σφάλματα προγράμματος περιήγησης στην κονσόλα"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Χρησιμοποιήστε τη λειτουργία CSS προβολής γραμματοσειράς, για να διασφαλίσετε ότι το κείμενο είναι ορατό στους χρήστες κατά τη φόρτωση των γραμματοσειρών ιστοτόπου. [Μάθετε περισσότερα](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Αξιοποιήστε τη λειτουργία CSS προβολής γραμματοσειρών (font-display), για να διασφαλίσετε ότι το κείμενο είναι ορατό στους χρήστες κατά τη φόρτωση των γραμματοσειρών ιστοτόπου. [Μάθετε περισσότερα](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Βεβαιωθείτε ότι το κείμενο παραμένει ορατό κατά τη διάρκεια της φόρτωσης γραμματοσειράς ιστοτόπου"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Όλο το κείμενο παραμένει ορατό κατά τη διάρκεια φορτώσεων γραμματοσειράς ιστοτόπου"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Το Lighthouse δεν μπόρεσε να ελέγξει αυτόματα την τιμή προβολής γραμματοσειράς (font-display) για το ακόλουθο URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Λόγος διαστάσεων (Πραγματικός)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Λόγος διαστάσεων (Προβολή)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Οι διαστάσεις προβολής των εικόνων πρέπει να συμφωνούν με τον φυσικό λόγο διαστάσεων. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Προβάλλει τις εικόνες με εσφαλμένο λόγο διαστάσεων"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Προβάλλει τις εικόνες με τον σωστό λόγο διαστάσεων"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Μη έγκυρες πληροφορίες διαστάσεων εικόνας {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Μη ασφαλές URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Όλοι οι ιστότοποι πρέπει να προστατεύονται με HTTPS, ακόμα και αν δεν χειρίζονται ευαίσθητα δεδομένα. Το HTTPS εμποδίζει τους εισβολείς από την αλλοίωση ή την παθητική ακρόαση των επικοινωνιών μεταξύ της εφαρμογής και των χρηστών σας. Επιπλέον, αποτελεί προαπαιτούμενο για το HTTP/2 και πολλά νέα API πλατφορών ιστού. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Βρέθηκε 1 μη ασφαλές αίτημα}other{Βρέθηκαν # μη ασφαλή αιτήματα}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Δεν χρησιμοποιεί HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Χρησιμοποιεί HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Η γρήγορη φόρτωση σελίδων μέσω ενός δικτύου κινητής τηλεφωνίας διασφαλίζει μια καλή εμπειρία χρήστη σε κινητά. [Μάθετε περισότερα](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Η γρήγορη φόρτωση των σελίδων μέσω ενός δικτύου κινητής τηλεφωνίας διασφαλίζει μια καλή εμπειρία για τους χρήστες κινητών. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Έγινε διαδραστική σε {timeInMs, number, seconds} δευτ."
+    "message": "Διαδραστική σε {timeInMs, number, seconds} δ."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Έγινε διαδραστική σε προσομοιωμένο δίκτυο κινητής τηλεφωνίας σε {timeInMs, number, seconds} δευτ."
+    "message": "Διαδραστική σε προσομοιωμένο δίκτυο κινητής τηλεφωνίας σε {timeInMs, number, seconds} δ."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Η φόρτωση σελίδας δεν είναι αρκετά γρήγορη σε δίκτυα κινητής τηλεφωνίας"
@@ -504,70 +735,97 @@
     "message": "Ελαχιστοποιεί την εργασία κύριου νήματος"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Ο Εκτιμώμενος λανθάνων χρόνος στοιχείων εισόδου αποτελεί εκτίμηση του χρόνου που απαιτείται προκειμένου η εφαρμογή σας να ανταποκριθεί στα στοιχεία εισόδου χρήστη, σε χιλιοστά του δευτερολέπτου, κατά τη διάρκεια εκτέλεσης του παραθύρου φόρτωσης σελίδας 5 δευτ. με τη μεγαλύτερη κινητικότητα. Εάν ο λανθάνων χρόνος είναι μεγαλύτερος από 50 ms, οι χρήστες μπορεί να θεωρήσουν ότι η εφαρμογή σας είναι αργή. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Ο εκτιμώμενος λανθάνων χρόνος στοιχείων εισόδου αποτελεί εκτίμηση του χρόνου που απαιτείται, σε χιλιοστά του δευτερολέπτου, προκειμένου η εφαρμογή σας να ανταποκριθεί στα στοιχεία εισόδου χρήστη στο διάστημα των 5 δευτερολέπτων με τον μεγαλύτερο φόρτο κατά τη φόρτωση της σελίδας. Εάν ο λανθάνων χρόνος είναι μεγαλύτερος από 50 χιλιοστά δευτερολέπτου, οι χρήστες μπορεί να θεωρήσουν ότι η εφαρμογή σας είναι αργή. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Εκτιμώμενος λανθάνων χρόνος στοιχείων εισόδου"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Η Πρώτη σχεδίαση περιεχομένου (FCP) υποδεικνύει πότε μορφοποιείται το πρώτο κείμενο ή η πρώτη εικόνα. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Η πρώτη μορφή με περιεχόμενο υποδεικνύει πότε σχεδιάζεται το πρώτο κείμενο ή η πρώτη εικόνα. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Πρώτη μορφή με περιεχόμενο"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "Η Πρώτη αδράνεια CPU υποδεικνύει την πρώτη φορά που το κύριο νήμα μιας σελίδας παρουσιάζει αρκετά χαμηλή κινητικότητα έτσι ώστε να διαχειριστεί στοιχεία εισόδου. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "Η πρώτη αδράνεια CPU υποδεικνύει πότε είναι η πρώτη φορά που η δραστηριότητα του κύριου νήματος είναι τόσο χαμηλή ώστε να διαχειριστεί στοιχεία εισόδου. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Πρώτη αδράνεια CPU"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Η Πρώτη χρήσιμη μορφή υπολογίζει πότε είναι ορατό το κύριο περιεχόμενο μιας σελίδας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Η πρώτη χρήσιμη μορφή υπολογίζει πότε καθίσταται ορατό το κύριο περιεχόμενο μιας σελίδας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Πρώτη χρήσιμη μορφή"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Ο Χρόνος για Αλληλεπίδραση είναι το διάστημα χρόνου που απαιτείται προκειμένου η σελίδα να γίνει πλήρως διαδραστική. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Ο χρόνος για αλληλεπίδραση είναι το χρονικό διάστημα που απαιτείται προκειμένου η σελίδα να γίνει πλήρως διαδραστική. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Χρόνος για Αλληλεπίδραση"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Η δυνητική Καθυστέρηση πρώτης εισόδου που θα μπορούσαν να αντιμετωπίσουν οι χρήστες σας είναι η διάρκεια, σε χιλιοστά του δευτερολέπτου, της πιο χρονοβόρας εργασίας."
+    "message": "Η μέγιστη δυνητική καθυστέρηση πρώτης εισόδου που θα μπορούσαν να αντιμετωπίσουν οι χρήστες είναι η διάρκεια, σε χιλιοστά δευτερολέπτου, της πιο χρονοβόρας εργασίας. [Μάθετε περισσότερα](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Μέγιστη δυνητική καθυστ. πρώτης εισόδου"
+    "message": "Μέγ. δυνατή καθυστέρηση πρώτης εισόδου"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Το Ευρετήριο ταχύτητας δείχνει πόσο γρήγορα γίνονται ορατά τα περιεχόμενα μιας σελίδας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Το ευρετήριο ταχύτητας δηλώνει πόσο γρήγορα γίνεται ορατό το περιεχόμενο μιας σελίδας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Ευρετήριο ταχύτητας"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Η συνολική διάρκεια, σε χιλιοστά δευτερολέπτου, των χρονικών διαστημάτων από την πρώτη μορφή με περιεχόμενο μέχρι τον χρόνο για αλληλεπίδραση, όταν η διάρκεια της εργασίας υπερβαίνει τα 50 χιλιοστά δευτερολέπτου."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Συνολικός χρόνος αποκλεισμού"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Οι χρόνοι αποστολής και επιστροφής δικτύου (RTT) έχουν μεγάλο αντίκτυπο στην απόδοση. Εάν ο χρόνος RTT προς μια προέλευση είναι υψηλός, αυτό αποτελεί ένδειξη ότι η χρήση διακομιστών πιο κοντά στον χρήστη θα μπορούσαν να βελτιώσουν την απόδοση. [Μάθετε περισσότερα](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Οι χρόνοι αποστολής και επιστροφής δικτύου (RTT) έχουν μεγάλο αντίκτυπο στην απόδοση. Εάν ο χρόνος RTT προς μια προέλευση είναι υψηλός, αυτό σημαίνει ότι η χρήση διακομιστών πιο κοντά στον χρήστη θα μπορούσε να βελτιώσει την απόδοση. [Μάθετε περισσότερα](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Χρόνοι αποστολής και επιστροφής δικτύου"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Οι λανθάνοντες χρόνοι διακομιστών μπορούν να επηρεάσουν την απόδοση στον ιστό. Εάν ο λανθάνων χρόνος του διακομιστή μιας προέλευσης είναι υψηλός, αυτό αποτελεί ένδειξη ότι ο διακομιστής είναι υπερφορτωμένος ή ότι έχει ανεπαρκές σύστημα υποστήριξης. [Μάθετε περισσότερα](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Οι λανθάνοντες χρόνοι των διακομιστών μπορούν να επηρεάσουν την απόδοση στον ιστό. Εάν ο λανθάνων χρόνος του διακομιστή μιας προέλευσης είναι υψηλός, αυτό αποτελεί ένδειξη ότι ο διακομιστής είναι υπερφορτωμένος ή ότι έχει ανεπαρκές σύστημα υποστήριξης. [Μάθετε περισσότερα](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Λανθάνοντες χρόνοι συστημάτων υποστήριξης διακομιστή"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Υπέρβαση προϋπολογισμού"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Διατηρήστε την ποσότητα και το μέγεθος των αιτημάτων δικτύου εντός των στόχων που ορίζονται από τον παρεχόμενο προϋπολογισμό απόδοσης. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 αίτημα}other{# αιτήματα}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Προϋπολογισμός απόδοσης"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Οι ανακατευθύνσεις δημιουργούν επιπλέον καθυστερήσεις προτού να είναι δυνατή η φόρτωση της σελίδας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Οι ανακατευθύνσεις προκαλούν πρόσθετες καθυστερήσεις στη φόρτωση της σελίδας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Αποφυγή ανακατευθύνσεων πολλών σελίδων"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Για τον ορισμό προϋπολογισμών για την ποσότητα και το μέγεθος των πόρων μιας σελίδας, προσθέστε ένα αρχείο budget.json. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 αίτημα}other{# αιτήματα}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Φροντίστε να διατηρείτε το πλήθος των αιτημάτων χαμηλό και το μέγεθος των μεταφορών μικρό"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Οι κανονικοί σύνδεσμοι προτείνουν ποιο URL πρέπει να εμφανιστεί στα αποτελέσματα αναζήτησης. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Οι κανονικοί σύνδεσμοι προτείνουν το URL που πρέπει να εμφανιστεί στα αποτελέσματα αναζήτησης. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Υπάρχουν πολλά URL σε διένεξη ({urlList})"
+    "message": "Πολλά URL σε διένεξη ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "Παραπέμπει σε διαφορετικό τομέα ({url})"
@@ -576,7 +834,7 @@
     "message": "Μη έγκυρο URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Παραπέμπει σε τοποθεσία με διαφορετικό \"hreflang\" ({url})"
+    "message": "Παραπέμπει σε μια άλλη τοποθεσία `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Σχετικό URL ({url})"
@@ -585,25 +843,22 @@
     "message": "Παραπέμπει στο ριζικό URL του τομέα (την αρχική σελίδα), αντί για μια αντίστοιχη σελίδα περιεχομένου"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Το έγγραφο δεν έχει έγκυρο σύνδεσμο \"rel=canonical\""
+    "message": "Το έγγραφο δεν έχει ένα έγκυρο `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Το έγγραφο έχει έγκυρο σύνδεσμο \"rel=canonical\""
+    "message": "Το έγγραφο έχει ένα έγκυρο `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Τα μεγέθη γραμματοσειράς που είναι λιγότερο από 12px είναι πολύ μικρά για να είναι ευανάγνωστα και οι επισκέπτες από κινητά χρειάζεται να μεγεθύνουν την οθόνη πλησιάζοντας τα δάκτυλα, προκειμένου να διαβάσουν το περιεχόμενο. Προσπαθήστε πάνω από το 60% του κειμένου σελίδας να έχει μέγεθος μεγαλύτερο από ή ίσο με 12px. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Τα μεγέθη γραμματοσειράς κάτω από 12px είναι πολύ μικρά για να είναι ευανάγνωστα, με αποτέλεσμα οι επισκέπτες από κινητά να χρειάζεται να μεγεθύνουν με τα δάχτυλά τους τη σελίδα για να διαβάσουν το περιεχόμενο. Προσπαθήστε πάνω από το 60% του κειμένου της σελίδας να έχει μέγεθος μεγαλύτερο από ή ίσο με 12px. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "{decimalProportion, number, extendedPercent} ευανάγνωστο κειμένο"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} του κειμένου είναι πολύ μικρό."
+    "message": "{decimalProportion, number, extendedPercent} ευανάγνωστο κείμενο"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Το κείμενο είναι δυσανάγνωστο επειδή δεν υπάρχει βελτιστοποιημένη μεταετικέτα θύρα προβολής για οθόνες κινητών."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} του κειμένου είναι υπερβολικά μικρό (με βάση δείγμα {decimalProportionVisited, number, extendedPercent})."
+    "message": "{decimalProportion, number, extendedPercent} του κειμένου είναι πολύ μικρό (βάσει ενός δείγματος {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Το έγγραφο δεν χρησιμοποιεί ευανάγνωστα μεγέθη γραμματοσειράς"
@@ -615,10 +870,10 @@
     "message": "Οι σύνδεσμοι hreflang ενημερώνουν τις μηχανές αναζήτησης σχετικά με την έκδοση σελίδας που πρέπει να αναφέρουν στα αποτελέσματα αναζήτησης για μια συγκεκριμένη γλώσσα ή περιοχή. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Το έγγραφο δεν έχει έγκυρο χαρακτηριστικό \"hreflang\""
+    "message": "Το έγγραφο δεν έχει ένα έγκυρο `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Το έγγραφο έχει έγκυρο χαρακτηριστικό \"hreflang\""
+    "message": "Το έγγραφο έχει ένα έγκυρο `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Οι σελίδες με ανεπιτυχείς κωδικούς κατάστασης HTTP μπορεί να μην ευρετηριαστούν σωστά. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -630,7 +885,7 @@
     "message": "Η σελίδα αποκρίνεται με επιτυχή κωδικό κατάστασης HTTP"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Οι μηχανές αναζήτησης δεν μπορούν να συμπεριλάβουν τις σελίδες σας στα αποτελέσματα αναζήτησης, εάν δεν έχουν άδεια να τις ανιχνεύσουν. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Οι μηχανές αναζήτησης δεν μπορούν να συμπεριλάβουν τις σελίδες σας στα αποτελέσματα αναζήτησης, εάν δεν έχουν άδεια για την εκτέλεση ανίχνευσης σε αυτές. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Η σελίδα αποκλείεται από την ευρετηρίαση"
@@ -657,7 +912,7 @@
     "message": "Τα δομημένα δεδομένα είναι έγκυρα"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Οι περιγραφές μεταδεδομένων μπορούν να συμπεριληφθούν στα αποτελέσματα αναζήτησης, παρέχοντας μια περιεκτική σύνοψη του περιεχομένου σελίδας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Οι περιγραφές μεταδεδομένων μπορούν να συμπεριληφθούν στα αποτελέσματα αναζήτησης για τη συνόψιση του περιεχομένου των σελίδων. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Το κείμενο περιγραφής είναι κενό."
@@ -669,7 +924,7 @@
     "message": "Το έγγραφο έχει περιγραφή μεταδεδομένων"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Οι μηχανές αναζήτησης δεν μπορούν να ευρετηριάσουν περιεχόμενο προσθηκών, ενώ πολλές συσκευές περιορίζουν ή δεν υποστηρίζουν τις προσθήκες. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Οι μηχανές αναζήτησης δεν μπορούν να ευρετηριάσουν το περιεχόμενο των προσθηκών, ενώ πολλές συσκευές περιορίζουν ή δεν υποστηρίζουν τις προσθήκες. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "Το έγγραφο χρησιμοποιεί προσθήκες"
@@ -681,7 +936,7 @@
     "message": "Εάν το αρχείο σας robots.txt έχει εσφαλμένη μορφή, οι ανιχνευτές ενδεχομένως να μην μπορούν να κατανοήσουν με ποιον τρόπο θέλετε να γίνεται η ανίχνευση ή ευρετηρίαση του ιστοτόπου σας."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "Το αίτημα για αρχείο robots.txt επέστρεψε κωδικό κατάστασης HTTP: {statusCode}"
+    "message": "Το αίτημα για το αρχείο robots.txt επέστρεψε τον κωδικό κατάστασης HTTP: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{Βρέθηκε 1 σφάλμα}other{Βρέθηκαν # σφάλματα}}"
@@ -696,10 +951,10 @@
     "message": "Το αρχείο robots.txt είναι έγκυρο"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Τα στοιχεία αλληλεπίδρασης, όπως είναι τα κουμπιά και οι σύνδεσμοι, πρέπει να είναι αρκετά μεγάλα (48x48px), και με επαρκή χώρο γύρω τους, ώστε να μπορούν εύκολα να πατηθούν από τους χρήστες χωρίς να επικαλύπτουν άλλα στοιχεία. [Μάθετε περισσότερα](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Τα στοιχεία αλληλεπίδρασης, όπως είναι τα κουμπιά και οι σύνδεσμοι, πρέπει να είναι αρκετά μεγάλα (48x48px) και με επαρκή χώρο γύρω τους, ώστε να μπορούν να πατηθούν εύκολα από τους χρήστες χωρίς να επικαλύπτουν άλλα στοιχεία. [Μάθετε περισσότερα](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "{decimalProportion, number, percent} των στοιχείων που επιλέγονται με πάτημα έχουν κατάλληλο μέγεθος"
+    "message": "Το {decimalProportion, number, percent} των επιλεγόμενων με πάτημα στοιχείων έχουν κατάλληλο μέγεθος"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "Τα στοιχεία που επιλέγονται με πάτημα είναι υπερβολικά μικρά γιατί δεν υπάρχει βελτιστοποιημένη μεταετικέτα θύρας προβολής για οθόνες κινητών"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Αλληλεπικαλυπτόμενο στοιχείο επιλογής με πάτημα"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Μέγεθος"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Στοιχείο επιλογής με πάτημα"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Τα στοιχεία που επιλέγονται με πάτημα έχουν το κατάλληλο μέγεθος"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Χρόνος κύριου νήματος"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Τρίτο μέρος"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Ο κώδικας τρίτων παρόχων μπορεί να επηρεάσει σημαντικά την απόδοση φόρτωσης. Περιορίστε τον αριθμό των περιττών τρίτων παρόχων και προσπαθήστε η φόρτωση του κώδικα τρίτων παρόχων να γίνεται αφού πρώτα έχει ολοκληρωθεί η φόρτωση της σελίδας σας. [Μάθετε περισσότερα](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Βρέθηκε 1 τρίτο μέρος}other{Βρέθηκαν # τρίτα μέρη}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Χρήση κώδικα τρίτου"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Ο Χρόνος μέχρι το πρώτο byte προσδιορίζει πότε ο διακομιστής σας στέλνει μια απόκριση. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "Ο χρόνος μέχρι το πρώτο byte προσδιορίζει τον χρόνο που χρειάζεται για την αποστολή μιας απόκρισης από τον διακομιστή σας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "Το αρχείο ρίζας χρειάστηκε {timeInMs, number, milliseconds} ms"
+    "message": "Το ριζικό έγγραφο χρειάστηκε {timeInMs, number, milliseconds} χλστ.δ."
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "Μείωση χρόνων απόκρισης διακομιστή (TTFB)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Διάρκεια"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Όνομα"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Ώρα έναρξης"
   },
@@ -744,7 +1008,7 @@
     "message": "Τύπος"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Εξετάστε το ενδεχόμενο ενίσχυσης της εφαρμογής σας με το User Timing API, για να καταμετράτε την πραγματική απόδοση της εφαρμογής σας κατά τη διάρκεια σημαντικών εμπειριών χρήστη. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Εξετάστε το ενδεχόμενο να προσθέσετε στην εφαρμογή σας το API χρόνων χρήστη (User Timing API) για να μετράτε την πραγματική απόδοση της εφαρμογής σας κατά τη διάρκεια σημαντικών εμπειριών χρήστη. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 χρόνος χρήστη}other{# χρόνοι χρήστη}}"
@@ -753,19 +1017,19 @@
     "message": "Ενδείξεις και μετρήσεις Χρόνων χρήστη"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Βρέθηκε <link> προσύνδεσης για το \"{securityOrigin}\", αλλά δεν χρησιμοποιήθηκε από το πρόγραμμα περιήγησης. Ελέγξτε ότι χρησιμοποιείτε σωστά το χαρακτηριστικό \"crossorigin\"."
+    "message": "Βρέθηκε ένα <link> προσύνδεσης για το {securityOrigin}, αλλά δεν χρησιμοποιήθηκε από το πρόγραμμα περιήγησης. Ελέγξτε ότι χρησιμοποιείτε σωστά το χαρακτηριστικό `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Εξετάστε το ενδεχόμενο προσθήκης υποδείξεων πόρου προσύνδεσης ή προανάλυσης dns, για τη δημιουργία πρώιμων συνδέσεων σε σημαντικές προελεύσεις τρίτου μέρους. [Μάθετε περισσότερα](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Εξετάστε το ενδεχόμενο προσθήκης υποδείξεων πόρων προσύνδεσης ή προανάλυσης dns για τη δημιουργία πρώιμων συνδέσεων σε σημαντικές προελεύσεις τρίτων. [Μάθετε περισσότερα](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Προσύνδεση σε απαιτούμενες προελεύσεις"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Βρέθηκε <link> προφόρτωσης για το \"{preloadURL}\", αλλά δεν χρησιμοποιήθηκε από το πρόγραμμα περιήγησης. Ελέγξτε ότι χρησιμοποιείτε σωστά το χαρακτηριστικό \"crossorigin\"."
+    "message": "Βρέθηκε ένα <link> προφόρτωσης για το {preloadURL}, αλλά δεν χρησιμοποιήθηκε από το πρόγραμμα περιήγησης. Ελέγξτε ότι χρησιμοποιείτε σωστά το χαρακτηριστικό `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Εξετάστε το ενδεχόμενο χρήσης <link rel=φορτίου δεδομένων>, για να δώσετε προτεραιότητα στην ανάλυση πόρων των οποίων το αίτημα εμφανίζεται αργότερα στη σελίδα. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Εξετάστε το ενδεχόμενο χρήσης του `<link rel=preload>` για την προτεραιοποίηση της ανάκτησης των πόρων που τώρα ζητούνται αργότερα κατά τη φόρτωση της σελίδας. [Μάθετε περισσότερα](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Σημαντικά αιτήματα προφόρτωσης"
@@ -789,10 +1053,10 @@
     "message": "Βέλτιστες πρακτικές"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Αυτοί οι έλεγχοι επισημαίνουν ευκαιρίες για να [βελτιώσετε την προσβασιμότητα της εφαρμογής ιστού σας](https://developers.google.com/web/fundamentals/accessibility). Ο αυτόματος εντοπισμός μπορεί να εντοπίσει ένα υποσύνολο μόνο ζητημάτων προσβασιμότητας, για αυτό συνιστώνται και οι μη αυτόματες δοκιμές."
+    "message": "Αυτοί οι έλεγχοι επισημαίνουν ευκαιρίες για τη [βελτίωση της προσβασιμότητας της εφαρμογής ιστού σας](https://developers.google.com/web/fundamentals/accessibility). Μόνο ένα μέρος των ζητημάτων προσβασιμότητας μπορεί να εντοπιστεί αυτόματα. Ως εκ τούτου, συνιστάται να προβείτε και σε μη αυτόματες δοκιμές."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Αυτά τα στοιχεία αφορούν τομείς τους οποίους δεν μπορεί να καλύψει ένα αυτοματοποιημένο εργαλείο δοκιμών. Μάθετε περισσότερα στον οδηγό μας σχετικά με τη [διεξαγωγή ενός ελέγχου προσβασιμότητας](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Αυτά τα στοιχεία σχετίζονται με τομείς τους οποίους δεν μπορεί να καλύψει ένα εργαλείο αυτοματοποιημένων δοκιμών. Μάθετε περισσότερα στον οδηγό μας σχετικά με τη [διεξαγωγή ενός ελέγχου προσβασιμότητας](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Προσβασιμότητα"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Πίνακες και λίστες"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Βέλτιστες πρακτικές"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Οι προϋπολογισμοί απόδοσης θέτουν τα πρότυπα για την απόδοση του ιστοτόπου σας."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Προϋπολογισμοί"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Περισσότερες πληροφορίες σχετικά με την απόδοση της εφαρμογής σας"
+    "message": "Περισσότερες πληροφορίες σχετικά με την απόδοση της εφαρμογής σας. Αυτά τα δεδομένα δεν [επηρεάζουν άμεσα](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) τη βαθμολογία απόδοσης."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Διαγνωστικά στοιχεία"
@@ -840,7 +1113,7 @@
     "message": "Βελτιώσεις πρώτης μορφής"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Αυτοί οι οργανισμοί μπορούν να επιταχύνουν τη φόρτωση της σελίδας σας."
+    "message": "Αυτές οι προτάσεις μπορούν να βοηθήσουν στην ταχύτερη φόρτωση της σελίδας σας. Δεν [επηρεάζουν άμεσα](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) τη βαθμολογία απόδοσης."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Ευκαιρίες"
@@ -867,7 +1140,7 @@
     "message": "Με βελτιστοποίηση PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Αυτοί οι έλεγχοι διασφαλίζουν ότι η σελίδα σας είναι βελτιστοποιημένη για κατάταξη στα αποτελέσματα μηχανών αναζήτησης. Υπάρχουν επιπλέον παράγοντες τους οποίους δεν ελέγχει το Lighthouse και που μπορούν να επηρεάσουν την κατάταξή σας στην αναζήτηση. [Μάθετε περισσότερα](https://support.google.com/webmasters/answer/35769)."
+    "message": "Αυτοί οι έλεγχοι διασφαλίζουν ότι η σελίδα σας είναι βελτιστοποιημένη για κατάταξη στα αποτελέσματα μηχανών αναζήτησης. Υπάρχουν επιπλέον παράγοντες που δεν ελέγχονται από το Lighthouse και μπορεί να επηρεάσουν την κατάταξη της σελίδας σας στην αναζήτηση. [Μάθετε περισσότερα](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Εκτελέστε αυτά τα πρόσθετα εργαλεία επικύρωσης, για να ελέγξετε περισσότερες βέλτιστες πρακτικές SEO."
@@ -888,7 +1161,7 @@
     "message": "Ανίχνευση και δημιουργία ευρετηρίου"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Βεβαιωθείτε ότι οι σελίδες σας είναι φιλικές προς κινητά, ώστε οι χρήστες να μην χρειάζεται να πλησιάζουν τα δάχτυλά τους ή να κάνουν μεγέθυνση, για να διαβάζουν τις σελίδες περιεχομένου. [Μάθετε περισσότερα](https://developers.google.com/search/mobile-sites/)."
+    "message": "Βεβαιωθείτε ότι οι σελίδες σας είναι κατάλληλα διαμορφωμένες για κινητά, ώστε οι χρήστες να μην χρειάζεται να πλησιάζουν τα δάχτυλά τους ή να κάνουν μεγέθυνση για να διαβάζουν τις σελίδες περιεχομένου. [Μάθετε περισσότερα](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Φιλική προς κινητά"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL κρυφής μνήμης"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Τοποθεσία"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Όνομα"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Αιτήματα"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Τύπος πόρου"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Μέγεθος (KB)"
+    "message": "Μέγεθος"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Χρόνος χρήσης"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Μέγεθος μεταφοράς"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Δυνητικές εξοικονομήσεις (KB)"
+    "message": "Δυνητικές εξοικονομήσεις"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Δυνητικές εξοικονομήσεις (ms)"
+    "message": "Δυνητικές εξοικονομήσεις"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Δυνητικές εξοικονομήσεις {wastedBytes, number, bytes} KB"
+    "message": "Δυνηητική εξοικονόμηση {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "Δυνητικές εξοικονομήσεις {wastedMs, number, milliseconds} ms"
+    "message": "Δυνητική εξοικονόμηση {wastedMs, number, milliseconds} χλστ.δ."
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Έγγραφο"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Γραμματοσειρά"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Εικόνα"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Μέσα"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds} ms"
+    "message": "{timeInMs, number, milliseconds} χλστ.δ."
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Άλλο"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Σενάριο"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} δ."
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Φύλλο στιλ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Τρίτο μέρος"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Σύνολο"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Παρουσιάστηκε κάποιο πρόβλημα με την εγγραφή του ίχνους κατά τη φόρτωση της σελίδας σας. Εκτελέστε ξανά το Lighthouse. ({errorCode})"
@@ -930,13 +1245,19 @@
     "message": "Λήξη χρονικού ορίου κατά την αναμονή για αρχική σύνδεση του πρωτοκόλλου εργαλείου εντοπισμού σφαλμάτων."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Το Chrome δεν συγκέντρωσε στιγμιότυπα οθόνης κατά τη διάρκεια της φόρτωσης σελίδας. Βεβαιωθείτε ότι υπάρχει ορατό περιεχόμενο στη σελίδα και έπειτα δοκιμάστε να εκτελέσετε ξανά το Lighthouse. ({errorCode})"
+    "message": "Το Chrome δεν συγκέντρωσε στιγμιότυπα οθόνης κατά τη φόρτωση της σελίδας. Βεβαιωθείτε ότι υπάρχει ορατό περιεχόμενο στη σελίδα και έπειτα δοκιμάστε να εκτελέσετε ξανά το Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Οι διακομιστές DNS δεν ήταν δυνατό να επιλύσουν τον παρεχόμενο τομέα."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Παρουσιάστηκε κάποιο σφάλμα στη λειτουργία συγκέντρωσης για τον απαιτούμενο πόρο {artifactName}: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Προέκυψε εσωτερικό σφάλμα Chrome. Επανεκκινήστε το Chrome και δοκιμάστε να εκτελέσετε ξανά το Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Δεν εκτελέστηκε η λειτουργία συγκέντρωσης για τον απαιτούμενο πόρο {artifactName}."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Το Lighthouse δεν ήταν δυνατό να φορτώσει με αξιοπιστία τη σελίδα που ζητήσατε. Βεβαιωθείτε ότι ελέγχετε το σωστό URL και ότι ο διακομιστής ανταποκρίνεται σωστά σε όλα τα αιτήματα."
@@ -945,19 +1266,22 @@
     "message": "Το Lighthouse δεν ήταν δυνατό να φορτώσει με αξιοπιστία το URL που ζητήσατε, επειδή η σελίδα σταμάτησε να ανταποκρίνεται."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Το URL που παρείχατε δεν έχει έγκυρα διαπιστευτήρια ασφαλείας. {securityMessages}"
+    "message": "Το URL που παρείχατε δεν έχει ένα έγκυρο πιστοποιητικό ασφάλειας. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Το Chrome εμπόδισε την εμφάνιση μιας σελίδας με παρενθετική διαφήμιση. Βεβαιωθείτε ότι ελέγχετε το σωστό URL και ότι ο διακομιστής αποκρίνεται σωστά σε όλα τα αιτήματα."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Το Lighthouse δεν ήταν δυνατό να φορτώσει με αξιοπιστία τη σελίδα που ζητήσατε. Βεβαιωθείτε ότι ελέγχετε το σωστό URL και ότι ο διακομιστής ανταποκρίνεται σωστά σε όλα τα αιτήματα. (Λεπτομέρειες: {errorDetails})"
+    "message": "Το Lighthouse δεν μπόρεσε να φορτώσει με αξιοπιστία τη σελίδα που ζητήσατε. Βεβαιωθείτε ότι ελέγχετε το σωστό URL και ότι ο διακομιστής αποκρίνεται σωστά σε όλα τα αιτήματα. (Λεπτομέρειες: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Το Lighthouse δεν ήταν δυνατό να φορτώσει με αξιοπιστία τη σελίδα που ζητήσατε. Βεβαιωθείτε ότι ελέγχετε το σωστό URL και ότι ο διακομιστής ανταποκρίνεται σωστά σε όλα τα αιτήματα. (Κωδικός κατάστασης: {statusCode})"
+    "message": "Το Lighthouse δεν μπόρεσε να φορτώσει με αξιοπιστία τη σελίδα που ζητήσατε. Βεβαιωθείτε ότι ελέγχετε το σωστό URL και ότι ο διακομιστής αποκρίνεται σωστά σε όλα τα αιτήματα. (Κωδικός κατάστασης: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
     "message": "Χρειάστηκε υπερβολικά πολύς χρόνος για τη φόρτωση της σελίδας σας. Συμβουλευτείτε τις ευκαιρίες στην αναφορά, για να μειώσετε τον χρόνο φόρτωσης της σελίδας, και έπειτα δοκιμάστε να εκτελέσετε ξανά το Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "Η αναμονή για απόκριση του πρωτοκόλλου DevTools έχει υπερβεί τον εκχωρημένο χρόνο. (Μέθοδος: {protocolMethod})"
+    "message": "Η αναμονή για απόκριση του πρωτοκόλλου DevTools έχει υπερβεί τον μέγιστο επιτρεπόμενο χρόνο. (Μέθοδος: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "Η λήψη περιεχομένου πόρων έχει υπερβεί τον εκχωρημένο χρόνο"
@@ -984,7 +1308,7 @@
     "message": "Εργαστηριακά δεδομένα"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) ανάλυση της τρέχουσας σελίδας σε προσομοιωμένο δίκτυο κινητής τηλεφωνίας. Οι τιμές είναι κατ' εκτίμηση και μπορεί να ποικίλλουν."
+    "message": "Ανάλυση της τρέχουσας σελίδας από το [Lighthouse](https://developers.google.com/web/tools/lighthouse/) σε ένα προσομειωμένο δίκτυο κινητής τηλεφωνίας. Οι τιμές είναι κατ' εκτίμηση και μπορεί να διαφέρουν."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Επιπλέον στοιχεία για μη αυτόματο έλεγχο"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Ανάπτυξη αποσπάσματος"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Εμφάνιση πόρων τρίτων"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Παρουσιάστηκαν ορισμένα ζητήματα τα οποία επηρεάζουν αυτήν την εκτέλεση του Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Οι τιμές εκτιμώνται και μπορεί να ποικίλουν."
+    "message": "Οι τιμές είναι κατ' εκτίμηση και μπορεί να διαφέρουν. Η βαθμολογία απόδοσης [βασίζεται σε αυτές τις μετρήσεις](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Έλεγχοι που ολοκληρώθηκαν αλλά με προειδοποιήσεις"
@@ -1023,10 +1350,10 @@
     "message": "Εξετάστε το ενδεχόμενο μεταφόρτωσης του GIF σε μια υπηρεσία η οποία θα το διαθέσει για ενσωμάτωση ως βίντεο HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Εγκαταστήστε μια [προσθήκη φόρτωσης με καθυστέρηση WordPress](https://wordpress.org/plugins/search/lazy+load/), η οποία παρέχει τη δυνατότητα αναβολής τυχόν εικόνων εκτός οθόνης ή κάντε εναλλαγή σε ένα θέμα που παρέχει αυτήν τη δυνατότητα. Εξετάστε επίσης το ενδεχόμενο χρήσης της [προσθήκης AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Εγκαταστήστε μια προσθήκη [WordPress αργής φόρτωσης](https://wordpress.org/plugins/search/lazy+load/) η οποία παρέχει τη δυνατότητα αναβολής φόρτωσης των εικόνων εκτός οθόνης. Εναλλακτικά, χρησιμοποιήστε ένα θέμα που παρέχει αυτή τη δυνατότητα. Εξετάστε επίσης το ενδεχόμενο χρήσης της [προσθήκης AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Υπάρχουν διάφορες προσθήκες WordPress που μπορούν να σας βοηθήσουν να [ενσωματώσετε σημαντικά στοιχεία](https://wordpress.org/plugins/search/critical+css/) ή να [αναβάλετε λιγότερο σημαντικούς πόρους](https://wordpress.org/plugins/search/defer+css+javascript/). Λάβετε υπόψη ότι οι βελτιστοποιήσεις που παρέχονται από αυτές τις προσθήκες ενδέχεται να προκαλέσουν προβλήματα σε λειτουργίες των θεμάτων ή των προσθηκών σας. Συνεπώς, πιθανώς να χρειαστεί να κάνετε αλλαγές κώδικα."
+    "message": "Υπάρχουν διάφορες προσθήκες WordPress που μπορούν να σας βοηθήσουν στην [ενσωμάτωση των σημαντικών στοιχείων](https://wordpress.org/plugins/search/critical+css/) ή στην [καθυστέρηση των λιγότερο σημαντικών πόρων](https://wordpress.org/plugins/search/defer+css+javascript/). Λάβετε υπόψη ότι οι βελτιστοποιήσεις που παρέχονται από αυτές τις προσθήκες ενδέχεται να προκαλέσουν προβλήματα στις λειτουργίες των θεμάτων ή των προσθηκών σας. Ως εκ τούτου, είναι πιθανό να χρειαστεί να κάνετε αλλαγές στον κώδικα."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Τα θέματα, οι προσθήκες και οι προδιαγραφές διακομιστή συμβάλλουν στον χρόνο απόκρισης του διακομιστή. Αν θέλετε, μπορείτε να ψάξετε για ένα περισσότερο βελτιστοποιημένο θέμα, να επιλέξετε προσεκτικά μια προσθήκη βελτιστοποίησης ή/και να αναβαθμίσετε τον διακομιστή σας."
@@ -1035,30 +1362,30 @@
     "message": "Εξετάστε το ενδεχόμενο εμφάνισης αποσπασμάτων στις λίστες αναρτήσεών σας (π.χ. μέσω της ετικέτας \"περισσότερες\"), μειώνοντας τον αριθμό των αναρτήσεων που εμφανίζονται σε μια συγκεκριμένη σελίδα, χωρίζοντας τις μεγάλες αναρτήσεις σε πολλές σελίδες ή χρησιμοποιώντας μια προσθήκη για φόρτωση με καθυστέρηση των σχολίων."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Ορισμένες [προσθήκες WordPress](https://wordpress.org/plugins/search/minify+css/) μπορούν να επιταχύνουν τον ιστότοπό σας συνενώνοντας, ελαχιστοποιώντας και συμπιέζοντας τα στιλ σας. Μπορείτε επίσης να χρησιμοποιήσετε μια διεργασία δόμησης για να πραγματοποιήσετε αυτήν την ελαχιστοποίηση εκ των προτέρων, αν υπάρχει αυτή η δυνατότητα."
+    "message": "Μερικές [προσθήκες WordPress](https://wordpress.org/plugins/search/minify+css/) μπορούν να επιταχύνουν τον ιστότοπό σας συνενώνοντας, ελαχιστοποιώντας και συμπιέζοντας τα στιλ σας. Μπορείτε επίσης να χρησιμοποιήσετε μια διεργασία δόμησης για την εκ των προτέρων πραγματοποίηση αυτής της ελαχιστοποίησης, εφόσον υπάρχει αυτή η δυνατότητα."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Ορισμένες [προσθήκες WordPress](https://wordpress.org/plugins/search/minify+javascript/) μπορούν να επιταχύνουν τον ιστότοπό σας συνενώνοντας, ελαχιστοποιώντας και συμπιέζοντας τα σενάριά σας. Μπορείτε επίσης να χρησιμοποιήσετε μια διεργασία δόμησης για να πραγματοποιήσετε αυτήν την ελαχιστοποίηση εκ των προτέρων, αν υπάρχει αυτή η δυνατότητα."
+    "message": "Μερικές [προσθήκες WordPress](https://wordpress.org/plugins/search/minify+javascript/) μπορούν να επιταχύνουν τον ιστότοπό σας συνενώνοντας, ελαχιστοποιώντας και συμπιέζοντας τα σενάριά σας. Μπορείτε επίσης να χρησιμοποιήσετε μια διεργασία δόμησης για την εκ των προτέρων πραγματοποίηση αυτής της ελαχιστοποίησης, εφόσον υπάρχει αυτή η δυνατότητα."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Εξετάστε το ενδεχόμενο μείωσης ή εναλλαγής του αριθμού [προσθηκών WordPress](https://wordpress.org/plugins/) που φορτώνουν στη σελίδα σας CSS που δεν χρησιμοποιείται. Για να προσδιορίσετε τις προσθήκες που προσθέτουν περιττή CSS, δοκιμάστε να εκτελέσετε [κάλυψη κώδικα](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) στο Chrome DevTools. Μπορείτε να προσδιορίσετε το θέμα ή την προσθήκη που ευθύνεται για το παραπάνω ζήτημα μέσω του URL του φύλλου στιλ. Αναζητήστε προσθήκες που διαθέτουν πολλά φύλλα στιλ στη λίστα, στα οποία ένα μεγάλο μέρος της κάλυψης κώδικα έχει κόκκινο χρώμα. Μια προσθήκη θα πρέπει να τοποθετεί στην ουρά ένα φύλλο στιλ, μόνο αν χρησιμοποιείται στη σελίδα."
+    "message": "Εξετάστε το ενδεχόμενο μείωσης ή αλλαγής των [προσθηκών WordPress](https://wordpress.org/plugins/) που φορτώνουν μη χρησιμοποιούμενα CSS στη σελίδα σας. Για να προσδιορίσετε τις προσθήκες που προσθέτουν περιττό κώδικα CSS, δοκιμάστε να εκτελέσετε [κάλυψη κώδικα](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) στο Chrome DevTools. Μπορείτε να προσδιορίσετε το θέμα ή την προσθήκη που ευθύνεται μέσω του URL του φύλλου στιλ. Αναζητήστε προσθήκες που διαθέτουν πολλά φύλλα στιλ στη λίστα, στα οποία ένα μεγάλο μέρος της κάλυψης κώδικα έχει κόκκινο χρώμα. Μια προσθήκη θα πρέπει να τοποθετεί στην ουρά ένα φύλλο στιλ, μόνο αν χρησιμοποιείται στη σελίδα."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Εξετάστε το ενδεχόμενο μείωσης ή εναλλαγής του αριθμού [προσθηκών WordPress](https://wordpress.org/plugins/) που φορτώνουν στη σελίδα σας JavaScript που δεν χρησιμοποιείται. Για να προσδιορίσετε τις προσθήκες που προσθέτουν περιττή JS, δοκιμάστε να εκτελέσετε [κάλυψη κώδικα](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) στο Chrome DevTools. Μπορείτε να προσδιορίσετε το θέμα ή την προσθήκη που ευθύνεται για το παραπάνω ζήτημα μέσω του URL του σεναρίου. Αναζητήστε προσθήκες που διαθέτουν πολλά σενάρια στη λίστα, στα οποία ένα μεγάλο μέρος της κάλυψης κώδικα έχει κόκκινο χρώμα. Μια προσθήκη θα πρέπει να τοποθετεί στην ουρά ένα σενάριο μόνο αν χρησιμοποιείται στη σελίδα."
+    "message": "Εξετάστε το ενδεχόμενο μείωσης ή αλλαγής των [προσθηκών WordPress](https://wordpress.org/plugins/) που φορτώνουν μη χρησιμοποιούμενη JavaScript στη σελίδα σας. Για να προσδιορίσετε τις προσθήκες που προσθέτουν περιττό κώδικα JS, δοκιμάστε να εκτελέσετε [κάλυψη κώδικα](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) στο Chrome DevTools. Μπορείτε να προσδιορίσετε το θέμα ή την προσθήκη που ευθύνεται μέσω του URL του σεναρίου. Αναζητήστε προσθήκες που διαθέτουν πολλά σενάρια στη λίστα, στα οποία ένα μεγάλο μέρος της κάλυψης κώδικα έχει κόκκινο χρώμα. Μια προσθήκη θα πρέπει να τοποθετεί στην ουρά ένα σενάριο μόνο αν χρησιμοποιείται στη σελίδα."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Διαβάστε σχετικά με τη [Λειτουργία κρυφής μνήμης προγράμματος περιήγησης στο WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Διαβάστε σχετικά με την [Κρυφή μνήμη προγράμματος περιήγησης στο WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Εξετάστε το ενδεχόμενο να χρησιμοποιήσετε μια [προσθήκη βελτιστοποίησης εικόνας WordPress](https://wordpress.org/plugins/search/optimize+images/) που συμπιέζει τις εικόνες σας διατηρώντας, παράλληλα, την ποιότητά τους."
+    "message": "Εξετάστε το ενδεχόμενο να χρησιμοποιήσετε μια [προσθήκη βελτιστοποίησης εικόνων WordPress](https://wordpress.org/plugins/search/optimize+images/) που συμπιέζει τις εικόνες διατηρώντας όμως την ποιότητά τους."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Ανεβάστε εικόνες απευθείας μέσω της [βιβλιοθήκης μέσων](https://codex.wordpress.org/Media_Library_Screen) για να διασφαλίσετε ότι τα απαιτούμενα μεγέθη εικόνας είναι διαθέσιμα και έπειτα εισαγάγετέ τα από τη βιβλιοθήκη μέσων ή χρησιμοποιήστε το γραφικό στοιχείο εικόνας για να διασφαλίσετε ότι χρησιμοποιούνται τα βέλτιστα μεγέθη εικόνας (συμπεριλαμβανομένων αυτών για τα αποκριτικά σημεία διακοπής). Αποφύγετε τη χρήση εικόνων Πλήρους μεγέθους εκτός αν οι διαστάσεις είναι κατάλληλες για τη χρήση τους. [Μάθετε περισσότερα](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Ανεβάστε εικόνες απευθείας μέσω της [βιβλιοθήκης μέσων](https://codex.wordpress.org/Media_Library_Screen) για να διασφαλίσετε ότι τα απαιτούμενα μεγέθη εικόνων είναι διαθέσιμα. Στη συνέχεια, μπορείτε να τις εισαγάγετε από τη βιβλιοθήκη μέσων ή να χρησιμοποιήσετε το γραφικό στοιχείο εικόνων για να διασφαλίσετε ότι χρησιμοποιούνται τα βέλτιστα μεγέθη (συμπεριλαμβανομένων αυτών για τα αποκριτικά σημεία διακοπής). Αποφύγετε τη χρήση εικόνων `Full Size`, εκτός αν οι διαστάσεις είναι κατάλληλες για τη χρήση τους. [Μάθετε περισσότερα](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Μπορείτε να ενεργοποιήσετε τη συμπίεση κειμένου στη διαμόρφωση του διακομιστή ιστού σας."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Εξετάστε το ενδεχόμενο χρήσης μιας [προσθήκης](https://wordpress.org/plugins/search/convert+webp/) ή υπηρεσίας που θα μετατρέπει αυτόματα τις εικόνες που έχετε ανεβάσει στις βέλτιστες μορφές."
+    "message": "Εξετάστε το ενδεχόμενο να χρησιμοποιήσετε μια [προσθήκη](https://wordpress.org/plugins/search/convert+webp/) ή μια υπηρεσία που θα μετατρέπει αυτόματα τις μεταφορτωμένες εικόνες σας στη βέλτιστη μορφή."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/en-GB.json
+++ b/lighthouse-core/lib/i18n/locales/en-GB.json
@@ -1,6 +1,6 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
     "message": "`[accesskey]` values are not unique"
@@ -9,7 +9,7 @@
     "message": "`[accesskey]` values are unique"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
     "message": "`[aria-*]` attributes do not match their roles"
@@ -18,7 +18,7 @@
     "message": "`[aria-*]` attributes match their roles"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Some ARIA roles have required attributes that describe the state of the element to screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Some ARIA roles have required attributes that describe the state of the element to screen readers. [Learn more](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
     "message": "`[role]`s do not have all required `[aria-*]` attributes"
@@ -27,7 +27,7 @@
     "message": "`[role]`s have all required `[aria-*]` attributes"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
     "message": "Elements with `[role]` that require specific children `[role]`s, are missing."
@@ -36,7 +36,7 @@
     "message": "Elements with `[role]` that require specific children `[role]`s, are present"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
     "message": "`[role]`s are not contained by their required parent element"
@@ -45,7 +45,7 @@
     "message": "`[role]`s are contained by their required parent element"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA roles must have valid values in order to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA roles must have valid values in order to perform their intended accessibility functions. [Learn more](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
     "message": "`[role]` values are not valid"
@@ -54,7 +54,7 @@
     "message": "`[role]` values are valid"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Assistive technologies, such as screen readers, can't interpret ARIA attributes with invalid values. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Assistive technologies, such as screen readers, can't interpret ARIA attributes with invalid values. [Learn more](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
     "message": "`[aria-*]` attributes do not have valid values"
@@ -63,7 +63,7 @@
     "message": "`[aria-*]` attributes have valid values"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Assistive technologies, such as screen readers, can't interpret ARIA attributes with invalid names. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Assistive technologies, such as screen readers, can't interpret ARIA attributes with invalid names. [Learn more](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
     "message": "`[aria-*]` attributes are not valid or misspelled"
@@ -72,7 +72,7 @@
     "message": "`[aria-*]` attributes are valid and not misspelled"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Captions make audio elements usable for deaf or hearing-impaired users, providing critical information such as who is talking, what they're saying and other non-speech information. [Learn more](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Captions make audio elements usable for deaf or hearing-impaired users, providing critical information such as who is talking, what they're saying and other non-speech information. [Learn more](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
     "message": "`<audio>` elements are missing a `<track>` element with `[kind=\"captions\"]`."
@@ -84,7 +84,7 @@
     "message": "Failing elements"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "When a button doesn't have an accessible name, screen readers announce it as 'button', making it unusable for users who rely on screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "When a button doesn't have an accessible name, screen readers announce it as 'button', making it unusable for users who rely on screen readers. [Learn more](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Buttons do not have an accessible name"
@@ -93,7 +93,7 @@
     "message": "Buttons have an accessible name"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Adding ways to bypass repetitive content lets keyboard users navigate the page more efficiently. [Learn more](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Adding ways to bypass repetitive content lets keyboard users navigate the page more efficiently. [Learn more](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "The page does not contain a heading, skip link or landmark region"
@@ -102,7 +102,7 @@
     "message": "The page contains a heading, skip link or landmark region"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Low-contrast text is difficult or impossible for many users to read. [Learn more](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Low-contrast text is difficult or impossible for many users to read. [Learn more](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Background and foreground colours do not have a sufficient contrast ratio."
@@ -111,16 +111,16 @@
     "message": "Background and foreground colours have a sufficient contrast ratio"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "When definition lists are not properly marked up, screen readers may produce confusing or inaccurate output. [Learn more](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "When definition lists are not properly marked up, screen readers may produce confusing or inaccurate output. [Learn more](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "`<dl>`'s do not contain only properly ordered `<dt>` and `<dd>` groups, `<script>` or `<template>` elements."
+    "message": "`<dl>`'s do not contain only properly-ordered `<dt>` and `<dd>` groups, `<script>` or `<template>` elements."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "`<dl>`'s contain only properly ordered `<dt>` and `<dd>` groups, `<script>` or `<template>` elements."
+    "message": "`<dl>`'s contain only properly-ordered `<dt>` and `<dd>` groups, `<script>` or `<template>` elements."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Definition list items (`<dt>` and `<dd>`) must be wrapped in a parent `<dl>` element to ensure that screen readers can properly announce them. [Learn more](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Definition list items (`<dt>` and `<dd>`) must be wrapped in a parent `<dl>` element to ensure that screen readers can properly announce them. [Learn more](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
     "message": "Definition list items are not wrapped in `<dl>` elements"
@@ -129,7 +129,7 @@
     "message": "Definition list items are wrapped in `<dl>` elements"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "The title gives screen reader users an overview of the page, and search engine users rely on it heavily to determine if a page is relevant to their search. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "The title gives screen reader users an overview of the page, and search engine users rely on it heavily to determine if a page is relevant to their search. [Learn more](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "Document doesn't have a `<title>` element"
@@ -138,7 +138,7 @@
     "message": "Document has a `<title>` element"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "The value of an ID attribute must be unique to prevent other instances from being overlooked by assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "The value of an ID attribute must be unique to prevent other instances from being overlooked by assistive technologies. [Learn more](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
     "message": "`[id]` attributes on the page are not unique"
@@ -147,7 +147,7 @@
     "message": "`[id]` attributes on the page are unique"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Screen reader users rely on frame titles to describe the contents of frames. [Learn more](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Screen reader users rely on frame titles to describe the contents of frames. [Learn more](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "`<frame>` or `<iframe>` elements do not have a title"
@@ -156,7 +156,7 @@
     "message": "`<frame>` or `<iframe>` elements have a title"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
     "message": "`<html>` element does not have a `[lang]` attribute"
@@ -165,7 +165,7 @@
     "message": "`<html>` element has a `[lang]` attribute"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) helps screen readers announce text properly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) helps screen readers announce text properly. [Learn more](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
     "message": "`<html>` element does not have a valid value for its `[lang]` attribute."
@@ -174,7 +174,7 @@
     "message": "`<html>` element has a valid value for its `[lang]` attribute"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informative elements should aim for short, descriptive alternative text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informative elements should aim for short, descriptive alternative text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
     "message": "Image elements do not have `[alt]` attributes"
@@ -183,7 +183,7 @@
     "message": "Image elements have `[alt]` attributes"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "When an image is being used as an `<input>` button, providing alternative text can help screen reader users understand the purpose of the button. [Learn more](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "When an image is being used as an `<input>` button, providing alternative text can help screen reader users understand the purpose of the button. [Learn more](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "`<input type=\"image\">` elements do not have `[alt]` text"
@@ -192,7 +192,7 @@
     "message": "`<input type=\"image\">` elements have `[alt]` text"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Labels ensure that form controls are announced properly by assistive technologies, such as screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Labels ensure that form controls are announced properly by assistive technologies, such as screen readers. [Learn more](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Form elements do not have associated labels"
@@ -201,7 +201,7 @@
     "message": "Form elements have associated labels"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "A table being used for layout purposes should not include data elements, such as the th, caption elements or the summary attribute, because this can create a confusing experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "A table being used for layout purposes should not include data elements, such as the caption elements or the summary attribute, because this can create a confusing experience for screen reader users. [Learn more](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
     "message": "Presentational `<table>` elements do not avoid using `<th>`, `<caption>` or the `[summary]` attribute."
@@ -210,7 +210,7 @@
     "message": "Presentational `<table>` elements avoid using `<th>`, `<caption>` or the `[summary]` attribute."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Link text (and alternative text for images, when used as links) that is discernible, unique and able to be focused, improves the navigation experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Link text (and alternative text for images, when used as links) that is discernible, unique and focusable improves the navigation experience for screen reader users. [Learn more](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Links do not have a discernible name"
@@ -219,16 +219,16 @@
     "message": "Links have a discernible name"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Screen readers have a specific way of announcing lists. Ensuring proper list structure aids screen reader output. [Learn more](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Screen readers have a specific way of announcing lists. Ensuring proper list structure aids screen reader output. [Learn more](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Lists do not contain only `<li>` elements and script-supporting elements (`<script>` and `<template>`)."
+    "message": "Lists do not contain only `<li>` elements and script supporting elements (`<script>` and `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Lists contain only `<li>` elements and script-supporting elements (`<script>` and `<template>`)."
+    "message": "Lists contain only `<li>` elements and script supporting elements (`<script>` and `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
     "message": "List items (`<li>`) are not contained within `<ul>` or `<ol>` parent elements."
@@ -237,7 +237,7 @@
     "message": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
     "message": "The document uses `<meta http-equiv=\"refresh\">`"
@@ -246,7 +246,7 @@
     "message": "The document does not use `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Disabling zooming is problematic for users with low vision who rely on screen magnification to properly see the contents of a web page. [Learn more](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Disabling zooming is problematic for users with low vision who rely on screen magnification to properly see the contents of a web page. [Learn more](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
     "message": "`[user-scalable=\"no\"]` is used in the `<meta name=\"viewport\">` element or the `[maximum-scale]` attribute is less than 5."
@@ -255,7 +255,7 @@
     "message": "`[user-scalable=\"no\"]` is not used in the `<meta name=\"viewport\">` element and the `[maximum-scale]` attribute is not less than 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Screen readers cannot translate non-text content. Adding alt text to `<object>` elements helps screen readers convey meaning to users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Screen readers cannot translate non-text content. Adding alt text to `<object>` elements helps screen readers convey meaning to users. [Learn more](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "`<object>` elements do not have `[alt]` text"
@@ -264,7 +264,7 @@
     "message": "`<object>` elements have `[alt]` text"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "A value greater than 0 implies an explicit navigation ordering. Although technically valid, this often creates frustrating experiences for users who rely on assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "A value greater than 0 implies an explicit navigation ordering. Although technically valid, this often creates frustrating experiences for users who rely on assistive technologies. [Learn more](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "Some elements have a `[tabindex]` value greater than 0"
@@ -273,25 +273,25 @@
     "message": "No element has a `[tabindex]` value greater than 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Screen readers have features to make navigating tables easier. Ensuring that `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Cells in a `<table>` element that use the `[headers]` attribute refer to other cells of that same table."
+    "message": "Cells in a `<table>` element that use the `[headers]` attribute refers to other cells of that same table."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
     "message": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other cells of that same table."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Screen readers have features to make navigating tables easier. Ensuring that table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Screen readers have features to make navigating tables easier. Ensuring that table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "`<th>` elements and elements with `[role=\"columnheader\"/\"rowheader\"]` do not have data cells that they describe."
+    "message": "`<th>` elements and elements with `[role=\"columnheader\"/\"rowheader\"]` do not have data cells they describe."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "`<th>` elements and elements with `[role=\"columnheader\"/\"rowheader\"]` have data cells that they describe."
+    "message": "`<th>` elements and elements with `[role=\"columnheader\"/\"rowheader\"]` have data cells they describe."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) on elements helps ensure that text is pronounced correctly by a screen reader. [Learn more](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) on elements helps ensure that text is pronounced correctly by a screen reader. [Learn more](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
     "message": "`[lang]` attributes do not have a valid value"
@@ -300,7 +300,7 @@
     "message": "`[lang]` attributes have a valid value"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "When a video provides a caption it is easier for deaf and hearing-impaired users to access its information. [Learn more](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "When a video provides a caption it is easier for deaf and hearing-impaired users to access its information. [Learn more](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
     "message": "`<video>` elements do not contain a `<track>` element with `[kind=\"captions\"]`."
@@ -309,13 +309,25 @@
     "message": "`<video>` elements contain a `<track>` element with `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Audio descriptions provide relevant information for videos that dialogue cannot, such as facial expressions and scenes. [Learn more](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Audio descriptions provide relevant information for videos that dialogue cannot, such as facial expressions and scenes. [Learn more](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
     "message": "`<video>` elements do not contain a `<track>` element with `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
     "message": "`<video>` elements contain a `<track>` element with `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "For ideal appearance on iOS when users add to the home screen, define an apple-touch-icon. It must point to a non-transparent 192px (or 180px) square PNG. [Learn more](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Does not provide a valid `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` is out of date; `apple-touch-icon` is preferred."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Provides a valid `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome extensions negatively affected this page's load performance. Try auditing the page in incognito mode or from a Chrome profile without extensions."
@@ -345,7 +357,7 @@
     "message": "Use video formats for animated content"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Consider lazy-loading off-screen and hidden images after all critical resources have finished loading to lower time to interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Consider lazy loading offscreen and hidden images after all critical resources have finished loading to lower time to interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Defer off-screen images"
@@ -429,13 +441,64 @@
     "message": "Serve images in next-gen formats"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "The Critical Request Chains below show you what resources are loaded with a high priority. Consider reducing the length of chains, reducing the download size of resources or deferring the download of unnecessary resources to improve page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "The critical request chains below show you what resources are loaded with a high priority. Consider reducing the length of chains, reducing the download size of resources or deferring the download of unnecessary resources to improve page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 chain found}other{# chains found}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimise Critical Requests Depth"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Deprecation/Warning"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Line"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 warning found}other{# warnings found}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Uses deprecated APIs"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Avoids deprecated APIs"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Application cache is deprecated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Found '{AppCacheManifest}'"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Uses application cache"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Avoids application cache"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Specifying a doctype prevents the browser from switching to quirks mode. Read more on the [MDN Web Docs page](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Doctype name must be the lowercase string `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Document must contain a doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Expected publicId to be an empty string"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Expected systemId to be an empty string"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Page lacks the HTML doctype, thus triggering quirks mode"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Page has the HTML doctype"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
@@ -447,7 +510,7 @@
     "message": "Value"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Browser engineers recommend pages contain fewer than ~1,500 DOM elements. The sweet spot is a tree depth < 32 elements and fewer than 60 children/parent element. A large DOM can increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Browser engineers recommend pages contain fewer than ~1,500 DOM elements. The sweet spot is a tree depth < 32 elements and fewer than 60 children/parent element. A large DOM can increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 element}other{# elements}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Avoids an excessive DOM size"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Target"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Add `rel=\"noopener\"` or `rel=\"noreferrer\"` to any external links to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Links to cross-origin destinations are unsafe"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Links to cross-origin destinations are safe"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Unable to determine the destination for anchor ({anchorHTML}). If not used as a hyperlink, consider removing target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to a user action instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Requests the geolocation permission on page load"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Avoids requesting the geolocation permission on page load"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Version"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "All front-end JavaScript libraries detected on the page."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Detected JavaScript libraries"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Uses `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Avoids `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Highest Severity"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Library version"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Vulnerability count"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Some third-party scripts may contain known security vulnerabilities that are easily identified and exploited by attackers. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 vulnerability detected}other{# vulnerabilities detected}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Includes front-end JavaScript libraries with known security vulnerabilities"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "High"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Low"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Medium"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Avoids front-end JavaScript libraries with known security vulnerabilities"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Requests the notification permission on page load"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Avoids requesting the notification permission on page load"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Failing Elements"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Preventing password pasting undermines good security policy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Prevents users to paste into password fields"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Allows users to paste into password fields"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 request not served via HTTP/2}other{# requests not served via HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Does not use HTTP/2 for all of its resources"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Uses HTTP/2 for its own resources"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Does not use passive listeners to improve scrolling performance"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Uses passive listeners to improve scrolling performance"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Description"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Errors logged to the console indicate unresolved problems. They can come from network request failures and other browser concerns."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Browser errors were logged to the console"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "No browser errors logged to the console"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading. [Learn more](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -475,6 +670,42 @@
   },
   "lighthouse-core/audits/font-display.js | title": {
     "message": "All text remains visible during webfont loads"
+  },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse was unable to automatically check the font-display value for the following URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Aspect ratio (actual)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Aspect ratio (displayed)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Image display dimensions should match natural aspect ratio. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Displays images with incorrect aspect ratio"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Displays images with correct aspect ratio"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Invalid image sizing information {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Insecure URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "All sites should be protected with HTTPS, even ones that don't handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 insecure request found}other{# insecure requests found}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Does not use HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Uses HTTPS"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "A fast page load over a mobile network ensures a good mobile user experience. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
@@ -504,13 +735,13 @@
     "message": "Minimises main-thread work"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Estimated Input Latency is an estimate of how long your app takes to respond to user input, in milliseconds, during the busiest 5s window of page load. If your latency is higher than 50 ms, users may perceive your app as laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Estimated input latency is an estimate of how long your app takes to respond to user input, in milliseconds, during the busiest 5s window of page load. If your latency is higher than 50 ms, users may perceive your app as laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Estimated Input Latency"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "First contentful paint marks the time at which the first text or image is painted. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "First Contentful Paint"
@@ -522,7 +753,7 @@
     "message": "First CPU Idle"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "First Meaningful Paint measures when the primary content of a page is visible. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "First meaningful paint measures when the primary content of a page is visible. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "First Meaningful Paint"
@@ -534,16 +765,22 @@
     "message": "Time to Interactive"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "The potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task."
+    "message": "The maximum potential first input delay that your users could experience is the duration, in milliseconds, of the longest task. [Learn more](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Max Potential FID"
+    "message": "Max potential first input delay"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Speed Index"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Total blocking time"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -552,16 +789,37 @@
     "message": "Network Return Times"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor back-end performance. [Learn more](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication that the server is overloaded or has poor back-end performance. [Learn more](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Server Back-end Latencies"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Over budget"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Keep the quantity and size of network requests under the targets set by the provided performance budget. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 request}other{# requests}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Performance budget"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Redirects introduce additional delays before the page can be loaded. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Avoid multiple page redirects"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "To set budgets for the quantity and size of page resources, add a budget.json file. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 request}other{# requests}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Keep request counts low and transfer sizes small"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Canonical links suggest which URL to show in search results. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
@@ -595,9 +853,6 @@
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} legible text"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} of text is too small."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Text is illegible because there's no viewport meta tag optimised for mobile screens."
@@ -669,7 +924,7 @@
     "message": "Document has a meta description"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Search engines can't index plugin content, and many devices restrict plugins or don't support them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Search engines can't index plug-in content, and many devices restrict plug-ins or don't support them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "Document uses plugins"
@@ -696,7 +951,7 @@
     "message": "robots.txt is valid"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Interactive elements such as buttons and links should be large enough (48x48px) and have enough space around them to be easy enough to tap without overlapping onto other elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Interactive elements such as buttons and links should be large enough (48 x 48px) and have enough space around them to be easy enough to tap without overlapping onto other elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} appropriately sized tap targets"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Overlapping target"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Size"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Tap target"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Tap targets are sized appropriately"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Main thread time"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Third-party"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and try to load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 third-party found}other{# third-parties found}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Third-party usage"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Time To First Byte identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "Time to first byte identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Root document took {timeInMs, number, milliseconds} ms"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Duration"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Name"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Start Time"
@@ -753,10 +1017,10 @@
     "message": "User Timing marks and measures"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "A preconnect <link> was found for \"{securityOrigin}\" but was not used by the browser. Check that you are using the `crossorigin` attribute properly."
+    "message": "A preconnect <link> was found for '{securityOrigin}' but was not used by the browser. Check that you are using the `crossorigin` attribute properly."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Consider adding pre-connect or DNS-prefetch resource hints to establish early connections to important third-party origins. [Learn more](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Consider adding preconnect or DNS-prefetch resource hints to establish early connections to important third-party origins. [Learn more](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Pre-connect to required origins"
@@ -765,7 +1029,7 @@
     "message": "A preload <link> was found for '{preloadURL}' but was not used by the browser. Check that you are using the `crossorigin` attribute properly."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Consider using <link rel=preload> to prioritise fetching resources that are currently requested later in page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Consider using `<link rel=preload>` to prioritise fetching resources that are currently requested later in page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Pre-load key requests"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tables and lists"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Best Practices"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Performance budgets set standards for the performance of your site."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budgets"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "More information about the performance of your application."
+    "message": "More information about the performance of your application. These numbers don't [directly affect](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) the performance score."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostics"
@@ -840,7 +1113,7 @@
     "message": "First Paint Improvements"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "These optimisations can speed up your page load."
+    "message": "These suggestions can help your page load faster. They don't [directly affect](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) the performance score."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Opportunities"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Cache TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Location"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Name"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Requests"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Resource type"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Size (KB)"
+    "message": "Size"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Time Spent"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Transfer size"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potential Savings (KB)"
+    "message": "Potential savings"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potential Savings (ms)"
+    "message": "Potential Savings"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Potential savings of {wastedBytes, number, bytes} KB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Potential savings of {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Document"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Font"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Image"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Media"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Other"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stylesheet"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Third-party"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Total"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Something went wrong with recording the trace over your page load. Please run Lighthouse again. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS servers could not resolve the provided domain."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Required {artifactName} gatherer encountered an error: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "An internal Chrome error occurred. Please restart Chrome and try re-running Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Required {artifactName} gatherer did not run."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse was unable to reliably load the page that you requested. Make sure that you are testing the correct URL and that the server is properly responding to all requests."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse was unable to reliably load the URL that you requested because the page stopped responding."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "The URL that you have provided does not have valid security credentials. {securityMessages}"
+    "message": "The URL you have provided does not have a valid security certificate. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome prevented page load with an interstitial. Make sure that you are testing the correct URL and that the server is properly responding to all requests."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse was unable to reliably load the page that you requested. Make sure that you are testing the correct URL and that the server is properly responding to all requests. (Details: {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Expand snippet"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Show 3rd-party resources"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "There were issues affecting this run of Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Values are estimated and may vary."
+    "message": "Values are estimated and may vary. The performance score is [based only on these metrics](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Passed audits but with warnings"
@@ -1023,7 +1350,7 @@
     "message": "Consider uploading your GIF to a service which will make it available to embed as an HTML5 video."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Install a [lazy-load WordPress plug-in](https://wordpress.org/plugins/search/lazy+load/) that provides the ability to defer any offscreen images, or switch to a theme that provides that functionality. Also consider using [the AMP plug-in](https://wordpress.org/plugins/amp/)."
+    "message": "Install a [lazy load WordPress plug-in](https://wordpress.org/plugins/search/lazy+load/) that provides the ability to defer any offscreen images, or switch to a theme that provides that functionality. Also consider using [the AMP plug-in](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "There are a number of WordPress plug-ins that can help you [inline critical assets](https://wordpress.org/plugins/search/critical+css/) or [defer less important resources](https://wordpress.org/plugins/search/defer+css+javascript/). Beware that optimisations provided by these plug-ins may break features of your theme or plug-ins, so you will likely need to make code changes."
@@ -1047,13 +1374,13 @@
     "message": "Consider reducing, or switching, the number of [WordPress plug-ins](https://wordpress.org/plugins/) loading unused JavaScript in your page. To identify plug-ins that are adding extraneous JS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/plug-in responsible from the URL of the script. Look out for plug-ins that have many scripts in the list which have a lot of red in code coverage. A plug-in should only enqueue a script if it is actually used on the page."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Read about [Browser Caching in WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Read about [browser caching in WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "Consider using an [image optimisation WordPress plug-in](https://wordpress.org/plugins/search/optimize+images/) that compresses your images while retaining quality."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Upload images directly through the [media library](https://codex.wordpress.org/Media_Library_Screen) to ensure that the required image sizes are available, and then insert them from the media library or use the image widget to ensure that the optimal image sizes are used (including those for the responsive breakpoints). Avoid using `Full Size` images unless the dimensions are adequate for their usage. [Learn More](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Upload images directly through the [media library](https://codex.wordpress.org/Media_Library_Screen) to ensure that the required image sizes are available, and then insert them from the media library or use the image widget to ensure that the optimal image sizes are used (including those for the responsive breakpoints). Avoid using `Full Size` images unless the dimensions are adequate for their usage. [Learn more](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "You can enable text compression in your web server configuration."

--- a/lighthouse-core/lib/i18n/locales/en-XA.json
+++ b/lighthouse-core/lib/i18n/locales/en-XA.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "[Åççéšš ķéýš ļéţ ûšéŕš qûîçķļý ƒöçûš å þåŕţ öƒ ţĥé þåĝé. Föŕ þŕöþéŕ ñåvîĝåţîöñ, éåçĥ åççéšš ķéý mûšţ бé ûñîqûé. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/åççéššķéýš¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
+    "message": "[Åççéšš ķéýš ļéţ ûšéŕš qûîçķļý ƒöçûš å þåŕţ öƒ ţĥé þåĝé. Föŕ þŕöþéŕ ñåvîĝåţîöñ, éåçĥ åççéšš ķéý mûšţ бé ûñîqûé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/accesskeys/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "[`[åççéššķéý]` våļûéš åŕé ñöţ ûñîqûé one two three four five six seven eight]"
+    "message": "[ᐅ`[accesskey]`ᐊ våļûéš åŕé ñöţ ûñîqûé one two three four five six]"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "[`[åççéššķéý]` våļûéš åŕé ûñîqûé one two three four five six seven]"
+    "message": "[ᐅ`[accesskey]`ᐊ våļûéš åŕé ûñîqûé one two three four five]"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "[Éåçĥ ÅŔÎÅ `ŕöļé` šûþþöŕţš å šþéçîƒîç šûбšéţ öƒ `åŕîå-*` åţţŕîбûţéš. Mîšmåţçĥîñĝ ţĥéšé îñvåļîðåţéš ţĥé `åŕîå-*` åţţŕîбûţéš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/åŕîå-åļļöŵéð-åţţŕ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Éåçĥ ÅŔÎÅ ᐅ`role`ᐊ šûþþöŕţš å šþéçîƒîç šûбšéţ öƒ ᐅ`aria-*`ᐊ åţţŕîбûţéš. Mîšmåţçĥîñĝ ţĥéšé îñvåļîðåţéš ţĥé ᐅ`aria-*`ᐊ åţţŕîбûţéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/aria-allowed-attr/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "[`[åŕîå-*]` åţţŕîбûţéš ðö ñöţ måţçĥ ţĥéîŕ ŕöļéš one two three four five six seven eight nine ten]"
+    "message": "[ᐅ`[aria-*]`ᐊ åţţŕîбûţéš ðö ñöţ måţçĥ ţĥéîŕ ŕöļéš one two three four five six seven eight]"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "[`[åŕîå-*]` åţţŕîбûţéš måţçĥ ţĥéîŕ ŕöļéš one two three four five six seven eight]"
+    "message": "[ᐅ`[aria-*]`ᐊ åţţŕîбûţéš måţçĥ ţĥéîŕ ŕöļéš one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "[Šömé ÅŔÎÅ ŕöļéš ĥåvé ŕéqûîŕéð åţţŕîбûţéš ţĥåţ ðéšçŕîбé ţĥé šţåţé öƒ ţĥé éļéméñţ ţö šçŕééñ ŕéåðéŕš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/åŕîå-ŕéqûîŕéð-åţţŕ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
+    "message": "[Šömé ÅŔÎÅ ŕöļéš ĥåvé ŕéqûîŕéð åţţŕîбûţéš ţĥåţ ðéšçŕîбé ţĥé šţåţé öƒ ţĥé éļéméñţ ţö šçŕééñ ŕéåðéŕš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/aria-required-attr/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "[`[ŕöļé]`š ðö ñöţ ĥåvé åļļ ŕéqûîŕéð `[åŕîå-*]` åţţŕîбûţéš one two three four five six seven eight nine ten eleven]"
+    "message": "[ᐅ`[role]`ᐊš ðö ñöţ ĥåvé åļļ ŕéqûîŕéð ᐅ`[aria-*]`ᐊ åţţŕîбûţéš one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "[`[ŕöļé]`š ĥåvé åļļ ŕéqûîŕéð `[åŕîå-*]` åţţŕîбûţéš one two three four five six seven eight nine ten]"
+    "message": "[ᐅ`[role]`ᐊš ĥåvé åļļ ŕéqûîŕéð ᐅ`[aria-*]`ᐊ åţţŕîбûţéš one two three four five six seven eight]"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "[Šömé ÅŔÎÅ þåŕéñţ ŕöļéš mûšţ çöñţåîñ šþéçîƒîç çĥîļð ŕöļéš ţö þéŕƒöŕm ţĥéîŕ îñţéñðéð åççéššîбîļîţý ƒûñçţîöñš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/åŕîå-ŕéqûîŕéð-çĥîļðŕéñ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Šömé ÅŔÎÅ þåŕéñţ ŕöļéš mûšţ çöñţåîñ šþéçîƒîç çĥîļð ŕöļéš ţö þéŕƒöŕm ţĥéîŕ îñţéñðéð åççéššîбîļîţý ƒûñçţîöñš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/aria-required-children/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "[Éļéméñţš ŵîţĥ `[ŕöļé]` ţĥåţ ŕéqûîŕé šþéçîƒîç çĥîļðŕéñ `[ŕöļé]`š, åŕé mîššîñĝ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+    "message": "[Éļéméñţš ŵîţĥ ᐅ`[role]`ᐊ ţĥåţ ŕéqûîŕé šþéçîƒîç çĥîļðŕéñ ᐅ`[role]`ᐊš, åŕé mîššîñĝ. one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "[Éļéméñţš ŵîţĥ `[ŕöļé]` ţĥåţ ŕéqûîŕé šþéçîƒîç çĥîļðŕéñ `[ŕöļé]`š, åŕé þŕéšéñţ one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+    "message": "[Éļéméñţš ŵîţĥ ᐅ`[role]`ᐊ ţĥåţ ŕéqûîŕé šþéçîƒîç çĥîļðŕéñ ᐅ`[role]`ᐊš, åŕé þŕéšéñţ one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "[Šömé ÅŔÎÅ çĥîļð ŕöļéš mûšţ бé çöñţåîñéð бý šþéçîƒîç þåŕéñţ ŕöļéš ţö þŕöþéŕļý þéŕƒöŕm ţĥéîŕ îñţéñðéð åççéššîбîļîţý ƒûñçţîöñš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/åŕîå-ŕéqûîŕéð-þåŕéñţ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine]"
+    "message": "[Šömé ÅŔÎÅ çĥîļð ŕöļéš mûšţ бé çöñţåîñéð бý šþéçîƒîç þåŕéñţ ŕöļéš ţö þŕöþéŕļý þéŕƒöŕm ţĥéîŕ îñţéñðéð åççéššîбîļîţý ƒûñçţîöñš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/aria-required-parent/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "[`[ŕöļé]`š åŕé ñöţ çöñţåîñéð бý ţĥéîŕ ŕéqûîŕéð þåŕéñţ éļéméñţ one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[ᐅ`[role]`ᐊš åŕé ñöţ çöñţåîñéð бý ţĥéîŕ ŕéqûîŕéð þåŕéñţ éļéméñţ one two three four five six seven eight nine ten eleven]"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "[`[ŕöļé]`š åŕé çöñţåîñéð бý ţĥéîŕ ŕéqûîŕéð þåŕéñţ éļéméñţ one two three four five six seven eight nine ten eleven]"
+    "message": "[ᐅ`[role]`ᐊš åŕé çöñţåîñéð бý ţĥéîŕ ŕéqûîŕéð þåŕéñţ éļéméñţ one two three four five six seven eight nine ten eleven]"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "[ÅŔÎÅ ŕöļéš mûšţ ĥåvé våļîð våļûéš îñ öŕðéŕ ţö þéŕƒöŕm ţĥéîŕ îñţéñðéð åççéššîбîļîţý ƒûñçţîöñš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/åŕîå-ŕöļéš¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
+    "message": "[ÅŔÎÅ ŕöļéš mûšţ ĥåvé våļîð våļûéš îñ öŕðéŕ ţö þéŕƒöŕm ţĥéîŕ îñţéñðéð åççéššîбîļîţý ƒûñçţîöñš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/aria-roles/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "[`[ŕöļé]` våļûéš åŕé ñöţ våļîð one two three four five six seven]"
+    "message": "[ᐅ`[role]`ᐊ våļûéš åŕé ñöţ våļîð one two three four five]"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "[`[ŕöļé]` våļûéš åŕé våļîð one two three four five six]"
+    "message": "[ᐅ`[role]`ᐊ våļûéš åŕé våļîð one two three four five]"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "[Åššîšţîvé ţéçĥñöļöĝîéš, ļîķé šçŕééñ ŕéåðéŕš, çåñ'ţ îñţéŕþŕéţ ÅŔÎÅ åţţŕîбûţéš ŵîţĥ îñvåļîð våļûéš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/åŕîå-våļîð-åţţŕ-våļûé¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
+    "message": "[Åššîšţîvé ţéçĥñöļöĝîéš, ļîķé šçŕééñ ŕéåðéŕš, çåñ'ţ îñţéŕþŕéţ ÅŔÎÅ åţţŕîбûţéš ŵîţĥ îñvåļîð våļûéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/aria-valid-attr-value/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "[`[åŕîå-*]` åţţŕîбûţéš ðö ñöţ ĥåvé våļîð våļûéš one two three four five six seven eight nine ten]"
+    "message": "[ᐅ`[aria-*]`ᐊ åţţŕîбûţéš ðö ñöţ ĥåvé våļîð våļûéš one two three four five six seven eight]"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "[`[åŕîå-*]` åţţŕîбûţéš ĥåvé våļîð våļûéš one two three four five six seven eight]"
+    "message": "[ᐅ`[aria-*]`ᐊ åţţŕîбûţéš ĥåvé våļîð våļûéš one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "[Åššîšţîvé ţéçĥñöļöĝîéš, ļîķé šçŕééñ ŕéåðéŕš, çåñ'ţ îñţéŕþŕéţ ÅŔÎÅ åţţŕîбûţéš ŵîţĥ îñvåļîð ñåméš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/åŕîå-våļîð-åţţŕ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
+    "message": "[Åššîšţîvé ţéçĥñöļöĝîéš, ļîķé šçŕééñ ŕéåðéŕš, çåñ'ţ îñţéŕþŕéţ ÅŔÎÅ åţţŕîбûţéš ŵîţĥ îñvåļîð ñåméš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/aria-valid-attr/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "[`[åŕîå-*]` åţţŕîбûţéš åŕé ñöţ våļîð öŕ mîššþéļļéð one two three four five six seven eight nine ten]"
+    "message": "[ᐅ`[aria-*]`ᐊ åţţŕîбûţéš åŕé ñöţ våļîð öŕ mîššþéļļéð one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "[`[åŕîå-*]` åţţŕîбûţéš åŕé våļîð åñð ñöţ mîššþéļļéð one two three four five six seven eight nine ten eleven]"
+    "message": "[ᐅ`[aria-*]`ᐊ åţţŕîбûţéš åŕé våļîð åñð ñöţ mîššþéļļéð one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "[Çåþţîöñš måķé åûðîö éļéméñţš ûšåбļé ƒöŕ ðéåƒ öŕ ĥéåŕîñĝ-îmþåîŕéð ûšéŕš, þŕövîðîñĝ çŕîţîçåļ îñƒöŕmåţîöñ šûçĥ åš ŵĥö îš ţåļķîñĝ, ŵĥåţ ţĥéý'ŕé šåýîñĝ, åñð öţĥéŕ ñöñ-šþééçĥ îñƒöŕmåţîöñ. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/åûðîö-çåþţîöñ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour]"
+    "message": "[Çåþţîöñš måķé åûðîö éļéméñţš ûšåбļé ƒöŕ ðéåƒ öŕ ĥéåŕîñĝ-îmþåîŕéð ûšéŕš, þŕövîðîñĝ çŕîţîçåļ îñƒöŕmåţîöñ šûçĥ åš ŵĥö îš ţåļķîñĝ, ŵĥåţ ţĥéý'ŕé šåýîñĝ, åñð öţĥéŕ ñöñ-šþééçĥ îñƒöŕmåţîöñ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/audio-caption/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "[`<audio>` éļéméñţš åŕé mîššîñĝ å `<track>` éļéméñţ ŵîţĥ `[ķîñð=\"çåþţîöñš\"]`. one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[ᐅ`<audio>`ᐊ éļéméñţš åŕé mîššîñĝ å ᐅ`<track>`ᐊ éļéméñţ ŵîţĥ ᐅ`[kind=\"captions\"]`ᐊ. one two three four five six seven eight nine ten]"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "[`<audio>` éļéméñţš çöñţåîñ å `<track>` éļéméñţ ŵîţĥ `[ķîñð=\"çåþţîöñš\"]` one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[ᐅ`<audio>`ᐊ éļéméñţš çöñţåîñ å ᐅ`<track>`ᐊ éļéméñţ ŵîţĥ ᐅ`[kind=\"captions\"]`ᐊ one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "[Fåîļîñĝ Éļéméñţš one two]"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "[Ŵĥéñ å бûţţöñ ðöéšñ'ţ ĥåvé åñ åççéššîбļé ñåmé, šçŕééñ ŕéåðéŕš åññöûñçé îţ åš \"бûţţöñ\", måķîñĝ îţ ûñûšåбļé ƒöŕ ûšéŕš ŵĥö ŕéļý öñ šçŕééñ ŕéåðéŕš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/бûţţöñ-ñåmé¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty]"
+    "message": "[Ŵĥéñ å бûţţöñ ðöéšñ'ţ ĥåvé åñ åççéššîбļé ñåmé, šçŕééñ ŕéåðéŕš åññöûñçé îţ åš \"бûţţöñ\", måķîñĝ îţ ûñûšåбļé ƒöŕ ûšéŕš ŵĥö ŕéļý öñ šçŕééñ ŕéåðéŕš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/button-name/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "[Бûţţöñš ðö ñöţ ĥåvé åñ åççéššîбļé ñåmé one two three four five six seven eight]"
@@ -93,7 +93,7 @@
     "message": "[Бûţţöñš ĥåvé åñ åççéššîбļé ñåmé one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "[Åððîñĝ ŵåýš ţö бýþåšš ŕéþéţîţîvé çöñţéñţ ļéţš ķéýбöåŕð ûšéŕš ñåvîĝåţé ţĥé þåĝé möŕé éƒƒîçîéñţļý. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/бýþåšš¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
+    "message": "[Åððîñĝ ŵåýš ţö бýþåšš ŕéþéţîţîvé çöñţéñţ ļéţš ķéýбöåŕð ûšéŕš ñåvîĝåţé ţĥé þåĝé möŕé éƒƒîçîéñţļý. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/bypass/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "[Ţĥé þåĝé ðöéš ñöţ çöñţåîñ å ĥéåðîñĝ, šķîþ ļîñķ, öŕ ļåñðmåŕķ ŕéĝîöñ one two three four five six seven eight nine ten eleven twelve thirteen]"
@@ -102,7 +102,7 @@
     "message": "[Ţĥé þåĝé çöñţåîñš å ĥéåðîñĝ, šķîþ ļîñķ, öŕ ļåñðmåŕķ ŕéĝîöñ one two three four five six seven eight nine ten eleven twelve]"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "[Ļöŵ-çöñţŕåšţ ţéxţ îš ðîƒƒîçûļţ öŕ îmþöššîбļé ƒöŕ måñý ûšéŕš ţö ŕéåð. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/çöļöŕ-çöñţŕåšţ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Ļöŵ-çöñţŕåšţ ţéxţ îš ðîƒƒîçûļţ öŕ îmþöššîбļé ƒöŕ måñý ûšéŕš ţö ŕéåð. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/color-contrast/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "[Бåçķĝŕöûñð åñð ƒöŕéĝŕöûñð çöļöŕš ðö ñöţ ĥåvé å šûƒƒîçîéñţ çöñţŕåšţ ŕåţîö. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
@@ -111,88 +111,88 @@
     "message": "[Бåçķĝŕöûñð åñð ƒöŕéĝŕöûñð çöļöŕš ĥåvé å šûƒƒîçîéñţ çöñţŕåšţ ŕåţîö one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "[Ŵĥéñ ðéƒîñîţîöñ ļîšţš åŕé ñöţ þŕöþéŕļý måŕķéð ûþ, šçŕééñ ŕéåðéŕš måý þŕöðûçé çöñƒûšîñĝ öŕ îñåççûŕåţé öûţþûţ. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ðéƒîñîţîöñ-ļîšţ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
+    "message": "[Ŵĥéñ ðéƒîñîţîöñ ļîšţš åŕé ñöţ þŕöþéŕļý måŕķéð ûþ, šçŕééñ ŕéåðéŕš måý þŕöðûçé çöñƒûšîñĝ öŕ îñåççûŕåţé öûţþûţ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/definition-list/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "[`<dl>`'š ðö ñöţ çöñţåîñ öñļý þŕöþéŕļý-öŕðéŕéð `<dt>` åñð `<dd>` ĝŕöûþš, `<script>` öŕ `<ţémþļåţé>` éļéméñţš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
+    "message": "[ᐅ`<dl>`ᐊ'š ðö ñöţ çöñţåîñ öñļý þŕöþéŕļý-öŕðéŕéð ᐅ`<dt>`ᐊ åñð ᐅ`<dd>`ᐊ ĝŕöûþš, ᐅ`<script>`ᐊ öŕ ᐅ`<template>`ᐊ éļéméñţš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "[`<dl>`'š çöñţåîñ öñļý þŕöþéŕļý-öŕðéŕéð `<dt>` åñð `<dd>` ĝŕöûþš, `<script>` öŕ `<ţémþļåţé>` éļéméñţš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+    "message": "[ᐅ`<dl>`ᐊ'š çöñţåîñ öñļý þŕöþéŕļý-öŕðéŕéð ᐅ`<dt>`ᐊ åñð ᐅ`<dd>`ᐊ ĝŕöûþš, ᐅ`<script>`ᐊ öŕ ᐅ`<template>`ᐊ éļéméñţš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "[Ðéƒîñîţîöñ ļîšţ îţémš (`<dt>` åñð `<dd>`) mûšţ бé ŵŕåþþéð îñ å þåŕéñţ `<dl>` éļéméñţ ţö éñšûŕé ţĥåţ šçŕééñ ŕéåðéŕš çåñ þŕöþéŕļý åññöûñçé ţĥém. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ðļîţém¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Ðéƒîñîţîöñ ļîšţ îţémš (ᐅ`<dt>`ᐊ åñð ᐅ`<dd>`ᐊ) mûšţ бé ŵŕåþþéð îñ å þåŕéñţ ᐅ`<dl>`ᐊ éļéméñţ ţö éñšûŕé ţĥåţ šçŕééñ ŕéåðéŕš çåñ þŕöþéŕļý åññöûñçé ţĥém. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/dlitem/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "[Ðéƒîñîţîöñ ļîšţ îţémš åŕé ñöţ ŵŕåþþéð îñ `<dl>` éļéméñţš one two three four five six seven eight nine ten eleven]"
+    "message": "[Ðéƒîñîţîöñ ļîšţ îţémš åŕé ñöţ ŵŕåþþéð îñ ᐅ`<dl>`ᐊ éļéméñţš one two three four five six seven eight nine ten eleven]"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "[Ðéƒîñîţîöñ ļîšţ îţémš åŕé ŵŕåþþéð îñ `<dl>` éļéméñţš one two three four five six seven eight nine ten]"
+    "message": "[Ðéƒîñîţîöñ ļîšţ îţémš åŕé ŵŕåþþéð îñ ᐅ`<dl>`ᐊ éļéméñţš one two three four five six seven eight nine ten]"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "[Ţĥé ţîţļé ĝîvéš šçŕééñ ŕéåðéŕ ûšéŕš åñ övéŕvîéŵ öƒ ţĥé þåĝé, åñð šéåŕçĥ éñĝîñé ûšéŕš ŕéļý öñ îţ ĥéåvîļý ţö ðéţéŕmîñé îƒ å þåĝé îš ŕéļévåñţ ţö ţĥéîŕ šéåŕçĥ. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ţîţļé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty]"
+    "message": "[Ţĥé ţîţļé ĝîvéš šçŕééñ ŕéåðéŕ ûšéŕš åñ övéŕvîéŵ öƒ ţĥé þåĝé, åñð šéåŕçĥ éñĝîñé ûšéŕš ŕéļý öñ îţ ĥéåvîļý ţö ðéţéŕmîñé îƒ å þåĝé îš ŕéļévåñţ ţö ţĥéîŕ šéåŕçĥ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/document-title/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "[Ðöçûméñţ ðöéšñ'ţ ĥåvé å `<title>` éļéméñţ one two three four five six seven]"
+    "message": "[Ðöçûméñţ ðöéšñ'ţ ĥåvé å ᐅ`<title>`ᐊ éļéméñţ one two three four five six seven eight]"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "[Ðöçûméñţ ĥåš å `<title>` éļéméñţ one two three four five six]"
+    "message": "[Ðöçûméñţ ĥåš å ᐅ`<title>`ᐊ éļéméñţ one two three four five six]"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "[Ţĥé våļûé öƒ åñ îð åţţŕîбûţé mûšţ бé ûñîqûé ţö þŕévéñţ öţĥéŕ îñšţåñçéš ƒŕöm бéîñĝ övéŕļööķéð бý åššîšţîvé ţéçĥñöļöĝîéš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ðûþļîçåţé-îð¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Ţĥé våļûé öƒ åñ îð åţţŕîбûţé mûšţ бé ûñîqûé ţö þŕévéñţ öţĥéŕ îñšţåñçéš ƒŕöm бéîñĝ övéŕļööķéð бý åššîšţîvé ţéçĥñöļöĝîéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/duplicate-id/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "[`[îð]` åţţŕîбûţéš öñ ţĥé þåĝé åŕé ñöţ ûñîqûé one two three four five six seven eight nine]"
+    "message": "[ᐅ`[id]`ᐊ åţţŕîбûţéš öñ ţĥé þåĝé åŕé ñöţ ûñîqûé one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "[`[îð]` åţţŕîбûţéš öñ ţĥé þåĝé åŕé ûñîqûé one two three four five six seven eight]"
+    "message": "[ᐅ`[id]`ᐊ åţţŕîбûţéš öñ ţĥé þåĝé åŕé ûñîqûé one two three four five six seven eight]"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "[Šçŕééñ ŕéåðéŕ ûšéŕš ŕéļý öñ ƒŕåmé ţîţļéš ţö ðéšçŕîбé ţĥé çöñţéñţš öƒ ƒŕåméš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ƒŕåmé-ţîţļé¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
+    "message": "[Šçŕééñ ŕéåðéŕ ûšéŕš ŕéļý öñ ƒŕåmé ţîţļéš ţö ðéšçŕîбé ţĥé çöñţéñţš öƒ ƒŕåméš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/frame-title/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "[`<frame>` öŕ `<iframe>` éļéméñţš ðö ñöţ ĥåvé å ţîţļé one two three four five six seven eight]"
+    "message": "[ᐅ`<frame>`ᐊ öŕ ᐅ`<iframe>`ᐊ éļéméñţš ðö ñöţ ĥåvé å ţîţļé one two three four five six seven eight]"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "[`<frame>` öŕ `<iframe>` éļéméñţš ĥåvé å ţîţļé one two three four five six seven]"
+    "message": "[ᐅ`<frame>`ᐊ öŕ ᐅ`<iframe>`ᐊ éļéméñţš ĥåvé å ţîţļé one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "[Îƒ å þåĝé ðöéšñ'ţ šþéçîƒý å ļåñĝ åţţŕîбûţé, å šçŕééñ ŕéåðéŕ åššûméš ţĥåţ ţĥé þåĝé îš îñ ţĥé ðéƒåûļţ ļåñĝûåĝé ţĥåţ ţĥé ûšéŕ çĥöšé ŵĥéñ šéţţîñĝ ûþ ţĥé šçŕééñ ŕéåðéŕ. Îƒ ţĥé þåĝé îšñ'ţ åçţûåļļý îñ ţĥé ðéƒåûļţ ļåñĝûåĝé, ţĥéñ ţĥé šçŕééñ ŕéåðéŕ mîĝĥţ ñöţ åññöûñçé ţĥé þåĝé'š ţéxţ çöŕŕéçţļý. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ĥţmļ-ĥåš-ļåñĝ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty one two three four five six seven eight]"
+    "message": "[Îƒ å þåĝé ðöéšñ'ţ šþéçîƒý å ļåñĝ åţţŕîбûţé, å šçŕééñ ŕéåðéŕ åššûméš ţĥåţ ţĥé þåĝé îš îñ ţĥé ðéƒåûļţ ļåñĝûåĝé ţĥåţ ţĥé ûšéŕ çĥöšé ŵĥéñ šéţţîñĝ ûþ ţĥé šçŕééñ ŕéåðéŕ. Îƒ ţĥé þåĝé îšñ'ţ åçţûåļļý îñ ţĥé ðéƒåûļţ ļåñĝûåĝé, ţĥéñ ţĥé šçŕééñ ŕéåðéŕ mîĝĥţ ñöţ åññöûñçé ţĥé þåĝé'š ţéxţ çöŕŕéçţļý. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/html-has-lang/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix]"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "[`<html>` éļéméñţ ðöéš ñöţ ĥåvé å `[ļåñĝ]` åţţŕîбûţé one two three four five six seven eight nine]"
+    "message": "[ᐅ`<html>`ᐊ éļéméñţ ðöéš ñöţ ĥåvé å ᐅ`[lang]`ᐊ åţţŕîбûţé one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "[`<html>` éļéméñţ ĥåš å `[ļåñĝ]` åţţŕîбûţé one two three four five six seven eight]"
+    "message": "[ᐅ`<html>`ᐊ éļéméñţ ĥåš å ᐅ`[lang]`ᐊ åţţŕîбûţé one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "[Šþéçîƒýîñĝ å våļîð [БÇÞ 47 ļåñĝûåĝé](ĥţţþš://ŵŵŵ.ŵ3.öŕĝ/Îñţéŕñåţîöñåļ/qûéšţîöñš/qå-çĥööšîñĝ-ļåñĝûåĝé-ţåĝš#qûéšţîöñ) ĥéļþš šçŕééñ ŕéåðéŕš åññöûñçé ţéxţ þŕöþéŕļý. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/våļîð-ļåñĝ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo]"
+    "message": "[Šþéçîƒýîñĝ å våļîð ᐅ[ᐊБÇÞ 47 ļåñĝûåĝéᐅ](https://www.w3.org/International/questions/qa-choosing-language-tags#question)ᐊ ĥéļþš šçŕééñ ŕéåðéŕš åññöûñçé ţéxţ þŕöþéŕļý. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/html-lang-valid/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "[`<html>` éļéméñţ ðöéš ñöţ ĥåvé å våļîð våļûé ƒöŕ îţš `[ļåñĝ]` åţţŕîбûţé. one two three four five six seven eight nine ten eleven twelve thirteen]"
+    "message": "[ᐅ`<html>`ᐊ éļéméñţ ðöéš ñöţ ĥåvé å våļîð våļûé ƒöŕ îţš ᐅ`[lang]`ᐊ åţţŕîбûţé. one two three four five six seven eight nine ten eleven twelve]"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "[`<html>` éļéméñţ ĥåš å våļîð våļûé ƒöŕ îţš `[ļåñĝ]` åţţŕîбûţé one two three four five six seven eight nine ten eleven]"
+    "message": "[ᐅ`<html>`ᐊ éļéméñţ ĥåš å våļîð våļûé ƒöŕ îţš ᐅ`[lang]`ᐊ åţţŕîбûţé one two three four five six seven eight nine ten eleven]"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "[Îñƒöŕmåţîvé éļéméñţš šĥöûļð åîm ƒöŕ šĥöŕţ, ðéšçŕîþţîvé åļţéŕñåţé ţéxţ. Ðéçöŕåţîvé éļéméñţš çåñ бé îĝñöŕéð ŵîţĥ åñ émþţý åļţ åţţŕîбûţé. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/îmåĝé-åļţ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine]"
+    "message": "[Îñƒöŕmåţîvé éļéméñţš šĥöûļð åîm ƒöŕ šĥöŕţ, ðéšçŕîþţîvé åļţéŕñåţé ţéxţ. Ðéçöŕåţîvé éļéméñţš çåñ бé îĝñöŕéð ŵîţĥ åñ émþţý åļţ åţţŕîбûţé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/image-alt/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "[Îmåĝé éļéméñţš ðö ñöţ ĥåvé `[åļţ]` åţţŕîбûţéš one two three four five six seven eight nine]"
+    "message": "[Îmåĝé éļéméñţš ðö ñöţ ĥåvé ᐅ`[alt]`ᐊ åţţŕîбûţéš one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "[Îmåĝé éļéméñţš ĥåvé `[åļţ]` åţţŕîбûţéš one two three four five six seven eight]"
+    "message": "[Îmåĝé éļéméñţš ĥåvé ᐅ`[alt]`ᐊ åţţŕîбûţéš one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "[Ŵĥéñ åñ îmåĝé îš бéîñĝ ûšéð åš åñ `<input>` бûţţöñ, þŕövîðîñĝ åļţéŕñåţîvé ţéxţ çåñ ĥéļþ šçŕééñ ŕéåðéŕ ûšéŕš ûñðéŕšţåñð ţĥé þûŕþöšé öƒ ţĥé бûţţöñ. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/îñþûţ-îmåĝé-åļţ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty]"
+    "message": "[Ŵĥéñ åñ îmåĝé îš бéîñĝ ûšéð åš åñ ᐅ`<input>`ᐊ бûţţöñ, þŕövîðîñĝ åļţéŕñåţîvé ţéxţ çåñ ĥéļþ šçŕééñ ŕéåðéŕ ûšéŕš ûñðéŕšţåñð ţĥé þûŕþöšé öƒ ţĥé бûţţöñ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/input-image-alt/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "[`<input type=\"image\">` éļéméñţš ðö ñöţ ĥåvé `[åļţ]` ţéxţ one two three four five six seven eight]"
+    "message": "[ᐅ`<input type=\"image\">`ᐊ éļéméñţš ðö ñöţ ĥåvé ᐅ`[alt]`ᐊ ţéxţ one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "[`<input type=\"image\">` éļéméñţš ĥåvé `[åļţ]` ţéxţ one two three four five six seven]"
+    "message": "[ᐅ`<input type=\"image\">`ᐊ éļéméñţš ĥåvé ᐅ`[alt]`ᐊ ţéxţ one two three four five six]"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "[Ļåбéļš éñšûŕé ţĥåţ ƒöŕm çöñţŕöļš åŕé åññöûñçéð þŕöþéŕļý бý åššîšţîvé ţéçĥñöļöĝîéš, ļîķé šçŕééñ ŕéåðéŕš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ļåбéļ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
+    "message": "[Ļåбéļš éñšûŕé ţĥåţ ƒöŕm çöñţŕöļš åŕé åññöûñçéð þŕöþéŕļý бý åššîšţîvé ţéçĥñöļöĝîéš, ļîķé šçŕééñ ŕéåðéŕš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/label/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "[Föŕm éļéméñţš ðö ñöţ ĥåvé åššöçîåţéð ļåбéļš one two three four five six seven eight nine]"
@@ -201,16 +201,16 @@
     "message": "[Föŕm éļéméñţš ĥåvé åššöçîåţéð ļåбéļš one two three four five six seven eight]"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "[Å ţåбļé бéîñĝ ûšéð ƒöŕ ļåýöûţ þûŕþöšéš šĥöûļð ñöţ îñçļûðé ðåţå éļéméñţš, šûçĥ åš ţĥé ţĥ öŕ çåþţîöñ éļéméñţš öŕ ţĥé šûmmåŕý åţţŕîбûţé, бéçåûšé ţĥîš çåñ çŕéåţé å çöñƒûšîñĝ éxþéŕîéñçé ƒöŕ šçŕééñ ŕéåðéŕ ûšéŕš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ļåýöûţ-ţåбļé¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix]"
+    "message": "[Å ţåбļé бéîñĝ ûšéð ƒöŕ ļåýöûţ þûŕþöšéš šĥöûļð ñöţ îñçļûðé ðåţå éļéméñţš, šûçĥ åš ţĥé ţĥ öŕ çåþţîöñ éļéméñţš öŕ ţĥé šûmmåŕý åţţŕîбûţé, бéçåûšé ţĥîš çåñ çŕéåţé å çöñƒûšîñĝ éxþéŕîéñçé ƒöŕ šçŕééñ ŕéåðéŕ ûšéŕš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/layout-table/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine]"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "[Þŕéšéñţåţîöñåļ `<table>` éļéméñţš ðö ñöţ åvöîð ûšîñĝ `<th>`, `<caption>` öŕ ţĥé `[šûmmåŕý]` åţţŕîбûţé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
+    "message": "[Þŕéšéñţåţîöñåļ ᐅ`<table>`ᐊ éļéméñţš ðö ñöţ åvöîð ûšîñĝ ᐅ`<th>`ᐊ, ᐅ`<caption>`ᐊ öŕ ţĥé ᐅ`[summary]`ᐊ åţţŕîбûţé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "[Þŕéšéñţåţîöñåļ `<table>` éļéméñţš åvöîð ûšîñĝ `<th>`, `<caption>` öŕ ţĥé `[šûmmåŕý]` åţţŕîбûţé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+    "message": "[Þŕéšéñţåţîöñåļ ᐅ`<table>`ᐊ éļéméñţš åvöîð ûšîñĝ ᐅ`<th>`ᐊ, ᐅ`<caption>`ᐊ öŕ ţĥé ᐅ`[summary]`ᐊ åţţŕîбûţé. one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "[Ļîñķ ţéxţ (åñð åļţéŕñåţé ţéxţ ƒöŕ îmåĝéš, ŵĥéñ ûšéð åš ļîñķš) ţĥåţ îš ðîšçéŕñîбļé, ûñîqûé, åñð ƒöçûšåбļé îmþŕövéš ţĥé ñåvîĝåţîöñ éxþéŕîéñçé ƒöŕ šçŕééñ ŕéåðéŕ ûšéŕš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ļîñķ-ñåmé¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo]"
+    "message": "[Ļîñķ ţéxţ (åñð åļţéŕñåţé ţéxţ ƒöŕ îmåĝéš, ŵĥéñ ûšéð åš ļîñķš) ţĥåţ îš ðîšçéŕñîбļé, ûñîqûé, åñð ƒöçûšåбļé îmþŕövéš ţĥé ñåvîĝåţîöñ éxþéŕîéñçé ƒöŕ šçŕééñ ŕéåðéŕ ûšéŕš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/link-name/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "[Ļîñķš ðö ñöţ ĥåvé å ðîšçéŕñîбļé ñåmé one two three four five six seven eight]"
@@ -219,103 +219,115 @@
     "message": "[Ļîñķš ĥåvé å ðîšçéŕñîбļé ñåmé one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "[Šçŕééñ ŕéåðéŕš ĥåvé å šþéçîƒîç ŵåý öƒ åññöûñçîñĝ ļîšţš. Éñšûŕîñĝ þŕöþéŕ ļîšţ šţŕûçţûŕé åîðš šçŕééñ ŕéåðéŕ öûţþûţ. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ļîšţ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
+    "message": "[Šçŕééñ ŕéåðéŕš ĥåvé å šþéçîƒîç ŵåý öƒ åññöûñçîñĝ ļîšţš. Éñšûŕîñĝ þŕöþéŕ ļîšţ šţŕûçţûŕé åîðš šçŕééñ ŕéåðéŕ öûţþûţ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/list/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "[Ļîšţš ðö ñöţ çöñţåîñ öñļý `<li>` éļéméñţš åñð šçŕîþţ šûþþöŕţîñĝ éļéméñţš (`<script>` åñð `<ţémþļåţé>`). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
+    "message": "[Ļîšţš ðö ñöţ çöñţåîñ öñļý ᐅ`<li>`ᐊ éļéméñţš åñð šçŕîþţ šûþþöŕţîñĝ éļéméñţš (ᐅ`<script>`ᐊ åñð ᐅ`<template>`ᐊ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "[Ļîšţš çöñţåîñ öñļý `<li>` éļéméñţš åñð šçŕîþţ šûþþöŕţîñĝ éļéméñţš (`<script>` åñð `<ţémþļåţé>`). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
+    "message": "[Ļîšţš çöñţåîñ öñļý ᐅ`<li>`ᐊ éļéméñţš åñð šçŕîþţ šûþþöŕţîñĝ éļéméñţš (ᐅ`<script>`ᐊ åñð ᐅ`<template>`ᐊ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "[Šçŕééñ ŕéåðéŕš ŕéqûîŕé ļîšţ îţémš (`<li>`) ţö бé çöñţåîñéð ŵîţĥîñ å þåŕéñţ `<ul>` öŕ `<ol>` ţö бé åññöûñçéð þŕöþéŕļý. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ļîšţîţém¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
+    "message": "[Šçŕééñ ŕéåðéŕš ŕéqûîŕé ļîšţ îţémš (ᐅ`<li>`ᐊ) ţö бé çöñţåîñéð ŵîţĥîñ å þåŕéñţ ᐅ`<ul>`ᐊ öŕ ᐅ`<ol>`ᐊ ţö бé åññöûñçéð þŕöþéŕļý. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/listitem/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "[Ļîšţ îţémš (`<li>`) åŕé ñöţ çöñţåîñéð ŵîţĥîñ `<ul>` öŕ `<ol>` þåŕéñţ éļéméñţš. one two three four five six seven eight nine ten eleven twelve thirteen]"
+    "message": "[Ļîšţ îţémš (ᐅ`<li>`ᐊ) åŕé ñöţ çöñţåîñéð ŵîţĥîñ ᐅ`<ul>`ᐊ öŕ ᐅ`<ol>`ᐊ þåŕéñţ éļéméñţš. one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "[Ļîšţ îţémš (`<li>`) åŕé çöñţåîñéð ŵîţĥîñ `<ul>` öŕ `<ol>` þåŕéñţ éļéméñţš one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[Ļîšţ îţémš (ᐅ`<li>`ᐊ) åŕé çöñţåîñéð ŵîţĥîñ ᐅ`<ul>`ᐊ öŕ ᐅ`<ol>`ᐊ þåŕéñţ éļéméñţš one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "[Ûšéŕš ðö ñöţ éxþéçţ å þåĝé ţö ŕéƒŕéšĥ åûţömåţîçåļļý, åñð ðöîñĝ šö ŵîļļ mövé ƒöçûš бåçķ ţö ţĥé ţöþ öƒ ţĥé þåĝé. Ţĥîš måý çŕéåţé å ƒŕûšţŕåţîñĝ öŕ çöñƒûšîñĝ éxþéŕîéñçé. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/méţå-ŕéƒŕéšĥ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo]"
+    "message": "[Ûšéŕš ðö ñöţ éxþéçţ å þåĝé ţö ŕéƒŕéšĥ åûţömåţîçåļļý, åñð ðöîñĝ šö ŵîļļ mövé ƒöçûš бåçķ ţö ţĥé ţöþ öƒ ţĥé þåĝé. Ţĥîš måý çŕéåţé å ƒŕûšţŕåţîñĝ öŕ çöñƒûšîñĝ éxþéŕîéñçé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/meta-refresh/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "[Ţĥé ðöçûméñţ ûšéš `<meta http-equiv=\"refresh\">` one two three four five]"
+    "message": "[Ţĥé ðöçûméñţ ûšéš ᐅ`<meta http-equiv=\"refresh\">`ᐊ one two three four five]"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "[Ţĥé ðöçûméñţ ðöéš ñöţ ûšé `<meta http-equiv=\"refresh\">` one two three four five six]"
+    "message": "[Ţĥé ðöçûméñţ ðöéš ñöţ ûšé ᐅ`<meta http-equiv=\"refresh\">`ᐊ one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "[Ðîšåбļîñĝ žöömîñĝ îš þŕöбļémåţîç ƒöŕ ûšéŕš ŵîţĥ ļöŵ vîšîöñ ŵĥö ŕéļý öñ šçŕééñ måĝñîƒîçåţîöñ ţö þŕöþéŕļý šéé ţĥé çöñţéñţš öƒ å ŵéб þåĝé. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/méţå-vîéŵþöŕţ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine]"
+    "message": "[Ðîšåбļîñĝ žöömîñĝ îš þŕöбļémåţîç ƒöŕ ûšéŕš ŵîţĥ ļöŵ vîšîöñ ŵĥö ŕéļý öñ šçŕééñ måĝñîƒîçåţîöñ ţö þŕöþéŕļý šéé ţĥé çöñţéñţš öƒ å ŵéб þåĝé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/meta-viewport/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "[`[ûšéŕ-šçåļåбļé=\"ñö\"]` îš ûšéð îñ ţĥé `<meta name=\"viewport\">` éļéméñţ öŕ ţĥé `[måxîmûm-šçåļé]` åţţŕîбûţé îš ļéšš ţĥåñ 5. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
+    "message": "[ᐅ`[user-scalable=\"no\"]`ᐊ îš ûšéð îñ ţĥé ᐅ`<meta name=\"viewport\">`ᐊ éļéméñţ öŕ ţĥé ᐅ`[maximum-scale]`ᐊ åţţŕîбûţé îš ļéšš ţĥåñ 5. one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "[`[ûšéŕ-šçåļåбļé=\"ñö\"]` îš ñöţ ûšéð îñ ţĥé `<meta name=\"viewport\">` éļéméñţ åñð ţĥé `[måxîmûm-šçåļé]` åţţŕîбûţé îš ñöţ ļéšš ţĥåñ 5. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
+    "message": "[ᐅ`[user-scalable=\"no\"]`ᐊ îš ñöţ ûšéð îñ ţĥé ᐅ`<meta name=\"viewport\">`ᐊ éļéméñţ åñð ţĥé ᐅ`[maximum-scale]`ᐊ åţţŕîбûţé îš ñöţ ļéšš ţĥåñ 5. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "[Šçŕééñ ŕéåðéŕš çåññöţ ţŕåñšļåţé ñöñ-ţéxţ çöñţéñţ. Åððîñĝ åļţ ţéxţ ţö `<object>` éļéméñţš ĥéļþš šçŕééñ ŕéåðéŕš çöñvéý méåñîñĝ ţö ûšéŕš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/öбĵéçţ-åļţ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Šçŕééñ ŕéåðéŕš çåññöţ ţŕåñšļåţé ñöñ-ţéxţ çöñţéñţ. Åððîñĝ åļţ ţéxţ ţö ᐅ`<object>`ᐊ éļéméñţš ĥéļþš šçŕééñ ŕéåðéŕš çöñvéý méåñîñĝ ţö ûšéŕš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/object-alt/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "[`<object>` éļéméñţš ðö ñöţ ĥåvé `[åļţ]` ţéxţ one two three four five six seven eight]"
+    "message": "[ᐅ`<object>`ᐊ éļéméñţš ðö ñöţ ĥåvé ᐅ`[alt]`ᐊ ţéxţ one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "[`<object>` éļéméñţš ĥåvé `[åļţ]` ţéxţ one two three four five six seven]"
+    "message": "[ᐅ`<object>`ᐊ éļéméñţš ĥåvé ᐅ`[alt]`ᐊ ţéxţ one two three four five six]"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "[Å våļûé ĝŕéåţéŕ ţĥåñ 0 îmþļîéš åñ éxþļîçîţ ñåvîĝåţîöñ öŕðéŕîñĝ. Åļţĥöûĝĥ ţéçĥñîçåļļý våļîð, ţĥîš öƒţéñ çŕéåţéš ƒŕûšţŕåţîñĝ éxþéŕîéñçéš ƒöŕ ûšéŕš ŵĥö ŕéļý öñ åššîšţîvé ţéçĥñöļöĝîéš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ţåбîñðéx¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree]"
+    "message": "[Å våļûé ĝŕéåţéŕ ţĥåñ 0 îmþļîéš åñ éxþļîçîţ ñåvîĝåţîöñ öŕðéŕîñĝ. Åļţĥöûĝĥ ţéçĥñîçåļļý våļîð, ţĥîš öƒţéñ çŕéåţéš ƒŕûšţŕåţîñĝ éxþéŕîéñçéš ƒöŕ ûšéŕš ŵĥö ŕéļý öñ åššîšţîvé ţéçĥñöļöĝîéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/tabindex/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "[Šömé éļéméñţš ĥåvé å `[ţåбîñðéx]` våļûé ĝŕéåţéŕ ţĥåñ 0 one two three four five six seven eight nine ten eleven]"
+    "message": "[Šömé éļéméñţš ĥåvé å ᐅ`[tabindex]`ᐊ våļûé ĝŕéåţéŕ ţĥåñ 0 one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "[Ñö éļéméñţ ĥåš å `[ţåбîñðéx]` våļûé ĝŕéåţéŕ ţĥåñ 0 one two three four five six seven eight nine ten eleven]"
+    "message": "[Ñö éļéméñţ ĥåš å ᐅ`[tabindex]`ᐊ våļûé ĝŕéåţéŕ ţĥåñ 0 one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "[Šçŕééñ ŕéåðéŕš ĥåvé ƒéåţûŕéš ţö måķé ñåvîĝåţîñĝ ţåбļéš éåšîéŕ. Éñšûŕîñĝ `<td>` çéļļš ûšîñĝ ţĥé `[ĥéåðéŕš]` åţţŕîбûţé öñļý ŕéƒéŕ ţö öţĥéŕ çéļļš îñ ţĥé šåmé ţåбļé måý îmþŕövé ţĥé éxþéŕîéñçé ƒöŕ šçŕééñ ŕéåðéŕ ûšéŕš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ţð-ĥéåðéŕš-åţţŕ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven]"
+    "message": "[Šçŕééñ ŕéåðéŕš ĥåvé ƒéåţûŕéš ţö måķé ñåvîĝåţîñĝ ţåбļéš éåšîéŕ. Éñšûŕîñĝ ᐅ`<td>`ᐊ çéļļš ûšîñĝ ţĥé ᐅ`[headers]`ᐊ åţţŕîбûţé öñļý ŕéƒéŕ ţö öţĥéŕ çéļļš îñ ţĥé šåmé ţåбļé måý îmþŕövé ţĥé éxþéŕîéñçé ƒöŕ šçŕééñ ŕéåðéŕ ûšéŕš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/td-headers-attr/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "[Çéļļš îñ å `<table>` éļéméñţ ţĥåţ ûšé ţĥé `[ĥéåðéŕš]` åţţŕîбûţé ŕéƒéŕš ţö öţĥéŕ çéļļš öƒ ţĥåţ šåmé ţåбļé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
+    "message": "[Çéļļš îñ å ᐅ`<table>`ᐊ éļéméñţ ţĥåţ ûšé ţĥé ᐅ`[headers]`ᐊ åţţŕîбûţé ŕéƒéŕš ţö öţĥéŕ çéļļš öƒ ţĥåţ šåmé ţåбļé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "[Çéļļš îñ å `<table>` éļéméñţ ţĥåţ ûšé ţĥé `[ĥéåðéŕš]` åţţŕîбûţé öñļý ŕéƒéŕ ţö öţĥéŕ çéļļš öƒ ţĥåţ šåmé ţåбļé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
+    "message": "[Çéļļš îñ å ᐅ`<table>`ᐊ éļéméñţ ţĥåţ ûšé ţĥé ᐅ`[headers]`ᐊ åţţŕîбûţé öñļý ŕéƒéŕ ţö öţĥéŕ çéļļš öƒ ţĥåţ šåmé ţåбļé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "[Šçŕééñ ŕéåðéŕš ĥåvé ƒéåţûŕéš ţö måķé ñåvîĝåţîñĝ ţåбļéš éåšîéŕ. Éñšûŕîñĝ ţåбļé ĥéåðéŕš åļŵåýš ŕéƒéŕ ţö šömé šéţ öƒ çéļļš måý îmþŕövé ţĥé éxþéŕîéñçé ƒöŕ šçŕééñ ŕéåðéŕ ûšéŕš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/ţĥ-ĥåš-ðåţå-çéļļš¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree]"
+    "message": "[Šçŕééñ ŕéåðéŕš ĥåvé ƒéåţûŕéš ţö måķé ñåvîĝåţîñĝ ţåбļéš éåšîéŕ. Éñšûŕîñĝ ţåбļé ĥéåðéŕš åļŵåýš ŕéƒéŕ ţö šömé šéţ öƒ çéļļš måý îmþŕövé ţĥé éxþéŕîéñçé ƒöŕ šçŕééñ ŕéåðéŕ ûšéŕš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/th-has-data-cells/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "[`<th>` éļéméñţš åñð éļéméñţš ŵîţĥ `[ŕöļé=\"çöļûmñĥéåðéŕ\"/\"ŕöŵĥéåðéŕ\"]` ðö ñöţ ĥåvé ðåţå çéļļš ţĥéý ðéšçŕîбé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
+    "message": "[ᐅ`<th>`ᐊ éļéméñţš åñð éļéméñţš ŵîţĥ ᐅ`[role=\"columnheader\"/\"rowheader\"]`ᐊ ðö ñöţ ĥåvé ðåţå çéļļš ţĥéý ðéšçŕîбé. one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "[`<th>` éļéméñţš åñð éļéméñţš ŵîţĥ `[ŕöļé=\"çöļûmñĥéåðéŕ\"/\"ŕöŵĥéåðéŕ\"]` ĥåvé ðåţå çéļļš ţĥéý ðéšçŕîбé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
+    "message": "[ᐅ`<th>`ᐊ éļéméñţš åñð éļéméñţš ŵîţĥ ᐅ`[role=\"columnheader\"/\"rowheader\"]`ᐊ ĥåvé ðåţå çéļļš ţĥéý ðéšçŕîбé. one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "[Šþéçîƒýîñĝ å våļîð [БÇÞ 47 ļåñĝûåĝé](ĥţţþš://ŵŵŵ.ŵ3.öŕĝ/Îñţéŕñåţîöñåļ/qûéšţîöñš/qå-çĥööšîñĝ-ļåñĝûåĝé-ţåĝš#qûéšţîöñ) öñ éļéméñţš ĥéļþš éñšûŕé ţĥåţ ţéxţ îš þŕöñöûñçéð çöŕŕéçţļý бý å šçŕééñ ŕéåðéŕ. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/våļîð-ļåñĝ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive]"
+    "message": "[Šþéçîƒýîñĝ å våļîð ᐅ[ᐊБÇÞ 47 ļåñĝûåĝéᐅ](https://www.w3.org/International/questions/qa-choosing-language-tags#question)ᐊ öñ éļéméñţš ĥéļþš éñšûŕé ţĥåţ ţéxţ îš þŕöñöûñçéð çöŕŕéçţļý бý å šçŕééñ ŕéåðéŕ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/valid-lang/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "[`[ļåñĝ]` åţţŕîбûţéš ðö ñöţ ĥåvé å våļîð våļûé one two three four five six seven eight nine]"
+    "message": "[ᐅ`[lang]`ᐊ åţţŕîбûţéš ðö ñöţ ĥåvé å våļîð våļûé one two three four five six seven eight]"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "[`[ļåñĝ]` åţţŕîбûţéš ĥåvé å våļîð våļûé one two three four five six seven eight]"
+    "message": "[ᐅ`[lang]`ᐊ åţţŕîбûţéš ĥåvé å våļîð våļûé one two three four five six seven]"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "[Ŵĥéñ å vîðéö þŕövîðéš å çåþţîöñ îţ îš éåšîéŕ ƒöŕ ðéåƒ åñð ĥéåŕîñĝ îmþåîŕéð ûšéŕš ţö åççéšš îţš îñƒöŕmåţîöñ. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/vîðéö-çåþţîöñ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
+    "message": "[Ŵĥéñ å vîðéö þŕövîðéš å çåþţîöñ îţ îš éåšîéŕ ƒöŕ ðéåƒ åñð ĥéåŕîñĝ îmþåîŕéð ûšéŕš ţö åççéšš îţš îñƒöŕmåţîöñ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/video-caption/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "[`<video>` éļéméñţš ðö ñöţ çöñţåîñ å `<track>` éļéméñţ ŵîţĥ `[ķîñð=\"çåþţîöñš\"]`. one two three four five six seven eight nine ten eleven twelve thirteen]"
+    "message": "[ᐅ`<video>`ᐊ éļéméñţš ðö ñöţ çöñţåîñ å ᐅ`<track>`ᐊ éļéméñţ ŵîţĥ ᐅ`[kind=\"captions\"]`ᐊ. one two three four five six seven eight nine ten eleven]"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "[`<video>` éļéméñţš çöñţåîñ å `<track>` éļéméñţ ŵîţĥ `[ķîñð=\"çåþţîöñš\"]` one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[ᐅ`<video>`ᐊ éļéméñţš çöñţåîñ å ᐅ`<track>`ᐊ éļéméñţ ŵîţĥ ᐅ`[kind=\"captions\"]`ᐊ one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "[Åûðîö ðéšçŕîþţîöñš þŕövîðé ŕéļévåñţ îñƒöŕmåţîöñ ƒöŕ vîðéöš ţĥåţ ðîåļöĝûé çåññöţ, šûçĥ åš ƒåçîåļ éxþŕéššîöñš åñð šçéñéš. [Ļéåŕñ möŕé](ĥţţþš://ðéqûéûñîvéŕšîţý.çöm/ŕûļéš/åxé/3.1/vîðéö-ðéšçŕîþţîöñ¿åþþļîçåţîöñ=ļîĝĥţĥöûšé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Åûðîö ðéšçŕîþţîöñš þŕövîðé ŕéļévåñţ îñƒöŕmåţîöñ ƒöŕ vîðéöš ţĥåţ ðîåļöĝûé çåññöţ, šûçĥ åš ƒåçîåļ éxþŕéššîöñš åñð šçéñéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/video-description/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "[`<video>` éļéméñţš ðö ñöţ çöñţåîñ å `<track>` éļéméñţ ŵîţĥ `[ķîñð=\"ðéšçŕîþţîöñ\"]`. one two three four five six seven eight nine ten eleven twelve thirteen]"
+    "message": "[ᐅ`<video>`ᐊ éļéméñţš ðö ñöţ çöñţåîñ å ᐅ`<track>`ᐊ éļéméñţ ŵîţĥ ᐅ`[kind=\"description\"]`ᐊ. one two three four five six seven eight nine ten eleven]"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "[`<video>` éļéméñţš çöñţåîñ å `<track>` éļéméñţ ŵîţĥ `[ķîñð=\"ðéšçŕîþţîöñ\"]` one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[ᐅ`<video>`ᐊ éļéméñţš çöñţåîñ å ᐅ`<track>`ᐊ éļéméñţ ŵîţĥ ᐅ`[kind=\"description\"]`ᐊ one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "[Föŕ îðéåļ åþþéåŕåñçé öñ îÖŠ ŵĥéñ ûšéŕš åðð ţö ţĥé ĥömé šçŕééñ, ðéƒîñé åñ åþþļé-ţöûçĥ-îçöñ. Îţ mûšţ þöîñţ ţö å ñöñ-ţŕåñšþåŕéñţ 192þx (öŕ 180þx) šqûåŕé ÞÑĜ. ᐅ[ᐊĻéåŕñ Möŕéᐅ](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "[Ðöéš ñöţ þŕövîðé å våļîð ᐅ`apple-touch-icon`ᐊ one two three four five six]"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "[ᐅ`apple-touch-icon-precomposed`ᐊ îš öûţ öƒ ðåţé; ᐅ`apple-touch-icon`ᐊ îš þŕéƒéŕŕéð. one two three four five six seven eight]"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "[Þŕövîðéš å våļîð ᐅ`apple-touch-icon`ᐊ one two three four five]"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "[Çĥŕömé éxţéñšîöñš ñéĝåţîvéļý åƒƒéçţéð ţĥîš þåĝé'š ļöåð þéŕƒöŕmåñçé. Ţŕý åûðîţîñĝ ţĥé þåĝé îñ îñçöĝñîţö möðé öŕ ƒŕöm å Çĥŕömé þŕöƒîļé ŵîţĥöûţ éxţéñšîöñš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
@@ -330,7 +342,7 @@
     "message": "[Ţöţåļ ÇÞÛ Ţîmé one two]"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "[Çöñšîðéŕ ŕéðûçîñĝ ţĥé ţîmé šþéñţ þåŕšîñĝ, çömþîļîñĝ, åñð éxéçûţîñĝ ĴŠ. Ýöû måý ƒîñð ðéļîvéŕîñĝ šmåļļéŕ ĴŠ þåýļöåðš ĥéļþš ŵîţĥ ţĥîš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/бööţûþ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Çöñšîðéŕ ŕéðûçîñĝ ţĥé ţîmé šþéñţ þåŕšîñĝ, çömþîļîñĝ, åñð éxéçûţîñĝ ĴŠ. Ýöû måý ƒîñð ðéļîvéŕîñĝ šmåļļéŕ ĴŠ þåýļöåðš ĥéļþš ŵîţĥ ţĥîš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/bootup)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "[Ŕéðûçé ĴåvåŠçŕîþţ éxéçûţîöñ ţîmé one two three four five six seven]"
@@ -339,28 +351,28 @@
     "message": "[ĴåvåŠçŕîþţ éxéçûţîöñ ţîmé one two three]"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "[Ļåŕĝé ĜÎFš åŕé îñéƒƒîçîéñţ ƒöŕ ðéļîvéŕîñĝ åñîmåţéð çöñţéñţ. Çöñšîðéŕ ûšîñĝ MÞÉĜ4/ŴéбM vîðéöš ƒöŕ åñîmåţîöñš åñð ÞÑĜ/ŴéбÞ ƒöŕ šţåţîç îmåĝéš îñšţéåð öƒ ĜÎF ţö šåvé ñéţŵöŕķ бýţéš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ƒûñðåméñţåļš/þéŕƒöŕmåñçé/öþţîmîžîñĝ-çöñţéñţ-éƒƒîçîéñçý/ŕéþļåçé-åñîmåţéð-ĝîƒš-ŵîţĥ-vîðéö/) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven]"
+    "message": "[Ļåŕĝé ĜÎFš åŕé îñéƒƒîçîéñţ ƒöŕ ðéļîvéŕîñĝ åñîmåţéð çöñţéñţ. Çöñšîðéŕ ûšîñĝ MÞÉĜ4/ŴéбM vîðéöš ƒöŕ åñîmåţîöñš åñð ÞÑĜ/ŴéбÞ ƒöŕ šţåţîç îmåĝéš îñšţéåð öƒ ĜÎF ţö šåvé ñéţŵöŕķ бýţéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)ᐊ one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "[Ûšé vîðéö ƒöŕmåţš ƒöŕ åñîmåţéð çöñţéñţ one two three four five six seven eight]"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "[Çöñšîðéŕ ļåžý-ļöåðîñĝ öƒƒšçŕééñ åñð ĥîððéñ îmåĝéš åƒţéŕ åļļ çŕîţîçåļ ŕéšöûŕçéš ĥåvé ƒîñîšĥéð ļöåðîñĝ ţö ļöŵéŕ ţîmé ţö îñţéŕåçţîvé. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/öƒƒšçŕééñ-îmåĝéš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Çöñšîðéŕ ļåžý-ļöåðîñĝ öƒƒšçŕééñ åñð ĥîððéñ îmåĝéš åƒţéŕ åļļ çŕîţîçåļ ŕéšöûŕçéš ĥåvé ƒîñîšĥéð ļöåðîñĝ ţö ļöŵéŕ ţîmé ţö îñţéŕåçţîvé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "[Ðéƒéŕ öƒƒšçŕééñ îmåĝéš one two three]"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "[Ŕéšöûŕçéš åŕé бļöçķîñĝ ţĥé ƒîŕšţ þåîñţ öƒ ýöûŕ þåĝé. Çöñšîðéŕ ðéļîvéŕîñĝ çŕîţîçåļ ĴŠ/ÇŠŠ îñļîñé åñð ðéƒéŕŕîñĝ åļļ ñöñ-çŕîţîçåļ ĴŠ/šţýļéš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/бļöçķîñĝ-ŕéšöûŕçéš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine]"
+    "message": "[Ŕéšöûŕçéš åŕé бļöçķîñĝ ţĥé ƒîŕšţ þåîñţ öƒ ýöûŕ þåĝé. Çöñšîðéŕ ðéļîvéŕîñĝ çŕîţîçåļ ĴŠ/ÇŠŠ îñļîñé åñð ðéƒéŕŕîñĝ åļļ ñöñ-çŕîţîçåļ ĴŠ/šţýļéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "[Éļîmîñåţé ŕéñðéŕ-бļöçķîñĝ ŕéšöûŕçéš one two three four]"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "[Ļåŕĝé ñéţŵöŕķ þåýļöåðš çöšţ ûšéŕš ŕéåļ möñéý åñð åŕé ĥîĝĥļý çöŕŕéļåţéð ŵîţĥ ļöñĝ ļöåð ţîméš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ñéţŵöŕķ-þåýļöåðš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
+    "message": "[Ļåŕĝé ñéţŵöŕķ þåýļöåðš çöšţ ûšéŕš ŕéåļ möñéý åñð åŕé ĥîĝĥļý çöŕŕéļåţéð ŵîţĥ ļöñĝ ļöåð ţîméš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "[Ţöţåļ šîžé ŵåš {ţöţåļБýţéš} ĶБ one two three four five six seven]"
+    "message": "[Ţöţåļ šîžé ŵåš ᐅ{totalBytes, number, bytes}ᐊ ĶБ one two three four five]"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "[Åvöîð éñöŕmöûš ñéţŵöŕķ þåýļöåðš one two three four five six seven]"
@@ -369,19 +381,19 @@
     "message": "[Åvöîðš éñöŕmöûš ñéţŵöŕķ þåýļöåðš one two three four five six seven]"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "[Mîñîƒýîñĝ ÇŠŠ ƒîļéš çåñ ŕéðûçé ñéţŵöŕķ þåýļöåð šîžéš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/mîñîƒý-çšš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
+    "message": "[Mîñîƒýîñĝ ÇŠŠ ƒîļéš çåñ ŕéðûçé ñéţŵöŕķ þåýļöåð šîžéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/minify-css)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "[Mîñîƒý ÇŠŠ one two]"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "[Mîñîƒýîñĝ ĴåvåŠçŕîþţ ƒîļéš çåñ ŕéðûçé þåýļöåð šîžéš åñð šçŕîþţ þåŕšé ţîmé. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/šþééð/ðöçš/îñšîĝĥţš/MîñîƒýŔéšöûŕçéš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Mîñîƒýîñĝ ĴåvåŠçŕîþţ ƒîļéš çåñ ŕéðûçé þåýļöåð šîžéš åñð šçŕîþţ þåŕšé ţîmé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/speed/docs/insights/MinifyResources)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "[Mîñîƒý ĴåvåŠçŕîþţ one two three]"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "[Ŕémövé ðéåð ŕûļéš ƒŕöm šţýļéšĥééţš åñð ðéƒéŕ ţĥé ļöåðîñĝ öƒ ÇŠŠ ñöţ ûšéð ƒöŕ åбövé-ţĥé-ƒöļð çöñţéñţ ţö ŕéðûçé ûññéçéššåŕý бýţéš çöñšûméð бý ñéţŵöŕķ åçţîvîţý. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ûñûšéð-çšš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone]"
+    "message": "[Ŕémövé ðéåð ŕûļéš ƒŕöm šţýļéšĥééţš åñð ðéƒéŕ ţĥé ļöåðîñĝ öƒ ÇŠŠ ñöţ ûšéð ƒöŕ åбövé-ţĥé-ƒöļð çöñţéñţ ţö ŕéðûçé ûññéçéššåŕý бýţéš çöñšûméð бý ñéţŵöŕķ åçţîvîţý. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/unused-css)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "[Ŕémövé ûñûšéð ÇŠŠ one two three]"
@@ -393,7 +405,7 @@
     "message": "[Ŕémövé ûñûšéð ĴåvåŠçŕîþţ one two three]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "[Å ļöñĝ çåçĥé ļîƒéţîmé çåñ šþééð ûþ ŕéþéåţ vîšîţš ţö ýöûŕ þåĝé. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/çåçĥé-þöļîçý). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
+    "message": "[Å ļöñĝ çåçĥé ļîƒéţîmé çåñ šþééð ûþ ŕéþéåţ vîšîţš ţö ýöûŕ þåĝé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{[1 ŕéšöûŕçé ƒöûñð one two]}other{[# ŕéšöûŕçéš ƒöûñð one two three]}}"
@@ -405,37 +417,88 @@
     "message": "[Ûšéš éƒƒîçîéñţ çåçĥé þöļîçý öñ šţåţîç åššéţš one two three four five six seven eight nine]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "[Öþţîmîžéð îmåĝéš ļöåð ƒåšţéŕ åñð çöñšûmé ļéšš çéļļûļåŕ ðåţå. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/öþţîmîžé-îmåĝéš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
+    "message": "[Öþţîmîžéð îmåĝéš ļöåð ƒåšţéŕ åñð çöñšûmé ļéšš çéļļûļåŕ ðåţå. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "[Éƒƒîçîéñţļý éñçöðé îmåĝéš one two three]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "[Šéŕvé îmåĝéš ţĥåţ åŕé åþþŕöþŕîåţéļý-šîžéð ţö šåvé çéļļûļåŕ ðåţå åñð îmþŕövé ļöåð ţîmé. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/övéŕšîžéð-îmåĝéš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
+    "message": "[Šéŕvé îmåĝéš ţĥåţ åŕé åþþŕöþŕîåţéļý-šîžéð ţö šåvé çéļļûļåŕ ðåţå åñð îmþŕövé ļöåð ţîmé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "[Þŕöþéŕļý šîžé îmåĝéš one two three]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "[Ţéxţ-бåšéð ŕéšöûŕçéš šĥöûļð бé šéŕvéð ŵîţĥ çömþŕéššîöñ (ĝžîþ, ðéƒļåţé öŕ бŕöţļî) ţö mîñîmîžé ţöţåļ ñéţŵöŕķ бýţéš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ţéxţ-çömþŕéššîöñ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
+    "message": "[Ţéxţ-бåšéð ŕéšöûŕçéš šĥöûļð бé šéŕvéð ŵîţĥ çömþŕéššîöñ (ĝžîþ, ðéƒļåţé öŕ бŕöţļî) ţö mîñîmîžé ţöţåļ ñéţŵöŕķ бýţéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/text-compression)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "[Éñåбļé ţéxţ çömþŕéššîöñ one two three]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "[Îmåĝé ƒöŕmåţš ļîķé ĴÞÉĜ 2000, ĴÞÉĜ XŔ, åñð ŴéбÞ öƒţéñ þŕövîðé бéţţéŕ çömþŕéššîöñ ţĥåñ ÞÑĜ öŕ ĴÞÉĜ, ŵĥîçĥ méåñš ƒåšţéŕ ðöŵñļöåðš åñð ļéšš ðåţå çöñšûmþţîöñ. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ŵéбþ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty]"
+    "message": "[Îmåĝé ƒöŕmåţš ļîķé ĴÞÉĜ 2000, ĴÞÉĜ XŔ, åñð ŴéбÞ öƒţéñ þŕövîðé бéţţéŕ çömþŕéššîöñ ţĥåñ ÞÑĜ öŕ ĴÞÉĜ, ŵĥîçĥ méåñš ƒåšţéŕ ðöŵñļöåðš åñð ļéšš ðåţå çöñšûmþţîöñ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/webp)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "[Šéŕvé îmåĝéš îñ ñéxţ-ĝéñ ƒöŕmåţš one two three four five six seven]"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "[Ţĥé Çŕîţîçåļ Ŕéqûéšţ Çĥåîñš бéļöŵ šĥöŵ ýöû ŵĥåţ ŕéšöûŕçéš åŕé ļöåðéð ŵîţĥ å ĥîĝĥ þŕîöŕîţý. Çöñšîðéŕ ŕéðûçîñĝ ţĥé ļéñĝţĥ öƒ çĥåîñš, ŕéðûçîñĝ ţĥé ðöŵñļöåð šîžé öƒ ŕéšöûŕçéš, öŕ ðéƒéŕŕîñĝ ţĥé ðöŵñļöåð öƒ ûññéçéššåŕý ŕéšöûŕçéš ţö îmþŕövé þåĝé ļöåð. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/çŕîţîçåļ-ŕéqûéšţ-çĥåîñš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty]"
+    "message": "[Ţĥé Çŕîţîçåļ Ŕéqûéšţ Çĥåîñš бéļöŵ šĥöŵ ýöû ŵĥåţ ŕéšöûŕçéš åŕé ļöåðéð ŵîţĥ å ĥîĝĥ þŕîöŕîţý. Çöñšîðéŕ ŕéðûçîñĝ ţĥé ļéñĝţĥ öƒ çĥåîñš, ŕéðûçîñĝ ţĥé ðöŵñļöåð šîžé öƒ ŕéšöûŕçéš, öŕ ðéƒéŕŕîñĝ ţĥé ðöŵñļöåð öƒ ûññéçéššåŕý ŕéšöûŕçéš ţö îmþŕövé þåĝé ļöåð. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree]"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{[1 çĥåîñ ƒöûñð one two]}other{[# çĥåîñš ƒöûñð one two]}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "[Mîñîmîžé Çŕîţîçåļ Ŕéqûéšţš Ðéþţĥ one two three four five six seven]"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "[Ðéþŕéçåţîöñ / Ŵåŕñîñĝ one two three]"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "[Ļîñé one]"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "[Ðéþŕéçåţéð ÅÞÎš ŵîļļ évéñţûåļļý бé ŕémövéð ƒŕöm ţĥé бŕöŵšéŕ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://www.chromestatus.com/features#deprecated)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{[1 ŵåŕñîñĝ ƒöûñð one two]}other{[# ŵåŕñîñĝš ƒöûñð one two]}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "[Ûšéš ðéþŕéçåţéð ÅÞÎš one two three]"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "[Åvöîðš ðéþŕéçåţéð ÅÞÎš one two three]"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "[Åþþļîçåţîöñ Çåçĥé îš ðéþŕéçåţéð. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/appcache)ᐊ. one two three four five six seven eight nine ten eleven]"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "[Föûñð \"ᐅ{AppCacheManifest}ᐊ\" one two three]"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "[Ûšéš Åþþļîçåţîöñ Çåçĥé one two three]"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "[Åvöîðš Åþþļîçåţîöñ Çåçĥé one two three]"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "[Šþéçîƒýîñĝ å ðöçţýþé þŕévéñţš ţĥé бŕöŵšéŕ ƒŕöm šŵîţçĥîñĝ ţö qûîŕķš-möðé. Ŕéåð möŕé öñ ţĥé ᐅ[ᐊMÐÑ Ŵéб Ðöçš þåĝéᐅ](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)ᐊ one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "[Ðöçţýþé ñåmé mûšţ бé ţĥé ļöŵéŕçåšé šţŕîñĝ ᐅ`html`ᐊ one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "[Ðöçûméñţ mûšţ çöñţåîñ å ðöçţýþé one two three four five six seven]"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "[Éxþéçţéð þûбļîçÎð ţö бé åñ émþţý šţŕîñĝ one two three four five six seven eight]"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "[Éxþéçţéð šýšţémÎð ţö бé åñ émþţý šţŕîñĝ one two three four five six seven eight]"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "[Þåĝé ļåçķš ţĥé ĤŢMĻ ðöçţýþé, ţĥûš ţŕîĝĝéŕîñĝ qûîŕķš-möðé one two three four five six seven eight nine ten eleven]"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "[Þåĝé ĥåš ţĥé ĤŢMĻ ðöçţýþé one two three four five six]"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "[Éļéméñţ one]"
@@ -447,7 +510,7 @@
     "message": "[Våļûé one]"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "[Бŕöŵšéŕ éñĝîñééŕš ŕéçömméñð þåĝéš çöñţåîñ ƒéŵéŕ ţĥåñ ~1,500 ÐÖM éļéméñţš. Ţĥé šŵééţ šþöţ îš å ţŕéé ðéþţĥ < 32 éļéméñţš åñð ƒéŵéŕ ţĥåñ 60 çĥîļðŕéñ/þåŕéñţ éļéméñţ. Å ļåŕĝé ÐÖM çåñ îñçŕéåšé mémöŕý ûšåĝé, çåûšé ļöñĝéŕ [šţýļé çåļçûļåţîöñš](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ƒûñðåméñţåļš/þéŕƒöŕmåñçé/ŕéñðéŕîñĝ/ŕéðûçé-ţĥé-šçöþé-åñð-çömþļéxîţý-öƒ-šţýļé-çåļçûļåţîöñš), åñð þŕöðûçé çöšţļý [ļåýöûţ ŕéƒļöŵš](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/šþééð/åŕţîçļéš/ŕéƒļöŵ). [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ðöm-šîžé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
+    "message": "[Бŕöŵšéŕ éñĝîñééŕš ŕéçömméñð þåĝéš çöñţåîñ ƒéŵéŕ ţĥåñ ~1,500 ÐÖM éļéméñţš. Ţĥé šŵééţ šþöţ îš å ţŕéé ðéþţĥ < 32 éļéméñţš åñð ƒéŵéŕ ţĥåñ 60 çĥîļðŕéñ/þåŕéñţ éļéméñţ. Å ļåŕĝé ÐÖM çåñ îñçŕéåšé mémöŕý ûšåĝé, çåûšé ļöñĝéŕ ᐅ[ᐊšţýļé çåļçûļåţîöñšᐅ](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)ᐊ, åñð þŕöðûçé çöšţļý ᐅ[ᐊļåýöûţ ŕéƒļöŵšᐅ](https://developers.google.com/speed/articles/reflow)ᐊ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/dom-size)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix]"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{[1 éļéméñţ one two]}other{[# éļéméñţš one two]}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "[Åvöîðš åñ éxçéššîvé ÐÖM šîžé one two three four five six]"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "[Ŕéļ one]"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "[Ţåŕĝéţ one]"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "[Åðð ᐅ`rel=\"noopener\"`ᐊ öŕ ᐅ`rel=\"noreferrer\"`ᐊ ţö åñý éxţéŕñåļ ļîñķš ţö îmþŕövé þéŕƒöŕmåñçé åñð þŕévéñţ šéçûŕîţý vûļñéŕåбîļîţîéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/noopener)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "[Ļîñķš ţö çŕöšš-öŕîĝîñ ðéšţîñåţîöñš åŕé ûñšåƒé one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "[Ļîñķš ţö çŕöšš-öŕîĝîñ ðéšţîñåţîöñš åŕé šåƒé one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "[Ûñåбļé ţö ðéţéŕmîñé ţĥé ðéšţîñåţîöñ ƒöŕ åñçĥöŕ (ᐅ{anchorHTML}ᐊ). Îƒ ñöţ ûšéð åš å ĥýþéŕļîñķ, çöñšîðéŕ ŕémövîñĝ ţåŕĝéţ=_бļåñķ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "[Ûšéŕš åŕé mîšţŕûšţƒûļ öƒ öŕ çöñƒûšéð бý šîţéš ţĥåţ ŕéqûéšţ ţĥéîŕ ļöçåţîöñ ŵîţĥöûţ çöñţéxţ. Çöñšîðéŕ ţýîñĝ ţĥé ŕéqûéšţ ţö å ûšéŕ åçţîöñ îñšţéåð. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "[Ŕéqûéšţš ţĥé ĝéöļöçåţîöñ þéŕmîššîöñ öñ þåĝé ļöåð one two three four five six seven eight nine ten]"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "[Åvöîðš ŕéqûéšţîñĝ ţĥé ĝéöļöçåţîöñ þéŕmîššîöñ öñ þåĝé ļöåð one two three four five six seven eight nine ten eleven twelve]"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "[Véŕšîöñ one]"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "[Åļļ ƒŕöñţ-éñð ĴåvåŠçŕîþţ ļîбŕåŕîéš ðéţéçţéð öñ ţĥé þåĝé. one two three four five six seven eight nine ten eleven]"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "[Ðéţéçţéð ĴåvåŠçŕîþţ ļîбŕåŕîéš one two three four]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "[Föŕ ûšéŕš öñ šļöŵ çöññéçţîöñš, éxţéŕñåļ šçŕîþţš ðýñåmîçåļļý îñĵéçţéð vîå ᐅ`document.write()`ᐊ çåñ ðéļåý þåĝé ļöåð бý ţéñš öƒ šéçöñðš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/document-write)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "[Ûšéš ᐅ`document.write()`ᐊ one two]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "[Åvöîðš ᐅ`document.write()`ᐊ one two three]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "[Ĥîĝĥéšţ Šévéŕîţý one two]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "[Ļîбŕåŕý Véŕšîöñ one two]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "[Vûļñéŕåбîļîţý Çöûñţ one two three]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "[Šömé ţĥîŕð-þåŕţý šçŕîþţš måý çöñţåîñ ķñöŵñ šéçûŕîţý vûļñéŕåбîļîţîéš ţĥåţ åŕé éåšîļý îðéñţîƒîéð åñð éxþļöîţéð бý åţţåçķéŕš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{[1 vûļñéŕåбîļîţý ðéţéçţéð one two three]}other{[# vûļñéŕåбîļîţîéš ðéţéçţéð one two three]}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "[Îñçļûðéš ƒŕöñţ-éñð ĴåvåŠçŕîþţ ļîбŕåŕîéš ŵîţĥ ķñöŵñ šéçûŕîţý vûļñéŕåбîļîţîéš one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "[Ĥîĝĥ one]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "[Ļöŵ one]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "[Méðîûm one]"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "[Åvöîðš ƒŕöñţ-éñð ĴåvåŠçŕîþţ ļîбŕåŕîéš ŵîţĥ ķñöŵñ šéçûŕîţý vûļñéŕåбîļîţîéš one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "[Ûšéŕš åŕé mîšţŕûšţƒûļ öƒ öŕ çöñƒûšéð бý šîţéš ţĥåţ ŕéqûéšţ ţö šéñð ñöţîƒîçåţîöñš ŵîţĥöûţ çöñţéxţ. Çöñšîðéŕ ţýîñĝ ţĥé ŕéqûéšţ ţö ûšéŕ ĝéšţûŕéš îñšţéåð. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "[Ŕéqûéšţš ţĥé ñöţîƒîçåţîöñ þéŕmîššîöñ öñ þåĝé ļöåð one two three four five six seven eight nine ten]"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "[Åvöîðš ŕéqûéšţîñĝ ţĥé ñöţîƒîçåţîöñ þéŕmîššîöñ öñ þåĝé ļöåð one two three four five six seven eight nine ten eleven twelve]"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "[Fåîļîñĝ Éļéméñţš one two]"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "[Þŕévéñţîñĝ þåššŵöŕð þåšţîñĝ ûñðéŕmîñéš ĝööð šéçûŕîţý þöļîçý. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "[Þŕévéñţš ûšéŕš ţö þåšţé îñţö þåššŵöŕð ƒîéļðš one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "[Åļļöŵš ûšéŕš ţö þåšţé îñţö þåššŵöŕð ƒîéļðš one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "[Þŕöţöçöļ one]"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "[ĤŢŢÞ/2 öƒƒéŕš måñý бéñéƒîţš övéŕ ĤŢŢÞ/1.1, îñçļûðîñĝ бîñåŕý ĥéåðéŕš, mûļţîþļéxîñĝ, åñð šéŕvéŕ þûšĥ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/http2)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{[1 ŕéqûéšţ ñöţ šéŕvéð vîå ĤŢŢÞ/2 one two three four five six seven]}other{[# ŕéqûéšţš ñöţ šéŕvéð vîå ĤŢŢÞ/2 one two three four five six seven]}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "[Ðöéš ñöţ ûšé ĤŢŢÞ/2 ƒöŕ åļļ öƒ îţš ŕéšöûŕçéš one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "[Ûšéš ĤŢŢÞ/2 ƒöŕ îţš öŵñ ŕéšöûŕçéš one two three four five six seven]"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "[Çöñšîðéŕ måŕķîñĝ ýöûŕ ţöûçĥ åñð ŵĥééļ évéñţ ļîšţéñéŕš åš ᐅ`passive`ᐊ ţö îmþŕövé ýöûŕ þåĝé'š šçŕöļļ þéŕƒöŕmåñçé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "[Ðöéš ñöţ ûšé þåššîvé ļîšţéñéŕš ţö îmþŕövé šçŕöļļîñĝ þéŕƒöŕmåñçé one two three four five six seven eight nine ten eleven twelve]"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "[Ûšéš þåššîvé ļîšţéñéŕš ţö îmþŕövé šçŕöļļîñĝ þéŕƒöŕmåñçé one two three four five six seven eight nine ten eleven]"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "[Ðéšçŕîþţîöñ one two]"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "[Éŕŕöŕš ļöĝĝéð ţö ţĥé çöñšöļé îñðîçåţé ûñŕéšöļvéð þŕöбļémš. Ţĥéý çåñ çömé ƒŕöm ñéţŵöŕķ ŕéqûéšţ ƒåîļûŕéš åñð öţĥéŕ бŕöŵšéŕ çöñçéŕñš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "[Бŕöŵšéŕ éŕŕöŕš ŵéŕé ļöĝĝéð ţö ţĥé çöñšöļé one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "[Ñö бŕöŵšéŕ éŕŕöŕš ļöĝĝéð ţö ţĥé çöñšöļé one two three four five six seven eight]"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "[Ļévéŕåĝé ţĥé ƒöñţ-ðîšþļåý ÇŠŠ ƒéåţûŕé ţö éñšûŕé ţéxţ îš ûšéŕ-vîšîбļé ŵĥîļé ŵéбƒöñţš åŕé ļöåðîñĝ. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ûþðåţéš/2016/02/ƒöñţ-ðîšþļåý). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
+    "message": "[Ļévéŕåĝé ţĥé ƒöñţ-ðîšþļåý ÇŠŠ ƒéåţûŕé ţö éñšûŕé ţéxţ îš ûšéŕ-vîšîбļé ŵĥîļé ŵéбƒöñţš åŕé ļöåðîñĝ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/updates/2016/02/font-display)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "[Éñšûŕé ţéxţ ŕémåîñš vîšîбļé ðûŕîñĝ ŵéбƒöñţ ļöåð one two three four five six seven eight nine ten]"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "[Åļļ ţéxţ ŕémåîñš vîšîбļé ðûŕîñĝ ŵéбƒöñţ ļöåðš one two three four five six seven eight nine]"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "[Ļîĝĥţĥöûšé ŵåš ûñåбļé ţö åûţömåţîçåļļý çĥéçķ ţĥé ƒöñţ-ðîšþļåý våļûé ƒöŕ ţĥé ƒöļļöŵîñĝ ÛŔĻ: ᐅ{fontURL}ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "[Åšþéçţ Ŕåţîö (Åçţûåļ) one two three]"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "[Åšþéçţ Ŕåţîö (Ðîšþļåýéð) one two three]"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "[Îmåĝé ðîšþļåý ðîméñšîöñš šĥöûļð måţçĥ ñåţûŕåļ åšþéçţ ŕåţîö. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "[Ðîšþļåýš îmåĝéš ŵîţĥ îñçöŕŕéçţ åšþéçţ ŕåţîö one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "[Ðîšþļåýš îmåĝéš ŵîţĥ çöŕŕéçţ åšþéçţ ŕåţîö one two three four five six seven eight nine]"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "[Îñvåļîð îmåĝé šîžîñĝ îñƒöŕmåţîöñ ᐅ{url}ᐊ one two three four five six seven eight]"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "[Îñšéçûŕé ÛŔĻ one two]"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "[Åļļ šîţéš šĥöûļð бé þŕöţéçţéð ŵîţĥ ĤŢŢÞŠ, évéñ öñéš ţĥåţ ðöñ'ţ ĥåñðļé šéñšîţîvé ðåţå. ĤŢŢÞŠ þŕévéñţš îñţŕûðéŕš ƒŕöm ţåmþéŕîñĝ ŵîţĥ öŕ þåššîvéļý ļîšţéñîñĝ îñ öñ ţĥé çömmûñîçåţîöñš бéţŵééñ ýöûŕ åþþ åñð ýöûŕ ûšéŕš, åñð îš å þŕéŕéqûîšîţé ƒöŕ ĤŢŢÞ/2 åñð måñý ñéŵ ŵéб þļåţƒöŕm ÅÞÎš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/https)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix]"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{[1 îñšéçûŕé ŕéqûéšţ ƒöûñð one two three four five]}other{[# îñšéçûŕé ŕéqûéšţš ƒöûñð one two three four five six]}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "[Ðöéš ñöţ ûšé ĤŢŢÞŠ one two three four]"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "[Ûšéš ĤŢŢÞŠ one two]"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "[Å ƒåšţ þåĝé ļöåð övéŕ å çéļļûļåŕ ñéţŵöŕķ éñšûŕéš å ĝööð möбîļé ûšéŕ éxþéŕîéñçé. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ƒåšţ-3ĝ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Å ƒåšţ þåĝé ļöåð övéŕ å çéļļûļåŕ ñéţŵöŕķ éñšûŕéš å ĝööð möбîļé ûšéŕ éxþéŕîéñçé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "[Îñţéŕåçţîvé åţ {ţîméÎñMšŠéç} š one two three four]"
+    "message": "[Îñţéŕåçţîvé åţ ᐅ{timeInMs, number, seconds}ᐊ š one two three four five]"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "[Îñţéŕåçţîvé öñ šîmûļåţéð möбîļé ñéţŵöŕķ åţ {ţîméÎñMšŠéç} š one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[Îñţéŕåçţîvé öñ šîmûļåţéð möбîļé ñéţŵöŕķ åţ ᐅ{timeInMs, number, seconds}ᐊ š one two three four five six seven eight nine ten]"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "[Þåĝé ļöåð îš ñöţ ƒåšţ éñöûĝĥ öñ möбîļé ñéţŵöŕķš one two three four five six seven eight nine ten]"
@@ -504,106 +735,130 @@
     "message": "[Mîñîmîžéš måîñ-ţĥŕéåð ŵöŕķ one two three]"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "[Éšţîmåţéð Îñþûţ Ļåţéñçý îš åñ éšţîmåţé öƒ ĥöŵ ļöñĝ ýöûŕ åþþ ţåķéš ţö ŕéšþöñð ţö ûšéŕ îñþûţ, îñ mîļļîšéçöñðš, ðûŕîñĝ ţĥé бûšîéšţ 5š ŵîñðöŵ öƒ þåĝé ļöåð. Îƒ ýöûŕ ļåţéñçý îš ĥîĝĥéŕ ţĥåñ 50 mš, ûšéŕš måý þéŕçéîvé ýöûŕ åþþ åš ļåĝĝý. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/éšţîmåţéð-îñþûţ-ļåţéñçý). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight]"
+    "message": "[Éšţîmåţéð Îñþûţ Ļåţéñçý îš åñ éšţîmåţé öƒ ĥöŵ ļöñĝ ýöûŕ åþþ ţåķéš ţö ŕéšþöñð ţö ûšéŕ îñþûţ, îñ mîļļîšéçöñðš, ðûŕîñĝ ţĥé бûšîéšţ 5š ŵîñðöŵ öƒ þåĝé ļöåð. Îƒ ýöûŕ ļåţéñçý îš ĥîĝĥéŕ ţĥåñ 50 mš, ûšéŕš måý þéŕçéîvé ýöûŕ åþþ åš ļåĝĝý. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone]"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "[Éšţîmåţéð Îñþûţ Ļåţéñçý one two three]"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "[Fîŕšţ Çöñţéñţƒûļ Þåîñţ måŕķš ţĥé ţîmé åţ ŵĥîçĥ ţĥé ƒîŕšţ ţéxţ öŕ îmåĝé îš þåîñţéð. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ƒîŕšţ-çöñţéñţƒûļ-þåîñţ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
+    "message": "[Fîŕšţ Çöñţéñţƒûļ Þåîñţ måŕķš ţĥé ţîmé åţ ŵĥîçĥ ţĥé ƒîŕšţ ţéxţ öŕ îmåĝé îš þåîñţéð. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "[Fîŕšţ Çöñţéñţƒûļ Þåîñţ one two three]"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "[Fîŕšţ ÇÞÛ Îðļé måŕķš ţĥé ƒîŕšţ ţîmé åţ ŵĥîçĥ ţĥé þåĝé'š måîñ ţĥŕéåð îš qûîéţ éñöûĝĥ ţö ĥåñðļé îñþûţ. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ƒîŕšţ-îñţéŕåçţîvé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
+    "message": "[Fîŕšţ ÇÞÛ Îðļé måŕķš ţĥé ƒîŕšţ ţîmé åţ ŵĥîçĥ ţĥé þåĝé'š måîñ ţĥŕéåð îš qûîéţ éñöûĝĥ ţö ĥåñðļé îñþûţ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "[Fîŕšţ ÇÞÛ Îðļé one two]"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "[Fîŕšţ Méåñîñĝƒûļ Þåîñţ méåšûŕéš ŵĥéñ ţĥé þŕîmåŕý çöñţéñţ öƒ å þåĝé îš vîšîбļé. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ƒîŕšţ-méåñîñĝƒûļ-þåîñţ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
+    "message": "[Fîŕšţ Méåñîñĝƒûļ Þåîñţ méåšûŕéš ŵĥéñ ţĥé þŕîmåŕý çöñţéñţ öƒ å þåĝé îš vîšîбļé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "[Fîŕšţ Méåñîñĝƒûļ Þåîñţ one two three]"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "[Ţîmé ţö îñţéŕåçţîvé îš ţĥé åmöûñţ öƒ ţîmé îţ ţåķéš ƒöŕ ţĥé þåĝé ţö бéçömé ƒûļļý îñţéŕåçţîvé. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/çöñšîšţéñţļý-îñţéŕåçţîvé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
+    "message": "[Ţîmé ţö îñţéŕåçţîvé îš ţĥé åmöûñţ öƒ ţîmé îţ ţåķéš ƒöŕ ţĥé þåĝé ţö бéçömé ƒûļļý îñţéŕåçţîvé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "[Ţîmé ţö Îñţéŕåçţîvé one two three]"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "[Ţĥé þöţéñţîåļ Fîŕšţ Îñþûţ Ðéļåý ţĥåţ ýöûŕ ûšéŕš çöûļð éxþéŕîéñçé îš ţĥé ðûŕåţîöñ, îñ mîļļîšéçöñðš, öƒ ţĥé ļöñĝéšţ ţåšķ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
+    "message": "[Ţĥé måxîmûm þöţéñţîåļ Fîŕšţ Îñþûţ Ðéļåý ţĥåţ ýöûŕ ûšéŕš çöûļð éxþéŕîéñçé îš ţĥé ðûŕåţîöñ, îñ mîļļîšéçöñðš, öƒ ţĥé ļöñĝéšţ ţåšķ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/updates/2018/05/first-input-delay)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "[Måx Þöţéñţîåļ FÎÐ one two three]"
+    "message": "[Måx Þöţéñţîåļ Fîŕšţ Îñþûţ Ðéļåý one two three four five six seven]"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "[Šþééð Îñðéx šĥöŵš ĥöŵ qûîçķļý ţĥé çöñţéñţš öƒ å þåĝé åŕé vîšîбļý þöþûļåţéð. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/šþééð-îñðéx). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Šþééð Îñðéx šĥöŵš ĥöŵ qûîçķļý ţĥé çöñţéñţš öƒ å þåĝé åŕé vîšîбļý þöþûļåţéð. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/speed-index)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "[Šþééð Îñðéx one two]"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "[Šûm öƒ åļļ ţîmé þéŕîöðš бéţŵééñ FÇÞ åñð Ţîmé ţö Îñţéŕåçţîvé, ŵĥéñ ţåšķ ļéñĝţĥ éxçééðéð 50mš, éxþŕéššéð îñ mîļļîšéçöñðš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "[Ţöţåļ Бļöçķîñĝ Ţîmé one two three]"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "[Ñéţŵöŕķ ŕöûñð ţŕîþ ţîméš (ŔŢŢ) ĥåvé å ļåŕĝé îmþåçţ öñ þéŕƒöŕmåñçé. Îƒ ţĥé ŔŢŢ ţö åñ öŕîĝîñ îš ĥîĝĥ, îţ'š åñ îñðîçåţîöñ ţĥåţ šéŕvéŕš çļöšéŕ ţö ţĥé ûšéŕ çöûļð îmþŕövé þéŕƒöŕmåñçé. [Ļéåŕñ möŕé](ĥţţþš://ĥþбñ.çö/þŕîméŕ-öñ-ļåţéñçý-åñð-бåñðŵîðţĥ/). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone]"
+    "message": "[Ñéţŵöŕķ ŕöûñð ţŕîþ ţîméš (ŔŢŢ) ĥåvé å ļåŕĝé îmþåçţ öñ þéŕƒöŕmåñçé. Îƒ ţĥé ŔŢŢ ţö åñ öŕîĝîñ îš ĥîĝĥ, îţ'š åñ îñðîçåţîöñ ţĥåţ šéŕvéŕš çļöšéŕ ţö ţĥé ûšéŕ çöûļð îmþŕövé þéŕƒöŕmåñçé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://hpbn.co/primer-on-latency-and-bandwidth/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "[Ñéţŵöŕķ Ŕöûñð Ţŕîþ Ţîméš one two three four five]"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "[Šéŕvéŕ ļåţéñçîéš çåñ îmþåçţ ŵéб þéŕƒöŕmåñçé. Îƒ ţĥé šéŕvéŕ ļåţéñçý öƒ åñ öŕîĝîñ îš ĥîĝĥ, îţ'š åñ îñðîçåţîöñ ţĥé šéŕvéŕ îš övéŕļöåðéð öŕ ĥåš þööŕ бåçķéñð þéŕƒöŕmåñçé. [Ļéåŕñ möŕé](ĥţţþš://ĥþбñ.çö/þŕîméŕ-öñ-ŵéб-þéŕƒöŕmåñçé/#åñåļýžîñĝ-ţĥé-ŕéšöûŕçé-ŵåţéŕƒåļļ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo]"
+    "message": "[Šéŕvéŕ ļåţéñçîéš çåñ îmþåçţ ŵéб þéŕƒöŕmåñçé. Îƒ ţĥé šéŕvéŕ ļåţéñçý öƒ åñ öŕîĝîñ îš ĥîĝĥ, îţ'š åñ îñðîçåţîöñ ţĥé šéŕvéŕ îš övéŕļöåðéð öŕ ĥåš þööŕ бåçķéñð þéŕƒöŕmåñçé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "[Šéŕvéŕ Бåçķéñð Ļåţéñçîéš one two three]"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "[Övéŕ Бûðĝéţ one two]"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "[Ķééþ ţĥé qûåñţîţý åñð šîžé öƒ ñéţŵöŕķ ŕéqûéšţš ûñðéŕ ţĥé ţåŕĝéţš šéţ бý ţĥé þŕövîðéð þéŕƒöŕmåñçé бûðĝéţ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/budgets)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{[1 ŕéqûéšţ one two]}other{[# ŕéqûéšţš one two]}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "[Þéŕƒöŕmåñçé бûðĝéţ one two three]"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "[Ŕéðîŕéçţš îñţŕöðûçé åððîţîöñåļ ðéļåýš бéƒöŕé ţĥé þåĝé çåñ бé ļöåðéð. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ŕéðîŕéçţš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
+    "message": "[Ŕéðîŕéçţš îñţŕöðûçé åððîţîöñåļ ðéļåýš бéƒöŕé ţĥé þåĝé çåñ бé ļöåðéð. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/redirects)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "[Åvöîð mûļţîþļé þåĝé ŕéðîŕéçţš one two three four five six seven]"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "[Ţö šéţ бûðĝéţš ƒöŕ ţĥé qûåñţîţý åñð šîžé öƒ þåĝé ŕéšöûŕçéš, åðð å бûðĝéţ.ĵšöñ ƒîļé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/budgets)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{[1 ŕéqûéšţ one two]}other{[# ŕéqûéšţš one two]}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "[Ķééþ ŕéqûéšţ çöûñţš ļöŵ åñð ţŕåñšƒéŕ šîžéš šmåļļ one two three four five six seven eight nine ten]"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "[Çåñöñîçåļ ļîñķš šûĝĝéšţ ŵĥîçĥ ÛŔĻ ţö šĥöŵ îñ šéåŕçĥ ŕéšûļţš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/çåñöñîçåļ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
+    "message": "[Çåñöñîçåļ ļîñķš šûĝĝéšţ ŵĥîçĥ ÛŔĻ ţö šĥöŵ îñ šéåŕçĥ ŕéšûļţš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/canonical)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "[Mûļţîþļé çöñƒļîçţîñĝ ÛŔĻš ({ûŕļĻîšţ}) one two three four five six seven eight]"
+    "message": "[Mûļţîþļé çöñƒļîçţîñĝ ÛŔĻš (ᐅ{urlList}ᐊ) one two three four five six seven]"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "[Þöîñţš ţö å ðîƒƒéŕéñţ ðömåîñ ({ûŕļ}) one two three four five six seven eight]"
+    "message": "[Þöîñţš ţö å ðîƒƒéŕéñţ ðömåîñ (ᐅ{url}ᐊ) one two three four five six seven]"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "[Îñvåļîð ÛŔĻ ({ûŕļ}) one two three]"
+    "message": "[Îñvåļîð ÛŔĻ (ᐅ{url}ᐊ) one two three four]"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "[Þöîñţš ţö åñöţĥéŕ `ĥŕéƒļåñĝ` ļöçåţîöñ ({ûŕļ}) one two three four five six seven eight nine]"
+    "message": "[Þöîñţš ţö åñöţĥéŕ ᐅ`hreflang`ᐊ ļöçåţîöñ (ᐅ{url}ᐊ) one two three four five six seven eight]"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "[Ŕéļåţîvé ÛŔĻ ({ûŕļ}) one two three]"
+    "message": "[Ŕéļåţîvé ÛŔĻ (ᐅ{url}ᐊ) one two three four]"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "[Þöîñţš ţö ţĥé ðömåîñ'š ŕööţ ÛŔĻ (ţĥé ĥöméþåĝé), îñšţéåð öƒ åñ éqûîvåļéñţ þåĝé öƒ çöñţéñţ one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "[Ðöçûméñţ ðöéš ñöţ ĥåvé å våļîð `ŕéļ=çåñöñîçåļ` one two three four five six seven eight nine ten]"
+    "message": "[Ðöçûméñţ ðöéš ñöţ ĥåvé å våļîð ᐅ`rel=canonical`ᐊ one two three four five six seven]"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "[Ðöçûméñţ ĥåš å våļîð `ŕéļ=çåñöñîçåļ` one two three four five six seven eight]"
+    "message": "[Ðöçûméñţ ĥåš å våļîð ᐅ`rel=canonical`ᐊ one two three four five]"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "[Föñţ šîžéš ļéšš ţĥåñ 12þx åŕé ţöö šmåļļ ţö бé ļéĝîбļé åñð ŕéqûîŕé möбîļé vîšîţöŕš ţö “þîñçĥ ţö žööm” îñ öŕðéŕ ţö ŕéåð. Šţŕîvé ţö ĥåvé >60% oƒ þåĝé ţéxţ ≥12þx. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ƒöñţ-šîžéš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone]"
+    "message": "[Föñţ šîžéš ļéšš ţĥåñ 12þx åŕé ţöö šmåļļ ţö бé ļéĝîбļé åñð ŕéqûîŕé möбîļé vîšîţöŕš ţö “þîñçĥ ţö žööm” îñ öŕðéŕ ţö ŕéåð. Šţŕîvé ţö ĥåvé >60% oƒ þåĝé ţéxţ ≥12þx. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "[{ðéçîmåļÞŕöþöŕţîöñÉxţéñðéðÞéŕçéñţ} ļéĝîбļé ţéxţ one two three four five]"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "[{ðéçîmåļÞŕöþöŕţîöñÉxţéñðéðÞéŕçéñţ} öƒ ţéxţ îš ţöö šmåļļ. one two three four five six seven eight nine ten eleven]"
+    "message": "[ᐅ{decimalProportion, number, extendedPercent}ᐊ ļéĝîбļé ţéxţ one two three four]"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "[Ţéxţ îš îļļéĝîбļé бéçåûšé ţĥéŕé'š ñö vîéŵþöŕţ méţå ţåĝ öþţîmîžéð ƒöŕ möбîļé šçŕééñš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "[{ðéçîmåļÞŕöþöŕţîöñÉxţéñðéðÞéŕçéñţ} öƒ ţéxţ îš ţöö šmåļļ (бåšéð öñ {ðéçîmåļÞŕöþöŕţîöñVîšîţéð} šåmþļé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
+    "message": "[ᐅ{decimalProportion, number, extendedPercent}ᐊ öƒ ţéxţ îš ţöö šmåļļ (бåšéð öñ ᐅ{decimalProportionVisited, number, extendedPercent}ᐊ šåmþļé). one two three four five six seven eight nine ten]"
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "[Ðöçûméñţ ðöéšñ'ţ ûšé ļéĝîбļé ƒöñţ šîžéš one two three four five six seven eight]"
@@ -612,16 +867,16 @@
     "message": "[Ðöçûméñţ ûšéš ļéĝîбļé ƒöñţ šîžéš one two three four five six seven]"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "[ĥŕéƒļåñĝ ļîñķš ţéļļ šéåŕçĥ éñĝîñéš ŵĥåţ véŕšîöñ öƒ å þåĝé ţĥéý šĥöûļð ļîšţ îñ šéåŕçĥ ŕéšûļţš ƒöŕ å ĝîvéñ ļåñĝûåĝé öŕ ŕéĝîöñ. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ĥŕéƒļåñĝ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
+    "message": "[ĥŕéƒļåñĝ ļîñķš ţéļļ šéåŕçĥ éñĝîñéš ŵĥåţ véŕšîöñ öƒ å þåĝé ţĥéý šĥöûļð ļîšţ îñ šéåŕçĥ ŕéšûļţš ƒöŕ å ĝîvéñ ļåñĝûåĝé öŕ ŕéĝîöñ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/hreflang)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "[Ðöçûméñţ ðöéšñ'ţ ĥåvé å våļîð `ĥŕéƒļåñĝ` one two three four five six seven eight]"
+    "message": "[Ðöçûméñţ ðöéšñ'ţ ĥåvé å våļîð ᐅ`hreflang`ᐊ one two three four five six seven]"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "[Ðöçûméñţ ĥåš å våļîð `ĥŕéƒļåñĝ` one two three four five six seven]"
+    "message": "[Ðöçûméñţ ĥåš å våļîð ᐅ`hreflang`ᐊ one two three four five]"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "[Þåĝéš ŵîţĥ ûñšûççéššƒûļ ĤŢŢÞ šţåţûš çöðéš måý ñöţ бé îñðéxéð þŕöþéŕļý. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/šûççéššƒûļ-ĥţţþ-çöðé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Þåĝéš ŵîţĥ ûñšûççéššƒûļ ĤŢŢÞ šţåţûš çöðéš måý ñöţ бé îñðéxéð þŕöþéŕļý. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "[Þåĝé ĥåš ûñšûççéššƒûļ ĤŢŢÞ šţåţûš çöðé one two three four five six seven eight]"
@@ -630,7 +885,7 @@
     "message": "[Þåĝé ĥåš šûççéššƒûļ ĤŢŢÞ šţåţûš çöðé one two three four five six seven eight]"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "[Šéåŕçĥ éñĝîñéš åŕé ûñåбļé ţö îñçļûðé ýöûŕ þåĝéš îñ šéåŕçĥ ŕéšûļţš îƒ ţĥéý ðöñ'ţ ĥåvé þéŕmîššîöñ ţö çŕåŵļ ţĥém. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/îñðéxîñĝ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
+    "message": "[Šéåŕçĥ éñĝîñéš åŕé ûñåбļé ţö îñçļûðé ýöûŕ þåĝéš îñ šéåŕçĥ ŕéšûļţš îƒ ţĥéý ðöñ'ţ ĥåvé þéŕmîššîöñ ţö çŕåŵļ ţĥém. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/indexing)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "[Þåĝé îš бļöçķéð ƒŕöm îñðéxîñĝ one two three four five six seven]"
@@ -639,7 +894,7 @@
     "message": "[Þåĝé îšñ’ţ бļöçķéð ƒŕöm îñðéxîñĝ one two three four five six seven]"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "[Ðéšçŕîþţîvé ļîñķ ţéxţ ĥéļþš šéåŕçĥ éñĝîñéš ûñðéŕšţåñð ýöûŕ çöñţéñţ. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ðéšçŕîþţîvé-ļîñķ-ţéxţ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Ðéšçŕîþţîvé ļîñķ ţéxţ ĥéļþš šéåŕçĥ éñĝîñéš ûñðéŕšţåñð ýöûŕ çöñţéñţ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{[1 ļîñķ ƒöûñð one two]}other{[# ļîñķš ƒöûñð one two]}}"
@@ -651,13 +906,13 @@
     "message": "[Ļîñķš ĥåvé ðéšçŕîþţîvé ţéxţ one two three four five six]"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "[Ŕûñ ţĥé [Šţŕûçţûŕéð Ðåţå Ţéšţîñĝ Ţööļ](ĥţţþš://šéåŕçĥ.ĝööĝļé.çöm/šţŕûçţûŕéð-ðåţå/ţéšţîñĝ-ţööļ/) åñð ţĥé [Šţŕûçţûŕéð Ðåţå Ļîñţéŕ](ĥţţþ://ļîñţéŕ.šţŕûçţûŕéð-ðåţå.öŕĝ/) ţö våļîðåţé šţŕûçţûŕéð ðåţå. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/šéåŕçĥ/ðöçš/ĝûîðéš/måŕķ-ûþ-çöñţéñţ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour]"
+    "message": "[Ŕûñ ţĥé ᐅ[ᐊŠţŕûçţûŕéð Ðåţå Ţéšţîñĝ Ţööļᐅ](https://search.google.com/structured-data/testing-tool/)ᐊ åñð ţĥé ᐅ[ᐊŠţŕûçţûŕéð Ðåţå Ļîñţéŕᐅ](http://linter.structured-data.org/)ᐊ ţö våļîðåţé šţŕûçţûŕéð ðåţå. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/search/docs/guides/mark-up-content)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "[Šţŕûçţûŕéð ðåţå îš våļîð one two three four five]"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "[Méţå ðéšçŕîþţîöñš måý бé îñçļûðéð îñ šéåŕçĥ ŕéšûļţš ţö çöñçîšéļý šûmmåŕîžé þåĝé çöñţéñţ. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ðéšçŕîþţîöñ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
+    "message": "[Méţå ðéšçŕîþţîöñš måý бé îñçļûðéð îñ šéåŕçĥ ŕéšûļţš ţö çöñçîšéļý šûmmåŕîžé þåĝé çöñţéñţ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/description)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "[Ðéšçŕîþţîöñ ţéxţ îš émþţý. one two three four five six]"
@@ -669,7 +924,7 @@
     "message": "[Ðöçûméñţ ĥåš å méţå ðéšçŕîþţîöñ one two three four five six seven]"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "[Šéåŕçĥ éñĝîñéš çåñ'ţ îñðéx þļûĝîñ çöñţéñţ, åñð måñý ðévîçéš ŕéšţŕîçţ þļûĝîñš öŕ ðöñ'ţ šûþþöŕţ ţĥém. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/þļûĝîñš). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
+    "message": "[Šéåŕçĥ éñĝîñéš çåñ'ţ îñðéx þļûĝîñ çöñţéñţ, åñð måñý ðévîçéš ŕéšţŕîçţ þļûĝîñš öŕ ðöñ'ţ šûþþöŕţ ţĥém. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/plugins)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "[Ðöçûméñţ ûšéš þļûĝîñš one two three]"
@@ -681,7 +936,7 @@
     "message": "[Îƒ ýöûŕ ŕöбöţš.ţxţ ƒîļé îš måļƒöŕméð, çŕåŵļéŕš måý ñöţ бé åбļé ţö ûñðéŕšţåñð ĥöŵ ýöû ŵåñţ ýöûŕ ŵéбšîţé ţö бé çŕåŵļéð öŕ îñðéxéð. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "[ŕéqûéšţ ƒöŕ ŕöбöţš.ţxţ ŕéţûŕñéð ĤŢŢÞ šţåţûš: {šţåţûšÇöðé} one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[ŕéqûéšţ ƒöŕ ŕöбöţš.ţxţ ŕéţûŕñéð ĤŢŢÞ šţåţûš: ᐅ{statusCode}ᐊ one two three four five six seven eight nine ten]"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{[1 éŕŕöŕ ƒöûñð one two]}other{[# éŕŕöŕš ƒöûñð one two]}}"
@@ -696,10 +951,10 @@
     "message": "[ŕöбöţš.ţxţ îš våļîð one two three]"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "[Îñţéŕåçţîvé éļéméñţš ļîķé бûţţöñš åñð ļîñķš šĥöûļð бé ļåŕĝé éñöûĝĥ (48x48þx), åñð ĥåvé éñöûĝĥ šþåçé åŕöûñð ţĥém, ţö бé éåšý éñöûĝĥ ţö ţåþ ŵîţĥöûţ övéŕļåþþîñĝ öñţö öţĥéŕ éļéméñţš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ƒûñðåméñţåļš/åççéššîбîļîţý/åççéššîбļé-šţýļéš#mûļţî-ðévîçé_ŕéšþöñšîvé_ðéšîĝñ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven]"
+    "message": "[Îñţéŕåçţîvé éļéméñţš ļîķé бûţţöñš åñð ļîñķš šĥöûļð бé ļåŕĝé éñöûĝĥ (48x48þx), åñð ĥåvé éñöûĝĥ šþåçé åŕöûñð ţĥém, ţö бé éåšý éñöûĝĥ ţö ţåþ ŵîţĥöûţ övéŕļåþþîñĝ öñţö öţĥéŕ éļéméñţš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "[{ðéçîmåļÞŕöþöŕţîöñÞéŕçéñţ} åþþŕöþŕîåţéļý šîžéð ţåþ ţåŕĝéţš one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[ᐅ{decimalProportion, number, percent}ᐊ åþþŕöþŕîåţéļý šîžéð ţåþ ţåŕĝéţš one two three four five six seven eight]"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "[Ţåþ ţåŕĝéţš åŕé ţöö šmåļļ бéçåûšé ţĥéŕé'š ñö vîéŵþöŕţ méţå ţåĝ öþţîmîžéð ƒöŕ möбîļé šçŕééñš one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "[Övéŕļåþþîñĝ Ţåŕĝéţ one two three]"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "[Šîžé one]"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "[Ţåþ Ţåŕĝéţ one two]"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "[Ţåþ ţåŕĝéţš åŕé šîžéð åþþŕöþŕîåţéļý one two three four five six seven eight]"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "[Måîñ Ţĥŕéåð Ţîmé one two]"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "[Ţĥîŕð-Þåŕţý one two]"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "[Ţĥîŕð-þåŕţý çöðé çåñ šîĝñîƒîçåñţļý îmþåçţ ļöåð þéŕƒöŕmåñçé. Ļîmîţ ţĥé ñûmбéŕ öƒ ŕéðûñðåñţ ţĥîŕð-þåŕţý þŕövîðéŕš åñð ţŕý ţö ļöåð ţĥîŕð-þåŕţý çöðé åƒţéŕ ýöûŕ þåĝé ĥåš þŕîmåŕîļý ƒîñîšĥéð ļöåðîñĝ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{[1 Ţĥîŕð-Þåŕţý Föûñð one two three]}other{[# Ţĥîŕð-Þåŕţîéš Föûñð one two three]}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "[Ţĥîŕð-Þåŕţý Ûšåĝé one two three]"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "[Ţîmé Ţö Fîŕšţ Бýţé îðéñţîƒîéš ţĥé ţîmé åţ ŵĥîçĥ ýöûŕ šéŕvéŕ šéñðš å ŕéšþöñšé. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ţţƒб). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Ţîmé Ţö Fîŕšţ Бýţé îðéñţîƒîéš ţĥé ţîmé åţ ŵĥîçĥ ýöûŕ šéŕvéŕ šéñðš å ŕéšþöñšé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/ttfb)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "[Ŕööţ ðöçûméñţ ţööķ {ţîméÎñMš} mš one two three four five six seven]"
+    "message": "[Ŕööţ ðöçûméñţ ţööķ ᐅ{timeInMs, number, milliseconds}ᐊ mš one two three four five six]"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "[Ŕéðûçé šéŕvéŕ ŕéšþöñšé ţîméš (ŢŢFБ) one two three four five six seven eight]"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "[Ðûŕåţîöñ one]"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "[Ñåmé one]"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "[Šţåŕţ Ţîmé one two]"
   },
@@ -744,7 +1008,7 @@
     "message": "[Ţýþé one]"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "[Çöñšîðéŕ îñšţŕûméñţîñĝ ýöûŕ åþþ ŵîţĥ ţĥé Ûšéŕ Ţîmîñĝ ÅÞÎ ţö méåšûŕé ýöûŕ åþþ'š ŕéåļ-ŵöŕļð þéŕƒöŕmåñçé ðûŕîñĝ ķéý ûšéŕ éxþéŕîéñçéš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/ûšéŕ-ţîmîñĝ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Çöñšîðéŕ îñšţŕûméñţîñĝ ýöûŕ åþþ ŵîţĥ ţĥé Ûšéŕ Ţîmîñĝ ÅÞÎ ţö méåšûŕé ýöûŕ åþþ'š ŕéåļ-ŵöŕļð þéŕƒöŕmåñçé ðûŕîñĝ ķéý ûšéŕ éxþéŕîéñçéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/user-timing)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{[1 ûšéŕ ţîmîñĝ one two]}other{[# ûšéŕ ţîmîñĝš one two]}}"
@@ -753,19 +1017,19 @@
     "message": "[Ûšéŕ Ţîmîñĝ måŕķš åñð méåšûŕéš one two three four five six seven]"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "[Å þŕéçöññéçţ <link> ŵåš ƒöûñð ƒöŕ \"{šéçûŕîţýÖŕîĝîñ}\" бûţ ŵåš ñöţ ûšéð бý ţĥé бŕöŵšéŕ. Çĥéçķ ţĥåţ ýöû åŕé ûšîñĝ ţĥé `çŕöššöŕîĝîñ` åţţŕîбûţé þŕöþéŕļý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
+    "message": "[Å þŕéçöññéçţ <link> ŵåš ƒöûñð ƒöŕ \"ᐅ{securityOrigin}ᐊ\" бûţ ŵåš ñöţ ûšéð бý ţĥé бŕöŵšéŕ. Çĥéçķ ţĥåţ ýöû åŕé ûšîñĝ ţĥé ᐅ`crossorigin`ᐊ åţţŕîбûţé þŕöþéŕļý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "[Çöñšîðéŕ åððîñĝ þŕéçöññéçţ öŕ ðñš-þŕéƒéţçĥ ŕéšöûŕçé ĥîñţš ţö éšţåбļîšĥ éåŕļý çöññéçţîöñš ţö îmþöŕţåñţ ţĥîŕð-þåŕţý öŕîĝîñš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ƒûñðåméñţåļš/þéŕƒöŕmåñçé/ŕéšöûŕçé-þŕîöŕîţîžåţîöñ#þŕéçöññéçţ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine]"
+    "message": "[Çöñšîðéŕ åððîñĝ þŕéçöññéçţ öŕ ðñš-þŕéƒéţçĥ ŕéšöûŕçé ĥîñţš ţö éšţåбļîšĥ éåŕļý çöññéçţîöñš ţö îmþöŕţåñţ ţĥîŕð-þåŕţý öŕîĝîñš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "[Þŕéçöññéçţ ţö ŕéqûîŕéð öŕîĝîñš one two three four five six seven]"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "[Å þŕéļöåð <link> ŵåš ƒöûñð ƒöŕ \"{þŕéļöåðÛŔĻ}\" бûţ ŵåš ñöţ ûšéð бý ţĥé бŕöŵšéŕ. Çĥéçķ ţĥåţ ýöû åŕé ûšîñĝ ţĥé `çŕöššöŕîĝîñ` åţţŕîбûţé þŕöþéŕļý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
+    "message": "[Å þŕéļöåð <link> ŵåš ƒöûñð ƒöŕ \"ᐅ{preloadURL}ᐊ\" бûţ ŵåš ñöţ ûšéð бý ţĥé бŕöŵšéŕ. Çĥéçķ ţĥåţ ýöû åŕé ûšîñĝ ţĥé ᐅ`crossorigin`ᐊ åţţŕîбûţé þŕöþéŕļý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "[Çöñšîðéŕ ûšîñĝ <link rel=preload> ţö þŕîöŕîţîžé ƒéţçĥîñĝ ŕéšöûŕçéš ţĥåţ åŕé çûŕŕéñţļý ŕéqûéšţéð ļåţéŕ îñ þåĝé ļöåð. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/åûðîţš/þŕéļöåð). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
+    "message": "[Çöñšîðéŕ ûšîñĝ ᐅ`<link rel=preload>`ᐊ ţö þŕîöŕîţîžé ƒéţçĥîñĝ ŕéšöûŕçéš ţĥåţ åŕé çûŕŕéñţļý ŕéqûéšţéð ļåţéŕ îñ þåĝé ļöåð. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/tools/lighthouse/audits/preload)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "[Þŕéļöåð ķéý ŕéqûéšţš one two three]"
@@ -789,10 +1053,10 @@
     "message": "[Бéšţ þŕåçţîçéš one two]"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "[Ţĥéšé çĥéçķš ĥîĝĥļîĝĥţ öþþöŕţûñîţîéš ţö [îmþŕövé ţĥé åççéššîбîļîţý öƒ ýöûŕ ŵéб åþþ](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ƒûñðåméñţåļš/åççéššîбîļîţý). Öñļý å šûбšéţ öƒ åççéššîбîļîţý îššûéš çåñ бé åûţömåţîçåļļý ðéţéçţéð šö måñûåļ ţéšţîñĝ îš åļšö éñçöûŕåĝéð. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo]"
+    "message": "[Ţĥéšé çĥéçķš ĥîĝĥļîĝĥţ öþþöŕţûñîţîéš ţö ᐅ[ᐊîmþŕövé ţĥé åççéššîбîļîţý öƒ ýöûŕ ŵéб åþþᐅ](https://developers.google.com/web/fundamentals/accessibility)ᐊ. Öñļý å šûбšéţ öƒ åççéššîбîļîţý îššûéš çåñ бé åûţömåţîçåļļý ðéţéçţéð šö måñûåļ ţéšţîñĝ îš åļšö éñçöûŕåĝéð. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "[Ţĥéšé îţémš åððŕéšš åŕéåš ŵĥîçĥ åñ åûţömåţéð ţéšţîñĝ ţööļ çåññöţ çövéŕ. Ļéåŕñ möŕé îñ öûŕ ĝûîðé öñ [çöñðûçţîñĝ åñ åççéššîбîļîţý ŕévîéŵ](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ƒûñðåméñţåļš/åççéššîбîļîţý/ĥöŵ-ţö-ŕévîéŵ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
+    "message": "[Ţĥéšé îţémš åððŕéšš åŕéåš ŵĥîçĥ åñ åûţömåţéð ţéšţîñĝ ţööļ çåññöţ çövéŕ. Ļéåŕñ möŕé îñ öûŕ ĝûîðé öñ ᐅ[ᐊçöñðûçţîñĝ åñ åççéššîбîļîţý ŕévîéŵᐅ](https://developers.google.com/web/fundamentals/accessibility/how-to-review)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone]"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "[Åççéššîбîļîţý one two]"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "[Ţåбļéš åñð ļîšţš one two]"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "[Бéšţ Þŕåçţîçéš one two]"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "[Þéŕƒöŕmåñçé бûðĝéţš šéţ šţåñðåŕðš ƒöŕ ţĥé þéŕƒöŕmåñçé öƒ ýöûŕ šîţé. one two three four five six seven eight nine ten eleven twelve thirteen]"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "[Бûðĝéţš one]"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "[Möŕé îñƒöŕmåţîöñ åбöûţ ţĥé þéŕƒöŕmåñçé öƒ ýöûŕ åþþļîçåţîöñ. one two three four five six seven eight nine ten eleven twelve]"
+    "message": "[Möŕé îñƒöŕmåţîöñ åбöûţ ţĥé þéŕƒöŕmåñçé öƒ ýöûŕ åþþļîçåţîöñ. Ţĥéšé ñûmбéŕš ðöñ'ţ ᐅ[ᐊðîŕéçţļý åƒƒéçţᐅ](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)ᐊ ţĥé Þéŕƒöŕmåñçé šçöŕé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "[Ðîåĝñöšţîçš one two]"
@@ -840,7 +1113,7 @@
     "message": "[Fîŕšţ Þåîñţ Îmþŕövéméñţš one two three]"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "[Ţĥéšé öþţîmîžåţîöñš çåñ šþééð ûþ ýöûŕ þåĝé ļöåð. one two three four five six seven eight nine ten]"
+    "message": "[Ţĥéšé šûĝĝéšţîöñš çåñ ĥéļþ ýöûŕ þåĝé ļöåð ƒåšţéŕ. Ţĥéý ðöñ'ţ ᐅ[ᐊðîŕéçţļý åƒƒéçţᐅ](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)ᐊ ţĥé Þéŕƒöŕmåñçé šçöŕé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "[Öþþöŕţûñîţîéš one two]"
@@ -867,7 +1140,7 @@
     "message": "[ÞŴÅ Öþţîmîžéð one two]"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "[Ţĥéšé çĥéçķš éñšûŕé ţĥåţ ýöûŕ þåĝé îš öþţîmîžéð ƒöŕ šéåŕçĥ éñĝîñé ŕéšûļţš ŕåñķîñĝ. Ţĥéŕé åŕé åððîţîöñåļ ƒåçţöŕš Ļîĝĥţĥöûšé ðöéš ñöţ çĥéçķ ţĥåţ måý åƒƒéçţ ýöûŕ šéåŕçĥ ŕåñķîñĝ. [Ļéåŕñ möŕé](ĥţţþš://šûþþöŕţ.ĝööĝļé.çöm/ŵéбmåšţéŕš/åñšŵéŕ/35769). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone]"
+    "message": "[Ţĥéšé çĥéçķš éñšûŕé ţĥåţ ýöûŕ þåĝé îš öþţîmîžéð ƒöŕ šéåŕçĥ éñĝîñé ŕéšûļţš ŕåñķîñĝ. Ţĥéŕé åŕé åððîţîöñåļ ƒåçţöŕš Ļîĝĥţĥöûšé ðöéš ñöţ çĥéçķ ţĥåţ måý åƒƒéçţ ýöûŕ šéåŕçĥ ŕåñķîñĝ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://support.google.com/webmasters/answer/35769)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "[Ŕûñ ţĥéšé åððîţîöñåļ våļîðåţöŕš öñ ýöûŕ šîţé ţö çĥéçķ åððîţîöñåļ ŠÉÖ бéšţ þŕåçţîçéš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
@@ -888,7 +1161,7 @@
     "message": "[Çŕåŵļîñĝ åñð Îñðéxîñĝ one two three]"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "[Måķé šûŕé ýöûŕ þåĝéš åŕé möбîļé ƒŕîéñðļý šö ûšéŕš ðöñ’ţ ĥåvé ţö þîñçĥ öŕ žööm îñ öŕðéŕ ţö ŕéåð ţĥé çöñţéñţ þåĝéš. [Ļéåŕñ möŕé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/šéåŕçĥ/möбîļé-šîţéš/). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
+    "message": "[Måķé šûŕé ýöûŕ þåĝéš åŕé möбîļé ƒŕîéñðļý šö ûšéŕš ðöñ’ţ ĥåvé ţö þîñçĥ öŕ žööm îñ öŕðéŕ ţö ŕéåð ţĥé çöñţéñţ þåĝéš. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/search/mobile-sites/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "[Möбîļé Fŕîéñðļý one two]"
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "[Çåçĥé ŢŢĻ one two]"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "[Ļöçåţîöñ one]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "[Ñåmé one]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "[Ŕéqûéšţš one]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "[Ŕéšöûŕçé Ţýþé one two]"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "[Šîžé (ĶБ) one two]"
+    "message": "[Šîžé one]"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "[Ţîmé Šþéñţ one two]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "[Ţŕåñšƒéŕ Šîžé one two]"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "[ÛŔĻ one]"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "[Þöţéñţîåļ Šåvîñĝš (ĶБ) one two three]"
+    "message": "[Þöţéñţîåļ Šåvîñĝš one two three]"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "[Þöţéñţîåļ Šåvîñĝš (mš) one two three]"
+    "message": "[Þöţéñţîåļ Šåvîñĝš one two three]"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "[Þöţéñţîåļ šåvîñĝš öƒ {ŵåšţéðБýţéš} ĶБ one two three four five six seven eight]"
+    "message": "[Þöţéñţîåļ šåvîñĝš öƒ ᐅ{wastedBytes, number, bytes}ᐊ ĶБ one two three four five six]"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "[Þöţéñţîåļ šåvîñĝš öƒ {ŵåšţéðMš} mš one two three four five six seven]"
+    "message": "[Þöţéñţîåļ šåvîñĝš öƒ ᐅ{wastedMs, number, milliseconds}ᐊ mš one two three four five six]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "[Ðöçûméñţ one]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "[Föñţ one]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "[Îmåĝé one]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "[Méðîå one]"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "[{ţîméÎñMš} mš one two]"
+    "message": "[ᐅ{timeInMs, number, milliseconds}ᐊ mš one two]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "[Öţĥéŕ one]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "[Šçŕîþţ one]"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "[{ţîméÎñMšŠéç} š one two]"
+    "message": "[ᐅ{timeInMs, number, seconds}ᐊ š one two]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "[Šţýļéšĥééţ one two]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "[Ţĥîŕð-þåŕţý one two]"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "[Ţöţåļ one]"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "[Šöméţĥîñĝ ŵéñţ ŵŕöñĝ ŵîţĥ ŕéçöŕðîñĝ ţĥé ţŕåçé övéŕ ýöûŕ þåĝé ļöåð. Þļéåšé ŕûñ Ļîĝĥţĥöûšé åĝåîñ. ({éŕŕöŕÇöðé}) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
+    "message": "[Šöméţĥîñĝ ŵéñţ ŵŕöñĝ ŵîţĥ ŕéçöŕðîñĝ ţĥé ţŕåçé övéŕ ýöûŕ þåĝé ļöåð. Þļéåšé ŕûñ Ļîĝĥţĥöûšé åĝåîñ. (ᐅ{errorCode}ᐊ) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen]"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "[Ţîméöûţ ŵåîţîñĝ ƒöŕ îñîţîåļ Ðéбûĝĝéŕ Þŕöţöçöļ çöññéçţîöñ. one two three four five six seven eight nine ten eleven twelve]"
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "[Çĥŕömé ðîðñ'ţ çöļļéçţ åñý šçŕééñšĥöţš ðûŕîñĝ ţĥé þåĝé ļöåð. Þļéåšé måķé šûŕé ţĥéŕé îš çöñţéñţ vîšîбļé öñ ţĥé þåĝé, åñð ţĥéñ ţŕý ŕé-ŕûññîñĝ Ļîĝĥţĥöûšé. ({éŕŕöŕÇöðé}) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Çĥŕömé ðîðñ'ţ çöļļéçţ åñý šçŕééñšĥöţš ðûŕîñĝ ţĥé þåĝé ļöåð. Þļéåšé måķé šûŕé ţĥéŕé îš çöñţéñţ vîšîбļé öñ ţĥé þåĝé, åñð ţĥéñ ţŕý ŕé-ŕûññîñĝ Ļîĝĥţĥöûšé. (ᐅ{errorCode}ᐊ) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "[ÐÑŠ šéŕvéŕš çöûļð ñöţ ŕéšöļvé ţĥé þŕövîðéð ðömåîñ. one two three four five six seven eight nine ten eleven]"
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "[Ŕéqûîŕéð ᐅ{artifactName}ᐊ ĝåţĥéŕéŕ éñçöûñţéŕéð åñ éŕŕöŕ: ᐅ{errorMessage}ᐊ one two three four five six seven eight nine ten]"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "[Åñ îñţéŕñåļ Çĥŕömé éŕŕöŕ öççûŕŕéð. Þļéåšé ŕéšţåŕţ Çĥŕömé åñð ţŕý ŕé-ŕûññîñĝ Ļîĝĥţĥöûšé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "[Ŕéqûîŕéð ᐅ{artifactName}ᐊ ĝåţĥéŕéŕ ðîð ñöţ ŕûñ. one two three four five six seven]"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "[Ļîĝĥţĥöûšé ŵåš ûñåбļé ţö ŕéļîåбļý ļöåð ţĥé þåĝé ýöû ŕéqûéšţéð. Måķé šûŕé ýöû åŕé ţéšţîñĝ ţĥé çöŕŕéçţ ÛŔĻ åñð ţĥåţ ţĥé šéŕvéŕ îš þŕöþéŕļý ŕéšþöñðîñĝ ţö åļļ ŕéqûéšţš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
@@ -945,19 +1266,22 @@
     "message": "[Ļîĝĥţĥöûšé ŵåš ûñåбļé ţö ŕéļîåбļý ļöåð ţĥé ÛŔĻ ýöû ŕéqûéšţéð бéçåûšé ţĥé þåĝé šţöþþéð ŕéšþöñðîñĝ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "[Ţĥé ÛŔĻ ýöû ĥåvé þŕövîðéð ðöéš ñöţ ĥåvé våļîð šéçûŕîţý çŕéðéñţîåļš. {šéçûŕîţýMéššåĝéš} one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
+    "message": "[Ţĥé ÛŔĻ ýöû ĥåvé þŕövîðéð ðöéš ñöţ ĥåvé å våļîð šéçûŕîţý çéŕţîƒîçåţé. ᐅ{securityMessages}ᐊ one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "[Çĥŕömé þŕévéñţéð þåĝé ļöåð ŵîţĥ åñ îñţéŕšţîţîåļ. Måķé šûŕé ýöû åŕé ţéšţîñĝ ţĥé çöŕŕéçţ ÛŔĻ åñð ţĥåţ ţĥé šéŕvéŕ îš þŕöþéŕļý ŕéšþöñðîñĝ ţö åļļ ŕéqûéšţš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "[Ļîĝĥţĥöûšé ŵåš ûñåбļé ţö ŕéļîåбļý ļöåð ţĥé þåĝé ýöû ŕéqûéšţéð. Måķé šûŕé ýöû åŕé ţéšţîñĝ ţĥé çöŕŕéçţ ÛŔĻ åñð ţĥåţ ţĥé šéŕvéŕ îš þŕöþéŕļý ŕéšþöñðîñĝ ţö åļļ ŕéqûéšţš. (Ðéţåîļš: {éŕŕöŕÐéţåîļš}) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
+    "message": "[Ļîĝĥţĥöûšé ŵåš ûñåбļé ţö ŕéļîåбļý ļöåð ţĥé þåĝé ýöû ŕéqûéšţéð. Måķé šûŕé ýöû åŕé ţéšţîñĝ ţĥé çöŕŕéçţ ÛŔĻ åñð ţĥåţ ţĥé šéŕvéŕ îš þŕöþéŕļý ŕéšþöñðîñĝ ţö åļļ ŕéqûéšţš. (Ðéţåîļš: ᐅ{errorDetails}ᐊ) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "[Ļîĝĥţĥöûšé ŵåš ûñåбļé ţö ŕéļîåбļý ļöåð ţĥé þåĝé ýöû ŕéqûéšţéð. Måķé šûŕé ýöû åŕé ţéšţîñĝ ţĥé çöŕŕéçţ ÛŔĻ åñð ţĥåţ ţĥé šéŕvéŕ îš þŕöþéŕļý ŕéšþöñðîñĝ ţö åļļ ŕéqûéšţš. (Šţåţûš çöðé: {šţåţûšÇöðé}) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
+    "message": "[Ļîĝĥţĥöûšé ŵåš ûñåбļé ţö ŕéļîåбļý ļöåð ţĥé þåĝé ýöû ŕéqûéšţéð. Måķé šûŕé ýöû åŕé ţéšţîñĝ ţĥé çöŕŕéçţ ÛŔĻ åñð ţĥåţ ţĥé šéŕvéŕ îš þŕöþéŕļý ŕéšþöñðîñĝ ţö åļļ ŕéqûéšţš. (Šţåţûš çöðé: ᐅ{statusCode}ᐊ) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive]"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "[Ýöûŕ þåĝé ţööķ ţöö ļöñĝ ţö ļöåð. Þļéåšé ƒöļļöŵ ţĥé öþþöŕţûñîţîéš îñ ţĥé ŕéþöŕţ ţö ŕéðûçé ýöûŕ þåĝé ļöåð ţîmé, åñð ţĥéñ ţŕý ŕé-ŕûññîñĝ Ļîĝĥţĥöûšé. ({éŕŕöŕÇöðé}) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Ýöûŕ þåĝé ţööķ ţöö ļöñĝ ţö ļöåð. Þļéåšé ƒöļļöŵ ţĥé öþþöŕţûñîţîéš îñ ţĥé ŕéþöŕţ ţö ŕéðûçé ýöûŕ þåĝé ļöåð ţîmé, åñð ţĥéñ ţŕý ŕé-ŕûññîñĝ Ļîĝĥţĥöûšé. (ᐅ{errorCode}ᐊ) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "[Ŵåîţîñĝ ƒöŕ ÐévŢööļš þŕöţöçöļ ŕéšþöñšé ĥåš éxçééðéð ţĥé åļļöţţéð ţîmé. (Méţĥöð: {þŕöţöçöļMéţĥöð}) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
+    "message": "[Ŵåîţîñĝ ƒöŕ ÐévŢööļš þŕöţöçöļ ŕéšþöñšé ĥåš éxçééðéð ţĥé åļļöţţéð ţîmé. (Méţĥöð: ᐅ{protocolMethod}ᐊ) one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen]"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "[Féţçĥîñĝ ŕéšöûŕçé çöñţéñţ ĥåš éxçééðéð ţĥé åļļöţţéð ţîmé one two three four five six seven eight nine ten eleven]"
@@ -984,7 +1308,7 @@
     "message": "[Ļåб Ðåţå one]"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[[Ļîĝĥţĥöûšé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ţööļš/ļîĝĥţĥöûšé/) åñåļýšîš öƒ ţĥé çûŕŕéñţ þåĝé öñ åñ émûļåţéð möбîļé ñéţŵöŕķ. Våļûéš åŕé éšţîmåţéð åñð måý våŕý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[ᐅ[ᐊĻîĝĥţĥöûšéᐅ](https://developers.google.com/web/tools/lighthouse/)ᐊ åñåļýšîš öƒ ţĥé çûŕŕéñţ þåĝé öñ åñ émûļåţéð möбîļé ñéţŵöŕķ. Våļûéš åŕé éšţîmåţéð åñð måý våŕý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "[Åððîţîöñåļ îţémš ţö måñûåļļý çĥéçķ one two three four five six seven]"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "[Éxþåñð šñîþþéţ one two]"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "[Šĥöŵ 3ŕð-þåŕţý ŕéšöûŕçéš one two three]"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "[Ţĥéŕé ŵéŕé îššûéš åƒƒéçţîñĝ ţĥîš ŕûñ öƒ Ļîĝĥţĥöûšé: one two three four five six seven eight nine ten eleven]"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "[Våļûéš åŕé éšţîmåţéð åñð måý våŕý. one two three four five six seven]"
+    "message": "[Våļûéš åŕé éšţîmåţéð åñð måý våŕý. Ţĥé þéŕƒöŕmåñçé šçöŕé îš ᐅ[ᐊбåšéð öñļý öñ ţĥéšé méţŕîçšᐅ](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "[Þåššéð åûðîţš бûţ ŵîţĥ ŵåŕñîñĝš one two three four five six seven]"
@@ -1023,10 +1350,10 @@
     "message": "[Çöñšîðéŕ ûþļöåðîñĝ ýöûŕ ĜÎF ţö å šéŕvîçé ŵĥîçĥ ŵîļļ måķé îţ åvåîļåбļé ţö émбéð åš åñ ĤŢMĻ5 vîðéö. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen]"
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "[Îñšţåļļ å [ļåžý-ļöåð ŴöŕðÞŕéšš þļûĝîñ](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/šéåŕçĥ/ļåžý+ļöåð/) ţĥåţ þŕövîðéš ţĥé åбîļîţý ţö ðéƒéŕ åñý öƒƒšçŕééñ îmåĝéš, öŕ šŵîţçĥ ţö å ţĥémé ţĥåţ þŕövîðéš ţĥåţ ƒûñçţîöñåļîţý. Åļšö çöñšîðéŕ ûšîñĝ [ţĥé ÅMÞ þļûĝîñ](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/åmþ/). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour]"
+    "message": "[Îñšţåļļ å ᐅ[ᐊļåžý-ļöåð ŴöŕðÞŕéšš þļûĝîñᐅ](https://wordpress.org/plugins/search/lazy+load/)ᐊ ţĥåţ þŕövîðéš ţĥé åбîļîţý ţö ðéƒéŕ åñý öƒƒšçŕééñ îmåĝéš, öŕ šŵîţçĥ ţö å ţĥémé ţĥåţ þŕövîðéš ţĥåţ ƒûñçţîöñåļîţý. Åļšö çöñšîðéŕ ûšîñĝ ᐅ[ᐊţĥé ÅMÞ þļûĝîñᐅ](https://wordpress.org/plugins/amp/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix]"
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "[Ţĥéŕé åŕé å ñûmбéŕ öƒ ŴöŕðÞŕéšš þļûĝîñš ţĥåţ çåñ ĥéļþ ýöû [îñļîñé çŕîţîçåļ åššéţš](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/šéåŕçĥ/çŕîţîçåļ+çšš/) öŕ [ðéƒéŕ ļéšš îmþöŕţåñţ ŕéšöûŕçéš](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/šéåŕçĥ/ðéƒéŕ+çšš+ĵåvåšçŕîþţ/). Бéŵåŕé ţĥåţ öþţîmîžåţîöñš þŕövîðéð бý ţĥéšé þļûĝîñš måý бŕéåķ ƒéåţûŕéš öƒ ýöûŕ ţĥémé öŕ þļûĝîñš, šö ýöû ŵîļļ ļîķéļý ñééð ţö måķé çöðé çĥåñĝéš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty one two three four five six seven]"
+    "message": "[Ţĥéŕé åŕé å ñûmбéŕ öƒ ŴöŕðÞŕéšš þļûĝîñš ţĥåţ çåñ ĥéļþ ýöû ᐅ[ᐊîñļîñé çŕîţîçåļ åššéţšᐅ](https://wordpress.org/plugins/search/critical+css/)ᐊ öŕ ᐅ[ᐊðéƒéŕ ļéšš îmþöŕţåñţ ŕéšöûŕçéšᐅ](https://wordpress.org/plugins/search/defer+css+javascript/)ᐊ. Бéŵåŕé ţĥåţ öþţîmîžåţîöñš þŕövîðéð бý ţĥéšé þļûĝîñš måý бŕéåķ ƒéåţûŕéš öƒ ýöûŕ ţĥémé öŕ þļûĝîñš, šö ýöû ŵîļļ ļîķéļý ñééð ţö måķé çöðé çĥåñĝéš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree]"
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "[Ţĥéméš, þļûĝîñš, åñð šéŕvéŕ šþéçîƒîçåţîöñš åļļ çöñţŕîбûţé ţö šéŕvéŕ ŕéšþöñšé ţîmé. Çöñšîðéŕ ƒîñðîñĝ å möŕé öþţîmîžéð ţĥémé, çåŕéƒûļļý šéļéçţîñĝ åñ öþţîmîžåţîöñ þļûĝîñ, åñð/öŕ ûþĝŕåðîñĝ ýöûŕ šéŕvéŕ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
@@ -1035,30 +1362,30 @@
     "message": "[Çöñšîðéŕ šĥöŵîñĝ éxçéŕþţš îñ ýöûŕ þöšţ ļîšţš (é.ĝ. vîå ţĥé möŕé ţåĝ), ŕéðûçîñĝ ţĥé ñûmбéŕ öƒ þöšţš šĥöŵñ öñ å ĝîvéñ þåĝé, бŕéåķîñĝ ýöûŕ ļöñĝ þöšţš îñţö mûļţîþļé þåĝéš, öŕ ûšîñĝ å þļûĝîñ ţö ļåžý-ļöåð çömméñţš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "[Å ñûmбéŕ öƒ [ŴöŕðÞŕéšš þļûĝîñš](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/šéåŕçĥ/mîñîƒý+çšš/) çåñ šþééð ûþ ýöûŕ šîţé бý çöñçåţéñåţîñĝ, mîñîƒýîñĝ, åñð çömþŕéššîñĝ ýöûŕ šţýļéš. Ýöû måý åļšö ŵåñţ ţö ûšé å бûîļð þŕöçéšš ţö ðö ţĥîš mîñîƒîçåţîöñ ûþ-ƒŕöñţ îƒ þöššîбļé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo]"
+    "message": "[Å ñûmбéŕ öƒ ᐅ[ᐊŴöŕðÞŕéšš þļûĝîñšᐅ](https://wordpress.org/plugins/search/minify+css/)ᐊ çåñ šþééð ûþ ýöûŕ šîţé бý çöñçåţéñåţîñĝ, mîñîƒýîñĝ, åñð çömþŕéššîñĝ ýöûŕ šţýļéš. Ýöû måý åļšö ŵåñţ ţö ûšé å бûîļð þŕöçéšš ţö ðö ţĥîš mîñîƒîçåţîöñ ûþ-ƒŕöñţ îƒ þöššîбļé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "[Å ñûmбéŕ öƒ [ŴöŕðÞŕéšš þļûĝîñš](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/šéåŕçĥ/mîñîƒý+ĵåvåšçŕîþţ/) çåñ šþééð ûþ ýöûŕ šîţé бý çöñçåţéñåţîñĝ, mîñîƒýîñĝ, åñð çömþŕéššîñĝ ýöûŕ šçŕîþţš. Ýöû måý åļšö ŵåñţ ţö ûšé å бûîļð þŕöçéšš ţö ðö ţĥîš mîñîƒîçåţîöñ ûþ ƒŕöñţ îƒ þöššîбļé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo]"
+    "message": "[Å ñûmбéŕ öƒ ᐅ[ᐊŴöŕðÞŕéšš þļûĝîñšᐅ](https://wordpress.org/plugins/search/minify+javascript/)ᐊ çåñ šþééð ûþ ýöûŕ šîţé бý çöñçåţéñåţîñĝ, mîñîƒýîñĝ, åñð çömþŕéššîñĝ ýöûŕ šçŕîþţš. Ýöû måý åļšö ŵåñţ ţö ûšé å бûîļð þŕöçéšš ţö ðö ţĥîš mîñîƒîçåţîöñ ûþ ƒŕöñţ îƒ þöššîбļé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven]"
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "[Çöñšîðéŕ ŕéðûçîñĝ, öŕ šŵîţçĥîñĝ, ţĥé ñûmбéŕ öƒ [ŴöŕðÞŕéšš þļûĝîñš](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/) ļöåðîñĝ ûñûšéð ÇŠŠ îñ ýöûŕ þåĝé. Ţö îðéñţîƒý þļûĝîñš ţĥåţ åŕé åððîñĝ éxţŕåñéöûš ÇŠŠ, ţŕý ŕûññîñĝ [çöðé çövéŕåĝé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ûþðåţéš/2017/04/ðévţööļš-ŕéļéåšé-ñöţéš#çövéŕåĝé) îñ Çĥŕömé ÐévŢööļš. Ýöû çåñ îðéñţîƒý ţĥé ţĥémé/þļûĝîñ ŕéšþöñšîбļé ƒŕöm ţĥé ÛŔĻ öƒ ţĥé šţýļéšĥééţ. Ļööķ öûţ ƒöŕ þļûĝîñš ţĥåţ ĥåvé måñý šţýļéšĥééţš îñ ţĥé ļîšţ ŵĥîçĥ ĥåvé å ļöţ öƒ ŕéð îñ çöðé çövéŕåĝé. Å þļûĝîñ šĥöûļð öñļý éñqûéûé å šţýļéšĥééţ îƒ îţ îš åçţûåļļý ûšéð öñ ţĥé þåĝé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine]"
+    "message": "[Çöñšîðéŕ ŕéðûçîñĝ, öŕ šŵîţçĥîñĝ, ţĥé ñûmбéŕ öƒ ᐅ[ᐊŴöŕðÞŕéšš þļûĝîñšᐅ](https://wordpress.org/plugins/)ᐊ ļöåðîñĝ ûñûšéð ÇŠŠ îñ ýöûŕ þåĝé. Ţö îðéñţîƒý þļûĝîñš ţĥåţ åŕé åððîñĝ éxţŕåñéöûš ÇŠŠ, ţŕý ŕûññîñĝ ᐅ[ᐊçöðé çövéŕåĝéᐅ](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)ᐊ îñ Çĥŕömé ÐévŢööļš. Ýöû çåñ îðéñţîƒý ţĥé ţĥémé/þļûĝîñ ŕéšþöñšîбļé ƒŕöm ţĥé ÛŔĻ öƒ ţĥé šţýļéšĥééţ. Ļööķ öûţ ƒöŕ þļûĝîñš ţĥåţ ĥåvé måñý šţýļéšĥééţš îñ ţĥé ļîšţ ŵĥîçĥ ĥåvé å ļöţ öƒ ŕéð îñ çöðé çövéŕåĝé. Å þļûĝîñ šĥöûļð öñļý éñqûéûé å šţýļéšĥééţ îƒ îţ îš åçţûåļļý ûšéð öñ ţĥé þåĝé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "[Çöñšîðéŕ ŕéðûçîñĝ, öŕ šŵîţçĥîñĝ, ţĥé ñûmбéŕ öƒ [ŴöŕðÞŕéšš þļûĝîñš](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/) ļöåðîñĝ ûñûšéð ĴåvåŠçŕîþţ îñ ýöûŕ þåĝé. Ţö îðéñţîƒý þļûĝîñš ţĥåţ åŕé åððîñĝ éxţŕåñéöûš ĴŠ, ţŕý ŕûññîñĝ [çöðé çövéŕåĝé](ĥţţþš://ðévéļöþéŕš.ĝööĝļé.çöm/ŵéб/ûþðåţéš/2017/04/ðévţööļš-ŕéļéåšé-ñöţéš#çövéŕåĝé) îñ Çĥŕömé ÐévŢööļš. Ýöû çåñ îðéñţîƒý ţĥé ţĥémé/þļûĝîñ ŕéšþöñšîбļé ƒŕöm ţĥé ÛŔĻ öƒ ţĥé šçŕîþţ. Ļööķ öûţ ƒöŕ þļûĝîñš ţĥåţ ĥåvé måñý šçŕîþţš îñ ţĥé ļîšţ ŵĥîçĥ ĥåvé å ļöţ öƒ ŕéð îñ çöðé çövéŕåĝé. Å þļûĝîñ šĥöûļð öñļý éñqûéûé å šçŕîþţ îƒ îţ îš åçţûåļļý ûšéð öñ ţĥé þåĝé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine]"
+    "message": "[Çöñšîðéŕ ŕéðûçîñĝ, öŕ šŵîţçĥîñĝ, ţĥé ñûmбéŕ öƒ ᐅ[ᐊŴöŕðÞŕéšš þļûĝîñšᐅ](https://wordpress.org/plugins/)ᐊ ļöåðîñĝ ûñûšéð ĴåvåŠçŕîþţ îñ ýöûŕ þåĝé. Ţö îðéñţîƒý þļûĝîñš ţĥåţ åŕé åððîñĝ éxţŕåñéöûš ĴŠ, ţŕý ŕûññîñĝ ᐅ[ᐊçöðé çövéŕåĝéᐅ](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)ᐊ îñ Çĥŕömé ÐévŢööļš. Ýöû çåñ îðéñţîƒý ţĥé ţĥémé/þļûĝîñ ŕéšþöñšîбļé ƒŕöm ţĥé ÛŔĻ öƒ ţĥé šçŕîþţ. Ļööķ öûţ ƒöŕ þļûĝîñš ţĥåţ ĥåvé måñý šçŕîþţš îñ ţĥé ļîšţ ŵĥîçĥ ĥåvé å ļöţ öƒ ŕéð îñ çöðé çövéŕåĝé. Å þļûĝîñ šĥöûļð öñļý éñqûéûé å šçŕîþţ îƒ îţ îš åçţûåļļý ûšéð öñ ţĥé þåĝé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "[Ŕéåð åбöûţ [Бŕöŵšéŕ Çåçĥîñĝ îñ ŴöŕðÞŕéšš](ĥţţþš://çöðéx.ŵöŕðþŕéšš.öŕĝ/ŴöŕðÞŕéšš_Öþţîmîžåţîöñ#Бŕöŵšéŕ_Çåçĥîñĝ). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
+    "message": "[Ŕéåð åбöûţ ᐅ[ᐊБŕöŵšéŕ Çåçĥîñĝ îñ ŴöŕðÞŕéššᐅ](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)ᐊ. one two three four five six seven eight nine ten]"
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "[Çöñšîðéŕ ûšîñĝ åñ [îmåĝé öþţîmîžåţîöñ ŴöŕðÞŕéšš þļûĝîñ](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/šéåŕçĥ/öþţîmîžé+îmåĝéš/) ţĥåţ çömþŕéššéš ýöûŕ îmåĝéš ŵĥîļé ŕéţåîñîñĝ qûåļîţý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree]"
+    "message": "[Çöñšîðéŕ ûšîñĝ åñ ᐅ[ᐊîmåĝé öþţîmîžåţîöñ ŴöŕðÞŕéšš þļûĝîñᐅ](https://wordpress.org/plugins/search/optimize+images/)ᐊ ţĥåţ çömþŕéššéš ýöûŕ îmåĝéš ŵĥîļé ŕéţåîñîñĝ qûåļîţý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen]"
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "[Ûþļöåð îmåĝéš ðîŕéçţļý ţĥŕöûĝĥ ţĥé [méðîå ļîбŕåŕý](ĥţţþš://çöðéx.ŵöŕðþŕéšš.öŕĝ/Méðîå_Ļîбŕåŕý_Šçŕééñ) ţö éñšûŕé ţĥåţ ţĥé ŕéqûîŕéð îmåĝé šîžéš åŕé åvåîļåбļé, åñð ţĥéñ îñšéŕţ ţĥém ƒŕöm ţĥé méðîå ļîбŕåŕý öŕ ûšé ţĥé îmåĝé ŵîðĝéţ ţö éñšûŕé ţĥé öþţîmåļ îmåĝé šîžéš åŕé ûšéð (îñçļûðîñĝ ţĥöšé ƒöŕ ţĥé ŕéšþöñšîvé бŕéåķþöîñţš). Åvöîð ûšîñĝ `Fûļļ Šîžé` îmåĝéš ûñļéšš ţĥé ðîméñšîöñš åŕé åðéqûåţé ƒöŕ ţĥéîŕ ûšåĝé. [Ļéåŕñ Möŕé](ĥţţþš://çöðéx.ŵöŕðþŕéšš.öŕĝ/Îñšéŕţîñĝ_Îmåĝéš_îñţö_Þöšţš_åñð_Þåĝéš#Îmåĝé_Šîžé). one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
+    "message": "[Ûþļöåð îmåĝéš ðîŕéçţļý ţĥŕöûĝĥ ţĥé ᐅ[ᐊméðîå ļîбŕåŕýᐅ](https://codex.wordpress.org/Media_Library_Screen)ᐊ ţö éñšûŕé ţĥåţ ţĥé ŕéqûîŕéð îmåĝé šîžéš åŕé åvåîļåбļé, åñð ţĥéñ îñšéŕţ ţĥém ƒŕöm ţĥé méðîå ļîбŕåŕý öŕ ûšé ţĥé îmåĝé ŵîðĝéţ ţö éñšûŕé ţĥé öþţîmåļ îmåĝé šîžéš åŕé ûšéð (îñçļûðîñĝ ţĥöšé ƒöŕ ţĥé ŕéšþöñšîvé бŕéåķþöîñţš). Åvöîð ûšîñĝ ᐅ`Full Size`ᐊ îmåĝéš ûñļéšš ţĥé ðîméñšîöñš åŕé åðéqûåţé ƒöŕ ţĥéîŕ ûšåĝé. ᐅ[ᐊĻéåŕñ Möŕéᐅ](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty thirtyone thirtytwo thirtythree thirtyfour thirtyfive thirtysix thirtyseven thirtyeight thirtynine forty one two three four five]"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "[Ýöû çåñ éñåбļé ţéxţ çömþŕéššîöñ îñ ýöûŕ ŵéб šéŕvéŕ çöñƒîĝûŕåţîöñ. one two three four five six seven eight nine ten eleven twelve thirteen]"
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "[Çöñšîðéŕ ûšîñĝ å [þļûĝîñ](ĥţţþš://ŵöŕðþŕéšš.öŕĝ/þļûĝîñš/šéåŕçĥ/çöñvéŕţ+ŵéбþ/) öŕ šéŕvîçé ţĥåţ ŵîļļ åûţömåţîçåļļý çöñvéŕţ ýöûŕ ûþļöåðéð îmåĝéš ţö ţĥé öþţîmåļ ƒöŕmåţš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
+    "message": "[Çöñšîðéŕ ûšîñĝ å ᐅ[ᐊþļûĝîñᐅ](https://wordpress.org/plugins/search/convert+webp/)ᐊ öŕ šéŕvîçé ţĥåţ ŵîļļ åûţömåţîçåļļý çöñvéŕţ ýöûŕ ûþļöåðéð îmåĝéš ţö ţĥé öþţîmåļ ƒöŕmåţš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   }
 }

--- a/lighthouse-core/lib/i18n/locales/es-419.json
+++ b/lighthouse-core/lib/i18n/locales/es-419.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Las claves de acceso permiten a los usuarios dirigirse rápidamente a una parte concreta de la página. Para facilitar una navegación correcta, las claves de acceso deben ser únicas. [Más información](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)"
+    "message": "Las claves de acceso permiten a los usuarios dirigirse rápidamente a una parte concreta de la página. Para facilitar una navegación correcta, las claves de acceso deben ser únicas. [Obtén más información](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Los valores de \"[accesskey]\" no son únicos"
+    "message": "Los valores de `[accesskey]` no son únicos"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Los valores de \"[accesskey]\" son únicos"
+    "message": "Los valores de `[accesskey]` son únicos"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Cada función de ARIA admite un subconjunto determinado de atributos \"aria-*\". Si no coinciden, se invalidarán los atributos \"aria-*\". [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)"
+    "message": "Cada `role` de ARIA admite un subconjunto específico de atributos de `aria-*`. Si no coinciden estos valores, los atributos de `aria-*` no serán válidos. [Obtén más información](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Los atributos \"[aria-*]\" no se corresponden con sus funciones"
+    "message": "Los atributos `[aria-*]` no coinciden con sus roles"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Los atributos \"[aria-*]\" se corresponden con sus funciones"
+    "message": "Los atributos `[aria-*]` coinciden con sus roles"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Algunas funciones de ARIA incluyen atributos obligatorios que describen el estado del elemento a los lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)"
+    "message": "Algunos roles de ARIA incluyen atributos obligatorios que describen el estado del elemento a los lectores de pantalla. [Obtén más información](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "\"[role]\" no incluyen todos los atributos \"[aria-*]\" necesarios"
+    "message": "Los elementos `[role]` no tienen todos los atributos `[aria-*]` necesarios"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "\"[role]\" incluyen todos los atributos \"[aria-*]\" necesarios"
+    "message": "Los elementos `[role]` tienen todos los atributos `[aria-*]` necesarios"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Algunas funciones principales de ARIA deben contener funciones secundarias específicas para llevar a cabo las funciones de accesibilidad correspondientes. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)"
+    "message": "Algunos roles principales de ARIA deben contener roles secundarios específicos para llevar a cabo las funciones de accesibilidad correspondientes. [Obtén más información](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Faltan elementos con atributos \"[role]\" que requieren otros atributos \"[role]\" secundarios específicos."
+    "message": "Faltan elementos con `[role]` que requieren elementos `[role]` secundarios específicos."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Se incluyeron los elementos con atributos \"[role]\" que requieren otros atributos \"[role]\" secundarios específicos"
+    "message": "Se incluyen elementos con roles `[role]` que requieren roles `[role]` secundarios específicos"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Algunas funciones secundarias de ARIA se deben incluir dentro de funciones principales concretas para poder llevar a cabo las funciones de accesibilidad correspondientes. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)"
+    "message": "Algunos roles secundarios de ARIA deben incluirse dentro de roles principales específicos para llevar a cabo de manera adecuada las funciones de accesibilidad correspondientes. [Obtén más información](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Los atributos \"[role]\" no se incluyen en los elementos principales necesarios"
+    "message": "Los elementos `[role]` no se incluyen en los elementos principales necesarios"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Los atributos \"[role]\" están incluidos en los elementos principales correspondientes"
+    "message": "Los elementos `[role]` se incluyen en los elementos principales correspondientes"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Las funciones de ARIA deben tener valores válidos para realizar las funciones de accesibilidad correspondientes. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)"
+    "message": "Los roles de ARIA deben tener valores válidos para realizar las funciones de accesibilidad correspondientes. [Obtén más información](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Los valores de \"[role]\" no son válidos"
+    "message": "Los valores de `[role]` no son válidos"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Los valores de \"[role]\" son válidos"
+    "message": "Los valores de `[role]` son válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Las tecnologías asistivas, como lectores de pantalla, no pueden interpretar atributos ARIA con valores no válidos. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)"
+    "message": "Las tecnologías de asistencia, como los lectores de pantalla, no pueden interpretar atributos de ARIA con valores no válidos. [Obtén más información](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Los atributos \"[aria-*]\" no tienen valores válidos"
+    "message": "Los atributos `[aria-*]` no tienen valores válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Los atributos \"[aria-*]\" tienen un valor válido"
+    "message": "Los atributos `[aria-*]` tienen valores válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Las tecnologías de asistencia, como los lectores de pantalla, no pueden interpretar los atributos ARIA cuyos valores no sean válidos. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)"
+    "message": "Las tecnologías de asistencia, como los lectores de pantalla, no pueden interpretar los atributos ARIA cuyos nombres no sean válidos. [Obtén más información](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Los atributos \"[aria-*]\" no son válidos o no están bien escritos"
+    "message": "Los atributos `[aria-*]` no son válidos o no están bien escritos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Los atributos \"[aria-*]\" son válidos y están bien escritos"
+    "message": "Los atributos `[aria-*]` son válidos y están bien escritos"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Los subtítulos permiten que los elementos de audio sean útiles para usuarios sordos o con problemas de audición, dado que proporcionan información fundamental, como identificar quién habla, lo que dicen y otros sonidos no verbales. [Más información](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)"
+    "message": "Los subtítulos permiten que los usuarios sordos o con dificultades auditivas aprovechen los elementos de audio, dado que proporcionan información fundamental, como la indicación de quién habla, lo que dice y otros datos no verbales. [Obtén más información](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Falta un elemento \"<track>\" con \"[kind=\"captions\"]\" en los elementos \"<audio>\"."
+    "message": "Falta un elemento `<track>` con `[kind=\"captions\"]` en los elementos `<audio>`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Los elementos \"<audio>\" contienen un elemento \"<track>\" con \"[kind=\"captions\"]\""
+    "message": "Los elementos `<audio>` contienen un elemento `<track>` con `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Elementos con errores"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Si un botón no tiene un nombre accesible, los lectores de pantalla lo leerán en voz alta como \"botón\", por lo que resultan inservibles para los usuarios que necesitan usar lectores de pantalla para navegar. [Más información](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)"
+    "message": "Si un botón no tiene un nombre accesible, los lectores de pantalla lo leerán en voz alta como \"botón\", por lo que resulta inservible para los usuarios que necesitan usar lectores de pantalla. [Obtén más información](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Los botones no tienen nombres accesibles"
@@ -93,7 +93,7 @@
     "message": "Los botones tienen nombres accesibles"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Incluir maneras de omitir el contenido repetitivo permite a los usuarios navegar por la página de forma más eficaz. [Más información](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)"
+    "message": "Incluir maneras de omitir el contenido repetitivo permite a los usuarios que usan un teclado navegar por la página con mayor eficiencia. [Obtén más información](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "La página no contiene ningún título, vínculo de omisión ni región de punto de referencia"
@@ -102,7 +102,7 @@
     "message": "La página contiene un título, un vínculo de omisión o una región de punto de referencia"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Los textos con poco contraste resultan difíciles o imposibles de leer para muchos usuarios. [Más información](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)"
+    "message": "Los textos con poco contraste resultan difíciles o imposibles de leer para muchos usuarios. [Obtén más información](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Los colores de fondo y de primer plano no tienen una relación de contraste adecuada."
@@ -111,88 +111,88 @@
     "message": "Los colores de fondo y de primer plano tienen una relación de contraste adecuada"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Si las listas de definiciones no están bien marcadas, es posible que los lectores de pantalla las interpreten de forma confusa o imprecisa. [Más información](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)"
+    "message": "Si las listas de definiciones no están bien marcadas, es posible que los lectores de pantalla las lean de forma confusa o imprecisa. [Obtén más información](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Los elementos \"<dl>\" no contienen únicamente grupos de \"<dt>\" y \"<dd>\" o elementos \"<script>\" o \"<template>\" ordenados correctamente."
+    "message": "Los elementos `<dl>` no contienen solo elementos `<script>` o `<template>`, o grupos de `<dt>` y `<dd>` ordenados correctamente."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Los elementos \"<dl>\" solo contienen grupos de \"<dt>\" y \"<dd>\" ordenados correctamente, o elementos \"<script>\" o \"<template>\"."
+    "message": "Los elementos `<dl>` contienen solo elementos `<script>` o `<template>`, o grupos de `<dt>` y `<dd>` ordenados correctamente."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Los elementos de la lista de definiciones (\"<dt>\" y \"<dd>\") deben estar incluidos en un elemento \"<dl>\" principal para asegurarte de que los lectores de pantalla puedan leerlos en voz alta correctamente. [Más información](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)"
+    "message": "Los elementos de la lista de definiciones (`<dt>` y `<dd>`) deben incluirse en un elemento `<dl>` principal para garantizar que los lectores de pantalla los lean correctamente. [Obtén más información](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Los elementos de la lista de definiciones no están incluidos en elementos \"<dl>\""
+    "message": "Los elementos de la lista de definiciones no se incluyen en los elementos `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Los elementos de la lista de definiciones se incluyen en los elementos \"<dl>\""
+    "message": "Los elementos de la lista de definiciones se incluyen en los elementos `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Con el título, los usuarios de lectores de pantalla obtienen una descripción general de la página. Los usuarios de motores de búsqueda lo utilizan para determinar si una página es relevante para su búsqueda. [Más información](https://developers.google.com/web/tools/lighthouse/audits/title)"
+    "message": "El título les brinda a los usuarios de lectores de pantalla una descripción general de la página. Por su parte, los usuarios de motores de búsqueda lo usan mucho para determinar si una página es relevante para su búsqueda. [Obtén más información](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "El documento no tiene ningún elemento \"<title>\""
+    "message": "El documento no tiene un elemento `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "El documento tiene un elemento \"<title>\""
+    "message": "El documento tiene un elemento `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "El valor de los atributos id debe ser único para evitar que las tecnologías de asistencia omitan otras instancias. [Más información](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)"
+    "message": "El valor de los atributos id debe ser único para evitar que las tecnologías de asistencia omitan otras instancias. [Obtén más información](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Los atributos \"[id]\" de la página no son únicos"
+    "message": "Los atributos `[id]` de la página no son únicos"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Los atributos \"[id]\" de la página son únicos"
+    "message": "Los atributos `[id]` de la página son únicos"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Los usuarios de lectores de pantalla necesitan que los marcos tengan títulos para que se describa su contenido. [Más información](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)"
+    "message": "Los usuarios de lectores de pantalla necesitan que los marcos tengan títulos para que se describa su contenido. [Obtén más información](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Los elementos \"<frame>\" o \"<iframe>\" no tienen título"
+    "message": "Los elementos `<frame>` o `<iframe>` no tienen título"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Los elementos \"<frame>\" o \"<iframe>\" tienen título"
+    "message": "Los elementos `<frame>` o `<iframe>` tienen un título"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Si no se especifica ningún atributo de idioma para una página, los lectores de pantalla asumirán que la página tiene el idioma predeterminado que el usuario eligió al configurar el lector de pantalla. Si el idioma de la página es diferente del predeterminado, es posible que el lector de pantalla no lea bien el texto de la página. [Más información](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)"
+    "message": "Si no se especifica ningún atributo de idioma para una página, los lectores de pantalla considerarán que la página está en el idioma predeterminado que el usuario eligió al configurar el lector de pantalla. Si el idioma de la página es diferente del predeterminado, es posible que el lector de pantalla no lea bien el texto de la página. [Obtén más información](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "El elemento \"<html>\" no contiene ningún atributo \"[lang]\""
+    "message": "El elemento `<html>` no tiene un atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "El elemento \"<html>\" tiene un atributo \"[lang]\""
+    "message": "El elemento `<html>` tiene un atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Especificar un [idioma BCP 47] válido (https://www.w3.org/International/questions/qa-choosing-language-tags#question) permite a los lectores de pantalla leer el texto en voz alta correctamente. [Más información](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)"
+    "message": "Especificar un [idioma BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido permite a los lectores de pantalla leer el texto en voz alta correctamente. [Obtén más información](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "El elemento \"<html>\" no tiene un valor válido para el atributo \"[lang]\"."
+    "message": "El elemento `<html>` no tiene un valor válido para el atributo `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "El elemento \"<html>\" tiene un valor válido para el atributo \"[lang]\""
+    "message": "El elemento `<html>` tiene un valor válido para su atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "El texto de los elementos informativos debe ser corto y descriptivo. Los elementos decorativos se pueden omitir usando un atributo alt vacío. [Más información](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)"
+    "message": "El texto de los elementos informativos debe ser corto y descriptivo. Los elementos decorativos se pueden omitir usando un atributo alt vacío. [Obtén más información](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Los elementos de imagen no tienen ningún atributo \"[alt]\""
+    "message": "Los elementos de imagen no tienen ningún atributo `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Los elementos de imagen tienen atributos \"[alt]\""
+    "message": "Los elementos de imagen tienen atributos `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Cuando se usa una imagen como botón \"<input>\", resulta útil proporcionar un texto alternativo para permitir que los usuarios de lectores de pantalla entiendan cuál es la función del botón. [Más información](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)"
+    "message": "Cuando se usa una imagen como botón `<input>`, resulta útil proporcionar un texto alternativo para permitir que los usuarios de lectores de pantalla entiendan cuál es la función del botón. [Obtén más información](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Los elementos \"<input type=\"image\">\" no tienen texto \"[alt]\""
+    "message": "Los elementos `<input type=\"image\">` no tienen texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Los elementos \"<input type=\"image\">\" no contienen texto \"[alt]\""
+    "message": "Los elementos `<input type=\"image\">` tienen texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Las etiquetas facilitan que las tecnologías de asistencia, como los lectores de pantalla, puedan leer los controles de los formularios de forma correcta. [Más información](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)"
+    "message": "Las etiquetas garantizan que las tecnologías de asistencia, como los lectores de pantalla, lean los controles de los formularios de forma correcta. [Obtén más información](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Los elementos de formulario no tienen ninguna etiqueta asociada"
@@ -201,16 +201,16 @@
     "message": "Los elementos de formulario tienen etiquetas asociadas"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Una tabla que se utilice para diseño no debe incluir elementos de datos (como ordinales), leyendas ni atributos de resumen, dado que pueden confundir a los usuarios de lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)"
+    "message": "Las tablas que se usen con fines de diseño no deben incluir elementos de datos (como ordinales, leyendas o atributos de resumen), dado que estos pueden confundir a los usuarios de lectores de pantalla. [Obtén más información](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Los elementos \"<table>\" de presentación no evitan el uso de \"<th>\", \"<caption>\" ni el atributo \"[summary]\"."
+    "message": "Los elementos `<table>` de presentación no evitan el uso de `<th>`, `<caption>` ni del atributo `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Los elementos \"<table>\" de presentación no utilizan elementos \"<th>\" o \"<caption>\" ni el atributo \"[summary]\"."
+    "message": "Los elementos `<table>` de presentación evitan el uso de `<th>`, `<caption>` o del atributo `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Usar textos de vínculo (y textos alternativos para las imágenes, si estas se usan como vínculos) que sean reconocibles, únicos y que se puedan seleccionar mejora la experiencia de navegación de los usuarios de lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)"
+    "message": "Usar textos de vínculo (y textos alternativos para las imágenes, si estas se usan como vínculos) que sean reconocibles y únicos, y que se puedan seleccionar mejora la experiencia de navegación de los usuarios de lectores de pantalla. [Obtén más información](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Los vínculos no tienen nombres reconocibles"
@@ -219,103 +219,115 @@
     "message": "Los vínculos tienen nombres reconocibles"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Los lectores de pantalla leen las listas en voz alta de una forma concreta. Se recomienda utilizar una estructura de listas adecuada para que los lectores de pantalla puedan leer las listas de forma correcta. [Más información](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)"
+    "message": "Los lectores de pantalla leen las listas en voz alta de una forma concreta. Se recomienda utilizar una estructura de lista adecuada para que los lectores de pantalla puedan leer las listas de forma correcta. [Obtén más información](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Las listas no contienen únicamente elementos \"<li>\" y elementos que admiten scripts (\"<script>\" y \"<template>\")."
+    "message": "Las listas no contienen solo elementos `<li>` y elementos que admiten secuencias de comandos (`<script>` y `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Las listas solo contienen elementos \"<li>\" y elementos que admiten scripts (\"<script>\" y \"<template>\")."
+    "message": "Las listas contienen solo elementos `<li>` y elementos que admiten secuencias de comando (`<script>` y `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Los lectores de pantalla requieren que los elementos de lista (\"<li>\") estén incluidos dentro de un elemento \"<ul>\" o \"<ol>\" principal para poder leerlos en voz alta correctamente. [Más información](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)"
+    "message": "Los lectores de pantalla requieren que los elementos de lista (`<li>`) se incluyan en un elemento `<ul>` o `<ol>` principal para leerlos correctamente. [Obtén más información](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Los elementos de lista (\"<li>\") no se encuentran dentro de los elementos principales \"<ul>\" o \"<ol>\"."
+    "message": "Los elementos de lista (`<li>`) no se encuentran dentro de elementos principales `<ul>` o `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Los objetos de lista (\"<li>\") están incluidos dentro de los elementos principales \"<ul>\" o \"<ol>\""
+    "message": "Los elementos de lista (`<li>`) se incluyen en los elementos principales `<ul>` o `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Los usuarios no esperan que una página se actualice automáticamente. Al hacerlo, se moverá el enfoque a la parte superior de la página. Esta acción puede generar una experiencia frustrante o confusa. [Más información](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)"
+    "message": "Los usuarios no esperan que una página se actualice automáticamente. Cuando eso sucede, vuelve a mostrarse la parte superior de la página. Esto puede generar una experiencia frustrante o confusa. [Obtén más información](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "El documento utiliza \"<meta http-equiv=\"refresh\">\""
+    "message": "El documento usa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "El documento no utiliza \"<meta http-equiv=\"refresh\">\""
+    "message": "El documento no usa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Desactivar el zoom provoca problemas para los usuarios con visión reducida, ya que necesitan ampliar la pantalla para poder ver correctamente el contenido de las páginas web. [Más información](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)"
+    "message": "Desactivar el zoom genera problemas para los usuarios con visión reducida, quienes necesitan ampliar la pantalla para ver correctamente el contenido de las páginas web. [Obtén más información](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "\"[user-scalable=\"no\"]\" se utiliza en el elemento \"<meta name=\"viewport\">\", o el atributo \"[maximum-scale]\" tiene un valor inferior a 5."
+    "message": "`[user-scalable=\"no\"]` se usa en el elemento `<meta name=\"viewport\">` o el atributo `[maximum-scale]` tiene un valor inferior a 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "\"[user-scalable=\"no\"]\" no se utiliza en el elemento \"<meta name=\"viewport\">\", y el atributo \"[maximum-scale]\" no tiene un valor inferior a 5."
+    "message": "No se usa `[user-scalable=\"no\"]` en el elemento `<meta name=\"viewport\">` y el atributo `[maximum-scale]` no tiene un valor inferior a 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Los lectores de pantalla no pueden traducir contenido que no sea texto. Al añadir texto alternativo a los elementos \"<object>\", los lectores de pantalla podrán transmitir su significado a los usuarios. [Más información](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)"
+    "message": "Los lectores de pantalla no pueden traducir contenido que no sea texto. El agregado de texto alternativo a los elementos `<object>` ayuda a los lectores de pantalla a transmitir el significado correspondiente a los usuarios. [Obtén más información](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Los elementos \"<object>\" no tienen texto \"[alt]\""
+    "message": "Los elementos `<object>` no tienen texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Los elementos \"<object>\" tienen texto \"[alt]\""
+    "message": "Los elementos `<object>` tienen texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Si el valor es superior a 0, significa que el orden de navegación es explícito. Aunque técnicamente es válido, esto suele producir experiencias frustrantes para los usuarios que necesitan usar tecnologías de asistencia. [Más información](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)"
+    "message": "Si el valor es superior a 0, el orden de navegación es explícito. Aunque técnicamente esta es una posibilidad válida, suele producir experiencias frustrantes en los usuarios que necesitan las tecnologías de asistencia. [Obtén más información](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Algunos elementos tienen un valor de \"[tabindex]\" superior a 0"
+    "message": "Algunos elementos tienen un valor de `[tabindex]` superior a 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "No hay ningún elemento con un valor de \"[tabindex]\" superior a 0"
+    "message": "No hay ningún elemento con un valor de `[tabindex]` superior a 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Los lectores de pantalla incluyen funciones para facilitar la navegación por las tablas. Debes asegurarte de que las celdas \"<td>\" que usan el atributo \"[headers]\" solo hagan referencia a otras celdas de la misma tabla a fin de mejorar la experiencia de los usuarios de lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)"
+    "message": "Los lectores de pantalla incluyen funciones para facilitar la navegación por las tablas. Asegurarse de que las celdas `<td>` que usan el atributo `[headers]` solo hagan referencia a otras celdas de la misma tabla puede mejorar la experiencia de los usuarios de lectores de pantalla. [Obtén más información](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Las celdas de los elementos \"<table>\" que usan el atributo \"[headers]\" hacen referencia a otras celdas de esa misma tabla."
+    "message": "Las celdas de un elemento `<table>` que usan el atributo `[headers]` hacen referencia a otras celdas de esa misma tabla."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Las celdas de los elementos \"<table>\" que usan el atributo \"[headers]\" solo hacen referencia a otras celdas de esa misma tabla."
+    "message": "Las celdas de un elemento `<table>` que usan el atributo `[headers]` solo hacen referencia a otras celdas de esa misma tabla."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Los lectores de pantalla incluyen funciones para facilitar la navegación por las tablas. Asegurarse de que los encabezados de las tablas siempre hagan referencia a un conjunto específico de celdas puede mejorar la experiencia de los usuarios de lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)"
+    "message": "Los lectores de pantalla incluyen funciones para facilitar la navegación por las tablas. Asegurarse de que los encabezados de las tablas siempre hagan referencia a un conjunto específico de celdas puede mejorar la experiencia de los usuarios de lectores de pantalla. [Obtén más información](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Los elementos \"<th>\" y los elementos con \"[role=\"columnheader\"/\"rowheader\"]\" no contienen las celdas de datos que describen."
+    "message": "Los elementos `<th>` y los elementos con `[role=\"columnheader\"/\"rowheader\"]` no contienen las celdas de datos que describen."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Los elementos \"<th>\" y los elementos con \"[role=\"columnheader\"/\"rowheader\"]\" contienen las celdas de datos que describen."
+    "message": "Los elementos `<th>` y los elementos con `[role=\"columnheader\"/\"rowheader\"]` contienen celdas de datos que describen."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Especificar un [idioma BCP 47] válido (https://www.w3.org/International/questions/qa-choosing-language-tags#question) en los elementos ayuda a asegurar que los lectores de pantalla pronuncien correctamente las palabras del texto. [Más información](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)"
+    "message": "Especificar un [idioma CP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido en los elementos ayuda a asegurar que los lectores de pantalla pronuncien bien el texto correspondiente. [Obtén más información](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Los atributos \"[lang]\" no tienen un valor válido"
+    "message": "Los atributos `[lang]` no tienen un valor válido"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Los atributos \"[lang]\" tienen un valor válido"
+    "message": "Los atributos `[lang]` tienen un valor válido"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Si un video tiene subtítulos, los usuarios sordos o con problemas auditivos pueden acceder a la información con más facilidad. [Más información](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)"
+    "message": "Si un video tiene subtítulos, los usuarios sordos o con dificultades auditivas pueden acceder a la información más fácilmente. [Obtén más información](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Los elementos \"<video>\" no contienen ningún elemento \"<track>\" con \"[kind=\"captions\"]\"."
+    "message": "Los elementos `<video>` no contienen un elemento `<track>` con `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Los elementos \"<video>\" contienen un elemento \"<track>\" con \"[kind=\"captions\"]\""
+    "message": "Los elementos `<video>` contienen un elemento `<track>` con `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Las descripciones de audio proporcionan información relevante en videos, cuyos diálogos no transmiten todo el contenido, como en el caso de las expresiones faciales y las escenas. [Más información](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)"
+    "message": "Las descripciones de audio incluidas en los videos proporcionan información relevante que no surge de los diálogos, como la relativa a expresiones faciales y escenografía. [Obtén más información](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Los elementos \"<video>\" no contienen ningún elemento \"<track>\" con \"[kind=\"description\"]\"."
+    "message": "Los elementos `<video>` no contienen un elemento `<track>` con `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Los elementos \"<video>\" contienen un elemento \"<track>\" con \"[kind=\"description\"]\""
+    "message": "Los elementos `<video>` contienen un elemento `<track>` con `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Define un atributo apple-touch-icon para mejorar la visualización en iOS cuando los usuarios agregan el sitio a la pantalla principal. El atributo debe apuntar a un archivo PNG cuadrado de 192 px (o 180 px) no transparente. [Obtén más información](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "No proporciona un ícono `apple-touch-icon` válido"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "El atributo `apple-touch-icon-precomposed` está desactualizado; usa en su lugar`apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Proporciona un `apple-touch-icon` válido"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Las extensiones de Chrome afectaron de forma negativa al rendimiento de carga de esta página. Prueba a auditarla en modo incógnito o desde un perfil de Chrome sin extensiones."
@@ -330,7 +342,7 @@
     "message": "Tiempo de CPU total"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Te recomendamos que reduzcas el tiempo de análisis, compilación y ejecución de JS. Para ello, puedes utilizar cargas útiles de JS más pequeñas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
+    "message": "Te recomendamos que reduzcas el tiempo de análisis, compilación y ejecución de secuencias JS. Para ello, puedes entregar cargas útiles de JS más pequeñas. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Reduce el tiempo de ejecución de JavaScript"
@@ -339,28 +351,28 @@
     "message": "Tiempo de ejecución de JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Los GIF de gran tamaño no son eficaces para mostrar contenido animado. En su lugar, considera utilizar formatos de video MPEG4/WebM para animaciones y formatos PNG/WebP para imágenes estáticas a fin de ahorrar bytes de la red. [Más información](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Los GIF de gran tamaño no son eficientes para mostrar contenido animado. En su lugar, puedes utilizar formatos de video MPEG4/WebM para animaciones y formatos PNG/WebP para imágenes estáticas a fin de ahorrar bytes de la red. [Más información](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Usa formatos de video para incluir contenido animado"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Te recomendamos que uses la carga diferida con imágenes ocultas y que no aparecen en pantalla una vez que todos los recursos críticos hayan terminado de cargarse para reducir el tiempo de carga. [Más información](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
+    "message": "Te recomendamos que uses la carga diferida para las imágenes ocultas y fuera de pantalla una vez que hayan terminado de cargarse todos los recursos críticos a fin de reducir el tiempo de carga. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Posterga la carga de imágenes que no aparecen en pantalla"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Hay recursos que bloquean el primer renderizado de la página. Te recomendamos que muestres los elementos JS/CSS críticos insertados y postergues todos los JS/styles que no sean críticos. [Más información](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
+    "message": "Hay recursos que bloquean el primer procesamiento de imagen de la página. Te recomendamos entregar los elementos JS/CSS críticos insertados y postergar todos los JS/estilos que no sean críticos. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Elimina los recursos que bloqueen el renderizado"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Si la carga útil de la red es muy grande, los usuarios consumen más datos móviles y las páginas tardan más en cargarse. [Más información](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
+    "message": "Trabajar con cargas útiles de red de gran tamaño resulta oneroso para el usuario, además de aumentar considerablemente el tiempo de carga de las páginas. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "Tamaño total: {totalBytes, number, bytes} KB"
+    "message": "El tamaño total era {totalBytes, number, bytes} KB"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Evita cargas útiles de red de gran tamaño"
@@ -369,19 +381,19 @@
     "message": "Evita cargas útiles de red de gran tamaño"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Si reduces los archivos CSS, se puede reducir el tamaño de la carga útil de la red. [Más información](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
+    "message": "Si reduces los archivos CSS, puedes achicar el tamaño de la carga útil de la red. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Reduce el uso de CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Si reduces los archivos JavaScript, se puede reducir el tamaño de la carga útil y el tiempo de análisis de la secuencia de comandos. [Más información](https://developers.google.com/speed/docs/insights/MinifyResources)"
+    "message": "Si reduces los archivos JavaScript, puedes achicar el tamaño de la carga útil y el tiempo de análisis de secuencias de comandos. [Obtén más información](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Reducir el uso de JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Elimina las reglas inactivas de las hojas de estilo y retrasa la carga de las CSS que no se utilicen para el contenido de la mitad superior de la página. Así, se reducirán los bytes consumidos innecesariamente por la actividad de red. [Más información](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
+    "message": "Quita las reglas inactivas de las hojas de estilo y retrasa la carga de secuencias CSS que no se utilicen para el contenido de la mitad superior de la página. Así, se reducirán los bytes que consume innecesariamente la actividad de red. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Quita los recursos CSS que no se usen"
@@ -393,7 +405,7 @@
     "message": "Quita el código JavaScript sin usar"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Una duración en caché más larga puede aumentar la cantidad de visitas repetidas a tu página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
+    "message": "La duración en caché por un período prolongado puede acelerar la carga de la página cuando el usuario la visita de manera repetida. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Se encontró 1 recurso}other{Se encontraron # recursos}}"
@@ -405,37 +417,88 @@
     "message": "Usa una política de caché eficaz en recursos estáticos"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Las imágenes optimizadas se cargan más rápido y consumen menos datos móviles. [Más información](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
+    "message": "Las imágenes optimizadas se cargan más rápido y consumen menos datos móviles. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Codifica las imágenes de forma eficaz"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Muestra imágenes con un tamaño adecuado para ahorrar datos móviles y mejorar el tiempo de carga. [Más información](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
+    "message": "Muestra imágenes con un tamaño adecuado para ahorrar datos móviles y reducir el tiempo de carga. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Usa un tamaño adecuado para las imágenes"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Los recursos basados en texto se deberían publicar comprimidos (gzip, deflate o brotli) para minimizar el total de bytes de la red. [Más información](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
+    "message": "Los recursos basados en texto se deberían publicar comprimidos (gzip, deflate o brotli) para minimizar el total de bytes de la red. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Habilita la compresión de texto"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Los formatos como JPEG 2000, JPEG XR y WebP comprimen mejor las imágenes que los formatos PNG o JPEG, lo que hace que se descarguen más rápido y consuman menos datos. [Más información](https://developers.google.com/web/tools/lighthouse/audits/webp)"
+    "message": "Los formatos como JPEG 2000, JPEG XR y WebP suelen comprimir mejor las imágenes que los formatos PNG o JPEG, lo que hace que se descarguen más rápido y consuman menos datos. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Publica imágenes con formatos de próxima generación"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Las cadenas de solicitud crítica que se muestran a continuación indican qué recursos son de alta prioridad. Te recomendamos que reduzcas la longitud de las cadenas, disminuyas el tamaño de los recursos o postergues la descarga de recursos innecesarios para mejorar la carga de la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
+    "message": "Las cadenas de solicitudes críticas que se muestran a continuación indican qué recursos son de alta prioridad en la carga. Te recomendamos que reduzcas la longitud de las cadenas, disminuyas el tamaño de los recursos para la descarga o postergues la descarga de recursos innecesarios para mejorar la carga de la página. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Se encontró 1 cadena}other{Se encontraron # cadenas}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimiza la profundidad de las solicitudes críticas"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Baja/advertencia"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Línea"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Con el tiempo, se quitarán las API obsoletas del navegador. [Obtén más información](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Se encontró 1 advertencia}other{Se encontraron # advertencias}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Usa API obsoletas"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Evita las API obsoletas"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "La caché de aplicaciones es obsoleta. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Se encontró \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Usa la caché de aplicaciones"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Evita la caché de aplicaciones"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Especificar un DOCTYPE evita que el navegador cambie al modo no estándar. Obtén más información en la [página MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "El nombre de DOCTYPE debe ser la cadena en minúsculas `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "El documento debe contener un DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Se esperaba que publicId fuera una string vacía"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Se esperaba que systemId fuera una string vacía"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "La página no tiene el DOCKTYPE de HTML; por lo tanto, activa el modo no estándar"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "La página tiene el DOCTYPE de HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elemento"
@@ -447,7 +510,7 @@
     "message": "Valor"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Los desarrolladores de navegadores recomiendan que las páginas contengan menos de 1500 elementos de DOM. Lo ideal es conseguir una profundidad de árbol inferior a 32 elementos y a 60 elementos secundarios por cada elemento principal. Los DOM de gran tamaño aumentan el uso de la memoria, hacen que los [cálculos de estilo](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) duren más y generan costosos [reinicios del flujo del diseño](https://developers.google.com/speed/articles/reflow). [Más información](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
+    "message": "Los desarrolladores de navegadores recomiendan que las páginas contengan menos de alrededor de 1500 elementos de DOM. Lo ideal es que la profundidad del árbol sea inferior a 32 elementos, con 60 elementos secundarios por elemento principal como máximo. Los DOM de gran tamaño pueden aumentar el uso de la memoria, hacer que los [cálculos de estilos](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) tarden más y generar costosos [reprocesamientos del diseño](https://developers.google.com/speed/articles/reflow). [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 elemento}other{# elementos}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Evita un tamaño excesivo de DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Objetivo"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Agrega `rel=\"noopener\"` o `rel=\"noreferrer\"` a cualquier vínculo externo para mejorar el rendimiento y evitar vulnerabilidades de seguridad. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Los vínculos a destinos con orígenes cruzados no son seguros"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Los vínculos a destinos con orígenes cruzados son seguros"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "No se puede determinar el destino de anclaje ({anchorHTML}). Si no se usa como hipervínculo, te recomendamos quitar target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Los sitios que solicitan a los usuarios su ubicación sin contexto los confunden o los hacen desconfiar. Te recomendamos vincular la solicitud a una acción del usuario. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Solicita el permiso de ubicación geográfica al cargar la página"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Evita solicitar el permiso de ubicación geográfica al cargar la página"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versión"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Se detectaron todas las bibliotecas JavaScript de frontend de la página."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Se detectaron bibliotecas JavaScript"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "En el caso de usuarios con una conexión lenta, las secuencias de comandos externas que se incorporan dinámicamente a través de`document.write()` pueden demorar la carga de la página decenas de segundos. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Usa `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "No usa `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Gravedad más alta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Versión de la biblioteca"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Recuento de vulnerabilidades"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Es posible que algunas secuencias de comandos de terceros contengan vulnerabilidades de seguridad conocidas que los atacantes pueden identificar y aprovechar fácilmente. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Se detectó una vulnerabilidad}other{Se detectaron # vulnerabilidades}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Incluye bibliotecas JavaScript de frontend con vulnerabilidades de seguridad conocidas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Alta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Baja"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Media"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Evita las bibliotecas JavaScript de frontend con vulnerabilidades de seguridad conocidas"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Los sitios que solicitan a los usuarios permiso para enviar notificaciones sin contexto los confunden o los hacen desconfiar. Te recomendamos vincular la solicitud a los gestos del usuario. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Solicita el permiso de notificaciones al cargar la página"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Evita solicitar el permiso de notificaciones al cargar la página"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elementos con errores"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Evitar el pegado de contraseñas debilita las buenas políticas de seguridad. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Evita que los usuarios peguen contenido en los campos de contraseña"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Permite que los usuarios peguen contenido en los campos de contraseña"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocolo"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ofrece más beneficios que HTTP/1.1, como los encabezados binarios, el multiplexado y los mensajes push del servidor. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 solicitud no se entregó mediante HTTP/2}other{# solicitudes no se entregaron mediante HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "No usa HTTP/2 para todos los recursos propios"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Usa HTTP/2 para sus propios recursos"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Puedes marcar tus objetos de escucha de eventos táctiles y de la rueda del mouse como `passive` para mejorar el rendimiento de desplazamiento de tu página. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "No usa objetos de escucha pasivos para mejorar el rendimiento del desplazamiento"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Usa objetos de escucha pasivos para mejorar el rendimiento del desplazamiento"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Descripción"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Los errores registrados en la consola indican la existencia de problemas no resueltos. Es posible que se deban a fallos en solicitudes de red y otros problemas del navegador."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Se registraron errores del navegador en la consola"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "No se registraron errores del navegador en la consola"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Utiliza la función de CSS font-display para que los usuarios vean el texto mientras se carga la fuente web. [Más información](https://developers.google.com/web/updates/2016/02/font-display)"
+    "message": "Utiliza la función font-display de CSS a fin de que los usuarios vean el texto mientras se carga la fuente para sitios web. [Obtén más información](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Asegúrate de que el texto permanezca visible mientras se carga la fuente web"
@@ -476,8 +671,44 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Todo el texto permanece visible mientras se carga la fuente para sitios web"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse no pudo comprobar automáticamente el valor de font-display para la siguiente URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Relación de aspecto (real)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Relación de aspecto (visualizada)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Las dimensiones de visualización de las imágenes deben coincidir con la relación de aspecto natural. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Muestra imágenes con una relación de aspecto incorrecta"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Muestra imágenes con una relación de aspecto correcta"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "La información sobre el tamaño de la imagen no es válida {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL no segura"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Todos los sitios deben estar protegidos con el protocolo HTTPS, incluso aquellos que no controlan datos sensibles. Este protocolo evita que intrusos manipulen o escuchen de forma pasiva las comunicaciones entre tu app y los usuarios. Además, HTTPS es un requisito del protocolo HTTP/2 y muchas API nuevas de Web Platform. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Se encontró una solicitud no segura}other{Se encontraron # solicitudes no seguras}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "No usa HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Usa HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Si las páginas se cargan rápidamente en las redes móviles, el usuario disfrutará de una buena experiencia. [Más información](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
+    "message": "Si las páginas se cargan rápidamente en las redes móviles, el usuario disfrutará de una buena experiencia. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
     "message": "Interactiva a los {timeInMs, number, seconds} s"
@@ -504,79 +735,106 @@
     "message": "Minimiza el trabajo del hilo principal"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "La latencia de entrada estimada es el tiempo, en milisegundos, que tarda tu app en responder a las acciones de los usuarios durante el periodo de 5 s más activo de carga de la página. Si la latencia es superior a 50 ms, es posible que los usuarios piensen que tu app es lenta. [Más información](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
+    "message": "La latencia de entrada estimada es el tiempo aproximado, en milisegundos, que tarda tu app en responder a las acciones de los usuarios durante el periodo de 5 s más activo de carga de la página. Si la latencia es superior a 50 ms, es posible que los usuarios piensen que tu app es lenta. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Latencia de entrada estimada"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "El primer procesamiento de imagen con contenido indica el momento en el que se procesa el primer texto o imagen. [Más información](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
+    "message": "El primer procesamiento de imagen con contenido indica el momento en el que se visualiza en la pantalla el primer texto o imagen. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Primer procesamiento de imagen con contenido"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "El primer tiempo inactivo de la CPU indica la primera vez que el hilo principal de la página está lo suficientemente inactivo para recibir acciones del usuario. [Más información](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
+    "message": "La métrica primer estado inactivo de la CPU indica la primera vez que el subproceso principal de la página está lo suficientemente inactivo para recibir entradas del usuario. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Primer tiempo inactivo de la CPU"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "La primera pintura significativa mide el momento en que se muestra el contenido principal de la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
+    "message": "La primera pintura significativa mide el momento en que se muestra el contenido principal de la página. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Primera pintura significativa"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "El tiempo de carga es el tiempo que tarda una página en ser totalmente interactiva. [Más información](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
+    "message": "El tiempo de carga indica cuánto tarda una página en ser totalmente interactiva. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Tiempo de carga"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "El posible retraso de primera entrada que podrían experimentar los usuarios es la duración (en milisegundos) de la tarea más larga."
+    "message": "El máximo retraso de primera entrada que podrían experimentar los usuarios es la duración (en milisegundos) de la tarea más larga. [Obtén más información](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID potencial máxima"
+    "message": "Máximo retraso de primera entrada posible"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "El índice de velocidad indica la rapidez con la que se puede ver el contenido de una página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
+    "message": "El índice de velocidad indica la rapidez con la que se puede ver el contenido de una página. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Índice de velocidad"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Suma todos los períodos entre FCP y el tiempo de carga, cuando la tarea tarda más de 50 ms. El resultado se expresa en milisegundos."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Tiempo total de bloqueo"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Los tiempos de ida y vuelta (RTT) de la red afectan mucho al rendimiento. Un RTT alto hasta un origen indica que usar servidores más cercanos al usuario podría mejorar el rendimiento. [Más información](https://hpbn.co/primer-on-latency-and-bandwidth/)"
+    "message": "Los tiempos de ida y vuelta (RTT) de la red afectan mucho el rendimiento. Los valores altos de RTT respecto de un origen son indicio de que usar servidores más cercanos al usuario podría mejorar el rendimiento. [Obtén más información](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Tiempos de ida y vuelta de la red"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Las latencias del servidor pueden afectar el rendimiento de la Web. Una latencia del servidor alta en un origen indica que el servidor está sobrecargado o que su rendimiento de backend es bajo. [Más información](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
+    "message": "Las latencias del servidor pueden afectar el rendimiento de la Web. Un nivel alto de latencia del servidor en un origen indica que el servidor está sobrecargado o que su rendimiento de backend es bajo. [Obtén más información](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latencias de backend del servidor"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Superior a la estimación"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Asegúrate de que la cantidad y el tamaño de las solicitudes de red sean menores que los valores objetivo establecidos en la estimación de rendimiento. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 solicitud}other{# solicitudes}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Estimación de rendimiento"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Las redirecciones provocan retrasos adicionales antes de que la página se pueda cargar. [Más información](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
+    "message": "Las redirecciones provocan retrasos adicionales antes de que la página se cargue. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Evita que haya varias redirecciones de página"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "A fin de configurar estimaciones para la cantidad y el tamaño de los recursos de la página, agrega un archivo budget.json. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 solicitud}other{# solicitudes}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Asegúrate de que la cantidad de solicitudes y los tamaños de transferencia sean reducidos"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Los vínculos canónicos sugieren qué URL mostrar en los resultados de la búsqueda. [Más información](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
+    "message": "Los vínculos canónicos indican qué URL mostrar en los resultados de la búsqueda. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Múltiples URL en conflicto ({urlList})"
+    "message": "Varias URL en conflicto ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Apunta a un dominio diferente ({url})"
+    "message": "Redirige al usuario a otro dominio ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL no válida ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Apunta a otra ubicación \"hreflang\" ({url})"
+    "message": "Hace referencia a otra ubicación de `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "URL relativa ({url})"
@@ -585,25 +843,22 @@
     "message": "Apunta a la URL raíz del dominio (la página principal), en lugar de a una página de contenido equivalente"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "El documento no tiene un vínculo \"rel=canonical\" válido"
+    "message": "El documento no tiene un vínculo `rel=canonical` válido"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "El documento tiene un enlace \"rel=canonical\" válido"
+    "message": "El documento tiene un atributo `rel=canonical` válido"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Las fuentes con un tamaño inferior a 12 px son demasiado pequeñas y poco legibles, lo que obliga a los visitantes que acceden con dispositivos móviles a pellizcar la pantalla para ampliarla y poder leer el texto. Intenta que más del 60% del texto de la página tenga un tamaño igual o superior a 12 px. [Más información](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
+    "message": "Las fuentes con un tamaño inferior a 12 px son demasiado pequeñas y poco legibles, lo que obliga a los visitantes que acceden con dispositivos móviles a pellizcar la pantalla para ampliarla y poder leer el texto. Intenta que más del 60% del texto de la página tenga un tamaño igual o superior a 12 px. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} del texto es legible"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "El {decimalProportion, number, extendedPercent} del texto es demasiado pequeño."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "El texto es ilegible porque no hay metaetiquetas de la vista del puerto optimizadas para pantallas de dispositivos móviles."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "El {decimalProportion, number, extendedPercent} del texto es demasiado pequeño (según la muestra {decimalProportionVisited, number, extendedPercent})."
+    "message": "El porcentaje {decimalProportion, number, extendedPercent} del texto es demasiado bajo (según la muestra {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "El documento no usa tamaños de fuente legibles"
@@ -612,16 +867,16 @@
     "message": "El documento usa tamaños de fuente legibles"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Los vínculos de hreflang indican a los motores de búsqueda qué versiones de las páginas deben incluir en los resultados de búsqueda de una región o un idioma determinados. [Más información](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
+    "message": "Los vínculos de hreflang indican a los motores de búsqueda qué versión de una página deben incluir en los resultados de la búsqueda para una región o un idioma determinados. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "El atributo \"hreflang\" del documento no es válido"
+    "message": "El documento no tiene un atributo `hreflang` válido"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "El atributo \"hreflang\" del documento es válido"
+    "message": "El documento tiene un atributo `hreflang` válido"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Es posible que las páginas con códigos de estado HTTP incorrectos no estén bien indexadas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
+    "message": "Es posible que las páginas con códigos de estado HTTP de error no se indexen correctamente. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "El código de estado HTTP de la página no es válido"
@@ -630,7 +885,7 @@
     "message": "El código de estado HTTP de la página es válido"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Los motores de búsqueda no pueden incluir tus páginas en los resultados de búsqueda si no tienen permiso para rastrearlas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
+    "message": "Los motores de búsqueda no pueden incluir tus páginas en los resultados de la búsqueda si no tienen permiso para rastrearlas. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Se bloqueó la indexación de la página"
@@ -639,7 +894,7 @@
     "message": "No se bloqueó la indexación de la página"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "El texto descriptivo de los vínculos ayuda a los motores de búsqueda a entender tu contenido. [Más información](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
+    "message": "El texto descriptivo de los vínculos ayuda a los motores de búsqueda a entender tu contenido. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{Se encontró 1 vínculo}other{Se encontraron # vínculos}}"
@@ -651,13 +906,13 @@
     "message": "Los vínculos tienen texto descriptivo"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Ejecuta la [Herramienta de pruebas de datos estructurados](https://search.google.com/structured-data/testing-tool/) y la herramienta [Structured Data Linter](http://linter.structured-data.org/) para validar los datos estructurados. [Más información](https://developers.google.com/search/docs/guides/mark-up-content)"
+    "message": "Ejecuta la [Herramienta de pruebas de datos estructurados](https://search.google.com/structured-data/testing-tool/) y la herramienta [Structured Data Linter](http://linter.structured-data.org/) para validar los datos estructurados. [Obtén más información](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Los datos estructurados son válidos"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Se pueden incluir metadescripciones en los resultados de búsqueda para resumir brevemente el contenido de la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/description)"
+    "message": "Se pueden incluir metadescripciones en los resultados de la búsqueda para resumir el contenido de la página. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "El texto de la descripción está vacío."
@@ -669,7 +924,7 @@
     "message": "El documento tiene una metadescripción"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Los motores de búsqueda no pueden indexar el contenido de los complementos, y muchos dispositivos limitan el uso de complementos o no los admiten. [Más información](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
+    "message": "Los motores de búsqueda no pueden indexar el contenido de los complementos y muchos dispositivos limitan el uso de complementos o no los admiten. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "El documento usa complementos"
@@ -681,7 +936,7 @@
     "message": "Si el formato del archivo robots.txt no es correcto, es posible que los rastreadores no puedan interpretar cómo quieres que se rastree o indexe tu sitio web."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "la solicitud de robots.txt ha devuelto el siguiente estado de HTTP: {statusCode}"
+    "message": "la solicitud de robots.txt mostró el siguiente estado de HTTP: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{Se encontró 1 error}other{Se encontraron # errores}}"
@@ -696,7 +951,7 @@
     "message": "robots.txt es válido"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Los elementos interactivos, como los botones y enlaces, deben ser suficientemente grandes (48 × 48 px) y tener suficiente espacio alrededor para poder tocarlos con facilidad sin superponerse con otros elementos. [Más información](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
+    "message": "Los elementos interactivos, como los botones y vínculos, deben ser suficientemente grandes (48 × 48 px) y tener alrededor el espacio necesario para que sea posible tocarlos con facilidad sin presionar otros elementos a la vez. [Obtén más información](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "El {decimalProportion, number, percent} de los elementos táctiles tiene un tamaño adecuado"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Elementos superpuestos"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Tamaño"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Elemento táctil"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "El tamaño de los elementos táctiles es el adecuado"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Tiempo del subproceso principal"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Terceros"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "El código de terceros puede reducir en gran medida el rendimiento de carga. Limita la cantidad de proveedores externos redundantes y prueba cargar el código de terceros después de que haya finalizado la carga principal de tu página. [Obtén más información](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Se encontró 1 código de terceros}other{Se encontraron # códigos de terceros}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Uso por parte de terceros"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "El tiempo hasta el primer byte indica el momento en el que el servidor envía una respuesta. [Más información](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
+    "message": "El tiempo hasta el primer byte indica el momento en el que el servidor envía una respuesta. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "El documento raíz tardó {timeInMs, number, milliseconds} ms"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Duración"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nombre"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Hora de inicio"
   },
@@ -744,7 +1008,7 @@
     "message": "Tipo"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Te recomendamos que uses la API de Tiempos de usuario en tu app para calcular su rendimiento real durante las principales experiencias de usuario. [Más información](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
+    "message": "Te recomendamos que incorpores la API de Tiempos de usuario en tu app para calcular su rendimiento real durante las principales experiencias de usuario. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 tiempo de usuario}other{# tiempos de usuario}}"
@@ -753,19 +1017,19 @@
     "message": "Medidas y marcas de Tiempos de usuario"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Se encontró un elemento <link> previo a la conexión para \"{securityOrigin}\", pero el navegador no lo usó. Comprueba que el atributo \"crossorigin\" se esté usando correctamente."
+    "message": "Se encontró un elemento <link> previo a la conexión para \"{securityOrigin}\", pero el navegador no lo usó. Comprueba que el atributo `crossorigin` se esté usando correctamente."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Te recomendamos que agregues sugerencias de recursos preconnect o dns-prefetch para establecer conexiones previas con orígenes externos importantes. [Más información](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
+    "message": "Te recomendamos agregar sugerencias de recursos preconnect o dns-prefetch para establecer conexiones tempranas con orígenes externos importantes. [Obtén más información](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Establece conexión previamente con los orígenes necesarios"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Se encontró un elemento <link> de precarga para \"{preloadURL}\", pero el navegador no lo utilizó. Comprueba que el atributo \"crossorigin\" se esté usando correctamente."
+    "message": "Se encontró un elemento <link> de precarga para \"{preloadURL}\", pero el navegador no lo usó. Comprueba que el atributo `crossorigin` se esté usando correctamente."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Te recomendamos que uses <link rel=preload> para dar prioridad a los recursos que se solicitan más tarde al cargar la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/preload)"
+    "message": "Te recomendamos usar `<link rel=preload>` para dar prioridad a la obtención de los recursos que, en este momento, se solicitan en una instancia posterior de la carga de la página. [Obtén más información](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Carga previamente las solicitudes clave"
@@ -789,10 +1053,10 @@
     "message": "Prácticas recomendadas"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Estas comprobaciones incluyen consejos para [mejorar la accesibilidad de tu app web](https://developers.google.com/web/fundamentals/accessibility). Solo se puede detectar un subconjunto de problemas de accesibilidad de forma automática. Por eso, te recomendamos realizar pruebas manuales."
+    "message": "Estas comprobaciones incluyen consejos para [mejorar la accesibilidad de tu app web](https://developers.google.com/web/fundamentals/accessibility). Solo algunos problemas de accesibilidad pueden detectarse de forma automática. Por eso, te recomendamos realizar también pruebas manuales."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Estos elementos se ocupan de áreas que las herramientas de prueba automáticas no pueden analizar. Obtén más información en nuestra guía sobre [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Estos elementos abarcan áreas que las herramientas de prueba automáticas no contemplan. Obtén más información en nuestra guía sobre [cómo revisar los aspectos de accesibilidad](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Accesibilidad"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tablas y listas"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Recomendaciones"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Las estimaciones de rendimiento establecen estándares para el rendimiento de tu sitio."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Estimaciones"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Obtén más información sobre el rendimiento de tu app."
+    "message": "Obtén más información sobre el rendimiento de tu app. Estos números no [afectan directamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) la medición del rendimiento."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnóstico"
@@ -840,7 +1113,7 @@
     "message": "Mejoras del primer procesamiento de imagen"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Estas optimizaciones pueden hacer que tus páginas se carguen más rápido."
+    "message": "Estas sugerencias pueden hacer que tus páginas se carguen más rápido. No [afectan directamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) la medición del rendimiento."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Oportunidades"
@@ -867,7 +1140,7 @@
     "message": "Optimizado para PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Estas comprobaciones aseguran que tu página esté optimizada para posicionarse en los resultados de los motores de búsqueda. Hay otros factores que Lighthouse no comprueba y que pueden afectar a tu posicionamiento en los buscadores. [Más información](https://support.google.com/webmasters/answer/35769)"
+    "message": "Estas comprobaciones aseguran que tu página esté optimizada para posicionarse bien en los resultados de los motores de búsqueda. Hay otros factores que Lighthouse no comprueba y que pueden afectar tu posicionamiento en los buscadores. [Obtén más información](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Ejecuta estos validadores adicionales en tu sitio web para comprobar más prácticas recomendadas de SEO."
@@ -888,7 +1161,7 @@
     "message": "Rastreo e indexación"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Asegúrate de que tus páginas estén optimizadas para dispositivos móviles a fin de que los usuarios no tengan que pellizcar ni hacer zoom para leer las páginas de contenido. [Más información](https://developers.google.com/search/mobile-sites/)"
+    "message": "Asegúrate de que tus páginas estén optimizadas para dispositivos móviles a fin de que los usuarios no tengan que pellizcar ni hacer zoom para leer las páginas de contenido. [Obtén más información](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Optimizada para dispositivos móviles"
@@ -896,35 +1169,77 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL en caché"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Ubicación"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nombre"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Solicitudes"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Tipo de recurso"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Tamaño (KB)"
+    "message": "Tamaño"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Tiempo de uso"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Tamaño de transferencia"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Ahorro posible (KB)"
+    "message": "Ahorros posibles"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Ahorro posible (ms)"
+    "message": "Ahorros posibles"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Ahorro posible de {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "Ahorro posible de {wastedMs, number, milliseconds} ms"
+    "message": "Ahorro posible en {wastedMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Documento"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Fuente"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Imagen"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Contenido multimedia"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Otro"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Secuencia de comandos"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
   },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Hoja de estilo"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Terceros"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Total"
+  },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Se produjo un error al registrar el rastro durante la carga de la página. Vuelve a ejecutar Lighthouse. ({errorCode})"
+    "message": "Se produjo un error de registro de seguimiento durante la carga de la página. Vuelve a ejecutar Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Se agotó el tiempo de espera de la conexión inicial del protocolo del depurador."
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Los servidores DNS no pudieron resolver el dominio proporcionado."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "El recopilador {artifactName} obligatorio encontró un error: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Se produjo un error interno de Chrome. Reinicia Chrome y vuelve a ejecutar Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "No se ejecutó el recopilador necesario para {artifactName}."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse no pudo cargar correctamente la página que solicitaste. Comprueba que estás probando la URL correcta y que el servidor responde correctamente a todas las solicitudes."
@@ -945,13 +1266,16 @@
     "message": "Lighthouse no pudo cargar correctamente la URL que solicitaste porque la página dejó de responder."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Las credenciales de seguridad de la URL que proporcionaste no son válidas. {securityMessages}"
+    "message": "La URL que proporcionaste no tiene un certificado de seguridad válido. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome evitó la carga de la página y mostró una pantalla intersticial. Verifica que estés probando la URL correcta y que el servidor responda adecuadamente a todas las solicitudes."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Lighthouse no pudo cargar correctamente la página que solicitaste. Comprueba que estás probando la URL correcta y que el servidor responde correctamente a todas las solicitudes. (Detalles: {errorDetails})"
+    "message": "Lighthouse no pudo cargar correctamente la página que solicitaste. Verifica que estés probando la URL correcta y que el servidor responda adecuadamente a todas las solicitudes. (Detalles: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Lighthouse no pudo cargar correctamente la página que solicitaste. Comprueba que estás probando la URL correcta y que el servidor responde correctamente a todas las solicitudes. (Código de estado: {statusCode})"
+    "message": "Lighthouse no pudo cargar correctamente la página que solicitaste. Verifica que estés probando la URL correcta y que el servidor responda adecuadamente a todas las solicitudes. (Código de estado: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
     "message": "La página tardó demasiado en cargarse. Sigue los consejos del informe para reducir el tiempo de carga de la página y vuelve a ejecutar Lighthouse. ({errorCode})"
@@ -984,7 +1308,7 @@
     "message": "Datos de prueba"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analizó la página actual en una red móvil emulada. Los valores son estimados y pueden variar."
+    "message": "Análisis de [Lighthouse](https://developers.google.com/web/tools/lighthouse/) de la página actual en una red móvil emulada. Los valores son estimados y pueden variar."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Elementos adicionales que se deben comprobar manualmente"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Expandir fragmento"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Mostrar recursos de terceros"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Algunos problemas afectaron la ejecución de Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Los valores son estimados y pueden variar."
+    "message": "Los valores son estimados y pueden variar. La medición del rendimiento se [basa solo en estas métricas](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Auditorías aprobadas con advertencias"
@@ -1023,10 +1350,10 @@
     "message": "Puedes subir tu GIF a un servicio que permita insertarlo como un video HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Instala un [complemento de carga diferida de WordPress](https://wordpress.org/plugins/search/lazy+load/) con la capacidad de postergar imágenes que no aparecen en la pantalla o cambia a un tema con esa función. También puedes usar [el complemento AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Instala un [complemento de carga diferida de WordPress](https://wordpress.org/plugins/search/lazy+load/) con la capacidad de postergar las imágenes fuera de pantalla o bien cambia a un tema que incluya esa función. También puedes usar [el complemento AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Existen varios complementos de WordPress que pueden ayudarte a [insertar recursos fundamentales](https://wordpress.org/plugins/search/critical+css/) o a [postergar recursos menos importantes](https://wordpress.org/plugins/search/defer+css+javascript/). Ten en cuenta que las optimizaciones que ofrecen estos complementos pueden bloquear funciones de tu tema o tus complementos, así que seguramente tengas que hacer cambios en el código."
+    "message": "Existen varios complementos de WordPress que pueden ayudarte a [insertar elementos fundamentales](https://wordpress.org/plugins/search/critical+css/) o a [postergar recursos menos importantes](https://wordpress.org/plugins/search/defer+css+javascript/). Ten en cuenta que las optimizaciones que ofrecen estos complementos pueden interferir con funciones de tu tema o complementos, por lo que seguramente tengas que hacer cambios en el código."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Los temas, los complementos y las especificaciones del servidor afectan al tiempo de respuesta. Puedes buscar un tema más optimizado, seleccionar un complemento de optimización o actualizar tu servidor."
@@ -1035,30 +1362,30 @@
     "message": "Puedes mostrar fragmentos en tus listas de entradas (por ejemplo, mediante la etiqueta \"<more>\"), reducir la cantidad de entradas que se muestran en cada página, dividir tus entradas más largas en múltiples páginas o usar un complemento para postergar la carga de los comentarios."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Hay varios [complementos de WordPress](https://wordpress.org/plugins/search/minify+css/) que pueden concatenar, reducir y comprimir tus estilos para acelerar tu sitio web. Te recomendamos que, si es posible, uses un proceso de creación para realizar la reducción de forma anticipada."
+    "message": "Hay varios [complementos de WordPress](https://wordpress.org/plugins/search/minify+css/) que pueden concatenar, reducir y comprimir los estilos para acelerar tu sitio web. Te recomendamos que, si es posible, uses un proceso de compilación para reducir los estilos de forma anticipada."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Hay varios [complementos de WordPress](https://wordpress.org/plugins/search/minify+javascript/) que pueden concatenar, reducir y comprimir tus estilos para acelerar tu sitio web. Te recomendamos que, si es posible, uses un proceso de creación para realizar la reducción de forma anticipada."
+    "message": "Hay varios [complementos de WordPress](https://wordpress.org/plugins/search/minify+javascript/) que pueden concatenar, reducir y comprimir las secuencias de comandos para acelerar tu sitio web. Te recomendamos que, si es posible, uses un proceso de compilación para realizar la reducción de forma anticipada."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Puedes reducir o cambiar la cantidad de [complementos de WordPress](https://wordpress.org/plugins/) que cargan archivos CSS sin usar en tu página. Para identificar los complementos que agregan archivos CSS externos, ejecuta [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) en DevTools de Chrome. Puedes identificar el tema o complemento en la URL de la hoja de estilo. Presta atención a los complementos con varias hojas de estilo en la lista y con muchos elementos en rojo en la cobertura de código. Un complemento solo debería poner en cola una hoja de estilo (si esta se usa en la página)."
+    "message": "Puedes reducir o cambiar la cantidad de [complementos de WordPress](https://wordpress.org/plugins/) que cargan hojas de estilo CSS que tu página no usa. Para identificar los complementos que agregan hojas de estilo CSS innecesarias, prueba ejecutar la [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) en DevTools de Chrome. Puedes identificar el tema o complemento concreto en la URL de la hoja de estilo. Presta atención a los complementos que tengan varias hojas de estilo en la lista con muchos elementos en rojo en la cobertura de código. Los complementos solo deberían poner en cola hojas de estilo que se usen en la página."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Puedes reducir o cambiar la cantidad de [complementos de WordPress](https://wordpress.org/plugins/) que cargan JavaScript sin usar en tu página. Para identificar los complementos que agregan JavaScript externo, ejecuta [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) en DevTools de Chrome. Puedes identificar el tema o complemento concreto en la URL de la secuencia de comandos. Presta atención a los complementos con varias secuencias de comandos en la lista y con muchos elementos en rojo en la cobertura de código. Un complemento solo debería poner en cola una secuencia de comandos (si esta se usa en la página)."
+    "message": "Puedes reducir o cambiar la cantidad de [complementos de WordPress](https://wordpress.org/plugins/) que cargan secuencias JavaScript que tu página no usa. Para identificar los complementos que agregan secuencias JS innecesarias, prueba ejecutar la [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) en DevTools de Chrome. Puedes identificar el tema o complemento concreto en la URL de la secuencia de comandos. Presta atención a los complementos que tengan varias secuencias de comandos en la lista con muchos elementos en rojo en la cobertura de código. Los complementos solo deberían poner en cola secuencias de comandos que se usen en la página."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Consulta información sobre el [almacenamiento en la memoria caché del navegador en WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Puedes utilizar un [complemento de optimización de imágenes de WordPress](https://wordpress.org/plugins/search/optimize+images/) que comprima tus imágenes y conserve la calidad."
+    "message": "Puedes usar un [complemento de optimización de imágenes de WordPress](https://wordpress.org/plugins/search/optimize+images/) que comprima tus imágenes y conserve la calidad."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Carga imágenes directamente a través de [media library](https://codex.wordpress.org/Media_Library_Screen) para garantizar que estén disponibles los tamaños de imagen requeridos y, luego, insértalas desde la biblioteca multimedia o usa el widget de imágenes para asegurarte de que se utilicen los tamaños de imagen óptimos (incluidos los que se utilizan para interrupciones de respuestas). Evita usar imágenes \"completas\", a menos que las dimensiones sean adecuadas para su uso. [Más información](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
+    "message": "Carga imágenes directamente a través de la [biblioteca de medios](https://codex.wordpress.org/Media_Library_Screen) para garantizar que estén disponibles los tamaños de imagen requeridos y, luego, insértalas desde la biblioteca de medios, o bien usa el widget de imágenes para asegurarte de que se utilicen los tamaños de imagen óptimos (incluidos los que se emplean para interrupciones receptivas). Evita usar imágenes `Full Size`, a menos que las dimensiones sean adecuadas para su empleo. [Obtén más información](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Puedes habilitar la compresión de texto en la configuración de tu servidor web."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Puedes utilizar un [complemento](https://wordpress.org/plugins/search/convert+webp/) o un servicio que convierta automáticamente las imágenes que subas en los formatos óptimos."
+    "message": "Puedes utilizar un [complemento](https://wordpress.org/plugins/search/convert+webp/) o servicio que convierta automáticamente las imágenes que subas a los formatos óptimos."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/es.json
+++ b/lighthouse-core/lib/i18n/locales/es.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Las claves de acceso permiten a los usuarios dirigirse rápidamente a una parte concreta de la página. Para facilitar una navegación correcta, las claves de acceso deben ser únicas. [Más información](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Las claves de acceso permiten a los usuarios dirigirse rápidamente a una parte concreta de la página. Para facilitar una navegación correcta, las claves de acceso deben ser únicas. [Más información](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Los valores de \"[accesskey]\" no son únicos"
+    "message": "Los valores de `[accesskey]` no son únicos"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Los valores de \"[accesskey]\" son únicos"
+    "message": "Los valores de `[accesskey]` son únicos"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Cada función de ARIA admite un subconjunto determinado de atributos \"aria-*\". Si no coinciden, los atributos \"aria-*\" se invalidarán. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Cada `role` de ARIA admite un subconjunto determinado de atributos `aria-*`. Si no coinciden, los atributos `aria-*` se invalidarán. [Más información](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Los atributos \"[aria-*]\" no se corresponden con sus funciones"
+    "message": "Los atributos `[aria-*]` no se corresponden con sus funciones"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Los atributos \"[aria-*]\" se corresponden con sus funciones"
+    "message": "Los atributos `[aria-*]` coinciden con sus funciones"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Algunas funciones de ARIA incluyen atributos obligatorios que describen el estado del elemento a los lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Algunas funciones de ARIA incluyen atributos obligatorios que describen el estado del elemento a los lectores de pantalla. [Más información](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Los elementos \"[role]\" no incluyen todos los atributos \"[aria-*]\" necesarios"
+    "message": "Los elementos `[role]` no incluyen todos los atributos `[aria-*]` necesarios"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Los elementos \"[role]\" incluyen todos los atributos \"[aria-*]\" necesarios"
+    "message": "Todos los elementos `[role]` tienen los atributos `[aria-*]` obligatorios"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Algunas funciones principales de ARIA deben contener funciones secundarias específicas para llevar a cabo las funciones de accesibilidad correspondientes. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Algunas funciones principales de ARIA deben contener funciones secundarias específicas para llevar a cabo las funciones de accesibilidad correspondientes. [Más información](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Faltan elementos con atributos \"[role]\" que requieren otros atributos \"[role]\" secundarios específicos."
+    "message": "Faltan elementos con atributos `[role]` que requieren otros atributos `[role]` secundarios específicos."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Se han incluido los elementos con atributos \"[role]\" que requieren otros atributos \"[role]\" secundarios específicos"
+    "message": "Se han incluido los elementos con atributos `[role]` que requieren otros atributos `[role]` secundarios específicos"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Algunas funciones secundarias de ARIA se deben incluir dentro de funciones principales concretas para poder llevar a cabo las funciones de accesibilidad correspondientes. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Algunas funciones secundarias de ARIA se deben incluir dentro de funciones principales concretas para poder llevar a cabo las funciones de accesibilidad correspondientes. [Más información](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Los atributos \"[role]\" no están incluidos en los elementos principales necesarios"
+    "message": "Los atributos `[role]` no están incluidos dentro de los elementos principales obligatorios"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Los atributos \"[role]\" están incluidos en los elementos principales correspondientes"
+    "message": "Los atributos `[role]` están incluidos en los elementos principales correspondientes"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Las funciones de ARIA deben tener valores válidos para realizar las funciones de accesibilidad correspondientes. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Las funciones de ARIA deben tener valores válidos para realizar las funciones de accesibilidad correspondientes. [Más información](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Los valores de \"[role]\" no son válidos"
+    "message": "Los valores de `[role]` no son válidos"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Los valores de \"[role]\" son válidos"
+    "message": "Los valores de `[role]` son válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Las tecnologías de asistencia, como los lectores de pantalla, no pueden interpretar los atributos ARIA cuyos valores no sean válidos. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Las tecnologías de asistencia, como los lectores de pantalla, no pueden interpretar los atributos ARIA cuyos valores no sean válidos. [Más información](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Los atributos \"[aria-*]\" no tienen valores válidos"
+    "message": "Los atributos `[aria-*]` no tienen valores válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Los atributos \"[aria-*]\" tienen valores válidos"
+    "message": "Los atributos `[aria-*]` tienen valores válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Las tecnologías de asistencia, como los lectores de pantalla, no pueden interpretar los atributos ARIA cuyos nombres no sean válidos. [Más información](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Las tecnologías de asistencia, como los lectores de pantalla, no pueden interpretar los atributos ARIA con nombres no válidos. [Más información](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Los atributos \"[aria-*]\" no son válidos o no están bien escritos"
+    "message": "Los atributos `[aria-*]` no son válidos o no están bien escritos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Los atributos \"[aria-*]\" son válidos y están bien escritos"
+    "message": "Los atributos `[aria-*]` son válidos y están bien escritos"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Los subtítulos permiten a los usuarios sordos o con problemas auditivos utilizar elementos de audio, ya que proporcionan detalles esenciales como quién habla, qué se dice e información no verbal adicional. [Más información](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Los subtítulos permiten a los usuarios sordos o con problemas auditivos utilizar elementos de audio, ya que proporcionan detalles esenciales como quién habla, qué se dice e información no verbal adicional. [Más información](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Falta un elemento \"<track>\" con \"[kind=\"captions\"]\" en los elementos \"<audio>\"."
+    "message": "A los elementos `<audio>` les falta un elemento `<track>` con el atributo `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Los elementos \"<audio>\" contienen un elemento \"<track>\" con \"[kind=\"captions\"]\""
+    "message": "Los elementos `<audio>` contienen un elemento `<track>` con el atributo `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Elementos con errores"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Si un botón no tiene un nombre accesible, los lectores de pantalla lo leerán en voz alta como \"botón\", por lo que resultan inservibles para los usuarios que necesitan usar lectores de pantalla para navegar. [Más información](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Si un botón no tiene un nombre accesible, los lectores de pantalla lo leerán en voz alta como \"botón\", por lo que resultan inservibles para los usuarios que necesitan usar lectores de pantalla para navegar. [Más información](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Los botones no tienen nombres accesibles"
@@ -93,7 +93,7 @@
     "message": "Los botones tienen nombres accesibles"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Incluir maneras de omitir el contenido repetitivo permite a los usuarios navegar por la página de forma más eficaz. [Más información](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Incluir maneras de omitir el contenido repetitivo permite a los usuarios con teclado navegar por la página de forma más eficaz. [Más información](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "La página no contiene ningún título, enlace de omisión ni región de punto de referencia"
@@ -102,7 +102,7 @@
     "message": "La página contiene un título, un enlace de omisión o una región de punto de referencia"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Los textos con poco contraste resultan difíciles o imposibles de leer para muchos usuarios. [Más información](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Los textos con poco contraste resultan difíciles o imposibles de leer para muchos usuarios. [Más información](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Los colores de fondo y de primer plano no tienen una relación de contraste adecuada."
@@ -111,88 +111,88 @@
     "message": "Los colores de fondo y de primer plano tienen una relación de contraste adecuada"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Si las listas de definiciones no están bien marcadas, es posible que los lectores de pantalla las interpreten de forma confusa o imprecisa. [Más información](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Si las listas de definiciones no están bien marcadas, es posible que los lectores de pantalla las interpreten de forma confusa o imprecisa. [Más información](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Los elementos \"<dl>\" no contienen únicamente grupos de \"<dt>\" y \"<dd>\" o elementos \"<script>\" o \"<template>\" ordenados correctamente."
+    "message": "Los elementos `<dl>` no contienen únicamente grupos de `<dt>` y `<dd>` o elementos `<script>` o `<template>` ordenados correctamente."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Los elementos \"<dl>\" solo contienen grupos de \"<dt>\" y \"<dd>\" ordenados correctamente, o elementos \"<script>\" o \"<template>\"."
+    "message": "Los elementos de `<dl>` solo contienen grupos de `<dt>` y `<dd>` o elementos `<script>` o `<template>` ordenados correctamente."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Los elementos de la lista de definiciones (\"<dt>\" y \"<dd>\") deben estar incluidos en un elemento \"<dl>\" principal para asegurarte de que los lectores de pantalla puedan leerlos en voz alta correctamente. [Más información](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Los elementos de la lista de definiciones (`<dt>` y`<dd>`) deben estar incluidos en un elemento `<dl>` principal para asegurarte de que los lectores de pantalla puedan leerlos en voz alta correctamente. [Más información](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Los elementos de la lista de definiciones no están incluidos dentro de elementos \"<dl>\""
+    "message": "Los elementos de la lista de definiciones están incluidos dentro de elementos `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Los elementos de la lista de definiciones están incluidos dentro de elementos \"<dl>\""
+    "message": "Los elementos de la lista de definiciones están incluidos dentro de elementos `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Los títulos proporcionan una idea general sobre la página a los usuarios de lectores de pantalla. Además, los usuarios de buscadores se basan principalmente en los títulos para determinar si una página es relevante para su búsqueda o no. [Más información](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Los títulos proporcionan una idea general sobre la página a los usuarios de lectores de pantalla. Además, los usuarios de buscadores se basan principalmente en los títulos para determinar si una página es relevante para su búsqueda o no. [Más información](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "El documento no tiene ningún elemento \"<title>\""
+    "message": "El documento no contiene un elemento `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "El documento tiene un elemento \"<title>\""
+    "message": "El documento tiene un elemento `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "El valor de los atributos \"id\" debe ser único para evitar que las tecnologías de asistencia omitan otras instancias. [Más información](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "El valor de los atributos id debe ser único para evitar que las tecnologías de asistencia omitan otras instancias. [Más información](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Los atributos \"[id]\" de la página no son únicos"
+    "message": "Los atributos `[id]` de la página no son únicos"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Los atributos \"[id]\" de la página son únicos"
+    "message": "Los atributos `[id]` de la página son únicos"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Los usuarios de lectores de pantalla necesitan que los marcos tengan títulos para que se describa su contenido. [Más información](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Los usuarios de lectores de pantalla confían en que los títulos describan el contenido de los marcos. [Más información](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Los elementos \"<frame>\" o \"<iframe>\" no tienen título"
+    "message": "Los elementos `<frame>` o `<iframe>` no tienen título"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Los elementos \"<frame>\" o \"<iframe>\" tienen título"
+    "message": "Los elementos `<frame>` o `<iframe>` tienen un título"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Si no se especifica ningún atributo de idioma para una página, los lectores de pantalla asumirán que la página tiene el idioma predeterminado que el usuario eligió al configurar el lector de pantalla. Si el idioma de la página es diferente del predeterminado, es posible que el lector de pantalla no lea bien el texto de la página. [Más información](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Si no se especifica ningún atributo de idioma en una página, los lectores de pantalla asumirán que la página está en el idioma predeterminado que el usuario eligió al configurar el lector de pantalla. Si el idioma de la página es diferente del predeterminado, es posible que el lector de pantalla no lea correctamente el texto de la página. [Más información](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "El elemento \"<html>\" no contiene ningún atributo \"[lang]\""
+    "message": "El elemento `<html>` no tiene un atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "El elemento \"<html>\" tiene un atributo \"[lang]\""
+    "message": "El elemento `<html>` tiene un atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Especificar un [idioma BCP 47] valido (https://www.w3.org/International/questions/qa-choosing-language-tags#question) permite a los lectores de pantalla leer el texto en voz alta correctamente. [Más información](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Especificar un [idioma BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido permite a los lectores de pantalla leer el texto correctamente en voz alta. [Más información](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "El elemento \"<html>\" no tiene un valor válido para el atributo \"[lang]\"."
+    "message": "El valor del atributo `[lang]` del elemento `<html>` no es válido."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "El elemento \"<html>\" tiene un valor válido para el atributo \"[lang]\""
+    "message": "El atributo `[lang]` del elemento `<html>` tiene un valor válido"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "El texto de los elementos informativos debe ser corto y descriptivo. Los elementos decorativos se pueden omitir usando un atributo \"alt\" vacío. [Más información](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Los elementos informativos deberían incluir textos alternativos cortos y descriptivos. Los elementos decorativos se pueden omitir usando un atributo \"alt\" vacío. [Más información](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Los elementos de imagen no tienen ningún atributo \"[alt]\""
+    "message": "Los elementos de imagen no tienen ningún atributo `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Los elementos de imagen tienen atributos \"[alt]\""
+    "message": "Los elementos de imagen tienen atributos `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Cuando se usa una imagen como botón \"<input>\", resulta útil proporcionar un texto alternativo para permitir que los usuarios de lectores de pantalla entiendan cuál es la función del botón. [Más información](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Cuando se usa una imagen como botón `<input>`, resulta útil proporcionar un texto alternativo para permitir que los usuarios de lectores de pantalla entiendan cuál es la función del botón. [Más información](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Los elementos \"<input type=\"image\">\" no contienen texto \"[alt]\""
+    "message": "Los elementos `<input type=\"image\">` no tienen texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Los elementos \"<input type=\"image\">\" tienen texto \"[alt]\""
+    "message": "Los elementos `<input type=\"image\">` contienen texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Las etiquetas facilitan que las tecnologías de asistencia, como los lectores de pantalla, puedan leer los controles de los formularios de forma correcta. [Más información](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Las etiquetas facilitan que las tecnologías de asistencia, como los lectores de pantalla, puedan leer los controles de los formularios de forma correcta. [Más información](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Los elementos de formulario no tienen ninguna etiqueta asociada"
@@ -201,16 +201,16 @@
     "message": "Los elementos de formulario tienen etiquetas asociadas"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Las tablas que solo se utilizan para crear un diseño no deben incluir elementos de datos, como los elementos th o caption, o el atributo summary, ya que podrían confundir a los usuarios de lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Las tablas que solo se utilizan para crear un diseño no deben incluir elementos de datos, como los elementos th o caption, o el atributo summary, ya que podrían confundir a los usuarios de lectores de pantalla. [Más información](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Los elementos \"<table>\" de presentación no evitan el uso de \"<th>\", \"<caption>\" ni el atributo \"[summary]\"."
+    "message": "Los elementos `<table>` de presentación no evitan el uso de `<th>`, `<caption>` ni del atributo `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Los elementos \"<table>\" de presentación no utilizan elementos \"<th>\" o \"<caption>\" ni el atributo \"[summary]\"."
+    "message": "Los elementos `<table>` de presentación no utilizan elementos `<th>` o `<caption>` ni el atributo `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Usar textos de enlace (y textos alternativos para las imágenes, si estas se usan como enlaces) que sean reconocibles, únicos y que se puedan seleccionar mejora la experiencia de navegación de los usuarios de lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Usar textos de enlace (y textos alternativos para las imágenes, si estas se usan como enlaces) que sean reconocibles, únicos y que se puedan seleccionar mejora la experiencia de navegación de los usuarios de lectores de pantalla. [Más información](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Los enlaces no tienen nombres reconocibles"
@@ -219,103 +219,115 @@
     "message": "Los enlaces tienen nombres reconocibles"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Los lectores de pantalla leen las listas en voz alta de una forma concreta. Se recomienda utilizar una estructura de listas adecuada para que los lectores de pantalla puedan leer las listas de forma correcta. [Más información](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Los lectores de pantalla leen las listas en voz alta de una forma concreta. Se recomienda utilizar una estructura de listas adecuada para que los lectores de pantalla puedan leer las listas de forma correcta. [Más información](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Las listas no contienen únicamente elementos \"<li>\" y elementos que admiten scripts (\"<script>\" y \"<template>\")."
+    "message": "Las listas no contienen únicamente elementos `<li>` y elementos que admiten secuencias de comandos (`<script>` y `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Las listas solo contienen elementos \"<li>\" y elementos que admiten scripts (\"<script>\" y \"<template>\")."
+    "message": "Las listas contienen únicamente elementos `<li>` y elementos que admiten secuencias de comandos (`<script>` y `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Los lectores de pantalla requieren que los elementos de lista (\"<li>\") estén incluidos dentro de un elemento \"<ol>\" o \"<ul>\" principal para poder leerlos en voz alta correctamente. [Más información](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Los lectores de pantalla requieren que los elementos de lista (`<li>`) estén incluidos dentro de un elemento `<ul>` o `<ol>` principal para poder leerlos correctamente en voz alta. [Más información](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Los elementos de lista (\"<li>\") no se encuentran dentro de los elementos principales \"<ul>\" o \"<ol>\"."
+    "message": "Los elementos de lista (`<li>`) no están incluidos dentro de elementos principales `<ul>` o `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Los objetos de lista (\"<li>\") están incluidos dentro de los elementos principales \"<ul>\" o \"<ol>\""
+    "message": "Los elementos de lista (`<li>`) están incluidos dentro de los elementos principales `<ul>` o `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Los usuarios no esperan que las páginas se actualicen automáticamente; si lo hacen, la atención se vuelve a centrar en el principio de la página, lo que puede dar lugar a una experiencia frustrante o confusa. [Más información](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Los usuarios no esperan que las páginas se actualicen automáticamente; si es así, se les volverá a dirigir a la parte superior de la página. Esto puede dar lugar a una experiencia frustrante o confusa. [Más información](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "El documento utiliza \"<meta http-equiv=\"refresh\">\""
+    "message": "El documento usa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "El documento no utiliza \"<meta http-equiv=\"refresh\">\""
+    "message": "El documento no usa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Desactivar el zoom provoca problemas para los usuarios con visión reducida, ya que necesitan ampliar la pantalla para poder ver correctamente el contenido de las páginas web. [Más información](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Inhabilitar el zoom provoca problemas a los usuarios con visión reducida que necesitan ampliar la pantalla para poder ver correctamente el contenido de las páginas web. [Más información](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "\"[user-scalable=\"no\"]\" se utiliza en el elemento \"<meta name=\"viewport\">\" o el atributo \"[maximum-scale]\" tiene un valor inferior a 5."
+    "message": "El atributo `[user-scalable=\"no\"]` se usa en el elemento `<meta name=\"viewport\">` o el valor del atributo `[maximum-scale]` es inferior a 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "\"[user-scalable=\"no\"]\" no se utiliza en el elemento \"<meta name=\"viewport\">\" y el atributo \"[maximum-scale]\" no tiene un valor inferior a 5."
+    "message": "`[user-scalable=\"no\"]` no se utiliza en el elemento `<meta name=\"viewport\">` y el valor del atributo `[maximum-scale]` no es inferior a 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Los lectores de pantalla no pueden traducir contenido que no sea texto. Al añadir texto alternativo a los elementos \"<object>\", los lectores de pantalla podrán transmitir su significado a los usuarios. [Más información](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Los lectores de pantalla no pueden traducir contenido que no sea texto. Al añadir texto alternativo a los elementos `<object>`, los lectores de pantalla podrán transmitir su significado a los usuarios. [Más información](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Los elementos \"<object>\" no contienen texto \"[alt]\""
+    "message": "Los elementos `<object>` no tienen texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Los elementos \"<object>\" tienen texto \"[alt]\""
+    "message": "Los elementos `<object>` contienen texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Si el valor es superior a 0, significa que el orden de navegación es explícito. Aunque técnicamente es válido, esto suele producir experiencias frustrantes para los usuarios que necesitan usar tecnologías de asistencia. [Más información](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Si el valor es superior a 0, significa que el orden de navegación es explícito. Aunque técnicamente es válido, esto suele producir experiencias frustrantes para los usuarios que necesitan usar tecnologías de asistencia. [Más información](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Algunos elementos tienen un valor de \"[tabindex]\" superior a 0"
+    "message": "Algunos elementos tienen un valor de `[tabindex]` superior a 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "No hay ningún elemento con un valor de \"[tabindex]\" superior a 0"
+    "message": "No hay ningún elemento con un valor de `[tabindex]` superior a 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Los lectores de pantalla incluyen funciones para facilitar la navegación por las tablas. Asegurarse de que las celdas \"<td>\" que usan el atributo \"[headers]\" solo hacen referencia a otras celdas de la misma tabla mejora la experiencia de los usuarios de lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Los lectores de pantalla incluyen funciones para facilitar la navegación por las tablas. Asegurarse de que las celdas `<td>` que usan el atributo `[headers]` solo hacen referencia a otras celdas de la misma tabla mejora la experiencia de los usuarios de lectores de pantalla. [Más información](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Las celdas de los elementos \"<table>\" que usan el atributo \"[headers]\" hacen referencia a otras celdas de esa misma tabla."
+    "message": "Las celdas de los elementos `<table>` que usen el atributo `[headers]` hacen referencia a otras celdas de esa misma tabla."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Las celdas de los elementos \"<table>\" que usan el atributo \"[headers]\" solo hacen referencia a otras celdas de esa misma tabla."
+    "message": "Las celdas de un elemento `<table>` que usa el atributo `[headers]` hacen referencia únicamente a otras celdas de la misma tabla."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Los lectores de pantalla incluyen funciones para facilitar la navegación por las tablas. Si te aseguras de que los encabezados de las tablas siempre hagan referencia a un conjunto de celdas, puedes mejorar la experiencia de los usuarios de lectores de pantalla. [Más información](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Los lectores de pantalla incluyen funciones para facilitar la navegación por las tablas. Si te aseguras de que los encabezados de las tablas siempre hagan referencia a un conjunto de celdas, puedes mejorar la experiencia de los usuarios de lectores de pantalla. [Más información](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Los elementos \"<th>\" y los elementos con \"[role=\"columnheader\"/\"rowheader\"]\" no contienen las celdas de datos que describen."
+    "message": "Los elementos `<th>` y los elementos con `[role=\"columnheader\"/\"rowheader\"]` no contienen las celdas de datos que describen."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Los elementos \"<th>\" y los elementos con \"[role=\"columnheader\"/\"rowheader\"]\" contienen las celdas de datos que describen."
+    "message": "Los elementos `<th>` y los elementos con atributos `[role=\"columnheader\"/\"rowheader\"]` contienen las celdas de datos que describen."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Especificar un [idioma BCP 47] válido (https://www.w3.org/International/questions/qa-choosing-language-tags#question) en los elementos ayuda a asegurar que los lectores de pantalla pronuncien correctamente las palabras del texto. [Más información](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Especificar un [idioma BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) en los elementos ayuda a asegurar que los lectores de pantalla pronuncien correctamente las palabras del texto. [Más información](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Los atributos \"[lang]\" no tienen un valor válido"
+    "message": "Los atributos `[lang]` no tienen un valor válido"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Los atributos \"[lang]\" tienen un valor válido"
+    "message": "Los atributos `[lang]` tienen un valor válido"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Si un vídeo tiene subtítulos, los usuarios sordos o con problemas auditivos pueden acceder a la información con más facilidad. [Más información](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Si un vídeo tiene subtítulos, los usuarios sordos o con problemas auditivos pueden acceder a la información con más facilidad. [Más información](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Los elementos \"<video>\" no contienen ningún elemento \"<track>\" con \"[kind=\"captions\"]\"."
+    "message": "Los elementos `<video>` no contienen ningún elemento `<track>` con el atributo `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Los elementos \"<video>\" contienen un elemento \"<track>\" con \"[kind=\"captions\"]\""
+    "message": "Los elementos `<video>` contienen un elemento `<track>` con el atributo `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Las audiodescripciones proporcionan información relevante en vídeos cuyos diálogos no transmiten todo el contenido, como en el caso de las expresiones faciales y las escenas. [Más información](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Las audiodescripciones proporcionan información pertinente en vídeos cuyos diálogos no transmiten todo el contenido, como en el caso de las expresiones faciales y las escenas. [Más información](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Los elementos \"<video>\" no contienen ningún elemento \"<track>\" con \"[kind=\"description\"]\"."
+    "message": "Los elementos `<video>` no contienen ningún elemento `<track>` con el atributo `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Los elementos \"<video>\" contienen un elemento \"<track>\" con el atributo \"[kind=\"description\"]\""
+    "message": "Los elementos `<video>` contienen un elemento `<track>` con el atributo `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Define un apple-touch-icon para que el aspecto en iOS sea el adecuado cuando los usuarios añadan la página a la pantalla de inicio. Debe apuntar a un archivo PNG cuadrado de 192 px (o 180 px) no transparente. [Más información](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "No proporciona un `apple-touch-icon` válido"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` está obsoleto; se recomienda usar `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Proporciona un `apple-touch-icon` válido"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Las extensiones de Chrome han afectado de forma negativa al rendimiento de carga de esta página. Prueba a auditarla en modo incógnito o desde un perfil de Chrome sin extensiones."
@@ -330,7 +342,7 @@
     "message": "Tiempo de CPU total"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Te recomendamos que reduzcas el tiempo de análisis, compilación y ejecución de JavaScript. Para ello, puedes utilizar cargas útiles de JS más pequeñas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
+    "message": "Te recomendamos que reduzcas el tiempo de análisis, compilación y ejecución de JavaScript. Para ello, puedes utilizar cargas útiles de JavaScript más pequeñas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Reduce el tiempo de ejecución de JavaScript"
@@ -339,19 +351,19 @@
     "message": "Tiempo de ejecución de JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Los GIF de gran tamaño no son eficaces para mostrar contenido animado. Para usar menos bytes de la red, te recomendamos que utilices los formatos de vídeo PEG4/WebM para incluir animaciones y los formatos PNG/WebP para añadir imágenes estáticas en lugar de GIFs. [Más información](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Los GIF de gran tamaño no son eficientes para mostrar contenido animado. Para usar menos bytes de la red, te recomendamos que utilices los formatos de vídeo MPEG4 o WebM para incluir animaciones y los formatos PNG o WebP para añadir imágenes estáticas en lugar del formato GIF. [Más información](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Usa formatos de vídeo para incluir contenido animado"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Te recomendamos que uses la carga diferida con imágenes ocultas y que no aparecen en pantalla una vez que todos los recursos críticos hayan terminado de cargarse para reducir el tiempo hasta que la página es interactiva. [Más información](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
+    "message": "Te recomendamos que uses la carga diferida con imágenes ocultas y que no aparecen en pantalla una vez que todos los recursos críticos hayan terminado de cargarse para reducir el tiempo que pasa hasta que la página es interactiva. [Más información](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Pospón la carga de imágenes que no aparecen en pantalla"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Hay recursos que bloquean el primer renderizado de la página. Te recomendamos que muestres los elementos JS/CSS críticos insertados y pospongas todos los JS/styles que no sean críticos. [Más información](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
+    "message": "Hay recursos que bloquean el primer renderizado de la página. Te recomendamos que muestres los elementos de JavaScript y CSS críticos insertados y pospongas todos los que no sean esenciales. [Más información](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Elimina los recursos que bloqueen el renderizado"
@@ -375,13 +387,13 @@
     "message": "Minifica los archivos CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Si minificas los archivos JavaScript, se puede reducir el tamaño de la carga útil y el tiempo de análisis de la secuencia de comandos. [Más información](https://developers.google.com/speed/docs/insights/MinifyResources)"
+    "message": "Si minificas los archivos de JavaScript, se puede reducir el tamaño de la carga útil y el tiempo de análisis de la secuencia de comandos. [Más información](https://developers.google.com/speed/docs/insights/MinifyResources)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Minifica los recursos JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Elimina las reglas inactivas de las hojas de estilo y retrasa la carga de las CSS que no se utilicen para el contenido de la mitad superior de la página. Así, se reducirán los bytes consumidos innecesariamente por la actividad de red. [Más información](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Elimina las reglas inactivas de las hojas de estilo y retrasa la carga de los archivos CSS que no se utilicen para el contenido de la mitad superior de la página. Así, se reducirán los bytes consumidos innecesariamente por la actividad de red. [Más información](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Elimina archivos CSS sin usar"
@@ -417,25 +429,76 @@
     "message": "Usa un tamaño adecuado para las imágenes"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Los recursos basados en texto se deberían publicar comprimidos (gzip, deflate o brotli) para minimizar el total de bytes de la red. [Más información](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
+    "message": "Los recursos de texto se deberían publicar comprimidos (gzip, deflate o brotli) para minimizar el total de bytes de la red. [Más información](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Habilita la compresión de texto"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Los formatos como JPEG 2000, JPEG XR y WebP comprimen mejor las imágenes que los formatos PNG o JPEG, lo que hace que se descarguen más rápido y consuman menos datos. [Más información](https://developers.google.com/web/tools/lighthouse/audits/webp)"
+    "message": "Los formatos JPEG 2000, JPEG XR y WebP comprimen mejor las imágenes que los formatos PNG o JPEG, lo que hace que se descarguen más rápido y consuman menos datos. [Más información](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Publica imágenes con formatos de próxima generación"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Las cadenas de solicitud crítica que se muestran a continuación indican qué recursos son de alta prioridad. Te recomendamos que reduzcas la longitud de las cadenas, disminuyas el tamaño de los recursos o pospongas la descarga de recursos innecesarios para mejorar la carga de la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Las cadenas de solicitud crítica que se muestran a continuación indican qué recursos son de alta prioridad. Te recomendamos que reduzcas la longitud de las cadenas, disminuyas el tamaño de los recursos o pospongas la descarga de recursos innecesarios para mejorar la carga de la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Se ha encontrado 1 cadena}other{Se han encontrado # cadenas}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimiza la profundidad de las solicitudes críticas"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Desactivación/Advertencia"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Línea"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Las API obsoletas se eliminarán del navegador en el futuro. [Más información](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Se ha encontrado 1 advertencia}other{Se han encontrado # advertencias}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Usa API obsoletas"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Evita las API obsoletas"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "La caché de aplicación está obsoleta. [Más información](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Se ha detectado \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Usa caché de aplicación"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Evita la caché de aplicación"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Especificar un DOCTYPE evita que el navegador cambie al modo Quirks. Consulta más información en la página [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "El nombre del DOCTYPE debe ser la cadena `html` en minúsculas"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "El documento debe contener un DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Se esperaba que publicId fuera una cadena vacía"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Se esperaba que systemId fuera una cadena vacía"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "A la página le falta el DOCTYPE de HTML, por lo que se ha activado el modo Quirks"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "La página tiene el DOCTYPE de HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elemento"
@@ -447,7 +510,7 @@
     "message": "Valor"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Los desarrolladores de navegadores recomiendan que las páginas contengan menos de 1500 elementos de DOM. Lo ideal es conseguir una profundidad de árbol inferior a 32 elementos y a 60 elementos secundarios por cada elemento principal. Los DOM de gran tamaño aumentan el uso de la memoria, hacen que los [cálculos de estilo](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) duren más y generan costosos [reinicios del flujo del diseño](https://developers.google.com/speed/articles/reflow). [Más información](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Los desarrolladores de navegadores recomiendan que las páginas contengan menos de 1500 elementos DOM. Lo ideal es conseguir una profundidad de árbol inferior a 32 elementos y a 60 elementos secundarios por cada elemento principal. Los DOM de gran tamaño aumentan el uso de memoria, hacen que los [cálculos de estilo](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) duren más y generan costosos [reinicios del flujo del diseño](https://developers.google.com/speed/articles/reflow). [Más información](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 elemento}other{# elementos}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Evita un tamaño excesivo de DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Target"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Añade `rel=\"noopener\"` o `rel=\"noreferrer\"` a cualquier enlace externo para mejorar el rendimiento y evitar vulnerabilidades de seguridad. [Más información](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Los enlaces a destinos de origen cruzado no son seguros"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Los enlaces a destinos de origen cruzado son seguros"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "No se ha podido determinar el destino del enlace ({anchorHTML}). Si no se usa como hiperenlace, se recomienda eliminar el atributo target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Los usuarios dudan o desconfían de los sitios web que solicitan su ubicación sin contexto. Como alternativa, puedes vincular la solicitud a una acción del usuario. [Más información](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Solicita el permiso de geolocalización al cargar la página"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Evita solicitar el permiso de geolocalización al cargar la página"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versión"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Todas las bibliotecas frontend de JavaScript detectadas en la página."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Bibliotecas de JavaScript detectadas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Las secuencias de comandos externas inyectadas dinámicamente mediante `document.write()` pueden retrasar la carga de la página varias decenas de segundos en conexiones lentas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Usa `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Evita `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Gravedad máxima"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Versión de la biblioteca"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Número de vulnerabilidades"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Algunas secuencias de comandos externas pueden contener vulnerabilidades de seguridad conocidas que pueden ser detectadas y aprovechadas por los atacantes. [Más información](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 vulnerabilidad detectada}other{# vulnerabilidades detectadas}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Incluye bibliotecas en el frontend de JavaScript con vulnerabilidades de seguridad conocidas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Alta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Baja"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Mediana"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Evita en el frontend las bibliotecas de JavaScript con vulnerabilidades de seguridad conocidas"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Los usuarios dudan o desconfían de los sitios web que solicitan enviar notificaciones sin contexto. Como alternativa, puedes vincular la solicitud a los gestos de los usuarios. [Más información](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Solicita el permiso de notificación al cargar la página"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Evita solicitar el permiso de notificación al cargar la página"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elementos con errores"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Evitar que se pueda pegar texto en el campo de contraseña debilita una buena política de seguridad. [Más información](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Impide que los usuarios peguen texto en los campos de contraseña"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Permite que los usuarios peguen texto en los campos de contraseña"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocolo"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ofrece muchas ventajas con respecto a HTTP/1.1, como encabezados binarios, multiplexación y servidor push. [Más información](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 solicitud no atendida mediante HTTP/2}other{# solicitudes no atendidas mediante HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "No usa HTTP/2 para todos sus recursos"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Usa HTTP/2 para sus propios recursos"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Se recomienda que los procesadores de eventos táctiles y de la rueda sean `passive` para mejorar el desplazamiento de tu página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "No usa listeners pasivos para mejorar el desplazamiento"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Usa listeners pasivos para mejorar el desplazamiento"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Descripción"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Los errores registrados en la consola indican problemas sin resolver. Pueden proceder de solicitudes fallidas de la red y otros errores del navegador."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Se han registrado errores del navegador en la consola"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "No se ha registrado en la consola ningún error del navegador"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Utiliza la función de CSS font-display para que los usuarios vean el texto mientras se carga la fuente web. [Más información](https://developers.google.com/web/updates/2016/02/font-display)"
+    "message": "Utiliza la característica de CSS \"font-display\" para que los usuarios vean el texto mientras se carga la fuente web. [Más información](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Asegúrate de que el texto permanece visible mientras se carga la fuente web"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Todo el texto permanece visible mientras se carga la fuente web"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse no ha podido comprobar automáticamente el valor de font-display de la siguiente URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Relación de aspecto (real)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Relación de aspecto (mostrada)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Las dimensiones de las imágenes mostradas deberían mantener su relación de aspecto natural. [Más información](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Muestra imágenes con una relación de aspecto incorrecta"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Muestra imágenes con la relación de aspecto adecuada"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "La información del tamaño de la imagen no es válida ({url})"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL insegura"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Todos los sitios web deberían estar protegidos con el protocolo HTTPS, incluso los que no gestionen datos sensibles. HTTPS evita que los intrusos alteren o escuchen pasivamente la comunicación entre tu aplicación y tus usuarios. Además, es un requisito previo para poder usar HTTP/2 y las API de muchas plataformas web nuevas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Se ha encontrado 1 solicitud insegura}other{Se han encontrado # solicitudes inseguras}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "No usa HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Usa HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Si las páginas se cargan rápidamente en las redes móviles, se asegurará una buena experiencia de usuario. [Más información](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Si las páginas se cargan rápidamente en las redes móviles, se asegurará una buena experiencia de usuario. [Más información](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interactiva a los {timeInMs, number, seconds} s"
+    "message": "Página interactiva en {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Interactiva en una red móvil simulada a los {timeInMs, number, seconds} s"
+    "message": "Página interactiva en una red móvil simulada en {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "La página no se carga suficientemente rápido en las redes móviles"
@@ -504,13 +735,13 @@
     "message": "Minimiza el trabajo del hilo principal"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "La latencia de entrada estimada es el tiempo, en milisegundos, que tarda tu aplicación en responder a las acciones de los usuarios durante el periodo de 5 s más activo de carga de la página. Si la latencia es superior a 50 ms, es posible que los usuarios piensen que tu aplicación es lenta. [Más información](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "La latencia de entrada estimada es el tiempo, en milisegundos, que tarda tu aplicación en responder a las acciones de los usuarios durante el periodo de 5 s más activo de carga de la página. Si tu latencia es superior a 50 ms, es posible que los usuarios perciban cierto retardo en tu aplicación. [Más información](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Latencia de entrada estimada"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "El primer renderizado con contenido indica el momento en el que se renderiza el primer texto o la primera imagen. [Más información](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "El primer renderizado con contenido indica el momento en el que se renderiza el primer texto o la primera imagen. [Más información](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Primer renderizado con contenido"
@@ -528,16 +759,16 @@
     "message": "Primer renderizado significativo"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "El tiempo hasta que está interactiva es el tiempo que tarda una página en ser totalmente interactiva. [Más información](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "El tiempo hasta que está interactiva es el tiempo que tarda una página en ser totalmente interactiva. [Más información](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Tiempo hasta que está interactiva"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "La latencia de la primera interacción que podrían experimentar los usuarios es la duración, en milisegundos, de la tarea más larga."
+    "message": "La latencia potencial máxima de la primera interacción que podrían experimentar los usuarios es la duración, en milisegundos, de la tarea más larga. [Más información](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID potencial máxima"
+    "message": "Latencia potencial máxima de la primera interacción"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "El índice de velocidad indica la rapidez con la que se puede ver el contenido de una página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
@@ -545,17 +776,35 @@
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Índice de velocidad"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Suma de los periodos, en milisegundos, entre el primer renderizado con contenido y el tiempo hasta que la página es interactiva cuando se exceden los 50 ms."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Tiempo total de bloqueo"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Los tiempos de ida y vuelta (RTT) de la red afectan mucho al rendimiento. Un RTT alto hasta un origen indica que usar servidores más cercanos al usuario podría mejorar el rendimiento. [Más información](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Los tiempos de ida y vuelta (RTT) de la red afectan mucho al rendimiento. Un RTT alto hasta un origen indica que usar servidores más cercanos al usuario podría mejorar el rendimiento. [Más información](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Tiempos de ida y vuelta de la red"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "La latencia del servidor puede afectar al rendimiento de la web. Una latencia del servidor alta en un origen indica que el servidor está sobrecargado o que su rendimiento de backend es bajo. [Más información] (https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "La latencia del servidor puede afectar al rendimiento del sitio web. Una latencia del servidor alta en un origen indica que el servidor está sobrecargado o que su rendimiento de backend es bajo. [Más información](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latencias de backend del servidor"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Superior a los recursos"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Mantiene la cantidad y el tamaño de las solicitudes de red por debajo de los límites definidos en los recursos de rendimiento. [Más información](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 solicitud}other{# solicitudes}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Recursos de rendimiento"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Las redirecciones provocan retrasos adicionales antes de que la página se pueda cargar. [Más información](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
@@ -563,20 +812,29 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Evita que haya varias redirecciones de página"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Para definir la cantidad y el tamaño de los recursos de la página, añade un archivo budget.json. [Más información](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 solicitud}other{# solicitudes}} • {byteCount, number, bytes} kB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Reduce el número de solicitudes y el tamaño de las transferencias"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Los enlaces canónicos sugieren qué URL se debe mostrar en los resultados de búsqueda. [Más información](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Los enlaces canónicos sugieren qué URL se debe mostrar en los resultados de búsqueda. [Más información](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Múltiples URL en conflicto ({urlList})"
+    "message": "Varias URL en conflicto ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Apunta a un dominio diferente ({url})"
+    "message": "Dirige a un dominio diferente ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "URL no válida ({url})"
+    "message": "La URL no es válida ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Apunta a otra ubicación \"hreflang\" ({url})"
+    "message": "Apunta a una ubicación de `hreflang` distinta ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "URL relativa ({url})"
@@ -585,25 +843,22 @@
     "message": "Apunta a la URL raíz del dominio (la página principal), en lugar de a una página de contenido equivalente"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "El documento no tiene un enlace \"rel=canonical\" válido"
+    "message": "El documento no tiene un atributo `rel=canonical` válido"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "El documento tiene un enlace \"rel=canonical\" válido"
+    "message": "El documento tiene un atributo `rel=canonical` válido"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Las fuentes con un tamaño inferior a 12 px son demasiado pequeñas y poco legibles, lo que obliga a los visitantes que acceden con dispositivos móviles a pellizcar la pantalla para ampliarla y poder leer el texto. Intenta que más del 60 % del texto de la página tenga un tamaño igual o superior a 12 px. [Más información](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Las fuentes con un tamaño inferior a 12 px son demasiado pequeñas y poco legibles, lo que obliga a los visitantes que acceden con dispositivos móviles a pellizcar la pantalla para ampliarla y poder leer el texto. Intenta que más del 60 % del texto de la página tenga un tamaño igual o superior a 12 px. [Más información](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "El {decimalProportion, number, extendedPercent} del texto es legible"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "El {decimalProportion, number, extendedPercent} del texto es demasiado pequeño."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "El texto es ilegible porque no hay metaetiquetas de viewport optimizadas para pantallas de dispositivos móviles."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "El {decimalProportion, number, extendedPercent} del texto es demasiado pequeño (según la muestra {decimalProportionVisited, number, extendedPercent})."
+    "message": "El {decimalProportion, number, extendedPercent} del texto es demasiado pequeño (según una muestra del {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "El documento no usa tamaños de fuente legibles"
@@ -612,16 +867,16 @@
     "message": "El documento usa tamaños de fuente legibles"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Los enlaces \"hreflang\" indican a los buscadores qué versiones de las páginas deben incluir en los resultados de búsqueda de una región o un idioma determinados. [Más información](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Los enlaces \"hreflang\" indican a los buscadores qué versiones de las páginas deben incluir en los resultados de búsqueda de una región o un idioma determinados. [Más información](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "El atributo \"hreflang\" del documento no es válido"
+    "message": "El atributo `hreflang` del documento no es válido"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "El \"hreflang\" del documento es válido"
+    "message": "El documento tiene un atributo `hreflang` válido"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Es posible que las páginas con códigos de estado HTTP no válidos no estén bien indexadas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Es posible que las páginas con códigos de estado HTTP no válidos no estén bien indexadas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "El código de estado HTTP de la página no es válido"
@@ -630,7 +885,7 @@
     "message": "El código de estado HTTP de la página es válido"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Los buscadores no pueden incluir tus páginas en los resultados de búsqueda si no tienen permiso para rastrearlas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Los buscadores no pueden incluir tus páginas en los resultados de búsqueda si no tienen permiso para rastrearlas. [Más información](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Se ha bloqueado la indexación de la página"
@@ -639,7 +894,7 @@
     "message": "No se ha bloqueado la indexación de la página"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "El texto descriptivo de los enlaces ayuda a los buscadores a entender tu contenido. [Más información](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "El texto descriptivo de los enlaces ayuda a los buscadores a entender tu contenido. [Más información](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 enlace encontrado}other{# enlaces encontrados}}"
@@ -651,13 +906,13 @@
     "message": "Los enlaces tienen texto descriptivo"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Ejecuta la [Herramienta de prueba de datos estructurados](https://search.google.com/structured-data/testing-tool/) y la herramienta [Structured Data Linter](http://linter.structured-data.org/) para validar los datos estructurados. [Más información](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Ejecuta la [Herramienta de prueba de datos estructurados](https://search.google.com/structured-data/testing-tool/) y la herramienta [Structured Data Linter](http://linter.structured-data.org/) para validar los datos estructurados. [Más información](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Los datos estructurados son válidos"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Se pueden incluir metadescripciones en los resultados de búsqueda para resumir brevemente el contenido de la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Se pueden incluir metadescripciones en los resultados de búsqueda para resumir brevemente el contenido de la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/description)"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "El texto de la descripción está vacío."
@@ -669,7 +924,7 @@
     "message": "El documento tiene una metadescripción"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Los buscadores no pueden indexar el contenido de los complementos, y muchos dispositivos limitan el uso de complementos o no los admiten. [Más información](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Los buscadores no pueden indexar el contenido de los complementos, y muchos dispositivos limitan el uso de complementos o no los admiten. [Más información](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "El documento usa complementos"
@@ -696,10 +951,10 @@
     "message": "robots.txt es válido"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Los elementos interactivos, como los botones y enlaces, deben ser suficientemente grandes (48x48 px) y tener suficiente espacio alrededor para poder tocarlos con facilidad sin superponerse con otros elementos. [Más información](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Los elementos interactivos, como los botones y enlaces, deben ser lo suficientemente grandes (48x48 px) y tener suficiente espacio alrededor para poder tocarlos con facilidad sin superponerse con otros elementos. [Más información](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "El {decimalProportion, number, percent} de los elementos táctiles tiene un tamaño adecuado."
+    "message": "El {decimalProportion, number, percent} de los elementos táctiles tiene un tamaño adecuado"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "Los elementos táctiles son demasiado pequeños porque no hay metaetiquetas de viewport optimizadas para pantallas de dispositivos móviles"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Elementos superpuestos"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Tamaño"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Elemento táctil"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "El tamaño de los elementos táctiles es el adecuado"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Tiempo del hilo principal"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Proveedor externo"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "El código externo puede afectar mucho a la velocidad de carga. Limita el número de proveedores externos redundantes e intenta cargar el código externo cuando se haya completado la carga principal de tu página. [Más información](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Se ha encontrado 1 entidad de terceros}other{Se han encontrado # entidades de terceros}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Uso de código externo"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "El tiempo hasta el primer byte indica el momento en el que el servidor envía una respuesta. [Más información](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Duración"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nombre"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Hora de inicio"
   },
@@ -744,7 +1008,7 @@
     "message": "Tipo"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Te recomendamos que uses la API User Timing en tu aplicación para calcular su rendimiento real durante las principales experiencias de usuario. [Más información](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Te recomendamos que uses la API Tiempos de usuario en tu aplicación para calcular su rendimiento real durante las principales experiencias de usuario. [Más información](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 tiempo de usuario}other{# tiempos de usuario}}"
@@ -753,19 +1017,19 @@
     "message": "Medidas y marcas de User Timing"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Se ha encontrado un elemento <link> previo a la conexión para \"{securityOrigin}\", pero el navegador no lo ha usado. Comprueba que el atributo \"crossorigin\" se esté usando correctamente."
+    "message": "Se ha encontrado un elemento <link> previo a la conexión para \"{securityOrigin}\", pero el navegador no lo ha usado. Comprueba que el atributo `crossorigin` se esté usando correctamente."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Te recomendamos que añadas sugerencias de recursos preconnect o dns-prefetch para establecer conexiones previas con orígenes externos. [Más información](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
+    "message": "Te recomendamos que añadas sugerencias de recursos preconnect o dns-prefetch para establecer conexiones previas con orígenes externos importantes. [Más información](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Establece conexión previamente con los orígenes necesarios"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Se ha encontrado un elemento <link> de precarga para \"{preloadURL}\", pero el navegador no lo ha utilizado. Comprueba que el atributo \"crossorigin\" se esté usando correctamente."
+    "message": "Se ha encontrado un elemento <link> de precarga para \"{preloadURL}\", pero el navegador no lo ha utilizado. Comprueba que el atributo `crossorigin` se esté usando correctamente."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Te recomendamos que uses <link rel=preload> para dar prioridad a los recursos que se solicitan más tarde al cargar la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/preload)"
+    "message": "Te recomendamos usar `<link rel=preload>` para dar prioridad a los recursos que se solicitan más tarde al cargar la página. [Más información](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Carga previamente las solicitudes clave"
@@ -792,7 +1056,7 @@
     "message": "Estas comprobaciones incluyen consejos para [mejorar la accesibilidad de tu aplicación web](https://developers.google.com/web/fundamentals/accessibility). Solo se pueden detectar un subconjunto de problemas de accesibilidad de forma automática. Por eso, te recomendamos realizar pruebas manuales."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Estos elementos se ocupan de áreas que las herramientas de prueba automáticas no pueden analizar. Obtén más información en nuestra guía para [revisar la accesibilidad](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Estos elementos se ocupan de áreas que las herramientas de prueba automáticas no pueden analizar. Consulta más información sobre cómo [revisar la accesibilidad](https://developers.google.com/web/fundamentals/accessibility/how-to-review) en nuestra guía."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Accesibilidad"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tablas y listas"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Prácticas recomendadas"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Los recursos de rendimiento definen los estándares de rendimiento de tu sitio web."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Objetivos"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Consulta más información sobre el rendimiento de tu aplicación."
+    "message": "Consulta más información sobre el rendimiento de tu aplicación. Estos datos no [afectan directamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) a la puntuación del rendimiento."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnósticos"
@@ -840,7 +1113,7 @@
     "message": "Mejoras del primer renderizado"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Estas optimizaciones pueden hacer que tus páginas se carguen más rápido."
+    "message": "Estas sugerencias pueden ayudar a que tu página cargue más rápido. No [afectan directamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) a la puntuación del rendimiento"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Oportunidades"
@@ -867,7 +1140,7 @@
     "message": "Optimizado para PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Estas comprobaciones aseguran que tu página esté optimizada para posicionarse en los resultados de los buscadores. Hay otros factores que Lighthouse no comprueba y que pueden afectar a tu posicionamiento en los buscadores. [Más información](https://support.google.com/webmasters/answer/35769)."
+    "message": "Estas comprobaciones aseguran que tu página esté optimizada para posicionarse en los resultados de los buscadores. Hay otros factores que Lighthouse no comprueba y que pueden afectar a tu posicionamiento en los buscadores. [Más información](https://support.google.com/webmasters/answer/35769)"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Ejecuta estos validadores adicionales en tu sitio web para comprobar más prácticas recomendadas de SEO."
@@ -888,7 +1161,7 @@
     "message": "Rastrear e indexar"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Asegúrate de que tus páginas están optimizadas para móviles de forma que los usuarios no tengan que pellizcar la pantalla o ampliarla para poder leer su contenido. [Más información](https://developers.google.com/search/mobile-sites/)."
+    "message": "Asegúrate de que tus páginas están optimizadas para móviles de forma que los usuarios no tengan que pellizcar la pantalla o ampliarla para poder leer su contenido. [Más información](https://developers.google.com/search/mobile-sites/)"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Optimización para móviles"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Tiempo de vida en caché"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Ubicación"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nombre"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Solicitudes"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Tipo de recurso"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Tamaño (kB)"
+    "message": "Tamaño"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Duración"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Tamaño de la transferencia"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Ahorro potencial (kB)"
+    "message": "Ahorro potencial"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Ahorro potencial (ms)"
+    "message": "Ahorro potencial"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Ahorro potencial de {wastedBytes, number, bytes} kB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Ahorro potencial de {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Documento"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Fuente"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Imagen"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Contenido multimedia"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Otros"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Secuencia de comandos"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Hoja de estilo"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Recursos externos"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Total"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Se ha producido un error al registrar el rastro durante la carga de la página. Ejecuta Lighthouse de nuevo. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Los servidores DNS no han podido resolver el dominio proporcionado."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "No se ha podido recuperar el recurso {artifactName} necesario: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Se ha producido un error interno de Chrome. Reinicia Chrome y prueba a ejecutar Lighthouse de nuevo."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "No se ha podido recuperar el recurso {artifactName} necesario."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse no ha podido cargar correctamente la página que has solicitado. Comprueba que estás probando la URL correcta y que el servidor responde correctamente a todas las solicitudes."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse no ha podido cargar correctamente la URL que has solicitado porque la página ha dejado de responder."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Las credenciales de seguridad de la URL que has proporcionado no son válidas. {securityMessages}"
+    "message": "La URL que has proporcionado no tiene un certificado de seguridad válido. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome ha evitado la carga de la página con un intersticial. Comprueba que estás probando la URL correcta y que el servidor responde correctamente a todas las solicitudes."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse no ha podido cargar correctamente la página que has solicitado. Comprueba que estás probando la URL correcta y que el servidor responde correctamente a todas las solicitudes. (Detalles: {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Mostrar fragmento"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Mostrar recursos externos"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Algunos problemas han afectado a la ejecución de Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Los valores son estimados y pueden variar."
+    "message": "Los valores son estimaciones y pueden variar. La puntuación del rendimiento [se basa solo en estas métricas](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Auditorías aprobadas con advertencias"
@@ -1023,10 +1350,10 @@
     "message": "Puedes subir tu GIF a un servicio que permita insertarlo como un vídeo HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Instala un [complemento de carga diferida de WordPress](https://wordpress.org/plugins/search/lazy+load/) con la capacidad de posponer imágenes que no aparecen en la pantalla, o cambia a un tema con esa función. También puedes usar [el complemento AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Instala un [complemento de carga en diferido de WordPress](https://wordpress.org/plugins/search/lazy+load/) con la capacidad de posponer imágenes que no aparecen en la pantalla, o cambia a un tema con esa función. También puedes usar el [complemento AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Existen varios complementos de WordPress que pueden ayudarte a [insertar recursos fundamentales](https://wordpress.org/plugins/search/critical+css/) o a [posponer recursos menos importantes](https://wordpress.org/plugins/search/defer+css+javascript/). Ten en cuenta que las optimizaciones que ofrecen estos complementos pueden bloquear funciones de tu tema o tus complementos, así que seguramente tengas que hacer cambios en el código."
+    "message": "Existen varios complementos de WordPress que pueden ayudarte a [insertar recursos fundamentales](https://wordpress.org/plugins/search/critical+css/) o [posponer recursos menos importantes](https://wordpress.org/plugins/search/defer+css+javascript/). Ten en cuenta que las optimizaciones que ofrecen estos complementos pueden bloquear funciones de tu tema o tus complementos, así que seguramente tengas que hacer cambios en el código."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Los temas, los complementos y las especificaciones del servidor afectan al tiempo de respuesta. Puedes buscar un tema más optimizado, seleccionar un complemento de optimización o actualizar tu servidor."
@@ -1041,24 +1368,24 @@
     "message": "Hay varios [complementos de WordPress](https://wordpress.org/plugins/search/minify+javascript/) que pueden concatenar, minificar y comprimir tus secuencias de comandos para acelerar tu sitio web. Te recomendamos que, si es posible, uses un proceso de creación para realizar la minificación de forma anticipada."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Puedes reducir o cambiar la cantidad de [complementos de WordPress](https://wordpress.org/plugins/) que cargan archivos CSS sin usar en tu página. Para identificar los complementos que añaden archivos CSS externos, ejecuta [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) en DevTools de Chrome. Puedes identificar el tema o complemento en la URL de la hoja de estilo. Presta atención a los complementos con varias hojas de estilo en la lista y con muchos elementos en rojo en la cobertura de código. Un complemento solo debería poner en cola una hoja de estilo (si esta se usa en la página)."
+    "message": "Puedes reducir o cambiar la cantidad de [complementos de WordPress](https://wordpress.org/plugins/) que cargan archivos CSS sin usar en tu página. Para identificar los complementos que añaden archivos CSS externos, ejecuta [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) en DevTools de Chrome. Puedes identificar el tema o complemento concreto en la URL de la hoja de estilo. Presta atención a los complementos con varias hojas de estilo en la lista y con muchos elementos en rojo en la cobertura de código. Un complemento solo debería poner en cola una hoja de estilo (si esta se usa en la página)."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Puedes reducir o cambiar la cantidad de [complementos de WordPress](https://wordpress.org/plugins/) que cargan JavaScript sin usar en tu página. Para identificar los complementos que añaden JavaScript externo, ejecuta [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) en DevTools de Chrome. Puedes identificar el tema o complemento concreto en la URL de la secuencia de comandos. Presta atención a los complementos con varias secuencias de comandos en la lista y con muchos elementos en rojo en la cobertura de código. Un complemento solo debería poner en cola una secuencia de comandos (si esta se usa en la página)."
+    "message": "Puedes reducir o cambiar la cantidad de [complementos de WordPress](https://wordpress.org/plugins/) que cargan código de JavaScript sin usar en tu página. Para identificar los complementos que añaden código de JavaScript externo, ejecuta [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) en DevTools de Chrome. Puedes identificar el tema o complemento concreto en la URL de la secuencia de comandos. Presta atención a los complementos con varias secuencias de comandos en la lista y con muchos elementos en rojo en la cobertura de código. Un complemento solo debería poner en cola una secuencia de comandos (si esta se usa en la página)."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Consulta información sobre el [almacenamiento en la memoria caché del navegador en WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Consulta más información sobre el [almacenamiento en la memoria caché del navegador en WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "Puedes utilizar un [complemento de optimización de imágenes de WordPress](https://wordpress.org/plugins/search/optimize+images/) que comprima tus imágenes conservando la calidad."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Sube imágenes directamente a la [biblioteca multimedia](https://codex.wordpress.org/Media_Library_Screen) para asegurarte de que estén disponibles los tamaños de imagen necesarios y, después, insértalas desde esa biblioteca multimedia o utiliza el widget de imagen para usar los tamaños de imagen óptimos (incluidos los tamaños de los breakpoints adaptables). Evita utilizar imágenes a tamaño completo, a no ser que las dimensiones sean las adecuadas para su uso. [Más información](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Sube imágenes directamente a la [biblioteca multimedia](https://codex.wordpress.org/Media_Library_Screen) para asegurarte de que estén disponibles los tamaños de imagen necesarios y, después, insértalas desde esa biblioteca multimedia o utiliza el widget de imagen para usar los tamaños de imagen óptimos (incluidos los tamaños de los puntos de interrupción adaptables). Evita usar imágenes `Full Size`, a no ser que las dimensiones sean las adecuadas para su uso. [Más información](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Puedes habilitar la compresión de texto en la configuración de tu servidor web."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Puedes utilizar un [complemento](https://wordpress.org/plugins/search/convert+webp/) o un servicio que convierta automáticamente las imágenes que subas en los formatos óptimos."
+    "message": "Puedes utilizar un [complemento](https://wordpress.org/plugins/search/convert+webp/) o servicio que convierta automáticamente las imágenes que subas en los formatos óptimos."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/fi.json
+++ b/lighthouse-core/lib/i18n/locales/fi.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Pääsyavaimien avulla käyttäjät voivat nopeasti kohdistaa tiettyyn sivun osaan. Jotta sivulla siirtyminen onnistuu, jokaisen pääsyavaimen on oltava yksilöllinen. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Pääsyavaimien avulla käyttäjät voivat nopeasti kohdistaa tiettyyn sivun osaan. Jotta sivulla siirtyminen onnistuu, jokaisen pääsyavaimen on oltava yksilöllinen. [Lue lisää](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "[accesskey]-arvot eivät ole yksilöllisiä"
+    "message": "`[accesskey]`-arvot eivät ole yksilöllisiä"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "[accesskey]-arvot ovat yksilöllisiä"
+    "message": "`[accesskey]`-arvot ovat yksilöllisiä."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Jokainen ARIA-rooli tukee tiettyä aria-*-määritteiden osaa. Vastaavuusjärjestyksen sekoittaminen mitätöi aria-*-määritteet. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Jokainen ARIA-`role` tukee tiettyä `aria-*`-määritteiden osaa. Vastaavuusjärjestyksen sekoittaminen mitätöi `aria-*`-määritteet. [Lue lisää](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "[aria-*]-määritteet eivät vastaa niiden rooleja"
+    "message": "`[aria-*]`-määritteet eivät vastaa rooleja"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "[aria-*]-määritteet vastaavat roolejaan"
+    "message": "`[aria-*]`-määritteet vastaavat roolejaan"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Joillakin ARIA-rooleilla on pakollisia määritteitä, jotka kuvaavat elementin tilaa näytönlukuohjelmille. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Joillakin ARIA-rooleilla on pakollisia määritteitä, jotka kuvaavat elementin tilaa näytönlukuohjelmille. [Lue lisää](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "[role]-elementeillä ei ole kaikkia vaadittuja ([aria-*])-määritteitä"
+    "message": "`[role]`-elementeissä ei ole kaikkia vaadittuja `[aria-*]`-määritteitä"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "[role]-elementeillä on kaikki pakolliset [aria-*]-määritteet"
+    "message": "`[role]`-elementeissä on kaikki vaaditut `[aria-*]`-määritteet"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Voidakseen suorittaa esteettömyyteen liittyvät toiminnot joidenkin alatason ARIA-roolien on kuuluttava tiettyihin ylätason rooleihin. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Voidakseen suorittaa esteettömyyteen liittyvät toiminnot joidenkin alatason ARIA-roolien on kuuluttava tiettyihin ylätason rooleihin. [Lue lisää](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Elementit, joissa on tiettyjä alatason rooleja ([role]) edellyttäviä rooleja ([role]), puuttuvat."
+    "message": "Sellaisia `[role]`:n sisältäviä elementtejä puuttuu, jotka edellyttävät tiettyjä alatason `[role]`-elementtejä"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "[role]:n sisältäviä elementtejä, jotka edellyttävät tiettyjä alatason [role]-elementtejä, on käytössä"
+    "message": "Käytössä on `[role]`:n sisältäviä elementtejä, jotka edellyttävät tiettyjä alatason `[role]`-elementtejä"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Voidakseen suorittaa esteettömyyteen liittyvät toiminnot joidenkin alatason ARIA-roolien on kuuluttava tiettyihin ylätason rooleihin. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Voidakseen suorittaa esteettömyyteen liittyvät toiminnot joidenkin alatason ARIA-roolien on kuuluttava tiettyihin ylätason rooleihin. [Lue lisää](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "[role]-elementit eivät sisälly niiden pakolliseen ylätason elementtiin"
+    "message": "`[role]`-elementit eivät sisälly niiden pakolliseen ylätason elementtiin"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "[role]-elementit sisältyvät niiden pakolliseen ylätason elementtiin"
+    "message": "`[role]`-elementit sisältyvät niiden pakolliseen ylätason elementtiin"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Voidakseen suorittaa esteettömyyteen liittyvät toiminnot ARIA-rooleilla on oltava kelvolliset arvot. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Voidakseen suorittaa esteettömyyteen liittyvät toiminnot ARIA-rooleilla on oltava kelvolliset arvot. [Lue lisää](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "[role]-arvot eivät ole kelvollisia"
+    "message": "`[role]`-arvot eivät ole kelvollisia"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "[role]-arvot ovat kelvollisia"
+    "message": "`[role]`-arvot ovat kelvollisia"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Avustustekniikat (kuten näytönlukuohjelmat) eivät voi tulkita ARIA-määritteitä, joissa on virheelliset arvot. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Avustustekniikat (kuten näytönlukuohjelmat) eivät voi tulkita ARIA-määritteitä, joissa on virheelliset arvot. [Lue lisää](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "[aria-*]-määritteiden arvot eivät ole kelvollisia"
+    "message": "`[aria-*]`-määritteiden arvot eivät ole kelvollisia"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "[aria-*]-määritteiden arvot ovat kelvollisia"
+    "message": "`[aria-*]`-määritteiden arvot ovat kelvollisia"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Avustustekniikat (kuten näytönlukuohjelmat) eivät voi tulkita ARIA-määritteitä, joilla on virheelliset nimet. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Avustustekniikat (kuten näytönlukuohjelmat) eivät voi tulkita ARIA-määritteitä, joilla on virheelliset nimet. [Lue lisää](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "[aria-*]-määritteet eivät ole kelvollisia tai sisältävät kirjoitusvirheitä"
+    "message": "`[aria-*]`-määritteet eivät ole kelvollisia tai sisältävät kirjoitusvirheitä"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "[aria-*]-määritteet ovat kelvollisia eivätkä sisällä kirjoitusvirheitä"
+    "message": "`[aria-*]`-määritteet ovat kelvollisia eivätkä sisällä kirjoitusvirheitä"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Tekstitykset tekevät äänielementeistä merkittäviä kuuroille tai heikkokuuloisille kertomalla kuka puhuu ja mitä sekä antamalla muita kuin puheeseen liittyviä tietoja. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Tekstitykset tekevät äänielementeistä merkittäviä kuuroille tai heikkokuuloisille kertomalla kuka puhuu ja mitä sekä antamalla muita kuin puheeseen liittyviä tietoja. [Lue lisää](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "<audio>-elementit eivät sisällä <track>-elementtiä, jossa on [kind=\"captions\"]."
+    "message": "`<audio>`-elementeistä puuttuu `<track>`-elementti, jossa on `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "<audio>-elementit sisältävät <track>-elementin, jossa on [kind=\"captions\"]"
+    "message": "`<audio>`-elementit sisältävät `<track>`-elementin, jossa on `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Hylätyt elementit"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Kun painikkeen nimi ei ole esteetön, näytönlukuohjelmat ilmoittavat sen painikkeeksi, jolloin se on hyödytön näytönlukuohjelmia tarvitseville käyttäjille. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Kun painikkeen nimi ei ole esteetön, näytönlukuohjelmat ilmoittavat sen painikkeeksi, jolloin se on hyödytön näytönlukuohjelmia tarvitseville käyttäjille. [Lue lisää](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Painikkeiden nimet eivät ole esteettömiä"
@@ -93,7 +93,7 @@
     "message": "Painikkeiden nimet ovat esteettömiä"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Tapojen lisääminen toistuvan sisällön ohittamiseen auttaa näppäimistön käyttäjiä siirtymään sivulla tehokkaammin. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Tapojen lisääminen toistuvan sisällön ohittamiseen auttaa näppäimistön käyttäjiä siirtymään sivulla tehokkaammin. [Lue lisää](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Sivu ei sisällä otsikkoa, ohituslinkkiä tai maamerkin aluetta"
@@ -102,7 +102,7 @@
     "message": "Sivu sisältää otsikon, ohituslinkin tai maamerkin alueen"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Alhaisen kontrastin teksti on monelle vaikea tai mahdoton lukea. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Alhaisen kontrastin teksti on monelle vaikea tai mahdoton lukea. [Lue lisää](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Taustan ja etualan värien kontrastisuhde ei ole riittävä."
@@ -111,88 +111,88 @@
     "message": "Taustan ja etualan värien kontrastisuhde on riittävä"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Kun määritelmäluetteloita ei ole merkitty kunnolla, näytönlukuohjelmien tuottama sisältö voi olla sekavaa tai epätarkkaa. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Kun määritelmäluetteloita ei ole merkitty kunnolla, näytönlukuohjelmien tuottama sisältö voi olla sekavaa tai epätarkkaa. [Lue lisää](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "(<dl>)-elementit eivät sisällä vain oikein järjestettyjä <dt>- ja <dd>-ryhmiä ja <script>- tai <template>-elementtejä."
+    "message": "`<dl>`-elementit eivät sisällä vain oikein järjestettyjä `<dt>`- ja `<dd>`-ryhmiä ja `<script>`- tai `<template>`-elementtejä"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "<dl>-elementit sisältävät vain oikein järjestettyjä <dt>- ja <dd>-ryhmiä ja <script>- tai <template>-elementtejä."
+    "message": "`<dl>`-elementit sisältävät vain oikein järjestettyjä `<dt>`- ja `<dd>`-ryhmiä ja `<script>`- tai `<template>`-elementtejä"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Määritelmien luettelokohdat (<dt> ja <dd>) on yhdistettävä ylätason <dl>-elementtiin, jotta näytönlukuohjelmat voivat varmasti lukea ne oikein. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Määritelmien luettelokohdat (`<dt>` ja `<dd>`) on yhdistettävä ylätason `<dl>`-elementtiin, jotta näytönlukuohjelmat voivat varmasti lukea ne oikein. [Lue lisää](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Määritelmien luettelokohtia ei ole yhdistetty <dl>-elementeillä"
+    "message": "Määritelmien luettelokohtia ei ole yhdistetty `<dl>`-elementeillä"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Määritelmien luettelokohdat on yhdistetty <dl>-elementteihin"
+    "message": "Määritelmien luettelokohdat on yhdistetty `<dl>`-elementeillä"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Nimi antaa näytönlukuohjelmaa käyttäville yleiskuvan sivusta, ja hakukoneen käyttäjille nimi on tärkeä oleellisten sivujen löytämiseen hakutuloksista. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Nimi antaa näytönlukuohjelmaa käyttäville yleiskuvan sivusta, ja hakukoneen käyttäjille nimi on tärkeä oleellisten sivujen löytämiseen hakutuloksista. [Lue lisää](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokumentissa ei ole <title>-elementtiä"
+    "message": "Dokumentissa ei ole `<title>`-elementtiä"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokumentissa on <title>-elementti"
+    "message": "Dokumentissa on `<title>`-elementti"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Tunnusmääritteen arvon on oltava yksilöllinen, jotta avustustekniikat eivät jätä muita esiintymiä huomioimatta. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Tunnusmääritteen arvon on oltava yksilöllinen, jotta avustustekniikat eivät jätä muita esiintymiä huomioimatta. [Lue lisää](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Sivulla olevat [id]-määritteet eivät ole yksilöllisiä"
+    "message": "Sivulla olevat `[id]`-määritteet eivät ole yksilöllisiä"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Sivulla olevat [id]-määritteet ovat yksilöllisiä"
+    "message": "Sivulla olevat `[id]`-määritteet ovat yksilöllisiä"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Näytönlukuohjelman käyttäjät saavat tietää kehysten sisällöt vain kehysten nimien avulla. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Näytönlukuohjelman käyttäjät saavat tietää kehysten sisällöt vain kehysten nimien avulla. [Lue lisää](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "<frame>- tai <iframe>-elementillä ei ole nimeä"
+    "message": "`<frame>`- tai `<iframe>`-elementeillä ei ole nimeä"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "<frame>- tai <iframe>-elementeillä on nimi"
+    "message": "`<frame>`- tai `<iframe>`-elementeillä on nimi"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Jos sivulla ei ole kielimääritettä, näytönlukuohjelma arvioi kieleksi oletuskielen, jonka käyttäjä valitsi ottaessaan näytönlukuohjelman käyttöön. Jos oletuskieli ei ole käytössä sivulla, näytönlukuohjelma voi ilmoittaa sivun tekstin väärin. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Jos sivulla ei ole kielimääritettä, näytönlukuohjelma arvioi kieleksi oletuskielen, jonka käyttäjä valitsi ottaessaan näytönlukuohjelman käyttöön. Jos oletuskieli ei ole käytössä sivulla, näytönlukuohjelma voi ilmoittaa sivun tekstin väärin. [Lue lisää](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "<html>-elementissä ei ole [lang]-määritettä"
+    "message": "`<html>`-elementissä ei ole `[lang]`-määritettä"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "<html>-elementissä on [lang]-määrite"
+    "message": "`<html>`-elementissä on `[lang]`-määrite"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Kelvollisen [BCP 47 language] ‑määritteen (https://www.w3.org/International/questions/qa-choosing-language-tags#question) antaminen elementeille auttaa näytönlukuohjelmaa kertomaan tekstin oikein. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Kelvollisen [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ‑määritteen ilmoittaminen elementeille auttaa näytönlukuohjelmaa kertomaan tekstin oikein. [Lue lisää](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "<html>-elementissä ei ole kelvollista arvoa [lang]-määritteelle."
+    "message": "`<html>`-elementin `[lang]`-määritteen arvo ei ole kelvollinen"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "<html>-elementin [lang]-määritteen arvo on kelvollinen"
+    "message": "`<html>`-elementin `[lang]`-määritteen arvo on kelvollinen"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informatiivisilla elementeillä pitäisi olla lyhyt ja kuvaileva vaihtoehtoinen teksti. Koristeelliset elementit voidaan ohittaa tyhjällä Alt-määritteellä. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informatiivisilla elementeillä pitäisi olla lyhyt ja kuvaileva vaihtoehtoinen teksti. Koristeelliset elementit voidaan ohittaa tyhjällä Alt-määritteellä. [Lue lisää](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Kuvaelementeillä ei ole [alt]-määritteitä"
+    "message": "Kuvaelementeillä ei ole `[alt]`-määritteitä"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Kuvaelementeillä on [alt]-määritteet"
+    "message": "Kuvaelementeillä on `[alt]`-määritteet"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Kun <input>-painikkeena käytetään kuvaa, vaihtoehtoisen tekstin lisääminen voi auttaa näytönlukuohjelman käyttäjiä ymmärtämään painikkeen tarkoituksen. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Kun `<input>`-painikkeena käytetään kuvaa, vaihtoehtoisen tekstin lisääminen voi auttaa näytönlukuohjelman käyttäjiä ymmärtämään painikkeen tarkoituksen. [Lue lisää](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "<input type=\"image\">-elementeillä ei ole [alt]-tekstiä"
+    "message": "`<input type=\"image\">`-elementeissä ei ole `[alt]`-tekstiä"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "<input type=\"image\">-elementeillä on [alt]-tekstit"
+    "message": "`<input type=\"image\">`-elementeissä on `[alt]`-teksti"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Tunnisteilla varmistetaan, että avustustekniikat (kuten näytönlukuohjelmat) ilmoittavat lomakkeiden ohjaimista oikein. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Tunnisteilla varmistetaan, että avustustekniikat (kuten näytönlukuohjelmat) ilmoittavat lomakkeiden ohjaimista oikein. [Lue lisää](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Lomakkeiden elementeillä ei ole niihin liittyviä tunnisteita"
@@ -201,16 +201,16 @@
     "message": "Lomake-elementeillä on niihin liittyvät tunnisteet"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Asettelua varten luodussa taulukossa ei pitäisi olla dataelementtejä, kuten taulukoiden otsikko ‑elementtejä, tekstityselementtejä tai yhteenvetomääritteitä, koska ne voivat tehdä näytönlukuohjelman käytöstä sekavaa. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Asettelua varten luodussa taulukossa ei pitäisi olla dataelementtejä, kuten taulukoiden otsikko ‑elementtejä, tekstityselementtejä tai yhteenvetomääritteitä, koska ne voivat tehdä näytönlukuohjelman käytöstä sekavaa. [Lue lisää](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Esittelyyn tarkoitetut <table>-elementit eivät vältä <th>- tai <caption>-elementtien tai [summary]-määritteiden käyttöä."
+    "message": "Esittelyyn tarkoitetut `<table>`-elementit eivät vältä `<th>`-,`<caption>`- tai `[summary]`-määritteen käyttöä"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Esittelyyn tarkoitetut <table>-elementit välttävät <th>- tai <caption>-elementtien tai [summary]-määritteiden käyttöä."
+    "message": "Esittelyyn tarkoitetut `<table>`-elementit välttävät `<th>`-,`<caption>`- tai `[summary]`-määritteiden käyttöä"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Linkkiteksti (ja vaihtoehtoinen teksti kuvia varten, kun niitä käytetään linkkeinä), joka on erottuva, yksilöllinen ja tarkennettavissa, parantaa näytönlukuohjelmaa käyttävien navigointikokemusta. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Linkkiteksti (ja vaihtoehtoinen teksti kuvia varten, kun niitä käytetään linkkeinä), joka on erottuva, yksilöllinen ja tarkennettavissa, parantaa näytönlukuohjelmaa käyttävien navigointikokemusta. [Lue lisää](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Linkkien nimet eivät ole helposti erottuvia"
@@ -219,103 +219,115 @@
     "message": "Linkkien nimet ovat helposti erottuvia"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Näytönlukuohjelmat ilmoittavat luettelot tietyillä tavoilla. Kelvollinen luettelorakenne tukee näytönlukuohjelman tuottamaa sisältöä. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Näytönlukuohjelmat ilmoittavat luettelot tietyillä tavoilla. Kelvollinen luettelorakenne tukee näytönlukuohjelman tuottamaa sisältöä. [Lue lisää](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Luettelot eivät sisällä ainoastaan <li>-elementtejä ja skriptiä tukevia elementtejä (<script> ja <template>)."
+    "message": "Luettelot eivät sisällä ainoastaan `<li>`-elementtejä ja skriptiä tukevia elementtejä (`<script>` ja `<template>`)"
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Luettelot sisältävät ainoastaan <li>-elementtejä ja skriptiä tukevia elementtejä (<script> ja <template>)."
+    "message": "Luettelot sisältävät ainoastaan `<li>`-elementtejä ja skriptiä tukevia elementtejä (`<script>` ja `<template>`)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Näytönlukuohjelmat edellyttävät, että luettelokohdat (<li>) sisältyvät ylätason elementteihin <ul> tai <ol>, jotta ne voidaan ilmoittaa oikein. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Näytönlukuohjelmat edellyttävät, että luettelokohdat (`<li>`) sisältyvät ylätason elementteihin `<ul>` tai `<ol>`, jotta ne voidaan ilmoittaa oikein. [Lue lisää](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Luettelokohdat (<li>) eivät sisälly ylätason elementteihin <ul> tai <ol>."
+    "message": "Luettelokohteet (`<li>`) eivät sisälly ylätason `<ul>`- tai `<ol>`-elementtiin"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Luettelokohdat (<li>) sisältyvät ylätason elementteihin <ul> tai <ol>"
+    "message": "Luettelokohdat (`<li>`) sisältyvät ylätason elementteihin `<ul>` tai `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Käyttäjät eivät odota sivun päivittyvän automaattisesti, ja päivittäminen siirtää kohdistuksen takaisin sivun yläreunaan. Tämä voi tehdä käytöstä turhauttavaa tai sekavaa. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Käyttäjät eivät odota sivun päivittyvän automaattisesti, ja päivittäminen siirtää kohdistuksen takaisin sivun yläreunaan. Tämä voi tehdä käytöstä turhauttavaa tai sekavaa. [Lue lisää](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokumentissa on käytössä <meta http-equiv=\"refresh\">"
+    "message": "Dokumentissa on käytössä `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "<meta http-equiv=\"refresh\"> ei ole käytössä dokumentissa"
+    "message": "Dokumentti ei käytä `<meta http-equiv=\"refresh\">`-tagia"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Zoomauksen poistaminen käytöstä aiheuttaa ongelmia heikkonäköisille käyttäjille, jotka tarvitsevat näytön suurennusta nähdäkseen verkkosivun sisällön kunnolla. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Zoomauksen poistaminen käytöstä aiheuttaa ongelmia heikkonäköisille käyttäjille, jotka tarvitsevat näytön suurennusta nähdäkseen verkkosivun sisällön kunnolla. [Lue lisää](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "[user-scalable=\"no\"] on käytössä elementissä <meta name=\"viewport\"> tai [maximum-scale]-määrite on pienempi kuin 5."
+    "message": "`[user-scalable=\"no\"]` on käytössä `<meta name=\"viewport\">`-elementissä tai `[maximum-scale]`-määrite on pienempi kuin 5"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "[user-scalable=\"no\"] ei ole käytössä <meta name=\"viewport\">-elementissä ja [maximum-scale]-määrite on vähintään 5."
+    "message": "`[user-scalable=\"no\"]` ei ole käytössä `<meta name=\"viewport\">`-elementissä, ja `[maximum-scale]`-määrite on vähintään 5"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Näytönlukuohjelmat eivät voi kääntää sisältöä, joka ei ole tekstiä. Vaihtoehtoisen tekstin lisääminen <object>-elementteihin auttaa näytönlukuohjelmia esittämään sisällön merkityksen käyttäjille. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Näytönlukuohjelmat eivät voi kääntää sisältöä, joka ei ole tekstiä. Vaihtoehtoisen tekstin lisääminen `<object>`-elementteihin auttaa näytönlukuohjelmia esittämään sisällön merkityksen käyttäjille. [Lue lisää](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "<object>-elementeillä ei ole [alt]-tekstiä"
+    "message": "`<object>`-elementeissä ei ole `[alt]`-tekstiä"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "<object>-elementeillä on [alt]-tekstit"
+    "message": "`<object>`-elementeissä on `[alt]`-teksti"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Navigointijärjestys on eksplisiittinen, jos arvo on suurempi kuin 0. Vaikka ratkaisu on teknisesti käypä, se tekee usein kokemuksesta turhauttavan avustustekniikkaa tarvitseville käyttäjille. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Navigointijärjestys on eksplisiittinen, jos arvo on suurempi kuin 0. Vaikka ratkaisu on teknisesti käypä, se tekee usein kokemuksesta turhauttavan avustustekniikkaa tarvitseville käyttäjille. [Lue lisää](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Joidenkin elementtien [tabindex]-arvo on suurempi kuin 0"
+    "message": "Joidenkin elementtien `[tabindex]`-arvo on suurempi kuin 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Yhdenkään elementin [tabindex]-arvo ei ole suurempi kuin 0"
+    "message": "Yhdenkään elementin `[tabindex]`-arvo ei ole suurempi kuin 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Näytönlukuohjelmissa on ominaisuuksia, jotka tekevät taulukoissa siirtymisestä helpompaa. Voit parantaa näytönlukuohjelman käyttäjien kokemusta varmistamalla, että [headers]-määritettä käyttävät <td>-solut viittaavat vain toisiin soluihin samassa taulukossa. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Näytönlukuohjelmissa on ominaisuuksia, jotka tekevät taulukoissa siirtymisestä helpompaa. Voit parantaa näytönlukuohjelman käyttäjien kokemusta varmistamalla, että `[headers]`-määritettä käyttävät `<td>`-solut viittaavat vain toisiin soluihin samassa taulukossa. [Lue lisää](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "<table>-elementissä on soluja, joiden [headers]-määritteet viittaavat saman taulukon toisiin soluihin."
+    "message": "`<table>`-elementissä on soluja, joiden `[headers]`-määritteet viittaavat saman taulukon toisiin soluihin"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "[headers]-määritettä käyttävät <table>-elementin solut viittaavat vain toisiin soluihin samassa taulukossa."
+    "message": "`<table>`-määritettä käyttävät `[headers]`-elementin solut viittaavat vain toisiin soluihin samassa taulukossa"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Näytönlukuohjelmissa on ominaisuuksia, jotka tekevät taulukoissa siirtymisestä helpompaa. Voit parantaa näytönlukuohjelmaa käyttävien kokemusta varmistamalla, että taulukoiden otsikot viittaavat aina johonkin solujoukkoon. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Näytönlukuohjelmissa on ominaisuuksia, jotka tekevät taulukoissa siirtymisestä helpompaa. Voit parantaa näytönlukuohjelmaa käyttävien kokemusta varmistamalla, että taulukoiden otsikot viittaavat aina johonkin solujoukkoon. [Lue lisää](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "(<th>)-elementit ja elementit, joissa on [role=\"columnheader\"/\"rowheader\"], eivät sisällä niissä kuvattuja datasoluja"
+    "message": "`<th>`-elementit ja elementit, joissa on `[role=\"columnheader\"/\"rowheader\"]`, eivät sisällä niissä kuvattuja datasoluja"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "(<th>)-elementit ja elementit, joissa on [role=\"columnheader\"/\"rowheader\"], sisältävät niissä kuvatut datasolut."
+    "message": "`<th>`-elementit ja elementit, joissa on `[role=\"columnheader\"/\"rowheader\"]`, sisältävät niissä kuvatut datasolut"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Kelvollisen [BCP 47 language] ‑määritteen (https://www.w3.org/International/questions/qa-choosing-language-tags#question) antaminen elementeille auttaa varmistamaan, että näytönlukuohjelma ääntää tekstin oikein. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Kelvollisen [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ‑määritteen ilmoittaminen elementeille auttaa varmistamaan, että näytönlukuohjelma ääntää tekstin oikein. [Lue lisää](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "[lang]-määritteiden arvot eivät ole kelvollisia"
+    "message": "`[lang]`-määritteiden arvot eivät ole kelvollisia"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "[lang]-määritteiden arvot ovat kelvollisia"
+    "message": "`[lang]`-määritteillä on kelvollinen arvo"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Kun videossa on tekstitykset, kuurot ja heikkokuuloiset saavat videon tiedot paremmin. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Kun videossa on tekstitykset, kuurot ja heikkokuuloiset saavat videon tiedot paremmin. [Lue lisää](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "<video>-elementit eivät sisällä <track>-elementtiä, jossa on [kind=\"captions\"]."
+    "message": "`<video>`-elementit eivät sisällä `<track>`-elementtiä, jossa on `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "<video>-elementit sisältävät <track>-elementin, jossa on [kind=\"captions\"]"
+    "message": "`<video>`-elementit sisältävät `<track>`-elementin, jossa on `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Äänikuvaukset antavat videoista oleellista tietoa (esimerkiksi ilmeistä ja tapahtumapaikoista), jota ei saa keskustelusta. [Lue lisää](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Äänikuvaukset antavat videoista oleellista tietoa (esimerkiksi ilmeistä ja tapahtumapaikoista), jota ei saa keskustelusta. [Lue lisää](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "<video>-elementit eivät sisällä <track>-elementtiä, jossa on [kind=\"description\"]."
+    "message": "`<video>`-elementit eivät sisällä `<track>`-elementtiä, jossa on `[kind=\"description\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "<video>-elementit sisältävät <track>-elementin, jossa on [kind=\"description\"]"
+    "message": "`<video>`-elementit sisältävät `<track>`-elementin, jossa on `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Määritä apple-touch-icon, jotta se näkyy iOS:ssa parhaalla mahdollisella tavalla, kun käyttäjä lisää sen aloitusnäytölle. Sen on viitattava läpinäkymättömään neliön muotoiseen (192 px tai 180 px) PNG-tiedostoon. [Lue lisää](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Ei sisällä kelvollista `apple-touch-icon`-arvoa"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` on vanhentunut; `apple-touch-icon`-määritettä suositellaan."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Sisältää kelvollisen `apple-touch-icon`-määritteen"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chromen laajennukset heikensivät tämän sivun latausnopeutta. Yritä tarkastaa sivu incognito-tilassa tai Chrome-profiililla, johon ei ole lisätty laajennuksia."
@@ -330,7 +342,7 @@
     "message": "Prosessoriaika yhteensä"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Suosittelemme vähentämään JS:n jäsentämiseen, kääntämiseen ja suorittamiseen kuluvaa aikaa. Pienempien JS-resurssien jakeleminen voi helpottaa tätä. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Suosittelemme lyhentämään JS:n jäsentämiseen, kääntämiseen ja suorittamiseen kuluvaa aikaa. Pienempien JS-resurssien jakaminen voi helpottaa tätä. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Vähennä JavaScriptin suorittamiseen kuluvaa aikaa"
@@ -345,7 +357,7 @@
     "message": "Jakele animaatiosisältöä videomuodossa"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Suosittelemme lykkäämään poissa näkyvistä olevien ja piilotettujen kuvien lataamista, kunnes kaikki kriittiset resurssit on ladattu. Tämä lyhentää interaktiivisuutta edeltävää aikaa. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Suosittelemme lykkäämään poissa näkyvistä olevien ja piilotettujen kuvien lataamista, kunnes kaikki kriittiset resurssit on ladattu. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Lykkää kuvien lataamista, jos ne eivät ole näkyvissä"
@@ -411,7 +423,7 @@
     "message": "Koodaa kuvat tehokkaasti"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Näytä sopivan kokoisia kuvia, jotta voit pienentää mobiilidatan kulutusta ja latausaikoja. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Näytä sopivan kokoisia kuvia, jotta voit vähentää mobiilidatan kulutusta ja lyhentää latausaikoja. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Määritä kuvien koko oikein"
@@ -423,7 +435,7 @@
     "message": "Ota tekstin pakkaus käyttöön"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Kuvamuodot, kuten JPEG 2000, JPEG XR ja WebP, pakkaavat sisältöä usein paremmin kuin PNG tai JPEG, minkä vuoksi ne auttavat nopeuttamaan latauksia ja vähentämään datan kulutusta. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Tietyt kuvamuodot, kuten JPEG 2000, JPEG XR ja WebP, pakkaavat sisältöä usein paremmin kuin PNG tai JPEG, minkä vuoksi ne auttavat nopeuttamaan latauksia ja vähentämään datan kulutusta. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Jakele kuvat seuraavan sukupolven muodoissa"
@@ -436,6 +448,57 @@
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimoi kriittisten pyyntöjen syvyys"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Käytöstä poistaminen / varoitus"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Rivi"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Käytöstä poistetut käyttöliittymät poistetaan aikanaan selaimesta. [Lue lisää](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 varoitus löydetty}other{# varoitusta löydetty}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Käyttää käytöstä poistettuja sovellusliittymiä"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Välttää käytöstä poistettuja sovellusliittymiä"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Sovellusvälimuisti on poistettu käytöstä. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Löydetty {AppCacheManifest}"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Käyttää sovellusvälimuistia"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Välttää sovellusvälimuistia"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Dokumenttityypin määrittäminen estää selainta siirtymästä quirks-tilaan. Lue lisää [MDN Web Docs ‑sivulta](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Dokumenttityypin nimen on oltava pienillä kirjaimilla kirjoitettu merkkijono `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokumentin täytyy sisältää dokumenttityyppi"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Oletettu publicId-arvo on tyhjä merkkijono"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Oletettu systemId-arvo on tyhjä merkkijono"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Sivulta puuttuu HTML-tiedostotyyppi, mikä käynnistää quirks-tilan"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Sivulla on HTML-dokumenttityyppi"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elementti"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Välttää liian suurta DOM:ää"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Kohde"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Lisää ulkoisiin linkkeihin `rel=\"noopener\"` tai `rel=\"noreferrer\"` parantaaksesi tehokkuutta ja estääksesi tietoturvahaavoittuvuuksia. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Eri lähteisiin johtavat linkit eivät ole turvallisia"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Eri lähteisiin johtavat linkit ovat turvallisia"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Ankkurin ({anchorHTML}) kohteen määritys epäonnistui. Sinun kannattaa ehkä poistaa target=_blank, jos sitä ei käytetä linkkinä."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Sivustot, jotka pyytävät sijainnin käyttöoikeutta ilman asiayhteyttä, saavat käyttäjät epäluuloisiksi tai hämmentävät heitä. Kokeile sen sijaan yhdistää pyyntö käyttäjätoimintoon. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Pyytää maantieteellistä sijaintia sivun latauksessa"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Välttää maantieteellisen sijainnin pyytämistä sivun latauksessa"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versio"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Kaikki käyttöliittymän JavaScript-kirjastot havaittu sivulla."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Havaitut JavaScript-kirjastot"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Hitaiden yhteyksien käyttäjien kohdalla `document.write()`-komennolla dynaamisesti lisätyt ulkoiset skriptit voivat hidastaa sivun latausta kymmenillä sekunneilla. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "`document.write()` on käytössä"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Vältetty: `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Vakavin mahdollinen"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Kirjaston versio"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Haavoittuvuuksien määrä"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Jotkin kolmannen osapuolen skriptit voivat sisältää tunnettuja tietoturvahaavoittuvuuksia, joita hyökkääjien on helppo tunnistaa ja hyödyntää. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 haavoittuvuus havaittu}other{# haavoittuvuutta havaittu}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Sisältää käyttöliittymän JavaScript-kirjastot, joissa on tunnettuja tietoturvahaavoittuvuuksia"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Vakava"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Vähäinen"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Kohtalainen"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Välttää käyttöliittymän JavaScript-kirjastoja, joissa on tunnettuja tietoturvahaavoittuvuuksia"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Sivustot, jotka pyytävät lupaa ilmoitusten lähettämiseen ilman asiayhteyttä, saavat käyttäjät epäluuloisiksi tai hämmentävät heitä. Kokeile sen sijaan yhdistää pyyntö käyttäjäeleisiin. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Pyytää ilmoitusten käyttöoikeutta sivun latauksessa"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Välttää ilmoitusten käyttöoikeuden pyytämistä sivun latauksessa"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Hylätyt elementit"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Salasanan liittämisen estäminen on hyvän tietoturvakäytännön vastaista. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Estää käyttäjiä liittämästä sisältöä salasanakenttiin"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Sallii käyttäjien liittää sisältöä salasanakenttiin"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokolla"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 tarjoaa monia etuja HTTP/1.1:een verrattuna, mukaan lukien binaariotsikot, kanavoinnin ja palvelinkehotteet. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 pyyntöä ei tehty HTTP/2:n kautta}other{# pyyntöä ei tehty HTTP/2:n kautta}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Ei käytä HTTP/2:ta kaikille resursseille"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Käyttää HTTP/2:ta omille resursseilleen"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Sinun kannattaa ehkä merkitä kosketus- ja vieritystapahtumien seurainten arvoksi `passive` sivun vieritystoiminnan parantamiseksi. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Ei käytä passiivisia seuraimia vieritystoiminnan parantamiseen"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Käyttää passiivisia seuraimia vieritystoiminnan parantamiseen"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Kuvaus"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Konsoliin kirjatut virheet viittaavat ratkaisemattomiin ongelmiin. Ne ovat peräisin epäonnistuneista verkkopyynnöistä ja muista selainongelmista."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Selainvirheet kirjattiin konsoliin"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Konsoliin ei kirjattu selainvirheitä"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Käytä CSS:n kirjasimennäyttöominaisuutta, jotta voit varmistaa, että käyttäjä näkee tekstin myös verkkofonttien lataamisen aikana. [Lue lisää](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -475,6 +670,42 @@
   },
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Kaikki teksti pysyy näkyvissä verkkofontin lataamisen aikana"
+  },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse ei pystynyt tarkistamaan seuraavan URL-osoitteen kirjasimennäyttöarvoa automaattisesti: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Kuvasuhde (todellinen)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Kuvasuhde (näkyvä)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Kuvan mittasuhteiden tulisi täsmätä luonnolliseen kuvasuhteeseen. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Näytä kuvat, joiden kuvasuhde on virheellinen"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Näytä kuvat, joiden kuvasuhde on oikea"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Virheelliset kuvan kokotiedot: {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Suojaamaton URL-osoite"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Kaikki sivustot tulee suojata HTTPS:llä, myös ne, jotka eivät käsittele arkaluontoista dataa. HTTPS estää tunkeutujia peukaloimasta sovelluksesi ja sen käyttäjien välistä toimintaa tai seuraamasta sitä passiivisesti. HTTPS:ää edellytetään HTTP/2:ssa ja monien uusien verkkoalustojen käyttöliittymissä. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 suojaamaton pyyntö löytyi}other{# suojaamatonta pyyntöä löytyi}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Ei käytä HTTPS:ää"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Käyttää HTTPS:ää"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Nopea sivun lataus mobiiliverkon kautta varmistaa hyvän mobiilikäyttökokemuksen. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
@@ -510,7 +741,7 @@
     "message": "Arvioitu syöttöviive"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Ensimmäinen merkityksellinen piirtäminen kertoo, milloin sivun ensisijainen sisältö tulee näkyviin. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Ensimmäinen sisällön renderöinti kertoo, milloin ensimmäinen tekstikohde tai kuva renderöidään. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Ensimmäinen sisällön renderöinti"
@@ -534,16 +765,22 @@
     "message": "Interaktiivisuutta edeltävä aika"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Käyttäjiesi mahdollinen ensimmäisen syötteen viive (First Input Delay) on pisimmän tehtävän kesto millisekunneissa."
+    "message": "Käyttäjiesi suurin mahdollinen ensimmäisen toiminnon viive on pisimmän tehtävän kesto millisekunneissa. [Lue lisää](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Suurin mahdollinen FID"
+    "message": "Suurin mahdollinen ensimmäisen toiminnon viive"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Nopeusindeksi kertoo, kuinka nopeasti sivun sisältö tulee näkyviin. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Nopeusindeksi"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Kaikkien FCP:n ja interaktiivisuutta edeltävän ajan väliset ajanjaksot yhteenlaskettuna, kun tehtävän pituus on yli 50 ms (ilmoitettu millisekunteina)"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Estoaika yhteensä"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Verkon meno-paluuajoilla (RTT) on suuri vaikutus suorituskykyyn. Jos RTT lähtöpaikkaan on korkea, se on merkki siitä, että käyttäjää lähellä olevien palvelimien suorituskyvyssä on parantamisen varaa. [Lue lisää](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,11 +794,32 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Palvelimen taustaviiveet"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Ylittää budjetin"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Pidä verkkopyyntöjen määrä ja koko tehokkuusbudjetissa määritettyjen tavoitteiden rajoissa. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 pyyntö}other{# pyyntöä}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Tehokkuusbudjetti"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Uudellenohjaukset viivästyttävät sivun lataamista. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Uudelleenohjaukset viivästyttävät sivun lataamista. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Vältä useita uudelleenohjauksia"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Jos haluat asettaa sivuresurssien määrälle ja koolle budjetin, lisää budget.json-tiedosto. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 pyyntö}other{# pyyntöä}} • {byteCount, number, bytes} kt"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Pidä pyyntöjen määrät alhaisina ja siirtojen koot pieninä"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Ensisijaiset linkit ehdottavat, mitä URL-osoitteita näyttää hakutuloksissa. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
@@ -570,13 +828,13 @@
     "message": "Useita ristiriitaisia URL-osoitteita ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Osoittaa eri verkkotunnukseen ({url})"
+    "message": "Viittaa toiseen verkkotunnukseen ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Virheellinen URL-osoite ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Osoittaa toiseen hreflang-sijaintiin ({url})"
+    "message": "Viittaa toiseen `hreflang`-sijaintiin ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Suhteellinen URL-osoite ({url})"
@@ -585,19 +843,16 @@
     "message": "Osoittaa verkkotunnuksen juuri-URL-osoitteeseen (kotisivulle) sitä vastaavan sisältösivun sijaan"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokumentissa ei ole kelvollista rel=canonical-arvoa"
+    "message": "Dokumentissa ei ole kelvollista `rel=canonical`-määritettä"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokumentissa on kelvollinen rel=canonical-arvo"
+    "message": "Dokumentissa on kelvollinen `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Alle 12 pikselin kirjasinkoot ovat liian pieniä luettavaksi ja edellyttävät mobiilivierailijoiden zoomaavan nipistämällä voidakseen lukea. Pyri siihen, että >60 % sivun tekstistä on ≥12 px. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Alle 12 pikselin kirjasinkoot ovat liian pieniä luettavaksi ja edellyttävät mobiilivierailijoiden zoomaavan nipistämällä voidakseen lukea. Pyri siihen, että >60 % sivun tekstistä on ≥12 px. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} lukukelpoista tekstiä"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} tekstistä on liian pientä."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Teksti on lukukelvotonta, koska näkymän sisällönkuvauskenttää ei ole optimoitu mobiilinäytöille."
@@ -615,10 +870,10 @@
     "message": "hreflang-linkit kertovat hakukoneille, mikä sivuversio niiden pitäisi lisätä tietyn kielen tai alueen hakutuloksiin. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokumentissa ei ole kelvollista hreflang-elementtiä"
+    "message": "Dokumentissa ei ole kelvollista `hreflang`-elementtiä"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokumentissa on kelvollinen hreflang-elementti"
+    "message": "Dokumentissa on kelvollinen `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Epäonnistuneita HTTP-tilakoodeja sisältäviä sivuja ei välttämättä indeksoida oikein. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Päällekkäinen kohde"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Koko"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Napautuskohde"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Napautuskohteet ovat sopivan kokoisia"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Pääsäikeen aika"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Kolmas osapuoli"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Kolmannen osapuolen koodi voi vaikuttaa lataustehokkuuteen merkittävästi. Rajoita tarpeettomien kolmannen osapuolen palveluntarjoajien määrää ja yritä ladata kolmannen osapuolen koodi sen jälkeen, kun sivun ensisijainen lataus on valmis. [Lue lisää](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 kolmas osapuoli löytyi}other{# kolmatta osapuolta löytyi}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Kolmannen osapuolen käyttö"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Ensimmäistä tavua edeltävä aika kertoo, kuinka kauan kestää, ennen kuin palvelimesi lähettää vastauksen. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Kesto"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nimi"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Aloitusaika"
   },
@@ -744,7 +1008,7 @@
     "message": "Tyyppi"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Suosittelemme käyttämään sovelluksen kehittämisessä User Timing ‑sovellusliittymää mittaamaan todellista toimivuutta tärkeiden käyttökokemuksien aikana. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Suosittelemme käyttämään sovelluksen kehittämisessä User Timing ‑sovellusliittymää mittaamaan todellista toimivuutta tärkeiden käyttökokemusten aikana. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 käyttäjän ajankäyttömerkintä}other{# käyttäjän ajankäyttömerkintää}}"
@@ -753,7 +1017,7 @@
     "message": "User Timing ‑merkinnät ja ‑mitat"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Yhteyttä edeltävä linkki (<link>) löytyi osoitteelle {securityOrigin}, mutta selain ei käyttänyt sitä. Varmista, että käytät eri lähteiden määritettä oikein."
+    "message": "Yhteyttä edeltävä linkki (<link>) löytyi osoitteelle {securityOrigin}, mutta selain ei käyttänyt sitä. Varmista, että käytät eri lähteiden `crossorigin`-määritettä oikein."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Suosittelemme lisäämään sivulle yhteyttä tai DNS:n noutamista edeltäviä resurssivihjeitä, joiden avulla yhteydet tärkeisiin kolmannen osapuolen kohteisiin voidaan muodostaa etukäteen. [Lue lisää](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Muodosta yhteydet pakollisiin kohteisiin etukäteen"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Esilatauslinkki <link> löytyi osoitteelle {preloadURL}, mutta selain ei käyttänyt sitä. Varmista, että käytät eri lähteiden määritettä oikein."
+    "message": "Esilatauslinkki <link> löytyi osoitteelle {preloadURL}, mutta selain ei käyttänyt sitä. Varmista, että käytät eri lähteiden `crossorigin`-määritettä oikein."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Suosittelemme käyttämään <link rel=preload>-tagia, jotta voit priorisoida resursseja, joiden noutamista pyydetään sivun lataamisen myöhemmässä vaiheessa. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Suosittelemme käyttämään `<link rel=preload>`-tagia, jotta voit priorisoida resursseja, joiden noutamista pyydetään sivun lataamisen myöhemmässä vaiheessa. [Lue lisää](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Lataa tärkeät pyynnöt etukäteen"
@@ -792,7 +1056,7 @@
     "message": "Nämä tarkistukset tuovat esiin kohtia, joissa voit [parantaa verkkosovelluksesi esteettömyyttä](https://developers.google.com/web/fundamentals/accessibility). Vain pieni joukko esteettömyysongelmia voidaan havaita automaattisesti, joten myös manuaalista testaamista suositellaan."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Nämä kohteet koskevat alueita, joita automaattinen testaustyökalu ei voi testata. Lue lisää [esteettömyystarkistuksen tekemisen] oppaastamme (https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Nämä kohteet koskevat alueita, joita automaattinen testaustyökalu ei voi testata. Lue lisää [esteettömyystarkistuksen tekemisen](https://developers.google.com/web/fundamentals/accessibility/how-to-review) oppaastamme."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Esteettömyys"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Taulukot ja luettelot"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Parhaat käytännöt"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Tehokkuusbudjetit määrittävät sivuston tehokkuuden standardit."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budjetit"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Lisätietoja sovelluksen toiminnasta"
+    "message": "Lisätietoja sovelluksen toiminnasta. Luvut eivät [suoraan vaikuta](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) tehokkuusprosenttiin."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostiikka"
@@ -840,7 +1113,7 @@
     "message": "Ensimmäistä renderöintiä koskevat parannusehdotukset"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Nämä optimointikeinot voivat nopeuttaa sivun lataamista."
+    "message": "Nämä ehdotukset voivat auttaa sivua latautumaan nopeammin. Ne eivät [suoraan vaikuta](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) tehokkuusprosenttiin."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Suositukset"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Välimuistin käyttöikä"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Sijainti"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nimi"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Pyynnöt"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Resurssin tyyppi"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Koko (kt)"
+    "message": "Koko"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Käytetty aika"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Siirron koko"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL-osoite"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potentiaalinen säästö (kt)"
+    "message": "Potentiaalinen säästö"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potentiaalinen säästö (ms)"
+    "message": "Potentiaalinen säästö"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Potentiaalinen säästö: {wastedBytes, number, bytes} kt"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Potentiaalinen säästö: {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokumentti"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Kirjasin"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Kuva"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Media"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Muu"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skripti"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Tyylisivu"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Kolmas osapuoli"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Yhteensä"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Sivun lataamisen jäljen tallennuksessa tapahtui virhe. Suorita Lighthouse uudelleen. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS-palvelimet eivät voineet ratkaista verkkotunnusta."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Vaadittu {artifactName}-keräystoiminto kohtasi virheen: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Tapahtui sisäinen Chrome-virhe. Käynnistä Chrome uudelleen ja yritä suorittaa Lighthouse sen jälkeen."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Vaadittua {artifactName}-keräystoimintoa ei suoritettu."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse ei pystynyt lataamaan pyytämääsi sivua luotettavasti. Varmista, että testaat oikeaa URL-osoitetta ja että palvelin vastaa kunnolla kaikkiin pyyntöihin."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse ei pystynyt lataamaan pyytämääsi URL-osoitetta luotettavasti, koska sivu lakkasi vastaamasta."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Kirjoittamasi URL-osoitteen tunnistetiedot eivät ole kelvolliset. {securityMessages}"
+    "message": "Ilmoittamasi URL-osoitteen suojausvarmenne ei ole kelvollinen. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome esti sivun lataamisen välimainoksella. Varmista, että testaat oikeaa URL-osoitetta ja että palvelin vastaa kunnolla kaikkiin pyyntöihin."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse ei pystynyt lataamaan pyytämääsi sivua luotettavasti. Varmista, että testaat oikeaa URL-osoitetta ja että palvelin vastaa kunnolla kaikkiin pyyntöihin. (Tiedot: {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Laajenna koodinpätkä"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Näytä kolmannen osapuolen resurssit"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Lighthousen suorituksessa havaittiin ongelmia:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Arvot ovat arvioita ja voivat vaihdella."
+    "message": "Arvot ovat arvioita ja voivat vaihdella. Tehokkuusprosentti [perustuu vain näihin mittareihin](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Läpäisi tarkastukset, mutta sai varoituksia"
@@ -1023,10 +1350,10 @@
     "message": "GIF kannattaa ehkä ladata palveluun, jonka avulla se voidaan upottaa HTML5-videona."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Asenna [WordPressin lazy load ‑laajennus](https://wordpress.org/plugins/search/lazy+load/), joka lykkää näytöllä näkymättömien kuvien lataamista, tai vaihtaa teemaan, joka tarjoaa tämän ominaisuuden. Harkitse myös [AMP-laajennuksen] käyttöä (https://wordpress.org/plugins/amp/)."
+    "message": "Asenna [WordPressin lazy load ‑laajennus](https://wordpress.org/plugins/search/lazy+load/), joka lykkää näytöllä näkymättömien kuvien lataamista, tai vaihda teemaan, joka tarjoaa tämän ominaisuuden. Harkitse myös [AMP-laajennuksen](https://wordpress.org/plugins/amp/) käyttöä."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Monet WordPress-laajennukset voivat [tuoda tärkeää materiaalia sivun sisälle] (https://wordpress.org/plugins/search/critical+css/) tai [lykätä vähemmän tärkeiden resurssien lataamista](https://wordpress.org/plugins/search/defer+css+javascript/). Huomaa, että näiden laajennusten tuomat optimoinnit voivat rikkoa teeman tai laajennusten toimintoja, joten sinun on todennäköisesti muutettava koodia."
+    "message": "Monet WordPress-laajennukset voivat [tuoda tärkeää materiaalia sivun sisälle](https://wordpress.org/plugins/search/critical+css/) tai [lykätä vähemmän tärkeiden resurssien lataamista](https://wordpress.org/plugins/search/defer+css+javascript/). Huomaa, että näiden laajennusten tuomat optimoinnit voivat rikkoa teeman tai laajennusten toimintoja, joten sinun on todennäköisesti muutettava koodia."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Teemat, laajennukset ja palvelinasetukset vaikuttavat kaikki palvelimen vastausaikaan. Sinun kannattaa ehkä etsiä optimoidumpi teema, valita optimointilaajennus tai päivittää palvelimesi."
@@ -1041,10 +1368,10 @@
     "message": "Monet [WordPress-laajennukset](https://wordpress.org/plugins/search/minify+javascript/) voivat nopeuttaa sivustosi toimintaa yhdistämällä, kutistamalla ja pakkaamalla skriptejä. Tämä kutistaminen voidaan mahdollisesti tehdä jo aiemmin kehitysvaiheen prosessilla."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Sinun kannattaa ehkä poistaa tai vaihtaa toisiin [WordPress-laajennuksia](https://wordpress.org/plugins/), jotka lataavat sivulla käyttämätöntä CSS:ää. Etsi tarpeetonta CSS:ää lisääviä laajennuksia [tutkimalla koodin testikattavuutta] (https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) Chromen DevToolsissa. Löydät syynä olevan teeman tai laajennuksen tyylitiedoston URL-osoitteen avulla. Etsi laajennuksia, joilla on monia tyylitiedostoja luettelossa ja paljon punaista koodin testikattavuudessa. Laajennuksen pitäisi lisätä tyylitiedosto jonoon vain, jos sitä todella käytetään sivulla."
+    "message": "Sinun kannattaa ehkä poistaa tai vaihtaa toisiin [WordPress-laajennuksia](https://wordpress.org/plugins/), jotka lataavat sivulla käyttämätöntä CSS:ää. Etsi tarpeetonta CSS:ää lisääviä laajennuksia [tutkimalla koodin testikattavuutta](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) Chromen DevToolsissa. Löydät syynä olevan teeman tai laajennuksen tyylitiedoston URL-osoitteen avulla. Etsi laajennuksia, joilla on monia tyylitiedostoja luettelossa ja paljon punaista koodin testikattavuudessa. Laajennuksen pitäisi lisätä tyylitiedosto jonoon vain, jos sitä todella käytetään sivulla."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Sinun kannattaa ehkä poistaa tai vaihtaa toisiin [WordPress-laajennuksia](https://wordpress.org/plugins/), jotka lataavat sivulla käyttämätöntä JavaScriptiä. Etsi tarpeetonta JS:ää lisääviä laajennuksia [tutkimalla koodin testikattavuutta] (https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) Chromen DevToolsissa. Löydät syynä olevan teeman tai laajennuksen skriptin URL-osoitteen avulla. Etsi laajennuksia, joilla on monia skriptejä luettelossa ja paljon punaista koodin testikattavuudessa. Laajennuksen pitäisi lisätä skripti jonoon vain, jos sitä todella käytetään sivulla."
+    "message": "Sinun kannattaa ehkä poistaa tai vaihtaa toisiin [WordPress-laajennuksia](https://wordpress.org/plugins/), jotka lataavat sivulla käyttämätöntä JavaScriptiä. Etsi tarpeetonta JS:ää lisääviä laajennuksia [tutkimalla koodin testikattavuutta](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) Chromen DevToolsissa. Löydät syynä olevan teeman tai laajennuksen skriptin URL-osoitteen avulla. Etsi laajennuksia, joilla on monia skriptejä luettelossa ja paljon punaista koodin testikattavuudessa. Laajennuksen pitäisi lisätä skripti jonoon vain, jos sitä todella käytetään sivulla."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Lue lisää [selaimen välimuistin käytöstä WordPressissä](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
@@ -1053,7 +1380,7 @@
     "message": "Harkitse [WordPressin kuvaoptimointilaajennusta](https://wordpress.org/plugins/search/optimize+images/), joka pakkaa kuvat mutta säilyttää niiden laadun."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Lataa kuvat suoraan [mediakirjastosta](https://codex.wordpress.org/Media_Library_Screen), jolloin oikeat kuvakoot ovat varmasti saatavilla, ja lisää ne kuvakirjastosta tai varmista oikeiden kuvakokojen käyttö kuva-widgetillä (myös responsiivisuuden raja-arvojen kohdalla). Älä käytä täysikokoisia kuvia, paitsi jos sivun koko on riittävä. [Lue lisää](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Lataa kuvat suoraan [mediakirjastosta](https://codex.wordpress.org/Media_Library_Screen), jolloin oikeat kuvakoot ovat varmasti saatavilla, ja lisää ne kuvakirjastosta tai varmista oikeiden kuvakokojen käyttö kuva-widgetillä (myös responsiivisuuden raja-arvojen kohdalla). Älä käytä kuvia, joiden koko on `Full Size`, paitsi jos sivun koko on riittävä. [Lue lisää](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Voit ottaa tekstin pakkaamisen käyttöön palvelimen määrityksistä."

--- a/lighthouse-core/lib/i18n/locales/fil.json
+++ b/lighthouse-core/lib/i18n/locales/fil.json
@@ -1,51 +1,51 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Hinahayaan ng mga access key ang mga user na mabilis na makatuon sa isang bahagi ng page. Para sa maayos na navigation, natatangi dapat ang bawat access key. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Hinahayaan ng mga access key ang mga user na mabilis na makatuon sa isang bahagi ng page. Para sa maayos na navigation, natatangi dapat ang bawat access key. [Matuto pa](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Hindi natatangi ang mga value ng `[accesskey]`"
+    "message": "Hindi natatangi ang mga value na `[accesskey]`"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
     "message": "Natatangi ang mga value ng `[accesskey]`"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Sumusuporta ang bawat `role` ng ARIA sa isang partikular na subset ng attribute na `aria-*.` Kapag hindi tumugma ang mga ito, magiging invalid ang mga attribute na `aria-*.` [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Sinusuportahan ng bawat `role` ng ARIA ang isang partikular na subset ng mga attribute na `aria-*`. Kapag hindi pinagtugma ang mga ito, magiging invalid ang mga attribute na `aria-*`. [Matuto pa](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Hindi tumutugma ang mga attribute na`[aria-*]` sa mga tungkulin ng mga ito"
+    "message": "Hindi tumutugma ang mga attribute na `[aria-*]` sa mga tungkulin ng mga ito"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
     "message": "Tumutugma ang mga attribute na `[aria-*]` sa mga tungkulin ng mga ito"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Ang ilang tungkulin ng ARIA ay may mga kinakailangang attribute na naglalarawan sa status ng element sa mga screen reader. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Ang ilang tungkulin ng ARIA ay may mga kinakailangang attribute na naglalarawan sa status ng element sa mga screen reader. [Matuto pa](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
     "message": "May mga kulang na kinakailangang attribute na `[aria-*]` ang mga `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Mayroon ng lahat ng kinakailangang attribute na `[aria-*]` ang mga `[role]"
+    "message": "Mayroon ng lahat ng kinakailangang attribute na `[aria-*]` ang mga `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Ang ilang pangunahing tungkulin ng ARIA ay dapat maglaman ng mga partikular na pangalawang tungkulin para maisagawa ang mga nilalayong function ng pagiging accessible ng mga ito. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Dapat maglaman ang ilang parent role ng ARIA ng mga partikular na child role para maisagawa nito ang mga nilalayong function sa pagiging accessible. [Matuto pa](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Kulang ng mga element na may `[role]` na nangangailangan ng mga partikular na pangalawang `[role].`"
+    "message": "Nawawala ang mga element na may `[role]` na nangangailangan ng mga partikular na child `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "May mga umiiral na element na may `[role]` na nangangailangan ng mga partikular na pangalawang `[role]`"
+    "message": "May mga element na may `[role]` na nangangailangan ng mga partikular na child `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Ang ilang pangalawang tungkulin ng ARIA ay laman dapat ng mga partikular na pangunahing tungkulin para maayos na maisagawa ang mga nilalayong function ng pagiging accessible ng mga ito. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Ang ilang child role ng ARIA ay laman dapat ng mga partikular na parent role para maayos na maisagawa ang mga nilalayong function sa pagiging accessible. [Matuto pa](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Hindi nakapaloob ang mga `[role]` sa kinakailangang pangunahing element ng mga ito"
+    "message": "Hindi nakapaloob ang mga `[role]` sa kinakailangang parent element ng mga ito"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Ang mga `[role]` ay nasa loob ng kailangang pangunahing element ng mga ito"
+    "message": "Nakapaloob ang mga `[role]` sa kinakailangang pangunahing element ng mga ito"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Dapat ay may mga valid na value ang mga tungkulin ng ARIA para maisagawa ang mga nilalayong function ng pagiging accessible ng mga ito. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Dapat ay may mga valid na value ang mga tungkulin ng ARIA para maisagawa ang mga nilalayong function sa pagiging accessible. [Matuto pa](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
     "message": "Hindi valid ang mga value ng `[role]`"
@@ -54,37 +54,37 @@
     "message": "Valid ang mga value ng `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Hindi mauunawaan ng mga nakakatulong na teknolohiya, gaya ng mga screen reader, ang mga attribute ng ARIA na may mga invalid na value. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Hindi mauunawaan ng mga nakakatulong na teknolohiya, gaya ng mga screen reader, ang mga attribute ng ARIA na may mga invalid na value. [Matuto pa](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Walang valid na value ang mga attribute na `[aria-*]`"
+    "message": "Walang valid na value ang mga attribute na`[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Mga mga valid na value ang mga attribute na `[aria-*]`"
+    "message": "May valid na value ang mga attribute na `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Hindi mauunawaan ng mga nakakatulong na teknolohiya, gaya ng mga screen reader, ang mga attribute ng ARIA na may mga invalid na pangalan. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Hindi mauunawaan ng mga nakakatulong na teknolohiya, gaya ng mga screen reader, ang mga attribute ng ARIA na may mga invalid na pangalan. [Matuto pa](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Hindi valid o mali ang spelling ng mga attribute na `[aria-*]`"
+    "message": "Hindi valid o hindi mali ang spelling ng mga attribute na `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
     "message": "Valid at hindi mali ang spelling ng mga attribute na `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Dahil sa mga caption, nagagamit ng mga user na bingi o may problema sa pandinig ang mga element ng audio, na nagbibigay ng napakahalagang impormasyon gaya ng kung sino ang nagsasalita, ano ang sinasabi nila, at iba pang hindi sinasalitang impormasyon. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Ginagawang kapaki-pakinabang ng mga caption ang mga element ng audio para sa mga user na bingi o may problema sa pandinig, nagbibigay ng mahalagang impormasyon gaya ng kung sino ang nagsasalita, ano ang kanilang sinasabi, at iba pang hindi binibigkas na impormasyon. [Matuto pa](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Ang mga element na `<audio>` ay kulang ng element na `<track>` na may `[kind=\"captions\"].`"
+    "message": "May kulang na element na `<track>` na may `[kind=\"captions\"]` ang mga element na `<audio>`"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Naglalaman ang mga element na `<audio>` ng element na `<track>` na may `[kind=\"captions\"]`"
+    "message": "Naglalaman ng element na `<track>` na may `[kind=\"captions\"]` ang mga element na `<audio>`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Mga Hindi Nakapasang Element"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Kapag walang naa-access na pangalan ang isang button, iaanunsyo ito ng mga screen reader bilang \"button,\" kaya naman hindi ito magagamit ng mga user na umaasa sa mga screen reader. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Kapag walang naa-access na pangalan ang isang button, iaanunsyo ito ng mga screen reader bilang \"button,\" kaya naman hindi ito magagamit ng mga user na umaasa sa mga screen reader. [Matuto pa](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Walang naa-access na pangalan ang mga button"
@@ -93,7 +93,7 @@
     "message": "May naa-access na pangalan ang mga button"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Kapag nagdagdag ng mga paraan para i-bypass ang paulit-ulit na content, mas madaling makakapag-navigate sa page ang mga user ng keyboard. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Kapag nagdagdag ng mga paraan para i-bypass ang paulit-ulit na content, mas madaling makakapag-navigate sa page ang mga user ng keyboard. [Matuto pa](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Walang heading, link ng paglaktaw, o rehiyon ng landmark ang page"
@@ -102,7 +102,7 @@
     "message": "Ang page ay naglalaman ng heading, link ng paglaktaw, o rehiyon ng landmark"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Mahirap o imposibleng basahin para sa maraming user ang text na mababa ang contrast. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Mahirap o imposibleng mabasa ng maraming user ang text na mababa ang contrast. [Matuto pa](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Kulang ang ratio ng contrast ng mga kulay ng background at foreground."
@@ -111,79 +111,79 @@
     "message": "May sapat na ratio ng contrast ang mga kulay ng background at foreground"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Kapag hindi naka-mark up nang maayos ang mga listahan ng kahulugan, puwedeng gumawa ng nakakalito o hindi tumpak na output ang mga screen reader. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Kapag hindi naka-mark up nang maayos ang mga listahan ng kahulugan, puwedeng gumawa ng nakakalito o hindi tumpak na output ang mga screen reader. [Matuto pa](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Hindi naglalaman ang mga `<dl>` ng mga nakaayos lang na pangkat na `<dt>` at `<dd>,` at mga element na `<script>` o `<template>.`"
+    "message": "Hindi naglalaman ang `<dl>` ng mga nakaayos lang na pangkat na `<dt>` at `<dd>`, mga element na `<script>` o `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Naglalaman lang ang mga `<dl>` ng mga nakaayos na pangkat na `<dt>` at `<dd>,` at mga element na `<script>` o `<template>.`"
+    "message": "Naglalaman ang `<dl>` ng mga nakaayos lang na `<dt>` at mga `<dd>` na pangkat, `<script>` o mga `<template>` na element."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Nakapaloob dapat ang mga item sa listahan ng kahulugan (`<dt>` at `<dd>`) sa isang pangunahing element na `<dl>` para matiyak na maayos na maiaanunsyo ng mga screen reader ang mga ito. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Nakapaloob dapat ang mga item sa listahan ng kahulugan (`<dt>` at `<dd>`) sa isang parent element na `<dl>` para matiyak na maayos na maiaanunsyo ng mga screen reader ang mga ito. [Matuto pa](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Hindi nakapaloob sa mga element na`<dl>` ang mga item sa listahan ng kahulugan"
+    "message": "Hindi nakapaloob sa mga element na `<dl>` ang mga item sa listahan ng kahulugan"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
     "message": "Nakapaloob sa mga element na `<dl>` ang mga item sa listahan ng kahulugan"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Binibigyan ng pamagat ang mga user ng screen reader ng pangkalahatang-ideya ng page, at lubos na umaasa ang mga user ng search engine dito para matukoy kung may kaugnayan ang isang page sa kanilang paghahanap. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Binibigyan ng pamagat ang mga user ng screen reader ng pangkalahatang-ideya ng page, at lubos na umaasa rito ang mga user ng search engine para matukoy kung may kaugnayan ang isang page sa kanilang paghahanap. [Matuto pa](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Walang element na`<title>` ang dokumento"
+    "message": "Walang element na `<title>` ang dokumento"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "May element na `<title>` ang dokumento"
+    "message": "May `<title>` na element ang dokumento"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Natatangi dapat ang value ng isang id attribute para hindi makaligtaan ng mga nakakatulong na teknolohiya ang iba pang instance. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Natatangi dapat ang value ng id attribute para hindi makaligtaan ng mga nakakatulong na teknolohiya ang iba pang instance. [Matuto pa](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Hindi natatangi ang mga attribute na `[id]` sa page"
+    "message": "Hindi natatangi ang mga attribute na `[id]`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
     "message": "Natatangi ang mga attribute na `[id]` sa page"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Umaasa ang mga user ng screen reader sa mga pamagat ng frame para ilarawan ang mga content ng mga frame. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Umaasa ang mga user ng screen reader sa mga pamagat ng frame para ilarawan ang mga content ng mga frame. [Matuto pa](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "Walang pamagat ang mga element na`<frame>` o `<iframe>`"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "May pamagat ang mga elemento na `<frame>` o `<iframe>`"
+    "message": "May pamagat ang mga elemento na`<frame>` o `<iframe>`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Kung hindi tutukoy ng attribute na lang ang isang page, ipagpapalagay ng screen reader na ang page ay nasa default na wikang pinili ng user noong na-set up ang screen reader. Kung wala talaga sa default na wika ang page, baka hindi maianunsyo nang tama ng screen reader ang text ng page. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Kung hindi tutukoy ng lang attribute ang isang page, ipagpapalagay ng screen reader na ang page ay nasa default na wikang pinili ng user noong sine-set up ang screen reader. Kung wala talaga sa default na wika ang page, puwedeng hindi maianunsyo nang tama ng screen reader ang text ng page. [Matuto pa](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
     "message": "Walang attribute na `[lang]` ang element na `<html>`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "May attribute na `[lang]` ang element na `<html>`"
+    "message": "Ang `<html>` na element ay may attribute na `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Nakakatulong sa mga screen reader ang pagtukoy ng valid na [wika ng BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) na maianunsyo nang tama ang text. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ang pagtukoy ng valid na [wika ng BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ay nakakatulong na maianunsyo nang maayos ang text. [Matuto pa](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Walang valid na value ang element na `<html>` para sa attribute na `[lang]` nito."
+    "message": "Walang valid na value ang element na `<html>` para sa attribute nitong `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "May valid na value ang element na`<html>` para sa attribute na `[lang]` nito"
+    "message": "May valid na value ang element na `<html>` para sa `[lang]` na attribute nito"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Layunin dapat ng mga nagbibigay-impormasyong element na magkaroon ng maikli at naglalarawang alternatibong text. Puwedeng balewalain ang mga palamuting element sa pamamagitan ng walang lamang kahaliling attribute. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Layunin dapat ng mga nagbibigay-impormasyong element na magkaroon ng maikli at naglalarawang alternatibong text. Puwedeng balewalain ang mga palamuting element sa pamamagitan ng walang lamang kahaliling attribute. [Matuto pa](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
     "message": "Walang attribute na `[alt]` ang mga element ng larawan"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "May mga attribute na `[alt]` ang mga element ng larawan"
+    "message": "May mga attribute na `[alt]` ang mga element na larawan"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Kapag gumagamit ng larawan bilang button na `<input>,` makakatulong sa mga user ng screen reader ang pagbibigay ng alternatibong text na maunawaan kung para saan ang button. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Kapag gumagamit ng larawan bilang button na `<input>`, makakatulong sa mga user ng screen reader ang pagbibigay ng alternatibong text na maunawaan kung para saan ang button. [Matuto pa](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "Walang text na `[alt]` ang mga element na `<input type=\"image\">`"
@@ -192,7 +192,7 @@
     "message": "May text na `[alt]` ang mga element na `<input type=\"image\">`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Tinitiyak ng mga label na maayos na naiaanunsyo ng mga nakakatulong na teknolohiya, gaya ng mga screen reader, ang mga kontrol ng form. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Tinitiyak ng mga label na maayos na inaanunsyo ang mga kontrol ng form ng mga nakakatulong na teknolohiya, tulad ng mga screen reader. [Matuto pa](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Walang nauugnay na label ang mga element ng form"
@@ -201,16 +201,16 @@
     "message": "May mga nauugnay na label ang mga element ng form"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Ang isang talahanayang ginagamit para sa mga layunin ng layout ay wala dapat element ng data, gaya ng th o mga element ng caption o attribute ng buod, dahil puwede itong magdulot ng nakakalitong karanasan para sa mga user ng screen reader. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Dapat ay walang kasamang element ng data ang isang talahanayang ginagamit para sa mga layunin ng layout, gaya ng th o mga element ng caption o attribute ng buod, dahil puwede itong gumawa ng nakakalitong karanasan para sa mga user ng screen reader. [Matuto pa](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Hindi iniiwasan ng mga pang-presentation na element na `<table>` ang paggamit ng attribute na `<th>,` `<caption>,` o `[summary].`"
+    "message": "Hindi iniiwasan ng mga pang-presentation na element na `<table>` ang paggamit ng attribute na `<th>`, `<caption>` o `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Iniiwasan ng mga pang-presentation na element na `<table>` ang paggamit ng attribute na `<th>,` `<caption>,` o `[summary].`"
+    "message": "Iniiwasan ng mga pang-presentation na element na `<table>` ang paggamit ng attribute na `<th>`, `<caption>` o `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Pinapaganda ng text ng link (at alternatibong text para sa mga larawan, kapag ginagamit bilang mga link) na nakikita, natatangi, at naitutuon ang karanasan sa navigation para sa mga user ng screen reader. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Pinapahusay ng text ng link (at alternatibong text para sa mga larawan, kapag ginamit bilang mga link) na nakikita, natatangi, at nafo-focus ang karanasan sa navigation para sa mga user ng screen reader. [Matuto pa](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Walang nakikitang pangalan ang mga link"
@@ -219,43 +219,43 @@
     "message": "May nakikitang pangalan ang mga link"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "May partikular na paraan ng pag-aanunsyo ng mga listahan ang mga screen reader. Makakatulong sa output ng screen reader ang pagtiyak na maayos ang istruktura ng listahan. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "May partikular na paraan ng pag-aanunsyo ng mga listahan ang mga screen reader. Makakatulong sa output ng screen reader ang pagtiyak na maayos ang istruktura ng listahan. [Matuto pa](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Hindi naglalaman ang mga listahan ng mga element na `<li>` at element na sumusuporta sa script (`<script>` at `<template>`)."
+    "message": "Hindi lang naglalaman ang listahan ng mga element na `<li>` at element na sumusuporta sa script (`<script>` at `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
     "message": "Naglalaman lang ang mga listahan ng mga element na `<li>` at element na sumusuporta sa script (`<script>` at `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Kailangang nakapaloob sa pangunahing `<ul>` o `<ol>` ang mga item sa listahan (`<li>`) para maayos itong maianunsyo ng mga screen reader. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Kailangang nakapaloob sa parent `<ul>` o `<ol>` ang mga item sa listahan `<li>` para maayos itong maianunsyo ng mga screen reader. [Matuto pa](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Hindi nakapaloob ang mga item sa listahan (`<li>`) sa mga pangunahing element na `<ul>` o `<ol>.`"
+    "message": "Hindi nakapaloob ang mga item sa listahan (`<li>`) sa mga parent element na `<ul>` o `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
     "message": "Nakapaloob ang mga item sa listahan (`<li>`) sa mga pangunahing element na `<ul>` o `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Hindi inaasahan ng mga user na awtomatikong magre-refresh ang isang page, at babalik sa itaas ng page ang focus kapag ginawa ito. Puwede itong magdulot ng nakakainis o nakakalitong karanasan. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Hindi inaasahan ng mga user na awtomatikong magre-refresh ang isang page, at babalik sa itaas ng page ang focus kapag ginawa ito. Puwede itong gumawa ng nakakainis o nakakalitong karanasan. [Matuto pa](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Gumagamit ang dokumento ng `<meta http-equiv=\"refresh\">`"
+    "message": "Gumagamit ng `<meta http-equiv=\"refresh\">` ang dokumento"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
     "message": "Hindi gumagamit ng `<meta http-equiv=\"refresh\">` ang dokumento"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Problema ang pag-disable ng pag-zoom para sa mga user na malabo ang paningin na umaasa sa pag-magnify ng screen para maayos na makita ang mga content ng isang web page. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Problema ang pag-disable ng pag-zoom para sa mga user na malabo ang paningin na umaasa sa pag-magnify ng screen para maayos na makita ang mga content ng isang web page. [Matuto pa](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "Ginagamit ang `[user-scalable=\"no\"]` sa element na `<meta name=\"viewport\">` o mas mababa sa 5 ang attribute na `[maximum-scale].`"
+    "message": "Ginagamit ang `[user-scalable=\"no\"]` sa element na `<meta name=\"viewport\">` o `[maximum-scale]` na attribute na mas mababa sa 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "Hindi ginagamit ang `[user-scalable=\"no\"]` sa element na `<meta name=\"viewport\">` at hindi mas mababa sa 5 ang attribute na `[maximum-scale].`"
+    "message": "Hindi ginagamit ang `[user-scalable=\"no\"]` sa element na `<meta name=\"viewport\">` at hindi mas mababa sa 5 ang attribute na `[maximum-scale]`."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Hindi makakapagsalin ng hindi text na content ang mga screen reader. Kapag nagdagdag ng alt text sa mga element na `<object>,` mapapadali ang pagpaparating ng mga screen reader ng kahulugan sa mga user. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Hindi makakapag-translate ng hindi text na content ang mga screen reader. Kapag nagdagdag ng alt text sa mga element na `<object>`, matutulungan ang mga screen reader sa pagpaparating ng kahulugan sa mga user. [Matuto pa](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "Walang text na `[alt]` ang mga element na `<object>`"
@@ -264,58 +264,70 @@
     "message": "May text na `[alt]` ang mga element na `<object>`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Nagpapahiwatig ng tahasang pagsasaayos ng navigation ang value na mas mataas kaysa sa 0. Bagama't kung tutuusin ay valid ito, madalas itong nagdudulot ng mga nakakainis na karanasan para sa mga user na umaasa sa mga nakakatulong na teknolohiya. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Nagpapahiwatig ng tahasang pagsasaayos ng navigation ang value na mas mataas sa 0. Bagama't kung tutuusin ay valid ito, madalas itong nagdudulot ng mga nakakainis na karanasan para sa mga user na umaasa sa mga nakakatulong na teknolohiya. [Matuto pa](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "Ang ilang element ay may value ng `[tabindex]` na mas mataas sa 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Walang element ang may value ng `[tabindex]` na mas mataas sa 0"
+    "message": "Walang element na may value na `[tabindex]` na mas mataas sa 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "May mga feature ang mga screen reader na mas nagpapadali sa pag-navigate sa mga talahanayan. Kapag tiniyak na ang mga cell na `<td>` na gumagamit sa attribute na `[headers]` ay tumutukoy lang sa iba pang cell sa talahanayang ding iyon, puwedeng mapaganda ang karanasan para sa mga user ng screen reader. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "May mga feature ang mga screen reader na mas nagpapadali ng pag-navigate sa mga talahanayan. Kapag tiniyak na ang mga cell na `<td>` na gumagamit sa attribute na `[headers]` ay tumutukoy lang sa iba pang cell sa talahanayang ding iyon, puwedeng mapaganda ang karanasan para sa mga user ng screen reader. [Matuto pa](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ang mga cell sa isang element na `<table>` na gumagamit sa attribute na `[headers]` ay tumutukoy sa iba pang cell na nasa talahanayang ding iyon."
+    "message": "Tumutukoy sa iba pang cell sa kaparehong talahanayan ang mga cell sa isang element na `<table>` na gumagamit sa attribute na `[headers]`"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
     "message": "Ang mga cell sa isang element na `<table>` na gumagamit sa attribute na `[headers]` ay tumutukoy lang sa iba pang cell sa talahanayang ding iyon."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "May mga feature ang mga screen reader na mas nagpapadali sa pag-navigate sa mga talahanayan. Kapag tiniyak na ang mga header ng talahanayan ay palaging tumutukoy sa isang hanay ng mga cell, puwedeng gumanda ang karanasan para sa mga user ng screen reader. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "May mga feature ang mga screen reader na mas nagpapadali ng pag-navigate sa mga talahanayan. Kapag tiniyak na ang mga header ng talahanayan ay tumutukoy sa ilang hanay ng mga cell, puwedeng mapahusay ang karanasan para sa mga user ng screen reader. [Matuto pa](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
     "message": "Ang mga element na `<th>` at element na may `[role=\"columnheader\"/\"rowheader\"]` ay walang cell ng data na inilalarawan ng mga ito."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Ang mga element na `<th>` at element na may `[role=\"columnheader\"/\"rowheader\"]` ay may mga cell ng data na inilalarawan ng mga ito."
+    "message": "May mga inilalarawang cell ng data ang mga element na `<th>` at element na may `[role=\"columnheader\"/\"rowheader\"]`."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Ang pagtukoy ng valid na [wika ng BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) sa mga element ay nakakatulong sa pagtiyak na tama ang pagbigkas ng screen reader sa text. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ang pagtukoy ng valid na [wika ng BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) sa mga element ay nakakatulong sa pagtiyak na tama ang pagbigkas ng screen reader sa text. [Matuto pa](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
     "message": "Walang valid na value ang mga attribute na `[lang]`"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "May valid na value ang mga attribute na`[lang]`"
+    "message": "May valid na value ang mga attribute na `[lang]`"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Kapag nagbigay ng caption ang isang video, mas madaling maa-access ng mga user na bingi at may problema sa pandinig ang impormasyon nito. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Kapag nagbigay ng caption ang isang video, mas madaling maa-access ng mga user na bingi at may problema sa pandinig ang impormasyon nito. [Matuto pa](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Ang mga element na `<video>` ay hindi naglalaman ng element na`<track>` na may `[kind=\"captions\"].`"
+    "message": "Hindi naglalaman ng element na `<track>` na may `[kind=\"captions\"]` ang mga element na `<video>`"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Naglalaman ang mga element na `<video>` ng element na `<track>` na may `[kind=\"captions\"]`"
+    "message": "Naglalaman ng element na `<track>` na may `[kind=\"captions\"]` ang mga element na `<video>`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Ang mga audio na paglalarawan ay nagbibigay ng may kaugnayang impormasyon para sa mga video na hindi magagawa ng dialogue, gaya ng mga expression ng mukha at eksena. [Matuto pa](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Nagbibigay ang mga audio na paglalarawan ng may kaugnayang impormasyon para sa mga video na hindi magagawa ng dialogue, gaya ng mga expression ng mukha at eksena. [Matuto pa](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Ang mga element na `<video>` ay hindi naglalaman ng element na `<track>` na may `[kind=\"description\"].`"
+    "message": "Hindi naglalaman ng element na `<track>` na may `[kind=\"description\"]` ang mga element na `<video>`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Ang mga element na `<video>` ay naglalaman ng element na `<track>` na may `[kind=\"description\"]`"
+    "message": "Naglalaman ng element na `<track>` na may `[kind=\"description\"]` ang mga element na `<video>`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Para sa mainam na hitsura sa iOS kapag nagdagdag ang mga user sa home screen, tumukoy ng isang apple-touch-icon. Dapat itong nakadirekta sa isang hindi transparent na kuwadradong 192px (o 180px) PNG. [Matuto Pa](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Hindi nagbibigay ng valid na `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Hindi napapanahon ang `apple-touch-icon-precomposed`; mas gusto ang `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Nagbibigay ng valid na `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Nagkaroon ng negatibong epekto ang mga extension ng Chrome sa performance ng pag-load ng page na ito. Subukang i-audit ang page sa incognito mode o mula sa isang profile sa Chrome nang walang extension."
@@ -330,7 +342,7 @@
     "message": "Kabuuang Oras ng CPU"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Pag-isipang bawasan ang oras na ginugugol sa pag-parse, pag-compile, at pagpapagana ng JS. Maaaring mapansin mong nakakatulong dito ang paghahatid ng mas maliliit na payload ng JS. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Pag-isipang bawasan ang oras na ginugugol sa pag-parse, pag-compile, at pagpapagana ng JS. Puwedeng mapansin mong nakakatulong dito ang paghahatid ng mas maliliit na payload ng JS. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Pabilisin ang pagpapagana ng JavaScript"
@@ -339,13 +351,13 @@
     "message": "Bilis ng pagpapagana ng JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Hindi mahusay ang malalaking GIF sa paghahatid ng animated na content. Pag-isipang gumamit ng mga MPEG4/WebM na video para sa mga animation at PNG/WebP para sa mga static na larawan sa halip na GIF para makatipid sa mga byte ng network. [Matuto pa](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Hindi mahusay ang malalaking GIF sa paghahatid ng animated na content. Pag-isipang gumamit ng mga MPEG4/WebM na video para sa mga animation at PNG/WebP para sa mga static na larawan sa halip na GIF para makatipid ng mga byte ng network. [Matuto pa](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Gumamit ng mga format ng video para sa animated na content"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Pag-isipang i-lazy load ang mga larawang wala sa screen at nakatago kapag tapos nang mag-load ang lahat ng mahalagang resource para mapabilis ang time to interactive. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Pag-isipang i-lazy load ang mga larawang wala sa screen at nakatago kapag tapos nang mag-load ang lahat ng mahalagang resource para mapabilis ang oras bago maging interactive. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Ipagpaliban ang mga larawang wala sa screen"
@@ -357,10 +369,10 @@
     "message": "Alisin ang mga resource na nagba-block ng pag-render"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Malaki ang nagagastos ng mga user sa malalaking payload ng network, at malaki ang kaugnayan ng mga ito sa matagal na pag-load. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Napapagastos ang mga user sa malalaking payload ng network, at malaki ang kaugnayan ng mga ito sa matagal na pag-load. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "Ang kabuuang laki ay {totalBytes, number, bytes} KB"
+    "message": "Ang kabuuang laki ay {totalBytes, number, bytes} KB"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Iwasan ang malalaking payload ng network"
@@ -369,13 +381,13 @@
     "message": "Umiiwas sa malalaking payload ng network"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Kapag pinaliit ang mga CSS file, maaaring lumiit ang payload ng network. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Puwedeng bawasan ng pagpapaliit ng mga file ng CSS ang laki ng payload ng network. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Paliitin ang CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Kapag pinaliit ang mga JavaScript file, maaaring lumiit ang payload at bumilis ang pag-parse ng script. [Matuto pa](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Puwedeng bawasan ng pagpapaliit ng mga file ng JavaScript ang laki ng payload at oras ng pag-parse ng script. [Matuto pa](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Paliitin ang JavaScript"
@@ -393,7 +405,7 @@
     "message": "Alisin ang hindi nagamit na JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Maaaring mapabilis ng mahabang lifetime ng cache ang mga umuulit na pagbisita sa iyong page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Puwedeng mapabilis ng mahabang lifetime ng cache ang mga umuulit na pagbisita sa iyong page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Nakakita ng 1 resource}one{Nakakita ng # resource}other{Nakakita ng # na resource}}"
@@ -405,7 +417,7 @@
     "message": "Gumagamit ng mahusay na patakaran sa cache sa mga static na asset"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Mas mabilis mag-load ang mga na-optimize na page at mas kaunti ang nakokonsumong cellular data ng mga ito. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Mas mabilis mag-load ang mga na-optimize na larawan at mas kaunti ang nakokonsumong cellular data ng mga ito. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Mahusay na mag-encode ng mga larawan"
@@ -417,25 +429,76 @@
     "message": "Iangkop ang laki ng mga larawan"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Dapat ihatid ang mga text-based na resource nang may compression (gzip, deflate, o brotli) para mabawasan ang kabuuang byte ng network. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Dapat maghatid ang mga text-based na resource nang may compression (gzip, deflate, o brotli) para mabawasan ang kabuuang mga byte ng network. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "I-enable ang compression ng text"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Kadalasan, mas mahusay ang compression ng mga format ng imahe gaya ng JPEG 2000, JPEG XR, at WebP kaysa sa compression ng PNG o JPEG, kaya mas mabilis ang pag-download at mas kaunti ang nakokonsumong data ng mga ito. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Kadalasan, mas mahusay ang pag-compress ng mga format ng larawan gaya ng JPEG 2000, JPEG XR, at WebP kaysa sa pag-compress ng PNG o JPEG, kaya mas mabilis ang pag-download at mas kaunti ang nakokonsumong data. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Maghatid ng mga larawan sa mga makabagong format"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Ipinapakita sa iyo ng Critical Request Chains sa ibaba kung anong mga resource ang nilo-load nang may mataas na priyoridad. Pag-isipang paikliin ang mga chain, paliitin ang mga dina-download sa mga resource, o ipagpaliban ang pag-download ng mga hindi kinakailangang resource para mapabilis ang pag-load ng page [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Ipinapakita sa iyo ng Mga Chain ng Mahahalagang Kahilingan kung anong mga resource ang nilo-load nang may mataas na priyoridad. Pag-isipang paikliin ang mga chain, paliitin ang mga dina-download na resource, o ipagpaliban ang pag-download ng mga hindi kinakailangang resource para mapabilis ang pag-load ng page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Nakakita ng 1 chain}one{Nakakita ng # chain}other{Nakakita ng # na chain}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "I-minimize ang Lalim ng Mahahalagang Kahilingan"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Paghinto sa Paggamit / Babala"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Linya"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Aalisin sa browser ang mga hindi na ginagamit na API sa paglaon. [Matuto pa](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{May nakitang 1 babala}one{May nakitang # babala}other{May nakitang # na babala}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Gumagamit ng mga hindi na ginagamit na API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Iniiwasan ang mga hindi na ginagamit na API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Hindi na ginagamit ang Cache ng Application. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Nakita ang \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Gumagamit ng Cache ng Application"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Iniiwasan ang Application Cache"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Ang pagtukoy ng doctype ay pumipigil sa browser na lumipat sa quirks-mode. Magbasa pa sa [page ng MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Ang pangalan ng doctype ay dapat ang nasa maliliit na titik na string na `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dapat maglaman ng doctype ang dokumento"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Walang lamang string ang inaasahang publicId"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Walang lamang string ang inaasahang systemId"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Walang HTML na doctype ang page, at dahil dito, na-trigger nito ang quirks-mode"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "May HTML na doctype ang page"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elemento"
@@ -447,7 +510,7 @@
     "message": "Value"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Inirerekomenda ng mga engineer ng browser ang mga page na naglalaman ng mas kaunti sa ~1,500 element ng DOM. Ang pinakamainam ay isang lalim ng tree na < 32 element at mas kaunti sa 60 child/parent na element. Kapag malaki ang DOM, puwedeng tumaas ang paggamit ng memory, magdulot ng mas mahahabang [pagkalkula ng istilo](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), at magdulot ng mamahaling [mga reflow ng layout](https://developers.google.com/speed/articles/reflow). [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Inirerekomenda ng mga engineer ng browser ang mga page na naglalaman ng mas kaunti sa ~1,500 element ng DOM. Ang pinakamainam ay isang lalim ng tree na < 32 element at mas kaunti sa 60 child/parent na element. Kapag malaki ang DOM, puwedeng tumaas ang paggamit ng memory, magdulot ng mas mahahabang [pagkalkula ng istilo](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), at makagawa ng mamahaling [mga reflow ng layout](https://developers.google.com/speed/articles/reflow). [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 element}one{# element}other{# na element}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Umiiwas sa masyadong malaking DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Target"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Idagdag ang `rel=\"noopener\"` o `rel=\"noreferrer\"` sa anumang external na link para pahusayin ang performance at pigilan ang mga kahinaan sa seguridad. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Hindi ligtas ang mga link sa mga cross-origin na destinasyon"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Ligtas ang mga link sa mga cross-origin na destinasyon"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Hindi matukoy ang destinasyon para sa anchor na ({anchorHTML}). Kung hindi ginagamit bilang hyperlink, pag-isipang alisin ang target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Walang tiwala o nalilito ang mga user sa mga site na humihiling ng kanilang lokasyon nang walang konteksto. Sa halip ay pag-isipang iugnay ang kahilingan sa pagkilos ng user. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Humihiling ng pahintulot sa geolocation sa pag-load ng page"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Iniiwasan ang paghiling ng pahintulot sa geolocation sa pag-load ng page"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Bersyon"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Lahat ng front-end na library ng JavaScript na natukoy sa page."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Natukoy na mga library ng JavaScript"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Para sa mga user na may mabagal na koneksyon, puwedeng maantala ang pag-load ng page dahil sa mga external na script na dynamic na inilagay sa pamamagitan ng `document.write()`. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Gumagamit ng `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Umiiwas sa `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Pinakamataas na Kalalaan"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Bersyon ng Library"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Bilang ng Kahinaan"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Puwedeng maglaman ng mga kilalang kahinaan sa seguridad ang ilang script ng third party na madaling natutukoy at nasasamantala ng mga nang-aatake. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 kahinaan ang natukoy}one{# kahinaan ang natukoy}other{# na kahinaan ang natukoy}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "May mga kasamang front-end na library ng JavaScript na may mga kilalang kahinaan sa seguridad"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Mataas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Mababa"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Katamtaman"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Umiiwas sa mga front-end na library ng JavaScript na may mga kilalang kahinaan sa seguridad"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Walang tiwala o nalilito ang mga user sa mga site na humihiling na magpadala ng mga notification nang walang konteksto. Sa halip ay pag-isipang iugnay ang kahilingan sa mga galaw ng user. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Humihiling ng pahintulot sa notification sa pag-load ng page"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Iniiwasan ang paghiling ng pahintulot sa notification sa pag-load ng page"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Mga Hindi Nakapasang Element"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Pinapahina ng paghadlang sa pag-paste ng password ang magandang patakarang panseguridad. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Pinipigilan ang mga user na mag-paste sa mga field ng password"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Pinapayagan ang mga user na mag-paste sa mga field ng password"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "Nag-aalok ang HTTP/2 ng mas maraming benepisyo kaysa sa HTTP/1.1, kasama ang mga binary header, multiplexing, at server push. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 kahilingan ang hindi naihatid sa pamamagitan ng HTTP/2}one{# kahilingan ang hindi naihatid sa pamamagitan ng HTTP/2}other{# na kahilingan ang hindi naihatid sa pamamagitan ng HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Hindi gumagamit ng HTTP/2 para sa lahat ng resource nito"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Hindi gumagamit ng HTTP/2 para sa mga sarili nitong resource"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Pag-isipang markahan ang iyong pan-detect ng event sa pagpindot at wheel bilang `passive` para mapahusay ang performance sa pag-scroll ng iyong page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Hindi gumagamit ng mga passive na listener para pahusayin ang performance sa pag-scroll"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Gumagamit ng mga passive na listener para pahusayin ang performance sa pag-scroll"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Paglalarawan"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Nagsasaad ng mga hindi naresolbang problema ang mga error na naka-log sa console Puwedeng manggaling ang mga ito sa mga hindi nagawang kahilingan sa network at iba pang alalahanin sa browser."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Na-log sa console ang mga error sa browser"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Walang naka-log na mga error sa browser sa console"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Gamitin ang feature na font-display ng CSS para matiyak na nakikita ng user ang text sa pag-load ng mga webfont. [Matuto pa](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Gamitin ang feature na font-display ng CSS para matiyak na nakikita ng user ang text habang nilo-load ang mga webfont. [Matuto pa](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Tiyaking patuloy na nakikita ang text sa pag-load ng webfont"
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Patuloy na nakikita ang lahat ng text sa pag-load ng webfont"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Hindi awtomatikong nasuri ng Lighthouse ang value na font-display para sa sumusunod na URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Aspect Ratio (Aktwal)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Aspect Ratio (Ipinakita)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Dapat na tumugma ang mga dimensyon ng display ng larawan sa natural na aspect ratio. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Ipinapakita ang mga larawang may maling aspect ratio"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Ipinapakita ang mga larawang may tamang aspect ratio"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Invalid ang laki ng larawan ng impormasyon {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Hindi secure na URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Dapat protektahan gamit ang HTTPS ang lahat ng site, kahit ang mga hindi nangangasiwa ng sensitibong data. Pinipigilan ng HTTPS ang mga nanghihimasok na makialam o tahimik na makinig sa mga pakikipag-ugnayan sa pagitan ng iyong app at mga user, at isa itong prerequisite para sa HTTP/2 at maraming bagong API ng web platform. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 hindi secure na kahilingan ang nakita}one{# hindi secure na kahilingan ang nakita}other{# na hindi secure na kahilingan ang nakita}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Hindi gumagamit ng HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Gumagamit ng HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Kapag mabilis ang pag-load ng page sa cellular network, nagkakaroon ng magandang karanasan ng user sa mobile. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interactive sa loob ng {timeInMs, number, seconds} s"
+    "message": "Interactive sa {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Interactive sa naka-simulate na mobile network sa loob ng {timeInMs, number, seconds} s"
@@ -504,58 +735,76 @@
     "message": "Binabawasan ang gawain sa pangunahing thread"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Ang Tinantyang Latency ng Input ay isang pagtatantya ng bilis ng pagtugon ng iyong app sa input ng user, na nasa millisecond, sa pinakaabalang 5 segundong palugit ng pag-load ng page. Kung mas mataas kaysa sa 50 ms ang iyong latency, baka ituring ng mga user na mabagal ang app mo. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Ang Tinantyang Latency ng Input ay isang pagtatantya ng bilis ng pagtugon ng iyong app sa input ng user, na nasa millisecond, sa pinakaabalang 5 segundong palugit ng pag-load ng page. Kung mas mataas kaysa sa 50 ms ang iyong latency, puwedeng ituring ng mga user na mabagal ang app mo. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Tinatayang Latency ng Input"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Minamarkahan ng First Contentful Paint ang oras ng pag-paint sa unang text o larawan. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Minamarkahan ng First Contentful Paint ang tagal bago ma-paint ang unang text o larawan. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "First Contentful Paint"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "Minamarkahan ng First CPU Idle ang unang beses kung kailan hindi abala ang pangunahing thread ng page at maaari itong mangasiwa ng input. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "Minamarkahan ng First CPU Idle ang unang beses kung kailan hindi abala ang pangunahing thread ng page at puwede itong mangasiwa ng input. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "First CPU Idle"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Sinusukat ng First Meaningful Paint ang bilis ng pagpapakita sa pangunahing content ng isang page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Sinusukat ng First Meaningful Paint ang bilis ng pagpapakita ng pangunahing content ng isang page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "First Meaningful Paint"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Ang tagal bago maging interactive ay ang haba ng oras na inaabot bago maging ganap na interactive ang page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Ang oras bago maging interactive ay ang haba ng oras na inaabot bago maging ganap na interactive ang page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Time to Interactive"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Ang potensyal na Pagkaantala sa Unang Input na puwedeng maranasan ng iyong mga user ay ang tagal, na nasa millisecond, ng pinakamahabang gawain."
+    "message": "Ang maximum na potensyal na First Input Delay na puwedeng maranasan ng iyong mga user ay ang tagal, na nasa millisecond, ng pinakamahabang gawain. [Matuto pa](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Max na Potensyal na FID"
+    "message": "Max na Potensyal na First Input Delay"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Ipinapakita ng Speed Index ang bilis ng pag-populate ng mga content ng isang page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Ipinapakita ng Speed Index ang bilis ng nakikitang pag-populate ng mga content ng isang page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Speed Index"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Kabuuan ng lahat ng yugto ng panahon sa pagitan ng FCP at Oras bago maging Interactive, kapag lumampas ang haba ng gawain sa 50ms, ipinahayag sa milliseconds."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Kabuuang Oras ng Pag-block"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Malaki ang epekto ng mga round trip time (RTT) sa performance. Kung mataas ang RTT sa isang pinagmulan, isa itong palatandaan na mapapahusay ng mga server na malapit sa user ang performance. [Matuto pa](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Malaki ang epekto ng mga round trip time (RTT) ng network sa performance. Kung mataas ang RTT sa isang pinagmulan, isa itong palatandaan na mapapahusay ng mga server na malapit sa user ang performance. [Matuto pa](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Mga Round Trip Time ng Network"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Puwedeng makaapekto sa performance sa web ang mga latency ng server. Kung mataas ang latency ng server ng isang pinagmulan, palatandaan iyon na na-overload ang server o hindi mahusay ang performance nito sa backend. [Matuto pa](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Puwedeng makaapekto sa performance sa web ang mga latency ng server. Kung mataas ang latency ng server ng isang pinagmulan, ito ay palatandaang na-overload ang server o hindi mahusay ang performance nito sa backend. [Matuto pa](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Mga Latency sa Backend ng Server"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Lampas sa Badyet"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Panatilihin ang dami at laki ng mga kahilingan sa network sa ilalim ng mga target na itinakda ng ibinigay na badyet sa performance. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 kahilingan}one{# kahilingan}other{# na kahilingan}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Badyet sa performance"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Nagpapasimula ang mga pag-redirect ng mga karagdagang pagkaantala bago ma-load ang page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
@@ -563,11 +812,20 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Iwasan ang mga pag-redirect sa maraming page"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Para magtakda ng mga badyet para sa dami at laki ng mga resource ng page, magdagdag ng budget.json na file. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 kahilingan}one{# kahilingan}other{# na kahilingan}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Panatilihing mababa ang mga bilang ng kahilingan at maliit ang mga paglipat"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Iminumungkahi ng mga canonical na link kung aling URL ang ipapakita sa mga resulta ng paghahanap. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Maraming nagsasalungatang URL ({urlList})"
+    "message": "Maraming URL ang hindi magkakatugma ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "Tumuturo sa ibang domain ({url})"
@@ -591,13 +849,10 @@
     "message": "May valid na `rel=canonical` ang dokumento"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Ang mga laki ng font na mas maliit kaysa sa 12px ay masyadong maliit para mabasa at dahil dito, kailangan ng mga bisita sa mobile na “mag-pinch para i-zoom” para mabasa ito. Subukang gawing ≥12px ang >60% ng text sa page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Ang mga laki ng font na mas mababa sa 12px ay masyadong maliit para mabasa at kinakailangan ng mga bisita sa mobile na “mag-pinch para mag-zoom in” para mabasa ito. Subukang gawing ≥12px ang >60% ng text sa page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} nababasang text"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "Masyadong maliit ang {decimalProportion, number, extendedPercent} ng text."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Hindi nababasa ang text dahil walang viewport meta tag na naka-optimize para sa mga screen ng mobile."
@@ -612,7 +867,7 @@
     "message": "Gumagamit ng mga nababasang laki ng font ang dokumento"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Sinasabi ng mga link na hreflang sa mga search engine kung anong bersyon ng isang page ang dapat nilang ilista sa mga resulta ng paghahanap para sa isang partikular na wika o rehiyon. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Sinasabi ng mga link na hreflang sa mga search engine kung anong bersyon ng isang page ang dapat ilista ng mga ito sa mga resulta ng paghahanap para sa isang partikular na wika o rehiyon. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
     "message": "Walang valid na `hreflang` ang dokumento"
@@ -651,7 +906,7 @@
     "message": "May naglalarawang text ang mga link"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Paganahin ang [Tool sa Pag-test ng Structured Data](https://search.google.com/structured-data/testing-tool/) at ang [Linter ng Structured Data](http://linter.structured-data.org/) para i-validate ang structured data. [Matuto pa](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Patakbuhin ang [Tool sa Pag-test ng Structured Data](https://search.google.com/structured-data/testing-tool/) at ang [Structured Data Linter](http://linter.structured-data.org/) para i-validate ang structured data. [Matuto pa](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Valid ang structured data"
@@ -681,7 +936,7 @@
     "message": "Kung sira ang iyong robots.txt, puwedeng hindi maunawaan ng mga crawler kung paano mo gustong ma-crawl o ma-index ang iyong website."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "Ang kahilingan para sa robots.txt ay nagbalik ng HTTP status na: {statusCode}"
+    "message": "ang kahilingan para sa robots.txt ay nagbalik ng HTTP status na: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{May nakitang 1 error}one{May nakitang # error}other{May nakitang # na error}}"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Nag-o-overlap na Target"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Laki"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Target ng Pag-tap"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Angkop ang laki ng mga target ng pag-tap"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Oras sa Main Thread"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Third-Party"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Puwedeng lubos na makaapekto ang code ng third party sa performance ng pag-load. Limitahan ang bilang ng paulit-ulit na mga third-party na provider at subukang i-load ang code ng third party pagkatapos ng pangunahing pag-load ng iyong page. [Matuto pa](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 Third Party ang Nakita}one{# Third Party ang Nakita}other{# na Third Party ang Nakita}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Paggamit ng Third Party"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Tinutukoy ng Time To First Byte ang oras kung kailan nagpapadala ng tugon ang iyong server. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "Tinutukoy ng Time To First Byte ang tagal bago makapagpadala ng tugon ang iyong server. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Inabot nang {timeInMs, number, milliseconds} ms ang root na dokumento"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Tagal"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Pangalan"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Oras ng Pagsisimula"
@@ -753,7 +1017,7 @@
     "message": "Mga marka at sukat ng User Timing"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "May nakitang preconnect <link> para sa \"{securityOrigin}\" ngunit hindi ito ginamit ng browser. Tingnan kung ginagamit mo nang tama ang attribute na `crossorigin.`"
+    "message": "May nakitang preconnect na <link> para sa \"{securityOrigin}\" pero hindi ito ginamit ng browser. Tingnan kung ginagamit mo nang maayos ang attribute na `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Pag-isipang magdagdag ng resource hint na preconnect o dns-prefetch para makapagtakda ng mga paunang koneksyon sa mahahalagang third-party na origin. [Matuto pa](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Mag-preconnect sa mga kinakailangang origin"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "May nakitang na-preload na <link> para sa \"{preloadURL}\" ngunit hindi ito ginamit ng browser. Tingnan kung ginagamit mo nang maayos ang attribute na `crossorigin.`"
+    "message": "May nakitang preload na <link> para sa \"{preloadURL}\" pero hindi ito ginamit ng browser. Tingnan kung ginagamit mo nang maayos ang attribute na `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Pag-isipang gumamit ng <link rel=preload> para mabigyang-priyoridad ang pagkuha ng mga resource na kasalukuyang hinihiling, sa pag-load ng page, para sa ibang pagkakataon. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Pag-isipang gumamit ng `<link rel=preload>` para mabigyang-priyoridad ang pagkuha ng mga resource na kasalukuyang hinihiling sa huling bahagi ng pag-load ng page. [Matuto pa](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "I-preload ang mahahalagang kahilingan"
@@ -789,10 +1053,10 @@
     "message": "Pinakamahuhusay na kagawian"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Hina-highlight ng mga pagsusuring ito ang mga pagkakataong [pahusayin ang pagiging accessible ng iyong web app](https://developers.google.com/web/fundamentals/accessibility). Isang subset lang ng mga isyu sa pagiging accessible ang awtomatikong made-detect kaya hinihikayat din ang manual na pagsusuri."
+    "message": "Hina-highlight ng mga pagsusuring ito ang mga pagkakataong [gawing mas accessible ng iyong web app](https://developers.google.com/web/fundamentals/accessibility). Isang subset lang ng mga isyu sa pagiging accessible ang awtomatikong matutukoy kaya hinihikayat din ang manual na pagsusuri."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Tinutugunan ng mga item na ito ang mga bahaging hindi masasaklawan ng naka-automate na tool sa pagsusuri. Matuto pa sa aming gabay sa [pagsasagawa ng pagsusuri sa pagiging accessible](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Tinutugunan ng mga item na ito ang mga bahaging hindi masasakop ng naka-automate na tool sa pagsusuri. Matuto pa sa aming gabay sa [pagsasagawa ng pagsusuri sa pagiging accessible](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Pagiging accessible"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Mga talahanayan at listahan"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Pinakamahuhusay na Kagawian"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Nagtatakda ng mga pamantayan para sa performance ng iyong site ang mga badyet ng performance."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Mga Badyet"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Higit pang impormasyon tungkol sa performance ng iyong application."
+    "message": "Higit pang impormasyon tungkol sa performance ng iyong application. Ang mga numerong ito ay hindi [direktang makakaapekto ](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) sa score sa Performance."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Mga Diagnostic"
@@ -840,7 +1113,7 @@
     "message": "Mga Pagpapahusay sa First Paint"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Maaaring mapabilis ng mga pag-optimize na ito ang pag-load ng iyong page."
+    "message": "Puwedeng makatulong ang mga suhestyon na ito na mapabilis ang pag-load ng iyong page. Hindi [direktang nakakaapekto](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) ang mga ito sa score sa Performance."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Mga Pagkakataon"
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL ng Cache"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Lokasyon"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Pangalan"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Mga Kahilingan"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Uri ng Resource"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Laki (KB)"
+    "message": "Laki"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Oras na Ginugol"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Laki ng Paglipat"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Maaaring Matipid (KB)"
+    "message": "Puwedeng Matipid"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Maaaring Matipid (ms)"
+    "message": "Puwedeng Matipid"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Maaaring makatipid ng {wastedBytes, number, bytes} KB"
+    "message": "Puwedeng makatipid ng {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "Maaaring makatipid ng {wastedMs, number, milliseconds} ms"
+    "message": "Puwedeng makatipid ng {wastedMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokumento"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Font"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Larawan"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Media"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Iba pa"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
   },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stylesheet"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Third-party"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Kabuuan"
+  },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Nagkaroon ng problema sa pag-record ng trace sa pag-load ng iyong page. Paganahing muli ang Lighthouse. ({errorCode})"
+    "message": "Nagkaroon ng problema sa pag-record ng trace sa pag-load ng iyong page. Paganahin ulit ang Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Nag-timeout habang naghihintay para sa paunang koneksyon sa Protocol ng Debugger."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Hindi nangolekta ang Chrome ng anumang screenshot habang nilo-load ang page. Pakitiyak na may nakikitang content sa page, at pagkatapos ay subukang muling paganahin ang Lighthouse. ({errorCode})"
+    "message": "Hindi nangolekta ang Chrome ng anumang screenshot habang nilo-load ang page. Pakitiyak na may nakikitang content sa page, at pagkatapos ay subukang paganahin ulit ang Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Hindi malutas ng mga DNS server ang ibinigay na domain."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Ang kinakailangang gatherer na {artifactName} ay nagkaroon ng error: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Nagkaroon ng internal na error sa Chrome. Paki-restart ang Chrome at subukang muling paganahin ang Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Hindi tumakbo ang kinakailangang gatherer na {artifactName}."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Hindi na-load nang maayos ng Lighthouse ang page na hiniling mo. Tiyaking tamang URL ang sinusubukan mo at tumutugon nang maayos ang server sa lahat ng kahilingan."
@@ -945,7 +1266,10 @@
     "message": "Hindi na-load nang maayos ng Lighthouse ang URL na hiniling mo dahil huminto sa pagtugon ang page."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Walang valid na panseguridad na kredensyal ang URL na ibinigay mo. {securityMessages}"
+    "message": "Walang valid na panseguridad na certificate ang URL na ibinigay mo. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Pinigilan ng Chrome ang pag-load ng page gamit ang interstitial. Tiyaking tamang URL ang sinusubukan mo at tumutugon nang maayos ang server sa lahat ng kahilingan."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Hindi na-load nang maayos ng Lighthouse ang page na hiniling mo. Tiyaking tamang URL ang sinusubukan mo at tumutugon nang maayos ang server sa lahat ng kahilingan. (Mga Detalye: {errorDetails})"
@@ -954,10 +1278,10 @@
     "message": "Hindi na-load nang maayos ng Lighthouse ang page na hiniling mo. Tiyaking tamang URL ang sinusubukan mo at tumutugon nang maayos ang server sa lahat ng kahilingan. (Status code: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Masyadong matagal na na-load ang iyong page. Pakisunod ang mga pagkakataon sa ulat para mabawasan ang tagal ng pag-load ng iyong page, at pagkatapos ay muling paganahin ang Lighthouse. ({errorCode})"
+    "message": "Masyadong matagal na na-load ang iyong page. Pakisunod ang mga pagkakataon sa ulat para mabawasan ang tagal ng pag-load ng iyong page, at pagkatapos ay paganahin ulit ang Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "Lumampas na sa nakalaang tagal ang paghihintay ng tugon ng DevTools protocol. (Pamamaraan: {protocolMethod})"
+    "message": "Lumampas na sa nakalaang oras ang paghihintay ng tugon ng DevTools protocol. (Pamamaraan: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "Lumampas na sa nakalaang panahon ang pag-fetch ng content ng resource"
@@ -984,7 +1308,7 @@
     "message": "Data ng Lab"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "Ang pagsusuri ng [Lighthouse](https://developers.google.com/web/tools/lighthouse/) ng kasalukuyang page sa isang ginayang mobile network. Pagtatantya ang mga value at maaaring mag-iba-iba ang mga ito."
+    "message": "Ang pagsusuri ng [Lighthouse](https://developers.google.com/web/tools/lighthouse/) ng kasalukuyang page sa isang na-emulate na mobile network. Tinantya at puwedeng mag-iba ang mga value."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Mga karagdagang item na manual na susuriin"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "I-expand ang snippet"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Ipakita ang mga resource ng 3rd party"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "May mga isyung nakakaapekto sa pagpapatakbong ito ng Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Tinataya lang at maaaring mag-iba ang mga value."
+    "message": "Tinantya at puwedeng mag-iba ang mga value. [Batay lang sa mga sukatang ito ](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) ang score sa performance."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Pumasa sa mga pag-audit ngunit may mga babala"
@@ -1023,10 +1350,10 @@
     "message": "Pag-isipang i-upload ang iyong GIF sa isang serbisyo kung saan gagawin itong available para i-embed bilang HTML5 video."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Mag-install ng [lazy-load na plugin sa WordPress](https://wordpress.org/plugins/search/lazy+load/) na nagbibigay ng kakayahang ipagpaliban ang anumang offscreen na larawan, o lumipat sa isang temang nagbibigay ng naturang functionality. Pag-isipan ding gamitin [ang AMP na plugin](https://wordpress.org/plugins/amp/)."
+    "message": "Mag-install ng [lazy-load na plugin sa WordPress](https://wordpress.org/plugins/search/lazy+load/) na nagbibigay ng kakayahang ipagpaliban ang anumang offscreen na larawan, o lumipat sa isang temang nagbibigay ng functionality. Pag-isipan ding gamiting [ang AMP na plugin](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "May ilang plugin sa WordPress na makakatulong sa iyong [i-inline ang mahahalagang asset](https://wordpress.org/plugins/search/critical+css/) o [ipagpaliban ang mas hindi mahahalagang resource](https://wordpress.org/plugins/search/defer+css+javascript/). Tandaang puwedeng makasira sa mga feature ng iyong tema o mga plugin ang mga pag-optimize na mula sa mga plugin na ito, kaya malamang na kakailanganin mong gumawa ng mga pagbabago sa code."
+    "message": "May ilang plugin sa WordPress na makakatulong sa iyong [i-inline ang mahahalagang asset](https://wordpress.org/plugins/search/critical+css/) o [ipagpaliban ang hindi masyadong mahahalagang resource](https://wordpress.org/plugins/search/defer+css+javascript/). Tandaang puwedeng makasira sa mga feature ng iyong tema o mga plugin ang mga pag-optimize na mula sa mga plugin na ito, kaya malamang na kakailanganin mong gumawa ng mga pagbabago sa code."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Nakakaapekto ang mga tema, plugin, at detalye ng server sa oras ng pagtugon ng server. Pag-isipang maghanap ng mas naka-optimize na tema, maingat na pumili ng plugin sa pag-optimize, at/o i-upgrade ang iyong server."
@@ -1038,27 +1365,27 @@
     "message": "Puwedeng pabilisin ng ilang [plugin sa WordPress](https://wordpress.org/plugins/search/minify+css/) ang iyong site sa pamamagitan ng pagsasama-sama, pagpapaliit, at pagko-compress ng mga istilo mo. Puwede ka ring gumamit ng proseso ng pagbuo para gawin ang pagpapaliit na ito nang mas maaga kung posible."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Puwedeng pabilisin ng ilang [plugin sa Wordpress](https://wordpress.org/plugins/search/minify+javascript/) ang iyong site sa pamamagitan ng pagsasama-sama, pagpapaliit, at pagko-compress ng mga script mo. Puwede ka ring gumamit ng proseso ng pagbuo para gawin ang pagpapaliit na ito nang mas maaga kung posible."
+    "message": "Puwedeng pabilisin ng ilang [plugin sa WordPress](https://wordpress.org/plugins/search/minify+javascript/) ang iyong site sa pamamagitan ng pagsasama-sama, pagpapaliit, at pagko-compress ng mga script mo. Puwede ka ring gumamit ng proseso ng pagbuo para gawin ang pagpapaliit na ito nang mas maaga kung posible."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Pag-isipang bawasan, o baguhin, ang bilang ng [plugin sa WordPress](https://wordpress.org/plugins/) na naglo-load ng mga hindi nagamit na CSS sa iyong page. Para tukuyin ang mga plugin na nagdaragdag ng hindi nauugnay na CSS, subukang patakbuhin ang [sakop ng code](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) sa Chrome DevTools. Puwede mong tukuyin ang nauugnay na tema/plugin mula sa URL ng stylesheet. Abangan ang mga plugin na may maraming stylesheet sa listahang may maraming pula sa sakop ng code. Dapat lang i-enqueue ng plugin ang isang stylesheet kung talagang ginagamit ito sa page."
+    "message": "Pag-isipang bawasan, o baguhin, ang bilang ng [mga plugin sa WordPress](https://wordpress.org/plugins/) na naglo-load ng mga hindi ginagamit na CSS sa iyong page. Para tukuyin ang mga plugin na nagdaragdag ng mga hindi nauugnay na CSS, subukang patakbuhin ang [sakop ng code](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) sa Chrome DevTools. Puwede mong tukuyin ang tema/plugin na sanhi nito mula sa URL ng stylesheet. Abangan ang mga plugin na maraming stylesheet sa listahang maraming pula sa sakop ng code. Dapat lang i-enqueue ng plugin ang isang stylesheet kung talagang ginagamit ito sa page."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Pag-isipang bawasan, o baguhin, ang bilang ng [plugin sa WordPress](https://wordpress.org/plugins/) na naglo-load ng mga hindi nagamit na JavaScript sa iyong page. Para tukuyin ang mga plugin na nagdaragdag ng mga hindi nauugnay na JS, subukang patakbuhin ang [sakop ng code](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) sa Chrome DevTools. Puwede mong tukuyin ang tema/plugin na sanhi nito mula sa URL ng script. Abangan ang mga plugin na may maraming script sa listahang may maraming pula sa sakop ng code. Dapat lang i-enqueue ng plugin ang isang script kung talagang ginagamit ito sa page."
+    "message": "Pag-isipang bawasan, o baguhin, ang bilang ng [mga plugin sa WordPress](https://wordpress.org/plugins/) na naglo-load ng mga hindi ginagamit na JavaScript sa iyong page. Para tukuyin ang mga plugin na nagdaragdag ng mga hindi nauugnay na JS, subukang patakbuhin ang [sakop ng code](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) sa Chrome DevTools. Puwede mong tukuyin ang tema/plugin na sanhi nito mula sa URL ng script. Abangan ang mga plugin na maraming script sa listahang may maraming pula sa sakop ng code. Dapat lang i-enqueue ng plugin ang isang script kung talagang ginagamit ito sa page."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Magbasa tungkol sa [Pag-cache ng browser sa WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Magbasa tungkol sa [Pag-cache ng Browser sa WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "Pag-isipang gumamit ng [plugin sa WordPress para sa pag-optimize ng larawan](https://wordpress.org/plugins/search/optimize+images/) na nagko-compress ng iyong mga larawan habang pinapanatili ang kalidad."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Direktang i-upload ang mga larawan sa pamamagitan ng [library ng media](https://codex.wordpress.org/Media_Library_Screen) para tiyaking available ang mga kinakailangang laki ng larawan, at pagkatapos ay ipasok ang mga ito sa library ng media o gamitin ang widget ng larawan para tiyaking ginagamit ang mga pinakaangkop na laki ng larawan (kabilang ang mga para sa tumutugong breakpoint). Iwasang gamitin ang mga larawang nasa `Buong Laki` maliban kung sapat ang mga dimensyon para sa paggamit ng mga ito. [Matuto pa](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Direktang i-upload ang mga larawan sa pamamagitan ng [library ng media](https://codex.wordpress.org/Media_Library_Screen) para tiyaking available ang mga kinakailangang laki ng larawan, at pagkatapos ay ilagay ang mga ito mula sa library ng media o gamitin ang widget ng larawan para tiyaking ginagamit ang mga pinakaangkop na laki ng larawan (kabilang ang para sa mga tumutugong breakpoint). Iwasang gamitin ang mga larawang nasa `Full Size` maliban kung sapat ang mga dimensyon para sa paggamit ng mga ito. [Matuto Pa](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Puwede mong i-enable ang pag-compress ng text sa configuration ng iyong server sa web."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Pag-isipang gumamit ng [plugin](https://wordpress.org/plugins/search/convert+webp/) o serbisyong awtomatikong magko-convert sa iyong mga na-upload na larawan sa mga pinakaangkop na format."
+    "message": "Pag-isipang gumamit ng [plugin](https://wordpress.org/plugins/search/convert+webp/) o serbisyong awtomatikong magko-convert ng iyong mga na-upload na larawan sa mga optimal na format."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/fr.json
+++ b/lighthouse-core/lib/i18n/locales/fr.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Les clés d'accès permettent aux utilisateurs de positionner rapidement le curseur dans une partie spécifique de la page. Pour les aider à naviguer correctement, pensez à définir des clés d'accès uniques. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Les clés d'accès permettent aux utilisateurs de positionner rapidement le curseur dans une partie spécifique de la page. Pour les aider à naviguer correctement, pensez à définir des clés d'accès uniques. [En savoir plus](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Les valeurs [accesskey] ne sont pas uniques"
+    "message": "Les valeurs `[accesskey]` ne sont pas uniques"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Les valeurs [accesskey] sont uniques"
+    "message": "Les valeurs `[accesskey]` sont uniques"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Chaque \"role\" ARIA est rattaché à un sous-ensemble spécifique d'attributs \"aria-*\". Si vous ne les associez pas correctement, vous risquez d'invalider les attributs \"aria-*\". [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Chaque `role` ARIA est rattaché à un sous-ensemble spécifique d'attributs `aria-*`. S'ils ne sont pas correctement associés, les attributs `aria-*` ne seront pas valides. [En savoir plus](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Les attributs [aria-*] ne correspondent pas à leurs rôles"
+    "message": "Les attributs `[aria-*]` ne correspondent pas à leurs rôles"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Les attributs [aria-*] correspondent à leurs rôles"
+    "message": "Les attributs `[aria-*]` correspondent à leurs rôles"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Certains rôles ARIA ont des attributs obligatoires qui décrivent l'état de l'élément aux lecteurs d'écran. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Certains rôles ARIA ont des attributs obligatoires qui décrivent l'état de l'élément aux lecteurs d'écran. [En savoir plus](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Les éléments [role] ne possèdent pas tous les attributs [aria-*] requis"
+    "message": "Les éléments `[role]` ne possèdent pas tous les attributs `[aria-*]` requis"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Les éléments [role] possèdent tous les attributs [aria-*] requis"
+    "message": "Tous les éléments `[role]` contiennent les attributs `[aria-*]` requis"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Certains rôles ARIA parents doivent contenir des rôles enfants spécifiques afin de remplir correctement leurs fonctions d'accessibilité. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Certains rôles ARIA parents doivent contenir des rôles enfants spécifiques afin de remplir correctement leurs fonctions d'accessibilité. [En savoir plus](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Les éléments associés à [role] et nécessitant des éléments [role] enfants spécifiques sont manquants"
+    "message": "Les éléments associés à `[role]` et nécessitant des éléments `[role]` enfants spécifiques sont manquants."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Les éléments associés à [role] et nécessitant des éléments [role] enfants spécifiques sont présents"
+    "message": "Les éléments associés à `[role]` et nécessitant des éléments `[role]` enfants spécifiques sont présents"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Certains rôles ARIA enfants doivent être inclus dans un rôle parent spécifique afin de remplir correctement leurs fonctions d'accessibilité. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Certains rôles ARIA enfants doivent être inclus dans un rôle parent spécifique afin de remplir correctement leurs fonctions d'accessibilité. [En savoir plus](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Les éléments [role] ne sont pas inclus dans l'élément parent requis"
+    "message": "Les éléments `[role]` ne sont pas inclus dans l'élément parent requis"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Les éléments [role] sont inclus dans l'élément parent approprié"
+    "message": "Les éléments `[role]` sont inclus dans l'élément parent approprié"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Les rôles ARIA doivent comporter des valeurs valides afin de remplir correctement leurs fonctions d'accessibilité. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Les rôles ARIA doivent comporter des valeurs valides afin de remplir correctement leurs fonctions d'accessibilité. [En savoir plus](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Les valeurs [role] ne sont pas valides"
+    "message": "Les valeurs `[role]` ne sont pas valides"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Les valeurs [role] sont valides"
+    "message": "Les valeurs `[role]` sont valides"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Les technologies d'assistance telles que les lecteurs d'écran ne peuvent pas interpréter les attributs ARIA si leurs valeurs ne sont pas valides. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Les technologies d'assistance telles que les lecteurs d'écran ne peuvent pas interpréter les attributs ARIA si leurs valeurs ne sont pas valides. [En savoir plus](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "La valeur des attributs [aria-*] n'est pas valide"
+    "message": "La valeur des attributs `[aria-*]` n'est pas valide"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Les attributs [aria-*] ont des valeurs valides"
+    "message": "Les attributs `[aria-*]` ont des valeurs valides"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Les technologies d'assistance telles que les lecteurs d'écran ne peuvent pas interpréter les attributs ARIA si leurs noms ne sont pas valides. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Les technologies d'assistance telles que les lecteurs d'écran ne peuvent pas interpréter les attributs ARIA si leurs noms ne sont pas valides. [En savoir plus](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Les attributs [aria-*] ne sont pas valides ou sont mal orthographiés"
+    "message": "Les attributs `[aria-*]` ne sont pas valides ou sont mal orthographiés"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Les attributs [aria-*] sont valides et correctement orthographiés"
+    "message": "Les attributs `[aria-*]` sont valides et correctement orthographiés"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Les sous-titres rendent les contenus audio accessibles aux personnes sourdes et malentendantes, en leur fournissant des informations essentielles (qui est en train de parler, ce que cette personne dit et d'autres informations non contenues dans le dialogue, par exemple). [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Les sous-titres rendent les contenus audio accessibles aux personnes sourdes et malentendantes, en leur fournissant des informations essentielles (qui est en train de parler, ce que cette personne dit et d'autres informations non contenues dans le dialogue, par exemple). [En savoir plus](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Il manque un élément <track> possédant l'attribut [kind=\"captions\"] dans les éléments <audio>"
+    "message": "Il manque un élément `<track>` possédant l'attribut `[kind=\"captions\"]` dans les éléments `<audio>`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Les éléments <audio> contiennent un élément <track> possédant l'attribut [kind=\"captions\"]"
+    "message": "Les éléments `<audio>` contiennent un élément `<track>` possédant l'attribut `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Éléments non conformes"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Lorsqu'un bouton n'a pas de nom accessible, les lecteurs d'écran annoncent simplement qu'il s'agit d'un \"bouton\", ce qui le rend inutilisable pour les personnes qui se servent de tels outils. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Lorsqu'un bouton n'a pas de nom accessible, les lecteurs d'écran annoncent simplement qu'il s'agit d'un \"bouton\", ce qui le rend inutilisable pour les personnes qui se servent de tels outils. [En savoir plus](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Les boutons n'ont pas de nom accessible"
@@ -93,7 +93,7 @@
     "message": "Les boutons ont un nom accessible"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "En ajoutant des méthodes pour contourner les contenus répétitifs, vous permettez aux internautes qui utilisent un clavier de naviguer plus efficacement sur la page. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "En ajoutant des méthodes pour contourner les contenus répétitifs, vous permettez aux internautes qui utilisent un clavier de naviguer plus efficacement sur la page. [En savoir plus](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "La page ne contient pas de titre, de lien \"Ignorer\" ni de point de repère"
@@ -102,7 +102,7 @@
     "message": "La page contient un titre, un lien \"Ignorer\" ou un point de repère"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Un texte faiblement contrasté est difficile, voire impossible à lire pour de nombreux utilisateurs. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Un texte faiblement contrasté est difficile, voire impossible à lire pour de nombreux utilisateurs. [En savoir plus](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Les couleurs d'arrière-plan et de premier plan ne sont pas suffisamment contrastées"
@@ -111,88 +111,88 @@
     "message": "Les couleurs d'arrière-plan et de premier plan sont suffisamment contrastées"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Si les listes de définition ne sont pas correctement balisées, les lecteurs d'écran risquent de donner des résultats confus ou imprécis. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Si les listes de définition ne sont pas correctement balisées, les lecteurs d'écran risquent de donner des résultats confus ou imprécis. [En savoir plus](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Les éléments <dl> ne contiennent pas uniquement des groupes <dt> et <dd> ainsi que des éléments <script> ou <template> dans le bon ordre"
+    "message": "Les éléments `<dl>` ne contiennent pas uniquement des groupes `<dt>` et `<dd>` ainsi que des éléments `<script>` ou `<template>` dans le bon ordre."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Les éléments <dl> contiennent uniquement des groupes <dt> et <dd> ainsi que des éléments <script> ou <template> dans le bon ordre"
+    "message": "Les éléments `<dl>` ne contiennent que des groupes `<dt>` et `<dd>` ainsi que des éléments `<script>` ou `<template>` dans le bon ordre."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Les éléments de liste de définition (<dt> et <dd>) doivent être encapsulés dans un élément <dl> parent afin que les lecteurs d'écran puissent les énoncer correctement. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Les éléments de liste de définition (`<dt>` et `<dd>`) doivent être encapsulés dans un élément `<dl>` parent afin que les lecteurs d'écran puissent les énoncer correctement. [En savoir plus](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Les éléments de liste de définition ne sont pas encapsulés dans des éléments <dl>"
+    "message": "Les éléments de liste de définition ne sont pas encapsulés dans des éléments `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Les éléments de liste de définition sont encapsulés dans des éléments <dl>"
+    "message": "Les éléments de liste de définition sont encapsulés dans des éléments `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Le titre donne aux utilisateurs de lecteurs d'écran un aperçu de la page. En outre, les moteurs de recherche s'appuient principalement sur ce dernier pour déterminer la pertinence du contenu proposé. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Le titre donne aux utilisateurs de lecteurs d'écran un aperçu de la page. En outre, les moteurs de recherche s'appuient principalement sur ce dernier pour déterminer la pertinence du contenu proposé. [En savoir plus](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Le document ne contient pas d'élément <title>"
+    "message": "Le document ne contient pas d'élément `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Le document comporte un élément <title>"
+    "message": "Le document contient un élément `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "La valeur de chaque attribut \"id\" doit être unique afin que les différentes instances soient toutes prises en compte par les technologies d'assistance. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "La valeur de chaque attribut \"id\" doit être unique afin que les différentes instances soient toutes prises en compte par les technologies d'assistance. [En savoir plus](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Les attributs [id] de la page ne sont pas uniques"
+    "message": "Les attributs `[id]` de la page ne sont pas uniques"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Les attributs [id] de la page sont uniques"
+    "message": "Les attributs `[id]` de la page sont uniques"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Les lecteurs d'écran s'appuient sur le titre des frames pour décrire le contenu de ces derniers aux utilisateurs. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Les lecteurs d'écran s'appuient sur le titre des frames pour décrire le contenu de ces derniers aux utilisateurs. [En savoir plus](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Les éléments <frame> ou <iframe> n'ont pas de titre"
+    "message": "Les éléments `<frame>` ou `<iframe>` n'ont pas de titre"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Les éléments <frame> ou <iframe> ont un titre"
+    "message": "Les éléments `<frame>` ou `<iframe>` ont un titre"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Lorsqu'une page ne spécifie pas d'attribut \"lang\", les lecteurs d'écran considèrent qu'elle est rédigée dans la langue par défaut sélectionnée au moment de leur configuration par l'utilisateur. Si la page n'est pas rédigée dans cette langue par défaut, les lecteurs d'écran risquent de ne pas énoncer correctement son contenu. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Lorsqu'une page ne spécifie pas d'attribut \"lang\", les lecteurs d'écran considèrent qu'elle est rédigée dans la langue par défaut sélectionnée au moment de leur configuration par l'utilisateur. Si la page n'est pas rédigée dans cette langue par défaut, les lecteurs d'écran risquent de ne pas énoncer correctement son contenu. [En savoir plus](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "L'élément <html> n'a pas d'attribut [lang]"
+    "message": "L'élément `<html>` n'a pas d'attribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "L'élément <html> possède un attribut [lang]"
+    "message": "L'élément `<html>` contient un attribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Le fait de spécifier une langue [BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valide permet d'aider les lecteurs d'écran à énoncer correctement le texte. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Le fait de spécifier une [langue BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valide permet d'aider les lecteurs d'écran à énoncer correctement le texte. [En savoir plus](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "La valeur de l'attribut [lang] de l'élément <html> n'est pas valide"
+    "message": "La valeur de l'attribut `[lang]` de l'élément `<html>` n'est pas valide."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "La valeur de l'attribut [lang] de l'élément <html> est valide"
+    "message": "La valeur de l'attribut `[lang]` de l'élément `<html>` est valide"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Les éléments informatifs doivent contenir un texte de substitution court et descriptif. L'attribut alt peut rester vide pour les éléments décoratifs. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Les éléments informatifs doivent contenir un texte de substitution court et descriptif. L'attribut alt peut rester vide pour les éléments décoratifs. [En savoir plus](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Des éléments d'image n'ont pas d'attribut [alt]"
+    "message": "Des éléments d'image n'ont pas d'attribut `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Les éléments d'image possèdent un attribut [alt]"
+    "message": "Les éléments d'image possèdent des attributs `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Lorsqu'une image est utilisée comme bouton <input>, vous pouvez aider les utilisateurs de lecteurs d'écran à comprendre son utilité en ajoutant du texte de substitution. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Lorsqu'une image est utilisée comme bouton `<input>`, vous pouvez aider les utilisateurs de lecteurs d'écran à comprendre son utilité en ajoutant un texte de substitution. [En savoir plus](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Les éléments <input type=\"image\"> n'ont pas de texte [alt]"
+    "message": "Les éléments `<input type=\"image\">` n'ont pas de texte `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Les éléments <input type=\"image\"> sont associés à du texte [alt]"
+    "message": "Les éléments `<input type=\"image\">` contiennent du texte `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Les libellés permettent de s'assurer que les éléments de contrôle des formulaires sont énoncés correctement par les technologies d'assistance, comme les lecteurs d'écran. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Les libellés permettent de s'assurer que les éléments de contrôle des formulaires sont énoncés correctement par les technologies d'assistance, comme les lecteurs d'écran. [En savoir plus](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Les éléments de formulaire ne sont pas associés à des libellés"
@@ -201,16 +201,16 @@
     "message": "Les éléments de formulaire sont associés à des libellés"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Un tableau utilisé à des fins de mise en page ne doit pas inclure d'éléments de données tels que les éléments \"th\" ou \"caption\", ou encore l'attribut \"summary\", car cela peut perturber l'expérience des utilisateurs de lecteurs d'écran. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Un tableau utilisé pour la mise en page ne doit pas inclure d'éléments de données tels que les éléments \"th\" ou \"caption\", ou encore l'attribut \"summary\", car cela peut perturber l'expérience des utilisateurs de lecteurs d'écran. [En savoir plus](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Les éléments <table> de présentation n'évitent pas d'utiliser <th>, <caption> ou l'attribut [summary]"
+    "message": "Les éléments `<table>` de présentation n'évitent pas d'utiliser `<th>`, `<caption>` ni l'attribut `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Les éléments <table> de type présentation ne font pas appel aux éléments <th> et <caption>, ni à l'attribut [summary]"
+    "message": "Les éléments `<table>` de présentation ne font pas appel aux éléments `<th>` et `<caption>`, ni à l'attribut `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Rédigez du texte visible et unique pour les liens (et pour le texte de substitution des images, si vous vous en servez dans des liens), afin que les utilisateurs de lecteurs d'écran puissent facilement positionner le curseur dessus et bénéficient d'une meilleure expérience de navigation. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Rédigez du texte visible et unique pour les liens (et pour le texte de substitution des images, si vous vous en servez dans des liens), afin que les utilisateurs de lecteurs d'écran puissent facilement positionner le curseur dessus et bénéficient d'une meilleure expérience de navigation. [En savoir plus](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Les liens n'ont pas de nom visible"
@@ -219,103 +219,115 @@
     "message": "Les liens ont un nom visible"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Les lecteurs d'écran ont une façon spécifique d'énoncer les listes. Pour leur permettre de donner de bons résultats, pensez à bien structurer ces dernières. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Les lecteurs d'écran ont une façon spécifique d'énoncer les listes. Pour leur permettre de donner de bons résultats, pensez à bien structurer ces dernières. [En savoir plus](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Les listes ne contiennent pas uniquement des éléments <li> et des éléments de type script (<script> et <template>)"
+    "message": "Les listes ne contiennent pas uniquement des éléments `<li>` et des éléments de type script (`<script>` et `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Les listes contiennent uniquement des éléments <li> et des éléments de type script (<script> et <template>)"
+    "message": "Les listes contiennent uniquement des éléments `<li>` et des éléments de type script (`<script>` et `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Les lecteurs d'écran requièrent que les éléments de liste <li> soient contenus dans un élément parent <ul> ou <ol> pour les énoncer correctement. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Les lecteurs d'écran requièrent que les éléments de liste (`<li>`) soient contenus dans un élément parent `<ul>` ou `<ol>` pour les énoncer correctement. [En savoir plus](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Les éléments de liste <li> ne sont pas inclus dans des éléments parents <ul> ou <ol>"
+    "message": "Les éléments de liste (`<li>`) ne sont pas inclus dans des éléments parents `<ul>` ni `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Les éléments de liste <li> sont inclus dans des éléments parents <ul> ou <ol>"
+    "message": "Les éléments de liste (`<li>`) sont inclus dans des éléments parents `<ul>` ou `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Les utilisateurs ne s'attendent pas à ce qu'une page s'actualise automatiquement. De plus, lorsque cela se produit, le curseur est aussitôt repositionné en haut de la page. Cela peut générer de la frustration et perturber l'expérience utilisateur. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Les utilisateurs ne s'attendent pas à ce qu'une page s'actualise automatiquement. De plus, lorsque cela se produit, le curseur est aussitôt repositionné en haut de la page. Cela peut générer de la frustration et perturber l'expérience utilisateur. [En savoir plus](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Le document utilise <meta http-equiv=\"refresh\">"
+    "message": "Le document utilise une balise Meta `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Le document n'utilise pas <meta http-equiv=\"refresh\">"
+    "message": "Le document n'utilise pas de balise Meta `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "La désactivation de la fonction de zoom peut être problématique pour les utilisateurs qui ne voient pas bien et qui ont besoin d'agrandir le contenu d'une page Web pour en saisir le sens. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "La désactivation de la fonction de zoom peut être problématique pour les utilisateurs qui ne voient pas bien et qui ont besoin d'agrandir le contenu d'une page Web pour en saisir le sens. [En savoir plus](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "L'attribut [user-scalable=\"no\"] est utilisé dans l'élément <meta name=\"viewport\">, ou l'attribut [maximum-scale] est inférieur à 5"
+    "message": "L'attribut `[user-scalable=\"no\"]` est utilisé dans l'élément `<meta name=\"viewport\">`, ou l'attribut `[maximum-scale]` est inférieur à 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "L'attribut [user-scalable=\"no\"] n'est pas utilisé dans l'élément <meta name=\"viewport\">, et l'attribut [maximum-scale] n'est pas inférieur à 5"
+    "message": "`[user-scalable=\"no\"]` n'est pas utilisé dans l'élément `<meta name=\"viewport\">`, et l'attribut `[maximum-scale]` n'est pas inférieur à 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Les lecteurs d'écran ne peuvent pas traduire les contenus non textuels. En ajoutant du texte alternatif aux éléments <object>, vous aiderez les lecteurs d'écran à transmettre votre message aux utilisateurs. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Les lecteurs d'écran ne peuvent pas traduire les contenus non textuels. En ajoutant un texte de substitution aux éléments `<object>`, vous aiderez les lecteurs d'écran à transmettre votre message aux utilisateurs. [En savoir plus](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Les éléments <object> n'ont pas de texte [alt]"
+    "message": "Les éléments `<object>` n'ont pas de texte `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Les éléments <object> sont associés à du texte [alt]"
+    "message": "Les éléments `<object>` contiennent du texte `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Une valeur supérieure à 0 implique un ordre de navigation explicite. Bien que cela soit valide d'un point de vue technique, cela crée souvent une expérience frustrante pour les utilisateurs qui s'appuient sur des technologies d'assistance. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Une valeur supérieure à 0 implique un ordre de navigation explicite. Bien que cela soit valide d'un point de vue technique, cela crée souvent une expérience frustrante pour les utilisateurs qui s'appuient sur des technologies d'assistance. [En savoir plus](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Certains éléments ont une valeur [tabindex] supérieure à 0"
+    "message": "Certains éléments ont une valeur `[tabindex]` supérieure à 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Aucun élément n'a de valeur [tabindex] supérieure à 0"
+    "message": "Aucun élément n'a de valeur `[tabindex]` supérieure à 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Les lecteurs d'écran proposent des fonctionnalités qui permettent de naviguer plus simplement dans les tableaux. En vous assurant que les cellules <td> qui comportent l'attribut [headers] fassent référence à d'autres cellules dans le même tableau uniquement, vous pourrez améliorer l'expérience des utilisateurs de lecteurs d'écran. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Les lecteurs d'écran proposent des fonctionnalités qui permettent de naviguer plus simplement dans les tableaux. En vous assurant que les cellules `<td>` qui comportent l'attribut `[headers]` fassent référence à d'autres cellules dans le même tableau uniquement, vous pourrez améliorer l'expérience des utilisateurs de lecteurs d'écran. [En savoir plus](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Les cellules d'un élément <table> qui utilisent l'attribut [headers] font référence à d'autres cellules du même tableau"
+    "message": "Les cellules d'un élément `<table>` qui utilisent l'attribut `[headers]` font référence à d'autres cellules du même tableau."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Les cellules d'un élément <table> qui utilisent l'attribut [headers] font uniquement référence à d'autres cellules dans le même tableau"
+    "message": "Les cellules d'un élément `<table>` qui utilisent l'attribut `[headers]` font uniquement référence à d'autres cellules dans le même tableau."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Les lecteurs d'écran proposent des fonctionnalités qui permettent de naviguer plus simplement dans les tableaux. En vous assurant que les en-têtes de tableaux fassent toujours référence à un ensemble de cellules spécifique, vous pourrez améliorer l'expérience des utilisateurs de lecteurs d'écran. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Les lecteurs d'écran proposent des fonctionnalités qui permettent de naviguer plus simplement dans les tableaux. En vous assurant que les en-têtes de tableaux fassent toujours référence à un ensemble de cellules spécifique, vous pourrez améliorer l'expérience des utilisateurs de lecteurs d'écran. [En savoir plus](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Les éléments <th> et les éléments portant l'attribut [role=\"columnheader\"/\"rowheader\"] ne décrivent aucune cellule de données"
+    "message": "Les éléments `<th>` et ceux portant l'attribut `[role=\"columnheader\"/\"rowheader\"]` ne décrivent aucune cellule de données."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Les éléments <th> et les éléments portant l'attribut [role=\"columnheader\"/\"rowheader\"] décrivent des cellules de données"
+    "message": "Les éléments `<th>` et ceux portant l'attribut `[role=\"columnheader\"/\"rowheader\"]` décrivent des cellules de données."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Le fait de spécifier une langue [BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valide pour les éléments permet de s'assurer que le texte sera prononcé correctement par les lecteurs d'écran. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Le fait de spécifier une [langue BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valide pour les éléments permet de s'assurer que le texte sera prononcé correctement par les lecteurs d'écran. [En savoir plus](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "La valeur des attributs [lang] n'est pas valide"
+    "message": "La valeur des attributs `[lang]` n'est pas valide"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Les attributs [lang] ont une valeur valide"
+    "message": "Les attributs `[lang]` ont une valeur valide"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Le fait d'ajouter des sous-titres à une vidéo rend cette dernière plus accessible aux personnes sourdes et malentendantes. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Le fait d'ajouter des sous-titres à une vidéo rend cette dernière plus accessible aux personnes sourdes et malentendantes. [En savoir plus](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Les éléments <video> ne contiennent pas d'élément <track> possédant l'attribut [kind=\"captions\"]"
+    "message": "Les éléments `<video>` ne contiennent pas d'élément `<track>` possédant l'attribut `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Les éléments <video> contiennent un élément <track> possédant l'attribut [kind=\"captions\"]"
+    "message": "Les éléments `<video>` contiennent un élément `<track>` possédant l'attribut `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Les descriptions audio fournissent des informations pertinentes qui ne sont pas comprises dans le dialogue des vidéos, comme les expressions faciales et les scènes. [En savoir plus](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Les descriptions audio fournissent des informations pertinentes qui ne sont pas comprises dans le dialogue des vidéos, comme les expressions faciales et les scènes. [En savoir plus](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Les éléments <video> ne contiennent pas d'élément <track> possédant l'attribut [kind=\"description\"]"
+    "message": "Les éléments `<video>` ne contiennent pas d'élément `<track>` possédant l'attribut `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Les éléments <video> contiennent un élément <track> possédant l'attribut [kind=\"description\"]"
+    "message": "Les éléments `<video>` contiennent un élément `<track>` possédant l'attribut `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Définissez un attribut apple-touch-icon pour un affichage idéal sur iOS lorsque les utilisateurs ajoutent un site sur l'écran d'accueil. Il doit mener vers une image PNG carrée opaque de 180 ou 192 pixels. [En savoir plus](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "La valeur de l'attribut `apple-touch-icon` n'est pas valide"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` est obsolète. Utilisez plutôt `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "La valeur de l'attribut `apple-touch-icon` est valide"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Les extensions Chrome ont eu un impact négatif sur les performances de chargement de la page. Essayez de contrôler la page en mode navigation privée ou depuis un profil Chrome sans extensions."
@@ -330,7 +342,7 @@
     "message": "Temps CPU total"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Envisagez de réduire le temps consacré à l'analyse, la compilation et l'exécution de JS. La livraison de charges utiles JS plus petites peut vous aider. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Envisagez de réduire le temps consacré à l'analyse, la compilation et l'exécution de JavaScript. La livraison de charges utiles JavaScript plus petites peut vous aider. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Réduisez le temps d'exécution de JavaScript"
@@ -345,22 +357,22 @@
     "message": "Utilisez des formats vidéo pour le contenu animé"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Envisagez de charger des images masquées ou hors écran après le chargement de toutes les ressources essentielles afin de réduire le délai avant interactivité. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Envisagez de charger des images masquées ou hors écran après le chargement de toutes les ressources essentielles afin de réduire le délai avant interactivité. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Différez le chargement des images hors écran"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Des ressources bloquent la première visualisation (first paint) de votre page. Envisagez de diffuser des feuilles JS/CSS essentielles en ligne et de différer la diffusion de toutes les feuilles JS/de style non essentielles. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Des ressources bloquent la première visualisation (first paint) de votre page. Envisagez de diffuser des feuilles JS/CSS essentielles en ligne et de différer la diffusion de toutes les feuilles JS/de style non essentielles. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Éliminez les ressources qui bloquent le rendu"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Les charges utiles des grands réseaux coûtent de l'argent réel aux utilisateurs et sont fortement corrélées aux délais de chargement interminables. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Les charges utiles des grands réseaux coûtent de l'argent réel aux utilisateurs et sont fortement corrélées aux délais de chargement interminables. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "La taille totale était de {totalBytes, number, bytes} Ko"
+    "message": "Taille totale : {totalBytes, number, bytes} Ko"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Évitez d'énormes charges utiles de réseau"
@@ -369,19 +381,19 @@
     "message": "Éviter d'énormes charges utiles de réseau"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "La réduction des fichiers CSS peut réduire la taille des charges utiles de réseau. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "La réduction des fichiers CSS peut réduire la taille des charges utiles de réseau. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Réduisez la taille des ressources CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "La minimisation des fichiers JavaScript peut réduire la taille des charges utiles et la durée d'analyse des scripts. [En savoir plus](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "La minimisation des fichiers JavaScript peut réduire la taille des charges utiles et la durée d'analyse des scripts. [En savoir plus](https://developers.google.com/speed/docs/insights/MinifyResources)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Réduisez la taille des ressources JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Supprimez les règles inutilisées des feuilles de style et différez le chargement des ressources CSS inutilisées pour le contenu au-dessus de la ligne de flottaison afin de réduire la quantité d'octets inutiles consommés par l'activité réseau. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Supprimez les règles inutilisées des feuilles de style et différez le chargement des ressources CSS inutilisées pour le contenu au-dessus de la ligne de flottaison afin de réduire la quantité d'octets inutiles consommés par l'activité réseau. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Supprimer les ressources CSS inutilisées"
@@ -393,7 +405,7 @@
     "message": "Supprimez les ressources JavaScript inutilisées"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Une longue durée de vie du cache peut accélérer les visites répétées sur votre page. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Une longue durée de vie du cache peut accélérer les visites répétées sur votre page. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 ressource trouvée}one{# ressource trouvée}other{# ressources trouvées}}"
@@ -405,37 +417,88 @@
     "message": "Utiliser des règles de cache efficaces sur les éléments statiques"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Les images optimisées se chargent plus rapidement et consomment moins de données mobiles. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Les images optimisées se chargent plus rapidement et consomment moins de données mobiles. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Encodez les images de manière efficace"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Diffusez des images de taille appropriée afin d'économiser des données mobiles et réduire le temps de chargement. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Diffusez des images de taille appropriée afin d'économiser des données mobiles et de réduire le temps de chargement. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Dimensionnez correctement les images"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Les ressources textuelles doivent être diffusées compressées (Gzip, Deflate ou Brotli) pour réduire le nombre total d'octets du réseau. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Les ressources textuelles doivent être diffusées compressées (Gzip, Deflate ou Brotli) pour réduire le nombre total d'octets du réseau. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Activez la compression de texte"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Les formats d'image comme JPEG 2000, JPEG XR et WebP proposent souvent une meilleure compression que les formats PNG ou JPEG. Par conséquent, les téléchargements sont plus rapides et la consommation de données est réduite. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Les formats d'image comme JPEG 2000, JPEG XR et WebP proposent souvent une meilleure compression que les formats PNG ou JPEG. Par conséquent, les téléchargements sont plus rapides et la consommation de données est réduite. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Diffusez des images aux formats nouvelle génération"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Les Chaînes de demandes critiques ci-dessous vous montrent quelles ressources sont chargées avec une priorité élevée. Envisagez de réduire la longueur des chaînes et la taille de téléchargement des ressources ou de reporter le téléchargement de ressources inutiles afin d'améliorer le chargement des pages. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Les chaînes de demandes critiques ci-dessous vous montrent quelles ressources sont chargées avec une priorité élevée. Envisagez de réduire la longueur des chaînes et la taille de téléchargement des ressources ou de reporter le téléchargement de ressources inutiles afin d'améliorer le chargement des pages. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 chaîne trouvée}one{# chaîne trouvée}other{# chaînes trouvées}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Réduisez la profondeur des demandes critiques"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "API obsolète/Avertissement"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Ligne"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Les API obsolètes seront finalement supprimées du navigateur. [En savoir plus](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 avertissement détecté}one{# avertissement détecté}other{# avertissements détectés}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "API obsolètes utilisées"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "La page n'utilise pas d'API obsolètes"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "L'API Application Cache est obsolète. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" trouvé"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "API Application Cache utilisée"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "API Application Cache non utilisée"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "La spécification d'un attribut doctype empêche le navigateur de passer en mode quirks. Pour en savoir plus, consultez la [page MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Le nom de l'attribut doctype doit être en minuscules `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Le document doit contenir un attribut doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "La chaîne publicId est censée être vide"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "La chaîne systemId est censée être vide"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "La page n'a pas d'attribut doctype HTML, ce qui déclenche le mode quirks"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "La page n'a pas d'attribut doctype HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Élément"
@@ -447,7 +510,7 @@
     "message": "Valeur"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Les ingénieurs en navigation recommandent que les pages contiennent moins de 1 500 éléments DOM environ. La zone d'écoute idéale est une profondeur d'arborescence inférieure à 32 éléments et contenant moins de 60 éléments enfant/parent. Un grand DOM peut accroître l'utilisation de la mémoire, entraîner de plus longs [calculs de style](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) et des [redispositions](https://developers.google.com/speed/articles/reflow) coûteuses. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Les ingénieurs en navigation recommandent que les pages contiennent moins de 1 500 éléments DOM environ. La zone d'écoute idéale est une profondeur d'arborescence inférieure à 32 éléments et contenant moins de 60 éléments enfant/parent. Un grand DOM peut accroître l'utilisation de la mémoire, et entraîner de plus longs [calculs de style](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) et de coûteux [ajustements de la mise en page](https://developers.google.com/speed/articles/reflow). [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 élément}one{# élément}other{# éléments}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Éviter une taille excessive de DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Cible"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Ajoutez les attributs `rel=\"noopener\"` ou `rel=\"noreferrer\"` à tous les liens externes pour améliorer les performances et prévenir les failles de sécurité. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Les liens vers les destinations multi-domaines sont dangereux"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Les liens vers les destinations multi-domaines sont sûrs"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Impossible de déterminer la destination de l'ancrage ({anchorHTML}). S'il n'est pas utilisé comme lien hypertexte, envisagez de supprimer target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Les utilisateurs se méfient des sites qui demandent leur position sans contexte. Envisagez plutôt d'associer la demande à des actions de l'utilisateur. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Demandes d'autorisation de géolocalisation lors du chargement de page"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Aucune autorisation de géolocalisation n'est demandée au chargement de la page"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Version"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Toutes les bibliothèques JavaScript frontales détectées sur la page."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Bibliothèques JavaScript détectées"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Pour les utilisateurs rencontrant des problèmes de connexion lente, les scripts externes injectés dynamiquement via `document.write()` peuvent retarder le chargement des pages de plusieurs dizaines de secondes. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "La page utilise l'attribut `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Évite `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Extrême"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Version de la bibliothèque"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Nombre de failles"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Certains scripts tiers peuvent présenter des failles de sécurité connues, faciles à identifier et à exploiter par des pirates informatiques. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 faille détectée}one{# faille détectée}other{# failles détectées}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "La page utilise des bibliothèques JavaScript frontales présentant des failles de sécurité connues"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Élevée"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Faible"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Moyenne"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Les bibliothèques JavaScript frontales ne présentent aucune faille de sécurité connue"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Les utilisateurs se méfient des sites qui demandent à envoyer des notifications sans contexte. Envisagez plutôt d'associer la demande à des gestes de l'utilisateur. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Demandes d'autorisation d'envoi de notifications lors du chargement de page"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Aucune autorisation d'envoi de notifications n'est demandée au chargement de la page"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Éléments non conformes"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Empêcher la copie de contenu dans les champs de mot de passe nuit aux règles de sécurité. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "La copie de contenu n'est pas autorisée dans les champs de mot de passe"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Autoriser les utilisateurs à copier un contenu dans les champs de mot de passe"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocole"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "Le protocole HTTP/2 offre de nombreux avantages par rapport à HTTP/1.1, comme les en-têtes binaires, le multiplexage et la fonctionnalité Push des serveurs. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 requête non traitée via le protocole HTTP/2}one{# requête non traitée via le protocole HTTP/2}other{# requêtes non traitées via le protocole HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "La page n'utilise pas le protocole HTTP/2 pour toutes ses ressources"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "La page utilise le protocole HTTP/2 pour ses propres ressources"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Envisagez de marquer vos écouteurs d'événements tactiles et à la molette comme `passive` pour améliorer les performances de défilement de votre page. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "La page n'utilise pas d'écouteurs d'événements passifs pour améliorer les performances de défilement"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "La page utilise des écouteurs d'événements passifs pour améliorer les performances de défilement"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Description"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Les erreurs enregistrées dans la console indiquent des problèmes non résolus. Ces derniers peuvent être dûs à des requêtes réseau qui ont échoué et à d'autres problèmes du navigateur."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Les erreurs de navigateur ont été enregistrées dans la console"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Aucune erreur de navigateur enregistrée dans la console"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Utilisez la fonction d'affichage de la police CSS afin que le texte soit visible par l'utilisateur pendant le chargement des polices Web. [En savoir plus](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Utilisez la fonction d'affichage de la police CSS afin que le texte soit visible par l'utilisateur pendant le chargement des polices Web. [En savoir plus](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Assurez-vous que le texte reste visible pendant le chargement des polices Web"
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "La totalité du texte reste visible pendant le chargement des polices Web"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse n'a pas pu vérifier automatiquement la valeur d'affichage de la police pour l'URL suivante : {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Format (image réelle)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Format (image affichée)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Les dimensions d'affichage des images doivent correspondre au format naturel. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Images affichées dans un format incorrect"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Images affichées au bon format"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Informations sur la taille d'image non valides {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL non sécurisée"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Tous les sites doivent être protégés par le protocole HTTPS, même ceux qui ne traitent pas de données sensibles. Le protocole HTTPS empêche les intrus de détourner ou d’écouter passivement les communications entre votre application et les utilisateurs. Il constitue également une condition préalable à l'utilisation de HTTP/2 et de nombreuses nouvelles API de plates-formes Web. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 requête non sécurisée trouvée}one{# requête non sécurisée trouvée}other{# requêtes non sécurisées trouvées}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "La page n'utilise pas le protocole HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Requêtes HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Le chargement rapide des pages sur un réseau mobile garantit une expérience utilisateur de qualité. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Le chargement rapide des pages sur un réseau mobile garantit une expérience utilisateur de qualité. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "La page est devenue interactive au bout de {timeInMs, number, seconds} s"
+    "message": "Page interactive en {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Page devenue interactive sur un réseau mobile au bout de {timeInMs, number, seconds} s"
@@ -504,79 +735,106 @@
     "message": "Réduire le travail du thread principal"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "L'estimation du temps de latence avant intervention est une estimation du temps en millisecondes que prend votre application pour réagir à l'intervention de l'utilisateur, pendant la fenêtre de pointe de 5 s de chargement de page. Si le temps de latence est supérieur à 50 ms, les utilisateurs peuvent percevoir votre application comme étant lente. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "La valeur \"Estimated Input Latency\" est une estimation du temps en millisecondes que prend votre application pour réagir à l'intervention de l'utilisateur, pendant la fenêtre de pointe de 5 s de chargement de la page. Si le temps de latence est supérieur à 50 ms, les utilisateurs peuvent percevoir votre application comme étant lente. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Estimation du temps de latence avant intervention"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "La statistique \"First Contentful Paint\" indique le moment où le premier texte ou la première image sont affichés. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "La statistique \"First Contentful Paint\" indique le moment où le premier texte ou la première image sont affichés. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "First Contentful Paint"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "La statistique \"Premier processeur inactif\" marque la première fois que le thread principal de la page est suffisamment silencieux pour gérer l'entrée. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "La statistique \"First CPU Idle\" marque la première fois que le thread principal de la page est suffisamment silencieux pour gérer l'entrée. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Premier processeur inactif"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "La statistique \"First Meaningful Paint\" mesure quand le contenu principal d'une page est visible. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "La statistique \"First Meaningful Paint\" mesure quand le contenu principal d'une page est visible. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "First Meaningful Paint"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Le délai avant interactivité correspond à la durée nécessaire pour que la page devienne entièrement interactive. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "La valeur \"Time to Interactive\" correspond au temps nécessaire pour que la page devienne entièrement interactive. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Délai avant interactivité"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Le retard que vos utilisateurs peuvent éventuellement rencontrer de la première interaction correspond à la durée, en millisecondes, de la tâche la plus longue."
+    "message": "Le retard maximal (Maximum Potential First Input Delay) auquel vos utilisateurs peuvent éventuellement être confrontés correspond à la durée, en millisecondes, de la tâche la plus longue. [En savoir plus](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID potentiel maximal"
+    "message": "Max Potential First Input Delay"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "L'indice de vitesse indique la rapidité avec laquelle le contenu d'une page est disponible. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "La valeur \"Speed Index\" indique la rapidité avec laquelle le contenu d'une page est disponible. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Indice de vitesse"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Somme en millisecondes de toutes les périodes entre le FCP et le délai avant interactivité, lorsque la durée de la tâche a dépassé 50 ms."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Total Blocking Time"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Les délais aller-retour (DAR) du réseau ont un impact important sur les performances. Si le DAR par rapport à un point d'origine est élevé, cela signifie que les performances des serveurs proches de l'utilisateur peuvent sans doute être améliorées. [En savoir plus](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Les délais aller-retour (DAR) du réseau ont un impact important sur les performances. Si le DAR par rapport à un point d'origine est élevé, cela signifie que les performances des serveurs proches de l'utilisateur peuvent sans doute être améliorées. [En savoir plus](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Délai aller-retour réseau"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "La latence du serveur peut avoir une incidence sur les performances Web. Si la latence serveur d'une origine est élevée, cela signifie que le serveur est en surcharge ou que ses performances backend sont médiocres. [En savoir plus](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "La latence du serveur peut avoir une incidence sur les performances Web. Si la latence serveur d'une origine est élevée, cela signifie que le serveur est en surcharge ou que ses performances backend sont médiocres. [En savoir plus](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latences du backend serveur"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Au-dessus du budget"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Maintenez le volume et la taille des requêtes réseau sous les objectifs définis par le budget de performances fourni. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 requête}one{# requête}other{# requêtes}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Budget de performances"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Les redirections entraînent des retards supplémentaires avant que la page ne puisse être chargée. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Les redirections entraînent des retards supplémentaires avant que la page ne puisse être chargée. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Évitez les redirections de page multiples"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Pour définir des budgets liés à la quantité et à la taille des ressources de pages, ajoutez un fichier budget.json. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 requête}one{# requête}other{# requêtes}} • {byteCount, number, bytes} Ko"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Réduisez au maximum le nombre de requêtes et la taille des transferts"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Les liens canoniques suggèrent l'URL à afficher dans les résultats de recherche. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Les liens canoniques suggèrent l'URL à afficher dans les résultats de recherche. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Conflit entre plusieurs URL ({urlList})"
+    "message": "Plusieurs URL en conflit ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Pointe vers un domaine différent ({url})"
+    "message": "L'URL mène à un autre domaine ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "URL non valide ({url})"
+    "message": "URL incorrecte ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Pointe vers un autre emplacement \"hreflang\" ({url})"
+    "message": "URL qui mène à un autre emplacement `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "URL relative ({url})"
@@ -585,19 +843,16 @@
     "message": "Pointe vers l'URL racine du domaine (la page d'accueil), et non vers une page de contenu équivalente"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "L'attribut \"rel=canonical\" du document n'est pas valide"
+    "message": "L'attribut `rel=canonical` du document n'est pas valide"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "L'attribut \"rel=canonical\" du document est valide"
+    "message": "L'attribut `rel=canonical` du document est valide"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Les tailles de police inférieures à 12 pixels sont trop petites pour être lisibles et nécessitent que les visiteurs sur la version mobile pincent l'écran pour zoomer et lire le texte. Veuillez utiliser une police de texte de plus de 12 pixels sur plus de 60 % du texte de la page. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Les tailles de police inférieures à 12 pixels sont trop petites pour être lisibles et nécessitent que les visiteurs sur la version mobile pincent l'écran pour zoomer et lire le texte. Veuillez utiliser une police de texte de plus de 12 pixels sur plus de 60 % du texte de la page. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} du texte lisibles"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} du texte sont trop petits."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Le texte est illisible, car aucune balise Meta de fenêtre d'affichage n'est optimisée pour les écrans mobiles."
@@ -612,16 +867,16 @@
     "message": "Le document utilise des tailles de police lisibles"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Les liens hreflang indiquent aux moteurs de recherche la version de la page qu'ils doivent répertorier dans les résultats de recherche pour une page ou une région donnée. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Les liens hreflang indiquent aux moteurs de recherche la version de la page qu'ils doivent répertorier dans les résultats de recherche pour une page ou une région donnée. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Le document ne contient pas d'attribut \"hreflang\" valide"
+    "message": "Le document ne contient pas d'attribut `hreflang` valide"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Le document contient un attribut \"hreflang\" valide"
+    "message": "L'attribut `hreflang` du document est valide"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Les pages renvoyant des codes d'état HTTP d'échec peuvent ne pas être indexées correctement. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Les pages renvoyant des codes d'état HTTP d'échec peuvent ne pas être indexées correctement. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "La page renvoie un code d'état HTTP d'échec"
@@ -630,7 +885,7 @@
     "message": "La page renvoie un code d'état HTTP de réussite"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Les moteurs de recherche ne peuvent pas inclure vos pages dans les résultats de recherche s'ils ne sont pas autorisés à les explorer. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Les moteurs de recherche ne peuvent pas inclure vos pages dans les résultats de recherche s'ils ne sont pas autorisés à les explorer. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "L'indexation de la page est bloquée"
@@ -639,7 +894,7 @@
     "message": "L'indexation de cette page n'est pas bloquée"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Le texte descriptif d'un lien aide les moteurs de recherche à comprendre votre contenu. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "Le texte descriptif d'un lien aide les moteurs de recherche à comprendre votre contenu. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 lien trouvé}one{# lien trouvé}other{# liens trouvés}}"
@@ -651,13 +906,13 @@
     "message": "Les liens contiennent un texte descriptif"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Exécutez l'[outil de test des données structurées](https://search.google.com/structured-data/testing-tool/) et le [validateur Lint de données structurées](http://linter.structured-data.org/) pour valider les données structurées. [En savoir plus](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Exécutez l'[outil de test des données structurées](https://search.google.com/structured-data/testing-tool/) et le [validateur Lint de données structurées](http://linter.structured-data.org/) pour valider les données structurées. [En savoir plus](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Les données structurées sont valides"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Les résultats de recherche peuvent inclure des attributs \"meta description\" pour résumer de façon concise le contenu de la page. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Les résultats de recherche peuvent inclure des attributs \"meta description\" pour résumer de façon concise le contenu de la page. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/description)"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Le texte de la description est vide."
@@ -669,7 +924,7 @@
     "message": "Le document contient un attribut \"meta description\""
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Les moteurs de recherche ne peuvent pas indexer le contenu des plug-ins, et de nombreux appareils limitent l'utilisation de ces derniers, voire ne les acceptent pas. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Les moteurs de recherche ne peuvent pas indexer le contenu des plug-ins, et de nombreux appareils limitent l'utilisation de ces derniers, voire ne les acceptent pas. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "Le document utilise des plug-ins"
@@ -696,7 +951,7 @@
     "message": "Le fichier robots.txt est valide"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Les éléments interactifs comme les boutons et les liens doivent être suffisamment larges (48 x 48 pixels) et avoir suffisamment d'espace autour d'eux pour que l'utilisateur puisse appuyer facilement dessus sans appuyer en même temps sur d'autres éléments. [En savoir plus](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Les éléments interactifs comme les boutons et les liens doivent être suffisamment larges (48 x 48 pixels) et avoir suffisamment d'espace autour d'eux pour que l'utilisateur puisse appuyer facilement dessus sans appuyer en même temps sur d'autres éléments. [En savoir plus](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} des éléments tactiles sont correctement dimensionnés"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Cible en chevauchement"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Taille"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Élément tactile"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Les éléments tactiles sont dimensionnés correctement"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Temps d'exécution sur le thread principal"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Tiers"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Le code tiers peut affecter considérablement les performances de chargement des pages. Limitez le nombre de fournisseurs tiers redondants, et essayez de charger du code tiers une fois le chargement de votre page terminé. [En savoir plus](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 entité tierce trouvée}one{# entité tierce trouvée}other{# entités tierces trouvées}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Utilisation tierce"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "La valeur \"Délai avant premier octet\" (Time To First Byte) identifie l'heure à laquelle votre serveur envoie une réponse. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "La valeur \"Time To First Byte\" identifie l'heure à laquelle votre serveur envoie une réponse. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Le document racine a pris {timeInMs, number, milliseconds} ms"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Durée"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nom"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Heure de début"
   },
@@ -744,7 +1008,7 @@
     "message": "Type"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Envisagez de doter votre application de l'API User Timing pour mesurer les performances réelles de votre application lors d'expériences utilisateur clés. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Envisagez de doter votre application de l'API User Timing pour mesurer ses performances réelles lors d'expériences utilisateur clés. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{[=1]1 temps utilisateur}one{# temps utilisateur}other{# temps utilisateur}}"
@@ -753,19 +1017,19 @@
     "message": "Marques et mesures du temps utilisateur"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Un élément <link> de pré-connexion a été trouvé pour {securityOrigin}, mais il n'a pas été utilisé par le navigateur. Vérifiez que vous utilisez correctement l'attribut \"crossorigin\"."
+    "message": "Un élément <link> de pré-connexion a été trouvé pour \"{securityOrigin}\", mais il n'a pas été utilisé par le navigateur. Vérifiez que vous utilisez correctement l'attribut \"`crossorigin`\"."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Envisagez d'ajouter des indices de ressources de préconnexion ou dns-prefetch pour établir les premières connexions avec des origines tierces importantes. [En savoir plus](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Envisagez d'ajouter des indices de ressources de préconnexion ou dns-prefetch pour établir les premières connexions avec des origines tierces importantes. [En savoir plus](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Connectez-vous à l'avance aux origines souhaitées"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Une balise <link> de préchargement a été détectée pour \"{preloadURL}\", mais n'a pas été utilisée par le navigateur. Vérifiez que vous utilisez correctement l'attribut \"crossorigin\"."
+    "message": "Une balise <link> de préchargement a été détectée pour \"{preloadURL}\", mais n'a pas été utilisée par le navigateur. Vérifiez que vous utilisez correctement l'attribut \"`crossorigin`\"."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Envisagez d'utiliser <link rel=preload> pour hiérarchiser la récupération des ressources actuellement requises pour le chargement ultérieur de la page. [En savoir plus](https://developers.google.com/web/ntools/lighthouse/audits/preload)."
+    "message": "Envisagez d'utiliser `<link rel=preload>` pour hiérarchiser la récupération des ressources actuellement requises pour le chargement ultérieur de la page. [En savoir plus](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Préchargez les demandes clés"
@@ -792,7 +1056,7 @@
     "message": "Ces vérifications permettent de connaître les possibilités d'[amélioration de l'accessibilité de vos applications Web](https://developers.google.com/web/fundamentals/accessibility). Seule une partie des problèmes d'accessibilité peut être détectée automatiquement. Il est donc conseillé d'effectuer un test manuel."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Ces éléments concernent des zones qu'un outil de test automatique ne peut pas couvrir. Consultez notre guide sur la [réalisation d'un examen d'accessibilité](https://developers.google.com/web/fundamentals/accessibility/how-to-review) pour en savoir plus."
+    "message": "Ces éléments concernent des zones qu'un outil de test automatique ne peut pas couvrir. Consultez notre guide sur la [réalisation d'un examen d'accessibilité](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Accessibilité"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tableaux et listes"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Bonnes pratiques"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Les budgets de performances établissent des normes sur les performances de votre site."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Au niveau des budgets"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Plus d'informations sur les performances de votre application."
+    "message": "Plus d'informations sur les performances de votre application. Ces chiffres n'ont pas d'[incidence directe](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) sur le score lié aux performances."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostic"
@@ -840,7 +1113,7 @@
     "message": "Amélioration de First Paint"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Ces optimisations peuvent accélérer le chargement de votre page."
+    "message": "Ces suggestions peuvent contribuer à charger votre page plus rapidement. En revanche, elles n'ont pas d'[incidence directe](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) sur le score lié aux performances."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Opportunités"
@@ -867,7 +1140,7 @@
     "message": "Optimisation PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Ces vérifications vous permettent de vous assurer que votre page est optimisée pour le classement dans les résultats sur les moteurs de recherche. Lighthouse ne vérifie pas certains facteurs supplémentaires susceptibles d'avoir un impact sur votre classement dans les moteurs de recherche. [En savoir plus](https://support.google.com/webmasters/answer/35769)."
+    "message": "Ces vérifications vous permettent de vous assurer que votre page est optimisée pour le classement dans les résultats sur les moteurs de recherche. Lighthouse ne vérifie pas certains facteurs supplémentaires susceptibles d'avoir un impact sur votre classement dans les moteurs de recherche. [En savoir plus](https://support.google.com/webmasters/answer/35769)"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Exécutez ces outils de validation supplémentaires sur votre site pour vérifier les bonnes pratiques de SEO complémentaires."
@@ -888,7 +1161,7 @@
     "message": "Exploration et indexation"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Assurez-vous que vos pages sont adaptées aux mobiles, afin que les utilisateurs n'aient pas besoin de pincer l'écran ni de zoomer pour lire votre contenu. [En savoir plus](https://developers.google.com/search/mobile-sites/)."
+    "message": "Assurez-vous que vos pages sont adaptées aux mobiles, afin que les utilisateurs n'aient pas besoin de pincer l'écran ni de zoomer pour lire votre contenu. [En savoir plus](https://developers.google.com/search/mobile-sites/)"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Adapté aux mobiles"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Cache de la valeur TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Emplacement"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nom"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Requêtes"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Type de ressource"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Taille (Ko)"
+    "message": "Taille"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Temps passé"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Taille de transfert"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Économies potentielles (Ko)"
+    "message": "Économies potentielles"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Économies potentielles (ms)"
+    "message": "Économies potentielles"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Économies potentielles de {wastedBytes, number, bytes} Ko"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Économies potentielles de {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Document"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Police de caractères"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Image"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Contenu multimédia"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Autre"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Feuille de style"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Tiers"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Total"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Un problème est survenu lors de l'enregistrement de la trace du chargement de votre page. Veuillez relancer Lighthouse. ({errorCode})"
@@ -930,13 +1245,19 @@
     "message": "Expiration du délai pendant la tentative de connexion initiale du protocole du débogueur."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome n'a collecté aucune capture d'écran pendant le chargement de la page. Veuillez vous assurer que du contenu soit visible sur la page, puis essayez de relancer Lighthouse. ({errorCode})"
+    "message": "Chrome n'a collecté aucune capture d'écran pendant le chargement de la page. Veuillez vous assurer que du contenu est visible sur la page, puis essayez de relancer Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Les serveurs DNS n'ont pas pu résoudre le domaine fourni."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Une erreur s'est produite lors de la collecte de la ressource {artifactName} requise : {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Une erreur Chrome interne s'est produite. Veuillez redémarrer Chrome et essayer de relancer Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "La ressource {artifactName} nécessaire n'a pas été collectée."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse n'a pas pu charger correctement la page que vous avez demandée. Assurez-vous de tester la bonne URL et vérifiez que le serveur répond correctement à toutes les requêtes."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse n'a pas pu charger correctement l'URL que vous avez demandée, car la page a cessé de répondre."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "L'URL que vous avez fournie n'est pas associée à des identifiants de sécurité valides. {securityMessages}"
+    "message": "L'URL que vous avez fournie n'est pas associée à un certificat de sécurité valide. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Le chargement de la page dans Chrome a été bloqué et remplacé par un écran interstitiel. Assurez-vous de tester la bonne URL et vérifiez que le serveur répond correctement à toutes les requêtes."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse n'a pas pu charger correctement la page que vous avez demandée. Assurez-vous de tester la bonne URL et vérifiez que le serveur répond correctement à toutes les requêtes. (Détails : {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Développer l'extrait"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Afficher les ressources tierces"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Cette exécution de Lighthouse a rencontré des problèmes :"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Les valeurs sont estimées et peuvent varier."
+    "message": "Les valeurs sont estimées et peuvent varier. Le score lié aux performances [ne repose que sur ces statistiques](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Réussite des audits, mais avec des avertissements"
@@ -1023,7 +1350,7 @@
     "message": "Vous pouvez envisager d'importer votre GIF dans un service qui permettra de l'intégrer dans une vidéo HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Installez un [plug-in WordPress de chargement différé](https://wordpress.org/plugins/search/lazy+load/) pour différer le chargement des images qui ne sont pas à l'écran, ou remplacez le thème par un autre qui offre cette fonctionnalité. Vous pouvez aussi envisager d'utiliser [le plug-in AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Installez un [plug-in WordPress de chargement différé](https://wordpress.org/plugins/search/lazy+load/) pour différer le chargement des images qui ne sont pas à l'écran, ou remplacez le thème par un autre qui offre cette fonctionnalité. Vous pouvez également envisager d'utiliser [le plug-in AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "Divers plug-ins WordPress peuvent vous aider à [aligner des éléments critiques](https://wordpress.org/plugins/search/critical+css/) ou à [différer le chargement des ressources moins importantes](https://wordpress.org/plugins/search/defer+css+javascript/). Gardez en tête qu'à cause des optimisations fournies par ces plug-ins, certaines fonctionnalités de votre thème ou de vos plug-ins peuvent cesser de fonctionner. Vous devrez donc probablement modifier le code."
@@ -1041,19 +1368,19 @@
     "message": "Un certain nombre de [plug-ins WordPress](https://wordpress.org/plugins/search/minify+javascript/) peuvent accélérer l'affichage de votre site en concaténant, en minimisant et en compressant vos scripts. Si possible, utilisez un processus de build pour réaliser cette minimisation en amont."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Vous pouvez envisager de réduire le nombre de [plug-ins WordPress](https://wordpress.org/plugins/) qui chargent des feuilles de style CSS inutilisées dans votre page, ou désactiver certains de ces plug-ins. Pour déterminer les plug-ins qui ajoutent des feuilles de style CSS superflues, exécutez une [couverture de code](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) dans Chrome DevTools. Vous pouvez identifier le thème ou le plug-in responsable à partir de l'URL de la feuille de style. Recherchez les plug-ins pour lesquels un grand nombre de feuilles de style présentent beaucoup d'éléments en rouge dans la couverture de code. Un plug-in ne doit mettre une feuille de style en file d'attente que si elle est effectivement utilisée dans la page."
+    "message": "Vous pouvez envisager de réduire le nombre de [plug-ins WordPress](https://wordpress.org/plugins/) qui chargent des feuilles de style CSS inutilisées dans votre page, ou désactiver certains de ces plug-ins. Pour déterminer les plug-ins qui ajoutent des feuilles de style CSS superflues, exécutez une [couverture de code](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) dans Chrome DevTools. Vous pouvez identifier le thème ou le plug-in responsable à partir de l'URL de la feuille de style. Recherchez les plug-ins pour lesquels un grand nombre de feuilles de style présentent beaucoup d'éléments en rouge dans la couverture de code. Un plug-in ne doit mettre une feuille de style en file d'attente que si elle est effectivement utilisée dans la page."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Vous pouvez envisager de réduire le nombre de [plug-ins WordPress](https://wordpress.org/plugins/) qui chargent des scripts JavaScript inutilisés dans votre page, ou désactiver certains de ces plug-ins. Pour déterminer les plug-ins qui ajoutent des scripts JavaScript superflus, exécutez une [couverture de code](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) dans Chrome DevTools. Vous pouvez identifier le thème ou le plug-in responsable à partir de l'URL du script. Recherchez les plug-ins pour lesquels un grand nombre de scripts présentent beaucoup d'éléments en rouge dans la couverture de code. Un plug-in ne doit mettre un script en file d'attente que s'il est effectivement utilisé dans la page."
+    "message": "Vous pouvez envisager de réduire le nombre de [plug-ins WordPress](https://wordpress.org/plugins/) qui chargent des scripts JavaScript inutilisés dans votre page, ou désactiver certains de ces plug-ins. Pour déterminer les plug-ins qui ajoutent des scripts JavaScript superflus, exécutez une [couverture de code](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) dans Chrome DevTools. Vous pouvez identifier le thème ou le plug-in responsable à partir de l'URL du script. Recherchez les plug-ins pour lesquels un grand nombre de scripts présentent beaucoup d'éléments en rouge dans la couverture de code. Un plug-in ne doit mettre un script en file d'attente que s'il est effectivement utilisé dans la page."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "En savoir plus sur la [mise en cache dans le navigateur dans WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "En savoir plus sur la [mise en cache dans le navigateur dans WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)"
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "Vous pouvez envisager d'utiliser un [plug-in WordPress d'optimisation d'image](https://wordpress.org/plugins/search/optimize+images/) pour compresser vos images sans dégrader leur qualité."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Importez des images directement via la [bibliothèque multimédia](https://codex.wordpress.org/Media_Library_Screen) pour vous assurer que les tailles d'images requises sont disponibles. Ensuite, insérez-les depuis la bibliothèque multimédia ou utilisez le widget d'image pour vous assurer que les tailles d'images optimales sont utilisées (y compris celles pour les points d'arrêt réactifs). Évitez d'utiliser les images en taille réelle, sauf si les dimensions sont adéquates pour l'utilisation prévue. [En savoir plus](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Importez des images directement via la [bibliothèque multimédia](https://codex.wordpress.org/Media_Library_Screen) pour vous assurer que les tailles d'images requises sont disponibles. Ensuite, insérez-les depuis la bibliothèque multimédia ou utilisez le widget d'image pour vous assurer que les tailles d'images optimales sont utilisées (y compris celles pour les points d'arrêt réactifs). Évitez d'utiliser les images `Full Size`, sauf si les dimensions sont adéquates pour l'utilisation prévue. [En savoir plus](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Vous pouvez activer la compression du texte dans la configuration de votre serveur Web."

--- a/lighthouse-core/lib/i18n/locales/he.json
+++ b/lighthouse-core/lib/i18n/locales/he.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "מקשי גישה מאפשרים למשתמשים להתמקד במהירות בחלק מסוים בדף. כדי לאפשר ניווט תקין, כל מקש גישה צריך להיות ייחודי. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "מקשי גישה מאפשרים למשתמשים להתמקד במהירות בחלק מסוים בדף. כדי לאפשר ניווט תקין, כל מקש גישה צריך להיות ייחודי. [מידע נוסף](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "ערכי `[accesskey]` אינם ייחודיים"
+    "message": "יש ערכי `[accesskey]` שאינם ייחודיים"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "ערכי `[accesskey]` הם ייחודיים"
+    "message": "`[accesskey]` הערכים ייחודיים"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "כל `role` ב-ARIA תומך בקבוצת משנה ספציפית של מאפייני `aria-*‎`. כשיש אי-התאמה ביניהם, מאפייני `aria-*‎` אינם חוקיים. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "כל ARIA `role` תומכת בקבוצת משנה ספציפית של `aria-*` מאפיינים. חוסר התאמה בין המאפיינים הופך אותם `aria-*` ללא חוקיים. [מידע נוסף](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "מאפייני `‎[aria-*]‎` אינם תואמים לתפקידים שלהם"
+    "message": "יש מאפייני `[aria-*]` שלא תואמים לתפקידים שלהם"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "מאפייני ‎`[aria-*]`‎ תואמים לתפקידים שלהם"
+    "message": "מאפייני ה-`[aria-*]`‎ תואמים לתפקידים שלהם"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "חלק מתפקידי ARIA כוללים מאפיינים נדרשים שמתארים לקוראי המסך את מצב הרכיב. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "חלק מתפקידי ה-ARIA כוללים מאפיינים נדרשים שמתארים לקוראי המסך את מצב הרכיב. [מידע נוסף](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "למאפייני `[role]` אין את כל מאפייני `‎[aria-*]‎` הנדרשים"
+    "message": "יש רכיבים מסוג `[role]` שאין להם את כל מאפייני ה-`[aria-*]` הנדרשים"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "למאפיינים `[role]` יש את כל מאפייני‎ `[aria-*]` ‎הנדרשים"
+    "message": "לכל הרכיבים מסוג `[role]` יש את כל מאפייני ה-`[aria-*]` הדרושים"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "תפקידי הורה מסוימים ב-ARIA צריכים לכלול תפקידי צאצא ספציפיים כדי לבצע את פונקציות הנגישות שלהם. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "תפקידי הורה מסוימים של ARIA צריכים לכלול תפקידי צאצא ספציפיים כדי לבצע את פונקציות הנגישות שלהם. [מידע נוסף](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "חסרים רכיבים עם `[role]` שדורשים מאפייני `[role]` ספציפיים ברמת צאצא."
+    "message": "חסרים רכיבים עם `[role]` שדורשים רכיבי צאצא ספציפיים של `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "קיימים רכיבים עם `[role]` שנדרשים עבורם רכיבי `[role]` ספציפיים"
+    "message": "קיימים רכיבים עם `[role]` שדורשים רכיבי צאצא ספציפיים של `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "חלק מתפקידי הצאצא ב-ARIA חייבים להיכלל בין תפקידי הורה ספציפיים כדי למלא באופן תקין את פונקציות הנגישות שלהם. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "חלק מתפקידי הצאצא מסוג ARIA חייבים להיכלל בין תפקידי הורה ספציפיים כדי למלא באופן תקין את פונקציות הנגישות שלהם. [מידע נוסף](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "מאפייני `[role]` אינם בין רכיבי ההורה הנדרשים"
+    "message": "מאפייני `[role]` לא נמצאים בתוך רכיב ההורה הנדרש שלהם"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "מאפייני `[role]` נמצאים בתוך רכיב ההורה הנדרש שלהם"
+    "message": "רכיבים מסוג `[role]` נמצאים בתוך רכיב ההורה הנדרש שלהם"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "תפקידי ARIA חייבים לכלול ערכים חוקיים כדי לבצע את פונקציות הנגישות שלהם. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "תפקידי ARIA חייבים לכלול ערכים חוקיים כדי לבצע את פונקציות הנגישות שלהם. [מידע נוסף](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "ערכי `[role]` אינם חוקיים"
+    "message": "יש ערכי `[role]` לא חוקיים"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "הערכים של `[role]` חוקיים"
+    "message": "ערכי ה-`[role]` חוקיים"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "טכנולוגיות לנגישות, כמו קוראי מסכים, לא יכולות לפענח מאפייני ARIA שהערכים שלהם אינם חוקיים. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "טכנולוגיות לנגישות, כמו קוראי מסך, לא יכולות לפענח מאפייני ARIA שהערכים שלהם לא חוקיים. [מידע נוסף](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
     "message": "למאפייני ‎`[aria-*]`‎ אין ערכים חוקיים"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "למאפייני ‎`[aria-*]`‎ יש ערכים חוקיים"
+    "message": "למאפייני ה-`[aria-*]` יש ערכים חוקיים"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "טכנולוגיות לנגישות, כמו קוראי מסך, לא יכולות לפענח מאפייני ARIA עם שמות לא חוקיים. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "טכנולוגיות לנגישות, כמו קוראי מסך, לא יכולות לפענח מאפייני ARIA עם שמות לא חוקיים. [מידע נוסף](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "מאפייני `‎[aria-*]‎` אינם חוקיים, או שהם כוללים שגיאות איות"
+    "message": "יש מאפייני `[aria-*]` שאינם חוקיים או שכוללים שגיאות איות"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "המאפיינים מסוג‎`[aria-*]` ‎חוקיים ואינם כוללים שגיאות איות"
+    "message": "מאפייני ה-`[aria-*]` חוקיים ולא כוללים שגיאות איות"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "כתוביות מאפשרות לחרשים ולקויי שמיעה להשתמש ברכיבי אודיו, ומספקות מידע קריטי, כמו זהות הדובר, המילים שנאמרות ומידע אחר שאינו מועבר בדיבור. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "כתוביות מאפשרות לאנשים חרשים ולקויי שמיעה להשתמש ברכיבי אודיו, ומספקות מידע קריטי, כמו זהות הדובר, המילים שנאמרות ומידע אחר שאינו מועבר בדיבור. [מידע נוסף](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "ברכיבי `<audio>` חסר רכיב `<track>` עם `‎[kind=\"captions\"]‎`."
+    "message": "יש רכיבי `<audio>` שחסר בהם רכיב `<track>` עם `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "רכיבי `<audio>` מכילים רכיב `<track>` עם ‎`[kind=\"captions\"]`‎"
+    "message": "רכיבי `<audio>` מכילים רכיב `<track>` עם `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "רכיבים שנכשלו בבדיקה"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "כשאין ללחצן שם נגיש, קוראי מסך אומרים את המילה \"לחצן\", ובמצב זה הלחצן אינו שימושי לאנשים שמסתמכים על קוראי מסך. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "כשאין ללחצן שם נגיש, קוראי מסך אומרים את המילה \"לחצן\", ובמצב כזה אנשים שמסתמכים על קוראי מסך יתקשו להשתמש בלחצן. [מידע נוסף](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "ללחצנים אין שמות ייחודיים"
@@ -93,7 +93,7 @@
     "message": "ללחצנים יש שם נגיש"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "הוספה של דרכים לעקיפת תוכן שחוזר על עצמו מאפשרת למשתמשי מקלדת לנווט בדף בצורה יעילה יותר. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "הוספה של דרכים לעקיפת תוכן שחוזר על עצמו מאפשרת לאנשים שמשתמשים במקלדת לנווט בדף בצורה יעילה יותר. [מידע נוסף](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "הדף לא כולל כותרת, קישור לדילוג או קטע שמסומן כ-landmark"
@@ -102,7 +102,7 @@
     "message": "הדף כולל כותרת, קישור לדילוג או קטע שמסומן כ-landmark"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "משתמשים רבים מתקשים, או לא מסוגלים כלל, לקרוא טקסט עם ניגודיות צבעים נמוכה. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "משתמשים רבים מתקשים לקרוא טקסט עם ניגודיות נמוכה, או לא מסוגלים לקרוא אותו. [מידע נוסף](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "יחס הניגודיות של צבעי הרקע והחזית אינו מספיק."
@@ -111,88 +111,88 @@
     "message": "יש יחס ניגודיות מספיק בין צבעי הרקע והחזית"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "כשרשימות של הגדרות אינן מסומנות כראוי, קוראי מסך עשויים להקריא טקסט באופן מבלבל או לא מדויק. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "כשרשימות של הגדרות לא מסומנות כראוי, קוראי מסך עשויים לספק פלט מבלבל או לא מדויק. [מידע נוסף](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "רכיבי `<dl>`' לא כוללים רק קבוצות `<dt>` ו-`<dd>` עם סדר תקין, רכיבי `<script>` או `<template>`."
+    "message": "יש רכיבי `<dl>` שלא מכילים רק רכיבי `<script>` או `<template>`, או קבוצות `<dt>` ו-`<dd>` עם סדר תקין."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "רכיבי `<dl>` כוללים רק קבוצות `<dt>` ו-`<dd>` עם סדר תקין‏, רכיבי `<script>` או `<template>`."
+    "message": "רכיבי `<dl>` מכילים רק רכיבי `<script>` או `<template>`, או קבוצות `<dt>` ו-`<dd>` עם סדר תקין."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "פריטים ברשימות של הגדרות (`<dt>` ו-`<dd>`) צריכים להופיע בין רכיבי הורה מסוג `<dl>` כדי לוודא שקוראי מסך יוכלו לקרוא אותם כראוי. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "פריטים ברשימות של הגדרות (`<dt>` ו-`<dd>`) צריכים להיות תחומים בתוך רכיב הורה מסוג `<dl>` כדי שקוראי מסך יוכלו להקריא אותם בצורה נכונה. [מידע נוסף](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "פריטים ברשימת הגדרות אינם בין רכיבי `<dl>`"
+    "message": "יש פריטים ברשימות של הגדרות שלא תחומים בין רכיבי `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "פריטים ברשימת הגדרות מופיעים בין רכיבי `<dl>`"
+    "message": "פריטים ברשימות של הגדרות מוצבים בין רכיבי `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "הכותרת מספקת למשתמשים של קוראי מסך סקירה כללית של הדף. בנוסף, משתמשים של מנועי חיפוש מסתמכים במידה רבה על הכותרת כדי להבין אם הדף רלוונטי לחיפוש שלהם. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "הכותרת מספקת סקירה כללית של הדף למשתמשים הנעזרים בקוראי מסך. בנוסף, משתמשים של מנועי חיפוש מסתמכים במידה רבה על הכותרת כדי להבין אם הדף רלוונטי לחיפוש שלהם. [מידע נוסף](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "אין למסמך רכיב `<title>`"
+    "message": "למסמך אין רכיב `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "המסמך כולל רכיב `<title>`"
+    "message": "המסמך מכיל רכיב `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "הערך של מאפיין זיהוי חייב להיות ייחודי כדי למנוע מטכנולוגיות לנגישות להתעלם ממופעים אחרים. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "הערך של מאפיין id חייב להיות ייחודי כדי למנוע מטכנולוגיות לנגישות להתעלם ממופעים אחרים. [מידע נוסף](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "מאפייני `[id]` בדף אינם ייחודיים"
+    "message": "יש בדף מאפייני `[id]` שאינם ייחודיים"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "מאפייני `[id]` בדף הם ייחודיים"
+    "message": "מאפייני ה-`[id]` בדף הם ייחודיים"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "משתמשים של קוראי מסכים מסתמכים על כותרות של מסגרות שמתארות את תוכן המסגרות. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "משתמשים הנעזרים בקוראי מסך מסתמכים על כותרות של מסגרות כדי להבין מה תוכן המסגרות. [מידע נוסף](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "לרכיבי `<frame>` או `<iframe>` אין כותרת"
+    "message": "לרכיבי `<frame>` או `<iframe>` אין מאפיין title"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "רכיבי `<frame>` או `<iframe>` כוללים כותרת"
+    "message": "לרכיבי `<frame>` או `<iframe>` יש מאפיין title"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "אם בדף לא מצוין מאפיין lang, קורא מסך יפעל כאילו שהדף כתוב בשפת ברירת המחדל שהמשתמש בחר במהלך הגדרת קורא המסך. אם שפת הדף אינהשפת ברירת המחדל, ייתכן שקורא המסך לא יקרא בצורה נכונה את הטקסט שבדף. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "אם בדף לא מצוין מאפיין lang, קורא המסך יפעל כאילו שהדף כתוב בשפת ברירת המחדל שהמשתמש בחר במהלך הגדרת קורא המסך. אם שפת הדף שונה משפת ברירת המחדל, ייתכן שקורא המסך לא יקרא בצורה נכונה את הטקסט שבדף. [מידע נוסף](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "לרכיב `<html>` אין מאפיין `[lang]`"
+    "message": "לרכיב `<html>` אין רכיב `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
     "message": "לרכיב `<html>` יש מאפיין `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "ציון של [שפת BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) חוקית עוזר לקוראי מסך להקריא טקסט באופן תקין. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "ציון של [שפת BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) חוקית עוזר לקוראי מסך להקריא טקסט בצורה נכונה. [מידע נוסף](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "לרכיב `<html>` אין ערך חוקי בשביל מאפיין `[lang]` שלו."
+    "message": "לרכיב `<html>` אין ערך חוקי עבור המאפיין `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "לרכיב `<html>` יש ערך תקין בשביל מאפיין `[lang]` שלו"
+    "message": "לרכיב `<html>` יש ערך חוקי עבור המאפיין `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "רכיבים אינפורמטיביים צריכים לכלול טקסט חלופי קצר ותיאורי. אפשר להתעלם מרכיבי עיצוב עם מאפיין alt ריק. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "רכיבים אינפורמטיביים צריכים לכלול טקסט חלופי קצר ותיאורי. אפשר להתעלם מרכיבי עיצוב עם מאפיין alt ריק. [מידע נוסף](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "לרכיבי תמונה אין מאפייני `[alt]`"
+    "message": "יש רכיבי תמונה ללא מאפייני `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
     "message": "לרכיבי תמונה יש מאפייני `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "כשתמונה משמשת כלחצן `<input>`, הוספה של טקסט חלופי יכולה לעזור למשתמשים של קוראי מסך להבין מה הלחצן עושה. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "כשתמונה משמשת כלחצן `<input>`, הוספה של טקסט חלופי יכולה לעזור למשתמשים הנעזרים בקוראי מסך להבין מה הלחצן עושה. [מידע נוסף](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "לרכיבי `‎<input type=\"image\">‎` אין טקסט `[alt]`"
+    "message": "יש רכיבי `<input type=\"image\">` שאין להם טקסט `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "לרכיבי `‎<input type=\"image\">‎` יש טקסט `[alt]`"
+    "message": "לרכיבים מסוג `<input type=\"image\">` יש טקסט `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "בעזרת תוויות אפשר לוודא ששמות של פקדי טפסים מוקראים באופן תקין על-ידי טכנולוגיות לנגישות, כמו קוראי מסך. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "תוויות עוזרות לוודא ששמות של פקדי טפסים מוקראים באופן תקין על ידי טכנולוגיות לנגישות, כמו קוראי מסך. [מידע נוסף](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "לא שויכו תוויות אל רכיבי טופס"
@@ -201,16 +201,16 @@
     "message": "לרכיבי טופס יש תוויות המשויכות אליהם"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "טבלה המשמשת לקביעת פריסה אינה יכולה לכלול רכיבי נתונים, כמו רכיבי th, ‏caption או המאפיין summary, מפני שהם יכולים ליצור חוויה מבלבלת עבור משתמשים הנעזרים בקורא מסך. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "טבלה המשמשת לקביעת פריסה אינה יכולה לכלול רכיבי נתונים, כמו הרכיב th, הרכיב ‏caption או המאפיין summary, כי הם עשויים ליצור חוויה מבלבלת עבור משתמשים הנעזרים בקורא מסך. [מידע נוסף](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "רכיבי `<table>` להצגה לא נמנעים משימוש ב-`<th>`, ‏`<caption>` או במאפיין `[summary]`."
+    "message": "ברכיבי `<table>` להצגה, אין הימנעות משימוש ב-`<th>`, ב-`<caption>` או במאפיין `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "רכיבי `<table>` להצגה אינם משתמשים ב-`<th>`‏, `<caption>` או במאפיין `[summary]`."
+    "message": "רכיבי `<table>` להצגה לא מכילים `<th>`, `<caption>` או את המאפיין `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "כשהטקסט של קישור מובן, ייחודי ואפשר להתמקד בו, משתמשים שנעזרים בקורא מסך נהנים מחוויית ניווט משופרת. מצב זה נכון גם לגבי טקסט חלופי של תמונות כשנעשה בהן שימוש כקישורים. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "כשהטקסט של הקישור מובן וייחודי ואפשר להתמקד בו, משתמשים שנעזרים בקורא מסך נהנים מחוויית ניווט משופרת. מצב זה נכון גם לגבי טקסט חלופי של תמונות כשנעשה בהן שימוש כקישורים. [מידע נוסף](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "לקישורים אין שמות ייחודיים"
@@ -219,52 +219,52 @@
     "message": "לקישורים יש שמות ייחודיים"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "קוראי מסך מקריאים רשימות בדרך ספציפית. שמירה על מבנה רשימות תקין מאפשרת הקראה תקינה על-ידי קורא המסך. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "קוראי מסך מקריאים רשימות בצורה מסוימת. שמירה על מבנה רשימות תקין מאפשרת הקראה תקינה על ידי קורא המסך. [מידע נוסף](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "הרשימות אינן כוללות רק רכיבי `<li>` ורכיבים שתומכים בסקריפט (`<script>` ו-`<template>`)."
+    "message": "הרשימות לא מכילות רק רכיבי `<li>` ורכיבים שתומכים בסקריפט (`<script>` ו- `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "הרשימות כוללות רק רכיבי `<li>` ורכיבים שתומכים בסקריפט (`<script>` ו-`<template>`)."
+    "message": "הרשימות מכילות רק רכיבי `<li>` ורכיבים שתומכים בסקריפט (`<script>` ו-`<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "כדי שקוראי מסך יוכלו לקרוא כראוי פריטים ברשימות, (`<li>`) הם צריכים להופיע בין רכיבי הורה מסוג `<ul>` או `<ol>`. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "כדי שקוראי מסך יוכלו לקרוא כראוי פריטים ברשימות, (`<li>`) הם צריכים להופיע בין רכיבי הורה מסוג `<ul>` או `<ol>`. [מידע נוסף](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "פריטי רשימה (`<li>`) אינם נמצאים בין רכיבי `<ul>` או `<ol>` ברמת הורה."
+    "message": "יש פריטים ברשימות (`<li>`) שלא נמצאים בין רכיבי הורה של `<ul>` או `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
     "message": "פריטים ברשימות (`<li>`) מופיעים בין רכיבי הורה `<ul>` או `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "משתמשים לא מצפים לרענון אוטומטי של הדף, ושימוש ברענון כזה יחזיר את ההתמקדות אל ראש הדף. מצב כזה יכול ליצור חוויה מתסכלת או מבלבלת. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "משתמשים לא מצפים לרענון אוטומטי של הדף, ושימוש ברענון כזה יחזיר את ההתמקדות אל ראש הדף. מצב כזה יכול ליצור חוויה מתסכלת או מבלבלת. [מידע נוסף](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "המסמך משתמש ב-`‎<meta http-equiv=\"refresh\">‎`"
+    "message": "המסמך מכיל `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "המסמך לא משתמש ב-‎`<meta http-equiv=\"refresh\">‎`‎"
+    "message": "המסמך לא כולל שימוש ב-`<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "השבתת האפשרות להגדיל את התוכן יוצרת בעיה עבור לקויי ראייה שמסתמכים על הגדלת המסך כדי לראות היטב את תוכן דף האינטרנט. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "השבתת האפשרות להגדיל את תצוגת התוכן יוצרת בעיה עבור משתמשים עם ליקויי ראייה שנוהגים להגדיל את המסך כדי לראות היטב את תוכן דף האינטרנט. [מידע נוסף](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "נעשה שימוש ב-`‎[user-scalable=\"no\"]‎` בתוך הרכיב `‎<meta name=\"viewport\">‎`, או שערך המאפיין `[maximum-scale]` קטן מ-5."
+    "message": "נעשה שימוש ב-`[user-scalable=\"no\"]` ברכיב `<meta name=\"viewport\">`, או שערך המאפיין `[maximum-scale]` קטן מ-5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "לא נעשה שימוש ב-`‎[user-scalable=\"no\"]‎` ברכיב `‎<meta name=\"viewport\">‎` וערך המאפיין `[maximum-scale]` אינו פחות מ-5."
+    "message": "לא נעשה שימוש ב-`[user-scalable=\"no\"]` ברכיב `<meta name=\"viewport\">` וערך המאפיין `[maximum-scale]` לא קטן מ-5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "קוראי מסך לא יכולים לתרגם תוכן שאינו טקסט. הוספה של טקסט alt ברכיבי `<object>` עוזרת לקוראי מסך להעביר למשתמשים את המשמעות. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "קוראי מסך לא יכולים לתרגם תוכן שאינו טקסט. הוספה של טקסט חלופי לרכיבי `<object>` עוזרת להבהיר את המשמעות כשמשתמשים בקוראי מסך. [מידע נוסף](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "לרכיבי `<object>` אין טקסט `[alt]`"
+    "message": "יש רכיבי `<object>` שאין להם טקסט `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "לרכיבי `<object>` יש טקסט `[alt]`"
+    "message": "לרכיבים מסוג `<object>` יש טקסט `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "ערך גדול מ-0 מציין סדר ניווט מפורש. למרות שאפשרות זו תקינה מבחינה טכנית, במקרים רבים היא גורמת לחוויה מתסכלת עבור משתמשים שמסתמכים על טכנולוגיות לנגישות. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "ערך גדול מ-0 מרמז על סדר ניווט מפורש. זו אפשרות תקינה מבחינה טכנית, אבל במקרים רבים היא גורמת לחוויה מתסכלת עבור משתמשים שמסתמכים על טכנולוגיות לנגישות. [מידע נוסף](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "לחלק מהרכיבים יש ערך `[tabindex]` גדול מ-0"
@@ -273,49 +273,61 @@
     "message": "לאף רכיב אין ערך `[tabindex]` גדול מ-0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "קוראי מסכים כוללים תכונות שמקלות את הניווט בטבלאות. כשתאי `<td>` שמשתמשים במאפיין `[headers]` מתייחסים רק לתאים אחרים באותה טבלה, משתמשים של קוראי מסך עשויים ליהנות מחוויה טובה יותר. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "קוראי מסך כוללים תכונות שמקלות את הניווט בטבלאות. כשתאי `<td>` שמשתמשים במאפיין `[headers]` מתייחסים רק לתאים אחרים באותה טבלה, משתמשים הנעזרים בקוראי מסך יכולים ליהנות מחוויה טובה יותר. [מידע נוסף](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "תאים ברכיב `<table>` שמשתמשים במאפיין `[headers]` מתייחסים לתאים אחרים באותה טבלה."
+    "message": "תאים ברכיב `<table>` שמשתמשים במאפיין `[headers]` מתייחסים לתאים אחרים באותה הטבלה."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "תאים ברכיב `<table>` שמשתמשים במאפיין `[headers]` מתייחסים רק לתאים באותה טבלה."
+    "message": "כל התאים שמוצבים בתוך רכיב `<table>` ומשתמשים במאפיין `[headers]` מתייחסים רק לתאים אחרים באותה טבלה."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "קוראי מסכים כוללים תכונות שמקלות את הניווט בטבלאות. הקפדה על כך שכותרות טבלה יתייחסו תמיד לקבוצה כלשהי של תאים, יכולה לשפר את החוויה של משתמשים הנעזרים בקורא מסך. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "קוראי מסך כוללים תכונות שמקלות את הניווט בטבלאות. כשכותרות של טבלאות מתייחסות תמיד לקבוצה כלשהי של תאים, משתמשים הנעזרים בקורא מסך יכולים ליהנות מחוויה טובה יותר. [מידע נוסף](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "לרכיבי `<th>` ולרכיבים עם `‎[role=\"columnheader\"/\"rowheader\"]‎` אין תאים שאותם הם מתארים."
+    "message": "יש רכיבי `<th>` ורכיבים עם `[role=\"columnheader\"/\"rowheader\"]` שאין להם את תאי הנתונים שהם מתארים."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "לרכיבי `<th>` ולרכיבים עם `‎[role=\"columnheader\"/\"rowheader\"]‎` יש תאים שאותם הם מתארים."
+    "message": "לרכיבי `<th>` ולרכיבים עם `[role=\"columnheader\"/\"rowheader\"]` יש תאי נתונים שהם מתארים."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "ציון של [שפת BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) חוקית ברכיבים עוזר להבטיח שהטקסט יבוטא באופן תקין על-ידי קורא המסך. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "ציון של [שפת BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) חוקית ברכיבים עוזר להבטיח הגייה נכונה של הטקסט על ידי קורא המסך. [מידע נוסף](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "למאפייני `[lang]` אין ערך חוקי"
+    "message": "יש מאפייני `[lang]` שאין להם ערך חוקי"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
     "message": "למאפייני `[lang]` יש ערך חוקי"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "כשסרטון כולל כתובית, המידע שהוא כולל נגיש יותר לחרשים ולקויי שמיעה. [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "כשסרטון כולל כתוביות, המידע שהוא כולל נגיש יותר למשתמשים חרשים ולקויי שמיעה. [מידע נוסף](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "רכיבי `<video>` אינם מכילים רכיב `<track>` עם `‎[kind=\"captions\"]‎`."
+    "message": "יש רכיבי `<video>` שלא מכילים רכיב `<track>` עם `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "ברכיבי `<video>` יש רכיב `<track>` עם `‎[kind=\"captions\"]‎`"
+    "message": "רכיבי `<video>` מכילים רכיב `<track>` עם `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "תיאורים קוליים מספקים מידע רלוונטי לגבי סרטונים במקרים שבהם הדבר לא אפשרי בעזרת דיאלוג (למשל: הבעות פנים ונופים). [מידע נוסף](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "בסרטונים, תיאורים קוליים מספקים מידע רלוונטי שאי אפשר להבין מהדיאלוג. למשל, הבעות פנים ונופים. [מידע נוסף](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "רכיבי `<video>` לא כוללים רכיב `<track>` עם ‎`[kind=\"description\"]`‎."
+    "message": "יש רכיבי `<video>` שלא מכילים רכיב `<track>` עם `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "רכיבי `<video>` כוללים רכיב `<track>` עם `‎[kind=\"description\"]‎`"
+    "message": "רכיבי `<video>` מכילים רכיב `<track>` עם `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "כדי שהדף יוצג למשתמשים באופן אידיאלי ב-iOS אחרי ההוספה למסך הבית, מומלץ להגדיר מאפיין apple-touch-icon. המאפיין חייב להפנות לתמונת PNG לא שקופה בפורמט ריבוע בגודל 192 פיקסלים (או 180 פיקסלים). [מידע נוסף](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "הדף לא מכיל `apple-touch-icon` חוקי"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` לא עדכני; עדיף להשתמש ב-`apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "האתר מכיל `apple-touch-icon` חוקי"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "תוספים ל-Chrome השפיעו לרעה על ביצועי הטעינה של הדף הזה. כדאי לבדוק את הדף במצב גלישה בסתר או באמצעות פרופיל Chrome שאינו כולל תוספים."
@@ -330,7 +342,7 @@
     "message": "זמן כולל של CPU (יחידת עיבוד מרכזית)"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "כדאי לשקול את האפשרות לקצר את הזמן הדרוש לניתוח, הידור וביצוע JS. לשם כך כדאי להשתמש במטענים ייעודיים (payload) קטנים יותר של JS. [מידע נוסף] (https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "כדאי לשקול את האפשרות לקצר את הזמן הדרוש לניתוח, הידור וביצוע של JS. לשם כך כדאי להשתמש במטענים ייעודיים (payloads) קטנים יותר של JS. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "יש לקצר את זמן הביצוע של JavaScript"
@@ -339,28 +351,28 @@
     "message": "זמן ביצוע של JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "קובצי GIF גדולים לא מעבירים תוכן אנימציה בצורה יעילה. כדי לצמצם את מספר הבייטים שמועברים ברשת, במקום קובצי GIF כדאי לשקול את האפשרות להשתמש בסרטוני MPEG4/WebM בשביל אנימציות ובקובצי PNG/WebP בשביל תמונות סטטיות. [מידע נוסף](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "קובצי GIF גדולים לא מעבירים אנימציות בצורה יעילה. כדי לצמצם את מספר הבייטים שמועברים ברשת, במקום קובצי GIF כדאי לשקול את האפשרות להשתמש בסרטוני MPEG4/WebM בשביל אנימציות ובקובצי PNG/WebP בשביל תמונות סטטיות. [מידע נוסף](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "יש להשתמש בפורמטים של וידאו כדי להציג תוכן אנימציה"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "כדי לקצר את הזמן עד לאינטראקטיביות (Time to Interactive) כדאי לשקול את האפשרות לבצע טעינה הדרגתית של תוכן שאינו מופיע במסך ושל תמונות מוסתרות, אחרי שכל המשאבים הקריטיים סיימו להיטען. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "כדי לקצר את הזמן עד לפעילות מלאה, כדאי לשקול לבצע טעינה הדרגתית של תמונות מוסתרות ותמונות שלא מופיעות מיד במסך, כך שייטענו רק אחרי סיום הטעינה של כל המשאבים הקריטיים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "יש לעכב טעינה של תמונות שאינן מופיעות במסך"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "משאבים חוסמים את העיבוד הראשון (First Paint) בדף. כדאי לשקול את האפשרות לספק תוכן JS/CSS קריטי באופן מוטבע ולעכב את כל תוכן ה-JS/סגנונות שאינם קריטיים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "משאבים חוסמים את הצגת התמונה הראשונית של הדף במסך כדאי לשקול את האפשרות לספק תוכן JS/CSS קריטי באופן מוטבע ולדחות את הטעינה של כל תוכן ה-JS/הסגנונות שאינם קריטיים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "יש להימנע ממשאבים שחוסמים עיבוד"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "מטענים ייעודיים (payload) בנפח גדול המועברים ברשת עולים למשתמשים כסף ולרוב מאריכים את זמני הטעינה. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "מטענים ייעודיים (payload) בנפח גדול המועברים ברשת עולים למשתמשים כסף ולעתים קרובות מאריכים את זמני הטעינה. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "הגודל הכולל היה {totalBytes, number, bytes} ‏KB"
+    "message": "הגודל הכולל היה ‎{totalBytes, number, bytes} KB"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "יש להימנע מהעברה של מטענים ייעודיים ענקיים (payload) ברשת"
@@ -369,19 +381,19 @@
     "message": "נמנע מהעברה של מטענים ייעודיים ענקיים (payload) ברשת"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "הקטנת קובצי CSS יכולה לצמצם את הגודל של מטענים ייעודיים (payload) שמועברים ברשת. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "הקטנה של קובצי CSS יכולה לצמצם את הגודל של מטענים ייעודיים (payloads) שמועברים ברשת. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "יש להקטין קובצי CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "הקטנת קובצי JavaScript יכולה לצמצם את המטען הייעודי (payload) ולקצר את משך הזמן הנדרש לניתוח סקריפט. [מידע נוסף](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "הקטנה של קובצי JavaScript יכולה לצמצם את המטען הייעודי (payload) ולקצר את משך הזמן הנדרש לניתוח סקריפט. [מידע נוסף](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "יש לקצר את קוד JavaScript למינימום ההכרחי"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "יש להסיר מגיליונות הסגנון כללים שאינם בשימוש ולדחות את הטעינה של רכיבי CSS שאינם חלק מהתוכן בחלק העליון והקבוע. כך תצטמצם צריכה בלתי נחוצה של נתונים כתוצאה מפעילות הרשת. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "יש להסיר מגיליונות הסגנונות כללים שאינם בשימוש ולדחות את הטעינה של רכיבי CSS שאינם חלק מהתוכן בחלק העליון והקבוע. הפעולה הזו תצמצם צריכה בלתי נחוצה של בייטים כתוצאה מפעילות הרשת. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "יש להסיר CSS שאינו בשימוש"
@@ -411,19 +423,19 @@
     "message": "יש לקודד תמונות בצורה יעילה"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "הצגת תמונות שהגודל שלהן הוגדר בצורה נכונה חוסכת צריכת נתונים בחבילת הגלישה ומקצרת את זמן הטעינה. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "הצגת תמונות שהגודל שלהן הוגדר בצורה נכונה עוזרת לחסוך בניצול חבילת הגלישה ולקצר את זמן הטעינה. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "יש להגדיר את גודל התמונות בצורה נכונה"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "הצגת משאבים המבוססים על טקסט צריכה להתבצע עם דחיסה (gzip‏, deflate או brotli) כדי לצמצם את סך הבייטים שמועברים ברשת. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "הצגת משאבים המבוססים על טקסט צריכה להתבצע עם דחיסה (gzip‏, deflate או brotli) כדי לצמצם את כמות הבייטים שמועברים ברשת. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "יש להפעיל דחיסת טקסט"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "לעתים קרובות, פורמטים של תמונות כמו JPEG 2000‏, JPEG XR ו-WebP מספקים דחיסה טובה יותר מאשר PNG או JPEG. שימוש בפורמטים האלה מקצר את זמן ההורדות ומצמצם את צריכת הנתונים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "לעתים קרובות, פורמטים של תמונות כמו JPEG 2000‏, JPEG XR ו-WebP מספקים דחיסה טובה יותר מאשר PNG או JPEG. הדחיסה המשופרת מקצרת את זמן ההורדות ומצמצמת את צריכת הנתונים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "יש להציג תמונות בפורמטים עדכניים"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "יש לצמצם את העומק של בקשות קריטיות"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "הוצאה משימוש/אזהרה"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "שורה"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "רכיבי API שהוצאו משימוש יוסרו בסופו של דבר מהדפדפן. [מידע נוסף](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{נמצאה אזהרה אחת}two{נמצאו # אזהרות}many{נמצאו # אזהרות}other{נמצאו # אזהרות}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "הדף מכיל רכיבי API שהוצאו משימוש"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "אין רכיבי API שהוצאו משימוש"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Application Cache הוצא משימוש. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "בשימוש: \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "נעשה שימוש ב-Application Cache"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "לא נעשה שימוש ב-Application Cache"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "ציון של doctype מונע מהדפדפן לעבור למצב תאימות (quirks mode). למידע נוסף על [הדף של MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "שם של Doctype חייב להיות המחרוזת `html` עם אותיות קטנות"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "המסמך חייב להכיל doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "publicId אמור להיות מחרוזת ריקה"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "systemId אמור להיות מחרוזת ריקה"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "ה-doctype של הדף אינו מוגדר ל-HTML, ולכן הופעל מצב תאימות (quirks mode)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "ה-doctype של הדף מוגדר ל-HTML"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "רכיב"
   },
@@ -447,7 +510,7 @@
     "message": "ערך"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "מפתחי דפדפנים ממליצים שדפים יכילו פחות מכ-1,500 רכיבי DOM. המצב האופטימלי הוא עץ בעומק של פחות מ-32 אלמנטים ופחות מ-60 אלמנטים ברמת צאצא/אב. DOM גדול יכול להגדיל את צריכת הזיכרון, להאריך [חישובי סגנון](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) ולגרום ל[זרימות חוזרות של פריסה] שצורכות נתונים רבים (https://developers.google.com/speed/articles/reflow). [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "מהנדסי דפדפנים ממליצים לכלול פחות מכ-1,500 רכיבי DOM בדפים. התצורה המועדפת היא עץ בעומק של פחות מ-32 רכיבים, ופחות מ-60 רכיבי צאצא לכל רכיב הורה. DOM גדול עשוי להגדיל את צריכת משאבי הזיכרון, להאריך את הזמן הדרוש ל[חישובי סגנונות](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) ולהוביל ל[זרימה חוזרת של פריסות](https://developers.google.com/speed/articles/reflow) שגוזלת משאבים יקרים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{רכיב אחד}two{# רכיבים}many{# רכיבים}other{# רכיבים}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "נמנע מ-DOM גדול מדי"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "יעד"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "כדי לשפר את הביצועים ולמנוע פגיעויות המסכנות את האבטחה, יש להוסיף `rel=\"noopener\"` או `rel=\"noreferrer\"` לקישורים חיצוניים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "הדף מכיל קישורים לא בטוחים ליעדים ממקורות שונים"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "כל הקישורים ליעדים ממקורות שונים בטוחים לשימוש"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "לא ניתן לקבוע את יעד העוגן ({anchorHTML}). אם target=_blank לא משמש כהיפר-קישור, כדאי לשקול להסיר אותו."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "אתרים שמבקשים לקבל גישה למיקום של המשתמשים, בלי לציין הקשר, מעוררים אצל המשתמשים תחושת בלבול או חשדנות. במקום זאת, כדאי לשקול לקשר את הבקשות לפעולה של המשתמשים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "הדף מבקש הרשאות למיקום גאוגרפי במהלך טעינת הדף"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "הדף לא מבקש הרשאות למיקום גאוגרפי במהלך טעינת הדף"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "גרסה"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "זו ביקורת שמטרתה לזהות את כל ספריות ה-JavaScript החזיתיות בדף."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "ספריות JavaScript שזוהו"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "אם החיבור איטי, סקריפטים חיצוניים המושתלים באופן דינמי דרך `document.write()` יכולים לעכב את טעינת הדף בעשרות שניות. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "הדף כולל שימוש ב-`document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "לא נעשה שימוש ב-`document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "רמת החומרה הגבוהה ביותר"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "גרסת הספרייה"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "מספר הפגיעויות"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "סקריפטים של צד שלישי עשויים להכיל פגיעויות ידועות באבטחה, שתוקפים יכולים לזהות ולנצל בקלות. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{זוהתה פגיעוּת אחת}two{זוהו # פגיעויות}many{זוהו # פגיעויות}other{זוהו # פגיעויות}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "הדף מכיל ספריות JavaScript חזיתיות בעלות פגיעויות ידועות באבטחה"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "גבוהה"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "נמוכה"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "בינונית"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "הדף לא מכיל ספריות JavaScript חזיתיות בעלות פגיעויות ידועות באבטחה"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "אתרים שמבקשים לשלוח התראות ללא הקשר מעוררים תחושת בלבול או חשדנות בקרב המשתמשים. במקום זאת, כדאי לשקול לקשר את הבקשות למחוות של המשתמשים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "הדף מבקש הרשאה להודעות במהלך טעינת הדף"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "הדף לא מבקש הרשאה להתראות במהלך טעינת הדף"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "רכיבים שנכשלו בבדיקה"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "מניעה של הדבקת סיסמאות פוגעת ביכולת לקיים מדיניות אבטחה טובה. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "בדף הזה משתמשים לא יכולים להדביק תוכן מועתק לתוך שדות של סיסמאות"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "בדף הזה משתמשים יכולים להדביק תוכן מועתק לתוך שדות של סיסמאות"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "פרוטוקול"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "ל-HTTP/2 יש הרבה יתרונות על-פני HTTP/1.1, ביניהם כותרות בינאריות, ריבוב והקצאות שרת מוקדמות (Server Push). [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{בקשה אחת לא מולאה דרך HTTP/2}two{# בקשות לא מולאו דרך HTTP/2}many{# בקשות לא מולאו דרך HTTP/2}other{# בקשות לא מולאו דרך HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "לא נעשה שימוש ב-HTTP/2 עבור כל משאבי הדף"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "נעשה שימוש ב-HTTP/2 עבור משאבי הדף"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "כדי לשפר את ביצועי הגלילה של הדף, מומלץ לשקול להוסיף סימון `passive` למעבדים של אירועי נגיעה וגלילה עם גלגל העכבר. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "לא נעשה שימוש ברכיבי listener פסיביים לשיפור ביצועי הגלילה"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "נעשה שימוש ברכיבי listener פסיביים לשיפור ביצועי הגלילה"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "תיאור"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "שגיאות שנרשמו במסוף מצביעות על בעיות לא פתורות. הן עשויות להופיע בעקבות כשל בבקשות ברשת או בעיות אחרות בדפדפן."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "נרשמו שגיאות דפדפן במסוף"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "לא נרשמו במסוף שגיאות דפדפן"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "שימוש בתכונת תצוגת הגופן של CSS מבטיח שהטקסט מוצג למשתמש בזמן טעינה של webfonts. [מידע נוסף](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "שימוש בתכונת תצוגת הגופן של CSS מבטיח שהטקסט מוצג למשתמש בזמן טעינה של גופני webfont. [מידע נוסף](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "יש לוודא שטקסט ממשיך להופיע במהלך טעינת webfont"
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "כל הטקסט ממשיך להופיע במהלך טעינות של webfont"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "מערכת Lighthouse לא הצליחה לבדוק באופן אוטומטי את ערך תצוגת הגופן של כתובת ה-URL הבאה: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "יחס גובה-רוחב (בפועל)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "יחס גובה-רוחב (בתצוגה)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "מידות התצוגה של התמונה צריכות להתאים ליחס הגובה-רוחב הטבעי. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "יש תמונות עם יחס גובה-רוחב שגוי"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "התמונות מוצגות ביחס גובה-רוחב נכון"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "נתוני הגודל של תמונה לא חוקיים: {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "כתובת URL של בקשה לא מאובטחת"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "יש להגן באמצעות פרוטוקול HTTPS על כל האתרים, אפילו אם הם לא מכילים נתונים רגישים. פרוטוקול HTTPS מונע מפורצים לעשות שימוש לרעה בתקשורת המתקיימת בין האפליקציה למשתמשים או לצותת לה. השימוש בפרוטוקול הזה הוא דרישה מוקדמת של HTTP/2 ושל רכיבי ה-API של רבות מפלטפורמות האינטרנט החדשות. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{נמצאה בקשה לא מאובטחת אחת}two{נמצאו # בקשות לא מאובטחות}many{נמצאו # בקשות לא מאובטחות}other{נמצאו # בקשות לא מאובטחות}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "לא נעשה שימוש ב-HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "שימוש ב-HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "כשהדף נטען במהירות ברשת סלולרית, חוויית המשתמש איכותית. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "הזמן עד לפעילות מלאה הוא {timeInMs, number, seconds} שניות"
+    "message": "פעילות מלאה תוך {timeInMs, number, seconds} שנ'"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "הזמן עד לפעילות מלאה בהדמיית רשת סלולרית הוא {timeInMs, number, seconds} שניות"
@@ -504,49 +735,55 @@
     "message": "מצמצם את העבודה על התהליכון הראשי"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "זמן אחזור מוערך של קלט הוא אומדן של משך הזמן הנדרש לאפליקציה כדי להגיב לקלט של משתמש. הערך מצוין באלפיות שנייה ומתייחס ל-5 השניות העמוסות ביותר בטעינת דף. אם זמן האחזור ארוך מ-50 אלפיות שנייה, המשתמשים עלולים להגיע למסקנה שהאפליקציה איטית. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "זמן אחזור מוערך של קלט הוא אומדן של משך הזמן הנדרש לאפליקציה כדי להגיב לקלט של משתמש. הערך מצוין באלפיות שנייה ומתייחס ל-5 השניות העמוסות ביותר בטעינת הדף. אם זמן האחזור ארוך מ-50 אלפיות שנייה, ייתכן שהמשתמשים יבחינו בעיכוב בפעילות האפליקציה. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "אומדן זמן האחזור של קלט"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "המדד 'הצגת תוכן ראשוני' (FCP) מציין את הזמן שבו הטקסט או התמונה הראשונים מוצגים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "המדד 'הצגת תוכן ראשוני (FCP)' מציין את הזמן שבו הטקסט או התמונה הראשונים מוצגים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "הצגת התוכן הראשוני"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "הערך 'מצב ראשון של חוסר פעילות ב-CPU' ‏(First CPU Idle) מציין את הפעם הראשונה שבה התהליכון הראשי של הדף פנוי מספיק בשביל להגיב לקלט. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "הערך 'מצב ראשון של חוסר פעילות ב-CPU' מציין את הפעם הראשונה שבה התהליכון הראשי של הדף פנוי מספיק בשביל להגיב לקלט. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "מצב ראשון של חוסר פעילות ב-CPU"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "הערך 'הצגת התוכן העיקרי' מציין מתי התוכן העיקרי של הדף מוצג. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "הערך 'הצגת התוכן העיקרי (FMP)' מציין מתי מוצג התוכן העיקרי של הדף. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "הצגת התוכן העיקרי"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "הזמן עד לפעילות מלאה הוא משך הזמן שחולף עד שהדף מאפשר אינטראקציה מלאה. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "הזמן עד לפעילות מלאה הוא משך הזמן שחולף עד שהדף מאפשר פעילות מלאה. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "זמן עד לאינטראקטיביות"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "עיכוב הקלט הראשון הפוטנציאלי שהמשתמשים יכולים לחוות הוא משך הזמן (באלפיות שנייה) של המשימה הארוכה ביותר."
+    "message": "ההשהיה הפוטנציאלית המרבית שהמשתמשים יכולים לחוות לאחר קלט ראשוני היא משך הזמן (באלפיות שנייה) של המשימה הארוכה ביותר. [מידע נוסף](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "עיכוב הקלט הראשון המקסימלי הפוטנציאלי"
+    "message": "השהיה פוטנציאלית מרבית לאחר קלט ראשוני"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "מדד המהירות (Speed Index) מראה באיזו מהירות מתמלא התוכן המוצג בדף. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "מדד המהירות (Speed Index) מראה באיזו מהירות מוצג התוכן בדף [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "מדד מהירות (Speed Index)"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "משך הזמן המצטבר של כל פרקי הזמן מרגע הצגת התוכן הראשוני (FCP) ועד לפעילות מלאה, במקרים שבהם משך המשימה חורג מ-50 אלפיות שנייה. הערך מבוטא באלפיות שנייה."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "זמן החסימה הכולל"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "לזמני הלוך ושוב ברשת (RTT) יש השפעה גדולה על הביצועים. אם נדרש RTT ארוך בתקשורת עם מקור, זה סימן לכך שאפשר לשפר את הביצועים בעזרת שרתים שממוקמים קרוב יותר אל המשתמש. [מידע נוסף](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "לזמני הלוך ושוב (RTT) ברשת יש השפעה גדולה על הביצועים. אם נדרש RTT ארוך בתקשורת עם מקור, זה סימן לכך שאפשר לשפר את הביצועים בעזרת שרתים שממוקמים קרוב יותר אל המשתמש. [מידע נוסף](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "זמני הלוך ושוב ברשת"
@@ -557,26 +794,47 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "זמני אחזור בקצה עורפי של שרת"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "גובה החריגה מהתקציב"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "הכמות והגודל של בקשות ברשת צריכים להיות מתחת ליעדים שהוגדרו בתקציב הביצועים הרלוונטי. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{בקשה אחת}two{# בקשות}many{# בקשות}other{# בקשות}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "תקציב ביצועים"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "הפניות אוטומטיות מוסיפות עיכובים לטעינת הדף. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "הפניות אוטומטיות מעכבות את טעינת הדף. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "יש להימנע מהפניות אוטומטיות מרובות"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "כדי להגדיר תקציבים עבור הכמות והגודל של משאבי הדף, יש להוסיף קובץ budget.json. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{בקשה אחת}two{# בקשות}many{# בקשות}other{# בקשות}} • ‏‎{byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "יש לצמצם ככל האפשר את מספר הבקשות ואת גודל ההעברות"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "קישורים קנוניים מציעים את כתובת ה-URL שיש להציג בתוצאות החיפוש. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "כתובות URL מרובות ומתנגשות ({urlList})"
+    "message": "התנגשויות בין כתובות URL מרובות ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "מצביע אל דומיין אחר ({url})"
+    "message": "הכתובת מפנה לדומיין אחר ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "כתובת URL לא חוקית ({url})"
+    "message": "כתובת אתר לא חוקית ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "מצביע אל מיקום `hreflang` אחר ({url})"
+    "message": "הכתובת מפנה למיקום `hreflang` אחר ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "כתובת URL יחסית ({url})"
@@ -585,19 +843,16 @@
     "message": "מצביע אל כתובת ה-URL הבסיסית של הדומיין (דף הבית), במקום אל דף תוכן מתאים"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "אין למסמך ערך `rel=canonical` חוקי"
+    "message": "למסמך אין `rel=canonical` חוקי"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "יש למסמך ערך `rel=canonical` חוקי"
+    "message": "למסמך יש `rel=canonical` חוקי"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "גופן בגודל של פחות מ-12 פיקסלים הוא קטן מדי לקריאה: מבקרים עם מכשיר נייד ייאלצו לשנות את המרחק מהתצוגה על מנת לקרוא את הטקסט. ההמלצה היא שיותר מ-60% מהטקסט יהיו בגודל של 12 פיקסלים או יותר. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "גופן בגודל של פחות מ-12 פיקסלים הוא קטן מדי לקריאה: מבקרים עם מכשיר נייד ייאלצו לעשות תנועת צביטה של התקרבות לתצוגה על מנת לקרוא את הטקסט. ההמלצה היא שיותר מ-60% מהטקסט יהיה בגודל של 12 פיקסלים לפחות. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "שיעור הטקסט הקריא: {decimalProportion, number, extendedPercent}"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "הגודל של {decimalProportion, number, extendedPercent} מהטקסט קטן מדי."
+    "message": "טקסט קריא: {decimalProportion, number, extendedPercent}"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "הטקסט לא קריא כי לא בוצעה אופטימיזציית מטא תג של אזור התצוגה בשביל מסכים של ניידים."
@@ -615,13 +870,13 @@
     "message": "קישורי hreflang עוזרים למנועי חיפוש להבין איזו גרסה של הדף הם צריכים להציג בתוצאות החיפוש בשביל שפה מסוימת או אזור מסוים. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "אין למסמך רכיב `hreflang` חוקי"
+    "message": "למסמך אין `hreflang` חוקי"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "יש למסמך ערך `hreflang` חוקי"
+    "message": "למסמך יש `hreflang` חוקי"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "ייתכנו שגיאות בהוספה לאינדקס של דפים עם קוד מצב HTTP המצביע על בעיות. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "כשלדפים יש קוד מצב HTTP לא תקין, עשויות להיות שגיאות בהוספה שלהם לאינדקס. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "לדף יש קוד מצב HTTP המצביע על בעיה"
@@ -630,7 +885,7 @@
     "message": "קוד מצב ה-HTTP של הדף הוא 'הצלחה'"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "מנועי חיפוש לא יכולים לכלול את הדפים בתוצאות החיפוש אם אין להם רשות לסרוק אותם. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "מנועי חיפוש לא יכולים לכלול את הדפים בתוצאות החיפוש אם אין להם הרשאה לסרוק אותם. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "הוספת הדף לאינדקס חסומה"
@@ -651,13 +906,13 @@
     "message": "לקישורים יש טקסט תיאורי"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "כדי לאמת את תקינות הנתונים המובְנים צריך להפעיל את [הכלי לבדיקת נתונים מובְנים](https://search.google.com/structured-data/testing-tool/) ואת [הלינטר לנתונים מובנְים](http://linter.structured-data.org/) to validate structured data. [מידע נוסף](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "כדי לאמת את תקינות הנתונים המובְנים צריך להפעיל את [הכלי לבדיקת הנתונים המובְנים](https://search.google.com/structured-data/testing-tool/) ואת [הלינטר (Linter) לנתונים מובנְים](http://linter.structured-data.org/). [מידע נוסף](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "הנתונים המובְנים חוקיים"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "מטא תיאורים יכולים להופיע בתוצאות החיפוש כדי לספק סיכום קצר של תוכן הדף. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "תיאורי מטא יכולים להופיע בתוצאות החיפוש כדי לספק סיכום תמציתי של תוכן הדף. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "טקסט התיאור ריק."
@@ -681,7 +936,7 @@
     "message": "אם קובץ robots.txt אינו תקין, ייתכן שסורקים לא יוכלו להבין איך ברצונך שהאתר ייסרק או ייתווסף לאינדקס."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "הבקשה לקובץ robots.txt החזירה מצב HTTP: {statusCode}"
+    "message": "הבקשה לקובץ robots.txt החזירה מצב HTTP‏: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{נמצאה שגיאה אחת}two{נמצאו # שגיאות}many{נמצאו # שגיאות}other{נמצאו # שגיאות}}"
@@ -696,10 +951,10 @@
     "message": "הקובץ robots.txt חוקי"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "כדי שיהיה קל להקיש על רכיבים אינטראקטיביים, כמו לחצנים וקישורים, בלי לגעת ברכיבים אחרים, הם צריכים להיות גדולים מספיק (48 על 48 פיקסלים) ועם ריווח גדול מספיק סביבם. [מידע נוסף](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "כדי שיהיה קל להקיש על רכיבים אינטראקטיביים, כמו לחצנים וקישורים, בלי לגעת ברכיבים אחרים, הם צריכים להיות גדולים מספיק (48x48 פיקסלים) ועם ריווח גדול מספיק סביבם. [מידע נוסף](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "{decimalProportion, number, percent} מרכיבי ההקשה הם בגודל תקין"
+    "message": "{decimalProportion, number, percent} מבין יעדי ההקשה הם בגודל תקין"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "רכיבי ההקשה קטנים מדי כי לא בוצעה אופטימיזציית מטא תגים של אזור התצוגה למסכים של ניידים"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "יעד חופף"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "גודל"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "רכיב הקשה"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "הרכיבים להקשה הוגדרו בגודל המתאים"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "משך הזמן של התהליכון הראשי"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "צד שלישי"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "קוד של צד שלישי עשוי להשפיע בצורה משמעותית על ביצועי הטעינה. מומלץ להגביל את הכמות של ספקי צד שלישי שאינם הכרחיים ולהשתדל לטעון קודים של צד שלישי רק אחרי שמסתיימת הטעינה של הדף. [מידע נוסף](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{נמצא צד שלישי אחד}two{נמצאו # צדדים שלישיים}many{נמצאו # צדדים שלישיים}other{נמצאו # צדדים שלישיים}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "שימוש של צד שלישי"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "'זמן עד בייט ראשון' (Time To First Byte) הוא פרק הזמן שחולף עד שהשרת שולח תגובה. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "משך זמן"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "שם"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "שעת התחלה"
   },
@@ -744,7 +1008,7 @@
     "message": "סוג"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "כדי למדוד את ביצועי האפליקציה בפועל במהלך חוויות משתמש חשובות, מומלץ להוסיף לאפליקציה את User Timing API. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "כדי למדוד את ביצועי האפליקציה בפועל במהלך חוויות משתמש חשובות, כדאי לשקול את האפשרות להוסיף לאפליקציה את User Timing API. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{תזמון משתמש אחד}two{# תזמוני משתמש}many{# תזמוני משתמש}other{# תזמוני משתמש}}"
@@ -756,7 +1020,7 @@
     "message": "נמצא רכיב <link> לקישור מראש בשביל \"{securityOrigin}\", אבל הדפדפן לא השתמש בו. יש לוודא שנעשה שימוש תקין במאפיין `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "כדאי לשקול את האפשרות להוסיף את רמזי המשאבים preconnect או dns-prefetch כדי ליצור מראש קישורים אל מקורות חשובים של צד שלישי. [מידע נוסף](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "כדאי לשקול את האפשרות להוסיף הינטים של משאבים לקישור מראש או לשליפה מוקדמת של נתוני DNS כדי ליצור מראש קישורים אל מקורות חשובים של צד שלישי. [מידע נוסף](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "יש להתחבר מראש למקורות נדרשים"
@@ -765,7 +1029,7 @@
     "message": "נמצא ערך <link> של טעינה מראש בשביל \"{preloadURL}\", אבל הדפדפן לא השתמש בו. יש לוודא שנעשה שימוש תקין במאפיין `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "כדאי לשקול את האפשרות להשתמש ב-<link rel=preload> כדי לקבוע את סדר העדיפויות של אחזור משאבים שנדרשים בשלב מאוחר יותר של טעינת הדף. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "כדאי לשקול את האפשרות להשתמש ב-`<link rel=preload>` כדי לקבוע את סדר העדיפויות של אחזור משאבים שנדרשים בשלב מאוחר יותר של טעינת הדף. [מידע נוסף](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "יש לטעון מראש בקשות עיקריות"
@@ -789,10 +1053,10 @@
     "message": "שיטות מומלצות"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "הבדיקות האלה מדגישות הזדמנויות ל[שיפור הנגישות של אפליקציית האינטרנט](https://developers.google.com/web/fundamentals/accessibility). אפשר לזהות באופן אוטומטי רק חלק מבעיות הנגישות, ולכן מומלץ לבצע גם בדיקות ידניות."
+    "message": "הבדיקות האלה מדגישות הזדמנויות [לשפר את הנגישות של אפליקציית האינטרנט](https://developers.google.com/web/fundamentals/accessibility). אפשר לזהות באופן אוטומטי רק חלק מבעיות הנגישות, ולכן מומלץ לבצע גם בדיקות ידניות."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "הפריטים האלה בודקים תחומים שלא ניתן לבדוק באמצעות כלי בדיקה אוטומטיים. מידע נוסף זמין במדריך שלנו לגבי [בדיקת נגישות](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "הפריטים האלה בודקים תחומים שלא ניתן לבדוק באמצעות כלי בדיקה אוטומטיים. מידע נוסף זמין במדריך שלנו שבו מוסבר [איך לערוך בדיקת נגישות](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "נגישות"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "טבלאות ורשימות"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "שיטות מומלצות"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "באמצעות תקציבי ביצועים ניתן להגדיר יעדי ביצועים עבור האתר."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "תקציבים"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "מידע נוסף לגבי ביצועי האפליקציה."
+    "message": "מידע נוסף לגבי ביצועי האפליקציה. למספרים האלה אין [השפעה ישירה](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) על ציון הביצועים."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "ניתוחים"
@@ -840,7 +1113,7 @@
     "message": "שיפורים בעיבוד ראשון"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "האופטימיזציות האלה יכולות לקצר את זמני טעינת הדף."
+    "message": "ההצעות האלה יכולות לעזור לך להאיץ את טעינת הדף. אין להן [השפעה ישירה](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) על ציון הביצועים."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "הזדמנויות"
@@ -888,7 +1161,7 @@
     "message": "סריקה והוספה לאינדקס"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "הדפים צריכים להתאים לניידים, כדי שמשתמשים לא יצטרכו לעשות תנועת צביטה או התקרבות כדי לקרוא את דפי התוכן. [מידע נוסף](https://developers.google.com/search/mobile-sites/)."
+    "message": "הדפים צריכים להתאים לניידים, כדי שמשתמשים לא יצטרכו לעשות תנועת צביטה או לשנות את המרחק מהתצוגה כדי לקרוא את דפי התוכן. [מידע נוסף](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "התאמה לניידים"
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "אורך חיים (TTL) של מטמון"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "מיקום"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "שם"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "בקשות"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "סוג המשאב"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "גודל (KB)"
+    "message": "גודל"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "משך הזמן שנדרש"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "גודל ההעברה"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "כתובת אתר"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "חיסכון פוטנציאלי (KB)"
+    "message": "פוטנציאל חיסכון"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "פוטנציאל חיסכון (אלפיות שנייה)"
+    "message": "פוטנציאל חיסכון"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "חיסכון פוטנציאלי של {wastedBytes, number, bytes} ‏KB"
+    "message": "צמצום של ‎{wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "חיסכון פוטנציאלי של {wastedMs, number, milliseconds} אלפיות שנייה"
+    "message": "פוטנציאל לקיצור זמן הטעינה ב-{wastedMs, number, milliseconds} אלפיות שנייה"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "מסמך"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "גופן"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "תמונה"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "מדיה"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds} אלפיות שנייה"
+    "message": "{timeInMs, number, milliseconds} אלפיות שנייה"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "אחר"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "סקריפט"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} שניות"
+    "message": "{timeInMs, number, seconds} שנ'"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "גליון סגנונות"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "צד שלישי"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "סה\"כ"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "משהו השתבש בתיעוד של טעינת הדף ובמעקב אחריה. יש להריץ שוב את Lighthouse. ({errorCode})"
+    "message": "משהו השתבש בתיעוד המעקב אחרי טעינת הדף. יש להריץ שוב את Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "חלף הזמן הקצוב לתפוגה בהמתנה לחיבור הראשוני של פרוטוקול Debugger."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome לא אסף צילומי מסך במהלך טעינת הדף. צריך לוודא שיש תוכן גלוי בדף, ולאחר מכן להריץ מחדש את Lighthouse. ({errorCode})"
+    "message": "לא נאספו צילומי מסך ב-Chrome במהלך טעינת הדף. כדאי לוודא תחילה שיש תוכן גלוי בדף, ורק אז להריץ מחדש את Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "שרתי DNS לא הצליחו לפענח את הדומיין שצוין."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "בפעולת האיסוף של המשאב הנדרש {artifactName} הייתה שגיאה: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "קרתה שגיאה פנימית של Chrome. יש להפעיל מחדש את Chrome ולנסות להריץ שוב את Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "פעולת האיסוף של המשאב הנדרש {artifactName} לא בוצעה."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "מערכת Lighthouse לא הצליחה לטעון באופן מהימן את הדף שביקשת. יש לוודא שהבדיקה מתבצעת בכתובת ה-URL הנכונה ושהשרת מגיב באופן תקין לכל הבקשות."
@@ -945,16 +1266,19 @@
     "message": "מערכת Lighthouse לא הצליחה לטעון באופן מהימן את כתובת ה-URL שביקשת, כי הדף הפסיק להגיב."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "לכתובת ה-URL שסיפקת אין אישורי אבטחה חוקיים {securityMessages}"
+    "message": "לכתובת ה-URL שסיפקת אין אישור אבטחה חוקי. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "דפדפן Chrome מנע טעינה של דף והציג מסך מעברון במקומו. יש לוודא שהבדיקה מתבצעת בכתובת ה-URL הנכונה ושהשרת מגיב באופן תקין לכל הבקשות."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "מערכת Lighthouse לא הצליחה לטעון באופן מהימן את הדף שביקשת. יש לוודא שהבדיקה מתבצעת בכתובת ה-URL הנכונה ושהשרת מגיב באופן תקין לכל הבקשות. (פרטים: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "מערכת Lighthouse לא הצליחה לטעון באופן מהימן את הדף שביקשת. יש לוודא שהבדיקה מתבצעת בכתובת ה-URL הנכונה ושהשרת מגיב באופן תקין לכל הבקשות. (קוד הסטטוס: {statusCode})"
+    "message": "מערכת Lighthouse לא הצליחה לטעון באופן מהימן את הדף שביקשת. יש לוודא שהבדיקה מתבצעת בכתובת ה-URL הנכונה ושהשרת מגיב באופן תקין לכל הבקשות. (קוד סטטוס: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "טעינת הדף שלך ארכה זמן רב מדי. מומלץ ליישם את ההזדמנויות שבדוח כדי לקצר את זמן הטעינה של הדף, ולאחר מכן לנסות להריץ שוב את Lighthouse. ({errorCode})"
+    "message": "טעינת הדף ארכה זמן רב מדי. מומלץ ליישם את ההמלצות שבדוח כדי לקצר את זמן הטעינה של הדף, ואז לנסות להריץ שוב את Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "משך ההמתנה לפרוטוקול DevTools חרג מהזמן המוקצב. (שיטה: {protocolMethod})"
@@ -984,7 +1308,7 @@
     "message": "נתוני בדיקה"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "ניתוח [Lighthouse](https://developers.google.com/web/tools/lighthouse/) של הדף הנוכחי בהדמיה של רשת סלולרית. הערכים מהווים אומדן והם עשויים להשתנות."
+    "message": "ניתוח [Lighthouse](https://developers.google.com/web/tools/lighthouse/) של הדף הנוכחי באמולציה של רשת סלולרית. הערכים מהווים אומדן והם עשויים להשתנות."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "פריטים נוספים שיש לבדוק באופן ידני"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "הרחבת קטע הטקסט"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "הצגה של משאבי צד שלישי"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "היו בעיות שהשפיעו על ההרצה הזו של Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "הערכים מהווים אומדן והם עשויים להשתנות."
+    "message": "הערכים מהווים אומדן והם עשויים להשתנות. ציון הביצועים [מבוסס רק על המדדים האלה](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "בדיקות שהסתיימו בציון 'עובר', אבל עם אזהרות"
@@ -1023,10 +1350,10 @@
     "message": "אפשר להעלות את ה-GIF לשירות שיאפשר להטמיע אותו כסרטון HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "אפשר להתקין [פלאגין של WordPress לטעינה מדורגת](https://wordpress.org/plugins/search/lazy+load/) שמאפשר לדחות טעינה של רכיבים שאינם מופיעים מיד במסך. ניתן גם להשתמש בעיצוב שמספק את התכונה הזו. עוד אפשרות היא להשתמש ב[פלאגין של AMP](https://wordpress.org/plugins/amp/)."
+    "message": "ניתן להתקין [פלאגין של WordPress לטעינה מדורגת](https://wordpress.org/plugins/search/lazy+load/) שמאפשר לדחות את הטעינה של רכיבים שאינם מופיעים מיד במסך. ניתן גם להשתמש בעיצוב שמספק את האפשרות הזו. אפשרות נוספת היא להשתמש ב[פלאגין של AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "יש כמה יישומי פלאגין של WordPress שיכולים לעזור לך [להטביע נכסים קריטיים](https://wordpress.org/plugins/search/critical+css/) או [לדחות טעינה של משאבים פחות חשובים](https://wordpress.org/plugins/search/defer+css+javascript/). חשוב: ייתכן שהאופטימיזציות המבוצעות על-ידי יישומי הפלאגין האלה יגרמו לתקלות בתכונות של העיצוב או יישומי הפלאגין האחרים, ולכן כנראה שיהיה צורך לבצע שינויים בקוד."
+    "message": "יש כמה יישומי פלאגין של WordPress שיכולים לעזור לך [להטביע נכסים קריטיים](https://wordpress.org/plugins/search/critical+css/) או [לדחות טעינה של משאבים פחות חשובים](https://wordpress.org/plugins/search/defer+css+javascript/). חשוב: ייתכן שהאופטימיזציות המבוצעות על ידי יישומי הפלאגין האלה יגרמו לתקלות בתכונות של העיצוב או יישומי הפלאגין האחרים, ולכן כנראה שיהיה צורך לבצע שינויים בקוד."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "עיצובים, יישומי פלאגין ומפרטי שרתים משפיעים על זמן התגובה של השרת. אפשר להשתמש בעיצוב שעבר אופטימיזציה, לבחור בקפידה פלאגין לאופטימיזציה ו/או לשדרג את השרת."
@@ -1035,30 +1362,30 @@
     "message": "אפשר להציג קטעים ברשימות הפוסטים (למשל, עם תג 'עוד'), לצמצם את מספר הפוסטים המוצגים בדף נתון, לחלק פוסטים ארוכים למספר דפים או להשתמש בפלאגין כדי לטעון תגובות בצורה מדורגת."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "יש כמה [יישומי פלאגין של WordPress](https://wordpress.org/plugins/search/minify+css/) שיכולים להאיץ את האתר בעזרת שרשור, הקטנה ודחיסה של הסגנונות. ניתן גם להשתמש בתהליך build כדי לבצע את ההקטנה מראש, אם אפשר."
+    "message": "יש כמה [יישומי פלאגין של WordPress](https://wordpress.org/plugins/search/minify+css/) שיכולים להאיץ את האתר על ידי שרשור, הקטנה ודחיסה של סגנונות. ניתן גם להשתמש בתהליך build כדי לבצע את ההקטנה מראש, אם אפשר."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "יש כמה [יישומי פלאגין של WordPress](https://wordpress.org/plugins/search/minify+javascript/) שיכולים להאיץ את האתר בעזרת שרשור, הקטנה ודחיסה של הסקריפטים. ניתן גם להשתמש בתהליך build כדי לבצע את ההקטנה מראש, אם אפשר."
+    "message": "יש כמה [יישומי פלאגין של WordPress](https://wordpress.org/plugins/search/minify+javascript/) שיכולים להאיץ את האתר על ידי שרשור, הקטנה ודחיסה של סקריפטים. ניתן גם להשתמש בתהליך build כדי לבצע את ההקטנה מראש, אם אפשר."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "אפשר לצמצם את מספר [יישומי הפלאגין של WordPress](https://wordpress.org/plugins/) שטוענים תוכן CSS בלתי נחוץ בדף, או להשבית אותם. כדי לזהות יישומי פלאגין שמוסיפים תוכן CSS מיותר, אפשר להפעיל [כיסוי קוד](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) ב-Chrome DevTools. ניתן לזהות את העיצוב/הפלאגין שמוסיפים CSS לפי כתובת ה-URL שבגיליון הסגנון. יישומי הפלאגין הבעייתיים הם אלה שברשימת גיליונות הסגנון שלהם יש כמות גדולה של כיסוי קוד באדום. פלאגין צריך להכניס גיליון סגנון לתור רק אם נעשה בו שימוש בדף."
+    "message": "כדאי לשקול לצמצם את מספר [יישומי הפלאגין של WordPress](https://wordpress.org/plugins/) שטוענים תוכן CSS בלתי נחוץ בדף, או להשבית אותם. כדי לזהות יישומי פלאגין שמוסיפים תוכן CSS מיותר, אפשר להפעיל [כיסוי קוד](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) ב-Chrome DevTools. לפי כתובת ה-URL של גיליון הסגנונות, ניתן לזהות את העיצוב/הפלאגין שאחראים להוספת התוכן. יישומי הפלאגין הבעייתיים הם אלה שברשימת גיליונות הסגנונות שלהם יש כמות גדולה של כיסוי קוד באדום. פלאגין צריך להכניס גיליון סגנונות לתור רק אם נעשה בו שימוש בדף."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "אפשר לצמצם את מספר [יישומי הפלאגין של WordPress](https://wordpress.org/plugins/) שטוענים תוכן JavaScript בלתי נחוץ בדף, או להסיר אותם. כדי לזהות יישומי פלאגין שמוסיפים תוכן JS מיותר אפשר להפעיל [כיסוי קוד](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) ב-Chrome DevTools. ניתן לזהות את העיצוב/הפלאגין שמוסיפים CSS לפי כתובת ה-URL שבסקריפט. יישומי הפלאגין הבעייתיים הם אלה שברשימת הסקריפטים שלהם יש כמות גדולה של כיסוי קוד באדום. פלאגין צריך להכניס סקריפט לתור רק אם נעשה בו שימוש בדף."
+    "message": "כדאי לשקול לצמצם את מספר [יישומי הפלאגין של WordPress](https://wordpress.org/plugins/) שטוענים תוכן JavaScript בלתי נחוץ בדף, או להשבית אותם. כדי לזהות יישומי פלאגין שמוסיפים תוכן JS מיותר, אפשר להפעיל [כיסוי קוד](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) ב-Chrome DevTools. לפי כתובת ה-URL של הסקריפט, ניתן לזהות את העיצוב/הפלאגין שאחראים להוספת התוכן. יישומי הפלאגין הבעייתיים הם אלה שברשימת הסקריפטים שלהם יש כמות גדולה של כיסוי קוד באדום. פלאגין צריך להכניס סקריפט לתור רק אם נעשה בו שימוש בדף."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "למידע על [שמירה במטמון הדפדפן ב-WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "אפשר להשתמש ב[בפלאגין של WordPress לאופטימיזציית תמונות](https://wordpress.org/plugins/search/optimize+images/) שדוחס את התמונות בלי לפגוע באיכות שלהן."
+    "message": "כדאי לשקול להשתמש ב[פלאגין של WordPress לאופטימיזציית תמונות](https://wordpress.org/plugins/search/optimize+images/) שדוחס את התמונות בלי לפגוע באיכות שלהן."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "העלאה של תמונות באופן ישיר דרך [ספריית המדיה](https://codex.wordpress.org/Media_Library_Screen) תאפשר לך לוודא שהתמונות זמינות במידות הדרושות. לאחר מכן אפשר להוסיף אותן מספריית המדיה או להשתמש בווידג'ט התמונות כדי לוודא שנעשה שימוש בתמונות במידות האופטימליות (כולל תמונות בשביל נקודות מעבר רספונסיביות). יש להימנע משימוש בתמונות בגודל מלא, אלא אם המימדים מתאים לשימוש שנעשה בהן. [מידע נוסף](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "העלאה של תמונות באופן ישיר דרך [ספריית המדיה](https://codex.wordpress.org/Media_Library_Screen) תאפשר לך לוודא שהתמונות זמינות במידות הדרושות. אחר כך אפשר להוסיף אותן מספריית המדיה או להשתמש בווידג'ט התמונות כדי לוודא שנעשה שימוש בתמונות במידות האופטימליות (כולל תמונות בשביל נקודות מעבר רספונסיביות). יש להימנע משימוש בתמונות ב`Full Size`, אלא אם המימדים מתאימים לשימוש שנעשה בהן. [מידע נוסף](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "אפשר להפעיל דחיסת טקסט בהגדרות שרת האינטרנט."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "אפשר להשתמש ב[פלאגין](https://wordpress.org/plugins/search/convert+webp/) או שירות שימיר באופן אוטומטי את התמונות שהעלית לפורמט האופטימלי."
+    "message": "כדאי לשקול להשתמש ב[פלאגין](https://wordpress.org/plugins/search/convert+webp/) או בשירות שימירו את התמונות שהועלו לפורמטים האופטימליים באופן אוטומטי."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/hi.json
+++ b/lighthouse-core/lib/i18n/locales/hi.json
@@ -1,51 +1,51 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "एक्सेस कुंजी से इस्तेमाल करने वाले पेज के किसी हिस्से पर तेज़ी से फ़ोकस कर सकते हैं. सही नेविगेशन के लिए, हर एक्सेस कुंजी सबसे अलग होनी चाहिए. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "ऐक्सेस कुंजी से उपयोगकर्ता तेज़ी से पेज के किसी भाग पर फ़ोकस कर सकते हैं. सही नेविगेशन के लिए, हर ऐक्सेस कुंजी सबसे अलग होनी चाहिए. [ज़्यादा जानें](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
     "message": "`[accesskey]` मान सबसे अलग नहीं हैं"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "`[accesskey]` मान सबसे अलग हैं"
+    "message": "`[accesskey]` के मान सबसे अलग हैं"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "`aria-*` विशेषताओं के खास सबसेट के लिए, हर ARIA `भूमिका` काम करती है. इनमें मिलान नहीं होने से `aria-*` विशेषताएं गलत हो जाती हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "हर एआरआईए `role`, `aria-*` विशेषताओं के खास सबसेट पर काम करती है. इनमें मिलान न होने पर `aria-*` विशेषताएं गलत हो जाती हैं. [ज़्यादा जानें](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "`[aria-*]` विशेषताओं का मिलान उनकी भूमिकाओं से नहीं होता है"
+    "message": "`[aria-*]` विशेषताएं और उनकी भूमिकाएं आपस में मेल नहीं खातीं"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "`[aria-*]` विशेषताओं के मिलान उनकी भूमिकाओं से होता है"
+    "message": "`[aria-*]` विशेषताएं और उनकी भूमिकाएं एक-दूसरे से मेल खाती हैं"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "कुछ ARIA भूमिकाओं में ऐसी विशेषताओं की ज़रूरत होती है जो स्क्रीन रीडर को एलिमेंट की स्थिति बताती हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "कुछ ARIA भूमिकाओं में ऐसी विशेषताओं की ज़रूरत होती है जो स्क्रीन रीडर को एलिमेंट की स्थिति बताती हैं. [ज़्यादा जानें](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "`[role]` की ज़रूरी `[aria-*]` विशेषताएं नहीं हैं"
+    "message": "`[role]`s में सभी ज़रूरी `[aria-*]` विशेषताएं नहीं हैं"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "`[role]`के पास ज़रूरी `[aria-*]` विशेषताएं हैं"
+    "message": "`[role]` के पास सभी ज़रूरी `[aria-*]` विशेषताएं हैं"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "कुछ ARIA पैरेंट भूमिकाओं में खास चाइल्ड भूमिकाएं होनी चाहिए ताकि वे तय किए गए सुलभता फ़ंक्शन कर सकें. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "कुछ ARIA पैरंट भूमिकाओं में खास चाइल्ड भूमिकाएं होनी चाहिए ताकि वे तय किए गए सुलभता फ़ंक्शन कर सकें. [ज़्यादा जानें](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "`[role]` वाले एलिमेंट जिन्हें खास चिल्ड्रन `[role]` की ज़रूरत होती है, वे मिल नहीं रहे हैं."
+    "message": "`[role]` वाले वे एलिमेंट नहीं मिले जिन्हें खास चिल्ड्रन `[role]` चाहिए होते हैं."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "`[role]` वाले एलिमेंट जिन्हें खास चिल्ड्रन `[role]`की ज़रूरत होती है, वे मिल नहीं रहे हैं."
+    "message": "`[role]` वाले वे एलिमेंट मौजूद हैं जिन्हें खास चिल्ड्रन `[role]` चाहिए होते हैं."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "कुछ ARIA चाइल्ड रोल अपने तय सुलभता फ़ंक्शन को ठीक से करें, इसके लिए उन्हें खास पैरेंट रोल में होना चाहिए. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "कुछ ARIA चाइल्ड रोल अपने तय सुलभता फ़ंक्शन को ठीक से कर पाएं. इसके लिए, उन्हें खास पैरंट रोल में शामिल होना चाहिए. [ज़्यादा जानें](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "`[role]` अपने ज़रूरी अभिभावक एलिमेंट में नहीं हैं"
+    "message": "`[role]` अपने ज़रूरी पैरंट एलिमेंट में शामिल नहीं हैं"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "`[role]` अपने ज़रूरी अभिभावक एलिमेंट में होते हैं"
+    "message": "`[role]`अपने लिए ज़रूरी पैरंट एलिमेंट में शामिल हैं."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA भूमिकाओं में सही मान होने चाहिए ताकि वे तय किए गए सुलभता फ़ंक्शन कर सकें. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA भूमिकाओं में सही मान होने चाहिए, ताकि वे तय किए गए सुलभता फ़ंक्शन कर सकें. [ज़्यादा जानें](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
     "message": "`[role]` मान सही नहीं हैं"
@@ -54,46 +54,46 @@
     "message": "`[role]` मान सही हैं"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "स्क्रीन रीडर जैसी सहायक तकनीकें, गलत मानों वाली ARIA विशेषताओं को समझ नहीं सकतीं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "स्क्रीन रीडर जैसी सहायक तकनीक, गलत मानों वाली ARIA विशेषताओं को समझ नहीं सकतीं. [ज़्यादा जानें](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
     "message": "`[aria-*]` विशेषताओं में सही मान नहीं हैं"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "`[aria-*]` विशेषताओं में सही मान हैं"
+    "message": "`[aria-*]` विशेषताओं के मान सही हैं"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "स्क्रीन रीडर जैसी सहायक तकनीकें, गलत नामों वाली ARIA विशेषताओं को समझ नहीं सकतीं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "स्क्रीन रीडर जैसी सहायक तकनीक, गलत नामों वाली ARIA विशेषताओं को समझ नहीं सकतीं. [ज़्यादा जानें](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
     "message": "`[aria-*]` विशेषताएं गलत हैं या उनकी वर्तनी गलत है"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "`[aria-*]` विशेषताएं मान्य हैं और उनकी वर्तनी गलत नहीं है"
+    "message": "`[aria-*]` विशेषताएं सही हैं और उनकी वर्तनी गलत नहीं है"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "कैप्शन, ऑडियो एलिमेंट को ऐसे इस्तेमाल करने वाले लोगों के लिए फ़ायदेमंद बनाते हैं, जो सुन नहीं पाते हैं या जिन्हें कम सुनाई देता है. साथ ही, ये कौन बा़त कर रहा है, वे क्या बोल रहे हैं, और बोली नहीं जाने वाली दूसरी जानकारी जैसी खास जानकारी भी देते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "ऑडियो एलिमेंट इस्तेमाल करने वाले जो लोग सुन नहीं पाते या जिन्हें कम सुनाई देता है, वे कैप्शन का इस्तेमाल करके एलिमेंट की जानकारी पढ़ सकते हैं. साथ ही, कैप्शन यह भी बताते हैं कि कौन बा़त कर रहा है, वे क्या बोल रहे हैं, और ऐसी ही दूसरी, बोली न जाने वाली जानकारी भी कैप्शन की मदद से लोगों को पता चलती है. [ज़्यादा जानें](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "`<audio>` एलिमेंट में `[kind=\"captions\"]` वाला `<track>` एलिमेंट नहीं है."
+    "message": "`<audio>` एलिमेंट में `[kind=\"captions\"]` के साथ `<track>` एलिमेंट नहीं है."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "`<audio>` एलिमेंट में `[kind=\"captions\"]` वाला `<track>` एलिमेंट है"
+    "message": "`<audio>` एलिमेंट में `[kind=\"captions\"]` वाला एक `<track>` एलिमेंट है"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
-    "message": "विफल रहने वाले एलिमेंट"
+    "message": "फ़ेल होने वाले एलिमेंट"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "बटन का एक्सेस करने लायक कोई नाम नहीं होने पर, स्क्रीन रीडर उसे \"बटन\" के रूप में बताते हैं. इस वजह से यह उन इस्तेमाल करने वालों के लिए बेकार हो जाता है जो स्क्रीन रीडर पर भरोसा करते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "अगर बटन का कोई ऐसा नाम नहीं है जिसे ऐक्सेस किया जा सकता है, तो स्क्रीन रीडर उसे \"बटन\" के रूप में बताते हैं. इस वजह से यह उन इस्तेमाल करने वालों के लिए किसी काम का नहीं रहता जो स्क्रीन रीडर से ही टेक्स्ट पढ़ या समझ सकते हैं. [ज़्यादा जानें](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
-    "message": "बटन के नाम एक्सेस करने लायक नहीं हैं"
+    "message": "बटन के नाम ऐक्सेस करने लायक नहीं हैं"
   },
   "lighthouse-core/audits/accessibility/button-name.js | title": {
     "message": "बटनों का एक सुलभता नाम है"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "दोहराव वाली सामग्री को नज़रअंदाज करके आगे बढ़ने के तरीके जोड़ने से, कीबोर्ड इस्तेमाल करने वाले लोग पेज पर ज़्यादा अच्छे से नेविगेट कर सकते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "दोहराव वाली सामग्री को नज़रअंदाज करके आगे बढ़ने के तरीके जोड़ने से, कीबोर्ड इस्तेमाल करने वाले लोग पेज पर ज़्यादा अच्छे से नेविगेट कर सकते हैं. [ज़्यादा जानें](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "पेज में 'हेडिंग', 'स्किप लिंक' या 'लैंडमार्क' क्षेत्र नहीं है"
@@ -102,7 +102,7 @@
     "message": "पेज में 'हेडिंग', 'स्किप लिंक' या 'लैंडमार्क' क्षेत्र हैं"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "कम-कंट्रास्ट वाला टेक्स्ट पढ़ना कई इस्तेमाल करने वालों के लिए कठिन या नामुमकिन हो जाता है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "इस्तेमाल करने वाले कई लोगों के लिए कम कंट्रास्ट वाला टेक्स्ट पढ़ना मुश्किल या नामुमकिन होता है. [ज़्यादा जानें](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "बैकग्राउंड और फ़ोरग्राउंड रंगों में काफ़ी कंट्रास्ट अनुपात नहीं है."
@@ -111,34 +111,34 @@
     "message": "बैकग्राउंड और फ़ोरग्राउंड के रंगों का कंट्रास्ट अनुपात काफ़ी है"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "जब परिभाषा सूचियां ठीक से मार्क अप नहीं की जाती हैं, तो स्क्रीन रीडर उलझन भरे या गलत आउटपुट दे सकते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "जब परिभाषा सूचियां ठीक से मार्क अप नहीं की जातीं, तो स्क्रीन रीडर उलझन भरे या गलत आउटपुट दे सकते हैं. [ज़्यादा जानें](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "`<dl>` में सिर्फ़ ठीक तरह से क्रम में लगे `<dt>` और `<dd>` समूह, `<script>` या `<template>` एलिमेंट नहीं हैं."
+    "message": "`<dl>` में ठीक क्रम से लगाए गए `<dt>` और `<dd>` ग्रुप, `<script>` या `<template>` एलिमेंट नहीं हैं."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "`<dl>` में सिर्फ़ ठीक तरह से क्रम में लगे `<dt>` और `<dd>` समूह, `<script>` या `<template>` एलिमेंट होते हैं."
+    "message": "`<dl>` में सिर्फ़ ठीक क्रम से लगे हुए`<dt>` और `<dd>` ग्रुप, `<script>` या `<template>` एलिमेंट हैं."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "परिभाषा सूची आइटम (<dt>` और `<dd>`) को पैरेंट `<dl>` एलिमेंट में रैप होना चाहिए, ताकि यह पक्का किया जा सके कि स्क्रीन रीडर उन्हें ठीक तरीके से बोल सकते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "परिभाषा सूची आइटम (`<dt>` और `<dd>`) को पैरंट `<dl>` एलिमेंट में रैप किया जाना चाहिए, ताकि यह पक्का किया जा सके कि स्क्रीन रीडर उन्हें ठीक तरीके से बोल सकते हैं. [ज़्यादा जानें](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "`<dl>` एलिमेंट में परिभाषा सूची के आइटम नहीं हैं"
+    "message": "परिभाषा सूची के आइटम `<dl>` एलिमेंट में रैप नहीं किए जाते"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "परिभाषा सूची के आइटम `<dl>` एलिमेंट में हैं"
+    "message": "परिभाषा सूची के आइटम `<dl>` एलिमेंट में रैप किए जाते हैं"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "शीर्षक से स्क्रीन रीडर उपयोगकर्ताओं को पेज की खास जानकारी मिलती है और खोज इंजन के उपयोगकर्ता यह तय करने में बहुत ज़्यादा भरोसा करते हैं कि कोई पेज उनकी खोज के संगत है या नहीं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "शीर्षक से स्क्रीन रीडर उपयोगकर्ताओं को पेज की खास जानकारी मिलती है. सर्च इंजन के उपयोगकर्ता शीर्षक के भरोसे यह तय करते हैं कि कोई पेज उनकी खोज के हिसाब से सही है या नहीं. [ज़्यादा जानें](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "दस्तावेज़ में `<title>` एलिमेंट नहीं है"
+    "message": "दस्तावेज़ में कोई `<title>` एलिमेंट नहीं है"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "दस्तावेज़ में `<title>` एलिमेंट है"
+    "message": "दस्तावेज़ में `<title>` एलिमेंट है"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "सहायक तकनीकों को दूसरे इंस्टेंस अनदेखा करने से रोकने के लिए, आईडी विशेषता का मान सबसे अलग होना चाहिए. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "सहायक तकनीकों को दूसरे इंस्टेंस अनदेखा करने से रोकने के लिए, आईडी विशेषता का मान सबसे अलग होना चाहिए. [ज़्यादा जानें](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
     "message": "पेज पर `[id]` विशेषताएं सबसे अलग नहीं हैं"
@@ -147,52 +147,52 @@
     "message": "पेज पर `[id]` विशेषताएं सबसे अलग हैं"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "स्क्रीन रीडर इस्तेमाल करने वाले फ़्रेम की सामग्रियों के बारे में जानने के लिए फ़्रेम के शीर्षकों पर भरोसा करते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "स्क्रीन रीडर उपयोगकर्ता, फ़्रेम की सामग्री के बारे में जानने के लिए फ़्रेम के शीर्षकों का इस्तेमाल करते हैं. [ज़्यादा जानें](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "`<frame>` या `<iframe>` एलिमेंट का कोई शीर्षक नहीं है"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "`<frame>` या `<iframe>` एलिमेंट में शीर्षक हैं"
+    "message": "`<frame>` या `<iframe>` एलिमेंट का एक शीर्षक है"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "अगर कोई पेज भाषा विशेषता तय नहीं करता है, तो स्क्रीन रीडर को लगता है कि पेज उस डिफ़ॉल्ट भाषा में है जो इस्तेमाल करने वाले ने स्क्रीन रीडर सेट अप करते समय चुनी थी. दरअसल, पेज अगर डिफ़ॉल्ट भाषा में नहीं होता है, तो स्क्रीन रीडर पेज का टेक्स्ट ठीक से नहीं बोल पाता है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "अगर कोई पेज, भाषा विशेषता तय नहीं करता है, तो स्क्रीन रीडर को लगता है कि पेज उस डिफ़ॉल्ट भाषा में है जो उपयोगकर्ता ने स्क्रीन रीडर सेट अप करते समय चुनी थी. अगर वह पेज डिफ़ॉल्ट भाषा में नहीं है, तो शायद स्क्रीन रीडर, पेज का टेक्स्ट ठीक से न बोल पाए. [ज़्यादा जानें](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "`<html>` एलिमेंट में एक `[lang]` विशेषता नहीं है"
+    "message": "`<html>` एलिमेंट में `[lang]` विशेषता नहीं है"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "`<html>` एलिमेंट में एक `[lang]` विशेषता है"
+    "message": "`<html>` एलिमेंट में `[lang]` विशेषता है"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "सही [BCP 47 भाषा](https://www.w3.org/International/questions/qa-choosing-language-tags#question) तय करने से स्क्रीन रीडर को टेक्स्ट ठीक से बोलने में मदद मिलती है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "सही [BCP 47 भाषा ](https://www.w3.org/International/questions/qa-choosing-language-tags#question) तय करने से स्क्रीन रीडर को टेक्स्ट ठीक से बोलने में मदद मिलती है. [ज़्यादा जानें](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "`<html>` एलिमेंट के पास इसकी `[lang]` विशेषता के लिए सही मान नहीं है."
+    "message": "`<html>` एलिमेंट के पास अपनी `[lang]`विशेषता के लिए कोई सही मान नहीं है."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "`<html>` एलिमेंट में इसकी `[lang]` विशेषता के लिए सही मान है"
+    "message": "`<html>` एलिमेंट के पास अपनी `[lang]` विशेषता के लिए एक सही मान है"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "जानकारी वाले एलिमेंट का मकसद छोटा, पूरी जानकारी देने वाला वैकल्पिक टेक्स्ट होना चाहिए. सजावटी एलिमेंट को एक खाली alt विशेषता के साथ अनदेखा किया जा सकता है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "जानकारी वाले एलिमेंट का मकसद यह होना चाहिए कि उनमें छोटा और पूरी जानकारी देने वाला वैकल्पिक टेक्स्ट शामिल हो. डेकोरेटिव एलिमेंट, एक खाली ऑल्ट एट्रिब्यूट के साथ अनदेखे किया जा सकते हैं. [ज़्यादा जानें](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
     "message": "इमेज एलिमेंट में `[alt]` विशेषताएं नहीं हैं"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "इमेज एलिमेंट में `[alt]` विशेषताएं हैं"
+    "message": "इमेज एलिमेंट में `[alt]` विशेषताएं शामिल हैं"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "जब किसी इमेज का इस्तेमाल एक `<input>` बटन के रूप में हो रहा हो, तो वैकल्पिक टेक्स्ट देने से स्क्रीन रीडर इस्तेमाल करने वालों को बटन के बारे में समझने में मदद मिलती है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "जब किसी इमेज को `<input>` बटन के रूप में इस्तेमाल किया जा रहा हो, तब वैकल्पिक टेक्स्ट देने से, स्क्रीन रीडर इस्तेमाल करने वाले लोगों को उस बटन के मकसद को समझने में मदद मिलती है. [ज़्यादा जानें](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "`<input type=\"image\">` एलिमेंट में `[alt]` टेक्स्ट नहीं है"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "`<input type=\"image\">` एलिमेंट में `[alt]` टेक्स्ट है"
+    "message": "`<input type=\"image\">` एलिमेंट में`[alt]` टेक्स्ट है"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "लेबल यह पक्का करते हैं कि स्क्रीन रीडर जैसी सहायक तकनीकें फ़ॉर्म नियंत्रणों को सही तरीके से बोलती हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "लेबल यह पक्का करते हैं कि स्क्रीन रीडर जैसी सहायक तकनीकें, फ़ॉर्म नियंत्रणों को सही तरीके से बोलें. [ज़्यादा जानें](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "फ़ॉर्म एलिमेंट में जुड़े हुए लेबल नहीं हैं"
@@ -201,16 +201,16 @@
     "message": "फ़ॉर्म एलिमेंट में सहभागी लेबल हैं"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "लेआउट के लिए इस्तेमाल की जाने वाली टेबल में th या कैप्शन वाले एलिमेंट जैसे डेटा एलिमेंट या सारांश विशेषता शामिल नहीं होनी चाहिए, क्योंकि इससे स्क्रीन रीडर इस्तेमाल करने वाले उलझन में पड़ सकते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "लेआउट के लिए इस्तेमाल की जाने वाली टेबल में th या कैप्शन वाले एलिमेंट जैसे, डेटा एलिमेंट या सारांश विशेषता शामिल नहीं होनी चाहिए, क्योंकि इससे स्क्रीन रीडर उपयोगकर्ताओं को उलझन हो सकती हैं. [ज़्यादा जानें](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "प्रस्तुतिकरण `<table>` वाले तत्व `<th>`, `<caption>` या `[summary]` विशेषता के इस्तेमाल को अनदेखा नहीं कर सकते."
+    "message": "प्रज़ेंटेशन के लिए इस्तेमाल होने वाले `<table>`एलिमेंट में `<th>`, `<caption>` या `[summary]` विशेषता का इस्तेमाल होता है."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "प्रस्तुतिकरण `<table>` वाले एलिमेंट में `<th>`, `<caption>` या `[summary]` विशेषता के इस्तेमाल को अनदेखा किया गया है."
+    "message": "प्रज़ेंटेशन के लिए इस्तेमाल होने वाले `<table>`एलिमेंट में `<th>`, `<caption>` या `[summary]` विशेषता का इस्तेमाल नहीं होता."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "लिंक टेक्स्ट (और इमेज को लिंक की तरह इस्तेमाल किए जाने पर उनके लिए वैकल्पिक टेक्स्ट) समझने लायक, सबसे अलग, और फ़ोकस किए जा सकने वाला होना चाहिए. इससे स्क्रीन रीडर इस्तेमाल करने वालों का नेविगेशन अनुभव बेहतर बनता है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "जो लिंक टेक्स्ट (और इमेज के लिए इस्तेमाल किया वैकल्पिक टेक्स्ट) समझने लायक, सबसे अलग, और फ़ोकस करने लायक है, उससे स्क्रीन रीडर उपयोगकर्ताओं का नेविगेशन अनुभव बेहतर बनता है. [ज़्यादा जानें](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "लिंक का समझने लायक नहीं है"
@@ -219,52 +219,52 @@
     "message": "लिंक का समझने लायक नाम है"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "स्क्रीन रीडर सूचियों को एक खास तरीके से बोलते हैं. सूची की सही बनावट पक्की करने से स्क्रीन रीडर को आउटपुट देने में मदद मिलती है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "स्क्रीन रीडर, सूचियों को एक खास तरीके से बोलते हैं. सूची की सही बनावट पक्की करने से स्क्रीन रीडर को आउटपुट देने में मदद मिलती है. [ज़्यादा जानें](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "सूचियों में सिर्फ़ `<li>`एलिमेंट और स्क्रिप्ट के साथ काम करने वाले एलिमेंट (`<script>` और `<template>`) ही शामिल नहीं हैं."
+    "message": "सूचियों में सिर्फ़ `<li>` एलिमेंट और स्क्रिप्ट के साथ काम करने वाले एलिमेंट (`<script>`और `<template>`) ही शामिल नहीं हैं."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "सूचियों में सिर्फ़ `<li>` एलिमेंट और स्क्रिप्ट के साथ काम करने वाले एलिमेंट (`<script>` और `<template>`) ही शामिल हैं."
+    "message": "सूची में सिर्फ़ `<li>` एलिमेंट और स्क्रिप्ट के साथ काम करने वाले एलिमेंट शामिल हैं (`<script>` और `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "स्क्रीन रीडर के लिए ज़रूरी है कि उनमें पैरेंट `<ul>` या `<ol>` में सूची आइटम (`<li>`) शामिल हों, ताकि उन्हें ठीक तरह से बोला जा सके. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "स्क्रीन रीडर के लिए ज़रूरी है कि उनमें `<ul>` या `<ol>` पैरंट में सूची आइटम (`<li>`) शामिल हों, ताकि उन्हें ठीक तरह से बोला जा सके. [ज़्यादा जानें](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "सूची वाले आइटम (`<li>`), `<ul>` या `<ol>` अभिभावक एलिमेंट में नहीं होते हैं."
+    "message": "सूची आइटम (`<li>`) `<ul>` या `<ol>` पैरंट एलिमेंट में शामिल नहीं हैं."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "सूची वाले आइटम (`<li>`), `<ul>` या `<ol>` अभिभावक एलिमेंट में हैं"
+    "message": "सूची वाले आइटम (`<li>`) `<ul>` या `<ol>` पैरंट एलिमेंट में हैं"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "इस्तेमाल करने वालों को ऐसी उम्मीद नहीं होती है कि कोई पेज अपने आप रीफ़्रेश हो जाएगा और इसके बाद फ़ोकस वापस पेज के सबसे ऊपर चला जाएगा. ऐसा होने पर वे परेशानी या उलझन में पड़ सकते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "उपयोगकर्ताओं को ऐसी उम्मीद नहीं होती कि कोई पेज अपने आप रीफ़्रेश हो जाएगा. इसके बाद, फ़ोकस वापस पेज के सबसे ऊपर चला जाएगा. इससे उन्हें परेशानी या उलझन हो सकती है. [ज़्यादा जानें](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "दस्तावेज़ `<meta http-equiv=\"refresh\">` का इस्तेमाल करता है"
+    "message": "यह दस्तावेज़ `<meta http-equiv=\"refresh\">` का इस्तेमाल करता है"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "यह दस्तावेज़ `<meta http-equiv=\"refresh\">` का इस्तेमाल नहीं करता है"
+    "message": "दस्तावेज़ `<meta http-equiv=\"refresh\">` का इस्तेमाल नहीं करते"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "ज़ूम की सुविधा बंद करने से इस्तेमाल करने वाले ऐसे लोगों को परेशानी होती है, जिन्हें कम दिखाई देता है. इस्तेमाल करने वाले ये लोग स्क्रीन बड़ी करके वेब पेज की सामग्रियों को ठीक से देख पाते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "ज़ूम करने की सुविधा को बंद करने से उन उपयोगकर्ताओं को परेशानी होती है जिन्हें कम दिखाई देता है. ऐसे उपयोगकर्ता वेब पेज की सामग्री को ठीक तरह से देखने के लिए स्क्रीन को बड़ा करते हैं. [ज़्यादा जानें](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "`[user-scalable=\"no\"]` का इस्तेमाल `<meta name=\"viewport\">` एलिमेंट में किया जाता है या `[maximum-scale]` विशेषता पाँच से कम है."
+    "message": "`[user-scalable=\"no\"]` का इस्तेमाल `<meta name=\"viewport\">` एलिमेंट में किया जाता है या `[maximum-scale]`विशेषता पांच से कम है."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "`[user-scalable=\"no\"]` का इस्तेमाल `<meta name=\"viewport\">` एलिमेंट में नहीं किया जा सकता और `[maximum-scale]` विशेषता पाँच से कम नहीं है."
+    "message": "`[user-scalable=\"no\"]` का इस्तेमाल `<meta name=\"viewport\">` एलिमेंट में नहीं किया जाता और `[maximum-scale]`विशेषता पाँच से कम नहीं है."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "स्क्रीन रीडर ऐसी सामग्री का अनुवाद नहीं कर सकते जिसमें टेक्स्ट नहीं होता है. `<object>` एलिमेंट में वैकल्पिक टेक्स्ट शामिल करने से, स्क्रीन रीडर को इस्तेमाल करने वालों को मतलब समझाने में मदद मिलती है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "स्क्रीन रीडर ऐसी सामग्री का अनुवाद नहीं कर सकते जिसमें टेक्स्ट नहीं है. `<object>` एलिमेंट में वैकल्पिक टेक्स्ट जोड़ने से, स्क्रीन रीडर आसानी से उपयोगकर्ताओं को बात का मतलब समझा सकते हैं. [ज़्यादा जानें](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "`<object>` एलिमेंट में `[alt]` टेक्स्ट नहीं है"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "`<object>` एलिमेंट में `[alt]` टेक्स्ट है"
+    "message": "`<object>` एलिमेंट में`[alt]` टेक्स्ट है"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "0 से ज़्यादा मान साफ़ तौर पर नेविगेशन क्रम को लागू करता है. हालांकि तकनीकी रूप से मान्य है. यह अक्सर ऐसे इस्तेमाल करने वालों को निराश करता है जो सहायक तकनीकों पर भरोसा करते हैं. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "0 से ज़्यादा मान साफ़ तौर पर नेविगेशन क्रम को लागू करता है. हालांकि, यह तकनीकी रूप से सही है, लेकिन यह अक्सर उन इस्तेमाल करने वालों को निराश करता है जो सहायक तकनीकों पर भरोसा करते हैं. [ज़्यादा जानें](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "कुछ एलिमेंट का `[tabindex]` मान 0 से ज़्यादा होता है"
@@ -273,49 +273,61 @@
     "message": "किसी भी एलिमेंट का `[tabindex]` मान 0 से ज़्यादा नहीं हो सकता"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "स्क्रीन रीडर में ऐसी सुविधाएं होती हैं जिनसे टेबल में जाना आसान हो जाता है. `[headers]` विशेषता का इस्तेमाल करने वाले `<td>` सेल सिर्फ़ उसी टेबल में दूसरे सेल के बारे में बताते हैं, इसे पक्का करने पर स्क्रीन रीडर इस्तेमाल करने वालों को बेहतर अनुभव मिल सकता है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "स्क्रीन रीडर में ऐसी सुविधाएं होती हैं जिनसे टेबल में जाना आसान हो जाता है. `[headers]` विशेषता का इस्तेमाल करके `<td>` सेल की मौजूदगी पक्की करने के लिए उसी टेबल में मौजूद दूसरे सेल का हवाला दिया जाता है. इससे स्क्रीन रीडर उपयोगकर्ताओं के अनुभव को बेहतर बनाया जा सकता है. [ज़्यादा जानें](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "`[headers]` विशेषता का इस्तेमाल करने वाले `<table>` एलिमेंट में मौजूद सेल, उसी टेबल में दूसरे सेल का हवाला देते हैं."
+    "message": "`<table>` विशेषता का इस्तेमाल करने वाले `[headers]` एलिमेंट में मौजूद सेल, उसी टेबल में दूसरे सेल का हवाला देते हैं."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "`<table>` विशेषता का इस्तेमाल करने वाले `[headers]` एलिमेंट में मौजूद सेल सिर्फ़ उसी टेबल के दूसरे सेल का हवाला देते हैं."
+    "message": "`<table>` एलिमेंट में शामिल सेल जो `[headers]` विशेषता का इस्तेमाल करते हैं, वे सिर्फ़ उसी टेबल में शामिल सेल का हवाला देते हैं."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "स्क्रीन रीडर में ऐसी सुविधाएं होती हैं जिनसे टेबल में जाना आसान हो जाता है. अगर यह पक्का कर लिया जाए कि टेबल हेडर हमेशा सेल के कुछ सेट के बारे में बताते हैं, तो स्क्रीन रीडर इस्तेमाल करने वालों को बेहतर अनुभव मिल सकता है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "स्क्रीन रीडर में ऐसी सुविधाएं होती हैं जिनसे टेबल में जाना आसान हो जाता है. यह पक्का करें कि टेबल हेडर हमेशा कुछ सेल के सेट के बारे में बताते हों. इससे स्क्रीन रीडर के उपयोगकर्ताओं को बेहतर अनुभव मिल सकता है. [ज़्यादा जानें](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "`<th>` एलिमेंट और `[role=\"columnheader\"/\"rowheader\"]` वाले एलिमेंट के पास उनके बताए हुए डेटा सेल नहीं हैं."
+    "message": "`<th>` एलिमेंट और `[role=\"columnheader\"/\"rowheader\"]` वाले एलिमेंट में वे डेटा सेल मौजूद नहीं हैं जो उनके ब्यौरे में शामिल हैं."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "`<th>` एलिमेंट और `[role=\"columnheader\"/\"rowheader\"]` वाले एलिमेंट के पास उनके बताए हुए डेटा सेल हैं."
+    "message": "`<th>` एलिमेंट और `[role=\"columnheader\"/\"rowheader\"]` वाले एलिमेंट में वे डेटा सेल शामिल हैं जिनकी वे जानकारी देते हैं."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "एलिमेंट पर सही [BCP 47 भाषा](https://www.w3.org/International/questions/qa-choosing-language-tags#question) तय करने से यह पक्का करने में मदद मिलती है कि स्क्रीन रीडर ने टेक्स्ट को सही तरीके से बोला है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "एलिमेंट पर एक सही [BCP 47 भाषा ](https://www.w3.org/International/questions/qa-choosing-language-tags#question) तय करने से आप पक्का कर सकते हैं कि स्क्रीन रीडर, टेक्स्ट को सही से बोले. [ज़्यादा जानें](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
     "message": "`[lang]` विशेषताओं का कोई सही मान नहीं है"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "`[lang]` विशेषताओं में सही मान है"
+    "message": "`[lang]` विशेषताओं का मान सही है"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "वीडियो में कैप्शन उपलब्ध कराने पर ऐसे इस्तेमाल करने वाले लोग जानकारी को आसानी से समझ सकते हैं, जो सुन नहीं पाते हैं और जिन्हें कम सुनाई देता है. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "वीडियो में कैप्शन उपलब्ध कराने पर वे उपयोगकर्ता आसानी से जानकारी समझ सकते हैं जो सुन नहीं पाते और जिन्हें कम सुनाई देता है. [ज़्यादा जानें](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "`<video>` एलिमेंट में `[kind=\"captions\"]` वाले `<track>` नहीं हैं."
+    "message": "`<video>` एलिमेंट में `[kind=\"captions\"]` वाला कोई `<track>` एलिमेंट नहीं है."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "`<video>` एलिमेंट में `[kind=\"captions\"]`वाला `<track>` एलिमेंट है"
+    "message": "`<video>` एलिमेंट में `[kind=\"captions\"]` वाला एक `<track>` एलिमेंट है"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "ऑडियो के ब्यौरे में वीडियो से जुड़ी काम की ऐसी जानकारी दी जाती है जो बातचीत से नहीं दी जा सकती, जैसे चेहरे के हावभाव और सीन. [ज़्यादा जानें](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "ऑडियो के ब्यौरे में वीडियो से जुड़ी काम की ऐसी जानकारी दी जाती है जो बातचीत से नहीं दी जा सकती. जैसे, चेहरे के हावभाव और सीन. [ज़्यादा जानें](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "`<video>` एलिमेंट में `[kind=\"description\"]`वाले `<track>` एलिमेंट शामिल नहीं हैं."
+    "message": "`<video>` एलिमेंट में `[kind=\"description\"]` वाला कोई `<track>` एलिमेंट नहीं है."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "`<video>` एलिमेंट में `[kind=\"description\"]` के साथ `<track>` एलिमेंट होता है"
+    "message": "`<video>` एलिमेंट में `[kind=\"description\"]` वाला एक `<track>` एलिमेंट है"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "उपयोगकर्ता जब होम स्क्रीन पर कुछ जोड़ें, तो iOS पर वह अच्छे से नज़र आए, इसके लिए apple-touch-icon तय करें. यह ज़रूरी है कि यह आइकॉन किसी ऐसे 192px (या 180px) के चौकोर PNG की तरफ़ इशारा करे जिसके आर-पार न देखा जा सके. [ज़्यादा जानें](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "एक सही `apple-touch-icon` नहीं उपलब्ध कराता"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` पुराना हो गया है; `apple-touch-icon` को प्राथमिकता दी जाती है."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "एक सही `apple-touch-icon` देता है"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome एक्सटेंशन ने इस पेज के लोड परफ़ॉर्मेंस पर नकारात्मक रूप से असर डाला है. 'गुप्त मोड' में या बिना किसी एक्सटेंशन के Chrome प्रोफ़ाइल से पेज ऑडिट करके देखें."
@@ -330,7 +342,7 @@
     "message": "कुल सीपीयू समय"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "JS को पार्स करने, कंपाइल करने और एक्ज़ीक्यूट करने में लगने वाला समय कम करने पर विचार करें. आप पाएंगे कि इसके ज़रिए छोटे-छोटे JS पेलोड डिलीवर करने में मदद मिलती है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "JS को पार्स करने, कंपाइल करने, और एक्ज़ीक्यूट करने में लगने वाला समय कम करें. आप देखेंगे कि इसकी मदद से छोटे-छोटे JS पेलोड डिलीवर करने में मदद मिलती है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "JavaScript क्रियान्वयन समय कम करें"
@@ -339,28 +351,28 @@
     "message": "JavaScript क्रियान्वयन समय"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "बड़े जीआईएफ़ ऐनिमेटेड सामग्री डिलीवर करने में नाकाफ़ी होते हैं. नेटवर्क बाइट बचाने के इरादे से जीआईएफ़ का इस्तेमाल करने के बजाय, ऐनिमेशन के लिए MPEG4/WebM वीडियो और स्थिर इमेज के लिए PNG/WebP का इस्तेमाल करने पर विचार करें. [ज़्यादा जानें](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "बड़ी GIFs ऐनिमेशन वाली सामग्री डिलीवर नहीं कर सकते. नेटवर्क बाइट बचाने के लिए GIF का इस्तेमाल करने के बजाय, ऐनिमेशन के लिए MPEG4/WebM वीडियो और स्टैटिक इमेज के लिए PNG/WebP का इस्तेमाल करें. [ज़्यादा जानें](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "ऐनिमेट की गई सामग्री के लिए वीडियो फ़ॉर्मेट का इस्तेमाल करें"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "इंटरेक्टिव में लगने वाला समय कम करने के लिए, सभी अहम संसाधन लोड हो जाने के बाद ऑफ़स्क्रीन और छिपी हुई इमेज को धीरे-धीरे लोड करने पर विचार करें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "इंटरैक्टिव में लगने वाला समय कम करने के लिए, सभी अहम संसाधन लोड हो जाने के बाद ऑफ़स्क्रीन और छिपी हुई इमेज को धीरे-धीरे लोड करें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "ऑफ़स्क्रीन इमेज टालें"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "संसाधन आपके पेज के पहले पेंट को ब्लॉक कर रहे हैं. अहम JS/CSS इनलाइन वितरित करने और सभी गैर-अहम JS/शैलियों को टालने पर विचार करें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "संसाधन आपके पेज का फ़र्स्ट पेंट ब्लॉक कर रहे हैं. ज़रूरी JS/सीएसएस इनलाइन डिलीवर करने और सभी गैर-ज़रूरी JS/शैलियों को टाल दें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "रेंडर ब्लॉक करने वाले संसाधनों को खत्म करें"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "बड़े नेटवर्क वाले पेलोड के लिए उपयोगकर्ताओं को ज़्यादा रकम खर्च करनी पड़ती है और उन पर लोड होने में ज़्यादा समय भी लगता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "बड़े नेटवर्क वाले पेलोड के लिए उपयोगकर्ताओं को रकम खर्च करनी होती है. साथ ही, उन पर लोड होने में ज़्यादा समय भी लगता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "कुल आकार {totalBytes, number, bytes} केबी था"
+    "message": "कुल आकार {totalBytes, number, bytes} केबी था"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "बहुत ज़्यादा नेटवर्क पेलोड से बचें"
@@ -369,19 +381,19 @@
     "message": "भारी नेटवर्क पेलोड से बचाता है"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "CSS फ़ाइलों का आकार कम करने से नेटवर्क पेलोड आकार कम किए जा सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "CSS फ़ाइलों को छोटा करने से नेटवर्क पेलोड आकार कम किए जा सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "CSS कम करें"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "JavaScript फ़ाइलों को छोटा करने से पेलोड का आकार और स्क्रिप्ट पार्स करने का समय कम हो सकता है. [ज़्यादा जानें](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "JavaScript फ़ाइलों को छोटा करने से पेलोड का आकार और स्क्रिप्ट पार्स करने में लगने वाला समय कम हो सकता है. [ज़्यादा जानें](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "JavaScript का आकार कम करें"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "स्टाइल-शीट से इस्तेमाल नहीं किए गए नियमों को हटाएं और पेज के ऊपरी हिस्से की सामग्री के लिए इस्तेमाल नहीं होने वाले CSS को लोड होने से टालें. ऐसा करके, नेटवर्क गतिविधि में खर्च होने वाले गैर-ज़रूरी बाइट कम किए जा सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "स्टाइलशीट से इस्तेमाल न किए गए नियमों को हटाएं और पेज के ऊपरी हिस्से की सामग्री के लिए इस्तेमाल न होने वाले CSS को लोड होने से टालें. ऐसा करके, नेटवर्क गतिविधि में खर्च होने वाले गैर-ज़रूरी बाइट कम किए जा सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "इस्तेमाल नहीं किए गए CSS को हटाएं"
@@ -393,7 +405,7 @@
     "message": "इस्तेमाल नहीं किया गया JavaScript हटाएं"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "लंबे कैश लाइफ़टाइम से आपके पेज पर दोहराए जाने वाले विज़िट की गति बढ़ सकती है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "अगर कैश मेमोरी ज़्यादा समय तक रहेगी, तो लोगों के आपकी साइट पर लौटने की प्रक्रिया में तेज़ी आएगी. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 संसाधन मिला}one{# संसाधन मिले}other{# संसाधन मिले}}"
@@ -405,37 +417,88 @@
     "message": "स्थिर एसेट पर कुशल कैश नीति का इस्तेमाल करता है"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "ऑप्टिमाइज़ की गई इमेज तेज़ी से लोड होती हैं और इसमें कम सेल्युलर डेटा खर्च होता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "ऑप्टिमाइज़ की गई इमेज तेज़ी से लोड होती हैं. साथ ही, इसमें कम सेल्युलर डेटा खर्च होता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "इमेज को कुशलता से एन्कोड करें"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "ऐसी इमेज ऑफ़र करें जिनका आकार सही हो ताकि सेल्युलर डेटा बचाया जा सके और लोड समय को बेहतर बनाया जा सके. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "ऐसी इमेज ऑफ़र करें जिनका आकार सही हो, ताकि सेल्युलर डेटा बचाया जा सके और लोड होने में लगने वाले समय को कम किया जा सके. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "सही तरीके के आकार वाली इमेज"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "कुल नेटवर्क बाइट को कम से कम करने के लिए, लेख आधारित संसाधन कंप्रेशन (gzip, deflate या brotli) के साथ ऑफ़र किए जाने चाहिए. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "कुल नेटवर्क बाइट को कम से कम करने के लिए, टेक्स्ट आधारित संसाधन, कंप्रेशन (gzip, deflate या brotli) के साथ ऑफ़र किए जाने चाहिए. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "लेख कंप्रेशन चालू करें"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "JPEG 2000, JPEG XR और WebP जैसे इमेज फ़ॉर्मेट में अक्सर PNG या JPEG के मुकाबले बेहतर कंप्रेशन मिलता है, जिसका मतलब है कि डाउनलोड तेज़ी से होते हैं और इनमें कम डेटा खर्च होता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "JPEG 2000, JPEG XR, और WebP जैसे इमेज फ़ॉर्मैट, ज़्यादातर PNG या JPEG से बेहतर कंप्रेस करते हैं जिससे उपयोगकर्ता कम डेटा खर्च करके तेज़ डाउनलोड कर सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "इमेज अगली जेनरेशन के फ़ॉर्मेट में ऑफ़र करें"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "नीचे दी गई अहम अनुरोध शृंखलाएं आपको वे संसाधन दिखाती हैं जो उच्च प्राथमिकता से भरपूर हैं. शृंखलाओं की अवधि कम करने पर विचार करें, जिससे संसाधनों का डाउनलोड आकार कम हो जाएगा या पेज लोड को बेहतर बनाने के लिए गैर-ज़रूरी संसाधनों का डाउनलोड टल जाएगा. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "नीचे दी गई अहम अनुरोध शृंखलाएं बताती हैं कि किन संसाधनों को ज़्यादा प्राथमिकता से लोड किया गया है. शृंखलाओं की अवधि कम करें. इससे संसाधनों का डाउनलोड आकार कम हो जाएगा या पेज लोड को बेहतर बनाने के लिए गैर-ज़रूरी संसाधनों का डाउनलोड टल जाएगा. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 शृंखला मिली}one{# शृंखलाएं मिलीं}other{# शृंखलाएं मिलीं}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "अहम अनुरोधों की गहराई कम से कम करें"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "रुक गया है / चेतावनी"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "लाइन"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "काम न करने वाले एपीआई आपके ब्राउज़र से हटा दिए जाएंगे. [ज़्यादा जानें](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 चेतावनी मिली}one{# चेतावनियां मिलीं}other{# चेतावनियां मिलीं}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "रुके हुए एपीआई का इस्तेमाल करता है"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "रुके हुई एपीआई का इस्तेमाल नहीं किया जाता"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "ऐप्लिकेशन की कैश मेमोरी अब काम नहीं करती. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" मिल गया"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "ऐप्लिकेशन की कैश मेमोरी का इस्तेमाल किया जाता है"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "ऐप्लिकेशन की कैश मेमोरी का इस्तेमाल नहीं किया जाता"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "doctype तय करने से, ब्राउज़र क्वर्क-मोड (पुराने वर्शन पर काम करने की सुविधा) पर स्विच नहीं करता. [MDN वेब दस्तावेज़ वाले पेज](https://developer.mozilla.org/en-US/docs/Glossary/Doctype) पर इस बारे में और जानें"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Doctype का नाम अंग्रेज़ी के छोटे अक्षरों वाली स्ट्रिंग `html` में होना चाहिए"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "दस्तावेज़ में doctype होना ज़रूरी है"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "उम्मीद थी कि publicId खाली स्ट्रिंग होगी"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "उम्मीद थी कि systemId खाली स्ट्रिंग होगी"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "पेज में HTML doctype नहीं है जिसकी वजह से क्वर्क-मोड (पुराने वर्शन पर काम करने की सुविधा) ट्रिगर हो रही है"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "पेज में एचटीएमएल doctype है"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "तत्व"
@@ -447,7 +510,7 @@
     "message": "मान"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "ब्राउज़र इंजीनियर सुझाव देते हैं कि पेज में ~1,500 से कम DOM ऐलिमेंट होने चाहिए. सबसे सही आंकड़ा है 32 से कम ऐलिमेंट वाली ट्री डेप्थ और 60 से कम चिल्ड्रन/पेरेंट ऐलिमेंट. ज़्यादा बड़े DOM से मेमोरी का इस्तेमाल बढ़ सकता है, जिससे ज़्यादा लंबे [स्टाइल कैल्युलेशन](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) हो सकते हैं और इनसे महंगे [लेआउट रीफ़्लो](https://developers.google.com/speed/articles/reflow) बन सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "ब्राउज़र इंजीनियर यह सुझाव देते हैं कि पेज में ~1,500 से कम DOM एलिमेंट शामिल हों. सबसे सही आंकड़ा है 32 से कम एलिमेंट वाली ट्री डेप्थ और 60 से कम चिल्ड्रन/पैरंट एलिमेंट. ज़्यादा बड़े DOM से मेमोरी का इस्तेमाल बढ़ सकता है जिससे ज़्यादा लंबे [स्टाइल कैल्युलेशन](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) हो सकते हैं और इनसे महंगे [लेआउट रीफ़्लो](https://developers.google.com/speed/articles/reflow) बन सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 ऐलिमेंट}one{# ऐलिमेंट}other{# ऐलिमेंट}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "बहुत ज़्यादा बड़े DOM आकार से बचता है"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "लक्ष्य"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "किसी बाहरी लिंक में `rel=\"noopener\"` या `rel=\"noreferrer\"` जोड़कर परफ़ॉर्मेंस बेहतर करें और सुरक्षा जोखिमों से बचें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "जिन जगहों पर दो डोमेन से होकर जाना होता है वे सुरक्षित नहीं हैं"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "जिन जगहों पर दो डोमेन से होकर जाना होता है वे सुरक्षित हैं"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "एंकर ({anchorHTML}) के भेजे जाने की जगह नहीं पता की जा सकी. अगर target=_blank का इस्तेमाल हाइपरलिंक की तरह नहीं हो रहा, तो इसे हटा दें."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "उपयोगकर्ता ऐसी साइटों पर भरोसा नहीं करते या उनकी वजह से उलझन में रहते हैं जो बिना किसी संदर्भ के उनकी जगह की जानकारी पता करने का अनुरोध करती हैं. इसके बजाय, उपयोगकर्ता के जेस्चर के हिसाब से अनुरोध करें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "पेज लोड पर भौगोलिक स्थान जानने का अनुरोध किया जाता है"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "पेज लोड पर भौगोलिक स्थान जानने की मंज़ूरी का अनुरोध नहीं किया जाता"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "वर्शन"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "इस पेज पर पहचानी गई सभी फ़्रंट-एंड JavaScript लाइब्रेरी."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "पहचानी गई JavaScript लाइब्रेरी"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "धीमे कनेक्शन वाले उपयोगकर्ताओं के लिए, `document.write()` की दी गई बाहरी स्क्रिप्ट की वजह से पेज लोड होने में दस से ज़्यादा सेकंड की देरी हो सकती है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "`document.write()` का इस्तेमाल होता है"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "`document.write()` का इस्तेमाल नहीं किया जाता"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "सबसे ज़्यादा गंभीर"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "लाइब्रेरी वर्शन"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "जोखिम की संभावना की संख्या"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "तीसरे पक्ष की कुछ स्क्रिप्ट में सुरक्षा के ऐसे जोखिम हो सकते हैं जिनके बारे में लोगों को पता है. साथ ही, जिन्हें हमलावर आसानी से पहचानकर उनका फ़ायदा उठा सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 जोखिम की संभावना का पता चला}one{# जोखिमों की संभावना का पता चला}other{# जोखिमों की संभावना का पता चला}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "ऐसी फ़्रंट-एंड JavaScript लाइब्रेरी का इस्तेमाल करता है जिनमें शामिल सुरक्षा जोखिमों के बारे में सबको पता होता है."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "ज़्यादा"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "कम"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "मीडियम"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "ऐसी फ़्रंट-एंड JavaScript लाइब्रेरी का इस्तेमाल नहीं करता जिनमें शामिल सुरक्षा जोखिमों के बारे में सबको पता होता है."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "उपयोगकर्ता ऐसी साइटों पर भरोसा नहीं करते या उनकी वजह से उलझन में रहते हैं जो उन्हें बिना किसी संदर्भ के सूचनाएं भेजने का अनुरोध करती हैं. इसके बजाय, उपयोगकर्ता के जेस्चर के हिसाब से अनुरोध करें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "पेज लोड पर सूचनाओं की अनुमति पाने का अनुरोध किया जाता है"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "पेज लोड पर सूचना भेजने की मंज़ूरी का अनुरोध नहीं किया जाता"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "फ़ेल होने वाले एलिमेंट"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "पासवर्ड वाले फ़ील्ड में कुछ कॉपी करके चिपकाने की सुविधा न लागू करने का मतलब है एक अच्छी सुरक्षा नीति को कमज़ोर समझना. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "इस्तेमाल करने वालों को पासवर्ड फ़ील्ड में पहले से कॉपी की गई जानकारी चिपकाने से रोकता है"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "इस्तेमाल करने वालों को पासवर्ड फ़ील्ड में पहले से कॉपी की गई जानकारी चिपकाने देता है"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "प्रोटोकॉल"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 , HTTP/1.1 से ज़्यादा फ़ायदे ऑफ़र करता है जिनमें बाइनरी हैडर, मल्टीप्लेक्सिंग, और सर्वर पुश शामिल हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 अनुरोध HTTP/2 से सर्व नहीं किया गया}one{# अनुरोध HTTP/2 से सर्व नहीं किए गए}other{# अनुरोध HTTP/2 से सर्व नहीं किए गए}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "अपने सभी संसाधनों के लिए HTTP/2 का इस्तेमाल नहीं करता"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "अपने संसाधन के लिए HTTP/2 का इस्तेमाल किया जाता है"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "अपने 'टच एंड व्हील' घटना श्रोता पर `passive` का निशान लगाएं, ताकि आपके पेज की स्क्रोल परफ़ॉर्मेंस को बेहतर किया जा सके. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "स्क्रोल परफ़ॉर्मेंस बेहतर करने के लिए पैसिव श्रोताओं का इस्तेमाल नहीं करता"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "पैसिव श्रोताओं की मदद से स्क्रोल परफ़ॉर्मेंस बेहतर की जाती है"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "ब्यौरा"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "कंसोल में लॉग की गई गड़बड़ियां उन मुश्किलों की तरफ़ इशारा करती हैं जिनका समाधान किया जाना अभी बाकी है. ये गड़बड़ियां नेटवर्क अनुरोधों के काम न करने और ब्राउज़र से जुड़ी दूसरी वजहों से आ सकती हैं."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "ब्राउज़र की गड़बड़ियां कंसोल में लॉग की गईं"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "ब्राउज़र की किसी गड़बड़ी को कंसोल में लॉग नहीं किया गया"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "यह पक्का करने के लिए फ़ॉन्ट-डिसप्ले CSS फ़ीचर का फ़ायदा उठाएं कि वेबफ़ॉन्ट लोड होने के दौरान उपयोगकर्ता को लेख दिखाई देता रहे. [ज़्यादा जानें](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "यह पक्का करने के लिए कि वेबफ़ॉन्ट लोड होने के दौरान उपयोगकर्ता को टेक्स्ट दिखाई देता रहे, फ़ॉन्ट-डिसप्ले सीएसएस फ़ीचर का फ़ायदा लें. [ज़्यादा जानें](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "पक्का करें कि वेबफ़ॉन्ट लोड होने के दौरान लेख दिखाई देता रहे"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "वेबफ़ॉन्ट लोड होने के दौरान सभी लेख दिखाई देते रहते हैं"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse इस यूआरएल के लिए, फ़ॉन्ट-डिसप्ले की अपने आप जांच नहीं कर सका: {fontURL}"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "चौड़ाई-ऊंचाई का अनुपात (असल)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "चौड़ाई-ऊंचाई का अनुपात (डिसप्ले किया गया)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "इमेज डिसप्ले डाइमेंशन, चौड़ाई-ऊंचाई के अनुपात जितने होने चाहिए. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "चौड़ाई-ऊंचाई के गलत अनुपात वाली इमेज दिखाता है"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "चौड़ाई-ऊंचाई के सही अनुपात वाली इमेज दिखाता है"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "इमेज के आकार की जानकारी गलत है {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "असुरक्षित यूआरएल"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "सभी साइटों को HTTPS से सुरक्षित किया जाना चाहिए, चाहे उनमें संवेदनशील डेटा हो या नहीं. HTTPS की वजह से अनचाहे लोग (घुसपैठिये), आपके ऐप्लिकेशन और उसके उपयोगकर्ताओं के बीच होने वाली बातों को न तो सुन पाएंगे और न ही उसके साथ किसी तरह की छेड़खानी कर पाएंगे. HTTP/2 और कई नए वेब प्लेटफ़ॉर्म एपीआई पर इस सुविधा के बिना साइटें नहीं बनाई जा सकतीं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 असुरक्षित अनुरोध मिला}one{# असुरक्षित अनुरोध मिले}other{# असुरक्षित अनुरोध मिले}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "HTTPS का इस्तेमाल नहीं किया जाता"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "HTTPS का इस्तेमाल करता है"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "सेल्युलर नेटवर्क पर तेज़ी से पेज लोड होने की सुविधा से मोबाइल इस्तेमाल करने वालों को अच्छा अनुभव मिलता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "सेल्युलर नेटवर्क पर तेज़ी से पेज लोड होने की सुविधा से मोबाइल इस्तेमाल करने वालों को अच्छा अनुभव मिलता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "{timeInMs, number, seconds} सेकंड में इंटरैक्टिव"
+    "message": "इंटरैक्शन {timeInMs, number, seconds} से. में शुरू हुआ"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "{timeInMs, number, seconds} सेकंड में सिम्युलेट किए गए मोबाइल नेटवर्क पर इंटरैक्टिव"
+    "message": "{timeInMs, number, seconds} से. में सिम्युलेट किए गए मोबाइल नेटवर्क पर इंटरैक्शन शुरू हुआ"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "मोबाइल नेटवर्क पर पेज लोड होने की गति ज़रूरत के मुताबिक तेज़ नहीं है"
@@ -504,79 +735,106 @@
     "message": "मुख्य थ्रेड के काम को कम करता है"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "अंदाजन इनपुट देरी इस बात का अनुमान होता है कि पेज लोड होने की सबसे व्यस्त 5 सेकंड की विंडो के दौरान आपके ऐप्लिकेशन को इस्तेमाल करने वाले के इनपुट का जवाब देने में, मिलीसेकंड में कितना समय लगेगा. अगर इंतज़ार का समय 50 मिलीसेकंड से ज़्यादा है, तो इस्तेमाल करने वाले आपके ऐप्लिकेशन को धीमा मान सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "इनपुट के इंतज़ार के समय का अंदाज़ा, इस बात से लगाया जाता है कि पेज लोड होने की सबसे व्यस्त पांच सेकंड की विंडो के दौरान आपके ऐप्लिकेशन को इस्तेमाल करने वाले के इनपुट का जवाब देने में कितना समय लगेगा. इस समय का हिसाब मिलीसेकंड में लगाया जाता है. अगर इंतज़ार का समय 50 मिलीसेकंड से ज़्यादा हो, तो इस्तेमाल करने वाले आपके ऐप्लिकेशन को धीमा मान सकते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "अनुमानित इनपुट प्रतीक्षा समय"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "फ़र्स्ट कॉन्टेंटफ़ुल पेंट वह समय चिह्नित करता है जब पहले लेख या इमेज को पेंट किया गया हो. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "फ़र्स्ट कॉन्टेंटफ़ुल पेंट से उस समय का पता चलता है जब पहले टेक्स्ट या इमेज को पेंट किया गया था. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "उपयोगी सामग्री वाला पहला पेंट"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "इस्तेमाल में नहीं पहला सीपीयू (CPU), वह पहला समय चिह्नित करता है जब पेज का मुख्य थ्रेड इनपुट को संभालने के लिए काफ़ी होता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "इस्तेमाल में न होने वाले पहले सीपीयू (CPU) का आंकड़ा, वह समय बताता है जब पेज का मुख्य थ्रेड पहली बार इनपुट को संभालने के लिए काफ़ी होता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "पहला सीपीयू (CPU) इस्तेमाल में नहीं"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "पहला सार्थक पेंट उस समय का मापन करता है जब किसी पेज की शुरुआती सामग्री दिखाई देती है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "फ़र्स्ट मीनिंगफ़ुल पेंट, पेज की मुख्य सामग्री दिखाई देने का समय बताता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "पहला सार्थक पेंट"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "इंटरैक्टिव में लगने वाला समय वह समय है जितनी देर में पेज पूरी तरह से इंटरैक्टिव हो जाता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "इंटरैक्टिव में लगने वाला समय, वह समय है जितनी देर में पेज पूरी तरह से इंटरैक्टिव हो जाता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "इंटरएक्टिव में लगने वाला समय"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "मिलीसेकंड में बताई जाने वाली सबसे लंबे टास्क की पहली संभावित इनपुट देरी. आपके इस्तेमाल करने वालों को यह समस्या आ सकती है."
+    "message": "आपके उपयोगकर्ताओं को अनुभव होने वाले संभावित फ़र्स्ट इनपुट डिले में सबसे लंबे टास्क की अवधि शामिल होती है. यह वह डिले है जिसकी वजह से आपके उपयोगकर्ताओं को सबसे ज़्यादा देरी का सामना करना पड़ सकता है. यह अवधि मिलीसेकंड इकाई में बताई जाती है. [ज़्यादा जानें](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "ज़्यादा से ज़्यादा संभावित एफ़आईडी"
+    "message": "सबसे ज़्यादा संभावित फ़र्स्ट इनपुट डिले"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "गति इंडेक्स दिखाता है कि किसी पेज की सामग्री विज़ुअल रूप से कितनी तेज़ी से पॉपुलेट होती हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "स्पीड इंडेक्स से पता चलता है कि किसी पेज की सामग्री, विज़ुअल रूप से कितनी तेज़ी से डाली गई है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "गति इंडेक्स"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "टास्क में लगने वाले समय की अवधि 50 मि. से. से ज़्यादा होने पर एफ़सीपी और इंटरैक्टिव में लगने वाले समय के बीच के कुल समय. यह समय मिलिसेकंड इकाई में बताया जाता है."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "ब्लॉक होने का कुल समय"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "नेटवर्क के 'दोतरफ़ा यात्रा के समय' (आरटीटी) का परफ़ॉर्मेंस पर बहुत गहरा असर होता है. शुरुआत की जगह पर आरटीटी ज़्यादा होने से यह पता चलता है कि अगर सर्वर इस्तेमाल करने वालों के करीब होंगे, तो परफ़ॉर्मेंस बेहतर हो सकती है. [ज़्यादा जानें](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "नेटवर्क के 'दोतरफ़ा यात्रा के समय' (आरटीटी) का परफ़ॉर्मेंस पर बहुत गहरा असर होता है. शुरुआत की जगह पर आरटीटी ज़्यादा होने से यह पता चलता है कि अगर सर्वर इस्तेमाल करने वालों के करीब होंगे, तो परफ़ॉर्मेंस बेहतर हो सकती है. [ज़्यादा जानें](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "नेटवर्क का दोतरफ़ा यात्रा का समय"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "सर्वर के इंतज़ार के समय का असर वेब परफ़ॉर्मेंस पर पड़ सकता है. शुरुआत की जगह के सर्वर का इंतज़ार का समय ज़्यादा होने से यह पता चलता है कि सर्वर ओवरलोड हो गया है या उसकी बैकएंड परफ़ॉर्मेंस खराब है. [ज़्यादा जानें](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "सर्वर के इंतज़ार के समय का असर वेब परफ़ॉर्मेंस पर हो सकता है. शुरुआती जगह के सर्वर के 'इंतज़ार का समय' ज़्यादा होने से यह पता चलता है कि सर्वर ओवरलोड हो गया है या उसकी बैकएंड परफ़ॉर्मेंस खराब है. [ज़्यादा जानें](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "सर्वर बैकएंड के इंतज़ार का समय"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "बजट से ज़्यादा"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "नेटवर्क अनुरोधों की संख्या और उनकी क्वालिटी, आपको दिए गए परफ़ॉर्मेंस बजट की ओर से सेट किए गए लक्ष्यों के हिसाब से होनी चाहिए. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{अनुरोध}one{# अनुरोध}other{# अनुरोध}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "परफ़ॉर्मेंस बजट"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "'रीडायरेक्ट' पेज लोड किए जाने से पहले और ज़्यादा प्रतीक्षा जोड़ता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "रीडायरेक्ट की वजह से पेज के लोड होने से लगने वाला समय और बढ़ जाता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "एक से ज़्यादा पेज रीडायरेक्ट करने से बचें"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "पेज संसाधनों की संख्या और आकार के बजट सेट करने के लिए, एक budget.json फ़ाइल जोड़ें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 अनुरोध}one{# अनुरोध}other{# अनुरोध}} • {byteCount, number, bytes} केबी"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "अनुरोधों की संख्या कम और ट्रांसफ़र का आकार छोटा रखें"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "कैननिकल लिंक, खोज नतीजों में दिखाए जाने वाले यूआरएल के बारे में बताते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "कैननिकल लिंक, खोज नतीजों में दिखाए जाने वाले यूआरएल के बारे में बताते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "कई विरोधी यूआरएल हैं ({urlList})"
+    "message": "कई कॉन्फ़्लिक्टिंग यूआरएल हैं ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "किसी अलग डोमेन पर ले जाता है ({url})"
+    "message": "किसी दूसरे डोमेन की तरफ़ इशारा करता है ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "गलत यूआरएल ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "किसी दूसरी `hreflang` जगह पर ले जाता है ({url})"
+    "message": "किसी दूसरी `hreflang` जगह वाली विशेषता ({url}) की तरफ़ इशारा करता है"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "मिलता-जुलता यूआरएल ({url})"
@@ -585,25 +843,22 @@
     "message": "मिलती-जुलती सामग्री वाले पेज पर ले जाने के बजाय डोमेन के रूट यूआरएल (होम पेज) पर ले जाता है"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "दस्तावेज़ में सही `rel=canonical` नहीं है"
+    "message": "दस्तावेज़ में सही `rel=canonical` नहीं है"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "दस्तावेज़ में सही `rel=canonical` है"
+    "message": "दस्तावेज़ में सही `rel=canonical` शामिल है"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "पढ़ने के नज़रिए से 12px से कम आकार वाले फ़ॉन्ट काफ़ी छोटे होते हैं. ऐसा होने पर, मोबाइल से वेबसाइट पर आने वालों को पढ़ने के लिए “पिंच करके ज़ूम करना” होगा. पेज का 60% से ज़्यादा टेक्स्ट 12px का या उससे बड़े आकार में रखने की कोशिश करें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "पढ़ने के नज़रिए से, 12px से कम आकार वाले फ़ॉन्ट काफ़ी छोटे होते हैं. ऐसा होने पर, मोबाइल से वेबसाइट पर आने वालों को पढ़ने के लिए “पिंच करके ज़ूम करना” होगा. कोशिश करें कि पेज का 60% से ज़्यादा टेक्स्ट 12px या उससे बड़े आकार का हो. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} टेक्स्ट पढ़ने लायक है"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} टेक्स्ट काफ़ी छोटा है."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "मोबाइल स्क्रीन के लिए कोई व्यूपोर्ट मेटा टैग ऑप्टिमाइज़ नहीं किए जाने की वजह से टेक्स्ट पढ़ने लायक नहीं है."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} टेक्स्ट काफ़ी छोटा है ({decimalProportionVisited, number, extendedPercent} नमूने के आधार पर)."
+    "message": "टेक्स्ट का {decimalProportion, number, extendedPercent} बहुत छोटा है ({decimalProportionVisited, number, extendedPercent} नमूने पर आधारित)."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "दस्तावेज़ पढ़ने लायक फ़ॉन्ट आकारों का इस्तेमाल नहीं करता है"
@@ -612,16 +867,16 @@
     "message": "दस्तावेज़ पढ़ने लायक फ़ॉन्ट आकारों का इस्तेमाल करता है"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "hreflang लिंक से सर्च इंजन को यह पता चलता है कि किसी खास भाषा या क्षेत्र के लिए पेज के किस वर्शन को खोज नतीजों में रखना चाहिए. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "hreflang लिंक से सर्च इंजन को यह पता चलता है कि किसी खास भाषा या क्षेत्र के लिए पेज के किस वर्शन को खोज नतीजों में रखना चाहिए. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
     "message": "दस्तावेज़ में सही `hreflang` नहीं है"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "दस्तावेज़ में सही `hreflang` है"
+    "message": "दस्तावेज़ में सही `hreflang` शामिल है"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "ऐसे पेज ठीक से इंडेक्स नहीं किए जा सकते जिनमें काम नहीं करने वाले एचटीटीपी स्थिति कोड होते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "ऐसे पेज ठीक से इंडेक्स नहीं किए जा सकते जिनमें काम न करने वाले एचटीटीपी स्टेटस कोड हों. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "पेज में काम नहीं करने वाला एचटीटीपी स्थिति कोड है"
@@ -630,7 +885,7 @@
     "message": "पेज में काम करने वाला एचटीटीपी स्थिति कोड है"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "अगर सर्च इंजन के पास आपके पेज क्रॉल करने की मंज़ूरी नहीं होती है, तो वे खोज नतीजों में आपके पेज शामिल नहीं कर पाएंगे. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "अगर सर्च इंजन के पास आपके पेज क्रॉल करने की मंज़ूरी नहीं होती, तो वे खोज नतीजों में आपके पेज शामिल नहीं कर पाएंगे. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "पेज को इंडेक्स करने से ब्लॉक किया गया है"
@@ -639,7 +894,7 @@
     "message": "पेज को इंडेक्स करने से ब्लॉक नहीं किया गया है"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "लिंक की पूरी जानकारी देने वाले टेक्स्ट की मदद से सर्च इंजन आपकी सामग्री के बारे में समझ पाते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "लिंक की पूरी जानकारी देने वाले टेक्स्ट की मदद से सर्च इंजन आपकी सामग्री के बारे में समझ पाते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 लिंक मिला}one{# लिंक मिले}other{# लिंक मिले}}"
@@ -651,13 +906,13 @@
     "message": "लिंक में पूरी जानकारी देने वाला टेक्स्ट है"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "स्ट्रक्चर्ड डेटा की पुष्टि करने के लिए [स्ट्रक्चर्ड डेटा टेस्टिंग टूल](https://search.google.com/structured-data/testing-tool/) और [स्ट्रक्चर्ड डेटा लिंटर](http://linter.structured-data.org/) चलाएं. [ज़्यादा जानें](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "स्ट्रक्चर्ड डेटा की पुष्टि करने के लिए [स्ट्रक्चर्ड डेटा टेस्टिंग टूल](https://search.google.com/structured-data/testing-tool/) और [ स्ट्रक्चर्ड डेटा लिंटर](http://linter.structured-data.org/) चलाएं. [ज़्यादा जानें](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "स्ट्रक्चर्ड डेटा सही है"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "खोज नतीजों में संक्षिप्त विवरण शामिल हो सकते हैं ताकि पेज सामग्री के बारे में थोड़े शब्दों में खास जानकारी दी जा सके. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "खोज नतीजों में मुख्य जानकारी शामिल हो सकती है, ताकि पेज सामग्री के बारे में थोड़े शब्दों में खास जानकारी दी जा सके. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "ब्यौरे का टेक्स्ट खाली है."
@@ -669,7 +924,7 @@
     "message": "दस्तावेज़ में संक्षिप्त विवरण है"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "सर्च इंजन प्लग इन की सामग्री इंडेक्स नहीं कर सकते. साथ ही, कई डिवाइस प्लग इन पर पाबंदी लगाते हैं या वे उन पर काम नहीं करते हैं. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "सर्च इंजन प्लग इन की सामग्री इंडेक्स नहीं कर सकते. साथ ही, कई डिवाइस प्लग इन पर पाबंदी लगाते हैं या वे उन पर काम नहीं करते. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "दस्तावेज़ प्लग इन का इस्तेमाल करता है"
@@ -696,10 +951,10 @@
     "message": "robots.txt सही है"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "बटन और लिंक जैसे इंटरैक्टिव एलिमेंट ज़रूरत के मुताबिक आकार वाले (48x48px) होने चाहिए और इनके आसपास जगह होनी चाहिए. ऐसा करने से, दूसरे एलिमेंट ओवरलैप किए बिना आसानी से उन पर टैप किया जा सकेगा. [ज़्यादा जानें](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "बटन और लिंक जैसे इंटरैक्टिव एलिमेंट, आकार में बड़े (48x48px) होने चाहिए और इनके आस-पास बड़ी जगह होनी चाहिए. ऐसा करने से, दूसरे एलिमेंट को ओवरलैप किए बिना आसानी से उन पर टैप किया जा सकेगा. [ज़्यादा जानें](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "टैप की जाने वाली {decimalProportion, number, percent} जगहें सही आकार में हैं"
+    "message": "{decimalProportion, number, percent} टैप की जाने वाली जगहें सही आकार में हैं"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "मोबाइल स्क्रीन के लिए कोई व्यूपोर्ट मेटा टैग ऑप्टिमाइज़ नहीं किए जाने की वजह से टैप की जाने वाली जगहें काफ़ी छोटी हैं"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "ओवरलैप करने वाली जगह"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "आकार"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "टैप की जाने वाली जगह"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "टैप की जाने वाली जगहें सही आकार में हैं"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "मुख्य थ्रेड में लगने वाला समय"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "तीसरा पक्ष"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "तीसरे पक्ष के कोड आपके पेज की लोड परफ़ॉर्मेंस पर गहरा असर कर सकते हैं. ऐसी तीसरे-पक्ष की सेवा देने वाली कंपनियों का इस्तेमाल ज़्यादा न करें जिनके कोड अब आपके काम के नहीं हैं. साथ ही, तीसरे पक्ष का कोड तब लोड करें जब आपके पेज पर मुख्य लोडिंग का काम पूरा हो गया हो. [ज़्यादा जानें](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 तीसरा पक्ष मिला}one{# तीसरे पक्ष मिले}other{# तीसरे पक्ष मिले}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "इसका इस्तेमाल तीसरा पक्ष करता है"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "पहली बाइट का समय, उस समय की पहचान करता है जब आपका सर्वर कोई जवाब भेजता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "पहली बाइट का समय, उस समय की पहचान करता है जब आपका सर्वर कोई जवाब भेजता है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "रूट दस्तावेज़ को {timeInMs, number, milliseconds} मिलीसेकंड लगे"
+    "message": "रुट दस्तावेज़ बनने में {timeInMs, number, milliseconds} मि.से. का समय लगा"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "सर्वर प्रतिक्रिया समय घटाएं (TTFB)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "कुल समय"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "नाम"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "शुरुआत का समय"
   },
@@ -744,7 +1008,7 @@
     "message": "प्रकार"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "प्रमुख उपयोगकर्ता अनुभवों के दौरान, असली दुनिया के माप तैयार करने के लिए अपने ऐप्लिकेशन को 'उपयोगकर्ता समय API (एपीआई)' के ज़रिए तैयार करने पर विचार करें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "मुख्य उपयोगकर्ता अनुभवों के दौरान, असली दुनिया के माप तैयार करने के लिए अपने ऐप्लिकेशन को 'उपयोगकर्ता समय एपीआई' की मदद से तैयार करें. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 उपयोगकर्ता समय}one{# उपयोगकर्ता समय}other{# उपयोगकर्ता समय}}"
@@ -753,19 +1017,19 @@
     "message": "उपयोगकर्ता समय अंक और मापन"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "\"{securityOrigin}\" के लिए एक पहले से कनेक्ट <link> मिला, लेकिन ब्राउज़र ने इस्तेमाल नहीं किया था. यह जाँचें कि आप `crossorigin` विशेषता का इस्तेमाल ठीक से कर रहे हैं."
+    "message": "\"{securityOrigin}\" के लिए पहले से कनेक्ट किया गया <link> मिला, लेकिन ब्राउज़र ने इसका इस्तेमाल नहीं किया था. यह पक्का कर लें कि आप `crossorigin` विशेषता का इस्तेमाल ठीक से कर रहे हैं."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "तीसरे पक्ष के अहम मूल से जल्दी कनेक्शन बनाने के लिए प्री-कनेक्ट या dns-प्रीफ़ेच संसाधन संकेत जोड़ने पर विचार करें. [ज़्यादा जानें](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "तीसरे पक्ष के अहम मूल से जल्दी कनेक्शन बनाने के लिए प्री-कनेक्ट या dns-प्रीफ़ेच संसाधन संकेत जोड़ें. [ज़्यादा जानें](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "ज़रूरी मूल से प्री-कनेक्ट करें"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "\"{preloadURL}\" के लिए पहले से लोड <link> मिला, लेकिन ब्राउज़र ने इस्तेमाल नहीं किया था. यह जाँचें कि आप `crossorigin` विशेषता का इस्तेमाल ठीक से कर रहे हैं."
+    "message": "\"{preloadURL}\" के लिए पहले से लोड किया गया <link> मिला, लेकिन ब्राउज़र ने इसका इस्तेमाल नहीं किया था. यह पक्का कर लें कि आप `crossorigin` विशेषता का इस्तेमाल ठीक से कर रहे हैं."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "ऐसे संसाधन फ़ेच करने को प्राथमिकता देने के लिए <link rel=preload> का इस्तेमाल करने पर विचार करें जिनका फ़िलहाल पेज लोड में बाद में अनुरोध किया गया है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "`<link rel=preload>` का इस्तेमाल करके उन संसाधनों को पाने को प्राथमिकता दें जिन्हें फ़िलहाल पेज लोड में 'बाद में चाहिए होंगे' का दर्जा दिया गया है. [ज़्यादा जानें](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "प्रमुख अनुरोधों को पहले से लोड करें"
@@ -789,10 +1053,10 @@
     "message": "सबसे अच्छे तरीके"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "ये जाँच [आपके वेब ऐप्लिकेशन की सुलभता को बेहतर बनाने](https://developers.google.com/web/fundamentals/accessibility) के अवसर हाइलाइट करती हैं. सिर्फ़ कुछ चुनिंदा सुलभता समस्याओं का अपने आप पता लगाया जा सकता है, इसलिए आपको खुद ही टेस्ट करने का भी सुझाव दिया जाता है."
+    "message": "ये सभी जांच आपको [आपके वेब ऐप्लिकेशन की सुलभता बेहतर करने](https://developers.google.com/web/fundamentals/accessibility) के अवसर देती हैं. सुलभता गड़बड़ियों के सिर्फ़ एक उपसेट के बारे में अपने आप पता लगाया जा सकता है, इसलिए हम मैन्युअल टेस्टिंग का सुझाव देते हैं."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "ये आइटम ऐसे मामलों में भी काम करते हैं जहां अपने आप काम करने वाला टेस्टिंग टूल नाकाम रहता है. हमारी मार्गदर्शिका में जाकर [सुलभता समीक्षा करने](https://developers.google.com/web/fundamentals/accessibility/how-to-review) के बारे में ज़्यादा जानें."
+    "message": "ये आइटम ऐसे मामलों में भी काम करते हैं जहां अपने आप काम करने वाला टेस्टिंग टूल नाकाम रहता है. हमारी गाइड में जाकर [सुलभता समीक्षा करने](https://developers.google.com/web/fundamentals/accessibility/how-to-review) के बारे में ज़्यादा जानें."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "सुलभता"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "टेबल और सूचियां"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "सबसे अच्छे तरीके"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "परफ़ॉर्मेंस बजट बनाकर आप अपनी साइट की परफ़ॉर्मेंस के मानक तय करते हैं."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "बजट"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "आपके ऐप्लिकेशन के परफ़ॉर्मेंस के बारे में ज़्यादा जानकारी."
+    "message": "आपके ऐप्लिकेशन के परफ़ॉर्मेंस के बारे में ज़्यादा जानकारी. इन आंकड़ों का परफ़ॉर्मेंस स्कोर पर [सीधा असर](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) नहीं पड़ता."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "निदान"
@@ -840,7 +1113,7 @@
     "message": "पहले पेंट के सुधार"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "इन ऑप्टिमाइज़ेशन से आपका पेज लोड होने की गति बढ़ सकती है."
+    "message": "इन सुझावों से आप अपने पेज को तेज़ी से लोड करा सकते हैं. इनसे आपके परफ़ॉर्मेंस स्कोर पर [सीधा असर](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) नहीं होगा."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "अवसर"
@@ -867,7 +1140,7 @@
     "message": "PWA ऑप्टिमाइज़ किया गया"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "ये जाँच पक्का करती हैं कि आपका पेज सर्च इंजन के नतीजे रैंक करने के लिए ऑप्टिमाइज़ किया हुआ है. दूसरी वजहों से Lighthouse जाँच नहीं करता है. इसका असर आपकी खोज की रैंकिंग पर पड़ सकता है. [ज़्यादा जानें](https://support.google.com/webmasters/answer/35769)."
+    "message": "ये जांच पक्का करती हैं कि आपका पेज, सर्च इंजन के नतीजे रैंक करने के लिए ऑप्टिमाइज़ किया हुआ है. दूसरी वजहों से Lighthouse जांच नहीं करता है. इसका असर आपकी खोज की रैंकिंग पर हो सकता है. [ज़्यादा जानें](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "SEO के दूसरे सबसे अच्छे तरीके देखने के लिए अपनी साइट पर पुष्टि करने वाले ये और भी टूल चलाएं."
@@ -882,13 +1155,13 @@
     "message": "सामग्री से जुड़े सबसे अच्छे तरीके"
   },
   "lighthouse-core/config/default-config.js | seoCrawlingGroupDescription": {
-    "message": "खोज नतीजों में दिखाई देने के लिए, क्रॉलर को आपके ऐप्लिकेशन का एक्सेस चाहिए."
+    "message": "खोज नतीजों में दिखाई देने के लिए, क्रॉलर को आपके ऐप्लिकेशन का ऐक्सेस चाहिए."
   },
   "lighthouse-core/config/default-config.js | seoCrawlingGroupTitle": {
     "message": "क्रॉल करना और इंडेक्स करना"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "यह पक्का करें कि आपके पेज मोबाइल फ़्रेंडली हों. इससे सामग्री वाले पेज पढ़ने के लिए उपयोगकर्ताओं को पिंच या ज़ूम नहीं करना पड़ेगा. [ज़्यादा जानें](https://developers.google.com/search/mobile-sites/)."
+    "message": "यह पक्का करें कि आपके पेज मोबाइल फ़्रेंडली हों. इससे सामग्री वाले पेज पढ़ने के लिए उपयोगकर्ताओं को पिंच या ज़ूम नहीं करना पड़ेगा. [ज़्यादा जानें](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "मोबाइल फ़्रेंडली"
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "कैश TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "जगह की जानकारी"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "नाम"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "अनुरोध"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "संसाधन का प्रकार"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "आकार (केबी)"
+    "message": "आकार"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "बिताया गया समय"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "ट्रांसफ़र आकार"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "यूआरएल"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "हो सकने वाली बचत (केबी)"
+    "message": "संभावित बचत"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "हो सकने वाली बचत (‍मिली सेकंड)"
+    "message": "संभावित बचत"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "{wastedBytes, number, bytes} केबी की हो सकने वाली बचत"
+    "message": "{wastedBytes, number, bytes} केबी की संभावित बचत"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "{wastedMs, number, milliseconds} मिलीसेकंड की हो सकने वाली बचत"
+    "message": "{wastedMs, number, milliseconds} मि. से. की संभावित बचत"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "दस्तावेज़"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "फ़ॉन्ट"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "इमेज"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "मीडिया"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds} मिलीसेकंड"
+    "message": "{timeInMs, number, milliseconds} मि.से."
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "कोई दूसरा विकल्प"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "स्क्रिप्ट"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} सेकंड"
+    "message": "{timeInMs, number, seconds} से."
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "स्टाइलशीट"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "तीसरा पक्ष"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "कुल"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "आपके पेज लोड में ट्रेस की रिकॉर्डिंग करते समय कुछ गलत हुआ. कृपया Lighthouse को फिर से चलाएं. ({errorCode})"
+    "message": "आपके पेज लोड में ट्रेस की रिकॉर्डिंग करते समय कोई गड़बड़ी हुई. कृपया Lighthouse को फिर से चलाएं. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "शुरुआती डीबगर प्रोटोकॉल कनेक्शन का इंतज़ार करते हुए समय खत्म हो गया."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome पेज लोड के दौरान कोई भी स्क्रीन शॉट इकट्ठा नहीं करता है. कृपया पक्का करें कि पेज पर सामग्री दिखाई दे रही है और तब Lighthouse को फिर से चलाकर देखें. ({errorCode})"
+    "message": "Chrome ने पेज लोड के दौरान कोई भी स्क्रीन शॉट इकट्ठा नहीं किया. कृपया पक्का करें कि पेज पर सामग्री दिखाई दे रही है. इसके बाद, Lighthouse को फिर से चलाकर देखें. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS सर्वर दिए गए डोमेन को हल नहीं कर सका."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "ज़रूरी {artifactName} इकट्ठा करने वाला संसाधन चलाने में गड़बड़ी हुई: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "एक अंदरूनी Chrome गड़बड़ी हुई. कृपया Chrome को रीस्टार्ट करें और Lighthouse को फिर से चलाकर देखें."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "ज़रूरी {artifactName} इकट्ठा करने वाला संसाधन नहीं चलाया जा सका."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse आपका अनुरोध किया गया पेज ठीक से लोड नहीं कर सका. पक्का करें कि आप सही यूआरएल को टेस्ट कर रहे हैं और सर्वर सभी अनुरोधों के लिए ठीक से काम कर रहा है."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse उस यूआरएल को भरोसेमंद रूप से लोड नहीं कर सका जिसका आपने अनुरोध किया था क्योंकि पेज ने काम करना बंद कर दिया था."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "आपके दिए गए यूआरएल के लिए सही सुरक्षा क्रेडेंशियल नहीं हैं. {securityMessages}"
+    "message": "आपके दिए यूआरएल में सही सुरक्षा सर्टिफ़िकेट नहीं है. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome ने वे पेज लोड नहीं किए जिन पर अचानक दिखने वाले विज्ञापन होते हैं. पक्का करें कि आप सही यूआरएल को टेस्ट कर रहे हैं और सर्वर सभी अनुरोधों के लिए ठीक से काम कर रहा है."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse आपका अनुरोध किया गया पेज ठीक से लोड नहीं कर सका. पक्का करें कि आप सही यूआरएल को टेस्ट कर रहे हैं और सर्वर सभी अनुरोधों के लिए ठीक से काम कर रहा है. (जानकारी: {errorDetails})"
@@ -954,10 +1278,10 @@
     "message": "Lighthouse आपका अनुरोध किया गया पेज ठीक से लोड नहीं कर सका. पक्का करें कि आप सही यूआरएल को टेस्ट कर रहे हैं और सर्वर सभी अनुरोधों के लिए ठीक से काम कर रहा है. (स्थिति कोड: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "आपके पेज को लोड होने में बहुत ज़्यादा समय लगा. अपने पेज के लोड होने का समय कम करने के लिए, कृपया रिपोर्ट में दिए गए अवसरों का फ़ायदा उठाएं. इसके बाद, Lighthouse को फिर से चलाकर देखें. ({errorCode})"
+    "message": "आपके पेज को लोड होने में बहुत ज़्यादा समय लगा. अपने पेज के लोड होने का समय कम करने के लिए, कृपया रिपोर्ट में दिए गए अवसरों का फ़ायदा लें. इसके बाद, Lighthouse को फिर से चलाकर देखें. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "DevTools प्रोटोकॉल जवाब के लिए इंतज़ार का समय, तय समय से ज़्यादा हो गया है. (तरीका: {protocolMethod})"
+    "message": "DevTools प्रोटोकॉल जवाब के लिए इंतज़ार का समय, तय समय से ज़्यादा हो गया है. (तरीका:{protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "संसाधन की सामग्री लाने में दिए गए समय से ज़्यादा समय लगा"
@@ -984,7 +1308,7 @@
     "message": "किसी नई या दुबारा जाँची जाने वाली ऐप्लिकेशन के लिए तैयार किया गया डेटा"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) प्रतियोगी मोबाइल नेटवर्क पर मौजूदा पेज के आंकड़े. मान अनुमानित हैं और इनमें अंतर हो सकता है."
+    "message": "एम्युलेट किए गए मोबाइल नेटवर्क पर मौजूद पेज का [Lighthouse](https://developers.google.com/web/tools/lighthouse/) विश्लेषण. मान अनुमान के हिसाब से लिखे गए हैं और इनमें अंतर हो सकता है."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "मैन्युअल रूप से देखे जाने वाले और ज़्यादा आइटम"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "स्निपेट को बड़ा करें"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "तीसरे पक्ष के संसाधन दिखाएं"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "कुछ समस्याएं आने के कारण Lighthouse के इस रन पर असर पड़ा है:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "मान अनुमानित हैं और इनमें अंतर हो सकता है."
+    "message": "मान अनुमान के हिसाब से लिखे गए हैं और इनमें अंतर हो सकता है. परफ़ॉर्मेंस स्कोर सिर्फ़ [इन मेट्रिक पर आधारित ](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) होता है."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "चेतावनियों के साथ पास हुए ऑडिट"
@@ -1023,10 +1350,10 @@
     "message": "किसी ऐसी सेवा में अपनी GIF अपलोड करने पर विचार करें जो उसे HTML5 वीडियो में एम्बेड करने के लिए उपलब्ध कराएगी."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "ऐसा [धीमे लोड होने वाले WordPress प्लगइन](https://wordpress.org/plugins/search/lazy+load/) इंस्टॉल करें जिससे किसी भी ऑफ़स्क्रीन इमेज को अलग करने की सुविधा हो. अगर नहीं, तो किसी ऐसी थीम पर जाएं जो यह फ़ंक्शन मुहैया कराती हो. साथ ही, [एएमपी प्लगइन](https://wordpress.org/plugins/amp/) का इस्तेमाल करने पर विचार करें."
+    "message": "ऐसा [धीमे लोड होने वाले WordPress प्लग इन](https://wordpress.org/plugins/search/lazy+load/) इंस्टॉल करें जिसमें किसी भी ऑफ़स्क्रीन इमेज को अलग करने की सुविधा हो. अगर नहीं, तो किसी ऐसी थीम पर जाएं जो यह सुविधा मुहैया कराती हो. साथ ही, [एएमपी प्लग इन](https://wordpress.org/plugins/amp/) का इस्तेमाल करें."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "ऐसे कई WordPress प्लगइन हैं जो [इनलाइन क्रिटिकल एसेट](https://wordpress.org/plugins/search/critical+css/) या [defer less important resources](https://wordpress.org/plugins/search/defer+css+javascript/) में आपकी मदद कर सकते हैं. ध्यान रखें कि इन प्लगइन से मिलने वाला ऑप्टिमाइज़ेशन आपकी थीम या प्लगइन की सुविधाएं बिगाड़ सकता है, इसलिए आपको कोड में बदलाव करने पड़ सकते हैं."
+    "message": "ऐसे कई WordPress प्लग इन हैं जो [क्रिटिकल एसेट इनलाइन करने ](https://wordpress.org/plugins/search/critical+css/) या [कम ज़रूरी संसाधनों को डेफ़र करने](https://wordpress.org/plugins/search/defer+css+javascript/) में आपकी मदद कर सकते हैं. ध्यान रखें कि ऐसी प्लग इन से मिलने वाले ऑप्टिमाइज़ेशन आपकी थीम या प्लग इन की सुविधाएं बिगाड़ सकते हैं. इसलिए, आपको कोड में बदलावों को करने की ज़रुरत हो सकती है."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "थीम, प्लगइन, और सर्वर की खास बातें सर्वर से जवाब मिलने के समय में योगदान करती हैं. ज़्यादा ऑप्टिमाइज़ की हुई थीम ढूंढने, एक ऑप्टिमाइज़ेशन प्लगइन को सावधानी से चुनने, और/या अपना सर्वर अपग्रेड करने पर विचार करें."
@@ -1035,30 +1362,30 @@
     "message": "अपनी पोस्ट सूचियों में खास हिस्से दिखाने पर विचार करें (जैसे 'ज़्यादा' टैग से), किसी पेज पर दिखाई गई पोस्ट की संख्या घटाने, अपनी लंबी पोस्ट को कई पेज में बाँटने या फिर टिप्पणियों को धीरे-धीरे लोड करने वाले प्लगइन का इस्तेमाल करने पर विचार करें."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "कई [WordPress plugins](https://wordpress.org/plugins/search/minify+css/) आपकी शैलियों की शृंखला बनाकर, उनमें काट-छांट करके, और कंप्रेस करके आपकी साइट की गति बढ़ा सकते हैं. हो सकता है कि आप काट-छांट करने की इस प्रक्रिया के लिए एक बिल्ड प्रोसेस का इस्तेमाल भी करना चाहें, अगर ऐसा करना मुमकिन हो."
+    "message": "कई [WordPress प्लग इन](https://wordpress.org/plugins/search/minify+css/) आपकी साइट की गति को बढ़ा सकते हैं. ऐसा करने के लिए वे आपके स्टाइल को जोड़ते हैं, उन्हें छोटा करते हैं, और कंप्रेस करते हैं. ऐसा हो सकता है कि आप काट-छांट करने के लिए, एक बिल्ड प्रोसेस का इस्तेमाल भी करना चाहें, अगर ऐसा करना मुमकिन हो."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "कई [WordPress प्लगइन](https://wordpress.org/plugins/search/minify+javascript/) आपकी स्क्रिप्ट की शृंखला बनाकर, उनमें काट-छांट करके, और कंप्रेस करके आपकी साइट की गति बढ़ा सकते हैं. हो सकता है कि आप काट-छांट करने की इस प्रक्रिया के लिए एक बिल्ड प्रोसेस का इस्तेमाल भी करना चाहें, अगर ऐसा करना मुमकिन हो."
+    "message": "कई [WordPress प्लग इन](https://wordpress.org/plugins/search/minify+javascript/) आपकी साइट की गति को बढ़ा सकते हैं. ऐसा करने के लिए वह आपकी स्क्रिप्ट को जोड़ते हैं, उन्हें छोटा करते हैं, और कंप्रेस करते हैं. ऐसा हो सकता है कि आप काट-छांट करने की इस प्रक्रिया के लिए, एक बिल्ड प्रोसेस का इस्तेमाल भी करना चाहें, अगर ऐसा करना मुमकिन हो."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "अपने पेज में इस्तेमाल नहीं किए गए सीएसएस लोड करके [WordPress प्लगइन](https://wordpress.org/plugins/) की संख्या घटाने या बदलने पर विचार करें. ऐसे प्लगइन की पहचान करने के लिए जो असंगत सीएसएस जोड़ रहे हैं, Chrome DevTools में [कोड कवरेज](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) चलाकर देखें. आप स्टाइल शीट के यूआरएल से थीम/प्लगइन की पहचान कर सकते हैं. ऐसे प्लगइन खोजें जिनके पास उस सूची की कई स्टाइल शीट हैं जिसमें कोड कवरेज में बहुत से लाल निशान हैं. प्लगइन को स्टाइल शीट तभी एन्क्यू करनी चाहिए अगर पेज पर उसका वाकई इस्तेमाल किया गया हो."
+    "message": "उन [WordPress प्लग इन](https://wordpress.org/plugins/) की संख्या कम करके या स्विच करके देखें जो आपके पेज में ऐसी सीएसएस लोड कर रहे हैं जिसका कभी इस्तेमाल नहीं हुआ. Chrome DevTools में [कोड कवरेज](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) चलाकर उन प्लग इन की पहचान करें जो आपके पेज में गैर-ज़रूरी सीएसएस जोड़ रहे हैं. आप स्क्रिप्ट के यूआरएल से पहचान सकते हैं कि ऐसा किस थीम/प्लग इन ने किया. ऐसे प्लग इन खोजें जिनके पास उस सूची की कई स्टाइल शीट हैं जिसमें कोड कवरेज में बहुत से लाल निशान हैं. प्लग इन को स्क्रिप्ट तभी क्यू में लगानी चाहिए, अगर पेज पर उसका वाकई इस्तेमाल किया गया हो."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "अपने पेज में इस्तेमाल नहीं किए गए JavaScript को लोड करने के लिए [WordPress प्लगइन] (https://wordpress.org/plugins/) की संख्या घटाने या बदलने पर विचार करें. ऐसे प्लगइन की पहचान करने के लिए, जो असंगत JS जोड़ रहे हैं, Chrome DevTools में [कोड कवरेज] (https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) चलाकर देखें. आप स्क्रिप्ट के यूआरएल से ज़िम्मेदार थीम/प्लगइन की पहचान कर सकते हैं. ऐसे प्लगइन खोजें जिनके पास उस सूची में कई स्क्रिप्ट हैं जिसमें कोड कवरेज में बहुत से लाल निशान हैं. प्लगइन को स्क्रिप्ट तभी एन्क्यू करना चाहिए अगर पेज पर उसका वाकई इस्तेमाल किया गया हो."
+    "message": "उन [WordPress प्लग इन](https://wordpress.org/plugins/) की संख्या कम करके या स्विच करके देखें जो आपके पेज में ऐसी JavaScript लोड कर रहे हैं जिसका कभी इस्तेमाल नहीं हुआ. Chrome DevTools में [कोड कवरेज](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) चलाकर उन प्लग इन की पहचान करें जो आपके पेज में गैर-ज़रूरी JS जोड़ रहे हैं. आप स्क्रिप्ट के यूआरएल से पहचान सकते हैं कि ऐसा किस थीम/प्लग इन ने किया. ऐसे प्लग इन खोजें जिनके पास उस सूची में कई स्क्रिप्ट हैं जिसमें कोड कवरेज में बहुत से लाल निशान हैं. प्लग इन को स्क्रिप्ट तभी क्यू में लगानी चाहिए, अगर पेज पर उसका वाकई इस्तेमाल किया गया हो."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "[WordPress में ब्राउज़र कैशिंग](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching) के बारे में पढ़ें."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "ऐसे [इमेज ऑप्टिमाइज़ेशन WordPress प्लगइन](https://wordpress.org/plugins/search/optimize+images/) का इस्तेमाल करने पर विचार करें, जो आपकी क्वालिटी बरकरार रखते हुए आपकी इमेज कंप्रेस करता है."
+    "message": "ऐसे [इमेज ऑप्टिमाइज़ेशन WordPress प्लग इन](https://wordpress.org/plugins/search/optimize+images/) का इस्तेमाल करें जो आपकी क्वालिटी बरकरार रखते हुए आपकी इमेज कंप्रेस करता है."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "सीधे [मीडिया लाइब्रेरी](https://codex.wordpress.org/Media_Library_Screen) के ज़रिए इमेज अपलोड करें ताकि यह पक्का हो जाए कि ज़रूरी इमेज आकार उपलब्ध हैं. इसके बाद उन्हें मीडिया गैलरी से शामिल करें या इमेज विजेट का इस्तेमाल करके यह पक्का करें कि सबसे सही इमेज आकार का इस्तेमाल किया गया है (इनमें जवाबदेह ब्रेकपॉइंट के लिए इमेज आकार भी शामिल हैं). `पूरे आकार` वाली इमेज तब तक इस्तेमाल न करें जब तक कि उनके इस्तेमाल के लिए डाइमेंशन सही न हों. [ज़्यादा जानें](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "[मीडिया लाइब्रेरी](https://codex.wordpress.org/Media_Library_Screen) की मदद से इमेज सीधे अपलोड करें, ताकि आप यह पक्का कर सकें कि आपके पास इमेज के वे आकार मौजूद हैं जिनकी आपको ज़रूरत पड़ेगी. इसके बाद, उन्हें डालने के लिए मीडिया लाइब्रेरी या इमेज विजेट का इस्तेमाल करें, ताकि आप यह पक्का कर सकें कि सबसे बेहतर इमेज आकारों का इस्तेमाल किया गया है (इसमें जवाब देने वाले ब्रेकपॉइंट की इमेज भी शामिल हैं). `Full Size` इमेज का इस्तेमाल तब तक न करें जब तक डाइमेंशन उनके इस्तेमाल के हिसाब से ठीक न हों. [ज़्यादा जानें](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "आप अपने वेब सर्वर कॉन्फ़िगरेशन में टेक्स्ट कंप्रेस करने की सुविधा चालू कर सकते हैं."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "ऐसे [प्लगइन](https://wordpress.org/plugins/search/convert+webp/) या सेवा का इस्तेमाल करने पर विचार करें जो आपकी अपलोड की गई इमेज को अपने आप ही सबसे सही फ़ॉर्मैट में बदल देगी."
+    "message": "ऐसे [प्लग इन](https://wordpress.org/plugins/search/convert+webp/) या सेवा का इस्तेमाल करें जो आपकी अपलोड की गई इमेज को अपने आप ही सबसे सही फ़ॉर्मैट में बदल देगी."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/hr.json
+++ b/lighthouse-core/lib/i18n/locales/hr.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Pristupne tipke omogućuju korisnicima da se brzo usredotoče na određeni dio stranice. Za pravilno kretanje svaka pristupna tipka mora biti jedinstvena. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Pristupne tipke omogućuju korisnicima da se brzo usredotoče na određeni dio stranice. Za pravilno kretanje svaka pristupna tipka mora biti jedinstvena. [Saznajte više](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Vrijednosti \"[accesskey]\" nisu jedinstvene"
+    "message": "Vrijednosti `[accesskey]` nisu jedinstvene"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Vrijednosti \"[accesskey]\" su jedinstvene"
+    "message": "`[accesskey]` vrijednosti su jedinstvene"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Svaka \"uloga\" ARIA-e podržava poseban podskup atributa \"aria-*\". Njihovo nepodudaranje poništit će atribute \"aria-*\". [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Svaki ARIA `role` podržava određeni podskup `aria-*` atributa. Njihovo nepodudaranje poništava `aria-*` atribute. [Saznajte više](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Atributi \"[aria-*]\" ne podudaraju se sa svojim ulogama"
+    "message": "Atributi `[aria-*]` ne podudaraju se sa svojim ulogama"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Atrubuti \"[aria-*]\" podudaraju se sa svojim ulogama"
+    "message": "Atributi `[aria-*]` podudaraju se sa svojim ulogama"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Neke uloge ARIA-e zahtijevaju atribute koji opisuju stanje elementa čitačima zaslona. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Neke uloge ARIA-e zahtijevaju atribute koji opisuju stanje elementa čitačima zaslona. [Saznajte više](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "\"[role]\" nemaju sve potrebne atribute \"[aria-*]\""
+    "message": "Elementi `[role]` nemaju sve potrebne atribute `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "\"[role]\" imaju sve potrebne atribute \"[aria-*]\""
+    "message": "`[role]` imaju sve obavezne atribute`[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Neke nadređene uloge ARIA-e moraju sadržavati posebne podređene uloge za izvršavanje svojih namijenjenih funkcija pristupačnosti. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Neke nadređene uloge ARIA moraju sadržavati posebne podređene uloge za izvršavanje svojih namijenjenih funkcija pristupačnosti. [Saznajte više](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Nedostaju elementi s ulogom \"[role]\" koji zahtijevaju specifičnu podređenu ulogu \"[role]\"."
+    "message": "Nedostaju elementi s ulogom `[role]` koji zahtijevaju određene podređene elemente `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Prisutni su elementi s ulogom \"[role]\" za koje su potrebne posebne podređene uloge \"[role]\""
+    "message": "Prisutni su elementi s ulogom `[role]` koji zahtijevaju određene podređene elemente `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Određene nadređene uloge moraju sadržavati neke podređene uloge ARIA-e kako bi mogle pravilno izvršavati namijenjene funkcije pristupačnosti. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Određene nadređene uloge moraju sadržavati neke podređene uloge ARIA kako bi mogle pravilno izvršavati namijenjene funkcije pristupačnosti. [Saznajte više](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Potrebni nadređeni element ne sadrži \"[role]\""
+    "message": "Potrebni nadređeni element ne sadrži `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "\"[role]\" su sadržani u potrebnom nadređenom elementu"
+    "message": "Potrebni nadređeni element sadrži `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Uloge ARIA-e moraju sadržavati valjane vrijednosti da bi se mogle izvršavati njihove namijenjene funkcije pristupačnosti. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Uloge ARIA moraju sadržavati valjane vrijednosti da bi se mogle izvršavati njihove namijenjene funkcije pristupačnosti. [Saznajte više](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Vrijednosti \"[role]\" nisu valjane"
+    "message": "Vrijednosti `[role]` nisu valjane"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Vrijednosti \"[role]\" su valjane"
+    "message": "Vrijednosti `[role]` su valjane"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Pomoćne tehnologije, poput čitača zaslona, ne mogu tumačiti atribute ARIA-e s nevažećim vrijednostima. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Pomoćne tehnologije, poput čitača zaslona, ne mogu tumačiti atribute ARIA s nevažećim vrijednostima. [Saznajte više](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Atributi \"[aria-*]\" ne sadrže valjane vrijednosti"
+    "message": "Atributi `[aria-*]` ne sadrže valjane vrijednosti"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Atributi \"[aria-*]\" sadrže valjane vrijednosti"
+    "message": "Atributi `[aria-*]` sadrže valjane vrijednosti"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Pomoćne tehnologije, poput čitača zaslona, ne mogu tumačiti atribute ARIA-e s nevažećim nazivima. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Pomoćne tehnologije, poput čitača zaslona, ne mogu tumačiti atribute ARIA s nevažećim nazivima. [Saznajte više](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Atributi \"[aria-*]\" nisu valjani ili su pogrešno napisani"
+    "message": "Atributi `[aria-*]` nisu valjani ili su pogrešno napisani"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Atributi \"[aria-*]\" su valjani i nisu pogrešno napisani"
+    "message": "Atributi `[aria-*]` su valjani i nisu pogrešno napisani"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Titlovi omogućuju gluhim i nagluhim korisnicima uporabu audioelemenata jer pružaju ključne informacije, primjerice tko govori, što govori i druge informacije osim govora. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Titlovi omogućuju gluhim i nagluhim korisnicima uporabu audioelemenata jer pružaju ključne informacije, primjerice tko govori, što govori i druge informacije osim govora. [Saznajte više](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Elementi \"<audio>\" ne sadrže element \"<track>\" s \"[kind=\"captions\"]\"."
+    "message": "Elementima `<audio>` nedostaje element `<track>` s `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Elementi \"<audio>\" sadrže element \"<track>\" s \"[kind=\"captions\"]\""
+    "message": "Elementi `<audio>` sadržavaju element `<track>` s `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Elementi koji nisu prošli provjeru"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Kada gumb nema pristupačan naziv, čitači zaslona najavljuju ga kao \"gumb\" te je on neupotrebljiv za korisnike koji se oslanjaju na čitače zaslona. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Kada gumb nema pristupačan naziv, čitači zaslona najavljuju ga kao \"gumb\" te je on neupotrebljiv za korisnike koji se oslanjaju na čitače zaslona. [Saznajte više](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Gumbi nemaju pristupačan naziv"
@@ -93,7 +93,7 @@
     "message": "Gumbi imaju pristupačan naziv"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Dodavanje načina za zaobilaženje repetitivnog sadržaja omogućuje korisnicima tipkovnice učinkovitije kretanje po stranici. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Dodavanje načina za zaobilaženje repetitivnog sadržaja omogućuje korisnicima tipkovnice učinkovitije kretanje po stranici. [Saznajte više](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Stranica ne sadrži naslov, vezu za preskakanje ili regiju kao orijentir"
@@ -102,7 +102,7 @@
     "message": "Stranica sadrži naslov, vezu za preskakanje ili regiju kao orijentir"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Mnogim je korisnicima teško ili nemoguće čitati tekst niskog kontrasta. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Mnogim je korisnicima teško ili nemoguće čitati tekst niskog kontrasta. [Saznajte više](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Boje u pozadini i prednjem planu nemaju zadovoljavajući omjer kontrasta."
@@ -111,88 +111,88 @@
     "message": "Boje u pozadini i prednjem planu imaju zadovoljavajući omjer kontrasta"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Kada popisi definicija nisu valjano označeni, čitači zaslona mogu proizvesti zbunjujući ili netočan izlaz. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Kada popisi definicija nisu valjano označeni, čitači zaslona mogu proizvesti zbunjujuć ili netočan izlaz. [Saznajte više](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "\"<dl>\" ne sadrže samo pravilno naručene grupe \"<dt>\" i \"<dd>\", elemente \"<script>\" ili \"<template>\"."
+    "message": "Elementi `<dl>` ne sadrže samo pravilno naručene grupe `<dt>` i `<dd>`, elemente `<script>` ili `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "\"<dl>\" sadrži samo pravilno naručene grupe \"<dt>\" i \"<dd>\", elemente \"<script>\" ili \"<template>\"."
+    "message": "`<dl>` sadrži samo pravilno naručene grupe `<dt>` i `<dd>` `<script>` ili elemente `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Stavke na popisu definicija (\"<dt>\" i \"<dd>\") moraju biti upakirane u naređeni element \"<dl>\" da bi ih čitači zaslona mogli pravilno najaviti. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Stavke na popisu definicija (`<dt>` i `<dd>`) moraju biti sadržane u nadređenom elementu `<dl>` da bi ih čitači zaslona mogli pravilno najaviti. [Saznajte više](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Stavke na popisu definicija nisu upakirane u elemente \"<dl>\""
+    "message": "Stavke na popisu definicija nisu upakirane u elemente `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Stavke na popisu definicija upakirane su u elemente \"<dl>\""
+    "message": "Stavke na popisu definicija upakirane su u elemente `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Naslov korisnicima čitača zaslona pruža pregled stranice, a korisnici tražilice značajno se na njega oslanjaju kako bi odredili je li neka stranica relevantna za njihovo pretraživanje. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Naslov korisnicima čitača zaslona pruža pregled stranice, a korisnici tražilice značajno se na njega oslanjaju kako bi odredili je li neka stranica relevantna za njihovo pretraživanje. [Saznajte više](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokument ne sadrži element \"<title>\""
+    "message": "Dokument ne sadrži element `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokument sadrži element \"<title>\""
+    "message": "Dokument sadrži element `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Vrijednost atributa ID mora biti jedinstvena kako bi se spriječilo da pomoćne tehnologije propuste druge instance. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Vrijednost atributa ID mora biti jedinstvena kako bi se spriječilo da pomoćne tehnologije propuste druge instance. [Saznajte više](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Atributi \"[id]\" na stranici nisu jedinstveni"
+    "message": "Atributi `[id]` na stranici nisu jedinstveni."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Atributi \"[id]\" na stranici su jedinstveni"
+    "message": "Atributi `[id]` na stranici su jedinstveni"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Korisnici čitača zaslona oslanjaju se na naslove okvira za opisivanje sadržaja okvira. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Korisnici čitača zaslona oslanjaju se na naslove okvira za opisivanje sadržaja okvira. [Saznajte više](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Elementi \"<frame>\" i \"<iframe>\" nemaju naslov"
+    "message": "Elementi `<frame>` ili `<iframe>` nemaju naslov"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Elementi \"<frame>\" ili \"<iframe>\" sadrže naslov"
+    "message": "Elementi `<frame>` ili `<iframe>` imaju naslov"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Ako za stranicu nije naveden atribut jezika, čitač zaslona pretpostavlja da je stranica na zadanom jeziku koji je korisnik odabrao prilikom postavljanja čitača zaslona. Ako stranica nije stvarno na zadanom jeziku, čitač zaslona možda neće ispravno najaviti tekst sa stranice. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Ako za stranicu nije naveden atribut jezika, čitač zaslona pretpostavlja da je stranica na zadanom jeziku koji je korisnik odabrao prilikom postavljanja čitača zaslona. Ako stranica nije stvarno na zadanom jeziku, čitač zaslona možda neće ispravno najaviti tekst sa stranice. [Saznajte više](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Element \"<html>\" ne sadrži atribut \"[lang]\""
+    "message": "Element `<html>` nema atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Element \"<html>\" sadrži atribut \"[lang]\""
+    "message": "Element `<html>` ima atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Navođenje valjanog [BCP 47 jezika](https://www.w3.org/International/questions/qa-choosing-language-tags#question) pomaže čitačima zaslona u pravilnom najavljivanju teksta. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Navođenje valjanog [BCP 47 jezika](https://www.w3.org/International/questions/qa-choosing-language-tags#question) pomaže čitačima zaslona u pravilnom najavljivanju teksta. [Saznajte više](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Element \"<html>\" nema valjanu vrijednost za svoj atribut \"[lang]\"."
+    "message": "Element `<html>` ne sadrži valjanu vrijednost za atribut `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Element \"<html>\" sadrži valjanu vrijednost za svoj atribut [lang]\""
+    "message": "Element `<html>` ima valjanu vrijednost za svoj atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informativni elementi trebali bi sadržavati kratak, opisni zamjenski tekst. Ukrasni elementi mogu se zanemariti praznim atributom alt. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informativni elementi trebali bi sadržavati kratak, opisni zamjenski tekst. Ukrasni elementi mogu se zanemariti praznim atributom alt. [Saznajte više](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Elementi slike nemaju atribute \"[alt]\""
+    "message": "Elementi slike nemaju atribute `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Elementi slike imaju atribute \"[alt]\""
+    "message": "Elementi slike imaju `[alt]` atribute"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Kada se slika upotrebljava kao gumb \"<input>\", navođenje zamjenskog teksta može pomoći korisnicima čitača zaslona da shvate svrhu gumba. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Kada se slika upotrebljava kao gumb `<input>`, navođenje zamjenskog teksta može pomoći korisnicima čitača zaslona da shvate svrhu gumba. [Saznajte više](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Elementi \"<input type=\"image\">\" ne sadrže tekst \"[alt]\""
+    "message": "Elementi `<input type=\"image\">` nemaju tekst`[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Elementi \"<input type=\"image\">\" sadrže tekst \"[alt]\""
+    "message": "Elementi `<input type=\"image\">` sadrže `[alt]` tekst"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Oznake osiguravaju da pomoćne tehnologije, poput čitača zaslona, pravilno najavljuju kontrole oblika. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Oznake osiguravaju da pomoćne tehnologije, poput čitača zaslona, pravilno najavljuju kontrole oblika. [Saznajte više](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Elementi oblika ne sadrže povezane oznake"
@@ -201,16 +201,16 @@
     "message": "Elementi oblika imaju povezane oznake"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Tablica koja se upotrebljava u svrhe izgleda ne smije sadržavati elemente podataka kao što su elementi th ili opis ili atribut sažetka jer to može zbuniti korisnike čitača zaslona. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Tablica koja se upotrebljava u svrhe izgleda ne smije sadržavati elemente podataka kao što su elementi th ili opis ili atribut sažetka jer to može zbuniti korisnike čitača zaslona. [Saznajte više](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Prezentacijski elementi za \"<table>\" ne izbjegavaju upotrebu atributa \"<th>\", \"<caption>\" ili \"[summary]\"."
+    "message": "Prezentacijski elementi za `<table>` ne izbjegavaju upotrebu atributa `<th>`, `<caption>` ili `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Prezentacijski elementi za \"<table>\" izbjegavaju upotrebu \"<th>\", \"<caption>\" ili atributa \"[summary]\"."
+    "message": "Prezentacijski elementi za `<table>` izbjegavaju upotrebu `<th>`, `<caption>` ili atributa `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Tekst veze (i zamjenski tekst za slike kada se upotrebljava kao veze) koji je prepoznatljiv, jedinstven i može se fokusirati omogućuje lakše kretanje korisnicima čitača zaslona. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Tekst veze (i zamjenski tekst za slike kada se upotrebljava kao veze) koji je prepoznatljiv, jedinstven i može se fokusirati omogućuje lakše kretanje korisnicima čitača zaslona. [Saznajte više](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Veze nemaju naziv koji je moguće raspoznati"
@@ -219,103 +219,115 @@
     "message": "Veze imaju naziv koji je moguće raspoznati"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Čitači zaslona imaju poseban način najavljivanja popisa. Osiguravanje pravilne strukture popisa pomaže izlazu čitača zaslona. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Čitači zaslona imaju poseban način najavljivanja popisa. Osiguravanje pravilne strukture popisa pomaže izlazu čitača zaslona. [Saznajte više](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Popisi ne sadrže samo elemente \"<li>\" i elemente koji podupiru skriptu (\"<script>\" i \"<template>\")."
+    "message": "Popisi ne sadrže samo elemente `<li>` i elemente koji podupiru skriptu (`<script>` i`<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Popisi sadrže samo elemente \"<li>\" i elemente koji podupiru skriptu (\"<script>\" i \"<template>\")."
+    "message": "Popisi sadrže samo elemente `<li>` i elemente koji podupiru skriptu (`<script>` i`<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Za čitače zaslona stavke na popisu (\"<li>\") moraju biti sadržane unutar nadređenog \"<ul>\" ili \"<ol>\" kako bi ih se moglo pravilno najaviti. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Za čitače zaslona stavke na popisu (`<li>`) moraju biti sadržane unutar nadređenog `<ul>` ili `<ol>` kako bi ih se moglo pravilno najaviti. [Saznajte više](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Stavke popisa (\"<li>\") nisu sadržane unutar nadređenih elemenata \"<ul>\" ili \"<ol>\"."
+    "message": "Stavke popisa (`<li>`) nisu sadržane unutar nadređenih elemenata `<ul>` ili `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Stavke popisa (\"<li>\") sadržane su unutar nadređenih elemenata \"<ul>\" ili \"<ol>\""
+    "message": "Stavke popisa (`<li>`) sadržane su unutar nadređenih elemenata `<ul>` ili `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Korisnici ne očekuju automatsko osvježavanje stranice. Ako se to dogodi, fokus se vraća na vrh stranice. To može biti frustrirajuće i zbuniti korisnike. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Korisnici ne očekuju automatsko osvježavanje stranice, pa se fokus vraća na vrh stranice. To može biti frustrirajuće i zbuniti korisnike. [Saznajte više](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokument upotrebljava \"<meta http-equiv=\"refresh\">\""
+    "message": "Dokument upotrebljava `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Dokument ne upotrebljava \"<meta http-equiv=\"refresh\">\""
+    "message": "Dokument ne upotrebljava `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Onemogućavanje zumiranja problematično je za slabovidne korisnike koji se oslanjaju na povećavanje zaslona kako bi pravilno vidjeli sadržaj web-stranice. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Onemogućavanje zumiranja problematično je za slabovidne korisnike koji se oslanjaju na povećavanje zaslona kako bi pravilno vidjeli sadržaj web-stranice. [Saznajte više](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "\"[user-scalable=\"no\"]\" se upotrebljava u elementu \"<meta name=\"viewport\">\" ili je atribut \"[maximum-scale]\" manji od pet."
+    "message": "`[user-scalable=\"no\"]` se upotrebljava u elementu `<meta name=\"viewport\">` ili je atribut `[maximum-scale]` manji od pet."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "\"[user-scalable=\"no\"]\" ne upotrebljava se u elementu \"<meta name=\"viewport\">\" i element \"[maximum-scale]\" nije manji od pet."
+    "message": "`[user-scalable=\"no\"]` se ne upotrebljava u elementu `<meta name=\"viewport\">` i atribut `[maximum-scale]` nije manji od pet."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Čitači zaslona ne mogu prevesti sadržaj osim teksta. Dodavanje zamjenskog teksta elementima \"<object>\" pomaže čitačima zaslona u prenošenju značenja korisnicima. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Čitači zaslona ne mogu prevesti sadržaj osim teksta. Dodavanje zamjenskog teksta elementima `<object>` pomaže čitačima zaslona u prenošenju značenja korisnicima. [Saznajte više](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Elementi \"<object>\" ne sadrže tekst \"[alt]\""
+    "message": "Elementi `<object>` nemaju tekst`[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Elementi \"<object>\" sadrže tekst \"[alt]\""
+    "message": "Elementi `<object>` sadrže `[alt]` tekst"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Vrijednost viša od 0 podrazumijeva eksplicitno naređivanje kretanja. Iako je tehnički valjano, to često frustrira korisnike koji se oslanjaju na pomoćne tehnologije. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Vrijednost viša od 0 podrazumijeva eksplicitno naređivanje kretanja. Iako je tehnički valjano, to često frustrira korisnike koji se oslanjaju na pomoćne tehnologije. [Saznajte više](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Neki elementi imaju vrijednost \"[tabindex]\" višu od 0"
+    "message": "Neki elementi imaju vrijednost `[tabindex]` višu od 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Nijedan element nema vrijednost \"[tabindex]\" višu od 0"
+    "message": "Nijedan element nema vrijednost `[tabindex]` veću od 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Čitači zaslona sadrže značajke za olakšavanje kretanja po tablicama. Potrebno je pripaziti da se ćelije \"<td>\" koje upotrebljavaju atribut \"[headers]\" odnose samo na druge ćelije u istoj tablici kako bi se korisnicima čitača zaslona omogućio bolji doživljaj. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Čitači zaslona sadrže značajke za olakšavanje kretanja po tablicama. Potrebno je pripaziti da se ćelije `<td>` koje upotrebljavaju atribut `[headers]` odnose samo na druge ćelije u istoj tablici kako bi se korisnicima čitača zaslona omogućio bolji doživljaj. [Saznajte više](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ćelije u elementu \"<table>\" koje upotrebljavaju atribut \"[headers]\" odnose se na druge ćelije te iste tablice."
+    "message": "Ćelije u elementu `<table>` koje upotrebljavaju atribut `[headers]` odnose se na druge ćelije te iste tablice."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Ćelije u elementu \"<table>\" koje upotrebljavaju atribut \"[headers]\" odnose se samo na druge ćelije te iste tablice."
+    "message": "Ćelije u elementu `<table>`koje upotrebljavaju atribut `[headers]` odnose se samo na druge ćelije u toj istoj tablici."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Čitači zaslona sadrže značajke za olakšavanje kretanja po tablicama. Osiguravanje da se zaglavlja tablice uvijek odnose na neki skup ćelija može poboljšati doživljaj za korisnike čitača zaslona. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Čitači zaslona sadrže značajke za olakšavanje kretanja po tablicama. Osiguravanje da se zaglavlja tablice uvijek odnose na neki skup ćelija može poboljšati doživljaj za korisnike čitača zaslona. [Saznajte više](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Elementi \"<th>\" i elementi s \"[role=\"columnheader\"/\"rowheader\"]\" nemaju ćelije s podacima koje opisuju."
+    "message": "Elementi `<th>` i elementi s`[role=\"columnheader\"/\"rowheader\"]` nemaju podatkovne ćelije koje oni opisuju."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Elementi \"<th>\" i elementi s \"[role=\"columnheader\"/\"rowheader\"]\" imaju ćelije s podacima koje opisuju."
+    "message": "Elementi `<th>` i elementi s `[role=\"columnheader\"/\"rowheader\"]` imaju podatkovne ćelije koje opisuju."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Navođenje valjanog [BCP 47 jezika](https://www.w3.org/International/questions/qa-choosing-language-tags#question) na elementima pomaže osigurati da čitač zaslona ispravno izgovara tekst. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Navođenje valjanog [BCP 47 jezika](https://www.w3.org/International/questions/qa-choosing-language-tags#question) u elementima pomaže osigurati da čitač zaslona ispravno izgovara tekst. [Saznajte više](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Atributi \"[lang]\" ne sadrže valjanu vrijednost"
+    "message": "Atributi `[lang]` ne sadrže valjanu vrijednost"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Atributi \"[lang]\" sadrže valjanu vrijednost"
+    "message": "Atributi `[lang]` imaju valjanu vrijednost"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Kada videozapis sadrži titlove, gluhim i nagluhim osobama jednostavnije je pristupiti njegovim informacijama. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Kada videozapis sadrži titlove, gluhim i nagluhim osobama jednostavnije je pristupiti njegovim informacijama. [Saznajte više](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Elementi \"<video>\" ne sadrže element \"<track>\" s \"[kind=\"captions\"]\"."
+    "message": "Elementi `<video>` ne sadrže element `<track>` s `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Elementi \"<video>\" sadrže element \"<track>\" s \"[kind=\"captions\"]\""
+    "message": "Elementi `<video>` sadržavaju element `<track>` s `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Audioopisi pružaju relevantne informacije za videozapise koje dijaloški okviri ne mogu pružiti, primjerice izraze lica i scene. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Audioopisi pružaju relevantne informacije za videozapise koje dijaloški okviri ne mogu pružiti, primjerice izraze lica i scene. [Saznajte više](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Elementi \"<video>\" ne sadrže element \"<track>\" s \"[kind=\"description\"]\"."
+    "message": "Elementi `<video>` ne sadrže element `<track>` s `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Elementi \"<video>\" sadrže element \"<track>\" s \"[kind=\"description\"]\""
+    "message": "Elementi `<video>` sadržavaju element `<track>` s `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Za idealan izgled na iOS-u kad korisnici dodaju na početni zaslon definirajte ikonu „apple-touch-icon”. Mora ukazivati na netransparentni kvadratni PNG od 192 px (ili 180 px). [Saznajte više](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Ne pruža valjani `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` je zastario; prednost ima `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Ima valjanu ikonu `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chromeova proširenja negativno su utjecala na izvedbu učitavanja ove stranice. Pokušajte pregledati stranicu anonimno ili putem Chromeovog profila bez proširenja."
@@ -339,7 +351,7 @@
     "message": "Vrijeme izvršavanja JavaScripta"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Veliki GIF-ovi nisu učinkoviti za isporuku animiranog sadržaja. Savjetujemo vam da umjesto GIF-a upotrebljavate MPEG4/WebM videozapise za animacije i PNG/WebP za statične slike da biste smanjili količinu mrežnih bajtova. [Saznajte više](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Veliki GIF-ovi nisu učinkoviti za prikaz animiranog sadržaja. Savjetujemo vam da umjesto GIF-a upotrebljavate MPEG4/WebM videozapise za animacije i PNG/WebP za statične slike da biste smanjili količinu mrežnih bajtova. [Saznajte više](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Upotrebljavajte formate videozapisa za animirani sadržaj"
@@ -351,7 +363,7 @@
     "message": "Odgodite slike izvan zaslona"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Resursi blokiraju prvo bojenje stranice. Savjetujemo vam da kritičan JS/CSS isporučite umetnuto i da odgodite sve nekritične JS-ove/stilove. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Resursi blokiraju prvo renderiranje vaše stranice. Savjetujemo vam da kljulan JS/CSS isporučite u tekstu te da da odgodite sve JS-ove/stilove koji nisu ključni. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Uklonite resurse koji blokiraju generiranje"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimizirajte dubinu kritičnih zahtjeva"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Ukidanje / upozorenje"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Redak"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Ukinuti API-ji na kraju će se ukloniti iz preglednika. [Saznajte više](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Pronađeno je jedno upozorenje}one{Broj pronađenih upozorenja: #}few{Broj pronađenih upozorenja: #}other{Broj pronađenih upozorenja: #}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Upotrebljava ukinute API-je"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Izbjegava ukinute API-je"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Ukinuta je predmemorija aplikacije. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "„{AppCacheManifest}” je pronađen"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Upotrebljava predmemoriju aplikacije"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Izbjegava predmemoriju aplikacije"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Specificiranje vrste dokumenta (doctype) sprječava preglednik da prijeđe u način rada sa starijim značajkama. Saznajte više na stranici [MDN web-dokumenti](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Naziv vrste dokumenta (doctype) mora biti niz napisan malim slovima `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "URL mora sadržavati vrstu dokumenta."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Očekivani javni ID bit će prazan niz"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Očekivani ID sustava bit će prazan niz"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Stranici nedostaje vrsta dokumenta HTML, stoga pokreće način rada sa starijim značajkama"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Stranica ima HTML vrstu dokumenta"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
   },
@@ -447,7 +510,7 @@
     "message": "Vrijednost"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Inženjeri preglednika preporučuju da stranice sadrže manje od ~1500 elemenata DOM-a. Idealno je da je dubina stabla manja od 32 elementa i da ima manje od 60 elemenata podređenih/nadređenih jedinica. Veliki DOM može trošiti više memorije, uzrokovati dulje [izračune stilova](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) i proizvesti zahtjevna [preoblikovanja izgleda](https://developers.google.com/speed/articles/reflow). [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Inženjeri za preglednike preporučuju da stranice sadrže manje od ~1500 DOM elemenata. Pravo mjesto jest drvo dubine < 32 elemenata te koje ima manje od 60 podređenih/nadređenih elemenata. Veliki DOM može povećati upotrebu memorije, uzrokovati duže [izračune stila](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) te dovesti do skupih [preoblikovanja izgleda](https://developers.google.com/speed/articles/reflow). [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{Jedan element}one{# element}few{# elementa}other{# elemenata}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Izbjegava pretjeranu veličinu DOM-a"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Cilj"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Dodajte `rel=\"noopener\"` ili `rel=\"noreferrer\"` bilo kojoj eksternoj vezi da biste unaprijedili uspješnost i spriječili sigurnosne propuste. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Veze na odredišta različitih polazišta nisu sigurne"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Veze na odredišta različitih polazišta sigurne su"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Nije moguće odrediti odredište sidrenja za ({anchorHTML}). Ako se ne upotrebljava kao hiperveza, razmislite o tome da uklonite target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Korisnici ne vjeruju web-lokacijama koje žele znati njihovu lokaciju bez konteksta ili ih takve web-lokacije zbunjuju. Razmislite o tome da umjesto toga zahtjev povežete s radnjama korisnika. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Zahtijeva dopuštenje za geolociranje pri učitavanju stranice"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Izbjegava traženje dopuštenja za geolociranje pri učitavanju stranice"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Verzija"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Sve pristupne JavaScript biblioteke otkrivene na stranici."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Pronađene JavaScript biblioteke"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Ako korisnici imaju spore veze, vanjske skripte koje se dinamički ubacuju pomoću `document.write()` mogu odgoditi učitavanje stranice za desetke sekundi. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Upotrebljava `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Izbjegava `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Najviši stupanj ozbiljnosti"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Verzija biblioteke"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Broj propusta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Neke skripte treće strane mogu sadržavati poznate sigurnosne propuste te ih napadači mogu lako identificirati i iskoristiti. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Otkriven je jedan sigurnosni propust}one{Broj otkrivenih sigurnosnih propusta: #}few{Broj otkrivenih sigurnosnih propusta: #}other{Broj otkrivenih sigurnosnih propusta: #}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Uključuje pristupne JavaScript biblioteke s poznatim sigurnosnim propustima"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Visok"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Nisko"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Srednje"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Izbjegava pristupne JavaScript biblioteke s poznatim sigurnosnim propustima"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Korisnici ne vjeruju web-lokacijama koje traže slanje obavijesti bez konteksta ili ih takve web-lokacije zbunjuju. Razmislite o tome da umjesto toga zahtjev povežete s pokretima korisnika. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Zahtijeva dopuštenje za obavještavanje pri učitavanju stranice"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Izbjegava traženje dopuštenja za obavještavanje pri učitavanju stranice"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elementi koji nisu prošli provjeru"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Sprječavanje lijepljenja zaporke narušava kvalitetu dobrih sigurnosnih pravila. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Onemogućuje korisnicima lijepljenje u polja za zaporku"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Omogućuje korisnicima lijepljenje u polja za zaporku"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ima brojne prednosti u odnosu na HTTP/1.1, uključujući binarna zaglavlja, multipleksiranja i oglašavanja poslužitelja. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{Jedan zahtjev koji nije poslužen protokolom HTTP/2}one{Broj zahtjeva koji nisu posluženi protokolom HTTP/2: #}few{Broj zahtjeva koji nisu posluženi protokolom HTTP/2: #}other{Broj zahtjeva koji nisu posluženi protokolom HTTP/2: #}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Ne upotrebljava HTTP/2 za sve svoje resurse"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Upotrebljava HTTP/2 za svoje resurse"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Razmislite o tome da svoje pasivne slušatelje događaja označite kao `passive` da biste poboljšali rezultate pretraživanja. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Ne upotrebljava pasivne osluškivače za unaprjeđenje rezultata pretraživanja"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Upotrebljava pasivne osluškivače za unaprjeđenje rezultata pretraživanja"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Opis"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Pogreške zabilježene u konzoli ukazuju na neriješene probleme. Rezultat su neuspjelih mrežnih zahtjeva i ostalih pitanja povezanih s preglednikom."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Pogreške preglednika zabilježene su u konzoli"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Na konzoli nema zabilježenih pogrešaka preglednika"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Iskoristite CSS značajku za prikaz fontova kako bi tekst bio vidljiv korisnicima dok se web-fontovi učitavaju. [Saznajte više](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Sav tekst ostaje vidljiv tijekom učitavanja web-fontova"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse nije mogao automatski provjeriti vrijednost prikazanog fonta za sljedeći URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Omjer slike (stvarni)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Omjer slike (prikazane)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Dimenzije prikaza slike trebale bi odgovarati prirodnom omjeru slike. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Prikazuje slike netočnog omjera"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Prikazuje slike točnog omjera"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Nevažeće informacije o veličini slike {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Nesiguran URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Sve web-lokacije trebale bi biti zaštićene HTTPS-om, čak i one koje ne obrađuju osjetljive podatke. HTTPS sprječava uljeze u neovlaštenom pristupu komunikacijama između vaše aplikacije i vaših korisnika te im onemogućuje pasivno slušanje tih komunikacija. Preduvjet je za HTTP/2 i API-je brojnih novih web-platformi. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Pronađen je jedan zahtjev koji nije siguran}one{Broj pronađenih zahtjeva koji nisu sigurni: #}few{Broj pronađenih zahtjeva koji nisu sigurni: #}other{Broj pronađenih zahtjeva koji nisu sigurni: #}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Ne upotrebljava HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Upotrebljava HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Brzo učitavanje stranice putem mobilne mreže omogućuje dobar doživljaj korisnicima na mobilnim uređajima. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interaktivno za {timeInMs, number, seconds} s"
+    "message": "Interaktivno u {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Interaktivno na simuliranoj mobilnoj mreži za {timeInMs, number, seconds} s"
@@ -522,7 +753,7 @@
     "message": "Prvi procesor u mirovanju"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Prvo smisleno bojenje mjeri kada je vidljiv primarni sadržaj stranice. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Prvo korisno renderiranje mjeri kada je vidljiv primarni sadržaj stranice. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Prvo smisleno bojenje"
@@ -534,10 +765,10 @@
     "message": "Vrijeme do interaktivnosti"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Potencijalno prvo kašnjenje unosa koje bi korisnik mogao doživjeti trajanje je, u milisekundama, najduljeg zadatka."
+    "message": "Maksimalno potencijalno prvo kašnjenje unosa koje bi korisnik mogao doživjeti trajanje je, u milisekundama, najduljeg zadatka. [Saznajte više](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Maksimalni potencijalni FID"
+    "message": "Maks. potencijalno kašnjenje odgovora na prvi unos"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Indeks brzine prikazuje koliko se brzo sadržaj stranice vidljivo popunjava. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
@@ -545,17 +776,35 @@
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Indeks brzine"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Zbroj svih razdoblja između PRS-a i vremena do interaktivnosti kada trajanje zadatka prelazi 50 ms, iskazano u milisekundama."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Ukupno vrijeme blokiranja"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Vrijeme od slanja upita do primanja odgovora (RTT) za mrežu ima velik utjecaj na izvedbu. Ako je RTT do izvorišta visok, to je znak da bi poslužitelji bliže korisniku mogli poboljšati izvedbu. [Saznajte više](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Vrijeme od slanja upita do primanja odgovora (RTT) za mrežu ima velik utjecaj na izvedbu. Ako je RTT do polazišta visok, to je znak da bi poslužitelji bliže korisniku mogli poboljšati izvedbu. [Saznajte više](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Vrijeme od slanja upita do primanja odgovora za mrežu"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Latencije poslužitelja mogu utjecati na izvedbu na webu. Ako je latencija poslužitelja izvorišta visoka, to je znak da je poslužitelj preopterećen ili da ima lošu pozadinsku izvedbu. [Saznajte više](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Latencije poslužitelja mogu utjecati na izvedbu na webu. Ako je latencija poslužitelja polazišta visoka, to je znak da je poslužitelj preopterećen ili da ima lošu pozadinsku izvedbu. [Saznajte više](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Pozadinske latencije poslužitelja"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Više od proračuna"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Zahtjeve za količinom i veličinom mreže održavajte ispod ciljeva utvrđenih danim proračunom za izvršavanje. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{Jedan zahtjev}one{Broj zahtjeva: #}few{Broj zahtjeva: #}other{Broj zahtjeva: #}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Proračun za izvedbu"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Preusmjeravanja uvode dodatna kašnjenja prije nego što se stranica može učitati. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
@@ -563,20 +812,29 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Izbjegavajte višestruka preusmjeravanja stranica"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Da biste postavili proračune za količinu i veličinu resursa stranice, dodajte datoteku budget.json. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 zahtjev }one{# zahtjev }few{# zahtjeva }other{# zahtjevi }} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Neka zahtjevi budu malobrojni, a veličine prijenosa male"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Kanonske veze ukazuju na to koji URL prikazati u rezultatima pretraživanja. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Više sukobljenih URL-ova ({urlList})"
+    "message": "Više URL-ova u sukobu ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Upućuje na neku drugu domenu ({url})"
+    "message": "Usmjerava na drugu domenu ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Nevažeći URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Upućuje na neku drugu \"hreflang\" lokaciju ({url})"
+    "message": "Usmjerava na drugu `hreflang` lokaciju ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relativni URL ({url})"
@@ -585,19 +843,16 @@
     "message": "Upućuje na korijenski URL domene (početnu stranicu), a ne na ekvivalentnu stranicu sadržaja"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokument ne sadrži važeći \"rel=canonical\""
+    "message": "Dokument ne sadrži valjanu vezu `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokument sadrži važeći \"rel=canonical\""
+    "message": "Dokument ima valjani `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Fontovi manji od 12 px premali su da bi bili čitljivi, pa posjetitelji na mobilnim uređajima moraju zumirati prstima. Neka više od 60% teksta na stranici ima veličinu od najmanje 12px. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} čitljivog teksta"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} teksta nije dovoljno veliko."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Tekst nije čitljiv jer nijedna metaoznaka vidljivog dijela nije optimizirana za zaslone mobilnih uređaja."
@@ -615,10 +870,10 @@
     "message": "Veze s atributom hreflang govore tražilicama koju verziju stranice trebaju navesti u rezultatima pretraživanja za određeni jezik ili regiju. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokument ne sadrži važeći \"hreflang\""
+    "message": "Dokument ne sadrži važeći `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokument ima valjani \"hreflang\""
+    "message": "Dokument ima valjani `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Stranice s neuspješnim HTTP kodom statusa možda se neće pravilno indeksirati. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -651,7 +906,7 @@
     "message": "Veze sadrže deskriptivan tekst"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Pokrenite [alat za testiranje strukturiranih podataka](https://search.google.com/structured-data/testing-tool/) i [alat za analiziranje strukturiranih podataka](http://linter.structured-data.org/) da biste provjerili strukturirane podatke. [Saznajte više](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Pokrenite [Alat za testiranje strukturiranih podataka](https://search.google.com/structured-data/testing-tool/) i [Datoteku za provjeru koda (linter) strukturiranih podataka](http://linter.structured-data.org/) da biste potvrdili strukturirane podatke. [Saznajte više](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Strukturirani su podaci važeći"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Preklapanje cilja"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Veličina"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Cilj dodira"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Ciljevi dodira odgovarajuće su veličine"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Vrijeme glavne niti"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Treća strana"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Kôd treće strane može znatno utjecati na uspješnost učitavanja. Ograničite broj suvišnih pružatelja treće strane i pokušajte učitati kôd treće strane nakon primarnog zavšetka učitavanja vaše stranice. [Saznajte više](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Pronađena je jedna treća strana}one{Broj pronađenih trećih strana: #}few{Broj pronađenih trećih strana: #}other{Broj pronađenih trećih strana: #}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Upotreba trećih strana"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Vrijeme do prvog bajta navodi vrijeme u koje poslužitelj šalje odgovor. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Trajanje"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Naziv"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Vrijeme početka"
@@ -753,7 +1017,7 @@
     "message": "Oznake i izmjere Praćenja korisničkog vremena"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "<link> za predpovezivanje pronađen je za \"{securityOrigin}\", ali ga preglednik nije upotrijebio. Provjerite upotrebljavate li atribut \"crossorigin\" pravilno."
+    "message": "Pronađen je <link> za pretpovezivanje za „{securityOrigin}”, ali ga preglednik nije upotrijebio. Provjerite upotrebljavate li atribut `crossorigin` pravilno."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Savjetujemo vam da dodate nagovještaje resursa za rano povezivanje ili prethodno dohvaćanje DNS-a radi uspostavljanja ranih veza s važnim izvorima trećih strana. [Saznajte više](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Rano se povežite s potrebnim izvorima"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Za \"{preloadURL}\" pronađen je <link> za predučitavanje, no preglednik ga nije upotrijebio. Provjerite upotrebljavate li atribut \"crossorigin\" pravilno."
+    "message": "Za „{preloadURL}” pronađen je <link> za predučitavanje, no preglednik ga nije upotrijebio. Provjerite upotrebljavate li atribut `crossorigin` pravilno."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Savjetujemo vam da koristite <link rel=preload> da biste dali prednost dohvaćanju resursa koji se trenutačno traže kasnije u učitavanju stranice. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Savjetujemo vam da koristite `<link rel=preload>` da biste dali prednost dohvaćanju resursa koji se trenutačno traže kasnije u učitavanju stranice. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Unaprijed učitajte ključne zahtjeve"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tablice i popisi"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Najbolji primjeri iz prakse"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Proračuni za izvedbu postavljaju standarde izvedbe vaše stranice."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Proračuni"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Više informacija o izvedbi vaše aplikacije."
+    "message": "Više informacija o izvedbi vaše aplikacije. Ovi brojevi ne [utječu izravno](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) na rezultat izvedbe."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Dijagnostika"
@@ -840,7 +1113,7 @@
     "message": "Poboljšanja prvog bojenja"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Ove optimizacije mogu ubrzati učitavanje stranice."
+    "message": "Ovi prijedlozi mogu vam pomoći da brže učitate stranicu. Oni ne [utječu izravno](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) na rezultat izvedbe."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Prilike"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL predmemoriranja"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Lokacija"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Naziv"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Zahtjevi"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Vrsta resursa"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Veličina (KB)"
+    "message": "Veličina"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Utrošeno vrijeme"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Veličina prijenosa"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potencijalna ušteda (KB)"
+    "message": "Potencijalna ušteda"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potencijalna ušteda (ms)"
+    "message": "Potencijalna ušteda"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Potencijalna ušteda {wastedBytes, number, bytes} KB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Potencijalna ušteda {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Font"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Slika"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Mediji"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Drugo"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skripta"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "List stila"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Treća strana"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Ukupno"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Nešto nije u redu sa snimanjem traga preko učitavanja stranice. Ponovno pokrenite Lighthouse. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS poslužitelji nisu mogli razriješiti navedenu domenu."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Potrebni prikupljač {artifactName} naišao je na pogrešku: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Došlo je do interne pogreške u Chromeu. Ponovo pokrenite Chrome i pokušajte ponovo pokrenuti Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Nije se pokrenuo potrebni prikupljač {artifactName}."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse nije mogao pouzdano učitati stranicu koju ste zatražili. Provjerite testirate li ispravan URL i odgovara li poslužitelj pravilno na sve zahtjeve."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse nije mogao pouzdano učitati URL koji ste zatražili jer je stranica prestala reagirati."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "URL koji ste naveli nema valjane sigurnosne vjerodajnice. {securityMessages}"
+    "message": "URL koji ste naveli nema valjani sigurnosni certifikat. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome je spriječio međuprostorno učitavanje stranice. Provjerite testirate li ispravan URL i odgovara li poslužitelj pravilno na sve zahtjeve."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse nije mogao pouzdano učitati stranicu koju ste zatražili. Provjerite testirate li ispravan URL i odgovara li poslužitelj pravilno na sve zahtjeve. (Pojedinosti: {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Proširi isječak"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Pokaži resurse treće strane"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Na ovo izvođenje Lighthousea utjecale su neke poteškoće:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Vrijednosti se procjenjuju i mogu se razlikovati."
+    "message": "Vrijednosti se procjenjuju i mogu se razlikovati. Rezultat izvedbe jest [, a temelji se samo na ovim mjernim podacima ](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Uspješni pregledi no s upozorenjima"
@@ -1053,7 +1380,7 @@
     "message": "Savjetujemo vam upotrebu [WordPressovog dodatka za optimizaciju slika](https://wordpress.org/plugins/search/optimize+images/) koji komprimira slike bez gubitka kvalitete."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Prenesite slike izravno pomoću [medijske biblioteke](https://codex.wordpress.org/Media_Library_Screen) kako bi bile dostupne potrebne veličine slika, a zatim ih umetnite iz medijske biblioteke ili upotrijebite widget za slike da bi se koristile optimalne veličine slika (uključujući one za responzivne prijelomne točke). Izbjegavajte upotrebu slika u \"punoj veličini\" osim ako su dimenzije adekvatne za njihovu upotrebu. [Saznajte više](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Prenesite slike izravno pomoću  [medijske biblioteke](https://codex.wordpress.org/Media_Library_Screen) kako bi bile dostupne potrebne veličine slika, a zatim ih umetnite iz medijske biblioteke ili upotrijebite widget za slike da bi se koristile optimalne veličine slika (uključujući one za responzivne prijelomne točke). Izbjegavajte upotrebu slika `Full Size` osim ako dimenzije odgovaraju njihovoj upotrebi. [Saznajte više](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Možete omogućiti kompresiju teksta u konfiguraciji web-poslužitelja."

--- a/lighthouse-core/lib/i18n/locales/hu.json
+++ b/lighthouse-core/lib/i18n/locales/hu.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "A hozzáférési kulcsok segítségével a felhasználók gyorsan fókuszálhatnak az oldal adott részeire. A megfelelő navigáció érdekében az összes hozzáférési kulcsnak egyedinek kell lennie. [További információ](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "A hozzáférési kulcsok segítségével a felhasználók gyorsan fókuszálhatnak az oldal adott részére. A megfelelő navigáció érdekében az összes hozzáférési kulcsnak egyedinek kell lennie. [További információ](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Nem egyedi `[accesskey]` értékek"
+    "message": "A(z) `[accesskey]` értékek nem egyediek"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Az `[accesskey]` értékek egyediek"
+    "message": "A következő értékek egyediek: `[accesskey]`"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Minden egyes ARIA `role` attribútum `aria-*` attribútumok konkrét alkészletét támogatja. Ha nem megfelelő alkészletet használ, érvényteleníti az `aria-*` attribútumokat. [További információ](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Minden egyes ARIA `role` szerepkör `aria-*` attribútumok konkrét részhalmazát támogatja. A hibás párosításuk érvényteleníti a(z) `aria-*` attribútumokat. [További információ](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Bizonyos `[aria-*]` attribútumok nem felelnek meg a szerepkörüknek"
+    "message": "Bizonyos `[aria-*]` attribútumok nem felelnek meg szerepkörüknek"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Az `[aria-*]` attribútumok megfelelnek a szerepkörüknek"
+    "message": "A(z) `[aria-*]` attribútumok megfelelnek szerepüknek"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Bizonyos ARIA-szerepkörök kötelező attribútumokkal rendelkeznek, amelyek az elem állapotát írják le a képernyőolvasók számára. [További információ](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Bizonyos ARIA-szerepkörök kötelező attribútumokkal rendelkeznek, amelyek az elem állapotát írják le a képernyőolvasók számára. [További információ](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Egyes `[role]` attribútumok nem rendelkeznek az összes szükséges `[aria-*]` attribútummal"
+    "message": "A(z) `[role]` elemek nem rendelkeznek minden szükséges `[aria-*]` attribútummal"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "A `[role]` attribútumok az összes szükséges `[aria-*]` attribútummal rendelkeznek"
+    "message": "A(z) `[role]` attribútumok minden szükséges `[aria-*]` attribútummal rendelkeznek"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Bizonyos fölérendelt ARIA-szerepköröknek konkrét alárendelt szerepköröket kell tartalmazniuk, hogy megfelelően teljesíthessék a kívánt kisegítő funkciójukat. [További információ](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Bizonyos fölérendelt ARIA-szerepköröknek meghatározott alárendelt szerepköröket kell tartalmazniuk, hogy megfelelően teljesíthessék a kívánt kisegítő funkciójukat. [További információ](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Hiányoznak olyan `[role]` attribútummal rendelkező elemek, amelyekhez konkrét alárendelt `[role]` attribútumokra van szükség."
+    "message": "Hiányoznak a(z) `[role]` tartalmú leszármazottai azon `[role]` tartalmú elemeknek, melyek meghatározott leszármazott elemeket igényelnek"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Olyan `[role]` attribútummal rendelkező elemek találhatók, amelyekhez konkrét alárendelt `[role]` attribútumokra van szükség."
+    "message": "A meghatározott `[role]` tartalmú leszármazottakat igénylő `[role]` tartalmú elemek rendelkeznek a szükséges leszármazottakkal."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Bizonyos alárendelt ARIA-szerepköröket konkrét fölérendelt szerepköröknek kell tartalmazniuk, hogy megfelelően teljesíthessék a kívánt kisegítő funkciójukat. [További információ](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Bizonyos alárendelt ARIA-szerepköröket meghatározott fölérendelt szerepköröknek kell tartalmazniuk, hogy megfelelően teljesíthessék a kívánt kisegítő funkciójukat. [További információ](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "A `[role]` attribútumok nem a kötelező fölérendelt elemükben találhatók"
+    "message": "A(z) `[role]` elemek nem a megfelelő szülőelemben vannak"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "A `[role]` attribútumok a kötelező fölérendelt elemben találhatók"
+    "message": "A(z) `[role]` elemek a megfelelő szülőelemben vannak"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Az ARIA-szerepköröknek érvényes értékekkel kell rendelkezniük, hogy megfelelően teljesíthessék a kívánt kisegítő funkciójukat. [További információ](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Az ARIA-szerepköröknek érvényes értékekkel kell rendelkezniük, hogy megfelelően teljesíthessék a kívánt kisegítő funkciójukat. [További információ](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Bizonyos `[role]` attribútumok értékei érvénytelenek"
+    "message": "A(z) `[role]` értékek nem érvényesek"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "A `[role]` attribútum értékei érvényesek"
+    "message": "A(z) `[role]` értékek érvényesek"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "A kisegítő technológiák (például képernyőolvasók) nem tudják értelmezni az érvénytelen értékkel rendelkező ARIA-attribútumokat. [További információ](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "A kisegítő technológiák (például a képernyőolvasók) nem tudják értelmezni az érvénytelen értékkel rendelkező ARIA-attribútumokat. [További információ](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Bizonyos `[aria-*]` attribútumok nem rendelkeznek érvényes értékekkel"
+    "message": "A(z) `[aria-*]` attribútumoknak nincs érvényes értékük"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Az `[aria-*]` attribútumok érvényes értékekkel rendelkeznek"
+    "message": "A(z) `[aria-*]` attribútumok érvényes értékkel rendelkeznek"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "A kisegítő technológiák (például képernyőolvasók) nem tudják értelmezni az érvénytelen névvel rendelkező ARIA-attribútumokat. [További információ](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "A kisegítő technológiák (például a képernyőolvasók) nem tudják értelmezni az érvénytelen névvel rendelkező ARIA-attribútumokat. [További információ](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Hiányzó vagy elgépelt `[aria-*]` attribútumok"
+    "message": "A(z) `[aria-*]` attribútumok nem érvényesek vagy elgépelést tartalmaznak"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Az `[aria-*]` attribútumok érvényesek és nincsenek elgépelve"
+    "message": "A(z) `[aria-*]` attribútumok érvényesek és nincsenek elgépelve"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "A feliratok használhatóvá teszik az audioelemeket a siket és hallássérült felhasználók számára a fontos információk megadásával (például ki beszél, mit mond, valamint egyéb, nem beszédalapú információk). [További információ](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "A feliratok a legfontosabb információk közlésével teszik használhatóvá az audioelemeket a siket és hallássérült felhasználók számára (például ki beszél, mit mond, valamint egyéb, nem beszédhez kötődő információk). [További információ](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Hiányzó `<track>` elem `[kind=\"captions\"]` attribútummal bizonyos `<audio>` elemeknél."
+    "message": "A(z) `<audio>` elemek nem rendelkeznek `[kind=\"captions\"]` tartalmú `<track>` elemmel."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Az `<audio>` elemek tartalmaznak `<track>` elemet `[kind=\"captions\"]` attribútummal."
+    "message": "A(z) `<audio>` elemekhez `[kind=\"captions\"]` tartalmú `<track>` elem tartozik"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Hibás elemek"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Ha valamelyik gomb nem rendelkezik hozzáférhető névvel, a képernyőolvasók „gombként” jelzik, ami használhatatlanná teszi a képernyőolvasóra hagyatkozó felhasználók számára. [További információ](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Ha valamelyik gomb nem rendelkezik hozzáférhető névvel, a képernyőolvasók „gomb” néven olvassák fel, ami nem igazán hasznos a képernyőolvasóra hagyatkozó felhasználók számára. [További információ](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Bizonyos gombok nem rendelkeznek hozzáférhető névvel"
@@ -93,7 +93,7 @@
     "message": "A gombok rendelkeznek kisegítő névvel"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Az ismétlődő tartalmakat megkerülő módszerek megvalósításával a billentyűzetet használó személyek hatékonyabban navigálhatnak az oldalon. [További információ](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Az ismétlődő tartalmakat megkerülő módszerek megvalósításával a billentyűzetet használó személyek hatékonyabban navigálhatnak az oldalon. [További információ](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Az oldal nem tartalmaz címsort, átugró linket vagy igazodásipont-régiót"
@@ -102,7 +102,7 @@
     "message": "Az oldal címsort, átugró linket vagy igazodásipont-régiót tartalmaz"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Az alacsony kontrasztú szöveg számos felhasználó számára nehezen vagy egyáltalán nem olvasható. [További információ](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Az alacsony kontrasztú szöveg sokak számára nehezen vagy egyáltalán nem olvasható. [További információ](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Nem megfelelő a háttér- és előtérszínek közötti kontrasztarány."
@@ -111,88 +111,88 @@
     "message": "Megfelelő a háttér- és előtérszínek közötti kontrasztarány"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Ha nem megfelelő a definíciós listák jelölése, a képernyőolvasók zavaros vagy pontatlan szöveget generálhatnak. [További információ](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Ha nem megfelelő a definíciós listák jelölése, a képernyőolvasók zavaros vagy pontatlan szöveget generálhatnak. [További információ](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Bizonyos `<dl>` elemek nem csak megfelelően rendezett `<dt>` és `<dd>` csoportokat, `<script>` vagy `<template>` elemeket tartalmaznak."
+    "message": "A(z) `<dl>` elemek nem csak megfelelően rendezett `<dt>` és `<dd>` csoportokat, illetve `<script>` vagy `<template>` elemeket tartalmaznak."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "A `<dl>` elemek csak megfelelően rendezett `<dt>` és `<dd>` csoportokat, `<script>` vagy `<template>` elemeket tartalmaznak."
+    "message": "A(z) `<dl>` elemek csak megfelelő sorrendű `<dt>` és `<dd>` csoportokat, illetve `<script>` vagy `<template>` elemeket tartalmaznak."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "A definíciós lista elemeit (`<dt>` és `<dd>`) fölérendelt `<dl>` elembe kell foglalni, hogy a képernyőolvasók megfelelően olvashassák fel őket. [További információ](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "A definíciós listák elemeit (`<dt>` és `<dd>`) `<dl>` szülőelembe kell foglalni, hogy a képernyőolvasók megfelelően felolvashassák őket. [További információ](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "A definíciós lista elemei nem `<dl>` elemek között találhatók"
+    "message": "A definíciós listák elemei nincsenek `<dl>` elemekben"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "A definíciós lista elemei `<dl>` elemek között találhatók"
+    "message": "A definíciós listák elemei `<dl>` elemekben vannak"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "A cím áttekintést ad az oldalról a képernyőolvasót használó személyeknek, a keresőmotorok pedig nagymértékben hagyatkoznak rá annak meghatározásához, hogy az oldal releváns-e az adott kereséshez. [További információ](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "A cím áttekintést ad az oldalról a képernyőolvasót használó személyeknek, a keresőmotorok pedig nagymértékben hagyatkoznak rá annak meghatározásához, hogy az oldal releváns-e az adott kereséshez. [További információ](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "A dokumentum nem rendelkezik `<title>` elemmel"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "A dokumentum rendelkezik `<title>` elemmel"
+    "message": "A dokumentum tartalmaz `<title>` elemet"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Az „id” attribútum értékének egyedinek kell lennie, hogy a kisegítő technológiák ne hagyhassák figyelmen kívül a további előfordulásokat. [További információ](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Az „id” attribútum értékének egyedinek kell lennie, hogy a kisegítő technológiák ne hagyják figyelmen kívül a többi előfordulást. [További információ](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Az oldalon található egyes `[id]` attribútumok nem egyediek"
+    "message": "Az oldal `[id]` attribútumai nem egyediek"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
     "message": "Az oldalon található `[id]` attribútumok egyediek"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "A képernyőolvasók a keretek címeire hagyatkoznak a keret tartalmának bemutatásához. [További információ](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "A képernyőolvasók a keretcímek alapján írják le a keretek tartalmát. [További információ](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Cím nélküli `<frame>` vagy `<iframe>` elemek"
+    "message": "A(z) `<frame>` és a(z) `<iframe>` elemeknek nincs címük"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "A `<frame>` vagy `<iframe>` elemek rendelkeznek címmel"
+    "message": "Van címe a(z) `<frame>` és `<iframe>` elemeknek"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Ha az oldal nem határoz meg „lang” attribútumot, a képernyőolvasó feltételezi, hogy az oldal nyelve megegyezik a felhasználó által a képernyőolvasó beállításakor megadott alapértelmezett nyelvvel. Ha az oldal tényleges nyelve eltér az alapértelmezett nyelvtől, akkor előfordulhat, hogy a képernyőolvasó helytelen kiejtéssel olvassa fel az oldal szövegét. [További információ](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Ha az oldal nem határoz meg „lang” attribútumot, a képernyőolvasók azt feltételezik majd, hogy az oldal nyelve megegyezik azzal az alapértelmezett nyelvvel, amelyet a felhasználó a képernyőolvasó beállításakor választott. Ha az oldal tényleges nyelve eltér az alapértelmezett nyelvtől, akkor előfordulhat, hogy a képernyőolvasók helytelen kiejtéssel olvassák majd fel az oldal szövegét. [További információ](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "A `<html>` elem nem rendelkezik `[lang]` attribútummal"
+    "message": "A(z) `<html>` elem nem rendelkezik `[lang]` attribútummal"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "A `<html>` elem rendelkezik `[lang]` attribútummal"
+    "message": "A(z) `<html>` elemhez tartozik `[lang]` attribútum"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Érvényes [BCP 47-nyelv](https://www.w3.org/International/questions/qa-choosing-language-tags#question) megadása segít a képernyőolvasónak a szöveg megfelelő felolvasásában. [További információ](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ha érvényes [BCP 47 által definiált nyelvet](https://www.w3.org/International/questions/qa-choosing-language-tags#question) használ, a képernyőolvasók könnyebben felolvassák a szövegeket. [További információ](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "A `<html>` elem esetében érvénytelen érték van megadva a `[lang]` attribútumnál."
+    "message": "A(z) `<html>` elem `[lang]` attribútumának nincs érvényes értéke."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "A `<html>` elem esetében érvényes érték van megadva a `[lang]` attribútumnál"
+    "message": "A(z) `<html>` elem `[lang]` attribútumának értéke érvényes"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "A tájékoztató elemeknél rövid, leíró alternatív szöveg használata ajánlott. A díszítőelemek figyelmen kívül hagyhatók üres „alt” attribútummal. [További információ](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Rövid, beszédes alternatív szöveget használjon a tájékoztató elemekhez. A díszítőelemek figyelmen kívül hagyhatók üres „alt” attribútummal. [További információ](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Bizonyos képelemek nem rendelkeznek `[alt]` attribútumokkal"
+    "message": "A képelemekhez nem tartozik `[alt]` attribútum"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "A képelemek rendelkeznek `[alt]` attribútumokkal"
+    "message": "A képelemekhez tartozik `[alt]` attribútum"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Ha képet használ `<input>` gombként, alternatív szöveg megadásával segíthet a képernyőolvasót használó személyek számára a gomb funkciójának megértésében. [További információ](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Ha a(z) `<input>` típusú gombként használt képekhez alternatív szöveget is megad, segíthet a képernyőolvasót használó látogatóknak a gomb rendeltetésének megértésében. [További információ](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Bizonyos `<input type=\"image\">` elemek nem rendelkeznek `[alt]` szöveggel"
+    "message": "A(z) `<input type=\"image\">` elemekhez nem tartozik `[alt]` szöveg"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Az `<input type=\"image\">` elemek rendelkeznek `[alt]` szöveggel"
+    "message": "A(z) `<input type=\"image\">` elemek rendelkeznek `[alt]` szöveggel"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "A címkék biztosítják, hogy a formátumvezérlőket megfelelően jelezze a rendszer a kisegítő technológiák (pl. képernyőolvasók) segítségével. [További információ](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "A címkék biztosítják, hogy a kisegítő technológiák (pl. a képernyőolvasók) megfelelően jelezzék az űrlapvezérlőket. [További információ](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Bizonyos formátumelemek nem rendelkeznek társított címkékkel"
@@ -201,16 +201,16 @@
     "message": "A formátumelemekhez megfelelő címkék vannak társítva"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Az elrendezési célokat szolgáló táblázat nem tartalmazhat adatelemeket (pl. „th” vagy „caption” elem, illetve „summary” attribútum), mert ez zavaró lehet a képernyőolvasót használó személyek számára. [További információ](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Az elrendezési célokat szolgáló táblázat ne tartalmazzon adatelemeket (pl. „th” vagy „caption” elemet, illetve „summary” attribútumot), mert zavarók lehetnek a képernyőolvasót használó személyek számára. [További információ](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "A prezentációs `<table>` elemek nem kerülik a `<th>`, `<caption>` elemek vagy a `[summary]` attribútumok használatát."
+    "message": "A prezentációs `<table>` elemek nem kerülik a(z) `<th>`, a(z) `<caption>` vagy a(z) `[summary]` attribútum használatát."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "A prezentációs `<table>` elemek kerülik a `<th>`, `<caption>` elemek vagy a `[summary]` attribútumok használatát."
+    "message": "A prezentációs `<table>` elemek kerülik a(z) `<th>`, a(z) `<caption>` vagy a(z) `[summary]` attribútum használatát."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "A felismerhető, egyedi és fókuszálható linkszövegek (és linkként használt képek alternatív szövegei) jobb navigációs élményt biztosítanak a képernyőolvasóra hagyatkozó felhasználók számára. [További információ](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "A felismerhető, egyedi és fókuszálható linkszövegek (és linkként használt képek alternatív szövegei) jobb navigációs élményt biztosítanak a képernyőolvasóra hagyatkozó felhasználók számára. [További információ](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "A linkekhez nem tartozik felismerhető név"
@@ -219,103 +219,115 @@
     "message": "A linkekhez felismerhető név tartozik"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "A képernyőolvasóknak külön módszerük van a listák felolvasására. A megfelelő listastruktúra biztosítása segíti a képernyőolvasók működését. [További információ](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "A képernyőolvasók sajátos módon olvassák fel a listákat. A megfelelő listastruktúra biztosítása segíti a képernyőolvasók működését. [További információ](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "A listák nem csak `<li>` elemeket és szkriptet támogató elemeket (`<script>` és `<template>`) tartalmaznak."
+    "message": "A listák nem csak `<li>` elemeket és szkripttámogató elemeket (`<script>` és `<template>`) tartalmaznak."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "A listák csak `<li>` elemeket és szkriptet támogató elemeket (`<script>` és `<template>`) tartalmaznak."
+    "message": "A listák csak `<li>` elemeket és szkripttámogató elemeket (`<script>`, `<template>`) tartalmaznak."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "A listaelemeket (`<li>`) fölérendelt `<ul>` vagy `<ol>` elemekben kell elhelyezni, hogy a képernyőolvasók megfelelően olvassák fel őket. [További információ](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "A listaelemeket (`<li>`) fölérendelt `<ul>` vagy `<ol>` elemekben kell elhelyezni, hogy a képernyőolvasók megfelelően olvassák fel őket. [További információ](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Bizonyos listaelemek (`<li>`) nem fölérendelt `<ul>` vagy `<ol>` elemek között találhatók."
+    "message": "A listaelemek (`<li>`) nem `<ul>` vagy `<ol>` szülőelemekben vannak."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "A listaelemek (`<li>`) fölérendelt `<ul>` vagy `<ol>` elemek között találhatók."
+    "message": "A listaelemek (`<li>`) `<ul>` vagy `<ol>` szülőelemekben vannak"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "A felhasználók nem számítanak az oldal automatikus frissítésére, ami visszahelyezi a fókuszt az oldal tetejére. Ez frusztráló vagy zavaró élményhez vezethet. [További információ](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "A felhasználók nem számítanak az oldal automatikus frissítésére, ráadásul a frissítés visszahelyezi a fókuszt az oldal tetejére. Ez frusztráló lehet, valamint összezavarhatja a felhasználót. [További információ](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "A dokumentum a `<meta http-equiv=\"refresh\">` metacímkét használja"
+    "message": "A dokumentum `<meta http-equiv=\"refresh\">` címkét használ"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "A dokumentum nem használja a `<meta http-equiv=\"refresh\">` metacímkét"
+    "message": "A dokumentum nem használja a(z) `<meta http-equiv=\"refresh\">` címkét"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "A nagyítás letiltása problémát jelent a gyengén látó felhasználók számára, akik a képernyőnagyításra hagyatkoznak ahhoz, hogy megfelelően láthassák a weboldal tartalmát. [További információ](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "A nagyítás letiltása problémát jelent a gyengén látó felhasználók számára, akik a képernyőnagyításra hagyatkoznak ahhoz, hogy megfelelően láthassák a weboldal tartalmát. [További információ](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "A `[user-scalable=\"no\"]` értéket használja a `<meta name=\"viewport\">` elemben vagy a `[maximum-scale]` attribútum értéke ötnél kevesebb."
+    "message": "A(z) `[user-scalable=\"no\"]` szerepel a(z) `<meta name=\"viewport\">` elemben, vagy a(z) `[maximum-scale]` attribútum 5-nél kisebb."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "Nem használja a `[user-scalable=\"no\"]` értéket a `<meta name=\"viewport\">` elemben, és a `[maximum-scale]` attribútum értéke nem kevesebb ötnél."
+    "message": "Nem használja a(z) `[user-scalable=\"no\"]` attribútumot a(z) `<meta name=\"viewport\">` elemben, a(z) `[maximum-scale]` attribútum pedig nem kevesebb 5-nél."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "A képernyőolvasók nem tudják lefordítani a nem szövegalapú tartalmakat. Ha helyettesítő szöveget ad hozzá az `<object>` elemekhez, segíti a képernyőolvasókat a tartalmak értelmezésében a felhasználók számára. [További információ](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "A képernyőolvasók nem tudják lefordítani a nem szövegalapú tartalmakat. Ha alternatív szöveget helyez el a(z) `<object>` elemekben, a képernyőolvasók kommunikálhatják az elemek jelentését a felhasználóknak. [További információ](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Bizonyos `<object>` elemek nem rendelkeznek `[alt]` szöveggel"
+    "message": "A(z) `<object>` elemekhez nem tartozik `[alt]` szöveg"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Az `<object>` elemek rendelkeznek `[alt]` szöveggel"
+    "message": "A(z) `<object>` elemek rendelkeznek `[alt]` szöveggel"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "A 0-nál nagyobb érték explicit navigációs sorrendet jelent. Ez ugyan technikailag érvényes, azonban gyakran frusztráló felhasználói élményt nyújt a kisegítő technológiákra hagyatkozó személyek számára. [További információ](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "A 0-nál nagyobb érték explicit navigációs sorrendet jelent. Ez ugyan technikailag érvényes, azonban gyakran problémát jelent a kisegítő technológiákra hagyatkozó felhasználók számára. [További információ](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Bizonyos elemek 0-nál nagyobb `[tabindex]` értékkel rendelkeznek"
+    "message": "Bizonyos elemek `[tabindex]` attribútuma 0-nál nagyobb értékkel rendelkezik."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Egy elemnek sincs 0-nál nagyobb `[tabindex]` értéke"
+    "message": "Egyetlen elem `[tabindex]` attribútumának sem 0-nál nagyobb az értéke"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "A képernyőolvasók rendelkeznek olyan funkciókkal, amelyek egyszerűbbé teszik a táblázatokban való navigációt. Annak biztosításával, hogy a `[headers]` attribútumot használó `<td>` cellák csak ugyanazon táblázat egyéb celláira hivatkoznak, javíthatja a képernyőolvasóra hagyatkozó felhasználók élményét. [További információ](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "A képernyőolvasók olyan funkciókkal is rendelkeznek, amelyek megkönnyítik a táblázatokban való navigációt. Ha a(z) `[headers]` attribútumot használó `<td>` cellák csak a saját táblázatuk más celláira hivatkoznak, jobb felhasználói élményt nyújthat a képernyő felolvasása során. [További információ](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "A `<table>` elem `[headers]` attribútumot használó cellái ugyanazon táblázat másik celláira hivatkoznak."
+    "message": "A(z) `<table>` elemben lévő, `[headers]` attribútumot használó cellák a saját táblázatuk celláira hivatkoznak."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "A `<table>` elem `[headers]` attribútumot használó cellái csak ugyanazon táblázat másik celláira hivatkoznak."
+    "message": "A(z) `<table>` elemben lévő, `[headers]` attribútumot használó cellák csak a saját táblázatuk celláira hivatkoznak."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "A képernyőolvasók rendelkeznek olyan funkciókkal, amelyek egyszerűbbé teszik a táblázatokban való navigációt. Annak biztosításával, hogy a táblák fejlécei mindig adott cellakészletre hivatkoznak, javíthatja a képernyőolvasóra hagyatkozó felhasználók élményét. [További információ](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "A képernyőolvasók olyan funkciókkal is rendelkeznek, amelyek megkönnyítik a táblázatokban való navigációt. Ha biztosítja, hogy a táblák fejlécei mindig hivatkozzanak cellákra, megkönnyítheti az oldal használatát a képernyőolvasóra hagyatkozó felhasználók számára. [További információ](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Bizonyos `<th>` elemeknél és `[role=\"columnheader\"/\"rowheader\"]` attribútummal rendelkező elemeknél hiányoznak az általuk leírt adatcellák."
+    "message": "A(z) `<th>` elemekhez és a(z) `[role=\"columnheader\"/\"rowheader\"]` tartalmú elemekhez nem tartoznak általuk leírt adatcellák."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "A `<th>` elemeknél és `[role=\"columnheader\"/\"rowheader\"]` attribútummal rendelkező elemeknél megtalálhatók az általuk leírt adatcellák."
+    "message": "A(z) `<th>` elemek és a(z) `[role=\"columnheader\"/\"rowheader\"]` tartalmú elemek rendelkeznek a leírt adatcellákkal."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Érvényes [BCP 47-nyelv](https://www.w3.org/International/questions/qa-choosing-language-tags#question) elemeknél való megadása segít biztosítani, hogy a szöveget helyes kiejtéssel olvassa fel a képernyőolvasó. [További információ](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ha az elemeken érvényes [BCP 47 által definiált nyelvet](https://www.w3.org/International/questions/qa-choosing-language-tags#question) határoz meg, akkor segíthet a képernyőolvasóknak a szöveg helyes kiejtésében. [További információ](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Bizonyos `[lang]` attribútumok nem rendelkeznek érvényes értékkel"
+    "message": "A(z) `[lang]` attribútumokhoz nem tartozik érvényes érték"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "A `[lang]` attribútumok érvényes értékkel rendelkeznek"
+    "message": "A(z) `[lang]` attribútumok érvényes értékkel rendelkeznek"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Ha a videóhoz felirat tartozik, a siket és hallássérült felhasználók egyszerűbben hozzájuthatnak a videóban található információkhoz. [További információ](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Ha a videóhoz felirat tartozik, a siket és hallássérült felhasználók egyszerűbben hozzájuthatnak a videóban található információkhoz. [További információ](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Bizonyos `<video>` elemek nem tartalmaznak `<track>` elemet `[kind=\"captions\"]` attribútummal."
+    "message": "A(z) `<video>` elemekhez nem tartozik `[kind=\"captions\"]` tartalmú `<track>` elem."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "A `<video>` elemek tartalmaznak `<track>` elemet `[kind=\"captions\"]` attribútummal."
+    "message": "A(z) `<video>` elemekhez `[kind=\"captions\"]` tartalmú `<track>` elem tartozik"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Az audiokommentárok olyan fontos információkat nyújtanak a videókhoz, amelyek a párbeszédekből nem derülnek ki (ilyenek például az arckifejezések és a jelenetek leírása). [További információ](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Az audiokommentárok olyan fontos információkat nyújtanak a videókhoz, amelyek a párbeszédekből nem derülnek ki (ilyen például az arckifejezések és a jelenetek leírása). [További információ](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Bizonyos `<video>` elemek nem tartalmaznak `<track>` elemet `[kind=\"description\"]` attribútummal."
+    "message": "A(z) `<video>` elemekhez nem tartozik `[kind=\"description\"]` tartalmú `<track>` elem."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "A `<video>` elemek tartalmaznak `<track>` elemet `[kind=\"description\"]` attribútummal."
+    "message": "A(z) `<video>` elemekhez `[kind=\"description\"]` tartalmú `<track>` elem tartozik"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Az apple-touch-icon meghatározásával ideális megjelenést nyújthat iOS-en, mikor a felhasználók ikont helyeznek a főképernyőre. Az ikonnak 192 képpont (vagy 180 képpont) méretű, nem átlátszó, négyzetes PNG-re kell mutatnia. [További információ](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Nincs érvényes `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "A(z) `apple-touch-icon-precomposed` elavult; a(z) `apple-touch-icon` használandó helyette."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Érvényes `apple-touch-icon` elemet tartalmaz"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Egyes Chrome-bővítmények kedvezőtlenül befolyásolták az oldal betöltési teljesítményét. Próbálkozzon az oldal inkognitómódban vagy bővítmények nélküli Chrome-profilból történő ellenőrzésével."
@@ -330,7 +342,7 @@
     "message": "Teljes processzoridő"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Érdemes csökkenteni a JS elemzésére, összeállítására és végrehajtására fordított időt. Ebben segítségére lehet a kisebb JS-hasznosadat-forgalom. [További információ](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Érdemes csökkenteni a JavaScript értelmezésére, összeállítására és végrehajtására fordított időt. Ebben segíthet, ha kisebb méretű JavaScript-forrásokat továbbít. [További információ](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Csökkentse a JavaScript végrehajtási idejét"
@@ -339,25 +351,25 @@
     "message": "JavaScript végrehajtási ideje"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "A nagy méretű GIF-ek nem megfelelők az animált tartalmak megjelenítéséhez. Érdemes MPEG4/WebM formátumú videókat használni az animációkhoz, illetve a PNG/WebP formátumot a statikus képekhez a GIF-ek helyett, hiszen így csökkenteni tudja a hálózati adatforgalmat. [További információ](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)."
+    "message": "A túl nagy GIF-fájlokkal nem lehet hatékonyan animált tartalmakat nyújtani. Az adatforgalom csökkentésének érdekében a GIF-ek helyett érdemes az animációkhoz MPEG4-/WebM-videókat használnia, a statikus képekhez pedig PNG-/WebP-képeket. [További információ](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Használjon videoformátumot az animált tartalmakhoz"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Vegye fontolóra a képernyőn kívüli és a rejtett képek késleltetett, a kritikus erőforrások betöltődésének végét követő betöltését, az interaktivitásig tartó idő csökkentése érdekében. [További információ](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Vegye fontolóra a képernyőn kívüli és rejtett képek késleltetett, kritikus források utáni betöltését, hogy az oldal hamarabb interaktívvá váljon. [További információ](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Késleltesse a képernyőn kívüli képek betöltését"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Az erőforrások blokkolják az oldal első leképezését. Fontolja meg a kritikus JS/CSS beillesztését, továbbá az összes nem kritikus JS/stílus késleltetését. [További információ](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Források blokkolják az oldal első vizuális válaszát. Javasoljuk, hogy a legfontosabb JavaScript-/CSS-elemeket beágyazva továbbítsa, a nem fontos JS-t/CSS-t pedig késleltesse [További információ](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Távolítsa el a megjelenítést gátló erőforrásokat"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "A nagy hálózati terhelés valódi költséggel jár a felhasználóknak, és jelentősen megnöveli a betöltési időt. [További információ](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "A nagy hálózati terhelés tényleges anyagi költséget jelenthet a felhasználóknak, és jellemzően jelentősen megnöveli a betöltési időt. [További információ](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "A teljes méret {totalBytes, number, bytes} kB volt"
@@ -369,13 +381,13 @@
     "message": "A nagyon nagy hálózati terhelés elkerülése"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "A CSS-fájlok minimalizálása csökkentheti a hálózati hasznosadat-forgalmat. [További információ](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "A CSS-fájlok minimalizálása csökkentheti a hálózaton továbbított adatok méretét. [További információ](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Minimalizálja a CSS-fájlokat"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "A JavaScript-fájlok minimalizálásával csökkenthető a hasznosadat-forgalom és a szkriptelemzési idő. [További információ](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "A JavaScript-fájlok minimalizálásával csökkenthető a továbbított adatok mérete és a szkriptek értelmezésére fordított idő. [További információ](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Minimalizálja a JavaScript-kódot"
@@ -393,7 +405,7 @@
     "message": "Távolítsa el a nem használt JavaScript-kódot"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "A hosszú gyorsítótári élettartam felgyorsíthatja az oldal ismételt látogatását. [További információ](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Ha a gyorsítótárak élettartama hosszú, gyorsabbá válnak a weboldal későbbi ismételt megnyitásai. [További információ](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 erőforrás található}other{# erőforrás található}}"
@@ -405,7 +417,7 @@
     "message": "Használjon hatékony gyorsítótár-házirendet a statikus eszközöknél"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Az optimalizált képek gyorsabban töltődnek be, és kisebb mobiladat-forgalommal járnak. [További információ](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Az optimalizált képek gyorsabban betöltődnek és kevesebb adatforgalmat generálnak. [További információ](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Kódolja hatékonyan a képeket"
@@ -417,25 +429,76 @@
     "message": "Méretezze megfelelően a képeket"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "A szöveges alapú erőforrásokat tömörítéssel (gzip, Deflate vagy Brotli) célszerű megjeleníteni a teljes hálózati adatforgalom minimalizálása érdekében. [További információ](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "A szövegalapú forrásokat tömörítéssel (gzip, Deflate vagy Brotli) célszerű továbbítani a hálózati adatforgalom minimalizálása érdekében. [További információ](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Engedélyezze a szövegtömörítést"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Az olyan képformátumok, mint a JPEG 2000, a JPEG XR és a WebP gyakran jobb tömörítést biztosítanak a PNG vagy a JPEG formátumnál, ami gyorsabb letöltést és kisebb adatforgalmat jelent. [További információ](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Az olyan képformátumok, mint a JPEG 2000, a JPEG XR és a WebP gyakran jobb tömörítést nyújtanak, mint a PNG és a JPEG, azaz kevesebb adatforgalom mellett gyorsabb letöltést biztosítanak. [További információ](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Jelenítse meg a képeket következő generációs formátumokban"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Az alábbi kritikuslekérdezés-láncok megmutatják, hogy milyen források töltődnek be prioritással. Az oldalbetöltés javítása érdekében fontolja meg a láncok hosszának csökkentését, a letöltött erőforrások méretének csökkentését, vagy a felesleges erőforrások letöltésének késleltetését. [További információ.](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Az alábbi kritikus kérésláncok megjelenítik, hogy milyen források töltődnek be magas prioritással. Az oldalbetöltés javítása érdekében fontolja meg a láncok hosszának csökkentését, a letöltött források méretének csökkentését, vagy a felesleges források letöltésének késleltetését. [További információ](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 lánc található}other{# lánc található}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimalizálja a kritikus lekérdezések mélységét"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Elavulás / Figyelmeztetés"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Sor"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Az elavult API-k előbb-utóbb kikerülnek a böngészőből. [További információ](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 figyelmeztetés}other{# figyelmeztetés}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Elavult API-kat használ"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Kerüli az elavult API-kat"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Az alkalmazás-gyorsítótár elavult. [További információ](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "A(z) „{AppCacheManifest}” van használatban"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Alkalmazás-gyorsítótárat használ"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Kerüli az alkalmazás-gyorsítótárat"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "A doctype meghatározásával elkerülhető, hogy a böngésző visszafelé kompatibilis módra váltson. További információ az [MDN Web Docs oldalon](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "A doctype nevének a kisbetűs `html` szövegnek kell lennie"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "A dokumentumnak doctype szakaszt kell tartalmaznia"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "A publicId nem üres karakterlánc"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "A systemId mező nem üres karakterlánc"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Az oldalon nincs HTML doctype, ezért visszafelé kompatibilis módot indít"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Az oldalon szerepel a HTML doctype"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elem"
@@ -447,7 +510,7 @@
     "message": "Érték"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "A böngészőket fejlesztő mérnökök azt javasolják, hogy az oldalakon ~1500 DOM-elemnél kevesebb legyen. A legkedvezőbb a 32 elemnél kisebb és a 60 alárendelt/fölérendelt elemnél kisebb famélység. A nagy DOM növelheti a memóriahasználatot, és hosszabb [stílusszámítást](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), valamint költséges [elrendezés-újraszámítást](https://developers.google.com/speed/articles/reflow) eredményezhet. [További információ](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "A böngészők fejlesztői azt javasolják, hogy az oldalak legfeljebb kb. 1500 DOM-elemet tartalmazzanak. Ideális esetben 32-nél kisebb mélységű fa és 60-nál kevesebb gyermek/szülő elem van. A nagy méretű DOM megnöveli a memóriahasználatot, hosszabb ideig tartó [stílusszámítást](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) igényel, valamint költséges [elrendezés-áttördeléssel](https://developers.google.com/speed/articles/reflow) jár. [További információ](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 elem}other{# elem}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Kerüli a túlzó DOM-méretet"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Cél"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Adjon `rel=\"noopener\"` vagy `rel=\"noreferrer\"` címkét a külső linkekhez, hogy javíthassa a teljesítményt és elkerülhesse a sebezhetőségeket. [További információ](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Az eredetközi célokra mutató linkek nem biztonságosak"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Az eredetközi célokra mutató linkek biztonságosak"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "A horgony célpontja nem meghatározható ({anchorHTML}). Ha nem hiperlinkről van szó, érdemes eltávolítania a target=_blank részt."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "A tartózkodási helyre vonatkozó engedély váratlan kérése bizalmatlanságra adhat okot, valamint összezavarhatja a felhasználókat. Érdemes inkább felhasználói műveletekhez kötni a kérést. [További információ](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Oldalbetöltéskor a földrajzi helyre vonatkozó engedélyt kéri"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Kerüli a földrajzi helyre vonatkozó engedély kérését oldalbetöltéskor"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Verzió"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Az oldalon észlelt minden front-end JavaScript-függvénytár."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Észlelt JavaScript-függvénytárak"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "A külső szkriptek `document.write()` segítségével történő dinamikus beillesztése több tíz másodperccel lassíthatja az oldalbetöltést a lassú kapcsolaton csatlakozó felhasználók esetében. [További információ](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "A(z) `document.write()` metódust használja"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Kerüli a(z) `document.write()` használatát"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Legmagasabb súlyosság"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Függvénytár verziója"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Sebezhetőségek száma"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "A harmadik felektől származó szkriptek ismert sebezhetőségeket tartalmazhatnak, melyeket a támadók könnyedén felismerhetnek és kihasználhatnak. [További információ](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 észlelt sebezhetőség}other{# észlelt sebezhetőség}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Ismert sebezhetőségeket tartalmazó front-end JavaScript-függvénytárakat használ"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Magas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Alacsony"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Közepes"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Kerüli az ismert sebezhetőségeket tartalmazó front-end JavaScript-függvénytárakat"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Az értesítésekre vonatkozó engedély váratlan kérése bizalmatlanságra adhat okot, valamint összezavarhatja a felhasználókat. Érdemes inkább felhasználói műveletekhez kötni a kérést. [További információ](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Oldalbetöltéskor az értesítésekre vonatkozó engedélyt kéri"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Kerüli az értesítésekre vonatkozó engedély kérését oldalbetöltéskor"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Hibás elemek"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "A jelszóbeillesztés megakadályozása rossz biztonsági gyakorlat. [További információ](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Megakadályozza, hogy a felhasználók szöveget illesszenek be a jelszómezőkbe"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Lehetővé teszi, hogy a felhasználók beillesszenek a jelszómezőkbe"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokoll"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "A HTTP/2 számos előnyt nyújt a HTTP/1.1-hez képest, például bináris fejléceket, multiplexelést és előzetes adatküldést (server push). [További információ](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 nem HTTP/2-t használó kérés}other{# nem HTTP/2-t használó kérés}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Nem minden forráshoz használ HTTP/2-t"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "HTTP/2-t használ a saját forrásokhoz"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Fontolja meg az érintési és görgetési eseményfigyelők megjelölését mint `passive`, hogy javuljon az oldal görgetést érintő teljesítménye. [További információ](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Nem használ passzív figyelőket a görgetés teljesítményének javításához"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Passzív figyelőket alkalmaz a görgetés teljesítményének javításához"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Leírás"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "A konzolon megjelenő hibák megoldatlan problémákat jeleznek. Okaik lehetnek sikertelen hálózati kérések, valamint más böngészős tényezők is."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "A böngészőhibák a konzolon láthatók"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Nem került böngészőhiba a konzolra"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Használja a betűtípus-megjelenítő CSS-funkciót annak biztosításához, hogy a szöveg már a webes betűtípusok betöltődése alatt látható legyen a felhasználó számára. [További információ](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Használja a CSS font-display leíróját, hogy a szövegek a webes betűtípusok betöltése közben is biztosan láthatók legyenek a felhasználók számára. [További információ](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Biztosítsa, hogy a szöveg látható marad a webes betűtípusok betöltése során"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Az összes szöveg látható marad a webes betűtípusok betöltésekor"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "A Lighthouse nem tudta automatikusan ellenőrizni a következő URL font-display értékét: {fontURL}"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Képarány (tényleges)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Képarány (megjelenített)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "A képmegjelenítési méretek ideális esetben természetes képarányt alkalmaznak. [További információ](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Hibás képaránnyal jeleníti meg a képeket"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Helyes képaránnyal jeleníti meg a képeket"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Érvénytelen képméretezési információ {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Nem biztonságos URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Minden webhelyet HTTPS-sel kell védeni, még akkor is, ha nem kezelnek bizalmas adatokat A HTTPS megakadályozza, hogy behatolók módosítsák vagy megfigyeljék az alkalmazás és a felhasználók közötti kommunikációt. Ezt a protokollt megköveteli a HTTP/2, valamint számos új webes API is. [További információ](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 nem biztonságos kérés}other{# nem biztonságos kérés}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Nem használ HTTPS-t"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "HTTPS-t használ"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "A mobilhálózatokon való gyors oldalbetöltés jó mobilos felhasználói élményt jelent. [További információ](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "A mobilhálózatokon is gyors oldalbetöltés jobb mobilos felhasználói élményt jelent. [További információ](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Ennyi idő telt el az interaktivitásig: {timeInMs, number, seconds} s"
+    "message": "{timeInMs, number, seconds} mp az interaktívvá válásig"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Ennyi idő telt el az interaktivitásig szimulált mobilhálózaton: {timeInMs, number, seconds} s"
+    "message": "Interaktívvá válás szimulált mobilhálózaton: {timeInMs, number, seconds} mp"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Az oldalbetöltés nem elég gyors mobilhálózatokon"
@@ -504,46 +735,52 @@
     "message": "Minimalizálja a fő szál terhelését"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Annak becsült értéke, hogy az alkalmazás mennyi idő alatt reagál – ezredmásodpercben (ms) megadva – a felhasználói adatbevitelre az oldalbetöltés legforgalmasabb 5 másodperces időkeretében. Ha a várakozási idő meghaladja az 50 ms-ot, a felhasználók késlekedést észlelhetnek az alkalmazás használata közben. [További információ](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "A becsült bemeneti késés annak a becsült értéke, hogy az alkalmazás mennyi idő alatt reagál – ezredmásodpercben (ms) megadva – a felhasználói interakciókra az oldalbetöltés legforgalmasabb 5 másodperces időkeretében. Ha a várakozási idő meghaladja az 50 ms-ot, a felhasználók lassúnak érezhetik az alkalmazást. [További információ](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Becsült bemeneti késés"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Az első vizuális tartalomválasz azt az időpontot jelöli, amikor a rendszer megkezdi az első szöveg vagy kép megjelenítését. [További információ.](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Az első vizuális tartalomválasz azt az időpontot jelöli, amikor a rendszer megkezdi az első szöveg vagy kép megjelenítését. [További információ](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Első, tartalommal rendelkező leképezés"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "Az első processzor-üresjárat mutató az első olyan alkalmat jelöli, amikor az oldal főszálának aktivitása elég alacsony ahhoz, hogy kezelni lehessen a bevitt mennyiséget. [További információ](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "Az első processzor-üresjárat mutató az első olyan alkalmat jelöli, amikor az oldal főszálának aktivitása elég alacsonnyá vált ahhoz, hogy kezelni tudja a felhasználói interakciókat. [További információ](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Első processzor-üresjárat"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Az első releváns leképezés azt méri, hogy mikor válik láthatóvá az adott oldal elsődleges tartalma. [További információ](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Az első releváns vizuális válasz azt méri, hogy mikor válik láthatóvá az oldal elsődleges tartalma. [További információ](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Első releváns leképezés"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Az interaktivitásig eltelt idő az az időmennyiség, amely ahhoz szükséges, hogy az oldal teljesen interaktívvá váljon. [További információ](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Az interaktivitásig eltelt idő az az idő, amely ahhoz szükséges, hogy az oldal teljesen interaktívvá váljon. [További információ](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Interaktivitásig eltelt idő"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "A felhasználók által tapasztalható, első interakciótól számított esetleges válaszkésés (First Input Delay, FID) a leghosszabb feladat időtartama (ezredmásodpercben)."
+    "message": "Az első interakciótól számított maximális potenciális válaszkésés a leghosszabb feladat időtartama ezredmásodpercben. [További információ](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Legnagyobb lehetséges FID"
+    "message": "Első interakciótól számított max. potenciális késés"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "A Sebességindex mutató azt jelzi, hogy az adott oldal tartalmai milyen gyorsan válnak láthatóvá. [További információ](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Sebességindex"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Az első vizuális tartalomválasz és az interaktivitásig eltelt idő közötti minden (50 ms-nál hosszabb feladatot jelentő) periódus időtartamának összege milliszekundumban kifejezve."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Blokkolás összideje"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "A hálózati oda-vissza út ideje (round trip time, RTT) nagy hatással van a teljesítményre. Ha túl magas az RTT értéke valamelyik eredet esetében, az azt jelenti, hogy a felhasználóhoz közelebbi szerverek javíthatják a teljesítményt. [További információ](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -552,31 +789,52 @@
     "message": "Oda-visszautak ideje a hálózaton"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "A szerverek várakozási ideje hatással lehet a webes teljesítményre. Ha valamelyik eredet szerverének várakozási ideje túl hosszú, az azt jelzi, hogy a szerver túl van terhelve, vagy hogy elégtelen a háttérrendszer teljesítménye. [További információ](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "A szerverek várakozási ideje hatással lehet a webes teljesítményre. Túlterhelést vagy nem megfelelő back-end teljesítmény jelez, ha az eredetszerver várakozási ideje túl magas. [További információ](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Várakozási idő a háttérszervereknél"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Büdzsén kívül"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "A hálózati kérések száma és mérete maradjon a megadott teljesítménybüdzsé célpontjai alatt. [További információ](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 kérés}other{# kérés}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Teljesítménybüdzsé"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Az átirányítások még azelőtt eredményeznek további késéseket, hogy az oldal betöltődhetne. [További információ](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Az átirányítások további késlekedéssel hosszabbítják meg az oldalbetöltéshez szükséges időt. [További információ](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Kerülje a többszörös oldalátirányítást"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Az oldal forrásainak mennyiségére és méretére vonatkozó büdzséket budget.json fájl hozzáadásával határozhatja meg. [További információ](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 kérés}other{# kérés}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "A kérések száma legyen kevés, az átvitelek pedig kis méretűek"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "A gyűjtőlinkek a keresési eredményben megjelenítendő URL-ekre tesznek javaslatot. [További információ](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "A gyűjtőlinkek a keresési eredményként megjelenítendő URL-re tesznek javaslatot. [További információ](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Több ütköző URL ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Másik domainre mutat ({url})"
+    "message": "Más domainre mutat ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Érvénytelen URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Másik „hreflang” helyre mutat ({url})"
+    "message": "Másik `hreflang` helyre mutat ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relatív URL ({url})"
@@ -585,25 +843,22 @@
     "message": "A domain gyökér-URL-jére (a kezdőlapra) mutat egyenértékű tartalommal rendelkező oldal helyett"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "A dokumentum nem rendelkezik érvényes „rel=canonical” attribútummal"
+    "message": "A dokumentumhoz nem tartozik érvényes `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "A dokumentum rendelkezik érvényes „rel=canonical” attribútummal"
+    "message": "A dokumentum érvényes `rel=canonical` attribútumot tartalmaz"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "A 12 képpontnál kisebb betűméretek nehezen láthatók, ezért a mobilhasználóknak ki kell nagyítaniuk a képernyőt, hogy elolvashassák a szöveget. Törekedjen arra, hogy az oldal szövegének legalább 60%-a minimum 12 képpontos betűmérettel szerepeljen. [További információ](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "A 12 képpontnál kisebb betűméretek nehezen láthatók, ezért a mobilhasználóknak a szöveget elolvasásához fel kell nagyítaniuk a képernyő tartalmát. Törekedjen arra, hogy az oldal szövegének legalább 60%-a minimum 12 képpontos betűmérettel jelenjen meg. [További információ](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "A szöveg {decimalProportion, number, extendedPercent}-a olvasható"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "A szöveg {decimalProportion, number, extendedPercent}-a túl kicsi."
+    "message": "{decimalProportion, number, extendedPercent}-nyi olvasható szöveg"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "A szöveg olvashatatlan, ugyanis a látható terület metacímkéje nincs optimalizálva a mobilképernyőkre"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "A szöveg {decimalProportion, number, extendedPercent}-a túl kicsi ({decimalProportionVisited, number, extendedPercent}-os minta alapján)."
+    "message": "A szöveg {decimalProportion, number, extendedPercent}-a túl kicsi (az összes szöveg {decimalProportionVisited, number, extendedPercent}-a alapján)."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "A dokumentum olvashatatlan betűméreteket használ"
@@ -612,13 +867,13 @@
     "message": "A dokumentum olvasható betűméreteket tartalmaz"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "A hreflang linkek azt mondják meg a keresőmotoroknak, hogy az oldal melyik változatát kell megjeleníteniük a keresési találatokban egy adott nyelv vagy régió esetében. [További információ](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "A hreflang linkek azt mondják meg a keresőmotoroknak, hogy nyelvtől vagy régiótól függően az oldal melyik változatát kell megjeleníteniük a keresési találatokban. [További információ](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "A dokumentum nem rendelkezik érvényes „hreflang” attribútummal"
+    "message": "A dokumentum nem rendelkezik érvényes `hreflang` attribútummal"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "A dokumentum rendelkezik érvényes „hreflang” attribútummal"
+    "message": "A dokumentum érvényes `hreflang` attribútumot tartalmaz"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "A sikertelenséget jelző HTTP-állapotkóddal rendelkező oldalak indexelése eredménytelen lehet. [További információ](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -630,7 +885,7 @@
     "message": "Az oldal sikerességet jelző HTTP-állapotkóddal rendelkezik"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "A keresőmotorok nem tudják megjeleníteni az oldalakat a keresési eredményben, ha nincs engedélyük a feltérképezésükre. [További információ](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "A keresőmotorok azokat az oldalakat nem tudják keresési eredményként megjeleníteni, amelyek feltérképezésére nincs engedélyük. [További információ](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Az oldal indexelését letiltották"
@@ -639,7 +894,7 @@
     "message": "Az oldalnál nincs letiltva az indexelés"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "A leíró jellegű linkszöveg segít a keresőmotoroknak a tartalom értelmezésében. [További információ](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "A leíró jellegű linkszövegek segítenek a keresőmotoroknak a tartalmak értelmezésében. [További információ](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 link található}other{# link található}}"
@@ -651,13 +906,13 @@
     "message": "A linkek leíró jellegű szöveggel rendelkeznek"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "A strukturált adatok ellenőrzéséhez használja a [Strukturált adatok tesztelőeszközét](https://search.google.com/structured-data/testing-tool/) és a [Structured Data Linter](http://linter.structured-data.org/) eszközt. [További információ](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Ellenőrizze a strukturált adatok érvényességét a [Strukturált adatok tesztelőeszköz](https://search.google.com/structured-data/testing-tool/) és a [Structured Data Linter](http://linter.structured-data.org/) segítségével. [További információ](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "A strukturált adatok érvényesek"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Az oldaltartalmat tömören összefoglaló metaleírások megjelenhetnek a keresési eredményben. [További információ](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Az oldaltartalom tömör összefoglalásának érdekében metaleírások szerepelhetnek a keresési eredményekben. [További információ](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "A Leírás mező üres."
@@ -669,7 +924,7 @@
     "message": "A dokumentum rendelkezik metaleírással"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "A keresőmotorok nem tudják indexelni a beépülő modulok tartalmát, és sok eszköz korlátozza vagy nem támogatja a beépülő modulokat. [További információ](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Sok eszköz korlátozza vagy nem támogatja a beépülő modulokat, a keresőmotorok pedig nem tudják indexelni a modulok által megjelenített tartalmakat. [További információ](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "A dokumentum beépülő modulokat használ"
@@ -681,7 +936,7 @@
     "message": "Ha a robots.txt fájl formázása rossz, előfordulhat, hogy a feltérképező robotok nem tudják értelmezni, hogy Ön hogyan szeretné feltérképeztetni vagy indexeltetni a webhelyét."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "A robots.txt fájlra irányuló kérésre a következő HTTP-állapotkód érkezett vissza: {statusCode}"
+    "message": "A robots.txt fájlra irányuló kérés a következő HTTP-állapotkóddal tért vissza: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{1 hiba található}other{# hiba található}}"
@@ -696,10 +951,10 @@
     "message": "A robots.txt fájl érvényes"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "A nagy méretű (48 × 48 képpont) gombok, linkek és más interaktív elemek körül elég területnek kell lennie ahhoz, hogy a felhasználó ne érjen hozzá más elemekhez, amikor rájuk koppint. [További információ](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Az interaktív elemeknek (például a gomboknak és a linkeknek) elég nagynak kell lenniük (48 × 48 képpont), és elég helynek kell lennie közöttük, hogy könnyen rájuk lehessen koppintani a szomszédos elemek megérintése nélkül. [További információ](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "A koppintási célok {decimalProportion, number, percent}-a megfelelő méretű"
+    "message": "{decimalProportion, number, percent}-nyi megfelelően méretezett koppintható elem"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "A koppintási célok túl kicsik, ugyanis a látható terület metacímkéje nincs optimalizálva a mobilképernyőkre"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Átfedésben lévő cél"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Méret"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Koppintási cél"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "A koppintási célok mérete megfelelő"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Főszálon töltött idő"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Harmadik fél"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "A harmadik felektől származó kódok jelentős hatással lehetnek a betöltés teljesítményére. Minél kevesebb harmadik féltől származó kódot használjon, és lehetőleg azután töltse be őket, hogy az oldal nagyrészt már betöltődött. [További információ](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 harmadik fél}other{# harmadik fél}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Harmadik féltől származó kód"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Az „első bájtig eltelt idő” mutató az Ön szervere válaszidejét jelöli. [További információ](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "Az első bájtig eltelt idő azt mutatja, hogy a szerver mikor küldött választ. [További információ](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "A gyökérdokumentum betöltése ennyi időt vett igénybe: {timeInMs, number, milliseconds} ms"
+    "message": "{timeInMs, number, milliseconds} ms a gyökérdokumentumhoz"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "Csökkentse a szerver válaszidejét (TTFB)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Időtartam"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Név"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Kezdés ideje"
   },
@@ -744,7 +1008,7 @@
     "message": "Típus"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Érdemes felhasználnia alkalmazásában a User Timing API-t, amellyel valós használat során mért teljesítményadatokat kaphat a legfontosabb felhasználói műveletekről. [További információ.](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Érdemes lehet felhasználnia alkalmazásában a User Timing API-t, amellyel valós használat során mért teljesítményadatokat kaphat a legfontosabb felhasználói műveletekről. [További információ](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 felhasználói időmérés}other{# felhasználói időmérés}}"
@@ -753,19 +1017,19 @@
     "message": "Felhasználói időzítőjelek és intézkedések"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Előcsatlakozási <link> található a \"{securityOrigin}\" objektumnál, de nem használja a böngésző. Ellenőrizze, hogy megfelelően használja-e a „crossorigin” attribútumot."
+    "message": "Előcsatlakozási <link> található a(z) {securityOrigin} címre vonatkozóan, de a böngésző nem használta. Ellenőrizze, hogy megfelelően használja-e a(z) `crossorigin` attribútumot."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Vegye fontolóra előcsatlakozási vagy előzetes DNS-lehívási erőforrástippek hozzáadását, hogy korai kapcsolatokat hozhasson létre harmadik felek fontos forrásaival. [További információ](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Vegye fontolóra előcsatlakozási vagy előzetes DNS-lehívási erőforrástippek hozzáadását, hogy korai kapcsolatokat hozhasson létre a harmadik felekhez tartozó fontos forrásokkal. [További információ](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Csatlakozzon előre a szükséges forrásokhoz"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "A „{preloadURL}” előtöltési <link> elemmel rendelkezik, de a böngésző nem használta. Ellenőrizze, hogy megfelelően használja-e a „crossorigin” attribútumot."
+    "message": "Előtöltési <link> található a(z) {preloadURL} címre vonatkozóan, de a böngésző nem használta. Ellenőrizze, hogy megfelelően használja-e a(z) `crossorigin` attribútumot."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Fontolja meg a <link rel=preload> parancs használatát az olyan erőforrások lekérdezésének rangsorolásához, amelyek az adott pillanatban az oldal betöltése során később következőként szerepelnek. [További információ](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Fontolja meg a(z) `<link rel=preload>` használatát, hogy prioritással tölthesse be azokat a forrásokat, melyeket az aktuális oldalbetöltés egyébként későbbre sorolt. [További információ](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Töltse be előre a kulcsfontosságú kéréseket"
@@ -789,10 +1053,10 @@
     "message": "Bevált módszerek"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Ezek az ellenőrzések kiemelik az [internetes alkalmazás kisegítő lehetőségeinek javítására] irányuló lehetőségeket(https://developers.google.com/web/fundamentals/accessibility). A kisegítő lehetőségekkel kapcsolatos problémáknak csak egy részét lehet automatikusan észlelni, ezért manuális ellenőrzés végrehajtása is ajánlott."
+    "message": "Ezek az ellenőrzések olyan lehetőségeket emelnek ki, melyekkel javíthatók a [webalkalmazás kisegítő lehetőségei](https://developers.google.com/web/fundamentals/accessibility). A kisegítő lehetőségekkel kapcsolatos problémáknak csak egy része észlelhető automatikusan, ezért a manuális ellenőrzés is ajánlott."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Ezek az elemek automatikus tesztelőeszközzel ellenőrizhetetlen területeken vannak. Olvassa el a [kisegítő lehetőségek felülvizsgálatáról](https://developers.google.com/web/fundamentals/accessibility/how-to-review) szóló útmutatónkat."
+    "message": "Az alábbiak automatikus tesztelőeszközzel nem ellenőrizhető területekre vonatkoznak. További információt a [kisegítő lehetőségek felülvizsgálatáról](https://developers.google.com/web/fundamentals/accessibility/how-to-review) szóló útmutatónkban talál."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Kisegítő lehetőségek"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Táblázatok és listák"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Bevált módszerek"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "A teljesítménybüdzsék elvárásokat határoznak meg a webhely teljesítményére vonatkozóan."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Büdzsék"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "További információ alkalmazása teljesítményéről."
+    "message": "További információ alkalmazása teljesítményéről. Ezek a számok [nem befolyásolják közvetlenül](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) a teljesítménypontszámot."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnosztika"
@@ -840,7 +1113,7 @@
     "message": "Az első leképezést érintő fejlesztések"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Ezek az optimalizációk felgyorsíthatják oldala betöltési idejét."
+    "message": "Ezek a javaslatok segíthetnek az oldalbetöltés felgyorsításában. Mindazonáltal a teljesítménypontszámra [nincs közvetlen hatásuk](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Lehetőségek"
@@ -867,7 +1140,7 @@
     "message": "PWA-optimalizálás"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Ezekkel az ellenőrzésekkel győződhet meg arról, hogy oldala optimalizálva van a keresőmotorok találati rangsorolásához. Vannak olyan egyéb, a Lighthouse által nem ellenőrzött tényezők is, amelyek befolyásolhatják a keresésekben elért helyezést. [További információ](https://support.google.com/webmasters/answer/35769)."
+    "message": "Ezekkel az ellenőrzésekkel győződhet meg arról, hogy oldala megfelelően optimalizált-e a keresőmotorok találati rangsorolásához. Vannak olyan egyéb, a Lighthouse által nem ellenőrzött tényezők is, amelyek befolyásolhatják a keresésekben elért helyezést. [További információ](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Ha ezeket a további érvényesítőket is futtatja webhelyén, egyéb bevált SEO-módszereket is ellenőrizhet."
@@ -888,7 +1161,7 @@
     "message": "Feltérképezés és indexelés"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Gondoskodjon oldalai mobilbaráttá tételéről, hogy a felhasználóknak ne kelljen ráközelíteniük a tartalmak elolvasásához. [További információ](https://developers.google.com/search/mobile-sites/)."
+    "message": "Ha mobilbarát oldalakat készít, a tartalmak felnagyítás nélkül is olvashatók lesznek. [További információ](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Mobilbarát"
@@ -896,35 +1169,77 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Gyorsítótár-TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Hely"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Név"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Kérések"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Forrás típusa"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Méret (kB)"
+    "message": "Méret"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Eltöltött idő"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Átviteli méret"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potenciális megtakarítás (kB)"
+    "message": "Potenciális megtakarítás"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potenciális megtakarítás (ms)"
+    "message": "Potenciális megtakarítás"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "{wastedBytes, number, bytes} kB potenciális megtakarítás"
+    "message": "Potenciálisan {wastedBytes, number, bytes} KB megtakarítás"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "Potenciális megtakarítás értéke: {wastedMs, number, milliseconds} ms"
+    "message": "Potenciálisan {wastedMs, number, milliseconds} ms megtakarítás"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokumentum"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Betűtípus"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Kép"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Média"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Egyéb"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Szkript"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} s"
+    "message": "{timeInMs, number, seconds} mp"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stíluslap"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Harmadik féltől származó"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Összes"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Valami hiba történt a nyom rögzítésekor az oldal betöltése során. Futtassa újra a Lighthouse szolgáltatást. ({errorCode})"
+    "message": "Hiba történt az oldalbetöltés nyomának rögzítése során. Futtassa újra a Lighthouse szolgáltatást. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Időtúllépés a hibaelhárító protokoll kezdeti kapcsolatára való várakozás során."
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "A DNS-szerverek nem tudták értelmezni a megadott domaint."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "A szükséges {artifactName} begyűjtő hibába ütközött: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Belső Chrome-hiba történt. Indítsa újra a Chrome-ot, és próbálja újra futtatni a Lighthouse szolgáltatást."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "A kötelező {artifactName} nem futott le."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "A Lighthouse nem tudta megfelelően betölteni a kért oldalt. Győződjön meg arról, hogy a helyes URL-t teszteli, és a szerver megfelelően válaszol az összes kérelemre."
@@ -945,19 +1266,22 @@
     "message": "A Lighthouse nem tudta megfelelően betölteni a kért URL-t, mert az oldal nem válaszol."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "A megadott URL nem rendelkezik érvényes biztonsági tanúsítvánnyal. {securityMessages}"
+    "message": "A megadott URL-hez nem tartozik érvényes biztonsági tanúsítvány. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "A Chrome közbeiktatott képernyő megjelenítésével megakadályozta az oldal betöltését. Ellenőrizze, hogy a helyes URL-t teszteli-e, és hogy a szerver minden kérésre megfelelően reagál-e."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "A Lighthouse nem tudta megfelelően betölteni a kért oldalt. Győződjön meg arról, hogy a helyes URL-t teszteli, és a szerver megfelelően válaszol az összes kérelemre. (Részletek: {errorDetails})"
+    "message": "A Lighthouse nem tudta megbízhatóan betölteni a kért oldalt. Ellenőrizze, hogy a helyes URL-t teszteli-e, és hogy a szerver minden kérésre megfelelően reagál-e. (Részletek: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "A Lighthouse nem tudta megfelelően betölteni a kért oldalt. Győződjön meg arról, hogy a helyes URL-t teszteli, és a szerver megfelelően válaszol az összes kérelemre. (Állapotkód: {statusCode})"
+    "message": "A Lighthouse nem tudta megbízhatóan betölteni a kért oldalt. Ellenőrizze, hogy a helyes URL-t teszteli-e, és hogy a szerver minden kérésre megfelelően reagál-e. (Állapotkód: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Túl sokáig tartott az oldal betöltése. Kövesse a jelentésben leírt lehetőséget az oldalbetöltési idő csökkentéséhez, majd próbálja újra futtatni a Lighthouse szolgáltatást. ({errorCode})"
+    "message": "Túl sokáig tartott az oldal betöltése. Csökkentse az oldalbetöltési időt a jelentésben leírt lehetőségeket követve, majd futtassa újra a Lighthouse-t. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "A DevTools protokoll válaszára való várakozás túllépte a megengedett időt. Módszer: {protocolMethod})"
+    "message": "A DevTools protokoll válaszára való várakozás túllépte a megengedett időt. (Módszer: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "A tartalom lekérése túllépte a megengedett időt"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Kódrészlet kibontása"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Harmadik féltől származó források megjelenítése"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "A Lighthouse-futtatást befolyásoló problémák fordultak elő:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Az értékek becsültek és változhatnak."
+    "message": "Az értékek becsültek és változhatnak. A teljesítménypontszám [csak ezeken a mutatókon alapszik](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Átment az ellenőrzéseken – figyelmeztetésekkel"
@@ -1026,7 +1353,7 @@
     "message": "Telepítsen [lusta betöltést biztosító WordPress-bővítményt](https://wordpress.org/plugins/search/lazy+load/), amely lehetőséget ad a képernyőn kívül eső képek késleltetett betöltésére – vagy váltson olyan témára, amely rendelkezik ezzel a funkcióval. Fontolja meg az [AMP-bővítmény](https://wordpress.org/plugins/amp/) használatát is."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Számos WordPress-bővítmény segíthet a [kritikus elemek beágyazásában](https://wordpress.org/plugins/search/critical+css/) vagy a [kevésbé fontos források késleltetésében](https://wordpress.org/plugins/search/defer+css+javascript/). Fontos, hogy az ilyen jellegű bővítmények által nyújtott optimalizációk működésképtelenné tehetik a témák vagy más bővítmények funkcióit, ezért valószínűleg módosítania kell majd a meglévő kódot."
+    "message": "Számos WordPress-bővítmény segíthet a [kritikus elemek beágyazásában](https://wordpress.org/plugins/search/critical+css/) és a [kevésbé fontos források](https://wordpress.org/plugins/search/defer+css+javascript/) késleltetésében. Fontos, hogy az ilyen jellegű bővítmények által nyújtott optimalizációk működésképtelenné tehetik a témák vagy más bővítmények funkcióit, ezért valószínűleg módosítania kell majd a meglévő kódot."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "A témák, a bővítmények és a szerver specifikációi mind befolyásolják a szerver válaszidejét. Érdemes lehet jobban optimalizált témát keresnie, megfelelő optimalizáló bővítményt választania és/vagy nagyobb teljesítményű szerverre váltania."
@@ -1035,30 +1362,30 @@
     "message": "Fontolja meg kivonatok megjelenítését a bejegyzéslistákban (pl. a more címkével), az oldalanként megjelenített bejegyzések számának csökkentését, a hosszabb bejegyzések több oldalra tördelését, valamint a hozzászólások lusta betöltését bővítmény segítségével."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Számos [WordPress-bővítmény](https://wordpress.org/plugins/search/minify+css/) gyorsíthat webhelyén a stíluslapok egyesítésével, minimalizálásával és tömörítésével. Ha lehetséges, a minimalizálást érdemes lehet buildfolyamat használatával előre elvégezni."
+    "message": "Számos [WordPress-bővítmény](https://wordpress.org/plugins/search/minify+css/) gyorsíthat webhelyén a stíluslapok egyesítésével, minimalizálásával és tömörítésével. Ha lehetséges, a minimalizálást érdemes buildfolyamat használatával előre elvégezni."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Számos [WordPress-bővítmény](https://wordpress.org/plugins/search/minify+javascript/) gyorsíthat webhelyén a szkriptek egyesítésével, minimalizálásával és tömörítésével. Ha lehetséges, a minimalizálást érdemes lehet buildfolyamat használatával előre elvégezni."
+    "message": "Számos [WordPress-bővítmény](https://wordpress.org/plugins/search/minify+javascript/) gyorsíthat webhelyén a szkriptek egyesítésével, minimalizálásával és tömörítésével. Ha lehetséges, a minimalizálást érdemes buildfolyamat használatával előre elvégezni."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Fontolja meg az oldalán a nem használt CSS-t betöltő [WordPress-bővítmények](https://wordpress.org/plugins/) lecserélését, illetve számuk csökkentését. A felesleges CSS-t elhelyező bővítmények azonosításában a Chrome DevTools [kódlefedettség](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) funkciója is segíthet. A felelős téma vagy bővítmény a stíluslap URL-je alapján azonosítható. Keressen olyan bővítményeket, amelyeknek több stíluslapjában is sok piros szín szerepel a kódlefedettségi listán. Ideális esetben a bővítmények csak az oldalon ténylegesen használt stíluslapokat állítják sorba."
+    "message": "Fontolja meg a nem használt CSS-t betöltő [WordPress-bővítmények](https://wordpress.org/plugins/) lecserélését, vagy számuk csökkentését. A felesleges CSS-t elhelyező bővítmények azonosításában a Chrome DevTools [kódlefedettség](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) eszköze is segíthet. A felelős téma vagy bővítmény a stíluslap URL-je alapján azonosítható. Keressen olyan bővítményeket, amelyeknek több stíluslapjában is sok piros szín szerepel a kódlefedettségi listán. Ideális esetben a bővítmények csak az oldalon ténylegesen használt stíluslapokat állítják sorba."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Fontolja meg az oldalán a nem használt JavaScriptet betöltő [WordPress-bővítmények](https://wordpress.org/plugins/) lecserélését, illetve számuk csökkentését. A felesleges JS-t elhelyező bővítmények azonosításában a Chrome DevTools [kódlefedettség](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) funkciója is segíthet. A felelős téma vagy bővítmény a szkript URL-je alapján azonosítható. Keressen olyan bővítményeket, amelyeknek több szkriptjében is sok piros szín szerepel a kódlefedettségi listán. Ideális esetben a bővítmények csak az oldalon ténylegesen használt szkripteket állítják sorba."
+    "message": "Fontolja meg a nem használt JavaScriptet betöltő [WordPress-bővítmények](https://wordpress.org/plugins/) lecserélését vagy számuk csökkentését. A felesleges JavaScriptet elhelyező bővítmények azonosításában a Chrome DevTools [kódlefedettség](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) eszköze is segíthet. A felelős téma vagy bővítmény a szkript URL-je alapján azonosítható. Keressen olyan bővítményeket, amelyeknek több szkriptjében is sok piros szín szerepel a kódlefedettségi listán. Ideális esetben a bővítmények csak az oldalon ténylegesen használt szkripteket állítják sorba."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "További információ: [Böngészős gyorsítótárazás a WordPress rendszerében](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "További információ a [WordPress böngészős gyorsítótárazásáról](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Fontolja meg [képoptimalizáló WordPress-bővítmény használatát](https://wordpress.org/plugins/search/optimize+images/), mellyel minőségromlás nélkül tömöríthetők a képek."
+    "message": "Fontolja meg olyan [képoptimalizáló WordPress-bővítmény](https://wordpress.org/plugins/search/optimize+images/) használatát, mellyel minőségromlás nélkül tömöríthetők a képek."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "A képeket közvetlenül a [Media Library](https://codex.wordpress.org/Media_Library_Screen) oldalán keresztül töltse fel, hogy biztosan rendelkezésre álljanak a szükséges képméretek. Ezt követően pedig a Media Library oldaláról vagy az Image Widget bővítménnyel illessze be őket, hogy az optimális képméreteket alkalmazhassa (a reszponzív töréspontok esetében is). Teljes méretű képeket csak akkor használjon, ha méretük megfelel a felhasználás módjának. [További információ](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "A képeket közvetlenül a [Media Library](https://codex.wordpress.org/Media_Library_Screen) felületén töltse fel, hogy biztosan minden szükséges képméret rendelkezésre álljon, ezután pedig innen szúrja be őket, vagy használja az Image Widgetet, hogy biztosan az optimális képméreteket alkalmazza (a reszponzív töréspontok esetében is) `Full Size` képeket csak akkor használjon, ha méretük megfelel a felhasználás módjának. [További információ](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "A szövegtömörítést a webszerver konfigurációjában engedélyezheti."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Fontolja meg olyan [bővítmény](https://wordpress.org/plugins/search/convert+webp/) vagy szolgáltatás használatát, amely automatikusan optimális formátumba konvertálja a feltöltött képeket."
+    "message": "Érdemes olyan [bővítményt](https://wordpress.org/plugins/search/convert+webp/) vagy szolgáltatást használnia, amely automatikusan az optimális formátumba konvertálja a feltöltött képeket."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/id.json
+++ b/lighthouse-core/lib/i18n/locales/id.json
@@ -1,15 +1,15 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Kunci akses memungkinkan pengguna memfokuskan bagian halaman dengan cepat. Untuk navigasi yang tepat, setiap kunci akses harus unik. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Kunci akses memungkinkan pengguna memfokuskan bagian halaman dengan cepat. Untuk navigasi yang tepat, setiap kunci akses harus unik. [Pelajari lebih lanjut](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Nilai `[accesskey]` tidak unik"
+    "message": "Nilai `[accesskey]` tidak unik."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Nilai `[accesskey]` unik"
+    "message": "Nilai `[accesskey]` bersifat unik"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Setiap `role` ARIA mendukung subset tertentu dari atribut `aria-*`. Ketidakcocokan dalam hal tersebut menjadikan atribut `aria-*` tidak valid. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Setiap ARIA `role` mendukung subset tertentu dari atribut `aria-*`. Membatalkan pencocokan ini akan membuat atribut `aria-*` menjadi tidak valid. [Pelajari lebih lanjut](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
     "message": "Atribut `[aria-*]` tidak cocok dengan perannya"
@@ -18,25 +18,25 @@
     "message": "Atribut `[aria-*]` cocok dengan perannya"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Beberapa peran ARIA memiliki atribut wajib yang menjelaskan status elemen ke pembaca layar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Beberapa peran ARIA memiliki atribut wajib yang menjelaskan status elemen ke pembaca layar. [Pelajari lebih lanjut](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
     "message": "`[role]` tidak memiliki semua atribut `[aria-*]` yang diperlukan"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "`[role]` memiliki semua atribut `[aria-*]` wajib"
+    "message": "`[role]` memiliki semua atribut `[aria-*]` yang diperlukan"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Beberapa peran induk ARIA harus memuat peran turunan tertentu agar dapat menjalankan fungsi aksesibilitas yang diinginkan. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Beberapa peran induk ARIA harus memuat peran turunan tertentu agar dapat menjalankan fungsi aksesibilitas yang diinginkan. [Pelajari lebih lanjut](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Elemen dengan `[role]` yang memerlukan `[role]` turunan tertentu tidak ada."
+    "message": "Tidak ada elemen dengan `[role]` yang memerlukan `[role]` turunan tertentu."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Elemen dengan `[role]` yang memerlukan `[role]` turunan tertentu sudah ada"
+    "message": "Elemen dengan `[role]` yang memerlukan `[role]` turunan tertentu sudah ada."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Beberapa peran turunan ARIA harus dimuat oleh peran induk tertentu agar dapat menjalankan fungsi aksesibilitas yang diinginkan dengan tepat. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Beberapa peran turunan ARIA harus dimuat oleh peran induk tertentu agar dapat menjalankan fungsi aksesibilitas yang diinginkan dengan tepat. [Pelajari lebih lanjut](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
     "message": "`[role]` tidak dimuat oleh elemen induk wajibnya"
@@ -45,7 +45,7 @@
     "message": "`[role]` dimuat oleh elemen induk wajibnya"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Peran ARIA harus memiliki nilai yang valid agar dapat menjalankan fungsi aksesibilitas yang diinginkan. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Peran ARIA harus memiliki nilai yang valid agar dapat menjalankan fungsi aksesibilitas yang diinginkan. [Pelajari lebih lanjut](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
     "message": "Nilai `[role]` tidak valid"
@@ -54,7 +54,7 @@
     "message": "Nilai `[role]` valid"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Teknologi asistif, seperti pembaca layar, tidak dapat menafsirkan atribut ARIA dengan nilai yang tidak valid. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Teknologi asistif, seperti pembaca layar, tidak dapat menafsirkan atribut ARIA dengan nilai yang tidak valid. [Pelajari lebih lanjut](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
     "message": "Atribut `[aria-*]` tidak memiliki nilai yang valid"
@@ -63,7 +63,7 @@
     "message": "Atribut `[aria-*]` memiliki nilai yang valid"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Teknologi asistif, seperti pembaca layar, tidak dapat menafsirkan atribut ARIA dengan nama yang tidak valid. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Teknologi asistif, seperti pembaca layar, tidak dapat menafsirkan atribut ARIA dengan nama yang tidak valid. [Pelajari lebih lanjut](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
     "message": "Atribut `[aria-*]` tidak valid atau salah eja"
@@ -72,7 +72,7 @@
     "message": "Atribut `[aria-*]` valid dan tidak salah eja"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Teks membuat elemen audio mudah digunakan oleh pengguna yang menyandang gangguan pendengaran atau tunarungu, sehingga memberikan informasi penting seperti siapa yang berbicara, apa yang diucapkan, dan informasi non-lisan lainnya. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Teks membuat elemen audio mudah digunakan oleh pengguna yang menyandang gangguan pendengaran atau tunarungu, sehingga memberikan informasi penting seperti siapa yang berbicara, apa yang diucapkan, dan informasi non-lisan lainnya. [Pelajari lebih lanjut](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
     "message": "Elemen `<audio>` tidak memiliki elemen `<track>` dengan `[kind=\"captions\"]`."
@@ -84,7 +84,7 @@
     "message": "Elemen yang Gagal"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Jika tombol tidak memiliki nama yang dapat diakses, pembaca layar akan mengucapkannya sebagai \"tombol\", yang tidak dapat digunakan oleh pengguna yang mengandalkan pembaca layar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Jika tombol tidak memiliki nama yang dapat diakses, pembaca layar akan mengucapkannya sebagai \"tombol\", sehingga tidak dapat digunakan oleh pengguna yang mengandalkan pembaca layar. [Pelajari lebih lanjut](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Tombol tidak memiliki nama yang dapat diakses"
@@ -93,7 +93,7 @@
     "message": "Tombol memiliki nama yang dapat diakses"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Dengan menambahkan cara untuk mengabaikan konten berulang, pengguna keyboard dapat membuka halaman dengan lebih efisien. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Dengan menambahkan cara untuk mengabaikan konten berulang, pengguna keyboard dapat membuka halaman dengan lebih efisien. [Pelajari lebih lanjut](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Halaman ini tidak memuat judul, link lewati, atau wilayah landmark"
@@ -102,7 +102,7 @@
     "message": "Halaman ini memuat judul, link lewati, atau wilayah landmark"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Teks yang memiliki kontras rendah sulit atau tidak mungkin dibaca oleh kebanyakan pengguna. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Teks yang memiliki kontras rendah sulit atau tidak mungkin dibaca oleh kebanyakan pengguna. [Pelajari lebih lanjut](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Warna latar belakang dan latar depan tidak memiliki rasio kontras yang cukup."
@@ -111,16 +111,16 @@
     "message": "Warna latar belakang dan latar depan memiliki rasio kontras yang cukup"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Jika daftar definisi tidak di-markup dengan tepat, pembaca layar dapat menghasilkan output yang membingungkan atau tidak akurat. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Jika daftar definisi tidak di-markup dengan tepat, pembaca layar dapat menghasilkan output yang membingungkan atau tidak akurat. [Pelajari lebih lanjut](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "`<dl>` tidak hanya memuat grup `<dt>` dan `<dd>`, `<script>`, atau elemen `<template>` yang diurutkan dengan tepat."
+    "message": "`<dl>` tidak memuat grup `<dt>` dan `<dd>`, `<script>`, atau elemen `<template>` yang diurutkan dengan tepat."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
     "message": "`<dl>` hanya memuat grup `<dt>` dan `<dd>`, `<script>`, atau elemen `<template>` yang diurutkan dengan tepat."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Item daftar definisi (`<dt>` dan `<dd>`) harus tergabung dalam elemen `<dl>` induk untuk memastikan bahwa pembaca layar dapat mengucapkannya dengan tepat. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Item daftar definisi (`<dt>` dan `<dd>`) harus tergabung dalam elemen `<dl>` induk untuk memastikan bahwa pembaca layar dapat mengucapkannya dengan tepat. [Pelajari lebih lanjut](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
     "message": "Item daftar definisi tidak tergabung dalam elemen `<dl>`"
@@ -129,7 +129,7 @@
     "message": "Item daftar definisi tergabung dalam elemen `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Judul ini memberi pengguna pembaca layar ringkasan halaman, dan pengguna mesin telusur sangat mengandalkannya untuk menentukan apakah halaman relevan dengan penelusurannya atau tidak. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Judul ini memberi pengguna pembaca layar ringkasan halaman, dan pengguna mesin telusur sangat mengandalkannya untuk menentukan apakah halaman relevan dengan penelusurannya atau tidak. [Pelajari lebih lanjut](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "Dokumen tidak memiliki elemen `<title>`"
@@ -138,7 +138,7 @@
     "message": "Dokumen memiliki elemen `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Nilai atribut id harus unik untuk mencegah instance lain terabaikan oleh teknologi asistif. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Nilai atribut ID harus unik untuk mencegah instance lain terabaikan oleh teknologi asistif. [Pelajari lebih lanjut](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
     "message": "Atribut `[id]` di halaman ini tidak unik"
@@ -147,7 +147,7 @@
     "message": "Atribut `[id]` di halaman ini unik"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Pengguna pembaca layar mengandalkan judul bingkai untuk menjelaskan isi bingkai. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Pengguna pembaca layar mengandalkan judul bingkai untuk menjelaskan isi bingkai. [Pelajari lebih lanjut](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "Elemen `<frame>` atau `<iframe>` tidak memiliki judul"
@@ -156,7 +156,7 @@
     "message": "Elemen `<frame>` atau `<iframe>` memiliki judul"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Jika halaman tidak menentukan atribut bahasa, pembaca layar akan mengasumsikan bahwa halaman menggunakan bahasa default yang dipilih pengguna saat menyiapkan pembaca layar. Jika halaman tidak dalam bahasa default, maka pembaca layar mungkin tidak mengucapkan teks di halaman tersebut dengan benar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Jika halaman tidak menentukan atribut bahasa, pembaca layar akan mengasumsikan bahwa halaman menggunakan bahasa default yang dipilih pengguna saat menyiapkan pembaca layar. Jika halaman tidak dalam bahasa default, pembaca layar mungkin tidak dapat mengucapkan teks di halaman tersebut dengan benar. [Pelajari lebih lanjut](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
     "message": "Elemen `<html>` tidak memiliki atribut `[lang]`"
@@ -165,7 +165,7 @@
     "message": "Elemen `<html>` memiliki atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Menentukan [BCP 47 language] (https://www.w3.org/International/questions/qa-choosing-language-tags#question) yang valid akan membantu pembaca layar mengucapkan teks dengan tepat. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Menentukan [bahasa BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) yang valid akan membantu pembaca layar mengucapkan teks dengan tepat. [Pelajari lebih lanjut](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
     "message": "Elemen `<html>` tidak memiliki nilai yang valid untuk atribut `[lang]`-nya."
@@ -174,16 +174,16 @@
     "message": "Elemen `<html>` memiliki nilai yang valid untuk atribut `[lang]`-nya"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Elemen informatif harus memberikan teks alternatif yang singkat dan deskriptif. Elemen dekoratif dapat diabaikan dengan atribut alt yang kosong. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Elemen informatif harus memberikan teks alternatif yang singkat dan deskriptif. Elemen dekoratif dapat diabaikan dengan atribut alt kosong. [Pelajari lebih lanjut](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
     "message": "Elemen gambar tidak memiliki atribut `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Elemen gambar memiliki atribut `[alt]`"
+    "message": "Elemen halaman memiliki atribut `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Saat suatu gambar digunakan sebagai tombol `<input>`, menyediakan teks alternatif dapat membantu pengguna pembaca layar memahami fungsi tombol tersebut. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Saat suatu gambar digunakan sebagai tombol `<input>`, menyediakan teks alternatif dapat membantu pengguna pembaca layar memahami fungsi tombol tersebut. [Pelajari lebih lanjut](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "Elemen `<input type=\"image\">` tidak memiliki teks `[alt]`"
@@ -192,7 +192,7 @@
     "message": "Elemen `<input type=\"image\">` memiliki teks `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Label memastikan bahwa kontrol bentuk diucapkan dengan tepat oleh teknologi asistif, seperti pembaca layar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Label memastikan bahwa kontrol bentuk diucapkan dengan tepat oleh teknologi asistif, seperti pembaca layar. [Pelajari lebih lanjut](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Elemen formulir tidak memiliki label yang terkait"
@@ -201,16 +201,16 @@
     "message": "Elemen formulir memiliki label yang terkait"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Tabel yang digunakan untuk tujuan tata letak sebaiknya tidak mencakup elemen data, seperti elemen th atau teks atau atribut ringkasan, karena hal ini dapat menyebabkan pengalaman yang membingungkan bagi pengguna pembaca layar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Tabel yang digunakan untuk tujuan tata letak sebaiknya tidak mencakup elemen data, seperti elemen th atau teks atau atribut ringkasan karena hal ini dapat menyebabkan pengalaman yang membingungkan bagi pengguna pembaca layar. [Pelajari lebih lanjut](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Elemen `<table>` presentasional tidak menghindari penggunaan `<th>`, `<caption>`, atau atribut `[summary]`."
+    "message": "Elemen `<table>` presentasional tidak menghindari penggunaan atribut `<th>`, `<caption>`, atau `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Elemen `<table>` presentasional menghindari penggunaan `<th>`, `<caption>`, atau atribut `[summary]`."
+    "message": "Elemen `<table>` yang bersifat presentasional menghindari penggunaan atribut `<th>`, `<caption>`, atau `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Teks link (dan teks alternatif untuk gambar, saat digunakan sebagai link) yang mudah dilihat, unik, dan dapat difokuskan meningkatkan pengalaman navigasi bagi pengguna pembaca layar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Teks link (dan teks alternatif untuk gambar, saat digunakan sebagai link) yang mudah dilihat, unik, dan dapat difokuskan menyempurnakan pengalaman navigasi bagi pengguna pembaca layar. [Pelajari lebih lanjut](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Link tidak memiliki nama yang dapat dikenali"
@@ -219,34 +219,34 @@
     "message": "Link memiliki nama yang dapat dikenali"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Pembaca layar memiliki cara tertentu untuk membacakan daftar. Memastikan struktur daftar dengan tepat akan membantu output pembaca layar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Pembaca layar memiliki cara tertentu untuk membacakan daftar. Memastikan struktur daftar dengan tepat akan membantu output pembaca layar. [Pelajari lebih lanjut](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Daftar tidak hanya memuat elemen `<li>` dan skrip yang mendukung elemen (`<script>` dan `<template>`)."
+    "message": "Daftar tidak hanya berisi elemen `<li>` dan skrip yang mendukung elemen (`<script>` dan `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
     "message": "Daftar hanya memuat elemen `<li>` dan skrip yang mendukung elemen (`<script>` dan `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Pembaca layar mengharuskan item daftar (`<li>`) dimuat dalam `<ul>` atau `<ol>` induk agar dapat diucapkan dengan tepat. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Pembaca layar mengharuskan item daftar (`<li>`) untuk dimuat dalam `<ul>` atau `<ol>` induk agar dapat diucapkan dengan tepat. [Pelajari lebih lanjut](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Item daftar (`<li>`) tidak dimuat dalam elemen induk `<ul>` atau `<ol>`."
+    "message": "Daftar item (`<li>`) tidak dimuat dalam elemen induk `<ul>` atau `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
     "message": "Item daftar (`<li>`) dimuat dalam elemen induk `<ul>` atau `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Pengguna tidak mengharapkan halaman dimuat ulang secara otomatis, karena tindakan tersebut akan memindahkan fokus kembali ke bagian atas halaman. Hal ini dapat menimbulkan pengalaman yang menjengkelkan atau membingungkan. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Pengguna tidak mengharapkan halaman dimuat ulang secara otomatis, karena tindakan tersebut akan memindahkan fokus kembali ke bagian atas halaman. Hal ini dapat menimbulkan pengalaman yang menjengkelkan atau membingungkan. [Pelajari lebih lanjut](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokumen ini menggunakan `<meta http-equiv=\"refresh\">`"
+    "message": "Dokumen menggunakan `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
     "message": "Dokumen tidak menggunakan `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Menonaktifkan zoom akan menimbulkan masalah bagi pengguna dengan gangguan penglihatan yang mengandalkan pembesaran layar untuk melihat konten halaman dengan tepat. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Menonaktifkan zoom akan menimbulkan masalah bagi pengguna dengan gangguan penglihatan yang mengandalkan pembesaran layar untuk melihat konten halaman dengan tepat. [Pelajari lebih lanjut](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
     "message": "`[user-scalable=\"no\"]` digunakan dalam elemen `<meta name=\"viewport\">` atau atribut `[maximum-scale]` kurang dari 5."
@@ -255,7 +255,7 @@
     "message": "`[user-scalable=\"no\"]` tidak digunakan dalam elemen `<meta name=\"viewport\">` dan atribut `[maximum-scale]` tidak kurang dari 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Pembaca layar tidak dapat menerjemahkan konten yang bukan teks. Menambahkan teks alternatif ke elemen `<object>` membantu pembaca layar menyampaikan makna kepada pengguna. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Pembaca layar tidak dapat menerjemahkan konten yang bukan teks. Menambahkan teks alternatif ke elemen `<object>` membantu pembaca layar menyampaikan makna kepada pengguna. [Pelajari lebih lanjut](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "Elemen `<object>` tidak memiliki teks `[alt]`"
@@ -264,34 +264,34 @@
     "message": "Elemen `<object>` memiliki teks `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Nilai yang lebih besar dari 0 menunjukkan pengurutan navigasi eksplisit. Walaupun secara teknis valid, hal ini sering menciptakan pengalaman yang membingungkan bagi pengguna yang mengandalkan teknologi asistif. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Nilai yang lebih besar dari 0 menunjukkan pengurutan navigasi eksplisit. Walaupun secara teknis valid, hal ini sering menciptakan pengalaman yang membingungkan bagi pengguna yang mengandalkan teknologi asistif. [Pelajari lebih lanjut](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Beberapa elemen memiliki nilai `[tabindex]` lebih besar dari 0"
+    "message": "Beberapa elemen memiliki nilai `[tabindex]` yang lebih besar dari 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
     "message": "Tidak ada elemen yang memiliki nilai `[tabindex]` lebih besar dari 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Pembaca layar memiliki fitur yang memudahkan navigasi tabel. Memastikan sel `<td>` yang menggunakan atribut `[headers]` hanya merujuk ke sel lain dalam tabel yang sama dapat meningkatkan pengalaman bagi pengguna pembaca layar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Pembaca layar memiliki fitur yang memudahkan navigasi tabel. Memastikan sel `<td>` yang menggunakan atribut `[headers]` hanya merujuk ke sel lain dalam tabel yang sama dapat menyempurnakan pengalaman bagi pengguna pembaca layar. [Pelajari lebih lanjut](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
     "message": "Sel dalam elemen `<table>` yang menggunakan atribut `[headers]` merujuk ke sel lain dalam tabel yang sama."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Sel dalam elemen `<table>` yang menggunakan atribut `[headers]` hanya merujuk ke sel lain dalam tabel yang sama."
+    "message": "Sel di elemen `<table>` yang menggunakan atribut `[headers]` hanya merujuk ke sel lain dari tabel yang sama."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Pembaca layar memiliki fitur yang memudahkan navigasi tabel. Memastikan header tabel selalu merujuk ke sekumpulan sel dapat meningkatkan pengalaman bagi pengguna pembaca layar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Pembaca layar memiliki fitur yang memudahkan navigasi tabel. Memastikan header tabel selalu merujuk ke sekumpulan sel dapat menyempurnakan pengalaman bagi pengguna pembaca layar. [Pelajari lebih lanjut](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
     "message": "Elemen `<th>` dan elemen dengan `[role=\"columnheader\"/\"rowheader\"]` tidak memiliki sel data yang dideskripsikannya."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Elemen `<th>` dan elemen dengan `[role=\"columnheader\"/\"rowheader\"]` memiliki sel data yang dideskripsikannya."
+    "message": "Elemen `<th>` dan elemen dengan `[role=\"columnheader\"/\"rowheader\"]` memiliki sel data yang dideskripsikan."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Menentukan [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) yang valid pada elemen membantu memastikan teks diucapkan dengan benar oleh pembaca layar. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Menentukan [bahasa BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) yang valid pada elemen membantu memastikan bahwa teks diucapkan dengan benar oleh pembaca layar. [Pelajari lebih lanjut](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
     "message": "Atribut `[lang]` tidak memiliki nilai yang valid"
@@ -300,7 +300,7 @@
     "message": "Atribut `[lang]` memiliki nilai yang valid"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Video yang menyediakan teks akan memudahkan pengguna yang menyandang gangguan pendengaran dan tunarungu untuk mengakses informasinya. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Video yang menyediakan teks akan memudahkan pengguna yang menyandang gangguan pendengaran dan tunarungu untuk mengakses informasinya. [Pelajari lebih lanjut](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
     "message": "Elemen `<video>` tidak memuat elemen `<track>` dengan `[kind=\"captions\"]`."
@@ -309,13 +309,25 @@
     "message": "Elemen `<video>` memuat elemen `<track>` dengan `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Deskripsi audio memberikan informasi yang relevan untuk video yang tidak dapat diberikan melalui dialog, seperti ekspresi wajah dan adegan. [Pelajari lebih lanjut](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Deskripsi audio memberikan informasi yang relevan untuk video yang tidak dapat diberikan melalui dialog, seperti ekspresi wajah dan adegan. [Pelajari lebih lanjut](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
     "message": "Elemen `<video>` tidak memuat elemen `<track>` dengan `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Elemen`<video>` memuat elemen `<track>` dengan `[kind=\"description\"]`"
+    "message": "Elemen `<video>` memuat elemen `<track>` dengan `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Untuk penampilan ideal di iOS saat pengguna menambahkan ke layar utama, tentukan apple-touch-icon. Ikon harus mengarah ke PNG persegi 192 piksel (atau 180 piksel) yang tidak transparan. [Pelajari Lebih Lanjut](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Tidak menyediakan `apple-touch-icon` yang valid"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` sudah usang; `apple-touch-icon` dipilih."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Memberikan `apple-touch-icon` yang valid"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Ekstensi Chrome berpengaruh negatif terhadap performa pemuatan halaman ini. Coba audit halaman dalam mode samaran atau dari profil Chrome tanpa ekstensi."
@@ -330,7 +342,7 @@
     "message": "Waktu CPU Total"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Pertimbangkan mengurangi waktu yang dihabiskan untuk mengurai, mengompilasi, dan mengeksekusi JS. Anda mungkin menemukan bahwa mengirim payload JS yang lebih kecil akan membantu mengurangi waktu. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Sebaiknya kurangi waktu yang dihabiskan untuk mengurai, mengompilasi, dan mengeksekusi JS. Coba kirim payload JS yang lebih kecil untuk membantu mengurangi waktu. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Mengurangi waktu eksekusi JavaScript"
@@ -339,19 +351,19 @@
     "message": "Waktu eksekusi JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "GIF berukuran besar tidak efisien untuk menayangkan konten animasi. Pertimbangkan untuk menggunakan video MPEG4/WebM sebagai animasi dan PNG/WebP sebagai gambar statis untuk menggantikan GIF guna menghemat byte jaringan. [Pelajari lebih lanjut](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "GIF berukuran besar tidak efisien untuk menayangkan konten animasi. Sebaiknya gunakan video MPEG4/WebM sebagai animasi dan PNG/WebP sebagai gambar statis untuk menggantikan GIF guna menghemat byte jaringan. [Pelajari lebih lanjut](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Gunakan format video untuk konten animasi"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Pertimbangkan pemuatan lambat di balik layar dan gambar tersembunyi setelah semua resource kritis selesai dimuat untuk mengurangi waktu interaktif. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Sebaiknya lakukan pemuatan lambat di balik layar dan gambar tersembunyi setelah semua resource kritis selesai dimuat guna mengurangi waktu untuk interaktif. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Tunda gambar di balik layar"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Resource memblokir paint pertama halaman. Pertimbangkan mengirim inline JS/CSS kritis dan menunda semua JS/gaya yang tidak kritis. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Resource memblokir first paint halaman. Sebaiknya kirim inline JS/CSS kritis dan tunda semua JS/gaya yang tidak kritis. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Hilangkan resource yang memblokir render"
@@ -360,7 +372,7 @@
     "message": "Payload jaringan yang besar menimbulkan biaya yang tinggi bagi pengguna dan berkorelasi erat dengan waktu pemuatan yang lama. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "Ukuran total {totalBytes, number, bytes} KB"
+    "message": "Total ukuran adalah {totalBytes, number, bytes} KB"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Menghindari payload jaringan yang sangat besar"
@@ -369,19 +381,19 @@
     "message": "Menghindari payload jaringan yang sangat besar"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Mengecilkan file CSS dapat mengurangi ukuran payload jaringan. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Meminifikasi file CSS dapat mengurangi ukuran payload jaringan. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Kecilkan CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Mengecilkan file JavaScript dapat mengurangi ukuran payload dan waktu penguraian skrip. [Pelajari lebih lanjut](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Meminifikasi file JavaScript dapat mengurangi ukuran payload dan waktu penguraian skrip. [Pelajari lebih lanjut](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Kecilkan ukuran JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Hapus aturan yang tidak berlaku dari stylesheet dan tunda pemuatan CSS yang tidak digunakan untuk konten paruh atas guna mengurangi byte yang tidak perlu yang digunakan oleh aktivitas jaringan. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Hapus aturan yang tidak berlaku dari stylesheet dan tunda pemuatan CSS yang tidak digunakan untuk konten paruh atas, guna mengurangi byte yang tidak perlu yang digunakan oleh aktivitas jaringan. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Hapus CSS yang tidak digunakan"
@@ -393,7 +405,7 @@
     "message": "Hapus JavaScript yang tidak digunakan"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Durasi cache yang panjang dapat mempercepat kunjungan berulang ke halaman. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Durasi cache yang panjang dapat mempercepat kunjungan berulang ke halaman Anda. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 resource ditemukan}other{# resource ditemukan}}"
@@ -405,7 +417,7 @@
     "message": "Menggunakan kebijakan cache yang efisien pada aset statis"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Gambar yang dioptimalkan dimuat lebih cepat dan menghabiskan lebih sedikit kuota. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Gambar yang dioptimalkan dimuat lebih cepat dan menghabiskan lebih sedikit data seluler. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Enkode gambar secara efisien"
@@ -423,19 +435,70 @@
     "message": "Aktifkan kompresi teks"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Format gambar seperti JPEG 2000, JPEG XR, dan WebP biasanya memberikan kompresi yang lebih baik daripada PNG atau JPEG, sehingga download lebih cepat dan konsumsi kuota lebih kecil. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Format gambar seperti JPEG 2000, JPEG XR, dan WebP biasanya memberikan kompresi yang lebih baik daripada PNG atau JPEG, sehingga download lebih cepat dan konsumsi data lebih kecil. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Tayangkan gambar dalam format generasi berikutnya"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Rantai Permintaan Penting di bawah menampilkan resource apa saja yang dimuat dengan prioritas tinggi. Pertimbangkan mengurangi panjang rantai, mengurangi ukuran download resource, atau menunda download resource yang tidak penting untuk mempercepat pemuatan halaman. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Rantai Permintaan Penting di bawah menampilkan resource apa saja yang dimuat dengan prioritas tinggi. Sebaiknya kurangi panjang rantai, kurangi ukuran download resource, atau tunda download resource yang tidak penting untuk mempercepat pemuatan halaman. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 rantai ditemukan}other{# rantai ditemukan}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimalkan Kedalaman Permintaan Penting"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Penghentian/Peringatan"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Baris"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "API yang tidak digunakan lagi pada akhirnya akan dihapus dari browser. [Pelajari lebih lanjut](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 peringatan ditemukan}other{# peringatan ditemukan}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Menggunakan API yang tidak digunakan lagi"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Menghindari API yang tidak digunakan lagi"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Cache Aplikasi tidak digunakan lagi. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Menemukan \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Menggunakan Cache Aplikasi"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Menghindari Cache Aplikasi"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Menentukan doctype akan mencegah browser beralih ke quirks mode. Baca selengkapnya di [halaman MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Nama doctype harus berupa string huruf kecil `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokumen harus berisi doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "PublicId diperkirakan menjadi string kosong"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "SystemId diperkirakan menjadi string kosong"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Halaman tidak memiliki doctype HTML sehingga memicu quirks mode"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Halaman memiliki doctype HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elemen"
@@ -447,7 +510,7 @@
     "message": "Nilai"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Engineer browser merekomendasikan halaman berisi kurang dari ~1.500 elemen DOM. Titik yang efektif adalah kedalaman hierarki < 32 elemen dan kurang dari 60 elemen turunan/induk. DOM yang besar dapat meningkatkan penggunaan memori, menyebabkan [penghitungan gaya] yang lebih lama(https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), dan menghasilkan [penyesuaian tata letak] yang mahal(https://developers.google.com/speed/articles/reflow). [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Engineer browser merekomendasikan halaman yang berisi kurang dari ~ 1.500 elemen DOM. Ukuran yang pas adalah suatu kedalaman hierarki yang terdiri dari <32 elemen dan kurang dari 60 elemen turunan/induk. DOM yang besar dapat meningkatkan penggunaan memori, menyebabkan [penghitungan gaya](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) yang lebih lama, dan menghasilkan [penyesuaian tata letak](https://developers.google.com/speed/articles/reflow) yang mahal. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 elemen}other{# elemen}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Menghindari ukuran DOM yang berlebihan"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Target"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Tambahkan `rel=\"noopener\"` atau `rel=\"noreferrer\"` ke link eksternal mana pun untuk menyempurnakan performa dan mencegah kerentanan keamanan. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Link ke tujuan lintas asal tidak aman"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Link ke tujuan lintas asal aman"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Tidak dapat menentukan tujuan untuk anchor ({anchorHTML}). Jika tidak digunakan sebagai hyperlink, sebaiknya hapus target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Pengguna tidak percaya atau bingung dengan situs yang meminta lokasi mereka tanpa konteks. Sebaiknya kaitkan permintaan dengan tindakan pengguna. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Meminta izin geolokasi pada pemuatan halaman"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Menghindari meminta izin geolokasi pada pemuatan halaman"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versi"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Semua library JavaScript front-end terdeteksi di halaman."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Library JavaScript yang terdeteksi"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Untuk pengguna dengan koneksi lambat, skrip eksternal secara dinamis dimasukkan melalui `document.write()` dapat menunda pemuatan halaman selama puluhan detik. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Menggunakan `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Menghindari `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Keparahan Tertinggi"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Versi Library"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Jumlah Kerentanan"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Beberapa skrip pihak ketiga dapat berisi kerentanan keamanan umum yang mudah diidentifikasi dan dimanfaatkan oleh penyerang. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 kerentanan terdeteksi}other{# kerentanan terdeteksi}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Menyertakan library JavaScript front-end yang memiliki kerentanan keamanan umum"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Tinggi"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Rendah"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Sedang"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Menghindari library JavaScript front-end yang memiliki kerentanan keamanan umum"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Pengguna tidak percaya atau bingung dengan situs yang meminta untuk mengirim pemberitahuan tanpa konteks. Sebaiknya kaitkan permintaan dengan gestur pengguna. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Meminta izin notifikasi pada pemuatan halaman"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Menghindari meminta izin notifikasi pada pemuatan halaman"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elemen yang Gagal"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Mencegah menempelkan sandi akan merusak kebijakan keamanan yang baik. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Mencegah pengguna menempelkan sesuatu ke kolom sandi."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Mengizinkan pengguna menempelkan sesuatu ke kolom sandi"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 menawarkan banyak manfaat dibandingkan HTTP/1.1, termasuk header biner, multiplexing, dan push server. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 permintaan tidak dilayani melalui HTTP/2}other{# permintaan tidak dilayani melalui HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Tidak menggunakan HTTP/2 untuk semua resourcenya"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Menggunakan HTTP/2 untuk resource miliknya sendiri"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Sebaiknya tandai sentuhan Anda dan pemroses peristiwa gulir sebagai `passive` untuk menyempurnakan performa scroll halaman Anda. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Tidak menggunakan pemroses pasif untuk menyempurnakan performa scroll"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Menggunakan pemroses pasif untuk menyempurnakan performa scroll"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Deskripsi"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Error yang dicatat di konsol menunjukkan masalah yang belum terselesaikan. Error dapat berasal dari permintaan jaringan yang gagal dan masalah browser lainnya."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Error browser dicatat di konsol"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Tidak ada error browser yang dicatat ke konsol"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Memanfaatkan fitur CSS tampilan font untuk memastikan teks terlihat oleh pengguna saat font web sedang dimuat. [Pelajari lebih lanjut](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Semua teks tetap terlihat selama pemuatan font web"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse tidak dapat secara otomatis memeriksa nilai tampilan font untuk URL berikut: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Rasio Tinggi Lebar (Aktual)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Rasio Tinggi Lebar (Ditampilkan)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Dimensi tampilan gambar harus cocok dengan rasio tinggi lebar natural. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Menampilkan gambar dengan rasio tinggi lebar yang salah"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Menampilkan gambar dengan rasio tinggi lebar yang benar"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Informasi ukuran gambar {url} tidak valid"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL yang tidak aman"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Semua situs harus dilindungi dengan HTTPS, termasuk situs-situs yang tidak menangani data sensitif. HTTPS mencegah penyusup merusak atau mendengarkan komunikasi secara pasif antara aplikasi dan pengguna, serta merupakan prasyarat untuk HTTP/2 dan banyak API platform web baru. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 permintaan tidak aman ditemukan}other{# permintaan tidak aman ditemukan}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Tidak menggunakan HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Menggunakan HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Pemuatan halaman yang cepat melalui jaringan seluler menjamin pengalaman pengguna seluler yang baik. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interaktif pada {timeInMs, number, seconds} d"
+    "message": "Interaktif di {timeInMs, number, seconds} dtk"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Interaktif di jaringan seluler tersimulasi pada {timeInMs, number, seconds} d"
+    "message": "Interaktif di jaringan seluler tersimulasi pada {timeInMs, number, seconds} dtk"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Pemuatan halaman tidak cukup cepat pada jaringan seluler"
@@ -504,13 +735,13 @@
     "message": "Meminimalkan pekerjaan thread utama"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Perkiraan Latensi Input adalah perkiraan durasi yang diperlukan aplikasi untuk merespons input pengguna, dalam milidetik, selama durasi 5 detik tersibuk saat pemuatan halaman. Jika latensi di atas 50 md, pengguna dapat menganggap aplikasi Anda lambat. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Perkiraan Latensi Masukan adalah perkiraan durasi yang diperlukan aplikasi untuk merespons masukan pengguna, dalam milidetik, selama durasi 5 detik tersibuk saat pemuatan halaman. Jika latensi di atas 50 md, pengguna dapat menganggap aplikasi Anda lambat. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Perkiraan Latensi Masukan"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "First Contentful Paint menandai waktu saat teks atau gambar pertama di-paint. [Pelajari lebih lanjut] (https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "First Contentful Paint menandai waktu saat teks atau gambar pertama di-paint. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "First Contentful Paint"
@@ -534,10 +765,10 @@
     "message": "Waktu untuk Interaktif"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Potensi Penundaan Input Pertama yang dapat dialami pengguna Anda adalah durasi tugas terpanjang, yang dinyatakan dalam milidetik."
+    "message": "Potensi maksimal Penundaan Input Pertama yang dapat dialami pengguna Anda adalah durasi tugas terpanjang, yang dinyatakan dalam milidetik. [Pelajari lebih lanjut](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID Potensi Maksimal"
+    "message": "Potensi Maksimal Penundaan Input Pertama"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Indeks Kecepatan menunjukkan seberapa cepat konten halaman terlihat terisi lengkap. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
@@ -545,8 +776,14 @@
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Indeks Kecepatan"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Jumlah semua jangka waktu antara FCP dan Waktu untuk Interaktif, ketika durasi tugas melebihi 50 md, dinyatakan dalam milidetik."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Total Waktu Pemblokiran"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Waktu round trip (RTT) jaringan berdampak besar pada performa. RTT ke asal yang tinggi merupakan indikasi bahwa server yang lebih dekat ke pengguna dapat meningkatkan performa. [Pelajari lebih lanjut](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Waktu round trip (RTT) jaringan berdampak besar pada performa. RTT ke asal yang tinggi merupakan indikasi bahwa server yang berjarak lebih dekat ke pengguna dapat meningkatkan performa. [Pelajari lebih lanjut](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Waktu Round Trip Jaringan"
@@ -557,29 +794,50 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latensi Backend Server"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Melebihi Anggaran"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Pertahankan jumlah dan ukuran permintaan jaringan di bawah target yang ditetapkan oleh anggaran performa yang disediakan. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 permintaan}other{# permintaan}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Anggaran performa"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Pengalihan mencakup penundaan tambahan sebelum halaman dapat dimuat. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Hindari pengalihan lebih dari satu halaman"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Untuk mengatur anggaran jumlah dan ukuran resource halaman, tambahkan file budget.json. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 permintaan}other{# permintaan}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Pertahankan jumlah permintaan tetap rendah dan ukuran transfer tetap kecil"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Link kanonis menyarankan URL yang akan ditampilkan dalam hasil penelusuran. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Beberapa URL bentrok ({urlList})"
+    "message": "Ada beberapa URL yang bertentangan ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Mengarah ke domain berbeda ({url})"
+    "message": "Mengarahkan ke domain yang berbeda ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "URL ({url}) tidak valid"
+    "message": "URL tidak valid ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Mengarah ke lokasi `hreflang` lain ({url})"
+    "message": "Mengarahkan ke lokasi `hreflang` lain ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "URL Relatif ({url})"
+    "message": "URL relatif ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "Mengarah ke URL root domain (halaman beranda), bukan ke halaman yang setara untuk konten itu"
@@ -594,16 +852,13 @@
     "message": "Ukuran font di bawah 12 piksel terlalu kecil untuk dapat dibaca dan memaksa pengunjung seluler “mencubit untuk memperbesar\" agar dapat membacanya. Usahakan untuk menampilkan >60% teks halaman dalam ukuran ≥12 piksel. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "{decimalProportion, number, extendedPercent} teks terbaca"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} teks terlalu kecil."
+    "message": "Teks yang dapat dibaca {decimalProportion, number, extendedPercent}"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Teks tidak terbaca karena tidak ada tag meta viewport yang dioptimalkan untuk layar seluler."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} teks terlalu kecil (berdasarkan {decimalProportionVisited, number, extendedPercent} sampel)."
+    "message": "{decimalProportion, number, extendedPercent} teks terlalu kecil (berdasarkan sampel {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Dokumen tidak menggunakan ukuran font yang terbaca"
@@ -621,7 +876,7 @@
     "message": "Dokumen memiliki `hreflang` yang valid"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Halaman dengan kode status HTTP tidak berhasil mungkin tidak akan diindeks dengan tepat. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Halaman dengan kode status HTTP yang tidak berhasil mungkin tidak akan diindeks dengan tepat. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "Halaman memiliki kode status HTTP yang tidak berhasil"
@@ -696,7 +951,7 @@
     "message": "robots.txt valid"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Elemen interaktif seperti tombol dan link harus cukup besar (48x48 piksel), dan memiliki cukup ruang di sekelilingnya, agar cukup mudah diketuk tanpa tumpang-tindih dengan elemen lain. [Pelajari lebih lanjut](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Elemen interaktif seperti tombol dan link harus berukuran cukup besar (48x48 piksel), dan memiliki cukup ruang di sekelilingnya, agar cukup mudah diketuk tanpa tumpang-tindih dengan elemen lain. [Pelajari lebih lanjut](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} target ketuk memiliki ukuran yang tepat"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Target Tumpang-Tindih"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Ukuran"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Target Ketuk"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Target ketuk memiliki ukuran yang tepat"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Waktu Thread Utama"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Pihak Ketiga"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Kode pihak ketiga dapat memberikan dampak signifikan terhadap performa muatan. Batasi jumlah penyedia pihak ketiga yang berlebihan dan coba muat kode pihak ketiga terutama setelah halaman selesai memuat. [Pelajari lebih lanjut](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 Pihak Ketiga Ditemukan}other{# Pihak Ketiga Ditemukan}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Penggunaan oleh Pihak Ketiga"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Time To First Byte mengidentifikasi waktu saat server mengirim respons. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Durasi"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nama"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Waktu Mulai"
   },
@@ -744,7 +1008,7 @@
     "message": "Jenis"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Pertimbangkan melengkapi aplikasi dengan User Timing API untuk mengukur performa sebenarnya aplikasi Anda selama pengalaman pengguna utama. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Sebaiknya lengkapi aplikasi Anda dengan User Timing API untuk mengukur performa aplikasi Anda yang sebenarnya selama pengalaman pengguna utama. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 waktu pengguna}other{# waktu pengguna}}"
@@ -753,19 +1017,19 @@
     "message": "Tanda dan ukuran Waktu Pengguna"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Sebuah <link> prakoneksi ditemukan untuk \"{securityOrigin}\" tetapi tidak digunakan oleh browser. Pastikan Anda menggunakan atribut `crossorigin` dengan tepat."
+    "message": "Sebuah <link> prakoneksi ditemukan untuk {securityOrigin}, tetapi tidak digunakan oleh browser. Pastikan Anda menggunakan atribut `crossorigin` dengan tepat."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Pertimbangkan menambahkan petunjuk menyambungkan terlebih dahulu atau mengambil terlebih dahulu dns resource untuk melakukan sambungan awal ke nama domain pihak ketiga yang penting. [Pelajari lebih lanjut](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Sebaiknya tambahkan petunjuk menyambungkan terlebih dahulu atau ambil dns resource terlebih dahulu untuk melakukan sambungan awal ke nama domain pihak ketiga yang penting. [Pelajari lebih lanjut](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Sambungkan terlebih dahulu ke nama domain yang diperlukan"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Sebuah pramuat <link> ditemukan untuk \"{preloadURL}\" tetapi tidak digunakan oleh browser. Pastikan Anda menggunakan atribut `crossorigin` dengan tepat."
+    "message": "Sebuah <link> pramuat ditemukan untuk {preloadURL}, tetapi tidak digunakan oleh browser. Pastikan Anda menggunakan atribut `crossorigin` dengan tepat."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Pertimbangkan menggunakan <link rel=preload> untuk memprioritaskan pengambilan resource yang saat ini diminta selama pemuatan halaman. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Sebaiknya gunakan `<link rel=preload>` untuk memprioritaskan pengambilan resource yang saat ini diminta selama pemuatan halaman. [Pelajari lebih lanjut](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Muat permintaan utama terlebih dahulu"
@@ -789,10 +1053,10 @@
     "message": "Praktik terbaik"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Pemeriksaan ini menandai peluang untuk [meningkatkan aksesibilitas aplikasi web Anda](https://developers.google.com/web/fundamentals/accessibility). Hanya sejumlah kecil masalah aksesibilitas yang dapat terdeteksi secara otomatis sehingga pengujian manual juga dianjurkan."
+    "message": "Pemeriksaan ini menandai peluang untuk [menyempurnakan aksesibilitas aplikasi web Anda](https://developers.google.com/web/fundamentals/accessibility). Hanya sejumlah kecil masalah aksesibilitas yang dapat terdeteksi secara otomatis, sehingga pengujian manual juga dianjurkan."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Item berikut ini menangani area yang tidak dapat dicakup oleh fitur pengujian otomatis. Pelajari lebih lanjut dalam panduan kami tentang [menjalankan ulasan aksesibilitas](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Item berikut ini menangani area yang tidak dapat dicakup oleh fitur pengujian otomatis. Pelajari lebih lanjut dalam panduan kami tentang [menjalankan tinjauan aksesibilitas](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Aksesibilitas"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabel dan daftar"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Praktik Terbaik"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Anggaran performa menetapkan standar performa situs Anda."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Anggaran"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Informasi selengkapnya tentang performa aplikasi Anda."
+    "message": "Informasi selengkapnya tentang performa aplikasi Anda. Angka ini tidak [secara langsung memengaruhi](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) skor Performa."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostik"
@@ -840,7 +1113,7 @@
     "message": "Penyempurnaan First Paint"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Pengoptimalan ini dapat mempercepat pemuatan halaman."
+    "message": "Saran ini dapat membantu pemuatan halaman menjadi lebih cepat. Saran tersebut tidak [secara langsung memengaruhi](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) skor Performa."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Peluang"
@@ -888,7 +1161,7 @@
     "message": "Crawling dan Pengindeksan"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Pastikan halaman Anda mobile friendly agar pengguna tidak perlu mencubit atau memperbesar untuk membaca halaman konten. [Pelajari lebih lanjut](https://developers.google.com/search/mobile-sites/)."
+    "message": "Pastikan halaman Anda mobile-friendly agar pengguna tidak perlu mencubit atau memperbesar untuk membaca halaman konten. [Pelajari lebih lanjut](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Mobile Friendly"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL Cache"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Lokasi"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nama"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Permintaan"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Jenis Resource"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Ukuran (KB)"
+    "message": "Ukuran"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Waktu yang Dihabiskan"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Ukuran Transfer"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potensi Penghematan (KB)"
+    "message": "Potensi Penghematan"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potensi Penghematan (md)"
+    "message": "Potensi Penghematan"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Potensi penghematan {wastedBytes, number, bytes} KB"
+    "message": "Potensi penghematan sebesar {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Potensi penghematan {wastedMs, number, milliseconds} md"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokumen"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Font"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Gambar"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Media"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} md"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Lainnya"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skrip"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} d"
+    "message": "{timeInMs, number, seconds} dtk"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stylesheet"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Pihak ketiga"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Total"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Terjadi kesalahan saat merekam jejak selama pemuatan halaman Anda. Harap jalankan Lighthouse kembali. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Server DNS tidak dapat menetapkan domain yang disediakan."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Terjadi error pada pengumpul {artifactName} wajib: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Terjadi error Chrome internal. Harap mulai ulang Chrome dan coba jalankan kembali Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Pengumpul {artifactName} yang diperlukan tidak berjalan."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse tidak dapat memuat halaman yang Anda minta dengan lancar. Pastikan Anda menguji URL yang benar dan server merespons semua permintaan dengan baik."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse tidak dapat memuat URL yang Anda minta dengan lancar karena halaman berhenti merespons."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "URL yang Anda berikan tidak memiliki kredensial keamanan yang valid. {securityMessages}"
+    "message": "URL yang Anda berikan tidak memiliki sertifikat keamanan yang valid. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome mencegah pemuatan halaman dengan interstisial. Pastikan Anda menguji URL yang benar dan server merespons semua permintaan dengan baik."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse tidak dapat memuat halaman yang Anda minta dengan lancar. Pastikan Anda menguji URL yang benar dan server merespons semua permintaan dengan baik. (Detail: {errorDetails})"
@@ -984,7 +1308,7 @@
     "message": "Data Lab"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analisis halaman saat ini pada jaringan seluler teremulasi. Nilai adalah hasil perkiraan dan dapat bervariasi."
+    "message": "Analisis [Lighthouse](https://developers.google.com/web/tools/lighthouse/) untuk halaman saat ini di jaringan seluler teremulasi. Nilai adalah hasil perkiraan dan dapat berbeda-beda."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Item tambahan untuk diperiksa secara manual"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Luaskan cuplikan"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Tampilkan resource pihak ketiga"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Ada masalah yang memengaruhi jalannya Lighthouse ini:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Nilai adalah hasil perkiraan dan dapat bervariasi."
+    "message": "Nilai adalah hasil perkiraan dan dapat berbeda-beda. Skor performa [hanya berdasarkan metrik-metrik ini](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Lulus audit tetapi dengan peringatan"
@@ -1023,10 +1350,10 @@
     "message": "Sebaiknya upload GIF ke server yang akan menyediakannya untuk disematkan sebagai video HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Instal [plugin lazy load di WordPress](https://wordpress.org/plugins/search/lazy+load/) yang menyediakan kemampuan untuk menunda pemuatan gambar di bagian halaman yang belum ditampilkan, atau beralih ke tema yang menyediakan fungsi tersebut. Selain itu, sebaiknya gunakan [plugin AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Instal [plugin pemuatan lambat di WordPress ](https://wordpress.org/plugins/search/lazy+load/) yang menyediakan kemampuan untuk menunda pemuatan gambar di bagian halaman yang belum ditampilkan, atau beralihlah ke tema yang menyediakan fungsi tersebut. Sebaiknya juga gunakan [plugin AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Ada sejumlah plugin WordPress yang dapat membantu Anda [menyejajarkan aset penting](https://wordpress.org/plugins/search/critical+css/) atau [menunda resource yang tidak penting](https://wordpress.org/plugins/search/defer+css+javascript/). Harap berhati-hati karena pengoptimalan yang disediakan oleh plugin ini dapat merusak fitur tema atau plugin, sehingga Anda cenderung perlu mengubah kode."
+    "message": "Terdapat sejumlah plugin di WordPress yang dapat membantu Anda [menyejajarkan aset penting](https://wordpress.org/plugins/search/critical+css/) atau [menunda resource yang tidak penting](https://wordpress.org/plugins/search/defer+css+javascript/). Harap berhati-hati karena pengoptimalan yang disediakan oleh plugin ini dapat merusak fitur tema atau plugin, sehingga Anda cenderung perlu mengubah kode."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Semua spesifikasi tema, plugin, dan server berkontribusi pada waktu respons server. Sebaiknya cari tema yang lebih optimal, pilih plugin pengoptimalan dengan hati-hati, dan/atau upgrade server Anda."
@@ -1035,16 +1362,16 @@
     "message": "Sebaiknya tampilkan kutipan dalam daftar postingan (misalnya melalui tag lainnya), kurangi jumlah postingan yang ditampilkan pada halaman yang ada, bagi postingan panjang menjadi beberapa halaman, atau gunakan plugin untuk menunda pemuatan (lazy-load) komentar."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Sejumlah [plugin WordPress](https://wordpress.org/plugins/search/minify+css/) dapat mempercepat situs Anda dengan menggabungkan, meminifikasi, dan mengompresi gaya. Anda juga dapat menggunakan proses pembuatan build untuk melakukan minifikasi di muka jika mungkin."
+    "message": "Sejumlah [plugin WordPress](https://wordpress.org/plugins/search/minify+css/) dapat mempercepat situs Anda dengan menggabungkan, meminifikasi, dan mengompresi gaya Anda. Anda juga dapat menggunakan proses pembuatan build untuk melakukan minifikasi di tahap awal jika memungkinkan."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Sejumlah [plugin WordPress](https://wordpress.org/plugins/search/minify+javascript/) dapat mempercepat situs Anda dengan menggabungkan, meminifikasi, dan mengompresi skrip Anda. Anda juga dapat menggunakan proses pembuatan build untuk melakukan minifikasi di awal jika mungkin."
+    "message": "Sejumlah [plugin WordPress](https://wordpress.org/plugins/search/minify+javascript/) dapat mempercepat situs Anda dengan menggabungkan, meminifikasi, dan mengompresi skrip. Anda juga dapat menggunakan proses pembuatan build untuk melakukan minifikasi di awal jika mungkin."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Sebaiknya kurangi atau ubah jumlah [plugin WordPress](https://wordpress.org/plugins/) yang memuat CSS yang tidak digunakan di halaman Anda. Untuk mengidentifikasi plugin yang menambahkan CSS tidak relevan, coba jalankan [cakupan kode](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) di Chrome DevTools. Anda dapat mengidentifikasi tema/plugin yang bertanggung jawab dari URL stylesheet. Cari plugin yang memiliki banyak stylesheet dalam daftar yang memiliki banyak warna merah dalam cakupan kode. Plugin sebaiknya hanya menambahkan stylesheet ke antrean jika memang benar digunakan pada halaman."
+    "message": "Sebaiknya kurangi atau ubah jumlah [plugin WordPress](https://wordpress.org/plugins/) yang memuat CSS yang tidak digunakan di halaman Anda. Untuk mengidentifikasi plugin yang menambahkan CSS tidak relevan, coba jalankan [cakupan kode](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) di Chrome DevTools. Anda dapat mengidentifikasi tema/plugin yang bertanggung jawab dari URL stylesheet. Cari plugin yang memiliki banyak stylesheet dalam daftar yang memiliki banyak warna merah dalam cakupan kode. Plugin sebaiknya hanya menambahkan stylesheet ke antrean jika memang benar digunakan di halaman."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Sebaiknya kurangi atau ubah jumlah [plugin WordPress](https://wordpress.org/plugins/) yang memuat JavaScript yang tidak digunakan di halaman. Untuk mengidentifikasi plugin yang menambahkan JS tidak relevan, coba jalankan [cakupan kode](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) di Chrome DevTools. Anda dapat mengidentifikasi tema/plugin yang bertanggung jawab dari URL skrip. Cari plugin dengan banyak skrip dalam daftar yang memiliki banyak warna merah dalam cakupan kode. Plugin sebaiknya hanya menambahkan skrip dalam antrean jika sebenarnya digunakan pada halaman."
+    "message": "Sebaiknya kurangi atau ubah jumlah [plugin WordPress](https://wordpress.org/plugins/) yang memuat JavaScript yang tidak digunakan di halaman Anda. Untuk mengidentifikasi plugin yang menambahkan JS tidak relevan, coba jalankan [cakupan kode](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) di Chrome DevTools. Anda dapat mengidentifikasi tema/plugin yang bertanggung jawab dari URL skrip. Cari plugin dengan banyak skrip dalam daftar yang memiliki banyak warna merah dalam cakupan kode. Plugin sebaiknya hanya menambahkan skrip ke dalam antrean jika memang benar digunakan di halaman."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Baca [Cache Browser di WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
@@ -1053,7 +1380,7 @@
     "message": "Sebaiknya gunakan [plugin WordPress untuk pengoptimalan gambar](https://wordpress.org/plugins/search/optimize+images/) yang mengompresi gambar Anda dengan tetap mempertahankan kualitas."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Upload gambar langsung melalui [library media](https://codex.wordpress.org/Media_Library_Screen) untuk memastikan bahwa ukuran gambar yang diperlukan tersedia, lalu masukkan dari library media atau gunakan widget gambar untuk memastikan ukuran gambar optimal digunakan (termasuk untuk titik henti sementara responsif). Hindari menggunakan gambar `Ukuran Penuh` kecuali dimensi memungkinkan untuk digunakan. [Pelajari Lebih Lanjut](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Upload gambar langsung melalui [koleksi media](https://codex.wordpress.org/Media_Library_Screen) untuk memastikan ukuran gambar yang diperlukan tersedia, lalu masukkan koleksi media atau gunakan widget gambar untuk memastikan ukuran gambar optimal digunakan (termasuk untuk titik henti sementara responsif). Hindari menggunakan gambar `Full Size`, kecuali dimensinya memungkinkan untuk digunakan. [Pelajari Lebih Lanjut](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Anda dapat mengaktifkan kompresi teks di konfigurasi server web."

--- a/lighthouse-core/lib/i18n/locales/it.json
+++ b/lighthouse-core/lib/i18n/locales/it.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Le chiavi di accesso consentono all'utente di impostare rapidamente lo stato attivo su una particolare sezione della pagina. Per assicurare una navigazione corretta, ogni chiave di accesso deve essere univoca. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Le chiavi di accesso consentono agli utenti di impostare rapidamente lo stato attivo su una parte della pagina. Per assicurare una navigazione corretta, ogni chiave di accesso deve essere univoca. [Ulteriori informazioni](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "I valori di \"[accesskey]\" non sono univoci"
+    "message": "I valori `[accesskey]` non sono univoci"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "I valori di \"[accesskey]\" sono univoci"
+    "message": "I valori `[accesskey]` sono univoci"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Ogni elemento \"role\" di ARIA supporta un determinato sottoinsieme di attributi \"aria-*\". Se non dovessero corrispondere, gli attributi \"aria-*\" non saranno considerati validi. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Ogni elemento `role` di ARIA supporta un determinato sottoinsieme di attributi `aria-*`. Se non dovessero corrispondere, gli attributi `aria-*` non saranno considerati validi. [Ulteriori informazioni](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Gli attributi \"[aria-*]\" non corrispondono ai rispettivi ruoli"
+    "message": "Gli attributi `[aria-*]` non corrispondono ai rispettivi ruoli"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Gli attributi \"[aria-*]\" corrispondono ai rispettivi ruoli"
+    "message": "Gli attributi `[aria-*]` corrispondono ai rispettivi ruoli"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Alcuni ruoli di ARIA hanno attributi obbligatori in grado di descrivere lo stato dell'elemento agli screen reader. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Alcuni ruoli di ARIA hanno attributi obbligatori che descrivono lo stato dell'elemento agli screen reader. [Ulteriori informazioni](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Gli elementi \"[role]\" non hanno tutti gli attributi \"[aria-*]\" obbligatori"
+    "message": "Gli elementi `[role]` non hanno tutti gli attributi `[aria-*]` obbligatori"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Gli elementi \"[role]\" hanno tutti gli attributi \"[aria-*]\" obbligatori"
+    "message": "Gli elementi `[role]` hanno tutti gli attributi `[aria-*]` obbligatori"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Alcuni ruoli principali di ARIA devono contenere specifici ruoli secondari per poter eseguire le funzionalità per l'accessibilità previste. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Alcuni ruoli principali di ARIA devono contenere specifici ruoli secondari per poter eseguire le funzionalità per l'accessibilità previste. [Ulteriori informazioni](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Non è presente alcun elemento con ruolo \"[role]\" che richiede specifici ruoli \"[role]\" secondari."
+    "message": "Mancano gli elementi con `[role]` che richiedono specifici`[role]` secondari."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Sono presenti elementi con ruolo \"[role]\" che richiedono specifici \"[role]\" secondari."
+    "message": "Sono presenti elementi con `[role]` che richiedono specifici elementi `[role]` secondari"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Alcuni ruoli secondari di ARIA devono essere contenuti in specifici ruoli principali per poter eseguire in modo corretto le funzionalità per l'accessibilità previste. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Alcuni ruoli secondari di ARIA devono essere contenuti in specifici ruoli principali per poter eseguire in modo corretto le funzionalità per l'accessibilità previste. [Ulteriori informazioni](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Gli elementi \"[role]\" non sono contenuti nei rispettivi elementi principali obbligatori"
+    "message": "Gli elementi `[role]` non sono contenuti nei rispettivi elementi principali obbligatori"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Gli elementi \"[role]\" sono contenuti nei rispettivi elementi principali obbligatori"
+    "message": "Gli elementi `[role]` sono contenuti nei rispettivi elementi principali obbligatori"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "I ruoli di ARIA devono contenere valori validi per poter eseguire le funzionalità per l'accessibilità previste. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "I ruoli di ARIA devono contenere valori validi per poter eseguire le funzionalità per l'accessibilità previste. [Ulteriori informazioni](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "I valori di \"[role]\" non sono validi"
+    "message": "I valori `[role]` non sono validi"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "I valori \"[role]\" sono validi"
+    "message": "I valori `[role]` sono validi"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Le tecnologie per la disabilità, come gli screen reader, non sono in grado di interpretare gli attributi di ARIA con valori non validi. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Le tecnologie di ausilio per la disabilità, come gli screen reader, non sono in grado di interpretare gli attributi di ARIA con valori non validi. [Ulteriori informazioni](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Gli attributi \"[aria-*]\" non hanno valori validi"
+    "message": "Gli attributi `[aria-*]` non hanno valori validi"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Gli attributi \"[aria-*]\" hanno valori validi"
+    "message": "Gli attributi `[aria-*]` hanno valori validi"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Le tecnologie per la disabilità, come gli screen reader, non sono in grado di interpretare gli attributi di ARIA con nomi non validi. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Le tecnologie di ausilio per la disabilità, come gli screen reader, non sono in grado di interpretare gli attributi di ARIA con nomi non validi. [Ulteriori informazioni](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Gli attributi \"[aria-*]\" non sono validi o contengono errori ortografici"
+    "message": "Gli attributi `[aria-*]` non sono validi o contengono errori ortografici"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Gli attributi \"[aria-*]\" sono validi e non contengono errori ortografici"
+    "message": "Gli attributi `[aria-*]` sono validi e non contengono errori ortografici"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Le didascalie forniscono informazioni essenziali relative agli elementi audio, come chi sta parlando, il contenuto del dialogo e altre informazioni di contorno utilizzabili da non udenti e utenti con problemi di udito. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "I sottotitoli forniscono informazioni essenziali relative agli elementi audio, come chi sta parlando, il contenuto del dialogo e altre informazioni di contorno utilizzabili da non udenti e utenti con problemi di udito. [Ulteriori informazioni](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Gli elementi \"<audio>\" non contengono alcun elemento \"<track>\" con didascalie \"[kind=\"captions\"]\""
+    "message": "Negli elementi `<audio>` manca un elemento `<track>` con `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Gli elementi \"<audio>\" contengono un elemento \"<track>\" con didascalie \"[kind=\"captions\"]\""
+    "message": "Gli elementi `<audio>` contengono un elemento `<track>` con `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Elementi respinti"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Quando un pulsante non ha un nome accessibile, gli screen reader lo descriveranno semplicemente come \"pulsante\", rendendolo inutilizzabile per gli utenti di screen reader. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Quando un pulsante non ha un nome accessibile, gli screen reader lo descrivono semplicemente come \"pulsante\", rendendolo inutilizzabile per gli utenti che si affidano agli screen reader. [Ulteriori informazioni](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "I pulsanti non hanno nomi accessibili"
@@ -93,7 +93,7 @@
     "message": "I pulsanti hanno un nome accessibile"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Quando si aggiungono metodi per ignorare contenuti ripetitivi, la navigazione della pagina diventa più efficiente per chi usa la tastiera. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Se aggiungi metodi per ignorare contenuti ripetitivi, la navigazione della pagina diventa più efficiente per chi usa la tastiera. [Ulteriori informazioni](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "La pagina non contiene alcun titolo, skip link o area di riferimento"
@@ -102,7 +102,7 @@
     "message": "La pagina contiene un titolo, uno skip link o un'area di riferimento"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Il testo a basso contrasto è difficile, se non impossibile, da leggere per molti utenti. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Il testo a basso contrasto è difficile, se non impossibile, da leggere per molti utenti. [Ulteriori informazioni](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Il rapporto di contrasto tra i colori di sfondo e primo piano non è sufficiente."
@@ -111,88 +111,88 @@
     "message": "Il rapporto di contrasto tra i colori di sfondo e primo piano è sufficiente"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Quando il mark up degli elenchi di definizioni non è stato eseguito in modo corretto, gli screen reader possono generare risultati ambigui o inesatti. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Se il markup degli elenchi di definizioni non è stato eseguito in modo corretto, gli screen reader possono generare risultati ambigui o imprecisi. [Ulteriori informazioni](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Gli elementi \"<dl>\" non contengono solo gruppi \"<dt>\" e \"<dd>\" ed elementi \"<script>\" o \"<template>\" nell'ordine corretto."
+    "message": "Gli elementi `<dl>` non contengono solo gruppi `<dt>` e `<dd>` ed elementi `<script>` o `<template>` nell'ordine corretto."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Gli elementi \"<dl>\" contengono solo gruppi \"<dt>\" e \"<dd>\" ed elementi \"<script>\" o \"<template>\" nell'ordine corretto."
+    "message": "Gli elementi `<dl>` contengono solo gruppi `<dt>` e `<dd>` ed elementi `<script>` o `<template>` nell'ordine corretto."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Gli elementi dell'elenco di definizioni (\"<dt>\" e \"<dd>\") devono essere aggregati all'elemento \"<dl>\" principale per assicurare che gli screen reader possano descriverli correttamente. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Gli elementi dell'elenco di definizioni (`<dt>` e `<dd>`) devono essere aggregati in un elemento `<dl>` principale affinché gli screen reader possano descriverli correttamente. [Ulteriori informazioni](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Gli elementi dell'elenco di definizioni non sono aggregati agli elementi \"<dl>\""
+    "message": "Gli elementi dell'elenco di definizioni non sono aggregati negli elementi `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Gli elementi dell'elenco di definizioni sono aggregati agli elementi \"<dl>\""
+    "message": "Gli elementi dell'elenco di definizioni sono aggregati negli elementi `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Il titolo fornisce agli utenti di screen reader una panoramica della pagina, mentre per gli utenti di motori di ricerca è utile per stabilire se una pagina è da considerarsi pertinente ai fini della loro ricerca. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Il titolo fornisce agli utenti di screen reader una panoramica della pagina, mentre per gli utenti di motori di ricerca è utile per stabilire se una pagina è attinente alla loro ricerca. [Ulteriori informazioni](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Il documento non contiene alcun elemento \"<title>\""
+    "message": "Il documento non ha un elemento `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Il documento contiene un elemento \"<title>\""
+    "message": "Il documento ha un elemento `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Il valore di un attributo id deve essere univoco per evitare che altre istanze vengano ignorate dalle tecnologie per la disabilità. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Il valore di un attributo id deve essere univoco per evitare che altre istanze vengano ignorate dalle tecnologie di ausilio per la disabilità. [Ulteriori informazioni](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Gli attributi \"[id]\" sulla pagina non sono univoci"
+    "message": "Gli attributi `[id]` nella pagina non sono univoci"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Gli attributi \"[id]\" sulla pagina sono univoci"
+    "message": "Gli attributi `[id]` nella pagina sono univoci"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Gli screen reader fanno ricorso ai titoli dei frame per descrivere i contenuti dei frame ai loro utenti. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Gli screen reader si affidano ai titoli dei frame per descrivere i contenuti dei frame agli utenti. [Ulteriori informazioni](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Gli elementi \"<frame>\" o \"<iframe>\" non hanno un titolo"
+    "message": "Gli elementi `<frame>` o `<iframe>` non hanno un titolo"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Gli elementi \"<frame>\" o \"<iframe>\" hanno un titolo"
+    "message": "Gli elementi `<frame>` o `<iframe>` hanno un titolo"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Se una pagina non specifica alcun attributo lang, lo screen reader presuppone che la pagina è impostata nella lingua predefinita scelta dall'utente per tale screen reader al momento della configurazione. Se la pagina non è effettivamente impostata nella lingua predefinita, lo screen reader potrebbe non pronunciare il testo della pagina in modo corretto. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Se per una pagina non viene specificato alcun attributo lang, lo screen reader presuppone che la lingua della pagina sia quella predefinita scelta dall'utente durante la configurazione dello screen reader. Se la lingua della pagina non è effettivamente quella predefinita, lo screen reader potrebbe non pronunciare correttamente il testo della pagina. [Ulteriori informazioni](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "L'elemento \"<html>\" non ha un attributo \"[lang]\""
+    "message": "L'elemento `<html>` non ha un attributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "L'elemento \"<html>\" ha un attributo \"[lang]\""
+    "message": "L'elemento `<html>` ha un attributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Specificare una [lingua definita nel documento BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) aiuta gli screen reader a pronunciare il testo correttamente. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "La specifica di una [lingua BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valida consente agli screen reader di pronunciare correttamente il testo. [Ulteriori informazioni](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "L'elemento \"<html>\" non ha un valore valido per il corrispettivo attributo \"[lang]\"."
+    "message": "L'attributo `[lang]` dell'elemento `<html>` non ha un valore valido."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "L'elemento \"<html>\" ha un valore valido per il corrispettivo attributo \"[lang]\""
+    "message": "L'attributo `[lang]` dell'elemento `<html>` ha un valore valido"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Gli elementi informativi dovrebbero puntare a mostrare testo alternativo che sia breve e descrittivo. Gli elementi decorativi possono essere ignorati in un attributo ALT vuoto. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Gli elementi informativi dovrebbero mostrare testo alternativo breve e descrittivo. Gli elementi decorativi possono essere ignorati con un attributo alt vuoto. [Ulteriori informazioni](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Gli elementi immagine non hanno attributi \"[alt]\""
+    "message": "Gli elementi immagine non hanno attributi `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Gli elementi immagine hanno attributi \"[alt]\""
+    "message": "Gli elementi immagine hanno attributi `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Quando viene utilizzata un'immagine come pulsante di inserimento \"<input>\", fornire del testo alternativo può aiutare gli utenti di screen reader a comprendere lo scopo del pulsante. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Quando viene utilizzata un'immagine come pulsante `<input>`, fornire del testo alternativo può aiutare gli utenti di screen reader a comprendere lo scopo del pulsante. [Ulteriori informazioni](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Gli elementi \"<input type=\"image\">\" non hanno testo \"[alt]\""
+    "message": "Gli elementi `<input type=\"image\">` non hanno testo `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Gli elementi \"<input type=\"image\">\" hanno testo \"[alt]\""
+    "message": "Gli elementi `<input type=\"image\">` hanno testo `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Le etichette fanno in modo che i comandi del modulo siano descritti in modo corretto dalle tecnologie per la disabilità, come gli screen reader. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Le etichette consentono di assicurarsi che i comandi dei moduli vengano descritti in modo corretto dalle tecnologie di ausilio per la disabilità, come gli screen reader. [Ulteriori informazioni](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Gli elementi del modulo non hanno le corrispondenti etichette"
@@ -201,16 +201,16 @@
     "message": "Gli elementi del modulo sono associati a etichette"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Una tabella utilizzata per il layout non deve includere elementi di dati, come elementi th, elementi didascalia o l'attributo riepilogo, per evitare di confondere gli utenti di screen reader. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Una tabella utilizzata per il layout non deve includere elementi di dati, come elementi th, elementi didascalia o l'attributo riepilogo, per evitare di confondere gli utenti di screen reader. [Ulteriori informazioni](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Gli elementi “<table>“ della presentazione non evitano di utilizzare \"<th>\", \"<caption>\" o l'attributo \"[summary]\"."
+    "message": "Gli elementi `<table>` della presentazione non evitano di utilizzare `<th>`, `<caption>` o l'attributo`[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Gli elementi “<table>“ della presentazione evitano di utilizzare \"<th>\", \"<caption>\" o l'attributo \"[summary]\"."
+    "message": "Gli elementi `<table>` della presentazione evitano di utilizzare `<th>`, `<caption>` o l'attributo `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Un testo del link, incluso il testo alternativo per le immagini (se usate come link), che sia distinguibile, univoco e di cui sia impostabile lo stato attivo migliora l'esperienza di navigazione per gli utenti di screen reader. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Un testo dei link (incluso il testo alternativo delle immagini, se usate come link) distinguibile, univoco e per cui sia impostabile lo stato attivo migliora l'esperienza di navigazione per gli utenti di screen reader. [Ulteriori informazioni](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Il nome dei link non è distinguibile"
@@ -219,103 +219,115 @@
     "message": "I link hanno un nome distinguibile"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Gli screen reader descrivono gli elenchi in un determinato modo. Una struttura dell'elenco corretta agevola il compito dello screen reader. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Gli screen reader descrivono gli elenchi in un determinato modo. Una struttura dell'elenco corretta agevola il compito dello screen reader. [Ulteriori informazioni](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Gli elenchi non contengono solo elementi \"<li>\" ed elementi che supportano script (\"<script>\" e \"<template>\")."
+    "message": "Gli elenchi non contengono solo elementi `<li>` ed elementi che supportano script (`<script>` e `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Gli elenchi contengono solo elementi \"<li>\" ed elementi che supportano gli script (\"<script>\" e \"<template>\")."
+    "message": "Gli elenchi contengono solo elementi `<li>` ed elementi che supportano gli script (`<script>` e `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Gli screen reader richiedono che gli elementi dell'elenco (\"<li>\") siano contenuti in un elemento \"<ul>\" o \"<ol>\" principale per poterli descrivere in modo corretto. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Gli screen reader richiedono che gli elementi dell'elenco (`<li>`) siano contenuti in un elemento `<ul>` o `<ol>` principale per poterli descrivere in modo corretto. [Ulteriori informazioni](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Gli elementi dell'elenco (\"<li>\") non sono contenuti negli elementi principali \"<ul>\" o \"<ol>\"."
+    "message": "Gli elementi dell'elenco (`<li>`) non sono contenuti in elementi principali `<ul>` o `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Gli elementi dell'elenco (\"<li>\") sono contenuti negli elementi principali \"<ul>\" o \"<ol>\"."
+    "message": "Gli elementi dell'elenco (`<li>`) sono contenuti in elementi principali `<ul>` o `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "L'aggiornamento automatico della pagina è un evento imprevisto per l'utente e, una volta verificatosi, imposta di nuovo lo stato attivo sulla parte superiore della pagina. Ciò può costituire motivo di frustrazione o confusione per l'utente. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "L'aggiornamento automatico della pagina è un evento imprevisto per l'utente e, una volta verificatosi, imposta di nuovo lo stato attivo sulla parte superiore della pagina. Ciò può costituire motivo di frustrazione o confusione per l'utente. [Ulteriori informazioni](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Il documento utilizza il meta tag \"<meta http-equiv=\"refresh\">\""
+    "message": "Il documento usa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Il documento non utilizza il meta tag \"<meta http-equiv=\"refresh\">\""
+    "message": "Il documento non usa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Disattivare lo zoom è problematico per gli utenti ipovedenti che si affidano all'ingrandimento dello schermo per vedere in modo chiaro i contenuti di una pagina web. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Disattivare lo zoom è problematico per gli utenti ipovedenti che si affidano all'ingrandimento dello schermo per vedere in modo chiaro i contenuti di una pagina web. [Ulteriori informazioni](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "\"[user-scalable=\"no\"]\" viene utilizzato dall'elemento \"<meta name=\"viewport\">\" o l'attributo \"[maximum-scale]\" è inferiore a 5."
+    "message": "`[user-scalable=\"no\"]` viene usato nell'elemento `<meta name=\"viewport\">` o l'attributo `[maximum-scale]` è inferiore a 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "\"[user-scalable=\"no\"]\" non viene utilizzato dall'elemento \"<meta name=\"viewport\">\" e l'attributo \"[maximum-scale]\" non è inferiore a 5."
+    "message": "`[user-scalable=\"no\"]` non viene usato nell'elemento `<meta name=\"viewport\">` e l'attributo `[maximum-scale]` non è inferiore a 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Gli screen reader non possono tradurre contenuti senza testo. Aggiungere testo alternativo agli elementi \"<object>\" aiuta gli screen reader a comunicare il significato all'utente. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Gli screen reader non possono tradurre contenuti non testuali. Aggiungere testo alternativo agli elementi `<object>` aiuta gli screen reader a comunicare il significato agli utenti. [Ulteriori informazioni](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Gli elementi \"<object>\" non hanno testo \"[alt]\""
+    "message": "Gli elementi `<object>` non hanno testo `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Gli elementi \"<object>\" hanno testo \"[alt]\""
+    "message": "Gli elementi `<object>` hanno testo `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Un valore maggiore di 0 implica un ordine di navigazione esplicito. Sebbene sia tecnicamente valido, spesso ciò genera un'esperienza frustrante per gli utenti di tecnologie per la disabilità. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Un valore maggiore di 0 implica un ordine di navigazione esplicito. Sebbene sia tecnicamente valido, spesso genera un'esperienza frustrante per gli utenti che usano tecnologie di ausilio per la disabilità. [Ulteriori informazioni](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Alcuni elementi hanno un valore \"[tabindex]\" maggiore di 0"
+    "message": "Alcuni elementi hanno un valore `[tabindex]` maggiore di 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Nessun elemento ha un valore \"[tabindex]\" maggiore di 0"
+    "message": "Nessun elemento ha un valore `[tabindex]` maggiore di 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Gli screen reader sono dotati di funzionalità che semplificano la navigazione delle tabelle. Assicurare che le celle \"<td>\" che utilizzano l'attributo \"[headers]\" facciano riferimento esclusivamente ad altre celle nella stessa tabella può migliorare l'esperienza degli utenti di screen reader. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Gli screen reader sono dotati di funzionalità che semplificano lo spostamento nelle tabelle. Se ti assicuri che le celle `<td>` che usano l'attributo `[headers]` facciano riferimento esclusivamente ad altre celle nella stessa tabella puoi migliorare l'esperienza degli utenti di screen reader. [Ulteriori informazioni](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Le celle in un elemento \"<table>\" che utilizzano l'attributo \"[headers]\" fanno riferimento ad altre celle della stessa tabella."
+    "message": "Le celle in un elemento `<table>` che utilizzano l'attributo `[headers]` fanno riferimento ad altre celle della stessa tabella."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Le celle in un elemento \"<table>\" che utilizzano l'attributo \"[headers]\" fanno riferimento esclusivamente ad altre celle della stessa tabella."
+    "message": "Le celle in un elemento `<table>` che utilizzano l'attributo `[headers]` fanno riferimento esclusivamente ad altre celle della stessa tabella."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Gli screen reader sono dotati di funzionalità che semplificano la navigazione delle tabelle. Assicurare che i titoli delle tabelle facciano sempre riferimento a un insieme di celle può migliorare l'esperienza degli utenti di screen reader. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Gli screen reader sono dotati di funzionalità che semplificano lo spostamento nelle tabelle. Se ti assicuri che le intestazioni delle tabelle facciano sempre riferimento a un insieme di celle puoi migliorare l'esperienza degli utenti di screen reader. [Ulteriori informazioni](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Gli elementi \"<th>\" e gli elementi con ruolo \"[role=\"columnheader\"/\"rowheader\"]\" non hanno le celle di dati da essi descritte."
+    "message": "Gli elementi `<th>` e gli elementi con `[role=\"columnheader\"/\"rowheader\"]` non hanno le celle di dati da essi descritte."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Gli elementi \"<th>\" e gli elementi con ruolo \"[role=\"columnheader\"/\"rowheader\"]\" hanno le celle di dati da essi descritte."
+    "message": "Gli elementi `<th>` e gli elementi con ruolo `[role=\"columnheader\"/\"rowheader\"]` hanno le celle di dati da essi descritte."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Specificare una [lingua definita nel documento BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valida per gli elementi aiuta ad assicurare che il testo sia proncunciato in modo corretto dallo screen reader. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "La specifica di una [lingua BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valida per gli elementi consente di assicurarsi che il testo sia pronunciato correttamente dallo screen reader. [Ulteriori informazioni](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Gli attributi \"[lang]\" non hanno un valore valido"
+    "message": "Gli attributi `[lang]` non hanno un valore valido"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Gli attributi \"[lang]\" hanno un valore valido"
+    "message": "Gli attributi `[lang]` hanno un valore valido"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Quando un video fornisce una didascalia è più facile accederne alle informazioni per i non udenti o gli utenti con problemi di udito. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Se un video ha i sottotitoli, per i non udenti o gli utenti con problemi di udito è più facile accedere alle relative informazioni. [Ulteriori informazioni](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Gli elementi \"<video>\" non contengono alcun elemento \"<track>\" con didascalie \"[kind=\"captions\"]\""
+    "message": "Gli elementi `<video>` non contengono un elemento `<track>` con `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Gli elementi \"<video>\" contengono un elemento \"<track>\" con didascalie \"[kind=\"captions\"]\""
+    "message": "Gli elementi `<video>` contengono un elemento `<track>` con `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Le descrizioni audio forniscono informazioni importanti che il dialogo non può trasmettere, come espressioni facciali e scene. [Ulteriori informazioni](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Le descrizioni audio forniscono informazioni importanti che il dialogo non può trasmettere, come espressioni facciali e scene. [Ulteriori informazioni](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Gli elementi \"<video>\" non contengono alcun elemento \"<track>\" con descrizione \"[kind=\"description\"]\""
+    "message": "Gli elementi `<video>` non contengono un elemento `<track>` con `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Gli elementi \"<video>\" contengono un elemento \"<track>\" con descrizione \"[kind=\"description\"]\""
+    "message": "Gli elementi `<video>` contengono un elemento `<track>` con `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Per una visualizzazione ottimale su iOS quando gli utenti aggiungono contenuti alla schermata Home, definisci un elemento apple-touch-icon, che deve rimandare a un'immagine PNG quadrata di 192 px (o 180 px). [Ulteriori informazioni](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Non fornisce un valore `apple-touch-icon` valido"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Il valore `apple-touch-icon-precomposed` è obsoleto, pertanto è preferibile usare `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Fornisce un valore `apple-touch-icon` valido"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Le estensioni di Chrome incidono negativamente sulle prestazioni di caricamento di questa pagina. Prova a controllare la pagina in modalità di navigazione in incognito o da un profilo Chrome senza estensioni."
@@ -330,7 +342,7 @@
     "message": "Tempo di CPU totale"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Potresti ridurre i tempi di analisi, compilazione ed esecuzione di JS. A tale scopo potrebbe essere utile pubblicare payload JS di dimensioni inferiori. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Potresti ridurre i tempi di analisi, compilazione ed esecuzione di JavaScript. A tale scopo potrebbe essere utile pubblicare payload JavaScript di dimensioni inferiori. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Riduci il tempo di esecuzione di JavaScript"
@@ -339,13 +351,13 @@
     "message": "Tempo di esecuzione JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Le GIF di grandi dimensioni non sono efficaci per pubblicare contenuti animati. Anziché le GIF potresti usare video MPEG4/WebM per le animazioni e PNG/WebP per le immagini statiche. In questo modo userai meno byte di rete. [Ulteriori informazioni](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "I file GIF di grandi dimensioni non sono efficaci per la pubblicazione di contenuti animati. Anziché il formato GIF potresti usare video MPEG4/WebM per le animazioni e PNG/WebP per le immagini statiche. In questo modo userai meno byte di rete. [Ulteriori informazioni](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Usa formati video per i contenuti animati"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Potresti caricare in modo differito le immagini fuori schermo e nascoste al termine del caricamento di tutte le risorse fondamentali per ridurre il tempo necessario per la completa interattività. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Potresti usare il caricamento lento per le immagini fuori schermo e nascoste al termine del caricamento di tutte le risorse fondamentali per ridurre il tempo necessario per la completa interattività. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Rimanda immagini fuori schermo"
@@ -360,7 +372,7 @@
     "message": "I payload di rete di grandi dimensioni comportano costi reali per gli utenti e sono strettamente correlati a lunghi tempi di caricamento. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "Dimensioni totali: {totalBytes, number, bytes} kB"
+    "message": "Dimensioni totali: {totalBytes, number, bytes} kB"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Evita payload di rete enormi"
@@ -393,7 +405,7 @@
     "message": "Rimuovi il codice JavaScript inutilizzato"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Una lunga durata della cache può velocizzare le visite abituali della tua pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "La memorizzazione nella cache per un lungo periodo di tempo può velocizzare le visite abituali alla tua pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 risorsa trovata}other{# risorse trovate}}"
@@ -429,13 +441,64 @@
     "message": "Pubblica immagini in formati più recenti"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Nella sezione Catene di richieste fondamentali indicata di seguito vengono mostrate le risorse caricate con priorità elevata. Potresti ridurre la lunghezza delle catene e le dimensioni del download delle risorse oppure posticipare il download delle risorse non necessarie per migliorare il caricamento della pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Nella sezione Catene di richieste fondamentali indicata di seguito vengono mostrate le risorse caricate con priorità elevata. Potresti ridurre la lunghezza delle catene e le dimensioni del download delle risorse oppure rimandare il download delle risorse non necessarie per velocizzare il caricamento della pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 catena trovata}other{# catene trovate}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Riduci al minimo la profondità delle richieste fondamentali"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Ritiro/avviso"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Riga"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Le API obsolete verranno rimosse dal browser prima o poi. [Ulteriori informazioni](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 avviso trovato}other{# avvisi trovati}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Usa API obsolete"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Evita le API obsolete"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "L'API Cache applicazione è obsoleta. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" trovato"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Usa l'API Cache applicazione"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Evita l'API Cache applicazione"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "La specifica di un doctype impedisce al browser di passare alla modalità non standard. Leggi ulteriori informazioni nella [pagina MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Il nome del doctype deve essere la stringa minuscola `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Il documento deve contenere un doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Il campo publicId dovrebbe essere vuoto"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Il campo systemId dovrebbe essere vuoto"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Nella pagina manca il doctype HTML e viene quindi attivata la modalità non standard"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "La pagina ha il doctype HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elemento"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Viene evitato un DOM di dimensioni eccessive"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Target"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Aggiungi `rel=\"noopener\"` o `rel=\"noreferrer\"` a eventuali link esterni per migliorare le prestazioni ed evitare vulnerabilità di sicurezza. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "I link che rimandano a destinazioni multiorigine non sono sicuri"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "I link che rimandano a destinazioni multiorigine sono sicuri"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Impossibile stabilire la destinazione dell'ancoraggio ({anchorHTML}). Se non viene usato come link ipertestuale, potresti rimuovere target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Gli utenti sono sospettosi nei confronti dei siti che chiedono la loro posizione senza contesto o sono confusi da tali siti. Potresti associare la richiesta a un'azione dell'utente. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Chiede l'autorizzazione alla geolocalizzazione durante il caricamento della pagina"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Evita di chiedere l'autorizzazione alla geolocalizzazione durante il caricamento della pagina"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versione"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Tutte le librerie JavaScript front-end rilevate nella pagina."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Librerie JavaScript rilevate"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Per gli utenti con connessioni lente, gli script esterni inseriti in modo dinamico tramite `document.write()` potrebbero ritardare il caricamento della pagina di decine di secondi. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Usa `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Evita `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Massima gravità"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Versione libreria"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Numero di vulnerabilità"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Alcuni script di terze parti potrebbero contenere vulnerabilità di sicurezza note facilmente identificate e sfruttate dai malintenzionati. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 vulnerabilità rilevata}other{# vulnerabilità rilevate}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Include librerie JavaScript front-end con vulnerabilità di sicurezza note"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Alta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Bassa"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Media"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Evita librerie JavaScript front-end con vulnerabilità di sicurezza note"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Gli utenti sono sospettosi nei confronti dei siti che chiedono di inviare notifiche senza contesto o sono confusi da tali siti. Potresti associare la richiesta ai gesti dell'utente. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Chiede l'autorizzazione di accesso alle notifiche durante il caricamento della pagina"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Evita di chiedere l'autorizzazione di accesso alle notifiche durante il caricamento della pagina"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elementi che non consentono di incollare"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Impedire di incollare le password pregiudica l'efficacia delle norme di sicurezza. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Impedisce agli utenti di incollare contenuti nei campi delle password"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Consente agli utenti di incollare contenuti nei campi delle password"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocollo"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 offre tanti vantaggi rispetto a HTTP/1.1, tra cui intestazioni binarie, multiplexing e push del server. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 richiesta non pubblicata tramite HTTP/2}other{# richieste non pubblicate tramite HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Non usa HTTP/2 per tutte le sue risorse"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Usa HTTP/2 per le proprie risorse"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Potresti contrassegnare i listener di eventi di tocco e rotellina come `passive` per migliorare le prestazioni di scorrimento della pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Non usa listener passivi per migliorare le prestazioni dello scorrimento"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Usa listener passivi per migliorare le prestazioni dello scorrimento"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Descrizione"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Gli errori registrati nella console indicano la presenza di problemi irrisolti che potrebbero riguardare richieste di rete non andate a buon fine e altri problemi del browser."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Gli errori del browser sono stati registrati nella console"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Nessun errore del browser registrato nella console"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Usa la funzione CSS font-display per assicurarti che il testo sia visibile agli utenti durante il caricamento dei caratteri web. [Ulteriori informazioni](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Usa la funzionalità CSS font-display per assicurarti che il testo sia visibile agli utenti durante il caricamento dei caratteri web. [Ulteriori informazioni](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Assicurati che il testo rimanga visibile durante il caricamento dei caratteri web"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Tutto il testo rimane visibile durante il caricamento dei caratteri web"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Impossibile controllare automaticamente in Lighthouse il valore font-display del seguente URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Proporzioni (effettive)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Proporzioni (visualizzate)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Le dimensioni di visualizzazione delle immagini dovrebbero corrispondere alle proporzioni naturali. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Visualizza immagini con proporzioni errate"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Visualizza immagini con proporzioni corrette"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Informazioni sulle dimensioni dell'immagine {url} non valide"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL non sicuro"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Tutti i siti dovrebbero essere protetti con HTTPS, anche quelli che non trattano dati sensibili. HTTPS impedisce agli intrusi di manomettere o ascoltare passivamente le comunicazioni tra la tua app e i tuoi utenti ed è un prerequisito per HTTP/2 e tante nuove API delle piattaforme web. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 richiesta non sicura trovata}other{# richieste non sicure trovate}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Non usa HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Usa HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Un caricamento di pagina veloce su una rete cellulare garantisce una buona esperienza utente mobile. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Il caricamento veloce delle pagine su una rete cellulare assicura una buona esperienza utente sui dispositivi mobili. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interattivo a {timeInMs, number, seconds} s"
+    "message": "Interattiva a {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Interattivo su una rete mobile simulata a {timeInMs, number, seconds} s"
+    "message": "Interattiva su una rete mobile simulata a {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Il caricamento della pagina non è abbastanza veloce sulle reti mobili"
@@ -504,13 +735,13 @@
     "message": "Il lavoro del thread principale è ridotto al minimo"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "La latenza input stimata è una stima del tempo impiegato dall'app, espresso in millisecondi, per rispondere all'input dell'utente durante il periodo di 5 s più impegnativo del caricamento della pagina. Se la latenza è superiore a 50 ms, gli utenti potrebbero considerare lenta la tua applicazione. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "La metrica Latenza input stimata fornisce una stima del tempo impiegato dall'app, espresso in millisecondi, per rispondere all'input dell'utente durante il periodo di 5 s più impegnativo del caricamento della pagina. Se la latenza è superiore a 50 ms, gli utenti potrebbero considerare lenta la tua app. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Latenza input stimata"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "La metrica Prima visualizzazione con contenuti indica il momento in cui vengono visualizzati il primo testo o la prima immagine. [Ulteriori informazioni] (https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "La metrica First Contentful Paint (prima visualizzazione con contenuti) indica il momento in cui vengono visualizzati il primo testo o la prima immagine. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Visualizzazione dei primi contenuti"
@@ -522,22 +753,22 @@
     "message": "Prima inattività CPU"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "La metrica Visualizzazione primi contenuti utili indica quando diventano visibili i contenuti principali di una pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "La metrica First Meaningful Paint (visualizzazione primo elemento utile) indica quando diventano visibili i contenuti principali di una pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Visualizzazione primi contenuti utili"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Il tempo all'interattività è la quantità di tempo che la pagina impiega affinché diventi completamente interattiva. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "La metrica Tempo all'interattività indica il tempo necessario affinché la pagina diventi completamente interattiva. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Tempo per interattività"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Il potenziale ritardo prima interazione che i tuoi utenti potrebbero sperimentare è la durata, in millisecondi, del task più lungo."
+    "message": "Il potenziale ritardo prima interazione massimo che i tuoi utenti potrebbero riscontrare è la durata, in millisecondi, del task più lungo. [Ulteriori informazioni](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "RPI potenziale massimo"
+    "message": "Ritardo prima interazione potenziale max"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "La metrica Indice velocità mostra la velocità con cui diventano visibili i contenuti di una pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
@@ -545,17 +776,35 @@
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Indice velocità"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Somma di tutti i periodi di tempo, espressi in millisecondi, tra FCP e Tempo all'interattività, quando la durata del task ha superato 50 ms."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Tempo di blocco totale"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "I tempi di round trip della rete (RTT) influiscono sulla prestazione. Quando l'RTT verso un'origine è elevato, significa che i server più vicini all'utente potrebbero migliorare la prestazione. [Ulteriori informazioni](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "I tempi di round trip della rete (RTT) influiscono notevolmente sulle prestazioni. Quando l'RTT verso un'origine è elevato, significa che i server più vicini all'utente potrebbero migliorare le prestazioni. [Ulteriori informazioni](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Tempi di round trip della rete"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Le latenze dei server possono influire sulle prestazioni della rete. Quando la latenza del server di un'origine è elevata, significa che il server è sovraccarico oppure ha prestazioni di backend scadenti. [Ulteriori informazioni](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Le latenze dei server possono influire sulle prestazioni del Web. Quando la latenza del server di un'origine è elevata, significa che il server è sovraccarico oppure ha prestazioni di backend scadenti. [Ulteriori informazioni](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latenze server backend"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Oltre il budget"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Mantieni la quantità e le dimensioni delle richieste di rete al di sotto dei target impostati tramite il budget per le prestazioni fornito. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 richiesta}other{# richieste}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Budget per le prestazioni"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "I reindirizzamenti comportano ulteriori ritardi prima del caricamento della pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
@@ -563,32 +812,41 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Evita i reindirizzamenti tra più pagine"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Per impostare budget relativi alla quantità e alle dimensioni delle risorse della pagina, aggiungi un file budget.json. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 richiesta}other{# richieste}} • {byteCount, number, bytes} kB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Mantieni un numero ridotto di richieste e dimensioni di trasferimento limitate"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "I link canonici suggeriscono quale URL mostrare nei risultati di ricerca. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "URL ({urlList}) multipli in conflitto"
+    "message": "Diversi URL in conflitto ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Indirizza a un dominio diverso ({url})"
+    "message": "Rimanda a un altro dominio ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "URL ({url}) non valido"
+    "message": "URL non valido ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Indirizza a un'altra posizione \"hreflang\" ({url})"
+    "message": "Rimanda a un'altra posizione `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "URL ({url}) relativo"
+    "message": "URL relativo ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "Indirizza all'URL principale del dominio (la home page), anziché a una pagina di contenuto equivalente"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Il documento non contiene un \"rel=canonical\" valido"
+    "message": "Il documento non ha un valore `rel=canonical` valido"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Il documento contiene un \"rel=canonical\" valido"
+    "message": "Il documento ha un elemento `rel=canonical` valido"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Le dimensioni dei caratteri minori di 12 px sono troppo piccole per essere leggibili e richiederebbero ai visitatori di dispositivi mobili di \"pizzicare per eseguire lo zoom\" e poter leggere la pagina. Cerca di avere più del 60% del testo della pagina con una dimensione uguale o superiore a 12 px. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
@@ -596,14 +854,11 @@
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} del testo leggibile"
   },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} del testo è troppo piccolo."
-  },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Il testo è illeggibile perché non esiste un meta tag viewport ottimizzato per gli schermi dei dispositivi mobili."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} del testo è troppo piccolo (in base a un campione del {decimalProportionVisited, number, extendedPercent})."
+    "message": "Il {decimalProportion, number, extendedPercent} del testo è troppo piccolo (in base a un campione del {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Il documento non usa dimensioni dei caratteri leggibili"
@@ -612,13 +867,13 @@
     "message": "Il documento utilizza dimensioni dei caratteri leggibili"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "I link hreflang indicano ai motori di ricerca quale versione di una pagina devono elencare nei risultati di ricerca per una determinata lingua o regione. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "I link hreflang indicano ai motori di ricerca quale versione di una pagina devono elencare nei risultati di ricerca per una determinata lingua o area geografica. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Il documento non contiene alcun \"hreflang\" valido"
+    "message": "Il documento non ha un elemento `hreflang` valido"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Il documento contiene un \"hreflang\" valido"
+    "message": "Il documento ha un elemento `hreflang` valido"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Le pagine con codici di stato HTTP non validi potrebbero non essere indicizzate correttamente. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -639,7 +894,7 @@
     "message": "L'indicizzazione della pagina non è bloccata"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Il testo del link descrittivo aiuta i motori di ricerca a comprendere i tuoi contenuti. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "Il testo descrittivo dei link aiuta i motori di ricerca a comprendere i tuoi contenuti. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 link trovato}other{# link trovati}}"
@@ -657,7 +912,7 @@
     "message": "Dati strutturati validi"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Le meta descrizioni possono essere incluse nei risultati di ricerca per riassumere brevemente il contenuto della pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Le meta descrizioni possono essere incluse nei risultati di ricerca per riassumere brevemente i contenuti della pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Il testo della descrizione è vuoto."
@@ -669,7 +924,7 @@
     "message": "Il documento ha una meta descrizione"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "I motori di ricerca non possono indicizzare il contenuto del plug-in e molti dispositivi limitano i plug-in o non li supportano. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "I motori di ricerca non possono indicizzare i contenuti dei plug-in e molti dispositivi limitano i plug-in o non li supportano. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "Il documento utilizza plug-in"
@@ -681,7 +936,7 @@
     "message": "Se il file robots.txt non è valido, i crawler potrebbero non essere in grado di capire come vuoi che il tuo sito web venga sottoposto a scansione o indicizzato."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "La richiesta per robots.txt restituisce uno stato HTTP: {statusCode}"
+    "message": "La richiesta per robots.txt ha restituito uno stato HTTP: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{1 errore trovato}other{# errori trovati}}"
@@ -699,7 +954,7 @@
     "message": "Gli elementi interattivi come pulsanti e link dovrebbero essere abbastanza grandi (48 x 48 px) e avere abbastanza spazio intorno a loro, per essere facili da toccare senza sovrapporsi ad altri elementi. [Ulteriori informazioni](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "{decimalProportion, number, percent} dei target dei tocchi è dimensionato in modo appropriato"
+    "message": "Il {decimalProportion, number, percent} dei target dei tocchi ha dimensioni appropriate"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "I target dei tocchi sono troppo piccoli perché non esiste un meta tag viewport ottimizzato per gli schermi dei dispositivi mobili"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Target sovrapposto"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Dimensioni"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Target dei tocchi"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "I target dei tocchi sono dimensionati in modo appropriato"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Tempo thread principale"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Terza parte"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Il codice di terze parti può incidere notevolmente sulle prestazioni del caricamento. Limita il numero di provider di terze parti superflui e prova a caricare il codice di terze parti al termine del caricamento della pagina. [Ulteriori informazioni](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 terza parte trovata}other{# terze parti trovate}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Uso di terze parti"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "La metrica Tempo per primo byte identifica il momento in cui il server invia una risposta. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "Il documento root ha richiesto {timeInMs, number, milliseconds} ms"
+    "message": "Il documento radice ha richiesto {timeInMs, number, milliseconds} ms"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "Riduci i tempi di risposta del server (TTFB)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Durata"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nome"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Inizio"
   },
@@ -744,7 +1008,7 @@
     "message": "Tipo"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Potresti dotare la tua app dell'API User Timing per misurare le prestazioni reali durante le esperienze utente chiave. [Ulteriori informazioni] (https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Potresti dotare la tua app dell'API User Timing per misurare le prestazioni reali dell'app durante le esperienze utente chiave. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 tempo utente}other{# tempi utente}}"
@@ -753,7 +1017,7 @@
     "message": "Indicatori e misure User Timing"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "È stato trovato un elemento <link> di preconnessione per \"{securityOrigin}\", ma non è stato utilizzato dal browser. Verificare che l'attributo \"crossorigin\" sia utilizzato in modo corretto."
+    "message": "È stato trovato un elemento <link> di preconnessione per \"{securityOrigin}\", ma non è stato utilizzato dal browser. Verifica che l'attributo `crossorigin` sia utilizzato in modo corretto."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Potresti aggiungere hint di precollegamento o prelettura DNS delle risorse per collegarti anticipatamente a importanti origini di terze parti. [Ulteriori informazioni](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Precollegati alle origini necessarie"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "È stato trovato un <link> per \"{preloadURL}\", ma non è stato utilizzato dal browser. Verifica che l'attributo \"crossorigin\" sia utilizzato in modo corretto."
+    "message": "È stato trovato un elemento <link> di precaricamento per \"{preloadURL}\", ma non è stato utilizzato dal browser. Verifica che l'attributo `crossorigin` sia utilizzato in modo corretto."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Potresti usare <link rel=preload> per dare la priorità al recupero delle risorse attualmente richieste in un secondo momento nel caricamento della pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Potresti usare `<link rel=preload>` per dare la priorità al recupero delle risorse attualmente richieste in un secondo momento nel caricamento della pagina. [Ulteriori informazioni](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Precarica le richieste fondamentali"
@@ -789,10 +1053,10 @@
     "message": "Best practice"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Questi controlli evidenziano le opportunità per [migliorare l'accessibilità della tua applicazione web] (https://developers.google.com/web/fundamentals/accessibility). Solo un sottoinsieme di problemi di accessibilità può essere rilevato automaticamente in modo da incoraggiare anche i test manuali."
+    "message": "Questi controlli mettono in evidenza le opportunità per [migliorare l'accessibilità della tua applicazione web](https://developers.google.com/web/fundamentals/accessibility). È possibile rilevare automaticamente soltanto un sottoinsieme di problemi di accessibilità, pertanto sono consigliati anche i test manuali."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Questi elementi riguardano aree che uno strumento di test automatizzato non può coprire. Ulteriori informazioni nella nostra guida su come [effettuare un esame di accessibilità](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Questi elementi riguardano aree che uno strumento di test automatizzato non può coprire. Leggi ulteriori informazioni nella nostra guida su come [effettuare un esame di accessibilità](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Accessibilità"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabelle ed elenchi"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Best practice"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "I budget per le prestazioni consentono di stabilire gli standard per le prestazioni del tuo sito."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budget"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Ulteriori informazioni sulle prestazioni della tua applicazione."
+    "message": "Ulteriori informazioni sulle prestazioni della tua applicazione. Questi valori non [incidono direttamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) sul punteggio Prestazioni."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostica"
@@ -840,7 +1113,7 @@
     "message": "Miglioramenti della prima visualizzazione"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Queste ottimizzazioni possono velocizzare il caricamento della pagina."
+    "message": "Questi suggerimenti possono aiutarti a velocizzare il caricamento della pagina. Non [incidono direttamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) sul punteggio Prestazioni."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Opportunità"
@@ -867,7 +1140,7 @@
     "message": "Ottimizzato per PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Questi controlli assicurano che la pagina sia ottimizzata per il ranking dei risultati del motore di ricerca. Ci sono altri fattori che Lighthouse non controlla che potrebbero influenzare il ranking nella ricerca. [Ulteriori informazioni](https://support.google.com/webmasters/answer/35769)."
+    "message": "Questi controlli assicurano che la pagina sia ottimizzata per il ranking dei risultati del motore di ricerca. Ci sono altri fattori che Lighthouse non controlla che potrebbero incidere sul ranking nella ricerca. [Ulteriori informazioni](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Esegui questi altri strumenti di convalida sul tuo sito per controllare ulteriori best practice per SEO."
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL cache"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Posizione"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nome"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Richieste"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Tipo di risorsa"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Dimensioni (kB)"
+    "message": "Dimensioni"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Tempo trascorso"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Dimensioni trasferimento"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potenziali risparmi (kB)"
+    "message": "Potenziali riduzioni"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potenziali risparmi (ms)"
+    "message": "Potenziali riduzioni"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Potenziali risparmi di {wastedBytes, number, bytes} kB"
+    "message": "Potenziali riduzioni di {wastedBytes, number, bytes} kB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "Potenziali risparmi di {wastedMs, number, milliseconds} ms"
+    "message": "Potenziali riduzioni di {wastedMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Documento"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Carattere"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Immagine"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Contenuti multimediali"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds} ms"
+    "message": "{timeInMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Altro"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} s"
+    "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Foglio di stile"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Terze parti"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Totale"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Si è verificato un problema con la registrazione della traccia durante il caricamento pagina. Esegui di nuovo Lighthouse. ({errorCode})"
+    "message": "Si è verificato un problema con la registrazione della traccia durante il caricamento della pagina. Esegui di nuovo Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Timeout durante l'attesa della connessione iniziale al protocollo del debugger."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome non ha raccolto nessuno screenshot durante il caricamento pagina. Assicurati che sulla pagina siano presenti contenuti visibili e prova a eseguire di nuovo Lighthouse. ({errorCode})"
+    "message": "Chrome non ha raccolto nessuno screenshot durante il caricamento pagina. Assicurati che nella pagina siano presenti contenuti visibili, quindi riprova a eseguire Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "I server DNS non sono stati in grado di risolvere il dominio fornito."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Il gatherer {artifactName} richiesto ha riscontrato un errore: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Errore interno di Chrome. Riavvia Chrome e prova a eseguire di nuovo Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Il gatherer {artifactName} richiesto non è stato eseguito."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse non può completare il caricamento della pagina richiesta. Assicurati che l'URL verificato sia quello corretto e che il server stia rispondendo opportunamente a tutte le richieste."
@@ -945,13 +1266,16 @@
     "message": "Lighthouse non può completare il caricamento dell'URL richiesto perché la pagina non risponde più."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Le credenziali di sicurezza dell'URL fornito non sono valide. {securityMessages}"
+    "message": "L'URL fornito non ha un certificato di sicurezza valido. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome ha impedito il caricamento della pagina con un interstitial. Assicurati che l'URL verificato sia quello corretto e che il server stia rispondendo opportunamente a tutte le richieste."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Lighthouse non può completare il caricamento della pagina richiesta. Assicurati che l'URL verificato sia quello corretto e che il server stia rispondendo opportunamente a tutte le richieste. (Dettagli: {errorDetails})"
+    "message": "Impossibile caricare la pagina richiesta in modo affidabile in Lighthouse. Assicurati che l'URL verificato sia quello corretto e che il server stia rispondendo opportunamente a tutte le richieste. Informazioni dettagliate: {errorDetails}"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Lighthouse non può completare il caricamento della pagina richiesta. Assicurati che l'URL verificato sia quello corretto e che il server stia rispondendo opportunamente a tutte le richieste. (Codice di stato: {statusCode})"
+    "message": "Impossibile caricare la pagina richiesta in modo affidabile in Lighthouse. Assicurati che l'URL verificato sia quello corretto e che il server stia rispondendo opportunamente a tutte le richieste. (Codice di stato: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
     "message": "Il caricamento della tua pagina ha richiesto troppo tempo. Segui le opportunità fornite nel rapporto per ridurre il tempo di caricamento della pagina e prova a eseguire di nuovo Lighthouse. ({errorCode})"
@@ -984,7 +1308,7 @@
     "message": "Dati di prova controllati"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse] (https://developers.google.com/web/tools/lighthouse/) analizza la pagina corrente su una rete mobile emulata. I valori sono delle stime e potrebbero variare."
+    "message": "Analisi [Lighthouse](https://developers.google.com/web/tools/lighthouse/) della pagina corrente su una rete mobile emulata. I valori sono delle stime e potrebbero variare."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Ulteriori elementi da controllare manualmente"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Espandi snippet"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Mostra risorse di terze parti"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Si sono verificati dei problemi che incidono su questa esecuzione di Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "I valori sono delle stime e potrebbero variare."
+    "message": "I valori sono delle stime e potrebbero variare. Il punteggio relativo alle prestazioni è [basato soltanto su queste metriche](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Controlli superati ma con avvisi"
@@ -1023,10 +1350,10 @@
     "message": "Prendi in considerazione la possibilità di caricare la tua GIF su un servizio che la renda disponibile per l'incorporamento come video HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Installa un [plug-in di WordPress per il caricamento differito](https://wordpress.org/plugins/search/lazy+load/) che offra la possibilità di rimandare qualsiasi immagine fuori schermo oppure passa a un tema che offra questa funzionalità. Prendi in considerazione l'utilizzo del [plug-in AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Installa un [plug-in di WordPress per il caricamento lento](https://wordpress.org/plugins/search/lazy+load/) che consenta di rimandare qualsiasi immagine fuori schermo oppure passa a un tema che offra questa funzionalità. Potresti anche usare [il plug-in AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Esistono diversi plug-in di WordPress che puoi utilizzare per [incorporare le risorse di importanza critica](https://wordpress.org/plugins/search/critical+css/) o per [rimandare le risorse meno importanti](https://wordpress.org/plugins/search/defer+css+javascript/). Fai attenzione perché le ottimizzazioni offerte da questi plug-in potrebbero interrompere le funzionalità del tuo tema o dei tuoi plug-in, per cui è possibile che tu debba modificare il codice."
+    "message": "Esistono diversi plug-in di WordPress che possono esserti utili per [incorporare le risorse di importanza critica](https://wordpress.org/plugins/search/critical+css/) o [rimandare le risorse meno importanti](https://wordpress.org/plugins/search/defer+css+javascript/). Fai attenzione perché le ottimizzazioni offerte da questi plug-in potrebbero interrompere le funzionalità del tuo tema o dei tuoi plug-in, pertanto potresti dover modificare il codice."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Le specifiche del server, i plug-in e i temi contribuiscono al tempo di risposta del server. Prendi in considerazione l'idea di utilizzare un tema più ottimizzato, selezionando con cura un plug-in per l'ottimizzazione e/o eseguendo l'upgrade del server."
@@ -1035,30 +1362,30 @@
     "message": "Prendi in considerazione la possibilità di mostrare degli estratti nell'elenco dei tuoi post (ad esempio utilizzando il tag more), riducendo il numero di post che vengono mostrati su una determinata pagina, spezzando i post più lunghi su più pagine o utilizzando un plug-in per il caricamento differito dei commenti."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Esistono diversi [plug-in di WordPress](https://wordpress.org/plugins/search/minify+css/) che possono rendere più veloce il tuo sito concatenando, minimizzando e comprimendo i tuoi stili. Puoi anche utilizzare una procedura di progettazione per eseguire la minimizzazione in anticipo, se possibile."
+    "message": "Esistono diversi [plug-in di WordPress](https://wordpress.org/plugins/search/minify+css/) in grado di velocizzare il tuo sito concatenando, minimizzando e comprimendo i tuoi stili. Puoi anche utilizzare una procedura di progettazione per eseguire la minimizzazione in anticipo, se possibile."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Una serie di [plug-in di WordPress](https://wordpress.org/plugins/search/minify+javascript/) può rendere più veloce il tuo sito concatenando, minimizzando e comprimendo i tuoi script. Puoi anche utilizzare una procedura di progettazione per eseguire la minimizzazione in anticipo, se possibile."
+    "message": "Esistono diversi [plug-in di WordPress](https://wordpress.org/plugins/search/minify+javascript/) in grado di velocizzare il tuo sito concatenando, minimizzando e comprimendo i tuoi script. Puoi anche utilizzare una procedura di progettazione per eseguire la minimizzazione in anticipo, se possibile."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Prendi in considerazione la possibilità di ridurre, o scegliere, il numero di [plug-in di WordPress](https://wordpress.org/plugins/) che caricano CSS inutilizzato nella tua pagina. Per individuare i plug-in che aggiungono CSS estraneo, prova a eseguire il [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. Puoi individuare il tema o il plug-in responsabile nell'URL del foglio di stile. Cerca i plug-in che nell'elenco hanno diversi fogli di stile con molto rosso nel code coverage. Un plug-in dovrebbe accodare un foglio di stile solo se la pagina lo utilizza davvero."
+    "message": "Potresti ridurre, o cambiare, il numero di [plug-in di WordPress](https://wordpress.org/plugins/) che caricano file CSS inutilizzati nella tua pagina. Per individuare i plug-in che aggiungono CSS estraneo, prova a eseguire il [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. Puoi individuare il tema o il plug-in responsabile nell'URL del foglio di stile. Cerca i plug-in che nell'elenco hanno diversi fogli di stile con molto rosso nel code coverage. Un plug-in dovrebbe aggiungere in coda un foglio di stile solo se viene effettivamente utilizzato nella pagina."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Prendi in considerazione la possibilità di ridurre, o scegliere, il numero di [plug-in di WordPress](https://wordpress.org/plugins/) che caricano JavaScript inutilizzato nella tua pagina. Per individuare i plug-in che aggiungono JavaScript estraneo, prova a eseguire il [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. Puoi individuare il tema o il plug-in responsabile nell'URL dello script. Cerca i plug-in che nell'elenco hanno diversi script con molto rosso nel code coverage. Un plug-in dovrebbe accodare uno script solo se la pagina lo utilizza davvero."
+    "message": "Potresti ridurre, o cambiare, il numero di [plug-in di WordPress](https://wordpress.org/plugins/) che caricano file JavaScript inutilizzati nella tua pagina. Per individuare i plug-in che aggiungono JavaScript estraneo, prova a eseguire il [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. Puoi individuare il tema o il plug-in responsabile nell'URL dello script. Cerca i plug-in che nell'elenco hanno diversi script con molto rosso nel code coverage. Un plug-in dovrebbe aggiungere in coda uno script solo se viene effettivamente utilizzato nella pagina."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Leggi informazioni sulla [memorizzazione nella cache del browser su WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Leggi informazioni sulla [memorizzazione nella cache del browser in WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Prendi in considerazione l'utilizzo di un [plug-in di WordPress per l'ottimizzazione delle immagini](https://wordpress.org/plugins/search/optimize+images/) in grado di comprimere le tue immagini conservandone la qualità."
+    "message": "Potresti usare un [plug-in di WordPress per l'ottimizzazione delle immagini](https://wordpress.org/plugins/search/optimize+images/) in grado di comprimere le tue immagini preservandone la qualità."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Carica le immagini direttamente tramite la [libreria multimediale](https://codex.wordpress.org/Media_Library_Screen) per assicurarti che siano disponibili le dimensioni dell'immagine richieste, quindi inseriscile tramite la libreria multimediale o utilizza un widget per immagini per assicurarti che vengano utilizzate le dimensioni ottimali (incluse quelle per i punti di interruzione adattabili). Evita di utilizzare immagini a grandezza originale, a meno che le dimensioni non siano adatte all'utilizzo che vuoi farne. [Ulteriori informazioni](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Carica le immagini direttamente tramite la [libreria multimediale](https://codex.wordpress.org/Media_Library_Screen) per assicurarti che siano disponibili le dimensioni delle immagini richieste, quindi inseriscile dalla libreria multimediale o utilizza il widget per immagini per assicurarti che vengano utilizzate le dimensioni ottimali (incluse quelle per i punti di interruzione adattabili). Evita di utilizzare immagini `Full Size`, a meno che le dimensioni siano adatte all'utilizzo previsto. [Ulteriori informazioni](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Puoi attivare la compressione del testo nella configurazione del server web."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Prendi in considerazione l'utilizzo di un [plug-in](https://wordpress.org/plugins/search/convert+webp/) o di un servizio che converta automaticamente le immagini che hai caricato nel formato ottimale."
+    "message": "Potresti usare un [plug-in](https://wordpress.org/plugins/search/convert+webp/) o un servizio che converta automaticamente le immagini caricate nei formati ottimali."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/ja.json
+++ b/lighthouse-core/lib/i18n/locales/ja.json
@@ -1,6 +1,6 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "アクセスキーを使用して、ユーザーはページの特定の部分にすばやくフォーカスを移動できるようになります。正しく操作できるよう、各アクセスキーは一意にする必要があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)"
+    "message": "アクセスキーは、ユーザーがページの特定の部分にすばやくフォーカスを移動するときに使います。正しく操作できるよう、各アクセスキーは一意にする必要があります。[詳細](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
     "message": "`[accesskey]` の値が一意ではありません"
@@ -9,7 +9,7 @@
     "message": "`[accesskey]` の値は一意です"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "各 ARIA `role` は、`aria-*` 属性の特定のサブセットに対応しています。これらが一致しない場合、`aria-*` 属性は無効になります。[詳細](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)"
+    "message": "各 ARIA `role` は、`aria-*` 属性の特定のサブセットに対応しています。これらが一致しない場合、`aria-*` 属性は無効になります。[詳細](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
     "message": "`[aria-*]` 属性は役割と一致していません"
@@ -18,7 +18,7 @@
     "message": "`[aria-*]` 属性は役割と一致しています"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "一部の ARIA 役割には、スクリーン リーダーに要素の状態を伝える必須の属性があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)"
+    "message": "一部の ARIA 役割には、スクリーン リーダーに要素の状態を伝える必須の属性があります。[詳細](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
     "message": "`[role]` に必須の `[aria-*]` 属性が一部指定されていません"
@@ -27,7 +27,7 @@
     "message": "`[role]` に必須の `[aria-*]` 属性がすべて指定されています"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "目的のユーザー補助機能を実行するには、一部の ARIA 親役割に特定の子役割を含める必要があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)"
+    "message": "目的のユーザー補助機能を実行するには、一部の ARIA 親役割に特定の子役割を含める必要があります。[詳細](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
     "message": "特定の子 `[role]` を必要とする `[role]` を指定した要素が見つかりません。"
@@ -36,7 +36,7 @@
     "message": "特定の子 `[role]` を必要とする `[role]` を指定した要素があります"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "目的のユーザー補助機能を正しく実行するには、一部の ARIA 子役割を特定の親役割に含める必要があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)"
+    "message": "目的のユーザー補助機能を正しく実行するには、一部の ARIA 子役割を特定の親役割に含める必要があります。[詳細](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
     "message": "`[role]` が必須の親要素に含まれていません"
@@ -45,7 +45,7 @@
     "message": "`[role]` は必須の親要素に含まれています"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "目的のユーザー補助機能を実行するには、ARIA 役割に有効な値を指定してください。[詳細](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "目的のユーザー補助機能を実行するには、ARIA 役割に有効な値を指定してください。[詳細](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
     "message": "`[role]` の値は無効です"
@@ -54,7 +54,7 @@
     "message": "`[role]` の値は有効です"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "支援技術（スクリーン リーダーなど）で、無効な値が指定された ARIA 属性を解釈できません。[詳細](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)"
+    "message": "支援技術（スクリーン リーダーなど）で、無効な値が指定された ARIA 属性を解釈できません。[詳細](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
     "message": "`[aria-*]` 属性に有効な値が指定されていません"
@@ -63,7 +63,7 @@
     "message": "`[aria-*]` 属性に有効な値が指定されています"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "支援技術（スクリーン リーダーなど）で、無効な名前が指定された ARIA 属性を解釈できません。[詳細](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)"
+    "message": "支援技術（スクリーン リーダーなど）で、無効な名前が指定された ARIA 属性を解釈できません。[詳細](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
     "message": "`[aria-*]` 属性は無効か、スペルミスがあります"
@@ -72,7 +72,7 @@
     "message": "`[aria-*]` 属性は有効で、スペルミスもありません"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "字幕を使用すると、聴覚障がいのあるユーザーが音声要素を利用できるようになります。話している人物やその内容、その他の会話以外の情報など、重要な情報を字幕で伝えることができます。[詳細](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)"
+    "message": "字幕を使用すると、聴覚障がいのあるユーザーが音声要素を利用できるようになります。話している人物やその内容、その他の会話以外の情報など、重要な情報を字幕で伝えることができます。[詳細](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
     "message": "`<audio>` 要素に `[kind=\"captions\"]` が指定された `<track>` 要素がありません。"
@@ -84,7 +84,7 @@
     "message": "問題のある要素"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "ボタンにユーザー補助機能名が指定されていない場合、スクリーン リーダーでは「ボタン」と読み上げられるため、スクリーン リーダーを使用しているユーザーはボタンの用途がわからず、使用することができなくなります。[詳細](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)"
+    "message": "ボタンにユーザー補助機能名が指定されていない場合、スクリーン リーダーでは「ボタン」と読み上げられるため、スクリーン リーダーを使用しているユーザーはボタンの用途がわからず、使用することができなくなります。[詳細](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "ボタンにユーザー補助機能名が指定されていません"
@@ -93,7 +93,7 @@
     "message": "ボタンにユーザー補助機能名が指定されています"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "重複するコンテンツをスキップする手段を追加すると、キーボードを使ったページの移動を効率化できます。[詳細](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)"
+    "message": "重複するコンテンツをスキップする手段を追加すると、キーボードを使ったページの移動を効率化できます。[詳細](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "ページに見出し、スキップリンク、またはランドマーク領域が設定されていません"
@@ -102,7 +102,7 @@
     "message": "ページに見出し、スキップリンク、またはランドマーク領域が設定されています"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "低コントラストのテキストを使用すると、多くのユーザーは読むことが困難または不可能になります。[詳細](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)"
+    "message": "低コントラストのテキストを使用すると、多くのユーザーは読むことが困難または不可能になります。[詳細](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "背景色と前景色には十分なコントラスト比がありません"
@@ -111,7 +111,7 @@
     "message": "背景色と前景色には十分なコントラスト比があります"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "定義リストが適切にマークアップされていないと、スクリーン リーダーで、誤解を招く内容や不正確な内容が読み上げられる可能性があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)"
+    "message": "定義リストが適切にマークアップされていないと、スクリーン リーダーで、誤解を招く内容や不正確な内容が読み上げられる可能性があります。[詳細](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
     "message": "`<dl>` には、正しく順序付けられた `<dt>` および `<dd>` グループ、`<script>` または `<template>` 要素以外も含まれています。"
@@ -120,7 +120,7 @@
     "message": "`<dl>` には、正しく順序付けられた `<dt>` および `<dd>` グループ、`<script>` または `<template>` 要素のみが含まれています。"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "スクリーン リーダーで正しく読み上げられるようにするには、定義リストの項目（`<dt>` と `<dd>`）を親の `<dl>` 要素でラップする必要があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)"
+    "message": "スクリーン リーダーで正しく読み上げられるようにするには、定義リストの項目（`<dt>` と `<dd>`）を親の `<dl>` 要素でラップする必要があります。[詳細](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
     "message": "定義リストの項目が `<dl>` 要素でラップされていません"
@@ -129,7 +129,7 @@
     "message": "定義リストの項目は `<dl>` 要素でラップされています"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "タイトルを指定すると、スクリーン リーダーのユーザーがページの概要を把握できるようになります。検索エンジンの使用時には、検索語句に関連するページかどうかを判断するための重要な要素となります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/title)"
+    "message": "タイトルを指定すると、スクリーン リーダーのユーザーがページの概要を把握できるようになります。検索エンジンの使用時には、検索語句に関連するページかどうかを判断するための重要な要素となります。[詳細](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "ドキュメントに `<title>` 要素が指定されていません"
@@ -138,7 +138,7 @@
     "message": "ドキュメントに `<title>` 要素が指定されています"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "他のインスタンスが支援技術によって見落とされることのないように、id 属性の値は一意にする必要があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)"
+    "message": "他のインスタンスが支援技術によって見落とされることのないように、id 属性の値は一意にする必要があります。[詳細](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
     "message": "ページの `[id]` 属性が一意ではありません"
@@ -147,7 +147,7 @@
     "message": "ページの `[id]` 属性は一意です"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "スクリーン リーダーでは、フレームのコンテンツを説明するためにフレームのタイトルが使用されます。[詳細](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)"
+    "message": "スクリーン リーダーでは、フレームのコンテンツを説明するためにフレームのタイトルが使用されます。[詳細](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "`<frame>` または `<iframe>` の要素にタイトルが指定されていません"
@@ -156,7 +156,7 @@
     "message": "`<frame>` または `<iframe>` の要素にタイトルが指定されています"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "ページで lang 属性が指定されていない場合、スクリーン リーダーは、スクリーン リーダーの設定時にユーザーが選択したデフォルト言語がページで使用されているものと見なします。そのページでデフォルト言語が実際には使用されていない場合、スクリーン リーダーはページのテキストを正しく読み上げられない可能性があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)"
+    "message": "ページで lang 属性が指定されていない場合、スクリーン リーダーは、スクリーン リーダーの設定時にユーザーが選択したデフォルト言語がページで使用されているものと見なします。そのページでデフォルト言語が実際には使用されていない場合、スクリーン リーダーはページのテキストを正しく読み上げられない可能性があります。[詳細](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
     "message": "`<html>` 要素に `[lang]` 属性が指定されていません"
@@ -165,7 +165,7 @@
     "message": "`<html>` 要素に `[lang]` 属性が指定されています"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "有効な [BCP 47 言語](https://www.w3.org/International/questions/qa-choosing-language-tags#question)を指定すると、スクリーン リーダーでテキストが正しく読み上げられるようになります。[詳細](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)"
+    "message": "有効な [BCP 47 言語](https://www.w3.org/International/questions/qa-choosing-language-tags#question)を指定すると、スクリーン リーダーでテキストが正しく読み上げられるようになります。[詳細](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
     "message": "`<html>` 要素の `[lang]` 属性に有効な値が指定されていません。"
@@ -174,7 +174,7 @@
     "message": "`<html>` 要素の `[lang]` 属性に有効な値が指定されています"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "説明的要素は、簡潔でわかりやすい代替テキストにする必要があります。装飾的要素は、alt 属性が空の場合は無視される可能性があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)"
+    "message": "説明的要素は、簡潔でわかりやすい代替テキストにする必要があります。装飾的要素は、alt 属性が空の場合は無視される可能性があります。[詳細](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
     "message": "画像要素に `[alt]` 属性が指定されていません"
@@ -183,7 +183,7 @@
     "message": "画像要素に `[alt]` 属性が指定されています"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "画像を `<input>` ボタンとして使用している場合は、代替テキストを指定すると、スクリーン リーダーのユーザーがボタンの用途を理解しやすくなります。[詳細](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)"
+    "message": "画像を `<input>` ボタンとして使用している場合は、代替テキストを指定すると、スクリーン リーダーのユーザーがボタンの用途を理解しやすくなります。[詳細](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "`<input type=\"image\">` 要素に `[alt]` テキストが指定されていません"
@@ -192,7 +192,7 @@
     "message": "`<input type=\"image\">` 要素に `[alt]` テキストが指定されています"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "ラベルを使用すると、フォームの各コントロールが支援技術（スクリーン リーダーなど）によって正しく読み上げられるようになります。[詳細](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)"
+    "message": "ラベルを使用すると、フォームの各コントロールが支援技術（スクリーン リーダーなど）によって正しく読み上げられるようになります。[詳細](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "フォームの要素にラベルが関連付けられていません"
@@ -201,7 +201,7 @@
     "message": "フォームの要素にラベルが関連付けられています"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "レイアウト目的で表を使用している場合は、th 要素、caption 要素、summary 属性などのデータ要素を含めないでください。スクリーン リーダーを操作しにくくなる可能性があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)"
+    "message": "レイアウト目的で表を使用している場合は、th 要素、caption 要素、summary 属性などのデータ要素を含めないでください。スクリーン リーダーを操作しにくくなる可能性があります。[詳細](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
     "message": "レイアウト用の `<table>` 要素で、`<th>`、`<caption>`、または `[summary]` 属性が使用されています。"
@@ -210,7 +210,7 @@
     "message": "レイアウト用の `<table>` 要素で、`<th>`、`<caption>`、または `[summary]` 属性は使用されていません。"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "識別可能、フォーカス可能な一意のリンクテキスト（および画像をリンクとして使用している場合はその代替テキスト）を使用すると、スクリーン リーダーでのナビゲーションの操作性が向上します。[詳細](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)"
+    "message": "識別可能、フォーカス可能な一意のリンクテキスト（および画像をリンクとして使用している場合はその代替テキスト）を使用すると、スクリーン リーダーでのナビゲーションの操作性が向上します。[詳細](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "リンクに識別可能な名前が指定されていません"
@@ -219,16 +219,16 @@
     "message": "リンクに識別可能な名前が指定されています"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "スクリーン リーダーでは、特殊な方法でリストが読み上げられます。適切に読み上げられるようにするには、正しいリスト構造を指定する必要があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)"
+    "message": "スクリーン リーダーでは、特殊な方法でリストが読み上げられます。適切に読み上げられるようにするには、正しいリスト構造を指定する必要があります。[詳細](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "リストには、`<li>` 要素と、要素をサポートするスクリプト（`<script>` と `<template>`）以外も含まれています。"
+    "message": "リストには、`<li>` 要素と、スクリプト対応要素（`<script>` と `<template>`）以外も含まれています。"
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "リストには、`<li>` 要素と、要素をサポートするスクリプト（`<script>` と `<template>`）のみが含まれています。"
+    "message": "リストには、`<li>` 要素と、スクリプト対応要素（`<script>` と `<template>`）のみが含まれています。"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "スクリーン リーダーで正しく読み上げられるようにするには、リスト項目（`<li>`）を親の `<ul>` または `<ol>` に含める必要があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)"
+    "message": "スクリーン リーダーで正しく読み上げられるようにするには、リスト項目（`<li>`）を親の `<ul>` または `<ol>` に含める必要があります。[詳細](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
     "message": "リスト項目（`<li>`）が `<ul>` または `<ol>` の親要素に含まれていません。"
@@ -237,7 +237,7 @@
     "message": "リスト項目（`<li>`）は `<ul>` または `<ol>` の親要素に含まれています"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "ユーザーはページが自動的に更新されると思っていないため、自動更新によってフォーカスがページ上部に戻ると、ユーザーの利便性が低下する可能性があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)"
+    "message": "ユーザーはページが自動的に更新されると思っていないため、自動更新によってフォーカスがページ上部に戻ると、ユーザーの利便性が低下する可能性があります。[詳細](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
     "message": "ドキュメントで `<meta http-equiv=\"refresh\">` が使用されています"
@@ -246,7 +246,7 @@
     "message": "ドキュメントで `<meta http-equiv=\"refresh\">` が使用されていません"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "ズーム機能を無効にすると、画面の拡大操作を利用する視力の弱いユーザーがウェブページのコンテンツを確認できなくなります。[詳細](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)"
+    "message": "ズーム機能を無効にすると、画面の拡大操作を利用する視力の弱いユーザーがウェブページのコンテンツを確認できなくなります。[詳細](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
     "message": "`[user-scalable=\"no\"]` が `<meta name=\"viewport\">` 要素で使用されているか、`[maximum-scale]` 属性が 5 未満に指定されています。"
@@ -255,7 +255,7 @@
     "message": "`[user-scalable=\"no\"]` は `<meta name=\"viewport\">` 要素で使用されておらず、`[maximum-scale]` 属性も 5 未満ではありません。"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "スクリーン リーダーでは、テキスト以外のコンテンツを解釈できません。`<object>` 要素に代替テキストを追加することで、スクリーン リーダーからユーザーに意味を伝えられるようになります。[詳細](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)"
+    "message": "スクリーン リーダーは、テキスト以外のコンテンツを解釈できません。`<object>` 要素に代替テキストを追加することで、スクリーン リーダーからユーザーに意味を伝えられるようになります。[詳細](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "`<object>` 要素に `[alt]` テキストが指定されていません"
@@ -264,7 +264,7 @@
     "message": "`<object>` 要素に `[alt]` テキストが指定されています"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "値が 0 より大きい場合は、明示的なナビゲーション順序を示します。技術的には有効ですが、多くの場合、支援技術を使用しているユーザーにとって利便性が低下します。[詳細](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)"
+    "message": "値が 0 より大きい場合は、明示的なナビゲーション順序を示します。技術的には有効ですが、多くの場合、支援技術を使用しているユーザーにとって利便性が低下します。[詳細](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "一部の要素で `[tabindex]` に 0 より大きい値が指定されています"
@@ -273,7 +273,7 @@
     "message": "`[tabindex]` に 0 より大きい値を指定している要素はありません"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "スクリーン リーダーには、表内の移動を補助する機能があります。`[headers]` 属性を使用している `<td>` セルが同じ表の他のセルのみを参照するように設定すると、スクリーン リーダーの利便性が向上する可能性があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)"
+    "message": "スクリーン リーダーには、表内の移動を補助する機能があります。`[headers]` 属性を使用している `<td>` セルが同じ表の他のセルのみを参照するように設定すると、スクリーン リーダーの利便性が向上する可能性があります。[詳細](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
     "message": "`[headers]` 属性を使用している `<table>` 要素内のセルは、同じ表の他のセルを参照しています。"
@@ -282,7 +282,7 @@
     "message": "`[headers]` 属性を使用している `<table>` 要素内のセルは、同じ表の他のセルのみを参照しています。"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "スクリーン リーダーには、表内の移動を補助する機能があります。表のヘッダーが常に一部のセルを参照するように設定すると、スクリーン リーダーの利便性が向上する可能性があります。[詳細](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)"
+    "message": "スクリーン リーダーには、表内の移動を補助する機能があります。表のヘッダーが常に一部のセルを参照するように設定すると、スクリーン リーダーの利便性が向上する可能性があります。[詳細](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
     "message": "`<th>` 要素および `[role=\"columnheader\"/\"rowheader\"]` が指定された要素に、記述されたデータセルがありません。"
@@ -291,7 +291,7 @@
     "message": "`<th>` 要素および `[role=\"columnheader\"/\"rowheader\"]` が指定された要素に、記述されたデータセルがあります。"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "要素に有効な [BCP 47 言語](https://www.w3.org/International/questions/qa-choosing-language-tags#question)を指定すると、スクリーン リーダーでテキストが正しく読み上げられるようになります。[詳細](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)"
+    "message": "要素に有効な [BCP 47 言語](https://www.w3.org/International/questions/qa-choosing-language-tags#question)を指定すると、スクリーン リーダーでテキストが正しく読み上げられるようになります。[詳細](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
     "message": "`[lang]` 属性に有効な値が指定されていません"
@@ -300,7 +300,7 @@
     "message": "`[lang]` 属性に有効な値が指定されています"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "動画に字幕を設定すると、聴覚障がいのあるユーザーが情報にアクセスしやすくなります。[詳細](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)"
+    "message": "動画に字幕を設定すると、聴覚障がいのあるユーザーが情報にアクセスしやすくなります。[詳細](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
     "message": "`<video>` 要素に、`[kind=\"captions\"]` が指定された `<track>` 要素が含まれていません。"
@@ -309,13 +309,25 @@
     "message": "`<video>` 要素に `[kind=\"captions\"]` が指定された `<track>` 要素が含まれています"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "音声による説明を使用すると、顔の表情や場面といった、会話で伝えることのできない動画の関連情報を提供できます。[詳細](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)"
+    "message": "音声による説明を使用すると、顔の表情や場面といった、会話で伝えることのできない動画の関連情報を提供できます。[詳細](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
     "message": "`<video>` 要素に、`[kind=\"description\"]` が指定された `<track>` 要素が含まれていません。"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "`<video>` 要素に、`[kind=\"description\"]` が指定された `<track>` 要素が含まれています"
+    "message": "`<video>` 要素に `[kind=\"description\"]` が指定された `<track>` 要素が含まれています"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "ユーザーがホーム画面に追加したときの iOS での望ましい表示方法を指定するには、apple-touch-icon を定義します。不透明な 192 px（または 180 px）の正方形 PNG を指す必要があります。[詳細](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "有効な `apple-touch-icon` が提供されていません"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` は古いバージョンです。`apple-touch-icon` を使用することをおすすめします。"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "有効な `apple-touch-icon` が提供されています"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome 拡張機能がこのページの読み込みに悪影響を及ぼしています。シークレット モードで、または拡張機能なしの Chrome プロファイルからページを監査してみてください。"
@@ -330,7 +342,7 @@
     "message": "合計 CPU 時間"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "JS の解析、コンパイル、実行にかかる時間の短縮をご検討ください。配信する JS ペイロードのサイズを抑えると効果が見込めます。[詳細](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
+    "message": "JavaScript の解析、コンパイル、実行にかかる時間の短縮をご検討ください。配信する JavaScript ペイロードのサイズを抑えると効果が見込めます。[詳細](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "JavaScript の実行にかかる時間の低減"
@@ -345,13 +357,13 @@
     "message": "アニメーション コンテンツでの動画フォーマットの使用"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "オフスクリーンの非表示の画像は、クリティカルなリソースをすべて読み込んだ後に遅れて読み込むようにして、インタラクティブになるまでの時間を短縮することをご検討ください。[Learn more](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "オフスクリーンの非表示の画像は、重要なリソースをすべて読み込んだ後に遅れて読み込むようにして、インタラクティブになるまでの時間を短縮することをご検討ください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "オフスクリーン画像の遅延読み込み"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "ページの初回ペイントをリソースが阻害しています。クリティカルな JS や CSS はインラインで配信し、それ以外の JS やスタイルはすべて遅らせることをご検討ください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
+    "message": "ページの初回ペイントをリソースがブロックしています。重要な JavaScript や CSS はインラインで配信し、それ以外の JavaScript やスタイルはすべて遅らせることをご検討ください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "レンダリングを妨げるリソースの除外"
@@ -360,7 +372,7 @@
     "message": "ネットワーク ペイロードのサイズが大きいと、ユーザーの金銭的負担が大きくなり、多くの場合、読み込み時間が長くなります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "合計サイズは {totalBytes, number, bytes} KB でした"
+    "message": "合計サイズは {totalBytes, number, bytes} KB でした"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "過大なネットワーク ペイロードの回避"
@@ -405,7 +417,7 @@
     "message": "静的なアセットでの効率的なキャッシュ ポリシーの使用"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "画像を最適化すると、読み込み時間を速くして、モバイルデータ量を抑えることができます。[詳細](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
+    "message": "画像を最適化すると、読み込み時間を短縮しモバイルデータ量を抑えることができます。[詳細](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "効率的な画像フォーマット"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "クリティカルなリクエストの深さの最小化"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "非推奨 / 警告"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "行"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "サポートの終了した API は最終的にブラウザから削除されます。[詳細](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 件の警告が見つかりました}other{# 件の警告が見つかりました}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "サポートを終了した API が使用されています"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "サポートを終了した API は使用されていません"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "アプリケーション キャッシュはサポートを終了しました。[詳細](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "「{AppCacheManifest}」が見つかりました"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "アプリケーション キャッシュを使用しています"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "アプリケーション キャッシュは使用していません"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "doctype を指定すると、ブラウザは後方互換モードに切り替えることができなくなります。詳しくは、[MDN Web Docs ページ](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)をご覧ください。"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "doctype 名には `html` を小文字の文字列で指定する必要があります"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "ドキュメントには doctype を指定する必要があります"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "publicId は空の文字列であることが想定されています"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "systemId は空の文字列であることが想定されています"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "ページに HTML doctype が指定されていないため、後方互換モードに切り替わります"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "ページに HTML doctype が指定されています"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "要素"
   },
@@ -447,7 +510,7 @@
     "message": "値"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "ブラウザ エンジニアは、ページに含まれる DOM の要素数が 1,500 個を超えないようにすることを推奨しています。ツリーの深さは 32 要素まで、子や親の要素数は 60 個までにするのが最適です。DOM サイズが大きいと、メモリの使用量が増え、[スタイルの計算](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)に時間がかかり、[レイアウトのリフロー](https://developers.google.com/speed/articles/reflow)というコストが発生します。[詳細](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
+    "message": "ブラウザ エンジニアは、ページに含まれる DOM の要素数が 1,500 個を超えないようにすることを推奨しています。ツリーの深さは 32 要素まで、子や親の要素数は 60 個までにするのが最適です。DOM サイズが大きいと、メモリの使用量が増え、[スタイルの計算](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)に時間がかかり、[レイアウトのリフロー](https://developers.google.com/speed/articles/reflow)というコストが発生する可能性があります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 件の要素}other{# 件の要素}}"
@@ -467,14 +530,182 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "過大な DOM サイズの回避"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "リンク先"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "パフォーマンスを向上し、セキュリティの脆弱性が生じないようにするには、`rel=\"noopener\"` または `rel=\"noreferrer\"` を外部リンクに追加します。[詳細](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "クロスオリジンへのリンクは安全ではありません"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "クロスオリジンへのリンクは安全です"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "アンカー（{anchorHTML}）のリンク先を特定できません。ハイパーリンクとして使用していない場合は、target=_blank を削除することをご検討ください。"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "サイトから脈絡なしに位置情報をリクエストされると、ユーザーは不信感を抱き、困惑します。リクエストはユーザーの操作と関連付けて行うようにしてください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "ページの読み込み時に位置情報がリクエストされます"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "ページの読み込み時に位置情報はリクエストされません"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "バージョン"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "ページで検出されたすべてのフロントエンドの JavaScript ライブラリです。"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "JavaScript ライブラリが検出されました"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "接続速度が遅い環境のユーザーの場合、`document.write()` で動的に挿入される外部スクリプトによってページの読み込みが数十秒遅れる可能性があります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "`document.write()` が使用されています"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "`document.write()` は使用されていません"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "最も高い重大度"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "ライブラリのバージョン"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "脆弱性の件数"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "一部の第三者スクリプトには、悪意のあるユーザーによって簡単に特定され利用されるような、既知のセキュリティの脆弱性が含まれていることがあります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 件の脆弱性が検出されました}other{# 件の脆弱性が検出されました}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "既知のセキュリティの脆弱性を含んだフロントエンドの JavaScript ライブラリが含まれています"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "高"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "低"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "中"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "既知のセキュリティの脆弱性を含んだフロントエンドの JavaScript ライブラリは除外されています"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "サイトから脈絡なしに通知の送信をリクエストされると、ユーザーは不信感を抱き、困惑します。リクエストはユーザーの操作と関連付けて行うようにしてください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "ページの読み込み時に通知パーミッションがリクエストされます"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "ページの読み込み時に通知パーミッションはリクエストされません"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "問題のある要素"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "パスワードの貼り付けを禁止すると、良好なセキュリティ ポリシーが損なわれます。[詳細](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "ユーザーはパスワード欄に貼り付けできません"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "ユーザーはパスワード欄に貼り付けできます"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "プロトコル"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 には、バイナリ ヘッダー、多重化、サーバー プッシュなど、HTTP/1.1 と比べて多くのメリットがあります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{HTTP/2 経由で配信されなかったリクエストが 1 件あります}other{HTTP/2 経由で配信されなかったリクエストが # 件あります}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "ページリソースの一部で HTTP/2 が使用されていません"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "ページ独自のリソースで HTTP/2 が使用されています"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "ページのスクロール パフォーマンスを高めるには、touch および wheel イベント リスナーを `passive` として指定することをご検討ください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "スクロール パフォーマンスを高める受動的なリスナーが使用されていません"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "スクロール パフォーマンスを高める受動的なリスナーが使用されています"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "説明"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "コンソールに記録されたエラーは未解決の問題を表します。ネットワーク リクエストの失敗や他のブラウザの問題が原因で表示される可能性があります。"
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "ブラウザのエラーがコンソールに記録されました"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "ブラウザのエラーはコンソールに記録されませんでした"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "フォント表示の CSS 機能を使用して、ウェブフォントの読み込み中にユーザーがテキストを見られるようにしてください。[詳細](https://developers.google.com/web/updates/2016/02/font-display)"
+    "message": "フォント表示の CSS 機能を使用して、ウェブフォントの読み込み中にユーザーがテキストを読めるようにしてください。[詳細](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "ウェブフォント読み込み中のテキストの表示"
   },
   "lighthouse-core/audits/font-display.js | title": {
     "message": "ウェブフォント読み込み中の全テキストの表示"
+  },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "次の URL の font-display の値を Lighthouse で確認できませんでした: {fontURL}"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "アスペクト比（実際）"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "アスペクト比（表示）"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "画像は本来のアスペクト比で表示する必要があります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "不適切なアスペクト比の画像が表示されています"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "正しいアスペクト比の画像が表示されています"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "画像サイズに関する情報（{url}）が正しくありません"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "安全でない URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "すべてのサイトは、機密性の高い情報を扱っていない場合でも、HTTPS で保護する必要があります。HTTPS は、侵入者があなたのアプリとユーザー間の通信を改ざんしたり、傍受したりするのを防ぎます。HTTPS は、HTTP/2 や多くの新しいウェブ プラットフォーム API を使用するための前提条件となります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{安全でないリクエストが 1 件見つかりました}other{安全でないリクエストが # 件見つかりました}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "HTTPS が使用されていません"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "HTTPS を使用しています"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "モバイル ネットワークでのページ読み込みを速くすることで、優れたモバイル ユーザー エクスペリエンスが実現されます。[詳細](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
@@ -504,7 +735,7 @@
     "message": "メインスレッド処理の最小化"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "入力の推定待ち時間とは、ページ読み込みの最もビジーな 5 秒間における、ユーザーの入力に対するアプリの推定応答時間（ミリ秒単位）です。待ち時間が 50 ミリ秒より長い場合、アプリの反応が悪いと思われる可能性があります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
+    "message": "入力の推定待ち時間とは、ページ読み込みの最もビジーな 5 秒間における、ユーザーの入力に対するアプリの推定応答時間（ミリ秒単位）です。待ち時間が 50 ミリ秒より長い場合、ユーザーはアプリの反応が悪いと感じる可能性があります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "入力の推定待ち時間"
@@ -534,10 +765,10 @@
     "message": "インタラクティブになるまでの時間"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "ユーザーに発生する可能性がある初回入力遅延とは、最も長いタスクの時間（ミリ秒単位）です。"
+    "message": "ユーザーに発生する可能性がある初回入力遅延の最大推定時間とは、最も長いタスクの時間（ミリ秒単位）です。[詳細](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "最大推定 FID"
+    "message": "初回入力遅延の最大推定時間"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "速度インデックスは、ページのコンテンツが取り込まれて表示される速さを表します。[詳細](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
@@ -545,17 +776,35 @@
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "速度インデックス"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "タスクの時間が 50 ミリ秒を上回った場合の、コンテンツの初回ペイントから操作可能になるまでのすべての時間の合計を、ミリ秒単位で表します。"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "合計ブロック時間"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "ネットワークのラウンドトリップ時間（RTT）はパフォーマンスに大きく影響します。発信元への RTT が高い場合は、サーバーの場所をユーザーの近くにするとパフォーマンスを改善できることを示します。[詳細](https://hpbn.co/primer-on-latency-and-bandwidth/)"
+    "message": "ネットワークのラウンドトリップ時間（RTT）はパフォーマンスに大きく影響します。発信元への RTT が高い場合は、サーバーの場所をユーザーの近くにするとパフォーマンスを改善できることを示しています。[詳細](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "ネットワークのラウンドトリップ時間"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "サーバーの待ち時間はウェブ パフォーマンスに影響することがあります。発信元のサーバー のレイテンシが高い場合は、サーバーが過負荷であるか、サーバーのバックエンド パフォーマンスが低いことを示します。[詳細](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
+    "message": "サーバーの待ち時間はウェブ パフォーマンスに影響することがあります。発信元のサーバーのレイテンシが高い場合は、サーバーが過負荷であるか、サーバーのバックエンド パフォーマンスが低いことを示しています。[詳細](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "サーバーのバックエンド待ち時間"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "予算超過"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "ネットワーク リクエストの数とサイズが、指定したパフォーマンス予算の設定目標内に収まるよう維持します。[詳細](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 件のリクエスト}other{# 件のリクエスト}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "パフォーマンス予算"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "リダイレクトを行うと、ページの読み込みにさらに時間がかかる可能性があります。[詳細](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
@@ -563,11 +812,20 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "複数のページ リダイレクトの回避"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "ページリソースの数とサイズの予算を設定するには、budget.json ファイルを追加します。[詳細](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 件のリクエスト}other{# 件のリクエスト}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "リクエスト数を少なく、転送サイズを小さく維持してください"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "正規リンクで、検索結果に表示する URL を指定します。[詳細](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "競合する URL が複数あります（{urlList}）"
+    "message": "複数の URL が競合しています（{urlList}）"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "別のドメイン（{url}）を指しています"
@@ -591,13 +849,10 @@
     "message": "ドキュメントに有効な `rel=canonical` が指定されています"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "12 px より小さいフォントサイズは小さすぎて判読できません。モバイル ユーザーは「ピンチしてズーム」操作を行う必要があります。60% を超えるページ テキストでフォント サイズを 12 px 以上になるようにしてください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
+    "message": "12 px より小さいフォントサイズは小さすぎて判読できず、モバイル ユーザーには「ピンチしてズーム」の操作が必要になります。60% を超えるページ テキストでフォント サイズを 12 px 以上になるようにしてください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "判読可能なテキスト: {decimalProportion, number, extendedPercent}"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "テキストの {decimalProportion, number, extendedPercent} が小さすぎます。"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "テキストが判読できません。モバイル スクリーン向けに最適化されたビューポート メタタグがありません。"
@@ -630,7 +885,7 @@
     "message": "ページに適切な HTTP ステータス コードが指定されています"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "ページをクロールする権限を検索エンジンに付与しないと、検索エンジンは検索結果にページを追加できません。[詳細](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
+    "message": "ページのクロールを許可しない場合、検索エンジンはそのページを検索結果に追加できません。[詳細](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "ページのインデックス登録を行えません"
@@ -651,7 +906,7 @@
     "message": "リンクにわかりやすいテキストが設定されています"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "[構造化データ テストツール](https://search.google.com/structured-data/testing-tool/)と[構造化データ用 Linter](http://linter.structured-data.org/)を実行して構造化データを検証してください。[詳細](https://developers.google.com/search/docs/guides/mark-up-content)"
+    "message": "[構造化データ テストツール](https://search.google.com/structured-data/testing-tool/)と[構造化データ用 Linter](http://linter.structured-data.org/) を実行して構造化データを検証してください。[詳細](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "構造化データが無効です"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "重複するターゲット"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "サイズ"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "タップ ターゲット"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "タップ ターゲットのサイズは適切に設定されています"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "メインスレッド時間"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "第三者"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "第三者コードによって、読み込み速度が著しく低下する可能性があります。重複する第三者プロバイダの数を制限したうえで、ページのメインの部分を読み込み終えた後に第三者コードを読み込んでみてください。[詳細](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 件の第三者が見つかりました}other{# 件の第三者が見つかりました}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "第三者の利用"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "最初の 1 バイトまでの時間は、サーバーが応答を返すまでにかかった時間を表しています。[詳細](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "ルート ドキュメントの読み込みに {timeInMs, number, milliseconds} ミリ秒かかりました"
+    "message": "ルート ドキュメントの読み込みに {timeInMs, number, milliseconds} ミリ秒かかりました"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "サーバー応答時間の短縮（TTFB）"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "継続時間"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "名前"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "開始時間"
@@ -765,7 +1029,7 @@
     "message": "「{preloadURL}」のプリロード <link> が見つかりましたが、ブラウザで使用されませんでした。`crossorigin` 属性を適切に使用していることをご確認ください。"
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "<link rel=preload> を使用して、現在ページ読み込みの後のほうでリクエストしているリソースを優先的に取得することをご検討ください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/preload)"
+    "message": "`<link rel=preload>` を使用して、現在ページ読み込みの後のほうでリクエストしているリソースを優先的に取得することをご検討ください。[詳細](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "キー リクエストのプリロード"
@@ -789,7 +1053,7 @@
     "message": "おすすめの方法"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "これらのチェックにより、[ウェブページのユーザー補助機能の改善点](https://developers.google.com/web/fundamentals/accessibility)が明確になります。自動的に検出できるユーザー補助の問題は一部に過ぎないため、手動テストも実行することをおすすめします。"
+    "message": "これらのチェックにより、[ウェブアプリのユーザー補助機能の改善点](https://developers.google.com/web/fundamentals/accessibility)が明確になります。自動的に検出できるユーザー補助の問題は一部に過ぎないため、手動テストも実施することをおすすめします。"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "ここに、自動テストツールではカバーできない範囲に対処する項目が表示されます。詳しくは、[ユーザー補助機能の審査を実施する](https://developers.google.com/web/fundamentals/accessibility/how-to-review)方法についてのガイドをご覧ください。"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "表とリスト"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "おすすめの方法"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "パフォーマンス予算は、サイトのパフォーマンスに関する基準を設定します。"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "予算"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "アプリケーションのパフォーマンスに関する詳細。"
+    "message": "アプリケーションのパフォーマンスに関する詳細。これらの数値は、パフォーマンス スコアには[直接影響](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)しません。"
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "診断"
@@ -840,7 +1113,7 @@
     "message": "初回ペイントの改善点"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "これらの項目を改善すると、ページの読み込み時間を短縮できます。"
+    "message": "これらの提案を実施すると、ページの読み込み時間を短縮できる可能性があります。なお、パフォーマンス スコアには[直接影響](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)しません。"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "改善できる項目"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "キャッシュの TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "場所"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "名前"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "リクエスト"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "リソースの種類"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "サイズ（KB）"
+    "message": "サイズ"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "かかった時間"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "転送サイズ"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "減らせるデータ量（KB）"
+    "message": "減らせるデータ量"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "短縮できる時間（ミリ秒）"
+    "message": "短縮できる時間"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "{wastedBytes, number, bytes} KB 減らせます"
+    "message": "{wastedBytes, number, bytes} KB 減らせます"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "{wastedMs, number, milliseconds} ミリ秒短縮できます"
+    "message": "{wastedMs, number, milliseconds} ミリ秒短縮できます"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "ドキュメント"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "フォント"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "画像"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "メディア"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds} ミリ秒"
+    "message": "{timeInMs, number, milliseconds} ミリ秒"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "その他"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "スクリプト"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} 秒"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "スタイルシート"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "第三者"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "合計"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "ページを読み込む際のトレースの記録中にエラーが発生しました。もう一度 Lighthouse を実行してください。（{errorCode}）"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS サーバーは指定したドメインを解決できませんでした。"
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "必須の {artifactName} の収集でエラー（{errorMessage}）が発生しました"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Chrome 内部エラーが発生しました。Chrome を再起動して Lighthouse を再実行してください。"
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "必須の {artifactName} の収集は行われませんでした。"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "リクエストしたページを Lighthouse で正確に読み込めませんでした。正しい URL でテストを行い、すべてのリクエストに対してサーバーからの応答が適切であることを確認してください。"
@@ -945,7 +1266,10 @@
     "message": "ページからの応答が停止されたため、リクエストした URL を Lighthouse で正確に読み込めませんでした。"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "指定した URL には有効なセキュリティ認証情報がありません。{securityMessages}"
+    "message": "指定した URL には有効なセキュリティ証明書がありません。{securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome によりページ読み込みが停止され、中間ページが表示されました。正しい URL でテストを行い、すべてのリクエストに対してサーバーからの応答が適切であることを確認してください。"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "リクエストしたページを Lighthouse で正確に読み込めませんでした。正しい URL でテストを行い、すべてのリクエストに対してサーバーからの応答が適切であることを確認してください。（詳細: {errorDetails}）"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "スニペットを展開"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "第三者リソースを表示"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Lighthouse の実行に影響する問題が発生しました。"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "推定値のため変動する可能性があります。"
+    "message": "推定値のため変動する可能性があります。パフォーマンス スコアは、[こちらの指標のみを基準に算出](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)されます。"
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "監査には合格しましたが警告があります"
@@ -1026,7 +1353,7 @@
     "message": "[WordPress の遅延読み込みプラグイン](https://wordpress.org/plugins/search/lazy+load/)をインストールすると、画面外の画像の読み込みを遅らせたり、遅延読み込み機能のあるテーマに切り替えたりできます。[AMP プラグイン](https://wordpress.org/plugins/amp/)の使用もご検討ください。"
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "[重要なアセットをインラインで読み込む](https://wordpress.org/plugins/search/critical+css/)または [重要度が低いリソースの読み込みを遅らせる](https://wordpress.org/plugins/search/defer+css+javascript/)ために役立つ、さまざまな WordPress プラグインがあります。ただし、これらのプラグインの最適化処理によって、テーマやプラグインの機能が阻害されることがあります。その場合は、コードを変更する必要があります。"
+    "message": "[重要なアセットをインラインで読み込む](https://wordpress.org/plugins/search/critical+css/)または[重要度が低いリソースの読み込みを遅らせる](https://wordpress.org/plugins/search/defer+css+javascript/)ために役立つ、さまざまな WordPress プラグインがあります。ただし、これらのプラグインの最適化処理によって、テーマやプラグインの機能が阻害されることがあります。その場合は、コードを変更する必要があります。"
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "テーマ、プラグイン、サーバー仕様はすべてサーバーの応答時間に影響します。より最適化されたテーマを探す、最適化プラグインを慎重に選ぶ、サーバーをアップグレードすることをおすすめします。"
@@ -1041,10 +1368,10 @@
     "message": "スクリプトを結合、軽量化、圧縮してサイトの動作を速くする、さまざまな [WordPress プラグイン](https://wordpress.org/plugins/search/minify+javascript/)があります。可能な場合は、ビルド処理で事前に軽量化しておくこともおすすめします。"
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "ページで使用されていない CSS を読み込む [WordPress プラグイン](https://wordpress.org/plugins/)の数を減らすか、他のプラグインに切り替えることをご検討ください。不要な CSS を読み込んでいるプラグインを特定するには、Chrome DevTools で [コードの Coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)を確認します。スタイルシートの URL から、それを使用しているテーマやプラグインを特定できます。多くのスタイルシートを使用しているプラグイン（コードの Coverage で赤色の部分が多いもの）をリストで探します。プラグインによってキューに追加されるスタイルシートは、実際にページで使用されるもののみにする必要があります。"
+    "message": "ページで使用されていない CSS を読み込む [WordPress プラグイン](https://wordpress.org/plugins/)の数を減らすか、他のプラグインに切り替えることをご検討ください。不要な CSS を読み込んでいるプラグインを特定するには、Chrome DevTools で[コードの Coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) を確認します。スタイルシートの URL から、それを使用しているテーマやプラグインを特定できます。多くのスタイルシートを使用しているプラグイン（コードの Coverage で赤色の部分が多いもの）をリストで探します。プラグインによってキューに追加されるスタイルシートは、実際にページで使用されるもののみにする必要があります。"
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "ページで使用されていない JavaScript を読み込む [WordPress プラグイン](https://wordpress.org/plugins/)の数を減らすか、他のプラグインに切り替えることをご検討ください。不要な JavaScript を読み込んでいるプラグインを特定するには、Chrome DevTools で [コードの Coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)を確認します。スクリプトの URL から、それを使用しているテーマやプラグインを特定できます。多くのスクリプトを使用しているプラグイン（コードの Coverage で赤色の部分が多いもの）をリストで探します。プラグインによってキューに追加されるスクリプトは、実際にページで使用されるもののみにする必要があります。"
+    "message": "ページで使用されていない JavaScript を読み込む [WordPress プラグイン](https://wordpress.org/plugins/)の数を減らすか、他のプラグインに切り替えることをご検討ください。不要な JavaScript を読み込んでいるプラグインを特定するには、Chrome DevTools で[コードの Coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) を確認します。スクリプトの URL から、該当のテーマやプラグインを特定できます。多くのスクリプトを使用しているプラグイン（コードの Coverage で赤色の部分が多いもの）をリストで探します。プラグインによってキューに追加されるスクリプトは、実際にページで使用されるもののみにする必要があります。"
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "[WordPress のブラウザ キャッシング](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)についてご確認ください。"
@@ -1053,12 +1380,12 @@
     "message": "画質を落とさずに画像を圧縮できる [WordPress の画像最適化プラグイン](https://wordpress.org/plugins/search/optimize+images/)の使用をご検討ください。"
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "[メディア ライブラリ](https://codex.wordpress.org/Media_Library_Screen)から直接画像をアップロードして必要な画像サイズを利用できるようにしたうえで、メディア ライブラリから挿入するか、画像ウィジェットを使用して、最適な画像サイズ（レスポンシブ ブレークポイントのサイズを含む）が使用されるようにします。「フルサイズ」の画像は、十分なスペースがある場合を除いて使用しないようにします。[詳細](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)をご覧ください。"
+    "message": "[メディア ライブラリ](https://codex.wordpress.org/Media_Library_Screen)から直接画像をアップロードして必要な画像サイズを利用できるようにしたうえで、メディア ライブラリから挿入するか、画像ウィジェットを使用して、最適な画像サイズ（レスポンシブ ブレークポイントのサイズを含む）が使用されるようにします。「`Full Size`」の画像は、十分なスペースがある場合を除いて使用しないようにします。[詳細](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "ウェブサーバーの設定でテキスト圧縮を有効にできます。"
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "アップロードした画像を最適なフォーマットに自動変換する [プラグイン](https://wordpress.org/plugins/search/convert+webp/)またはサービスの使用をご検討ください。"
+    "message": "アップロードした画像を最適なフォーマットに自動変換する[プラグイン](https://wordpress.org/plugins/search/convert+webp/)またはサービスの使用をご検討ください。"
   }
 }

--- a/lighthouse-core/lib/i18n/locales/ko.json
+++ b/lighthouse-core/lib/i18n/locales/ko.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "액세스 키를 사용하면 사용자가 페이지의 특정 부분에 신속하게 초점을 맞출 수 있습니다. 올바르게 탐색할 수 있으려면 모든 액세스 키가 고유해야 합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "액세스 키를 사용하면 사용자가 페이지의 특정 부분에 신속하게 포커스를 맞출 수 있습니다. 정상적으로 탐색하려면 모든 액세스 키가 고유해야 합니다. [자세히 알아보기](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "`[accesskey]` 값이 고유하지 않습니다"
+    "message": "`[accesskey]` 값이 고유하지 않음"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
     "message": "`[accesskey]` 값이 고유합니다"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "각각의 ARIA `역할`은 `aria-*` 속성으로 구성된 특정 하위 세트를 지원합니다. 이 두 가지가 일치하지 않으면 `aria-*` 속성이 유효하지 않게 됩니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "각 ARIA `role`은(는) `aria-*` 속성으로 구성된 특정 하위 세트를 지원합니다. 이 두 가지가 일치하지 않으면 `aria-*` 속성이 유효하지 않게 됩니다. [자세히 알아보기](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "`[aria-*]` 속성이 역할과 일치하지 않습니다"
+    "message": "`[aria-*]` 속성이 역할과 일치하지 않음"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "`[aria-*]` 속성이 역할과 일치합니다"
+    "message": "`[aria-*]` 속성이 역할과 일치함"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "일부 ARIA 역할에는 스크린 리더에 관한 요소의 상태를 설명하는 속성이 필요합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "일부 ARIA 역할에는 스크린 리더에 관한 요소의 상태를 설명하는 속성이 필요합니다. [자세히 알아보기](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "`[role]`에 필요한 모든 `[aria-*]` 속성이 포함되어 있지 않습니다"
+    "message": "`[role]`에 필요한 `[aria-*]` 속성이 모두 포함되지 않음"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "`[role]`에 모든 필수 `[aria-*]` 속성이 포함되어 있습니다"
+    "message": "`[role]`에 필요한 모든 `[aria-*]` 속성이 있음"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "일부 ARIA 상위 역할에서 의도한 접근성 기능을 실행하려면 특정 하위 역할을 포함하고 있어야 합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "일부 ARIA 상위 역할에서 의도한 접근성 기능을 실행하려면 특정 하위 역할을 포함하고 있어야 합니다. [자세히 알아보기](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "특정 하위 `[role]`이 필요한 요소에 `[role]`이 누락되었습니다"
+    "message": "특정 하위 `[role]`이(가) 필요한 `[role]` 지원 요소가 누락됨"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "특정 하위 `[role]`이 필요한 요소에 `[role]`이 있습니다"
+    "message": "특정 하위 `[role]`이(가) 필요한 `[role]` 지원 요소가 존재함"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "일부 ARIA 하위 역할에서 의도한 접근성 기능을 올바르게 실행하려면 특정 상위 역할에 포함되어 있어야 합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "일부 ARIA 하위 역할에서 의도한 접근성 기능을 올바르게 실행하려면 특정 상위 역할에 포함되어 있어야 합니다. [자세히 알아보기](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "필수 상위 요소에 `[role]`이 포함되어 있지 않습니다"
+    "message": "`[role]`이(가) 필수 상위 요소에 포함되지 않음"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "`[role]`은 필수 상위 요소에 포함됩니다"
+    "message": "`[role]`이(가) 필수 상위 요소에 포함됨"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA 역할에서 의도한 접근성 기능을 실행하려면 유효한 값을 포함하고 있어야 합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA 역할에서 의도한 접근성 기능을 실행하려면 유효한 값을 포함하고 있어야 합니다. [자세히 알아보기](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "`[role]` 값이 유효하지 않습니다"
+    "message": "`[role]` 값이 유효하지 않음"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "`[role]` 값이 유효합니다"
+    "message": "`[role]` 값이 유효함"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "스크린 리더와 같은 보조 기술은 잘못된 값이 있는 ARIA 속성을 해석하지 못합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "스크린 리더와 같은 보조 기술은 잘못된 값이 있는 ARIA 속성을 해석하지 못합니다. [자세히 알아보기](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "`[aria-*]` 속성에 유효한 값이 포함되어 있지 않습니다"
+    "message": "`[aria-*]` 속성에 유효한 값이 없음"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "`[aria-*]` 속성에 유효한 값이 포함되어 있습니다"
+    "message": "`[aria-*]` 속성에 유효한 값이 있음"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "스크린 리더와 같은 보조 기술은 잘못된 이름이 있는 ARIA 속성을 해석하지 못합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "스크린 리더와 같은 보조 기술은 잘못된 이름이 있는 ARIA 속성을 해석하지 못합니다. [자세히 알아보기](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "`[aria-*]` 속성이 잘못되었거나 철자가 틀렸습니다"
+    "message": "`[aria-*]` 속성이 유효하지 않거나 맞춤법 오류가 있음"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "`[aria-*]` 속성이 유효하며 철자가 틀리지 않았습니다"
+    "message": "`[aria-*]` 속성이 유효하며 맞춤법 오류가 없음"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "자막이 있으면 청각장애인이나 청각에 문제가 있는 사용자도 오디오 요소를 사용할 수 있게 되며 말하고 있는 사람, 말하는 내용, 기타 비음성적 정보와 같은 중요 정보가 제공됩니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "자막이 있으면 청각장애인이나 청각에 문제가 있는 사용자도 오디오 요소를 사용할 수 있게 되며 말하고 있는 사람, 말하는 내용, 기타 비음성적 정보와 같은 중요 정보가 제공됩니다. [자세히 알아보기](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "`<audio>` 요소에 `[kind=\"captions\"]`가 있는 `<track>` 요소가 누락되어 있습니다"
+    "message": "`<audio>` 요소에서 `[kind=\"captions\"]` 지원 `<track>` 요소가 누락됨"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "`<audio>` 요소에 `[kind=\"captions\"]`가 있는 `<track>` 요소가 포함되어 있습니다"
+    "message": "`<audio>` 요소에 `[kind=\"captions\"]` 지원 `<track>` 요소가 포함됨"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
-    "message": "실패한 요소"
+    "message": "통과하지 못한 요소"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "버튼에 접근 가능한 이름이 없는 경우 스크린 리더에서 '버튼'이라고 읽기 때문에 스크린 리더에 의존하는 사용자가 사용할 수 없게 됩니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "버튼에 접근 가능한 이름이 없는 경우 스크린 리더에서 '버튼'으로만 읽기 때문에 스크린 리더에 의존하는 사용자에게는 해당 버튼이 유용하지 않게 됩니다. [자세히 알아보기](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "버튼에 접근 가능한 이름이 없습니다"
@@ -93,7 +93,7 @@
     "message": "버튼에 접근 가능한 이름이 있습니다"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "반복적인 콘텐츠를 건너뛸 수 있는 방법을 추가하면 키보드 사용자가 페이지를 좀 더 효율적으로 탐색할 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "반복적인 콘텐츠를 건너뛸 방법을 추가하면 키보드 사용자가 페이지를 더 효율적으로 탐색할 수 있습니다. [자세히 알아보기](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "페이지에 제목, 링크 건너뛰기, 랜드마크 영역이 포함되어 있지 않습니다"
@@ -102,7 +102,7 @@
     "message": "페이지에 제목, 링크 건너뛰기, 랜드마크 영역이 포함되어 있습니다"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "많은 사용자가 저대비 텍스트를 읽는 데 어려움을 겪거나 전혀 읽지 못합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "많은 사용자가 저대비 텍스트를 읽는 데 어려움을 겪거나 전혀 읽지 못합니다. [자세히 알아보기](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "백그라운드 및 포그라운드 색상의 대비율이 충분하지 않습니다"
@@ -111,88 +111,88 @@
     "message": "백그라운드 및 포그라운드 색상의 대비율이 충분합니다"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "정의 목록이 올바르게 표시되지 않으면 스크린 리더에서 혼란스럽거나 정확하지 않은 내용을 말할 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "정의 목록이 올바르게 표시되지 않으면 스크린 리더에서 혼란스럽거나 정확하지 않은 내용을 말할 수 있습니다. [자세히 알아보기](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "`<dl>`에 순서가 올바른 `<dt>` 및 `<dd>` 그룹, `<script>` 또는 `<template>` 요소만 포함되어 있지 않습니다"
+    "message": "`<dl>`에 순서가 올바른 `<dt>` 및 `<dd>` 그룹, `<script>` 또는 `<template>` 요소만 포함되지 않음"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "`<dl>`이 순서가 올바른 `<dt>` 및 `<dd>` 그룹, `<script>` 또는 `<template>` 요소만 포함합니다"
+    "message": "`<dl>`에 순서가 올바른 `<dt>` 및 `<dd>` 그룹, `<script>` 또는 `<template>` 요소만 포함됨"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "스크린 리더에서 정의 목록 항목(`<dt>` 및 `<dd>`)을 올바르게 읽으려면 정의 목록 항목이 상위 `<dl>` 요소에 래핑되어 있어야 합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "스크린 리더에서 정의 목록 항목(`<dt>` 및 `<dd>`)을 올바르게 읽으려면 정의 목록 항목이 상위 `<dl>` 요소에 래핑되어 있어야 합니다. [자세히 알아보기](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "정의 목록 항목이 `<dl>` 요소에 래핑되어 있지 않습니다"
+    "message": "정의 목록 항목이 `<dl>` 요소에서 래핑되어 있지 않음"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "정의 목록 항목이 `<dl>` 요소에 래핑되어 있습니다"
+    "message": "정의 목록 항목이 `<dl>` 요소에서 래핑되어 있음"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "제목을 사용하면 스크린 리더 사용자에게는 페이지의 개요를 제공할 수 있으며 검색엔진 사용자는 페이지가 자신의 검색어와 관련되어 있는지 판단하기 위해 제목에 크게 의존합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/title)"
+    "message": "제목을 사용하면 스크린 리더 사용자에게는 페이지의 개요를 제공할 수 있으며 검색엔진 사용자는 페이지가 자신의 검색어와 관련되어 있는지 판단하기 위해 제목에 크게 의존합니다. [자세히 알아보기](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "문서에 `<title>` 요소가 없습니다"
+    "message": "문서에 `<title>` 요소가 없음"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "문서에 `<title>` 요소가 있습니다"
+    "message": "문서에 `<title>` 요소가 있음"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "보조 기술에서 다른 인스턴스를 놓치지 않도록 하려면 ID 속성값이 고유해야 합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "보조 기술에서 다른 인스턴스를 놓치지 않도록 하려면 ID 속성값이 고유해야 합니다. [자세히 알아보기](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "페이지에 있는 `[id]` 속성이 고유하지 않습니다"
+    "message": "페이지에 있는 `[id]` 속성이 고유하지 않음"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "페이지에 있는 `[id]` 속성이 고유합니다"
+    "message": "페이지에 있는 `[id]` 속성이 고유함"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "스크린 리더 사용자는 프레임 콘텐츠를 설명해 주는 프레임 제목을 사용합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "스크린 리더 사용자는 프레임 콘텐츠를 설명해 주는 프레임 제목을 사용합니다. [자세히 알아보기](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "`<frame>` 또는 `<iframe>` 요소에 제목이 없습니다"
+    "message": "`<frame>` 또는 `<iframe>` 요소에 제목이 없음"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "`<frame>` 또는 `<iframe>` 요소에 제목이 있습니다"
+    "message": "`<frame>` 또는 `<iframe>` 요소에 제목이 있음"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "페이지에서 lang 속성을 지정하지 않는 경우 스크린 리더는 사용자가 스크린 리더를 설정할 때 선택한 기본 언어로 페이지가 작성되어 있다고 가정합니다. 페이지가 기본 언어로 작성되어 있지 않으면 스크린 리더에서 페이지에 있는 텍스트를 제대로 읽어줄 수 없습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "페이지에서 lang 속성을 지정하지 않는 경우 스크린 리더는 사용자가 스크린 리더를 설정할 때 선택한 기본 언어로 페이지가 작성되어 있다고 가정합니다. 페이지가 기본 언어로 작성되어 있지 않으면 스크린 리더에서 페이지에 있는 텍스트를 제대로 읽어줄 수 없습니다. [자세히 알아보기](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "`<html>` 요소에 `[lang]` 속성이 없습니다"
+    "message": "`<html>` 요소에 `[lang]` 속성이 없음"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "`<html>` 요소에 `[lang]` 속성이 있습니다"
+    "message": "`<html>` 요소에 `[lang]` 속성이 있음"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "유효한 [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question)를 지정하면 스크린 리더에서 텍스트를 올바르게 읽는 데 도움이 됩니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "유효한 [BCP 47 언어](https://www.w3.org/International/questions/qa-choosing-language-tags#question)를 지정하면 스크린 리더에서 텍스트를 올바르게 읽는 데 도움이 됩니다. [자세히 알아보기](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "`<html>` 요소에 `[lang]` 속성에 맞는 유효한 값이 포함되어 있지 않습니다"
+    "message": "`<html>` 요소의 `[lang]` 속성에 유효한 값이 없음"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "`<html>` 요소에 `[lang]` 속성에 맞는 유효한 값이 포함되어 있습니다"
+    "message": "`<html>` 요소에 `[lang]` 속성의 유효한 값이 있음"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "정보 요소는 짧아야 하며 설명을 제공하는 대체 텍스트를 목표로 해야 합니다. 장식 요소는 Alt 속성이 비어 있는 경우 무시될 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "정보 요소는 짧아야 하며 설명을 제공하는 대체 텍스트를 목표로 해야 합니다. 장식 요소는 Alt 속성이 비어 있는 경우 무시될 수 있습니다. [자세히 알아보기](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "이미지 요소에 `[alt]` 속성이 포함되어 있지 않습니다"
+    "message": "이미지 요소에 `[alt]` 속성 없음"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "이미지 요소에 `[alt]` 속성이 있습니다"
+    "message": "이미지 요소에 `[alt]` 속성이 있음"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "이미지가 `<input>` 버튼으로 사용되는 경우 대체 텍스트를 제공하면 스크린 리더 사용자가 버튼의 목적을 쉽게 이해할 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "이미지가 `<input>` 버튼으로 사용되는 경우 대체 텍스트를 제공하면 스크린 리더 사용자가 버튼의 목적을 쉽게 이해하는 데 도움이 됩니다. [자세히 알아보기](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "`<input type=\"image\">` 요소에 `[alt]` 텍스트가 없습니다"
+    "message": "`<input type=\"image\">` 요소에 `[alt]` 텍스트가 없음"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "`<input type=\"image\">` 요소에 `[alt]` 텍스트가 있습니다"
+    "message": "`<input type=\"image\">` 요소에 `[alt]` 텍스트가 있음"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "라벨을 사용하면 스크린 리더와 같은 보조 기술에서 양식 컨트롤을 올바르게 읽을 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "라벨을 사용하면 스크린 리더와 같은 보조 기술에서 양식 컨트롤을 올바르게 읽을 수 있습니다. [자세히 알아보기](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "양식 요소에 관련 라벨이 포함되어 있지 않습니다"
@@ -201,16 +201,16 @@
     "message": "양식 요소에 관련 라벨이 포함되어 있습니다"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "스크린 리더 사용자에게 혼란스러운 환경이 생길 수 있으므로 레이아웃 용도로 사용되는 표에는 th 또는 caption 요소와 같은 데이터 요소나 summary 속성이 포함되지 않아야 합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "스크린 리더 사용자에게 혼란스러운 환경이 생길 수 있으므로 레이아웃 용도로 사용되는 표에는 th 또는 caption 요소와 같은 데이터 요소나 summary 속성이 포함되지 않아야 합니다. [자세히 알아보기](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "프레젠테이션과 관련된 `<table>` 요소가 `<th>`, `<caption>` 또는 `[summary]` 속성 사용을 방지하지 않습니다"
+    "message": "프레젠테이션 `<table>` 요소에서 `<th>`, `<caption>` 또는 `[summary]` 속성의 사용이 지양되지 않음"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "프레젠테이션과 관련된 `<table>` 요소가 `<th>`, `<caption>` 또는 `[summary]` 속성 사용을 방지합니다"
+    "message": "프레젠테이션 `<table>` 요소에서 `<th>`, `<caption>` 또는 `[summary]` 속성을 가급적 사용하지 않음"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "인식하기 쉽고, 고유하고, 초점을 맞추기 쉬운 링크 텍스트(및 이미지가 링크로 사용되는 경우 이미지의 대체 텍스트)를 사용하면 스크린 리더 사용자의 탐색 환경을 개선할 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "인식하기 쉽고, 고유하고, 초점을 맞추기 쉬운 링크 텍스트(및 이미지가 링크로 사용되는 경우 이미지의 대체 텍스트)를 사용하면 스크린 리더 사용자의 탐색 환경을 개선할 수 있습니다. [자세히 알아보기](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "링크에 인식 가능한 이름이 포함되어 있지 않습니다"
@@ -219,103 +219,115 @@
     "message": "링크에 인식 가능한 이름이 포함되어 있습니다"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "스크린 리더에는 목록을 읽는 특정 방식이 있습니다. 목록 구조를 적절히 작성하면 스크린 리더 출력에 도움이 됩니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "스크린 리더에는 목록을 읽는 특정 방식이 있습니다. 목록 구조를 적절히 작성하면 스크린 리더 출력에 도움이 됩니다. [자세히 알아보기](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "목록에 `<li>` 요소 및 스크립트 지원 요소(`<script>` 및 `<template>`)만 포함되어 있지 않습니다"
+    "message": "목록에 `<li>` 요소와 스크립트 지원 요소(`<script>` 및 `<template>`)만 포함되지 않음"
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "목록에 `<li>` 요소 및 스크립트 지원 요소(`<script>` 및 `<template>`)만 포함되어 있습니다"
+    "message": "목록에 `<li>` 요소와 요소 지원 스크립트(`<script>` 및 `<template>`)만 포함됨"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "스크린 리더에서 목록 항목(`<li>`)을 올바르게 읽으려면 목록 항목이 상위 `<ul>` 또는 `<ol>`에 포함되어 있어야 합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "스크린 리더에서 목록 항목(`<li>`)을 올바르게 읽으려면 목록 항목이 상위 `<ul>` 또는 `<ol>`에 포함되어 있어야 합니다. [자세히 알아보기](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "목록 항목(`<li>`)이 `<ul>`또는 `<ol>` 상위 요소에 포함되어 있지 않습니다"
+    "message": "목록 항목(`<li>`)이 `<ul>` 또는 `<ol>` 상위 요소 내에 포함되지 않음"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "목록 항목(`<li>`)이 `<ul>` 또는 `<ol>` 상위 요소에 포함되어 있습니다"
+    "message": "목록 항목(`<li>`)이 `<ul>` 또는 `<ol>` 상위 요소 내에 포함되어 있음"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "사용자는 페이지가 자동으로 새로고침된다고 예상하지 못하기 때문에 페이지가 자동으로 새로고침되면 초점이 다시 페이지 상단에 맞춰집니다. 이로 인해 불쾌하거나 혼란스러운 상황이 발생할 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "사용자는 페이지가 자동으로 새로고침된다고 예상하지 못하기 때문에 페이지가 자동으로 새로고침되면 초점이 다시 페이지 상단에 맞춰집니다. 이로 인해 불쾌하거나 혼란스러운 상황이 발생할 수 있습니다. [자세히 알아보기](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "문서에 `<meta http-equiv=\"refresh\">` 태그가 사용됩니다"
+    "message": "문서에서 `<meta http-equiv=\"refresh\">` 사용됨"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "문서에 `<meta http-equiv=\"refresh\">`가 사용되지 않습니다"
+    "message": "문서에서 `<meta http-equiv=\"refresh\">`이(가) 사용되지 않음"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "확대/축소를 사용 중지하면 저시력으로 인해 웹페이지의 콘텐츠를 제대로 확인하기 위해 화면 확대를 사용하는 사용자에게 문제가 될 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "확대/축소를 사용 중지하면 저시력으로 인해 웹페이지의 콘텐츠를 제대로 확인하기 위해 화면 확대를 사용하는 사용자에게 문제가 될 수 있습니다. [자세히 알아보기](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "`<meta name=\"viewport\">` 요소에 `[user-scalable=\"no\"]`가 사용되거나 `[maximum-scale]` 속성이 5보다 작습니다"
+    "message": "`[user-scalable=\"no\"]`이(가) `<meta name=\"viewport\">` 요소에서 사용되었거나 `[maximum-scale]` 속성이 5보다 작음"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "`<meta name=\"viewport\">` 요소에 `[user-scalable=\"no\"]`가 사용되어 있지 않으며 `[maximum-scale]` 속성이 5 미만이 아닙니다"
+    "message": "`[user-scalable=\"no\"]`은(는) `<meta name=\"viewport\">` 요소에 사용되지 않으며 `[maximum-scale]` 속성이 5보다 작지 않음"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "스크린 리더는 텍스트가 아닌 콘텐츠를 번역할 수 없습니다. `<object>` 요소에 alt 텍스트를 추가하면 스크린 리더에서 사용자에게 의미를 전달하는 데 도움이 됩니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "스크린 리더는 텍스트가 아닌 콘텐츠를 번역할 수 없습니다. `<object>` 요소에 Alt 텍스트를 추가하면 스크린 리더에서 사용자에게 텍스트의 의미를 전달하는 데 도움이 됩니다. [자세히 알아보기](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "`<object>` 요소에 `[alt]` 텍스트가 없습니다"
+    "message": "`<object>` 요소에 `[alt]` 텍스트가 없음"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "`<object>` 요소에 `[alt]` 텍스트가 있습니다"
+    "message": "`<object>` 요소에 `[alt]` 텍스트가 있음"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "0보다 큰 값은 명시적인 탐색 순서를 나타냅니다. 기술적으로는 유효하나 보조 기술에 의존하는 사용자에게 불편한 환경이 생기는 경우가 많습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "0보다 큰 값은 명시적인 탐색 순서를 나타냅니다. 기술적으로는 유효하나 보조 기술에 의존하는 사용자에게 불편한 환경이 생기는 경우가 많습니다. [자세히 알아보기](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "일부 요소에 0보다 큰 `[tabindex]` 값이 있습니다"
+    "message": "일부 요소의 `[tabindex]` 값이 0보다 큼"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "요소에 0보다 큰 `[tabindex]` 값이 없습니다"
+    "message": "`[tabindex]` 값이 0보다 큰 요소가 없음"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "스크린 리더에는 표를 좀 더 쉽게 탐색하는 기능이 있습니다. `[headers]` 속성을 사용하는 `<td>` 셀이 동일한 표에 있는 다른 셀만 참조하게 하면 스크린 리더 사용자 환경을 개선할 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "스크린 리더에는 표를 좀 더 쉽게 탐색하는 기능이 있습니다. `[headers]` 속성을 사용하는 `<td>` 셀이 동일한 테이블에 있는 다른 셀만 참조하게 하면 스크린 리더 사용자 환경을 개선할 수 있습니다. [자세히 알아보기](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "`[header]` 속성을 사용하는 `<table>` 요소의 셀이 동일한 표에 있는 다른 셀을 참조합니다"
+    "message": "`[headers]` 속성을 사용하는 `<table>` 요소의 셀이 동일한 테이블의 다른 셀을 참조함"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "`[headers]` 속성을 사용하는 `<table>` 요소의 셀이 동일한 표에 있는 다른 셀만 참조하고 있습니다"
+    "message": "`[headers]` 속성을 사용하는 `<table>` 요소의 셀은 동일한 테이블의 다른 셀만 참조함"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "스크린 리더에는 표를 좀 더 쉽게 탐색하는 기능이 있습니다. 표 헤더에서 항상 셀 세트 일부를 참조하게 하면 스크린 리더 사용자 환경이 개선될 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "스크린 리더에는 표를 좀 더 쉽게 탐색하는 기능이 있습니다. 표 헤더에서 항상 셀 세트 일부를 참조하게 하면 스크린 리더 사용자 환경이 개선될 수 있습니다. [자세히 알아보기](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "`<th>` 요소 및 `[role=\"columnheader\"/\"rowheader\"]`가 있는 요소에 해당 요소에서 설명하는 데이터 셀이 포함되어 있지 않습니다"
+    "message": "`<th>` 요소와 `[role=\"columnheader\"/\"rowheader\"]` 지원 요소가 설명하는 데이터 셀이 해당 요소에 포함되지 않음"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "`<th>` 요소 및 `[role=\"columnheader\"/\"rowheader\"]`가 있는 요소에 해당 요소에서 설명하는 데이터 셀이 포함되어 있습니다"
+    "message": "`<th>` 요소와 `[role=\"columnheader\"/\"rowheader\"]` 지원 요소가 설명하는 데이터 셀이 해당 요소에 포함됨"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "요소에 유효한 [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question)를 지정하면 스크린 리더에서 텍스트를 올바르게 읽는 데 도움이 됩니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "요소에 유효한 [BCP 47 언어](https://www.w3.org/International/questions/qa-choosing-language-tags#question)를 지정하면 스크린 리더에서 텍스트를 올바르게 읽는 데 도움이 됩니다. [자세히 알아보기](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "`[lang]` 속성에 유효한 값이 없습니다"
+    "message": "`[lang]` 속성에 유효한 값이 없음"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "`[lang]` 속성에 유효한 값이 포함되어 있습니다"
+    "message": "`[lang]` 속성에 유효한 값이 있음"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "동영상에 자막이 제공되면 청각장애인이나 난청이 있는 사용자가 동영상의 정보에 보다 쉽게 접근할 수 있습니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "동영상에 자막이 제공되면 청각장애인이나 난청이 있는 사용자가 동영상의 정보에 더 쉽게 접근할 수 있습니다. [자세히 알아보기](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "`<video>` 요소에 `[kind=\"captions\"]`가 있는 `<track>` 요소가 포함되어 있지 않습니다"
+    "message": "`<video>` 요소에 `[kind=\"captions\"]` 지원 `<track>` 요소가 포함되지 않음"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "`<video>` 요소에 `[kind=\"captions\"]`가 있는 `<track>` 요소가 포함되어 있습니다"
+    "message": "`<video>` 요소에 `[kind=\"captions\"]` 지원 `<track>` 요소가 포함됨"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "오디오 설명은 표정 및 장면과 같이 대화에서 제공할 수 없는 동영상에 관한 정보를 제공합니다. [자세히 알아보기](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "오디오 설명은 표정 및 장면과 같이 대화에서 제공할 수 없는 동영상에 관한 정보를 제공합니다. [자세히 알아보기](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "`<video>` 요소에 `[kind=\"description\"]`이 있는 `<track>` 요소가 포함되어 있지 않습니다"
+    "message": "`<video>` 요소에 `[kind=\"description\"]` 지원 `<track>` 요소가 포함되지 않음"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "`<video>` 요소에 `[kind=\"description\"]`이 있는 `<track>` 요소가 포함되어 있습니다"
+    "message": "`<video>` 요소에 `[kind=\"description\"]` 지원 `<track>` 요소가 포함됨"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "사용자가 홈 화면에 추가했을 때 iOS에서 제대로 표시되려면 apple-touch-icon을 정의해야 합니다. 투명하지 않은 192px 또는 180px 정사각형 PNG로 설정되어야 합니다. [자세히 알아보기](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "유효한 `apple-touch-icon`이(가) 제공되지 않음"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed`이(가) 최신 버전이 아니므로 `apple-touch-icon`이(가) 적합합니다."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "유효한 `apple-touch-icon` 제공"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome 확장 프로그램이 이 페이지의 로드 성능에 부정적인 영향을 미쳤습니다. 시크릿 모드나 확장 프로그램이 없는 Chrome 프로필에서 페이지를 검사해 보세요."
@@ -330,7 +342,7 @@
     "message": "총 CPU 시간"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "JS 파싱, 컴파일, 실행에 소요되는 시간을 줄이세요. 용량이 적은 JS 페이로드를 제공하는 것이 도움이 될 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
+    "message": "JS 파싱, 컴파일, 실행에 소요되는 시간을 줄여 보세요. 용량이 적은 JS 페이로드를 제공하면 도움이 될 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "자바스크립트 실행 시간 단축"
@@ -339,7 +351,7 @@
     "message": "자바스크립트 실행 시간"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "대용량 GIF는 애니메이션 콘텐츠를 전달하는 데 비효율적입니다. 애니메이션에는 MPEG4/WebM 동영상을, 정적인 이미지에는 PNG/WebP를 GIF 대신 사용하여 네트워크 바이트를 절약하세요. [자세히 알아보기](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "대용량의 GIF는 애니메이션 콘텐츠를 전달하는 데 비효율적입니다. 애니메이션에는 MPEG4/WebM 동영상을, 정적인 이미지에는 GIF 대신 PNG/WebP를 사용하여 네트워크 바이트를 절약하세요. [자세히 알아보기](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "애니메이션 콘텐츠에 동영상 형식 사용하기"
@@ -351,7 +363,7 @@
     "message": "오프스크린 이미지 지연하기"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "리소스가 페이지의 첫 번째 페인트를 차단하고 있습니다. 중요한 JS/CSS를 인라인으로 전달하고 중요하지 않은 모든 JS/style을 지연하는 것이 좋습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
+    "message": "리소스가 페이지의 첫 페인트를 차단하고 있습니다. 중요한 JS/CSS를 인라인으로 전달하고 중요하지 않은 모든 JS/Style을 지연하는 것이 좋습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "렌더링 차단 리소스 제거하기"
@@ -360,7 +372,7 @@
     "message": "네트워크 페이로드가 커지면 사용자에게 실제 비용 부담이 되며 로드 시간이 길어질 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "총 크기: {totalBytes, number, bytes}KB"
+    "message": "총 크기: {totalBytes, number, bytes}KB"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "네트워크 페이로드가 커지지 않도록 관리하기"
@@ -369,19 +381,19 @@
     "message": "대규모 네트워크 페이로드 방지하기"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "CSS 파일을 축소하면 네트워크 페이로드의 크기가 줄어들 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
+    "message": "CSS 파일을 축소하면 네트워크 페이로드 크기를 줄일 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "CSS 축소하기"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "자바스크립트 파일을 줄이면 페이로드 크기 및 스크립트 파싱 시간이 줄어들 수 있습니다. [자세히 알아보기](https://developers.google.com/speed/docs/insights/MinifyResources)"
+    "message": "자바스크립트 파일을 축소하면 페이로드 크기와 스크립트 파싱 시간을 줄일 수 있습니다. [자세히 알아보기](https://developers.google.com/speed/docs/insights/MinifyResources)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "자바스크립트 줄이기"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "스타일시트에서 사용하지 않는 규칙을 제거하고 스크롤 없이 볼 수 있는 부분에 사용되지 않는 CSS 로딩을 지연시켜 네트워크 활동에 소비되는 불필요한 바이트를 줄이세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "스타일시트에서 사용하지 않는 규칙을 삭제하고 스크롤 없이 볼 수 있는 부분에 사용되지 않는 CSS의 로드를 지연시켜 네트워크 활동에 소비되는 불필요한 바이트를 줄이세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "사용하지 않는 CSS 제거"
@@ -405,13 +417,13 @@
     "message": "정적인 애셋에 효율적인 캐시 정책 사용하기"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "최적화된 이미지는 빨리 로드되며 모바일 데이터를 적게 소비합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
+    "message": "최적화된 이미지는 빠르게 로드되며 모바일 데이터를 적게 소비합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "효율적으로 이미지 인코딩하기"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "알맞은 크기의 이미지를 게재하여 모바일 데이터를 절약하고 로드 시간을 단축하세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
+    "message": "적절한 크기의 이미지를 게재하여 모바일 데이터를 절약하고 로드 시간을 단축하세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "이미지 크기 적절하게 설정하기"
@@ -423,19 +435,70 @@
     "message": "텍스트 압축 사용"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "JPEG 2000, JPEG XR, WebP와 같은 이미지 형식을 사용하면 PNG 또는 JPEG보다 압축률이 높기 때문에 다운로드 속도가 빠르고 데이터 소비량도 줄어듭니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/webp)"
+    "message": "JPEG 2000, JPEG XR, WebP와 같은 이미지 형식을 사용하면 PNG 또는 JPEG보다 압축률이 높으므로 다운로드 속도가 빠르고 데이터 소비량도 줄어듭니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "차세대 형식을 사용해 이미지 제공하기"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "다음의 크리티컬 요청 체인(Critical Request Chains)은 로드 시 우선순위가 높은 리소스를 보여줍니다. 체인의 길이를 줄이고, 리소스의 다운로드 크기를 줄이거나 불필요한 리소스의 다운로드를 지연하여 페이지 로드 속도를 높이는 것이 좋습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "다음의 크리티컬 요청 체인은 로드 시 우선순위가 높은 리소스를 보여줍니다. 체인의 길이를 줄이고, 리소스의 다운로드 크기를 줄이거나 불필요한 리소스의 다운로드를 지연하여 페이지 로드 속도를 높이는 것이 좋습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1개 체인 발견됨}other{#개 체인 발견됨}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "중요 요청 깊이 최소화하기"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "지원 중단/경고"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "행"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "이후에 지원 중단된 API는 브라우저에서 삭제됩니다. [자세히 알아보기](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{경고 1개가 발견됨}other{경고 #개가 발견됨}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "지원 중단된 API 사용"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "지원 중단 API 지양하기"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "애플리케이션 캐시는 지원이 중단되었습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "검색된 ‘{AppCacheManifest}’"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "애플리케이션 캐시 사용"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "애플리케이션 캐시 지양하기"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Doctype을 지정하면 브라우저가 쿼크 모드로 전환할 수 없습니다. [MDN 웹 문서 페이지](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)에서 자세히 알아보세요."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Doctype 이름은 소문자 문자열 `html`이어야 합니다."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "문서에는 Doctype이 포함되어 있어야 합니다."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "publicId가 빈 문자열일 것으로 예상됨"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "systemId가 빈 문자열일 것으로 예상됨"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "페이지에 HTML Doctype이 없으므로 쿼크 모드가 트리거됨"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "페이지에 HTML Doctype 있음"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "요소"
@@ -447,7 +510,7 @@
     "message": "값"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "브라우저 엔지니어들은 페이지에 1,500개 미만의 DOM 요소를 포함하는 것을 권장합니다. 최적값은 트리 깊이가 요소 32개 미만이고 하위/상위 요소 60개 미만일 때입니다. DOM이 크면 메모리 사용량이 늘어나고 [스타일 계산](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) 시간이 길어질 수 있으며, 큰 비용이 드는 [레이아웃 리플로우](https://developers.google.com/speed/articles/reflow)가 발생할 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
+    "message": "브라우저 엔지니어들은 페이지에 1,500개 미만의 DOM 요소를 포함하는 것을 권장합니다. 최적값은 트리 깊이가 요소 32개 미만이고 하위/상위 요소 60개 미만일 때입니다. DOM이 크면 메모리 사용량이 늘어나고 [스타일 계산](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) 시간이 길어질 수 있으며 큰 비용이 드는 [레이아웃 리플로우](https://developers.google.com/speed/articles/reflow)가 발생할 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{요소 1개}other{요소 #개}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "과도한 DOM 크기 지양하기"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "타겟"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "성능을 개선하고 보안 취약점을 예방하려면 `rel=\"noopener\"` 또는 `rel=\"noreferrer\"`을(를) 외부 링크에 추가합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "교차 도메인 대상 링크가 안전하지 않음"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "교차 도메인 대상 링크가 안전함"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "앵커({anchorHTML})의 대상을 확인하지 못했습니다. 하이퍼링크로 사용되지 않는 경우 target=_blank를 삭제하는 것이 좋습니다."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "사용자가 컨텍스트 없이 위치 정보를 요청한 사이트를 신뢰할 수 없거나 이로 인해 혼란스러운 상태입니다. 대신 사용자 작업 요청 입력을 고려해 보세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "페이지 로드 시 위치정보 권한 요청"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "페이지 로드 시 위치정보 권한 요청 방지하기"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "버전"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "페이지에서 감지된 모든 프런트 엔드 JavaScript 라이브러리입니다."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "감지된 JavaScript 라이브러리"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "연결이 느린 사용자의 경우 `document.write()`에서 동적으로 삽입된 외부 스크립트로 인해 페이지 로드가 몇십 초까지 지연될 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "`document.write()`을(를) 사용함"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "`document.write()` 지양하기"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "높은 심각도순"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "라이브러리 버전"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "취약점 수"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "일부 타사 스크립트에는 공격자가 쉽게 식별하고 공격할 수 있는 알려진 보안 취약점이 포함되어 있을 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{취약점 1개가 감지됨}other{취약점 #개가 감지됨}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "알려진 보안 취약점이 있는 프런트 엔드 JavaScript 라이브러리가 포함됨"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "높음"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "낮음"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "보통"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "알려진 보안 취약점이 있는 프런트 엔드 JavaScript 라이브러리를 사용하지 않음"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "사용자가 컨텍스트 없이 알림 전송을 요청한 사이트를 신뢰할 수 없거나 이로 인해 혼란스러운 상태입니다. 대신 사용자 동작에 대한 요청 입력을 고려해 보세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "페이지 로드 시 알림 권한 요청"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "페이지 로드 시 알림 권한 요청 방지하기"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "통과하지 못한 요소"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "비밀번호 붙여넣기 방지로 인해 타당한 보안 정책이 저해됩니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "사용자가 비밀번호 입력란에 내용을 붙여넣지 못하도록 차단"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "사용자가 비밀번호 입력란에 붙여넣을 수 있도록 허용"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "프로토콜"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2는 HTTP/1.1에 비해 바이너리 헤더, 멀티플렉싱, 서버 푸시 등의 다양한 이점을 제공합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{HTTP/2를 통해 게재되지 않는 요청 1건}other{HTTP/2를 통해 게재되지 않는 요청 #건}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "모든 리소스에 HTTP/2를 사용하지 않음"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "자체 리소스에 HTTP/2 사용"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "터치 및 휠 이벤트 리스너를 `passive`(으)로 표시하면 페이지 스크롤 성능을 개선할 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "스크롤 성능 개선에 패시브 리스너를 사용하지 않음"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "스크롤 성능 개선에 패시브 리스너 사용"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "설명"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "콘솔에 로그된 오류는 해결되지 않은 문제를 의미합니다. 네트워크 요청 실패를 비롯한 기타 브라우저 문제로 인해 발생할 수 있습니다."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "브라우저 오류가 콘솔에 로그됨"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "콘솔에 로그된 브라우저 오류 없음"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "웹폰트가 로드되는 동안 사용자에게 텍스트가 표시되도록 글꼴 표시 CSS 기능을 사용하세요. [자세히 알아보기](https://developers.google.com/web/updates/2016/02/font-display)"
+    "message": "웹폰트가 로드되는 동안 사용자에게 텍스트가 표시되도록 글꼴 표시 CSS 기능을 사용합니다. [자세히 알아보기](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "웹폰트가 로드되는 동안 텍스트가 계속 표시되는지 확인하기"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "웹폰트가 로드되는 동안 모든 텍스트가 계속 표시됩니다"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse에서 다음 URL의 글꼴 표시 값을 자동으로 확인하지 못했습니다. {fontURL}"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "가로세로 비율(실제)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "가로세로 비율(표시됨)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "이미지 표시 측정기준은 원래 가로세로 비율과 일치해야 합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "이미지를 올바르지 않은 가로세로 비율로 표시"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "이미지를 올바른 가로세로 비율로 표시"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "잘못된 이미지 크기 정보 {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "안전하지 않은 URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "민감한 데이터를 다루지 않는 사이트를 포함한 모든 사이트는 HTTPS로 보호해야 합니다. HTTPS는 침입자가 앱과 사용자 사이의 통신을 조작하거나 통신에 대해 패시브 리스너를 사용하지 못하도록 방지하며 HTTP/2와 여러 신규 웹 플랫폼 API의 필수 요건이기도 합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{안전하지 않은 요청 1건 검색됨}other{안전하지 않은 요청 #건 검색됨}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "HTTPS 사용하지 않음"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "HTTPS 사용"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "셀룰러 네트워크에서 페이지 로딩이 빠르면 우수한 모바일 사용자 환경을 보장할 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "셀룰러 네트워크에서 페이지 로드가 빠르면 우수한 모바일 사용자 환경을 보장할 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "페이지와 상호작용할 수 있게 될 때까지 걸린 시간: {timeInMs, number, seconds}초"
+    "message": "페이지와 상호작용할 수 있게 될 때까지 걸린 시간: {timeInMs, number, seconds}초"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "시뮬레이션된 모바일 네트워크에서 페이지와 상호작용할 수 있게 될 때까지 걸린 시간: {timeInMs, number, seconds}초"
+    "message": "시뮬레이션된 모바일 네트워크에서 페이지와 상호작용할 수 있게 될 때까지 걸린 시간: {timeInMs, number, seconds}초"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "모바일 네트워크에서 페이지 로딩이 충분히 빠르지 않음"
@@ -510,7 +741,7 @@
     "message": "예상 입력 대기시간"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "콘텐츠가 포함된 첫 페인트는 첫 번째 텍스트 또는 이미지가 표시되는 시간을 나타냅니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "콘텐츠가 포함된 첫 페인트는 첫 번째 텍스트 또는 이미지가 표시되는 시간을 나타냅니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "최초 만족 페인트"
@@ -522,22 +753,22 @@
     "message": "최초 CPU 유휴 상태"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "최초 유의미 페인트는 페이지의 기본 콘텐츠가 표시되는 경우를 측정합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
+    "message": "유의미한 첫 페인트는 페이지의 기본 콘텐츠가 표시되는 경우를 측정합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "최초 유의미 페인트"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "사용할 수 있을 때까지 걸리는 시간은 완전히 페이지와 상호작용할 수 있게 될 때까지 걸리는 시간입니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "사용할 수 있을 때까지 걸리는 시간은 완전히 페이지와 상호작용할 수 있게 될 때까지 걸리는 시간입니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "상호작용 시간"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "사용자가 경험할 수 있는 첫 입력 지연은 가장 긴 작업의 길이(밀리초)입니다."
+    "message": "사용자가 경험할 수 있는 잠재적인 최대 첫 입력 지연은 가장 긴 작업의 길이(밀리초)입니다. [자세히 알아보기](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "잠재적인 최대 FID"
+    "message": "잠재적인 최대 첫 입력 지연"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "속도 색인은 페이지 콘텐츠가 얼마나 빨리 표시되는지 보여줍니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
@@ -545,17 +776,35 @@
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "속도 색인"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "FCP와 상호작용 시간 사이의 모든 시간의 합으로 작업 지속 시간이 50ms를 넘으면 밀리초 단위로 표현됩니다."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "총 차단 시간"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "네트워크 왕복 시간(RTT)이 성능에 큰 영향을 줍니다. 출발지로의 RTT가 크면 서버가 사용자에게 가까울 때 성능이 향상될 수 있음을 나타냅니다. [자세히 알아보기](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "네트워크 왕복 시간(RTT)이 성능에 큰 영향을 줍니다. 출발지로의 RTT가 크면 서버가 사용자에게 가까울 때 성능이 향상될 수 있음을 나타냅니다. [자세히 알아보기](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "네트워크 왕복 시간"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "서버 지연 시간은 웹 성능에 영향을 줄 수 있습니다. 출발지의 서버 지연 시간이 길면 서버에 과부하가 걸렸거나 백엔드 성능이 낮음을 나타냅니다. [자세히 알아보기](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "서버 지연 시간은 웹 성능에 영향을 줄 수 있습니다. 출발지의 서버 지연 시간이 길면 서버에 과부하가 걸렸거나 백엔드 성능이 낮음을 나타냅니다. [자세히 알아보기](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "서버 백엔드 지연 시간"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "예산 초과"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "네트워크 요청의 양과 크기는 제공된 성능 예산에 따라 설정된 목표치 아래로 유지하세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{요청 1건}other{요청 #건}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "성능 예산"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "리디렉션을 사용하면 페이지가 로드되기 전 추가적인 지연이 발생합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
@@ -563,20 +812,29 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "여러 차례의 페이지 리디렉션 피하기"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "페이지 리소스의 수량과 크기와 관련해 예산을 설정하려면 budget.json 파일을 추가하세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{요청 1건}other{요청 #건}} • {byteCount, number, bytes}KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "요청 수는 낮게, 전송 크기는 작게 유지하기"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "표준 링크는 검색결과에 어떤 URL을 표시할지 알려줍니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "표준 링크는 검색결과에 어떤 URL을 표시할지 알려줍니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "여러 개의 URL 충돌({urlList})"
+    "message": "여러 개의 URL({urlList})이 충돌됨"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "다른 도메인을 가리킴({url})"
+    "message": "다른 도메인({url})을 가리킵니다."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "잘못된 URL({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "다른 `hreflang` 위치({url})를 가리킴"
+    "message": "다른 `hreflang` 위치({url})를 가리킵니다."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "상대 URL({url})"
@@ -585,19 +843,16 @@
     "message": "콘텐츠 페이지가 아닌 도메인의 루트 URL(홈페이지)을 가리킴"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "문서에 유효한 `rel=canonical`이 없음"
+    "message": "문서에 유효한 `rel=canonical` 없음"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "문서에 유효한 `rel=canonical`이 있음"
+    "message": "문서에 유효한 `rel=canonical` 있음"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "12px보다 글꼴 크기가 작으면 읽기 어렵기 때문에 모바일 방문자가 '손가락으로 확대'해야만 읽을 수 있습니다. 페이지 텍스트의 60% 이상을 12px 이상으로 유지하도록 노력하세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "12px보다 글꼴 크기가 작으면 읽기 어렵기 때문에 모바일 방문자가 '손가락으로 확대'해야만 읽을 수 있습니다. 페이지 텍스트의 60% 이상을 12px 이상으로 유지하도록 노력하세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} 읽기 쉬운 텍스트"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "텍스트의 {decimalProportion, number, extendedPercent} 값이 너무 작습니다."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "모바일 화면에 최적화된 표시 영역 메타 태그가 없어서 텍스트를 알아볼 수 없음"
@@ -612,16 +867,16 @@
     "message": "문서가 읽기 쉬운 글꼴 크기를 사용함"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "hreflang 링크는 검색엔진에 특정 언어나 지역에서 페이지의 어떤 버전을 검색결과로 표시해야 할지 알려줍니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "hreflang 링크는 검색엔진에 특정 언어나 지역에서 페이지의 어떤 버전을 검색결과로 표시해야 할지 알려줍니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "문서에 유효한 `hreflang`이 없음"
+    "message": "문서에 유효한 `hreflang` 없음"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "문서에 유효한 `hreflang`이 있음"
+    "message": "문서에 유효한 `hreflang` 있음"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "실패한 HTTP 상태 코드가 있는 페이지는 제대로 색인이 생성되지 않을 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "실패한 HTTP 상태 코드가 있는 페이지는 제대로 색인이 생성되지 않을 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "페이지에 실패한 HTTP 상태 코드가 있음"
@@ -630,7 +885,7 @@
     "message": "페이지에 성공적인 HTTP 상태 코드가 있음"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "검색엔진이 페이지를 크롤링할 권한이 없으면 검색결과에 포함할 수 없습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "검색엔진이 페이지를 크롤링할 권한이 없으면 검색결과에 포함할 수 없습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "페이지의 색인 생성이 차단됨"
@@ -639,7 +894,7 @@
     "message": "페이지의 색인 생성이 차단되지 않음"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "설명적인 링크 텍스트는 검색엔진에서 콘텐츠를 이해하는 데 도움을 줍니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "구체적인 링크 텍스트는 검색엔진에서 콘텐츠를 이해하는 데 도움이 됩니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{링크 1개 찾음}other{링크 #개 찾음}}"
@@ -651,13 +906,13 @@
     "message": "링크에 설명 텍스트가 있음"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "[구조화된 데이터용 테스트 도구](https://search.google.com/structured-data/testing-tool/)와 [구조화된 데이터 Linter](http://linter.structured-data.org/)를 실행하여 구조화된 데이터를 검증합니다. [자세히 알아보기](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "[구조화된 데이터용 테스트 도구](https://search.google.com/structured-data/testing-tool/)와 [구조화된 데이터 Linter](http://linter.structured-data.org/)를 실행하여 구조화된 데이터를 검증합니다. [자세히 알아보기](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "구조화된 데이터가 유효함"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "검색결과에 페이지 콘텐츠를 간략하게 요약하기 위한 메타 설명이 포함될 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "검색결과에 페이지 콘텐츠를 간략하게 요약하기 위한 메타 설명이 포함될 수 있습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/description)"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "설명 텍스트가 비어 있습니다."
@@ -669,7 +924,7 @@
     "message": "문서에 메타 설명이 있음"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "검색엔진은 플러그인 콘텐츠의 색인을 생성할 수 없고 플러그인을 제한하거나 지원하지 않는 기기도 많습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "검색엔진은 플러그인 콘텐츠의 색인을 생성할 수 없고 플러그인을 제한하거나 지원하지 않는 기기도 많습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "문서가 플러그인을 사용함"
@@ -696,7 +951,7 @@
     "message": "robots.txt가 유효함"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "버튼이나 링크 같은 상호작용 요소는 충분히 커야 하며(48x48px), 주변에 충분한 공간이 있고 다른 요소와 겹치지 않아 쉽게 탭할 수 있어야 합니다. [자세히 알아보기](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "버튼이나 링크 같은 상호작용 요소는 충분히 커야 하며(48 x 48px), 주변에 충분한 공간이 있고 다른 요소와 겹치지 않아 쉽게 탭할 수 있어야 합니다. [자세히 알아보기](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} 탭 타겟 크기가 적절함"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "타겟이 중복됨"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "크기"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "탭 타겟"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "탭 타겟의 크기가 적절함"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "기본 스레드 시간"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "타사"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "타사 코드는 로드 성능에 크게 영향을 미칠 수 있습니다. 페이지에서 먼저 로딩을 끝낸 후 중복되는 타사 공급업체의 수를 제한하고 타사 코드를 로드해 보세요. [자세히 알아보기](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{타사 항목 1개 검색됨}other{타사 항목 #개 검색됨}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "타사 사용"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Time To First Byte는 서버가 응답을 보내는 시간을 식별합니다. [자세히 알아보기] (https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
+    "message": "Time To First Byte는 서버가 응답을 보내는 시간을 식별합니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "루트 문서에 {timeInMs, number, milliseconds}ms 소요됨"
+    "message": "루트 문서에 {timeInMs, number, milliseconds} ms 소요됨"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "서버 응답 시간(TTFB) 단축"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "시간"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "이름"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "시작 시간"
   },
@@ -744,7 +1008,7 @@
     "message": "유형"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "앱에 User Timing API를 사용하여 중요 사용자 경험이 이루어지는 동안의 실적을 측정하세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "앱에서 User Timing API를 사용하여 중요 사용자 경험이 이루어지는 동안의 실제 성능을 측정하세요. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{사용자 시간 1회}other{사용자 시간 #회}}"
@@ -753,7 +1017,7 @@
     "message": "사용자 타이밍 표시 및 측정 값"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "'{securityOrigin}'에 사전 연결 <link>가 있으나 브라우저에서 사용되지 않습니다. `crossorigin` 속성을 적절하게 사용하고 있는지 확인하세요."
+    "message": "‘{securityOrigin}’에 사전 연결 <link>가 있으나 브라우저에서 사용되지 않습니다. `crossorigin` 속성을 올바르게 사용하고 있는지 확인하세요."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "사전 연결 또는 DNS 프리페치 리소스 힌트를 추가하여 중요한 타사 원본에 대한 조기 연결을 수립하는 것이 좋습니다. [자세히 알아보기](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
@@ -765,7 +1029,7 @@
     "message": "'{preloadURL}'에 사전 로드 <link>가 있으나 브라우저에서 사용되지 않습니다. `crossorigin` 속성을 올바르게 사용하고 있는지 확인하세요."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "<link rel=preload>를 사용하여 페이지 로드에서 현재 나중에 요청되는 리소스를 가져오는 데 우선순위를 두는 것이 좋습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/preload)"
+    "message": "`<link rel=preload>`을(를) 사용하여 페이지 로드에서 현재 나중에 요청되는 리소스를 가져오는 데 우선순위를 두는 것이 좋습니다. [자세히 알아보기](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "중요한 요청을 미리 로드하기"
@@ -789,10 +1053,10 @@
     "message": "권장사항"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "이 검사에서는 [웹 앱의 접근성을 개선하도록] 추천된 사항을 강조합니다(https://developers.google.com/web/fundamentals/accessibility). 접근성 문제의 일부만 자동으로 감지되므로 직접 테스트하는 것도 좋습니다."
+    "message": "이 검사에서는 [웹 앱의 접근성을 개선](https://developers.google.com/web/fundamentals/accessibility)하도록 추천된 사항을 강조합니다. 접근성 문제의 일부만 자동으로 감지되므로 직접 테스트하는 것도 좋습니다."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "자동화된 테스트 도구가 처리할 수 없는 영역을 다루는 항목입니다. [접근성 검토 실시]에 관한 가이드에서 자세히 알아보세요(https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "자동화된 테스트 도구가 처리할 수 없는 영역을 다루는 항목입니다. [접근성 검토 실시](https://developers.google.com/web/fundamentals/accessibility/how-to-review)에 관한 가이드에서 자세히 알아보세요."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "접근성"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "표와 목록"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "권장사항"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "성능 예산은 사이트 성능의 표준을 설정합니다."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "예산"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "애플리케이션 성능 관련 추가 정보"
+    "message": "애플리케이션 성능과 관련된 추가 정보입니다. 이러한 숫자는 성능 점수에 [직접적인 영향](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)을 미치지 않습니다."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "진단"
@@ -840,7 +1113,7 @@
     "message": "최초 페인트 개선"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "다음의 최적화 방법을 사용하면 페이지 로드 속도를 높일 수 있습니다."
+    "message": "이러한 권장사항은 페이지를 더 빠르게 로드하는 데 도움이 될 수 있습니다. 성능 점수에는 [직접적인 영향](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)을 미치지 않습니다."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "추천"
@@ -867,7 +1140,7 @@
     "message": "PWA 최적화됨"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "이와 같은 검사를 통해 페이지가 검색엔진 결과 순위에 최적화되도록 할 수 있습니다. Lighthouse에서 점검하지 않는 추가적인 요소가 검색 순위에 영향을 줄 수도 있습니다. [자세히 알아보기](https://support.google.com/webmasters/answer/35769)."
+    "message": "이와 같은 검사를 통해 페이지가 검색엔진 결과 순위에 최적화되도록 할 수 있습니다. Lighthouse에서 점검하지 않는 추가적인 요소가 검색 순위에 영향을 줄 수도 있습니다. [자세히 알아보기](https://support.google.com/webmasters/answer/35769)"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "사이트에서 이러한 추가 검증 도구를 실행하여 추가적인 검색엔진 최적화 권장사항을 확인합니다."
@@ -888,7 +1161,7 @@
     "message": "크롤링 및 색인 생성"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "사용자가 콘텐츠를 읽기 위해 페이지를 확대하거나 축소할 필요가 없도록 모바일 친화적인 페이지를 지원하세요. [자세히 알아보기](https://developers.google.com/search/mobile-sites/)."
+    "message": "사용자가 콘텐츠를 읽기 위해 페이지를 확대하거나 축소할 필요가 없도록 모바일 친화적인 페이지를 지원하세요. [자세히 알아보기](https://developers.google.com/search/mobile-sites/)"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "모바일 친화적"
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "캐시 TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "위치"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "이름"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "요청"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "리소스 유형"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "크기(KB)"
+    "message": "크기"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "소요 시간"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "전송 크기"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "절감 가능치(KB)"
+    "message": "가능한 절감 효과"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "절감 가능한 페이지 로드 시간(ms)"
+    "message": "가능한 절감 효과"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "절감 가능치: {wastedBytes, number, bytes}KB"
+    "message": "절감 가능치: {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "절감 가능 {wastedMs, number, milliseconds}ms"
+    "message": "절감 가능치: {wastedMs, number, milliseconds} 밀리초"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "문서"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "글꼴"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "이미지"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "미디어"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds}ms"
+    "message": "{timeInMs, number, milliseconds} 밀리초"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "기타"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "스크립트"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds}초"
+    "message": "{timeInMs, number, seconds} 초"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "스타일시트"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "타사"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "합계"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "페이지 로드의 추적을 기록하는 동안 문제가 발생했습니다. Lighthouse를 다시 실행해 주세요. ({errorCode})"
+    "message": "페이지 로드 중 처리한 추적을 기록하던 중 문제가 발생했습니다. Lighthouse를 다시 실행하세요. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "초기 디버거 프로토콜 연결 대기 시간이 초과되었습니다."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome은 페이지가 로드되는 동안 어떠한 스크린샷도 수집하지 않습니다. 페이지에 표시되는 콘텐츠가 있는지 확인한 다음 Lighthouse를 다시 실행해 주세요. ({errorCode})"
+    "message": "Chrome이 페이지 로드 중 스크린샷을 수집하지 않았습니다. 페이지에 표시된 콘텐츠가 있는지 확인한 다음 Lighthouse를 다시 실행해 보세요. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS 서버에서 제공된 도메인을 해결하지 못했습니다."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "필수 {artifactName} 수집기에 다음 오류가 발생했습니다. {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Chrome 내부 오류가 발생했습니다. Chrome을 다시 시작한 다음 Lighthouse를 다시 실행해 주세요."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "필수 {artifactName} 수집기가 실행되지 않았습니다."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse에서 사용자가 요청한 페이지를 안정적으로 로드하지 못했습니다. 올바른 URL을 테스트하고 있으며 서버에서 모든 요청에 적절하게 응답하고 있는지 확인하세요."
@@ -945,19 +1266,22 @@
     "message": "페이지 응답이 중지되었기 때문에 Lighthouse에서 사용자가 요청한 URL을 안정적으로 로드하지 못했습니다."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "제공한 URL에 유효한 보안 사용자 인증 정보가 포함되어 있지 않습니다. {securityMessages}"
+    "message": "제공한 URL에 유효한 보안 인증서가 포함되어 있지 않습니다. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome에서 전면 광고가 있는 페이지를 로드하지 못하도록 했습니다. 올바른 URL로 테스트하고 있으며 서버가 모든 요청에 적절하게 응답하고 있는지 확인하세요."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Lighthouse에서 사용자가 요청한 페이지를 안정적으로 로드하지 못했습니다. 올바른 URL을 테스트하고 있으며 서버에서 모든 요청에 적절하게 응답하고 있는지 확인하세요. (세부정보: {errorDetails})"
+    "message": "Lighthouse에서 사용자가 요청한 페이지를 안정적으로 로드하지 못했습니다. 올바른 URL로 테스트하고 있으며 서버가 모든 요청에 적절하게 응답하고 있는지 확인하세요. (세부정보: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Lighthouse에서 사용자가 요청한 페이지를 안정적으로 로드하지 못했습니다. 올바른 URL을 테스트하고 있으며 서버에서 모든 요청에 적절하게 응답하고 있는지 확인하세요. (상태 코드: {statusCode})"
+    "message": "Lighthouse에서 사용자가 요청한 페이지를 안정적으로 로드하지 못했습니다. 올바른 URL로 테스트하고 있으며 서버가 모든 요청에 적절하게 응답하고 있는지 확인하세요. (상태 코드: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "페이지를 로드하는데 시간이 너무 오래 걸립니다. 보고서에 있는 추천 내용에 따라 페이지 로드 시간을 줄인 다음 Lighthouse를 다시 실행해 주세요. ({errorCode})"
+    "message": "페이지 로드에 시간이 너무 오래 걸립니다. 보고서의 추천에 따라 페이지 로드 시간을 줄인 다음 Lighthouse를 다시 실행해 보세요. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "DevTools 프로토콜 응답 대기시간이 할당된 시간을 초과했습니다. (메소드: {protocolMethod})"
+    "message": "DevTools 프로토콜 응답 대기가 할당된 시간을 초과했습니다. (메서드: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "리소스 콘텐츠 가져오기 시간이 할당된 시간을 초과했습니다"
@@ -984,7 +1308,7 @@
     "message": "실험실 데이터"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "에뮬레이트된 모바일 네트워크에서 분석한 현재 페이지의 [Lighthouse](https://developers.google.com/web/tools/lighthouse/) 결과입니다. 값은 추정치이며 달라질 수 있습니다."
+    "message": "에뮬레이션된 모바일 네트워크에서 분석한 현재 페이지의 [Lighthouse](https://developers.google.com/web/tools/lighthouse/) 결과입니다. 값은 추정치이며 달라질 수 있습니다."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "직접 확인해야 하는 추가 항목"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "스니펫 펼치기"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "타사 리소스 표시"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Lighthouse 실행에 영향을 미치는 문제가 발생했습니다."
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "값은 추정치이며 달라질 수 있습니다."
+    "message": "값은 추정치이며 달라질 수 있습니다. 성능 점수는 [이 측정항목만을 기준](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)으로 합니다."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "감사를 통과했으나 경고를 받음"
@@ -1026,7 +1353,7 @@
     "message": "[지연 로드 WordPress 플러그인](https://wordpress.org/plugins/search/lazy+load/)을 설치하면 화면에 모든 오프스크린 이미지를 지연하거나 이 기능을 제공하는 테마로 전환할 수 있습니다. [AMP 플러그인](https://wordpress.org/plugins/amp/) 사용도 고려해 보세요."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "[중요한 애셋을 인라인](https://wordpress.org/plugins/search/critical+css/)하거나 [덜 중요한 리소스를 지연](https://wordpress.org/plugins/search/defer+css+javascript/)할 수 있게 도와주는 여러 WordPress 플러그인이 있습니다. 이러한 플러그인에서 제공하는 최적화로 인해 내가 사용하는 테마 또는 플러그인의 기능이 깨질 수 있으므로 코드를 변경해야 할 가능성이 높습니다."
+    "message": "[중요한 애셋을 인라인](https://wordpress.org/plugins/search/critical+css/)하거나 [덜 중요한 리소스를 지연](https://wordpress.org/plugins/search/defer+css+javascript/)할 수 있게 도와주는 다양한 WordPress 플러그인이 있습니다. 이러한 플러그인에서 제공하는 최적화로 인해 내가 사용하는 테마 또는 플러그인의 기능이 깨질 수 있으므로 코드를 변경해야 할 가능성이 큽니다."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "테마, 플러그인, 서버 사양은 모두 서버 응답 시간을 길어지게 만듭니다. 보다 최적화된 테마를 찾고, 최적화 플러그인을 신중하게 선택하고, 서버 업그레이드를 고려해 보세요."
@@ -1044,7 +1371,7 @@
     "message": "페이지에서 사용되지 않는 CSS를 로드하는 [WordPress 플러그인](https://wordpress.org/plugins/) 개수를 줄이거나 전환하는 것이 좋습니다. 과도한 CSS를 부가하는 플러그인이 무엇인지 확인하려면 Chrome DevTools의 [코드 범위](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)를 실행해 보세요. 스타일시트의 URL에서 관련된 테마 또는 플러그인을 확인할 수 있습니다. 목록에서 코드 범위에 빨간색이 길게 표시된 스타일시트가 있는 플러그인을 찾아보세요. 실제로 페이지에서 사용되는 플러그인은 대기열에 하나의 스타일시트만 포함해야 합니다."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "페이지에서 사용되지 않는 자바스크립트를 로드하는 [WordPress 플러그인](https://wordpress.org/plugins/) 개수를 줄이거나 전환하는 것이 좋습니다. 과도한 JS를 더하는 플러그인이 무엇인지 확인하려면 Chrome DevTools의 [코드 범위](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)를 실행해 보세요. 스크립트의 URL에서 관련 테마 또는 플러그인을 확인할 수 있습니다. 목록에서 코드 범위에 빨간색이 길게 표시된 스타일시트가 있는 플러그인을 찾아보세요. 실제로 페이지에서 사용되는 플러그인은 대기열에 하나의 스크립트만 포함해야 합니다."
+    "message": "페이지에서 사용되지 않는 JavaScript를 로드하는 [WordPress 플러그인](https://wordpress.org/plugins/) 개수를 줄이거나 전환하는 것이 좋습니다. 과도한 JS를 부가하는 플러그인이 무엇인지 확인하려면 Chrome DevTools의 [코드 범위](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)를 실행해 보세요. 스크립트의 URL에서 관련 테마 또는 플러그인을 확인할 수 있습니다. 목록에서 코드 범위에 빨간색이 길게 표시된 스크립트가 있는 플러그인을 찾아보세요. 실제로 페이지에서 사용되는 플러그인은 대기열에 하나의 스크립트만 포함해야 합니다."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "[WordPress 브라우저 캐싱](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)에 관해 자세히 알아보세요."
@@ -1053,12 +1380,12 @@
     "message": "품질은 그대로 유지하면서 이미지를 압축해주는 [이미지 최적화 WordPress 플러그인](https://wordpress.org/plugins/search/optimize+images/)을 사용해 보세요."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "필수 이미지 크기를 사용할 수 있도록 [미디어 라이브러리](https://codex.wordpress.org/Media_Library_Screen)에서 직접 이미지를 업로드하세요. 그런 다음 미디어 라이브러리 이미지를 삽입하거나 이미지 위젯을 사용하여 최적의 이미지 크기를 사용하는지 확인하세요(반응형 중단점용 이미지 포함). 이미지 크기가 용도에 적합하지 않다면 '원본 크기' 이미지는 사용하지 않는 것이 좋습니다. [자세히 알아보기](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
+    "message": "필수 이미지 크기를 사용할 수 있도록 [미디어 라이브러리](https://codex.wordpress.org/Media_Library_Screen)에서 직접 이미지를 업로드하세요. 그런 다음 미디어 라이브러리에서 이미지를 삽입하거나 이미지 위젯을 사용하여 최적의 이미지 크기를 사용하는지 확인하세요(반응형 중단점용 이미지 포함). 이미지 크기가 용도에 적합하지 않다면 `Full Size` 이미지는 사용하지 않는 것이 좋습니다. [자세히 알아보기](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "웹 서버 구성에서 텍스트 압축을 사용 설정할 수 있습니다."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "업로드한 이미지를 최적화된 형식으로 자동 변환해주는 [플러그인](https://wordpress.org/plugins/search/convert+webp/) 또는 서비스를 사용하는 것이 좋습니다."
+    "message": "업로드한 이미지를 최적화된 양식으로 자동 변환해주는 [플러그인](https://wordpress.org/plugins/search/convert+webp/) 또는 서비스를 사용하는 것이 좋습니다."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/lt.json
+++ b/lighthouse-core/lib/i18n/locales/lt.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Naudodami prieigos raktus naudotojai gali greitai suaktyvinti puslapio dalį. Kad naršymas veiktų tinkamai, kiekvienas prieigos raktas turi būti unikalus. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Naudodami prieigos raktus naudotojai gali greitai suaktyvinti puslapio dalį. Kad naršymas veiktų tinkamai, kiekvienas prieigos raktas turi būti unikalus. [Sužinokite daugiau](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "„[accesskey]“ vertės nėra unikalios"
+    "message": "Elemento „`[accesskey]`“ vertės nėra unikalios"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Elementų „[accesskey]“ vertės unikalios"
+    "message": "„`[accesskey]`“ vertės yra unikalios"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Kiekviename ARIA elemente „role“ palaikoma tik dalis konkrečių atributų „aria-*“. Jei jie nebus suderinti, atributai „aria-*“ taps netinkami. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Kiekviename ARIA elemente „`role`“ palaikoma tik dalis konkrečių atributų „`aria-*`“. Jei jie nebus suderinti, atributai „`aria-*`“ taps netinkami. [Sužinokite daugiau](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Atributai „[aria-*]“ neatitinka savo vaidmenų"
+    "message": "Atributai „`[aria-*]`“ neatitinka savo vaidmenų"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Atributai „[aria-*]“ atitinka savo vaidmenis"
+    "message": "Atributai „`[aria-*]`“ atitinka savo vaidmenis"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Kai kuriems ARIA vaidmenims reikia atributų, aprašančių elementų būseną ekrano skaitytuvams. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Kai kuriems ARIA vaidmenims reikia atributų, aprašančių elementų būseną ekrano skaitytuvams. [Sužinokite daugiau](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Elementuose „[role]“ nėra visų privalomų atributų „[aria-*]“"
+    "message": "Elementuose „`[role]`“ nėra visų privalomų atributų „`[aria-*]`“"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Elementuose „[role]“ yra visi reikalingi atributai „[aria-*]“"
+    "message": "Elementuose „`[role]`“ yra visi būtini atributai „`[aria-*]`“"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Kai kuriuose ARIA pirminiuose vaidmenyse turi būti konkrečių antrinių vaidmenų, kad būtų galima atlikti numatytas pritaikomumo funkcijas. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Kai kuriuose ARIA pirminiuose vaidmenyse turi būti konkrečių antrinių vaidmenų, kad būtų galima atlikti numatytas pritaikomumo funkcijas. [Sužinokite daugiau](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Trūksta elementų su elementais „[role]“, kuriems reikia konkrečių antrinių elementų „[role]“."
+    "message": "Trūksta elementų su atributu „`[role]`“, kuriam reikia konkrečių antrinių elementų „`[role]`“."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Elementai su elementu „[role]“, kuriam reikia konkrečių antrinių elementų „[role]“, nurodyti"
+    "message": "Elementai su atributu „`[role]`“, kuriam reikia konkrečių antrinių elementų „`[role]`“ yra pateikti"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Kai kurie ARIA antriniai vaidmenys turi būti konkrečiuose pirminiuose vaidmenyse, kad būtų tinkamai vykdomos numatytosios pritaikomumo funkcijos. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Kai kurie ARIA antriniai vaidmenys turi būti konkrečiuose pirminiuose vaidmenyse, kad būtų tinkamai vykdomos numatytosios pritaikomumo funkcijos. [Sužinokite daugiau](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Elementų „[role]“ nėra būtiname pirminiame elemente"
+    "message": "Elementų „`[role]`“ nėra būtiname pirminiame elemente"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Elementai „[role]“ yra tinkamame pirminiame elemente"
+    "message": "Elementai „`[role]`“ yra būtiname pirminiame elemente"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA vaidmenų vertės turi būti tinkamos, kad būtų galima atlikti numatytas pritaikomumo funkcijas. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA vaidmenų vertės turi būti tinkamos, kad būtų galima atlikti numatytas pritaikomumo funkcijas. [Sužinokite daugiau](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Elemento „[role]“ vertės netinkamos"
+    "message": "Elemento „`[role]`“ vertės yra netinkamos"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Elemento „[role]“ vertės tinkamos"
+    "message": "Elemento „`[role]`“ vertės yra tinkamos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Pagalbinės technologijos, pvz., ekrano skaitytuvai, negali interpretuoti ARIA atributų su netinkamomis vertėmis. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Pagalbinės technologijos, pvz., ekrano skaitytuvai, negali interpretuoti ARIA atributų su netinkamomis vertėmis. [Sužinokite daugiau](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Atributuose „[aria-*]“ nėra tinkamų verčių"
+    "message": "Atributuose „`[aria-*]`“ nėra tinkamų verčių"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Atributų „[aria-*]“ vertės tinkamos"
+    "message": "Atributų „`[aria-*]`“ vertės yra tinkamos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Pagalbinės technologijos, pvz., ekrano skaitytuvai, negali tinkamai interpretuoti ARIA atributų su netinkamais pavadinimais. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Pagalbinės technologijos, pvz., ekrano skaitytuvai, negali tinkamai interpretuoti ARIA atributų su netinkamais pavadinimais. [Sužinokite daugiau](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Atributai „[aria-*]“ netinkami arba jų rašyba neteisinga"
+    "message": "Atributai „`[aria-*]`“ netinkami arba yra rašybos klaidų"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Atributai „[aria-*]“ yra tinkami ir jų rašyba teisinga"
+    "message": "Atributai „`[aria-*]`“ yra tinkami, rašybos klaidų nėra"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Nurodžius antraštes garso įrašų elementus gali naudoti kurtieji arba sutrikusios klausos naudotojai. Jiems teikiama labai svarbi informacija, pvz., kas kalba, ką jie sako ir kita ne kalbos informacija. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Nurodžius antraštes garso įrašų elementus gali naudoti kurtieji arba sutrikusios klausos naudotojai. Jiems teikiama svarbi informacija, pvz., kas kalba, kas sakoma ir kita nekalbinė informacija. [Sužinokite daugiau](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Elementuose „<audio>“ trūksta elemento „<track>“ su atributu „[kind=\"captions\"]“."
+    "message": "Elementuose „`<audio>`“ trūksta elemento „`<track>`“ su atributu „`[kind=\"captions\"]`“."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Elementuose „<audio>“ yra elementas „<track>“ su atributu „[kind=\"captions\"]“"
+    "message": "Elementuose „`<audio>`“ yra elementas „`<track>`“ su atributu „`[kind=\"captions\"]`“"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
-    "message": "Klaidingi elementai"
+    "message": "Netinkami elementai"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Kai nenurodytas neįgaliesiems pritaikytas mygtuko pavadinimas, ekrano skaitytuvai apie jį praneša kaip „button“ (mygtukas), todėl jo negali naudoti ekrano skaitytuvo naudotojai. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Kai nenurodytas neįgaliesiems pritaikytas mygtuko pavadinimas, ekrano skaitytuvai apie jį praneša kaip „button“ (mygtukas), todėl jo negali naudoti ekrano skaitytuvo naudotojai. [Sužinokite daugiau](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Nenurodyti neįgaliesiems pritaikyti mygtukų pavadinimai"
@@ -93,7 +93,7 @@
     "message": "Mygtukų pavadinimai pritaikyti neįgaliesiems"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Pridėjus būdų apeiti pasikartojantį turinį klaviatūros naudotojai galės efektyviau naršyti puslapį. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Pridėjus būdų apeiti pasikartojantį turinį, klaviatūros naudotojai galės efektyviau naršyti puslapį. [Sužinokite daugiau](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Puslapyje nėra antraštės, praleidimo nuorodos arba orientyro regiono"
@@ -102,7 +102,7 @@
     "message": "Puslapyje yra antraštė, praleidžiama nuoroda arba orientyro regionas"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Mažo kontrasto tekstą daugumai naudotojų yra sudėtinga arba neįmanoma perskaityti. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Mažo kontrasto tekstą daugumai naudotojų yra sudėtinga arba neįmanoma perskaityti. [Sužinokite daugiau](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Nepakankamas fono ir priekinio fono spalvų kontrasto santykis."
@@ -111,88 +111,88 @@
     "message": "Fono ir priekinio plano spalvų kontrasto santykis pakankamas"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Kai aprašo sąrašai netinkamai pažymėti, ekrano skaitytuvai gali pateikti klaidinančią arba netikslią išvestį. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Kai aprašo sąrašai netinkamai pažymėti, ekrano skaitytuvai gali pateikti klaidinančią arba netikslią išvestį. [Sužinokite daugiau](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Elementuose „<dl>“ nurodytos ne tik tinkamai surikiuotos grupės „<dt>“ ir „<dd>“ bei elementai „<script>“ arba „<template>“."
+    "message": "Elementuose „`<dl>`“ nurodytos ne tik tinkamai surikiuotos grupės „`<dt>`“ ir „`<dd>`“ bei elementai „`<script>`“ arba „`<template>`“."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Elementuose „<dl>“ yra tik tinkamai surikiuotos grupės „<dt>“ ir „<dd>“ bei elementai „<script>“ arba „<template>“."
+    "message": "Elementuose „`<dl>`“ nurodytos tik tinkamai surikiuotos grupės „`<dt>`“ ir „`<dd>`“ ir elementai „`<script>`“ arba „`<template>`“."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Aprašo sąrašo elementai („<dt>“ ir „<dd>“) turi būti sujungti elementu „<dl>“, kad ekrano skaitytuvai galėtų apie juos tinkamai pranešti. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Aprašo sąrašo elementai („`<dt>`“ ir „`<dd>`“) turi būti sujungti pirminiame elemente „`<dl>`“, kad ekrano skaitytuvai galėtų apie juos tinkamai pranešti. [Sužinokite daugiau](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Aprašo sąrašo elementai nesujungti elementais „<dl>“"
+    "message": "Aprašo sąrašo elementai nesujungti elementuose „`<dl>`“"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Aprašo sąrašo elementai sujungti elementais „<dl>“"
+    "message": "Aprašo sąrašo elementai sujungti elementuose „`<dl>`“"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Pavadinimas teikia ekrano skaitytuvo naudotojams puslapio apžvalgą, o paieškos variklio naudotojams teikia svarbią informaciją nustatant, ar puslapis atitinka jų paiešką. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Pagal pavadinimą ekrano skaitytuvo naudotojai sužino, apie ką yra puslapio turinys, o paieškos variklio naudotojai gali nuspręsti, ar puslapis atitinka jų paiešką. [Sužinokite daugiau](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokumente nėra elemento „<title>“"
+    "message": "Dokumente nėra elemento „`<title>`“"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokumente yra elementas „<title>“"
+    "message": "Dokumente yra elementas „`<title>`“"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Atributo „id“ vertė turi būti unikali, kad pagalbinės technologijos nebepraleistų kitų objektų. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Atributo „id“ vertė turi būti unikali, kad pagalbinės technologijos nepraleistų kitų objektų. [Sužinokite daugiau](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Puslapio atributai „[id]“ nėra unikalūs"
+    "message": "Puslapio atributai „`[id]`“ nėra unikalūs"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Puslapio atributai „[id]“ yra unikalūs"
+    "message": "Puslapio atributai „`[id]`“ yra unikalūs"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Rėmelių pavadinimai ekrano skaitytuvų naudotojams apibūdina rėmelių turinį. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Pagal rėmelių pavadinimus ekrano skaitytuvų naudotojai sužino, koks yra rėmelių turinys. [Sužinokite daugiau](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Nėra elementų „<frame>“ arba „<iframe>“ pavadinimo"
+    "message": "Elementas „`<frame>`“ arba „`<iframe>`“ neturi pavadinimo"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Elementuose „<frame>“ arba „<iframe>“ yra pavadinimas"
+    "message": "Elementai „`<frame>`“ arba „`<iframe>`“ turi pavadinimą"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Jei puslapyje nenurodytas atributas „lang“, ekrano skaitytuvas manys, kad puslapio kalba atitinka naudotojo pasirinktą numatytąją kalbą, kai buvo nustatomas ekrano skaitytuvas. Jei puslapio kalba neatitinka numatytosios kalbos, gali būti, kad ekrano skaitytuvas netinkamai skaitys puslapio tekstą. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Jei puslapyje nenurodytas atributas „lang“, ekrano skaitytuvas manys, kad puslapio kalba atitinka naudotojo pasirinktą numatytąją kalbą, kai buvo nustatomas ekrano skaitytuvas. Jei puslapio kalba neatitinka numatytosios kalbos, gali būti, kad ekrano skaitytuvas netinkamai skaitys puslapio tekstą. [Sužinokite daugiau](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Elemente „<html>“ nėra atributo „[lang]“"
+    "message": "Elemente „`<html>`“ nėra atributo „`[lang]`“"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Elemente „<html>“ yra atributas „[lang]“"
+    "message": "Elemente „`<html>`“ yra atributas „`[lang]`“"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Nurodžius tinkamą [„BCP 47“ kalbą] (https://www.w3.org/International/questions/qa-choosing-language-tags#question) ekrano skaitytuvai gali tinkamai pranešti tekstą. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Nurodžius tinkamą [BCP 47 kalbą](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ekrano skaitytuvai gali tinkamai pranešti tekstą. [Sužinokite daugiau](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Elemento „<html>“ atributo „[lang]“ vertė netinkama."
+    "message": "Elemente „`<html>`“ nenurodyta tinkama atributo „`[lang]`“ vertė."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Elemento „<html>“ atributo „[lang]“ vertė tinkama"
+    "message": "Elemento „`<html>`“ atributo „`[lang]`“ vertė yra tinkama"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informaciniuose elementuose turėtų būti pateiktas trumpas, aprašomasis alternatyvus tekstas. Dekoratyvinių elementų galima nepaisyti nurodžius tuščią alternatyvų atributą. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informaciniuose elementuose turėtų būti pateiktas trumpas, aprašomasis alternatyvus tekstas. Dekoratyvinių elementų galima nepaisyti nurodžius tuščią alternatyvų atributą. [Sužinokite daugiau](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Vaizdo elementuose nėra atributų „[alt]“"
+    "message": "Vaizdo elementuose nėra atributų „`[alt]`“"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Vaizdo elementuose yra atributai „[alt]“"
+    "message": "Vaizdo elementuose yra atributų „`[alt]`“"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Kai vaizdas naudojamas kaip mygtukas „<input>“, pateikus alternatyvų tekstą ekrano skaitytuvo naudotojams bus lengviau suprasti mygtuko tekstą. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Kai vaizdas naudojamas kaip mygtukas „`<input>`“, pateikus alternatyvų tekstą ekrano skaitytuvo naudotojams bus lengviau suprasti mygtuko tikslą. [Sužinokite daugiau](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Elementuose „<input type=\"image\">“ nėra „[alt]“ teksto"
+    "message": "Elementuose „`<input type=\"image\">`“ nėra „`[alt]`“ teksto"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Elementuose „<input type=\"image\">“ yra „[alt]“ tekstas"
+    "message": "Elementuose „`<input type=\"image\">`“ yra „`[alt]`“ teksto"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Etiketės užtikrina, kad pagalbinės technologijos, pvz., ekrano skaitytuvai, tinkamai praneša apie formų valdiklius. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Etiketės užtikrina, kad pagalbinės technologijos, pvz., ekrano skaitytuvai, tinkamai praneštų apie formų valdiklius. [Sužinokite daugiau](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Nėra susietų formos elementų etikečių"
@@ -201,16 +201,16 @@
     "message": "Formos elementuose yra atitinkamų etikečių"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Lentelėje, kuri naudojama išdėstymo tikslais, neturėtų būti duomenų elementų, pvz., elementų „th“ ar „caption“ arba atributo „summary“, nes taip ekrano skaitytuvų naudotojams gali būti teikiama trikdanti patirtis. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Lentelėje, kuri naudojama išdėstymo tikslais, neturėtų būti duomenų elementų, pvz., elementų „th“ ar „caption“ arba atributo „summary“, nes taip ekrano skaitytuvų naudotojams gali būti teikiama trikdanti patirtis. [Sužinokite daugiau](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Pristatomuose elementuose „<table>“ nėra vengiama naudoti atributų „<th>“, „<caption>“ arba „[summary]“."
+    "message": "Pristatomuose elementuose „`<table>`“ nevengiama naudoti atributų „`<th>`“, „`<caption>`“ arba „`[summary]`“."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Pristatomuose elementuose „<table>“ vengiama naudoti atributus „<th>“, „<caption>“ arba „[summary]“."
+    "message": "Pristatomuose elementuose „`<table>`“ vengiama naudoti atributus „`<th>`“, „`<caption>`“ ar „`[summary]`“."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Aiškus ir unikalus nuorodos tekstas (ir alternatyvusis vaizdų tekstas, kai jie naudojami kaip nuorodos), į kurį lengva sutelkti dėmesį, pagerina naršymo patirtį ekrano skaitytuvų naudotojams. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Aiškus ir unikalus nuorodos tekstas (ir alternatyvusis vaizdų tekstas, kai jie naudojami kaip nuorodos), į kurį lengva sutelkti dėmesį, pagerina naršymo patirtį ekrano skaitytuvų naudotojams. [Sužinokite daugiau](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Nėra aiškių nuorodų pavadinimų"
@@ -219,103 +219,115 @@
     "message": "Nuorodų pavadinimai aiškūs"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Ekrano skaitytuvai apie sąrašus praneša tam tikru būdu. Tinkama sąrašo struktūra padeda ekrano skaitytuvams pateikti tinkamą išvestį. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Ekrano skaitytuvai apie sąrašus praneša tam tikru būdu. Tinkama sąrašo struktūra padeda ekrano skaitytuvams pateikti tinkamą išvestį. [Sužinokite daugiau](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Sąrašuose pateikiami ne tik elementai „<li>“ ir scenarijaus palaikymo elementai („<script>“ ir „<template>“)."
+    "message": "Sąrašuose pateikiami ne tik elementai „`<li>`“ ir scenarijaus palaikymo elementai („`<script>`“ ir „`<template>`“)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Sąrašuose pateikiami tik elementai „<li>“ ir scenarijaus palaikymo elementai („<script>“ ir „<template>“)."
+    "message": "Sąrašuose pateikiami tik elementai „`<li>`“ ir scenarijaus palaikymo elementai („`<script>`“ ir „`<template>`“)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Ekrano skaitytuvams reikia, kad sąrašo elementai („<li>“) būtų pirminiame elemente „<ul>“ arba „<ol>“, kad būtų galima apie juos tinkamai pranešti. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Naudojant ekrano skaitytuvus reikia, kad sąrašo elementai („`<li>`“) būtų pirminiame elemente „`<ul>`“ arba „`<ol>`“, kad apie juos būtų galima tinkamai pranešti. [Sužinokite daugiau](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Sąrašo elementų („<li>“) nėra pirminiuose elementuose „<ul>“ arba „<ol>“."
+    "message": "Sąrašo elementų („`<li>`“) nėra pirminiuose elementuose „`<ul>`“ arba „`<ol>`“."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Sąrašo elementai („<li>“) yra pirminiuose elementuose „<ul>“ arba „<ol>“"
+    "message": "Sąrašo elementai („`<li>`“) yra pirminiuose elementuose „`<ul>`“ arba „`<ol>`“"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Naudotojai nesitiki, kad puslapis bus atnaujintas automatiškai. Tai atlikus sutelkiamas dėmesys į puslapio viršų. Dėl to galima erzinanti arba klaidinanti patirtis. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Naudotojai nesitiki, kad puslapis bus atnaujintas automatiškai. Tai atlikus dėmesys vėl sutelkiamas į puslapio viršų. Dėl to galima erzinanti arba klaidinanti patirtis. [Sužinokite daugiau](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokumente naudojama „<meta http-equiv=\"refresh\">“"
+    "message": "Dokumente naudojama metažyma „`<meta http-equiv=\"refresh\">`“"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Dokumente nenaudojamas atributas „<meta http-equiv=\"refresh\">“"
+    "message": "Dokumente nenaudojama metažyma „`<meta http-equiv=\"refresh\">`“"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Išjungus mastelio keitimą gali kilti problemų sutrikusio regėjimo naudotojams, kurie padidina ekraną, kad tinkamai matytų tinklalapio turinį. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Išjungus mastelio keitimą gali kilti problemų sutrikusio regėjimo naudotojams, kurie padidina ekraną, kad tinkamai matytų tinklalapio turinį. [Sužinokite daugiau](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "Atributas „[user-scalable=\"no\"]“ naudojamas elemente „<meta name=\"viewport\">“ arba atributas „[maximum-scale]“ yra mažesnis nei 5."
+    "message": "Atributas „`[user-scalable=\"no\"]`“ naudojamas elemente „`<meta name=\"viewport\">`“ arba atributas „`[maximum-scale]`“ yra mažesnis nei 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "Atributas „[user-scalable=\"no\"]“ nėra naudojamas elemente „<meta name=\"viewport\">“, o atributas „[maximum-scale]“ nėra mažesnis nei 5."
+    "message": "Atributas „`[user-scalable=\"no\"]`“ nenaudojamas elemente „`<meta name=\"viewport\">`“, o atributas „`[maximum-scale]`“ yra ne mažesnis nei 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Ekrano skaitytuvai negali išversti turinio, kuris nėra tekstas. Pridėję alternatyviojo teksto prie elementų „<object>“ padėsite ekrano skaitytuvams perteikti reikšmę naudotojams. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Ekrano skaitytuvai negali išversti turinio, kuris nėra tekstas. Prie elementų „`<object>`“ pridėjus alternatyviojo teksto, ekrano skaitytuvai naudotojams geriau perteikia reiškmę. [Sužinokite daugiau](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Elementuose „<object>“ nėra „[alt]“ teksto"
+    "message": "Elementuose „`<object>`“ nėra „`[alt]`“ teksto"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Elementuose „<object>“ yra „[alt]“ tekstas"
+    "message": "Elementuose „`<object>`“ yra „`[alt]`“ teksto"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Didesnė nei 0 vertė nurodo naršymo tvarką. Tai techniškai tinkamas sprendimas, bet naudojant šią funkciją pagalbinių technologijų naudotojams dažnai teikiama erzinanti patirtis. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Didesnė nei 0 vertė aiškiai nurodo naršymo tvarką. Iš tiesų tai yra tinkamas sprendimas, tačiau tai dažnai gali erzinti pagalbinių technologijų naudotojus. [Sužinokite daugiau](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Kai kurių elementų „[tabindex]“ vertė yra didesnė nei 0"
+    "message": "Kai kurių elementų „`[tabindex]`“ vertė yra didesnė nei 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Nėra elemento su didesne nei 0 „[tabindex]“ verte"
+    "message": "Nėra elemento su didesne nei 0 „`[tabindex]`“ verte"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Ekrano skaitytuvuose naudojamos funkcijos, padedančios lengviau naršyti lenteles. Užtikrinus, kad langeliai „<td>“, kuriuose naudojamas atributas „[headers]“, nurodo tik langelius toje pačioje lentelėje, gali būti pagerinta ekrano skaitytuvų naudotojų patirtis. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Ekrano skaitytuvuose naudojamos funkcijos, padedančios lengviau naršyti lenteles. Užtikrinus, kad langeliai „`<td>`“, kuriuose naudojamas atributas „`[headers]`“, nurodo tik langelius toje pačioje lentelėje, gali būti pagerinta ekrano skaitytuvų naudotojų patirtis. [Sužinokite daugiau](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Langeliai elemente „<table>“, kuriuose naudojamas atributas „[headers]“, nurodo kitus tos pačios lentelės langelius."
+    "message": "Langeliai elemente „`<table>`“, kuriuose naudojamas atributas „`[headers]`“, nurodo tik kitus tos pačios lentelės langelius."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Langeliai elemente „<table>“, kuriuose naudojamas atributas „[headers]“, nurodo tik kitus tos pačios lentelės langelius."
+    "message": "Langeliai elemente „`<table>`“, kuriuose naudojamas atributas „`[headers]`“, nurodo tik kitus tos pačios lentelės langelius."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Ekrano skaitytuvuose naudojamos funkcijos, padedančios lengviau naršyti lenteles. Užtikrinus, kad lentelės antraštės visada nurodo tam tikrą langelių rinkinį, gali būti pagerinta ekrano skaitytuvų naudotojų patirtis. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Ekrano skaitytuvuose naudojamos funkcijos, padedančios lengviau naršyti lenteles. Užtikrinus, kad lentelės antraštės visada nurodo tam tikrą langelių rinkinį, gali būti pagerinta ekrano skaitytuvų naudotojų patirtis. [Sužinokite daugiau](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Elementuose „<th>“ ir elementuose su atributu „[role=\"columnheader\"/\"rowheader\"]“ nėra duomenų langelių, kuriuos jie aprašo."
+    "message": "Elementuose „`<th>`“ ir elementuose su atributu „`[role=\"columnheader\"/\"rowheader\"]`“ nėra duomenų langelių, kuriuos jie aprašo."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Elementuose „<th>“ ir elementuose su atributu „[role=\"columnheader\"/\"rowheader\"]“ yra duomenų langelių, kuriuos jie aprašo."
+    "message": "Elementuose „`<th>`“ ir elementuose su atributu „`[role=\"columnheader\"/\"rowheader\"]`“ yra duomenų langelių, kuriuos jie aprašo."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Nurodžius tinkamą elementų [„BCP 47“ kalbą](https://www.w3.org/International/questions/qa-choosing-language-tags#question) užtikrinama, kad ekrano skaitytuvas tinkamai ištars tekstą. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Nurodžius tinkamą elementų [BCP 47 kalbą](https://www.w3.org/International/questions/qa-choosing-language-tags#question), užtikrinama, kad ekrano skaitytuvas tinkamai ištars tekstą. [Sužinokite daugiau](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Atributuose „[lang]“ nėra tinkamos vertės"
+    "message": "Atributuose „`[lang]`“ nėra tinkamos vertės"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Atributų „[lang]“ vertė tinkama"
+    "message": "Atributų „`[lang]`“ vertė tinkama"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Kai pateikiama vaizdo įrašo antraštė, kurtiems ir sutrikusios klausos naudotojams lengviau pasiekti jos informaciją. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Kai pateikiama vaizdo įrašo antraštė, kurtiems ir sutrikusios klausos naudotojams lengviau suprasti pateikiamą informaciją. [Sužinokite daugiau](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Elemente „<video>“ nėra elemento „<track>“ su atributu „[kind=\"captions\"]“."
+    "message": "Elementuose „`<video>`“ nėra elemento „`<track>`“ su atributu „`[kind=\"captions\"]`“."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Elementuose „<video>“ yra elementas „<track>“ su atributu „[kind=\"captions\"]“"
+    "message": "Elementuose „`<video>`“ yra elementas „`<track>`“ su atributu „`[kind=\"captions\"]`“"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Garso įrašų aprašai teikia reikiamą informaciją apie vaizdo įrašus, kurios negalima pateikti dialoge, pvz., susijusios su veido išraiškomis ir scenomis. [Sužinokite daugiau](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Garso įrašų aprašai teikia reikiamą informaciją apie vaizdo įrašus, kurios negalima pateikti dialoge, pvz., susijusios su veido išraiškomis ir scenomis. [Sužinokite daugiau](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Elementuose „<video>“ nėra elemento „<track>“ su atributu „[kind=\"description\"]“."
+    "message": "Elementuose „`<video>`“ nėra elemento „`<track>`“ su atributu „`[kind=\"description\"]`“."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Elementuose „<video>“ yra elementas „<track>“ su atributu „[kind=\"description\"]“"
+    "message": "Elementuose „`<video>`“ yra elementas „`<track>`“ su atributu „`[kind=\"description\"]`“"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Kad būtų tinkamai rodoma sistemoje „iOS“, kai naudotojai prideda prie pagrindinio ekrano, nurodykite piktogramą „apple-touch-icon“. Ji turi nukreipti į neskaidrų 192 piks. (arba 180 piks.) kvadratinį PNG failą. [Sužinokite daugiau](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Nepateikiama tinkama piktograma „`apple-touch-icon`“"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "„`apple-touch-icon-precomposed`“ paseno, verčiau naudokite „`apple-touch-icon`“."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Pateikiama tinkama piktograma „`apple-touch-icon`“"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "„Chrome“ plėtiniai neigiamai paveikė šio puslapio įkėlimo našumą. Pabandykite patikrinti puslapį inkognito režimu arba naudodami „Chrome“ profilį be plėtinių."
@@ -330,7 +342,7 @@
     "message": "Bendras centrinio procesoriaus laikas"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Apsvarstykite, ar neverta sutrumpinti JS analizei, kompiliavimui ir vykdymui skiriamo laiko. Mažesnės JS naudingosios apkrovos gali padėti tai padaryti. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Apsvarstykite galimybę sutrumpinti JS analizei, kompiliavimui ir vykdymui skiriamą laiką. Mažesnės JS naudingosios apkrovos gali padėti tai padaryti. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Sutrumpinkite „JavaScript“ vykdymo laiką"
@@ -339,25 +351,25 @@
     "message": "„JavaScript“ vykdymo laikas"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Dideli GIF failai nėra efektyvus animuoto turinio pateikimo būdas. Vietoje GIF galite naudoti MPEG4 ar „WebM“ vaizdo įrašų animacijai ir PNG ar „WebP“ statiniams vaizdams pateikti, kad sutaupytumėte tinklo baitų. [Sužinokite daugiau](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Dideli GIF failai nėra efektyvus animuoto turinio pateikimo būdas. Kad sutaupytumėte tinklo baitų, vietoje GIF failų galite naudoti MPEG4 ar „WebM“ vaizdo įrašų animacijai ir PNG ar „WebP“ statiniams vaizdams pateikti. [Sužinokite daugiau](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Naudokite vaizdo įrašo formatus animuotam turiniui pateikti"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Galbūt verta įkelti ne ekraninius ir paslėptus vaizdus tik tada, kai bus įkelti visi svarbiausi ištekliai, kad sutrumpėtų laikas iki sąveikos. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Apsvarstykite galimybę įkelti ne ekraninius ir paslėptus vaizdus tik tada, kai bus įkelti visi svarbiausi ištekliai, kad sutrumpėtų laikas iki sąveikos. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Atidėkite ne ekraninius vaizdus"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Ištekliai blokuoja pirmąjį puslapio parodymą. Galbūt verta pateikti svarbiausius JS ar CSS kaip eilutinius elementus ir atidėti visus nesvarbius JS ar stilius. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Šaltiniai blokuoja puslapio pirmą žymėjimą. Apsvarstykite galimybę pateikti svarbiausius JS ar CSS kaip eilutinius elementus ir atidėti visus nesvarbius JS ar stilius. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Pašalinkite pateikimą blokuojančius išteklius"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Dėl didelių tinklo naudingųjų apkrovų naudotojai praranda pinigus ir jos glaudžiai susijusios su ilgu įkėlimo laiku. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Naudotojai turi mokėti už dideles tinklo naudingąsias apkrovas, be to, jos glaudžiai susijusios su ilgu įkėlimo laiku. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Bendras dydis: {totalBytes, number, bytes} KB"
@@ -381,7 +393,7 @@
     "message": "Sumažinkite „JavaScript“"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Pašalinkite neveikiančias taisykles iš stiliaus failų ir atidėkite CSS kalbos, nenaudojamos turiniui virš matomos ribos, įkėlimą, kad tinklo veikla sunaudotų mažiau nereikalingų baitų. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Pašalinkite neveikiančias taisykles iš stiliaus failų ir atidėkite CSS kalbos, nenaudojamos turiniui virš matomos ribos, įkėlimą, kad tinklo veikla sunaudotų mažiau baitų. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Pašalinkite nevartojamą CSS kalbą"
@@ -393,7 +405,7 @@
     "message": "Pašalinkite nenaudojamą „JavaScript“"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Jei talpykla galios ilgiau, pakartotiniai apsilankymai puslapyje gali pagreitėti. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Jei talpykla galios ilgiau, greičiau sulauksite pakartotinių apsilankymų puslapyje. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Rastas 1 išteklius}one{Rastas # išteklius}few{Rasti # ištekliai}many{Rasta # ištekliaus}other{Rasta # išteklių}}"
@@ -417,7 +429,7 @@
     "message": "Pasirinkite tinkamo dydžio vaizdus"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Tekstinius išteklius reikėtų suglaudinti (Naudojant „Gzip“, „Deflate“ arba „Brotli“), kad bendrai būtų sunaudojama kuo mažiau tinklo baitų. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Tekstinius išteklius reikėtų suglaudinti (naudojant „Gzip“, „Deflate“ arba „Brotli“), kad bendrai būtų sunaudojama kuo mažiau tinklo baitų. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Įgalinkite teksto glaudinimą"
@@ -429,13 +441,64 @@
     "message": "Pateikite naujos kartos formatų vaizdus"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Toliau pateiktose svarbiausių užklausų grandinėse nurodoma, kurie ištekliai įkelti nurodant aukštą prioritetą. Kad puslapio įkėlimas būtų sklandesnis, galbūt verta sutrumpinti grandines, sumažinti atsisiunčiamų išteklių dydį arba atidėti nereikalingų išteklių atsisiuntimą. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Toliau pateiktose svarbiausių užklausų grandinėse nurodoma, kurie ištekliai įkelti nurodant aukštą prioritetą. Kad puslapio įkėlimas būtų sklandesnis, apsvarstykite galimybę sutrumpinti grandines, sumažinti atsisiunčiamų išteklių dydį arba atidėti nebūtinų išteklių atsisiuntimą. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Rasta 1 grandinė}one{Rasta # grandinė}few{Rastos # grandinės}many{Rasta # grandinės}other{Rasta # grandinių}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Sumažinkite svarbiausių užklausų gylį"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Naudojimo nutraukimas / įspėjimas"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Linija"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Nebenaudojamos API galiausiai bus pašalintos iš naršyklės. [Sužinokite daugiau](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Rastas 1 įspėjimas}one{Rastas # įspėjimas}few{Rasti # įspėjimai}many{Rasta # įspėjimo}other{Rasta # įspėjimų}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Naudojamos pasenusios API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Vengiama nebenaudojamų API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Programos talpykla nebenaudojama. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Rastas elementas „{AppCacheManifest}“"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Naudojama programos talpykla"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Vengiama naudoti programos talpyklą"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Nurodžius DOCTYPE, naršyklė neperjungia į seno standarto tinklalapių palaikymo režimą. Skaitykite daugiau [MDN žiniatinklio dokumentų puslapyje](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "DOCTYPE pavadinimas turi būti mažosiomis raidėmis nurodyta eilutė „`html`“"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokumente turi būti nurodytas DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Laukas „publicId“ turėtų būti tuščias"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Laukas „systemId“ turėtų būti tuščias"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Puslapyje trūksta HTML DOCTYPE, todėl aktyvinamas seno standarto tinklalapių palaikymo režimas"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Puslapyje yra HTML DOCTYPE"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elementas"
@@ -447,7 +510,7 @@
     "message": "Vertė"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Naršyklių inžinieriai rekomenduoja puslapiuose turėti ne daugiau nei apytiksliai 1,5 tūkst. DOM elementų. Optimaliausias medžio gylis – mažiau nei 32 elementai ir mažiau nei 60 poelemenčių bei viršelemenčių. Dėl didelio DOM gali būti sunaudojama daugiau atminties, ilgiau [skaičiuojami stiliai](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) ir reikia brangių [išdėstymo perskaičiavimų](https://developers.google.com/speed/articles/reflow). [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Naršyklių inžinieriai rekomenduoja puslapiuose naudoti ne daugiau kaip apytiksliai 1,5 tūkst. DOM elementų. Optimaliausias medžio gylis – mažiau nei 32 elementai ir mažiau nei 60 antrinių bei pirminių elementų. Dėl didelio DOM elementų skaičiaus gali būti sunaudojama daugiau atminties, ilgiau [skaičiuojami stiliai](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) ir gali reikėti brangių [išdėstymo perskaičiavimų](https://developers.google.com/speed/articles/reflow). [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 elementas}one{# elementas}few{# elementai}many{# elemento}other{# elementų}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Išvengiama per didelių DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Atributas „rel“"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Taikymas"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Pridėkite fragmentus „`rel=\"noopener\"`“ arba „`rel=\"noreferrer\"`“ prie bet kurių išorinių nuorodų, kad pagerintumėte našumą ir išvengtumėte saugos pažeidimų. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Nuorodos į mišrios kilmės paskirties vietas yra nesaugios"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Nuorodos į mišrios kilmės paskirties vietas yra saugios"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Nepavyko nustatyti prieraišo ({anchorHTML}) paskirties vietos. Jei jo nenaudojate kaip hipersaito, apsvarstykite galimybę pašalinti atributą „target=_blank“."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Naudotojai gali būti įtarūs arba sumišę, jei svetainėse bus prašoma suteikti leidimą pasiekti vietovės duomenis be jokio konteksto. Apsvarstykite galimybę susieti užklausą su naudotojų veiksmu. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Įkeliant puslapį pateikiama užklausa dėl pranešimų leidimo"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Įkeliant puslapį vengiama pateikti užklausą dėl leidimo nustatyti geografinę vietovę"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versija"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Puslapyje aptiktos visos „Java Script“ sąsajos bibliotekos."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Aptikta „JavaScript“ bibliotekų"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Esant lėtam ryšiui, išoriniai scenarijai, dinamiškai įterpiami naudojant „`document.write()`“, gali atidėti puslapio įkėlimą dešimtimis sekundžių. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Naudojamas „`document.write()`“"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Vengiama naudoti „`document.write()`“"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Rimčiausias pažeidimas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Bibliotekos versija"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Pažeidimų skaičius"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Kai kuriuose trečiųjų šalių scenarijuose gali būti žinomų saugos pažeidimų, kuriuos užpuolėjai gali lengvai nustatyti ir jais pasinaudoti. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Aptiktas 1 pažeidimas}one{Aptiktas # pažeidimas}few{Aptikti # pažeidimai}many{Aptikta # pažeidimo}other{Aptikta # pažeidimų}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Puslapyje yra „JavaScript“ sąsajos bibliotekų, kuriose yra žinomų saugos pažeidimų"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Didelis"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Mažas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Vidutinis"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Vengiama „JavaScript“ sąsajos bibliotekų, kuriose yra žinomų saugos pažeidimų"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Naudotojai gali būti įtarūs arba sumišę, jei svetainėse bus prašoma suteikti pranešimų leidimą be jokio konteksto. Apsvarstykite galimybę susieti užklausą su naudotojų gestais. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Įkeliant puslapį pateikiama užklausa dėl pranešimų leidimo"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Įkeliant puslapį vengiama pateikti užklausą dėl pranešimų leidimo"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Netinkami elementai"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Neleidžiant įklijuoti slaptažodžių, pažeidžiama tinkamos saugos politika. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Naudotojams neleidžiama įklijuoti teksto į slaptažodžių laukus"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Naudotojams leidžiama įklijuoti tekstą į slaptažodžių laukus"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokolas"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "Naudodami HTTP/2 gaunate daugiau privalumų, nei naudodami HTTP/1.1, pvz., dvigubas antraštes, tankinimą ir serverio įkėlimo funkciją. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 užklausa nepateikta naudojant HTTP/2}one{# užklausa nepateikta naudojant HTTP/2}few{# užklausos nepateiktos naudojant HTTP/2}many{# užklausos nepateikta naudojant HTTP/2}other{# užklausų nepateikta naudojant HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Nenaudojamas HTTP/2 visuose šaltiniuose"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Naudojamas HTTP/2 puslapio šaltiniuose"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Apsvarstykite galimybę pažymėti lietimo ir pelės ratuko sukimo įvykių apdorojimą kaip „`passive`“, kad pagerintumėte puslapio slinkimo našumą. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Nenaudojamos pasyvios apdorojimo priemonės siekiant pagerinti slinkimo našumą"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Naudojamos pasyvios apdorojimo priemonės siekiant pagerinti slinkimo našumą"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Aprašas"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Pulte užregistruotos klaidos nurodo, kad esama neišspręstų problemų. Jos galėjo kilti nepavykus pateikti tinklo užklausų arba dėl kitų naršyklės problemų."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Naršyklės klaidos registruojamos pulte"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Pulte neužregistruota naršyklės klaidų"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Pasinaudokite šriftų pateikimo CSS funkcija, kad tekstas būtų matomas naudotojui, kol įkeliami žiniatinklio šriftai. [Sužinokite daugiau](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Įkeliant žiniatinklio šriftą matomas visas tekstas"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "„Lighthouse“ nepavyko automatiškai patikrinti toliau nurodyto URL šriftų pateikimo vertės: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Formato koeficientas (faktinis)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Formato koeficientas (rodomas)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Rodomo vaizdo matmenys turi atitikti natūralų formato koeficientą. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Rodomi vaizdai su netinkamu formato koeficientu"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Rodomi vaizdai su tinkamu formato koeficientu"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Netinkama vaizdo dydžio informacija: {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Nesaugus URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Visos svetainės turėtų būti apsaugotos naudojant HTTPS, net ir tos, kuriose nėra neskelbtinų duomenų. Naudojant HTTPS įsibrovėliams neleidžiama gadinti ar pasyviai klausytis jūsų programos ir jos naudotojų komunikacijos, be to, jį privaloma naudoti HTTP/2 ir daugelyje naujų žiniatinklio platformų API. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Rasta 1 nesaugi užklausa}one{Rasta # nesaugi užklausa}few{Rastos # nesaugios užklausos}many{Rasta # nesaugos užklausos}other{Rasta # nesaugių užklausų}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Nenaudojamas HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Naudojamas HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Spartus puslapių įkėlimas mobiliojo ryšio tinkle užtikrina gerą mobiliųjų įrenginių naudotojų patirtį. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interaktyvus {timeInMs, number, seconds} sek."
+    "message": "Laikas iki sąveikos – {timeInMs, number, seconds} sek."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Interaktyvus imituojamame mobiliojo ryšio tinkle {timeInMs, number, seconds} sek."
+    "message": "Laikas iki sąveikos imituojamame mobiliojo ryšio tinkle – {timeInMs, number, seconds} sek."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Puslapis įkeliamas nepakankamai sparčiai mobiliojo ryšio tinkluose"
@@ -504,7 +735,7 @@
     "message": "Sutrumpinamas pagrindinės grupės veikimas"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Įvertinta įvesties delsa – tai įvertintas laikas milisekundėmis, per kurį programa atsako į naudotojo įvestį per labiausiai užimtas puslapio įkėlimo 5 sekundes. Jei delsa ilgesnė nei 50 ms, naudotojams gali pasirodyti, kad programa veikia lėtai. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Įvertinta įvesties delsa yra įvertintas laikas milisekundėmis, per kurį programa atsako į naudotojo įvestį per labiausiai užimtas puslapio įkėlimo 5 sekundes. Jei delsa ilgesnė nei 50 ms, naudotojams gali atrodyti, kad programa veikia lėtai. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Įvertinta įvesties delsa"
@@ -516,7 +747,7 @@
     "message": "Pirmasis „Contentful“ parodymas"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "Pirmas cent. procesoriaus laisvas laikas nurodo pirmą laiką, kai pagrindinė puslapio grupė buvo pakankamai neaktyvi, kad galėtų apdoroti įvestį. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "Pirmas centrinio procesoriaus neaktyvumo laikas nurodo pirmą kartą, kai pagrindinė puslapio grupė buvo pakankamai neaktyvi, kad galėtų apdoroti įvestį. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Pirmas cent. procesoriaus laisvas laikas"
@@ -528,22 +759,28 @@
     "message": "Pirmasis reikšmingas parodymas"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Laikas iki sąveikos – vertė, nurodanti, kiek laiko reikia, kol puslapis tampa visiškai interaktyvus. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Laikas iki sąveikos yra vertė, nurodanti, kiek laiko reikia, kol puslapis tampa visiškai interaktyvus. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Laikas iki sąveikos"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Potenciali naudotojų patiriama pirmosios įvesties delsa – tai ilgiausios užduoties trukmė milisekundėmis."
+    "message": "Didžiausia potenciali naudotojų patiriama pirmosios įvesties delsa yra ilgiausios užduoties trukmė milisekundėmis. [Sužinokite daugiau](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Didžiausia potenciali PĮD"
+    "message": "Maksimali potenciali pirmosios įvesties delsa"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Greičio rodiklis parodo, kaip greitai pavaizduojamas puslapio turinys. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Greičio rodiklis"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Visų laikotarpių tarp PTŽ ir laiko iki sąveikos suma milisekundėmis, kai užduoties atlikimo laikas viršija 50 ms."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Bendras blokavimo laikas"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Abipusis tinklo laikas (RTT) turi didelės įtakos našumui. Didelė RTT į šaltinį vertė nurodo, kad arčiau naudotojo esantys serveriai galėtų padidinti našumą. [Sužinokite daugiau](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,14 +794,35 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Serverio vidinės pusės delsa"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Viršijo biudžetą"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Tinklo užklausų kiekis ir dydis neturi viršyti tikslinių verčių, nustatytų našumo biudžete. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 užklausa}one{# užklausa}few{# užklausos}many{# užklausos}other{# užklausų}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Našumo biudžetas"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Peradresuojant puslapio įkėlimas dar labiau delsia. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Peradresuojant puslapio įkėlimo delsos laikas dar labiau pailgėja. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Venkite kelių puslapio peradresavimų"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Kad nustatytumėte puslapio išteklių kiekio ir dydžio biudžetus, pridėkite biudžeto .json failą. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 užklausa}one{# užklausa}few{# užklausos}many{# užklausos}other{# užklausų}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Pasistenkite neteikti daug užklausų ir neperkelti daug duomenų"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Kanoninės nuorodos siūlo, kurį URL rodyti paieškos rezultatuose. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Standartizuotos nuorodos siūlo, kurį URL rodyti paieškos rezultatuose. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Keli nesuderinami URL ({urlList})"
@@ -573,10 +831,10 @@
     "message": "Nukreipia į kitą domeną ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "Netinkamas URL ({url})"
+    "message": "Negaliojantis URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Nukreipia į kitą „hreflang“ vietą ({url})"
+    "message": "Nukreipia į kitą „`hreflang`“ vietą ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Susijęs URL ({url})"
@@ -585,25 +843,22 @@
     "message": "Nukreipiama į domeno šakninį URL (pagrindinį puslapį) vietoje atitinkamo turinio puslapio"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokumento vertė „rel=canonical“ netinkama"
+    "message": "Dokumente nėra tinkamo atributo „`rel=canonical`“"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokumento vertė „rel=canonical“ tinkama"
+    "message": "Dokumente yra tinkamas atributas „`rel=canonical`“"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Mažesnis nei 12 piksel. šriftas per mažas, kad būtų įskaitomas, todėl mobiliuosius įrenginius naudojantys lankytojai turi keisti mastelį suėmę pirštais, kad galėtų perskaityti. Pasistenkite, kad daugiau nei 60 proc. puslapio teksto šrifto dydis būtų 12 piksel. arba didesnis. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Mažesnis nei 12 piks. šriftas yra per mažas, kad būtų įskaitomas, todėl mobiliuosius įrenginius naudojantys lankytojai turi keisti mastelį suėmę pirštais, kad galėtų perskaityti. Pasistenkite, kad daugiau nei 60 proc. puslapio teksto šrifto dydis būtų 12 piks. arba didesnis. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} aiškaus teksto"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} teksto per mažas."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Tekstas neįskaitomas, nes nėra mobiliųjų įrenginių ekranams optimizuotos peržiūros srities metažymos"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} teksto per mažas (atsižvelgiant į {decimalProportionVisited, number, extendedPercent} pavyzdinį dydį)."
+    "message": "{decimalProportion, number, extendedPercent} teksto yra per mažo dydžio (atsižvelgiant į pavyzdį – {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Dokumente naudojami neįskaitomo dydžio šriftai"
@@ -615,10 +870,10 @@
     "message": "„hreflang“ nuorodos nurodo paieškos varikliams, kokią puslapio versiją jie turėtų pateikti paieškos rezultatuose pagal nurodytą kalbą ar regioną. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokumente nėra tinkamo atributo „hreflang“"
+    "message": "Dokumente nėra tinkamo atributo „`hreflang`“"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokumente yra galiojantis atributas „hreflang“"
+    "message": "Dokumente yra tinkamas atributas „`hreflang`“"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Puslapiai, kurių HTTP būsenos kodų nepavyko pateikti, gali būti indeksuojami netinkamai. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -630,7 +885,7 @@
     "message": "Sėkmingai pateiktas puslapio HTTP būsenos kodas"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Paieško varikliai negali įtraukti puslapių į paieškos rezultatus, jei neturi leidimo jų tikrinti. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Paieškos varikliai negali įtraukti puslapių į paieškos rezultatus, jei neturi leidimo jų tikrinti. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Puslapio indeksavimas blokuojamas"
@@ -651,13 +906,13 @@
     "message": "Nuorodose yra aprašomojo teksto"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Paleiskite [struktūrinių duomenų bandymo įrankį](https://search.google.com/structured-data/testing-tool/) ir [„Structured Data Linter“](http://linter.structured-data.org/) struktūriniams duomenims patvirtinti. [Sužinokite daugiau](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Paleiskite [struktūrinių duomenų bandymo įrankį](https://search.google.com/structured-data/testing-tool/) ir [„Structured Data Linter“](http://linter.structured-data.org/), kad būtų patvirtinti struktūriniai duomenys. [Sužinokite daugiau](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Struktūriniai duomenys tinkami"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Norint glaustai apibendrinti puslapio turinį galima įtraukti metaaprašų į paieškos rezultatus. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Norint glaustai apibendrinti puslapio turinį, į paieškos rezultatus galima įtraukti metaaprašų. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Nepateiktas aprašomasis tekstas."
@@ -696,7 +951,7 @@
     "message": "robots.txt tinkamas"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Interaktyvūs elementai, pvz., mygtukai ir nuorodos, turi būti pakankamai dideli (48 x 48 piksel.) ir aplink juos turi būti pakankamai vietos, kad juos būtų galima lengvai paliesti ir kad jie nepersidengtų su kitais elementais. [Sužinokite daugiau](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Interaktyvūs elementai, pvz., mygtukai ir nuorodos, turi būti pakankamai dideli (48 x 48 piks.) ir aplink juos turi būti pakankamai vietos, kad būtų galima lengvai paliesti ir kad jie nepersidengtų su kitais elementais. [Sužinokite daugiau](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} tinkamo dydžio liečiamų objektų"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Persidengiantis objektas"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Dydis"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Liečiamas objektas"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Liečiami objektai tinkamo dydžio"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Pagrindinės grupės laikas"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Trečioji šalis"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Trečiosios šalies kodas gali smarkiai paveikti įkėlimo našumą. Apribokite trečiosios šalies teikėjų skaičių ir pabandykite įkelti trečiosios šalies kodą, kai puslapis bus įkeltas. [Sužinokite daugiau](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Rasta 1 trečioji šalis}one{Rasta # trečioji šalis}few{Rastos # trečiosios šalys}many{Rasta # trečiosios šalies}other{Rasta # trečiųjų šalių}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Trečiosios šalies naudojimas"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Laikas iki pirmojo baito nurodo laiką, per kurį serveris atsako. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Trukmė"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Pavadinimas"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Pradžios laikas"
   },
@@ -744,7 +1008,7 @@
     "message": "Tipas"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Galbūt verta apdoroti programą naudojant naudotojo laiko API ir įvertinti programos realų našumą atsižvelgiant į pagrindines naudotojo funkcijas. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Apsvarstykite galimybę apdoroti programą naudojant naudotojo laiko API ir įvertinti programos realų našumą, kai naudotojas naudoja pagrindines funkcijas. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 naudotojo laikas}one{# naudotojo laikas}few{# naudotojo laikai}many{# naudotojo laiko}other{# naudotojo laikų}}"
@@ -753,19 +1017,19 @@
     "message": "Naudotojo laiko žymės ir matavimas"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Rasta atributo „{securityOrigin}“ išankstinio sujungimo nuoroda „<link>“, bet jos naršyklė nenaudojo. Užtikrinkite, kad atributas „crossorigin“ naudojamas teisingai."
+    "message": "Rasta atributo „{securityOrigin}“ išankstinio sujungimo nuoroda „<link>“, bet naršyklė jos nenaudojo. Patikrinkite, ar atributas „`crossorigin`“ naudojamas tinkamai."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Galbūt verta pridėti išankstinio prijungimo arba DNS išankstinės iškvietos ištekliaus nurodymus, kad ryšys su svarbiais trečiųjų šalių šaltiniais būtų užmezgamas iš anksto. [Sužinokite daugiau](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Apsvarstykite galimybę pridėti išankstinio prijungimo arba DNS išankstinės iškvietos ištekliaus nurodymus, kad ryšys su svarbiais trečiųjų šalių šaltiniais būtų užmezgamas iš anksto. [Sužinokite daugiau](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Iš anksto prisijunkite prie reikiamų šaltinių"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Rasta atributo „{preloadURL}“ išankstinio įkėlimo nuoroda „<link>“, bet jos naršyklė nenaudojo. Užtikrinkite, kad atributas „crossorigin“ naudojamas tinkamai."
+    "message": "Rasta atributo „{preloadURL}“ išankstinio įkėlimo nuoroda „<link>“, bet naršyklė jos nenaudojo. Patikrinkite, ar atributas „`crossorigin`“ naudojamas tinkamai."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Galbūt verta naudoti <link rel=preload> ir suteikti prioritetą gaunamiems ištekliams, kurių užklausos šiuo metu teikiamos vėliau įkeliant puslapį. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Apsvarstykite galimybę naudoti „`<link rel=preload>`“ ir suteikti pirmenybę gaunamiems ištekliams, kurių užklausos šiuo metu teikiamos vėliau įkeliant puslapį. [Sužinokite daugiau](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Iš anksto įkelkite svarbiausias užklausas"
@@ -789,10 +1053,10 @@
     "message": "Geriausia praktika"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Atlikę šias patikras sužinosite, kaip galite [geriau pritaikyti žiniatinklio programą] (https://developers.google.com/web/fundamentals/accessibility). Automatiškai galima aptikti tik dalį pritaikomumo problemų, todėl taip pat rekomenduojama atlikti neautomatinį testavimą."
+    "message": "Atlikę šias patikras sužinosite, kaip galite [geriau pritaikyti žiniatinklio programą](https://developers.google.com/web/fundamentals/accessibility). Automatiškai galima aptikti tik dalį pritaikomumo problemų, todėl rekomenduojama atlikti ir neautomatinį tikrinimą."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Šie elementai apima sritis, kurių automatinio testavimo įrankis negali apimti. Sužinokite daugiau mūsų vadove, kaip [atlikti pritaikomumo peržiūrą](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Šie elementai apima sritis, kurių automatinio bandymo įrankis negali aprėpti. Mūsų vadove sužinokite daugiau apie tai, kaip [atlikti pritaikomumo peržiūrą](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Pritaikomumas"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Lentelės ir sąrašai"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Geriausios praktikos pavyzdžiai"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Nuo kategorijoje „Našumas“ nustatyto biudžeto priklauso svetainės našumas."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Biudžetai"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Daugiau informacijos apie jūsų programos našumą."
+    "message": "Daugiau informacijos apie programos našumą. Šie skaičiai [tiesiogiai nepaveikia](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) našumo įvertinimo."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostika"
@@ -840,7 +1113,7 @@
     "message": "Pirmojo parodymo patobulinimai"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Toks optimizavimas gali padėti pagreitinti puslapio įkėlimą."
+    "message": "Pasinaudojus šiais pasiūlymais puslapis gali būti įkeliamas greičiau. Tai [tiesiogiai nepaveiks](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) našumo įvertinimo."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Galimybės"
@@ -888,7 +1161,7 @@
     "message": "Tikrinimas ir indeksavimas"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Įsitikinkite, kad puslapiai yra pritaikyti mobiliesiems, kad naudotojams nereikėtų keisti mastelį arba suėmus artinti norint perskaityti puslapių turinį. [Sužinokite daugiau](https://developers.google.com/search/mobile-sites/)."
+    "message": "Įsitikinkite, kad puslapiai yra pritaikyti mobiliesiems, kad naudotojams nereikėtų suėmus artinti ar keisti mastelio norint perskaityti puslapių turinį. [Sužinokite daugiau](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Pritaikyta mobiliesiems"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Talpyklos TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Vietovė"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Pavadinimas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Užklausos"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Ištekliaus tipas"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Dydis (KB)"
+    "message": "Dydis"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Sugaištas laikas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Failų perkėlimo dydis"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Galima sutaupyti (KB)"
+    "message": "Galima sutaupyti"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Galima sutaupyti (ms)"
+    "message": "Galima sutaupyti"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Galima sutaupyti {wastedBytes, number, bytes} KB"
@@ -917,14 +1205,41 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Galima sutaupyti {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokumentas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Šriftas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Vaizdas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Medija"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Kita"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Scenarijus"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} sek."
   },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stiliaus failas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Trečioji šalis"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Iš viso"
+  },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Kilo problema įrašant pėdsaką įkeliant puslapį. Dar kartą vykdykite „Lighthouse“. ({errorCode})"
+    "message": "Įkeliant puslapį kilo su pėdsako įrašymu susijusi problema. Dar kartą paleiskite „Lighthouse“. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Laukiant, kol bus inicijuotas derintuvės protokolo ryšys, baigėsi skirtasis laikas."
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS serveriams nepavyko nustatyti pateikto domeno."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Įvyko su reikiamo ištekliaus „{artifactName}“ rinkimo priemone susijusi klaida: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Įvyko vidinės „Chrome“ klaida. Iš naujo paleiskite „Chrome“ ir pabandykite iš naujo paleisti „Lighthouse“."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Reikiamo ištekliaus „{artifactName}“ rinkimo priemonė nebuvo paleista."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "„Lighthouse“ nepavyko patikimai įkelti puslapio, kurio užklausą pateikėte. Įsitikinkite, kad testuojate tinkamą URL ir kad serveris tinkamai atsako į visas užklausas."
@@ -945,19 +1266,22 @@
     "message": "„Lighthouse“ nepavyko patikimai įkelti URL, kurio užklausą pateikėte, nes puslapis nebeatsako."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Pateikto URL saugos prisijungimo duomenys netinkami. {securityMessages}"
+    "message": "Pateiktame URL nėra tinkamo saugos sertifikato: {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "„Chrome“ neleido įkelti puslapio ir buvo parodytas tarpinis ekranas. Įsitikinkite, kad tikrinate tinkamą URL ir kad serveris tinkamai atsako į visas užklausas."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "„Lighthouse“ nepavyko patikimai įkelti puslapio, kurio užklausą pateikėte. Įsitikinkite, kad testuojate tinkamą URL ir kad serveris tinkamai atsako į visas užklausas. (Išsami informacija: {errorDetails})"
+    "message": "„Lighthouse“ nepavyko patikimai įkelti puslapio, kurio užklausą pateikėte. Įsitikinkite, kad tikrinate tinkamą URL ir kad serveris tinkamai atsako į visas užklausas. (Išsami informacija: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "„Lighthouse“ nepavyko patikimai įkelti puslapio, kurio užklausą pateikėte. Įsitikinkite, kad testuojate tinkamą URL ir kad serveris tinkamai atsako į visas užklausas. (Būsenos kodas: {statusCode})"
+    "message": "„Lighthouse“ nepavyko patikimai įkelti puslapio, kurio užklausą pateikėte. Įsitikinkite, kad tikrinate tinkamą URL ir kad serveris tinkamai atsako į visas užklausas. (Būsenos kodas: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
     "message": "Puslapis buvo įkeliamas per ilgai. Pasinaudokite ataskaitoje pateiktomis galimybėmis ir sumažinkite puslapio įkėlimo laiką, tada pabandykite iš naujo paleisti „Lighthouse“. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "Palaukite, kol „DevTools“ protokolo atsakymas viršys skirtąjį laiką. (Metodas: {protocolMethod})"
+    "message": "Laukiama, kol „DevTools“ protokolo atsakymas viršys skirtąjį laiką. (Metodas: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "Šaltinio turinio gavimas viršijo skirtąjį laiką"
@@ -984,7 +1308,7 @@
     "message": "Laboratorijos duomenys"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[„Lighthouse“](https://developers.google.com/web/tools/lighthouse/) dabartinio puslapio analizė emuliuotame mobiliojo ryšio tinkle. Vertės yra numatytos ir gali skirtis."
+    "message": "[„Lighthouse“](https://developers.google.com/web/tools/lighthouse/) dabartinio puslapio analizė emuliuotame mobiliojo ryšio tinkle. Vertės yra apytikslės ir gali skirtis."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Papildomi elementai, kuriuos reikia patikrinti neautomatiškai"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Išplėsti fragmentą"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Rodyti trečiųjų šalių išteklius"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Paleidžiant „Lighthouse“ kilo problemų."
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Vertės yra numatytos ir gali skirtis."
+    "message": "Vertės yra apytikslės ir gali skirtis. Našumo įvertinimas nustatomas [tik pagal šias metrikas](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Sėkmingos patikros, bet pateikta įspėjimų"
@@ -1026,7 +1353,7 @@
     "message": "Įdiekite [atidėtojo įkėlimo „WordPress“ papildinį](https://wordpress.org/plugins/search/lazy+load/), leidžiantį atidėti bet kokius ne ekraninius vaizdus, arba perjunkite į šią funkciją teikiančią temą. Be to, apsvarstykite galimybę naudoti [AMP papildinį](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Yra įvairių „WordPress“ papildinių, kuriuos naudodami galite [įterpti svarbių išteklių](https://wordpress.org/plugins/search/critical+css/) ar [atidėti nelabai svarbius šaltinius](https://wordpress.org/plugins/search/defer+css+javascript/). Atminkite, kad dėl šių papildinių teikiamo optimizavimo gali būti pažeistos jūsų temos ar papildinių funkcijos, todėl tikriausiai turėsite atlikti kodo pakeitimų."
+    "message": "Yra įvairių „WordPress“ papildinių, kuriuos naudodami galite [įterpti svarbių išteklių](https://wordpress.org/plugins/search/critical+css/) arba [atidėti mažiau svarbius šaltinius](https://wordpress.org/plugins/search/defer+css+javascript/). Atminkite, kad dėl šių papildinių teikiamo optimizavimo gali būti pažeistos jūsų temos ar papildinių funkcijos, todėl tikriausiai turėsite atlikti kodo pakeitimų."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Temos, papildiniai ir serverio specifikacijos – visa tai turi įtakos serverio atsako laikui. Galbūt vertėtų surasti geriau optimizuotą temą, atidžiai pasirinkti optimizavimo papildinį ir (arba) naujovinti serverį."
@@ -1035,30 +1362,30 @@
     "message": "Apsvarstykite galimybę rodyti ištraukas įrašų sąrašuose (pvz., naudodami daugiau elementų žymą), sumažinti nurodytame puslapyje rodomų įrašų skaičių, suskaidyti ilgus įrašus į kelis puslapius arba naudoti komentarų atidėtojo įkėlimo papildinį."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Įvairūs [„WordPress“ papildiniai](https://wordpress.org/plugins/search/minify+css/) gali padėti svetainei sparčiau veikti, sujungdami, suglaudindami stilius ir pašalindami jų nereikalingus duomenis. Be to, galbūt norėsite pasinaudoti kūrimo procesu, kad iš anksto pašalintumėte nereikalingus duomenis, jei įmanoma."
+    "message": "Įvairūs [„WordPress“ papildiniai](https://wordpress.org/plugins/search/minify+css/) gali padėti svetainei sparčiau veikti sujungdami, sumažindami ar suglaudindami stilius. Be to, galbūt norėsite pasinaudoti kūrimo procesu, kad sumažintumėte iš anksto (jei tai įmanoma)."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Įvairūs [„WordPress“ papildiniai](https://wordpress.org/plugins/search/minify+javascript/) gali padėti svetainei sparčiau veikti, sujungdami, suglaudindami scenarijus ir pašalindami jų nereikalingus duomenis. Be to, galbūt norėsite pasinaudoti kūrimo procesu, kad iš anksto pašalintumėte nereikalingus duomenis, jei įmanoma."
+    "message": "Įvairūs [„WordPress“ papildiniai](https://wordpress.org/plugins/search/minify+javascript/) gali padėti svetainei sparčiau veikti sujungdami, sumažindami ar suglaudindami scenarijus. Be to, galbūt norėsite pasinaudoti kūrimo procesu, kad sumažintumėte iš anksto (jei tai įmanoma)."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Apsvarstykite galimybę sumažinti [„WordPress“ papildinių](https://wordpress.org/plugins/), įkeliančių nenaudojamą CSS kalbą jūsų puslapyje, skaičių arba perjungti juos. Kad nustatytumėte papildinius, pridedančius nesusijusios CSS kalbos, pabandykite vykdyti [kodo aprėpties procesą](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) naudodami „Chrome DevTools“. Susijusią temą / papildinį galite nustatyti pagal stiliaus failo URL. Ieškokite papildinių, kurių sąraše pateikta daug stiliaus failų, kurių kodo aprėptyje yra daug raudonos spalvos. Papildinys turėtų įtraukti į eilę stiliaus failą, tik jei jis tikrai naudojamas puslapyje."
+    "message": "Apsvarstykite galimybę sumažinti [„WordPress“ papildinių](https://wordpress.org/plugins/), įkeliančių nenaudojamą CSS kalbą jūsų puslapyje, skaičių arba juos pakeisti. Kad nustatytumėte papildinius, pridedančius nesusijusios CSS kalbos, pabandykite vykdyti [kodo aprėpties procesą](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) naudodami „Chrome DevTools“. Susijusią temą / papildinį galite nustatyti pagal stiliaus failo URL. Ieškokite papildinių, kurių sąraše pateikta daug stiliaus failų, kurių kodo aprėptyje yra daug raudonos spalvos. Papildinys įtraukti stiliaus failą į eilę turėtų tik tokiu atveju, jei jis tikrai naudojamas puslapyje."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Apsvarstykite galimybę sumažinti [„WordPress“ papildinių](https://wordpress.org/plugins/), įkeliančių nenaudojamą „JavaScript“ jūsų puslapyje, skaičių arba perjungti juos. Kad nustatytumėte papildinius, pridedančius nesusijusios JS, pabandykite vykdyti [kodo aprėpties procesą](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) naudodami „Chrome DevTools“. Susijusią temą / papildinį galite nustatyti pagal scenarijaus URL. Ieškokite papildinių, kurių sąraše pateikta daug scenarijų, kurių kodo aprėptyje yra daug raudonos spalvos. Papildinys turėtų įtraukti į eilę scenarijų, tik jei jis tikrai naudojamas puslapyje."
+    "message": "Apsvarstykite galimybę sumažinti [„WordPress“ papildinių](https://wordpress.org/plugins/), įkeliančių nenaudojamą „JavaScript“ jūsų puslapyje, skaičių arba juos pakeisti. Kad nustatytumėte papildinius, pridedančius nesusijusios JS, pabandykite vykdyti [kodo aprėpties procesą](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) naudodami „Chrome DevTools“. Susijusią temą / papildinį galite nustatyti pagal scenarijaus URL. Ieškokite papildinių, kurių sąraše pateikta daug scenarijų, kurių kodo aprėptyje yra daug raudonos spalvos. Papildinys įtraukti scenarijų į eilę turėtų tik tokiu atveju, jei jis tikrai naudojamas puslapyje."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Skaitykite apie [naršyklės saugojimo talpykloje funkciją sistemoje „WordPress“](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Apsvarstykite galimybę naudoti [vaizdų optimizavimo „WordPress“ papildinį](https://wordpress.org/plugins/search/optimize+images/), leidžiantį suglaudinti vaizdus išsaugant kokybę."
+    "message": "Apsvarstykite galimybę naudoti [vaizdų optimizavimo „WordPress“ papildinį](https://wordpress.org/plugins/search/optimize+images/), leidžiantį suglaudinti vaizdus išlaikant kokybę."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Įkelkite vaizdus tiesiai per [medijos biblioteką](https://codex.wordpress.org/Media_Library_Screen), kad įsitikintumėte, jog pasiekiami reikiami vaizdų dydžiai, tada įterpkite juos iš medijos bibliotekos arba naudokite vaizdų valdiklį, kad užtikrintumėte, jog naudojami optimalaus dydžio vaizdai (įskaitant tuos, kurie naudojami interaktyviems atskaitos taškams). Nenaudokite viso dydžio vaizdų, nebent galima naudoti tokių matmenų vaizdus. [Sužinokite daugiau](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Įkelkite vaizdus tiesiai per [medijos biblioteką](https://codex.wordpress.org/Media_Library_Screen), kad būtų pasiekiami reikiami vaizdų dydžiai, tada įterpkite juos iš medijos bibliotekos arba naudokite vaizdų valdiklį, kad užtikrintumėte, jog naudojami optimalaus dydžio vaizdai (įskaitant tuos, kurie naudojami interaktyviems atskaitos taškams). Stenkitės nenaudoti vaizdų „`Full Size`“, nebent galima naudoti tokių matmenų vaizdus. [Sužinokite daugiau](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Galite įgalinti teksto glaudinimą žiniatinklio serverio konfigūracijoje."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Apsvarstykite galimybę naudoti [papildinį](https://wordpress.org/plugins/search/convert+webp/) arba paslaugą, kuri automatiškai konvertuos įkeltus vaizdus pagal optimalius formatus."
+    "message": "Apsvarstykite galimybę naudoti [papildinį](https://wordpress.org/plugins/search/convert+webp/) arba paslaugą, kuri automatiškai konvertuotų įkeltus vaizdus į optimalius formatus."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/lv.json
+++ b/lighthouse-core/lib/i18n/locales/lv.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Piekļuves atslēgas ļauj lietotājiem ātri pievērsties lapas daļai. Lai navigācija būtu pareiza, katrai piekļuves atslēgai ir jābūt unikālai. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Piekļuves atslēgas ļauj lietotājiem ātri pievērsties lapas daļai. Lai navigācija būtu pareiza, katrai piekļuves atslēgai ir jābūt unikālai. [Uzziniet vairāk](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Atribūta [accesskey] vērtības nav unikālas"
+    "message": "Atribūtu `[accesskey]` vērtības nav unikālas"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Atribūta [accesskey] vērtības ir unikālas"
+    "message": "Atribūta “`[accesskey]`” vērtības ir unikālas"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Katrs ARIA elements “role” atbalsta konkrētu atribūtu “aria-*” apakškopu. Ja tie netiek norādīti pareizi, atribūti “aria-*” nav derīgi. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Katrs ARIA elements “`role`” atbalsta konkrētu atribūtu “`aria-*`” apakškopu. Ja tie netiek norādīti pareizi, atribūti “`aria-*`” nav derīgi. [Uzziniet vairāk](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Atribūti [aria-*] neatbilst savām lomām"
+    "message": "Atribūti `[aria-*]` neatbilst savām lomām"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Atribūti [aria-*] atbilst savām lomām"
+    "message": "Atribūti `[aria-*]` atbilst savām lomām"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Dažām ARIA lomām ir obligāti atribūti, kas ekrāna lasītājiem norāda elementa statusu. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Dažām ARIA lomām ir obligāti atribūti, kas ekrāna lasītājiem norāda elementa statusu. [Uzziniet vairāk](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Atribūtiem [role] nav visu obligāto atribūtu [aria-*]"
+    "message": "Elementiem `[role]` nav visu pieprasīto atribūtu `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Atribūtiem [role] ir visi obligātie atribūti [aria-*]"
+    "message": "Visiem elementiem `[role]` ir nepieciešamie atribūti `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Dažām ARIA vecāklomām ir jāietver konkrētas pakārtotās lomas, lai varētu nodrošināt piekļūstamības funkcijas. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Dažām ARIA vecāklomām ir jāietver konkrētas pakārtotās lomas, lai varētu nodrošināt pieejamības funkcijas. [Uzziniet vairāk](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Trūkst elementu ar atribūtu [role], kuriem ir nepieciešami konkrēti pakārtoti atribūti [role]."
+    "message": "Trūkst elementu ar elementiem `[role]`, kuriem ir nepieciešamas konkrētas bērna lomas (`[role]`)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Ir elementi ar atribūtu [role], kuriem ir nepieciešami konkrēti pakārtoti atribūti [role]."
+    "message": "Elementi ar atribūtiem `[role]`, kuriem ir nepieciešamas konkrētas bērna lomas (`[role]`), ir klātesoši"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Dažām ARIA pakārtotajām lomām ir jābūt ietvertām konkrētās vecāklomās, lai varētu nodrošināt piekļūstamības funkcijas. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Dažām ARIA pakārtotajām lomām ir jābūt ietvertām konkrētās vecāklomās, lai varētu nodrošināt pieejamības funkcijas. [Uzziniet vairāk](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Atribūti [role] nav ietverti obligātajos vecākelementos"
+    "message": "Atribūts `[role]` neietver pieprasīto vecākelementu"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Atribūti [role] ir ietverti obligātajos vecākelementos"
+    "message": "Atribūtā `[role]` ir ietverts pieprasītais vecākelements"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA lomām ir nepieciešamas derīgas vērtības, lai varētu nodrošināt piekļūstamības funkcijas. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA lomām ir nepieciešamas derīgas vērtības, lai varētu nodrošināt pieejamības funkcijas. [Uzziniet vairāk](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Atribūta [role] vērtības nav derīgas"
+    "message": "Atribūta `[role]` vērtības nav derīgas"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Atribūta [role] vērtības ir derīgas"
+    "message": "Atribūta `[role]` vērtības ir derīgas"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Palīgtehnoloģijas, piemēram, ekrāna lasītāji, nevar interpretēt ARIA atribūtus ar nederīgām vērtībām. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Palīgtehnoloģijas, piemēram, ekrāna lasītāji, nevar interpretēt ARIA atribūtus ar nederīgām vērtībām. [Uzziniet vairāk](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Atribūtiem [aria-*] nav derīgu vērtību"
+    "message": "Atribūtiem `[aria-*]` nav derīgu vērtību"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Atribūtiem [aria-*] ir derīgas vērtības"
+    "message": "Atribūtiem `[aria-*]` ir derīgas vērtības"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Palīgtehnoloģijas, piemēram, ekrāna lasītāji, nevar interpretēt ARIA atribūtus ar nederīgiem nosaukumiem. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Palīgtehnoloģijas, piemēram, ekrāna lasītāji, nevar interpretēt ARIA atribūtus ar nederīgiem nosaukumiem. [Uzziniet vairāk](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Atribūti [aria-*] nav derīgi vai nav norādīti pareizi"
+    "message": "Atribūti `[aria-*]` nav derīgi vai ir kļūdaini uzrakstīti"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Atribūti [aria-*] ir derīgi un norādīti pareizi"
+    "message": "Atribūti `[aria-*]` ir derīgi un pareizi uzrakstīti"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Izmantojot subtitrus, nedzirdīgi lietotāji vai lietotāji ar dzirdes traucējumiem var piekļūt audio elementiem, kuri nodrošina būtisku informāciju, piemēram, runātājus, sarunu saturu, kā arī citu informāciju, kas nav sarunas. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Izmantojot subtitrus, nedzirdīgi lietotāji vai lietotāji ar dzirdes traucējumiem var piekļūt audio elementiem, kuri nodrošina būtisku informāciju, piemēram, runātājus, sarunu saturu, kā arī citu informāciju, kas nav sarunas. [Uzziniet vairāk](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Elementos <audio> nav elementu <track> ar atribūtu [kind=\"captions\"]."
+    "message": "Elementos `<audio>` trūkst elementu `<track>` ar parametru `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Elementos <audio> ir ietverti elementi <track> ar atribūtu [kind=\"captions\"]"
+    "message": "Elementi `<audio>` ietver elementu `<track>` ar parametru `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
-    "message": "Elementi ar kļūdām"
+    "message": "Nederīgi elementi"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Ja pogai nav atbilstoša nosaukuma, ko ekrāni lasītāji var nolasīt, tad ekrāna lasītāji to atskaņo kā “Poga”. Tādējādi lietotāji kuri izmanto ekrāna lasītājus, nesapratīs tās nozīmi. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Ja pogai nav atbilstoša nosaukuma, ko var nolasīt ekrāna lasītāji, tad ekrāna lasītāji to atskaņo kā “Poga”. Tādējādi lietotāji, kuri izmanto ekrāna lasītājus, nesapratīs tās nozīmi. [Uzziniet vairāk](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Pogām nav piekļūstamības principiem atbilstošu nosaukumu"
@@ -93,7 +93,7 @@
     "message": "Pogām ir piekļūstamības principiem atbilstoši nosaukumi"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Ja nodrošināsiet iespēju apiet atkārtotu saturu, tastatūras lietotāji varēs labāk pārvietoties lapā. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Ja nodrošināsiet iespēju apiet atkārtotu saturu, tastatūras lietotāji varēs labāk pārvietoties lapā. [Uzziniet vairāk](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Lapā nav virsraksta, izlaišanas saites vai orientieru daļas"
@@ -102,7 +102,7 @@
     "message": "Lapā ir virsraksts, izlaišanas saite vai orientieru daļa"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Daudziem lasītājiem ir grūti vai pat neiespējami izlasīt tekstu ar zemu kontrastu. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Daudziem lasītājiem ir grūti vai pat neiespējami izlasīt tekstu ar zemu kontrastu. [Uzziniet vairāk](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Fona un priekšplāna krāsu kontrasta koeficients nav pietiekams."
@@ -111,88 +111,88 @@
     "message": "Fona un priekšplāna krāsām ir pietiekams kontrasta koeficients"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Ja definīciju saraksti nav marķēti pareizi, ekrāna lasītāju atskaņotais saturs var būt mulsinošs vai neprecīzs. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Ja definīciju saraksti nav marķēti pareizi, ekrāna lasītāju atskaņotais saturs var būt mulsinošs vai neprecīzs. [Uzziniet vairāk](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Elementi <dl> neietver tikai pareizi kārtotas <dt> un <dd> grupas, elementus <script> vai <template>."
+    "message": "Atribūtā `<dl>` nav ietvertas tikai pareizā secībā sakārtotas elementu `<dt>` un `<dd>` grupas, elements `<script>` vai elements `<template>`"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Elementi <dl> ietver tikai pareizi kārtotas <dt> un <dd> grupas, elementus <script> vai <template>."
+    "message": "Atribūtā `<dl>` ir ietvertas tikai pareizā secībā sakārtotas elementu `<dt>` un `<dd>` grupas, elements `<script>` vai elements `<template>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Definīciju saraksta vienumiem (<dt> un <dd>) ir jābūt ietvertiem vecākelementā <dl>, lai ekrāna lasītāji tos varētu pareizi atskaņot. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Definīciju saraksta vienumiem (`<dt>` un `<dd>`) ir jābūt ietvertiem vecākelementā `<dl>`, lai ekrāna lasītāji tos varētu pareizi atskaņot. [Uzziniet vairāk](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Definīciju saraksta vienumi nav ietverti elementos <dl>"
+    "message": "Definīciju saraksta vienumi netiek apvienoti elementos `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Definīciju saraksta vienumi ir ietverti elementos <dl>"
+    "message": "Definīciju saraksta vienumi tiek apvienoti elementos `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Nosaukums ļauj lietotājiem, kuri izmanto ekrāna lasītājus, uzzināt lapas kopsavilkumu. Lietotājiem, kuri izmanto meklētājprogrammas, nosaukums ļauj saprast, vai lapa atbilst meklētajam vaicājumam. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Nosaukums sniedz lapas kopsavilkumu ekrāna lasītāja lietotājiem, un meklētājprogrammas lietotāji ļoti paļaujas uz to, lai noteiktu, vai lapa ir atbilstoša viņu meklēšanai. [Uzziniet vairāk](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokumentam nav elementa <title>"
+    "message": "Dokumentā nav elementa `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokumentā ir elements <title>"
+    "message": "Dokumentā ir ietverts elements `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "ID atribūta vērtībai ir jābūt unikālai, lai palīgtehnoloģijas neizlaistu citas instances. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "ID atribūta vērtībai ir jābūt unikālai, lai palīgtehnoloģijas neizlaistu citas instances. [Uzziniet vairāk](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Lapas atribūti [id] nav unikāli"
+    "message": "Atribūti `[id]` lapā nav unikāli"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Lapas atribūti [id] ir unikāli"
+    "message": "Atribūti `[id]` lapā ir unikāli"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Ekrāna lasītāji izmanto ietvaru nosaukumus, lai raksturotu ietvaru saturu. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Ekrāna lasītāji izmanto ietvaru nosaukumus, lai raksturotu ietvaru saturu. [Uzziniet vairāk](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Elementiem <frame> vai <iframe> nav nosaukuma"
+    "message": "Elementiem `<frame>` vai `<iframe>` nav nosaukuma"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Elementiem <frame> vai <iframe> ir nosaukums"
+    "message": "Elementiem `<frame>` vai `<iframe>` ir nosaukums"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Ja lapā nav norādīts atribūts “lang”, ekrāna lasītājā tiek pieņemts, ka lapas saturs ir noklusējuma valodā, kuru lietotājs izvēlējās, iestatot ekrāna lasītāju. Ja lapas saturs nav noklusējuma valodā, iespējams, ekrāna lasītājs tekstu neatskaņos pareizi. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Ja lapā nav norādīts atribūts “lang”, ekrāna lasītājā tiek pieņemts, ka lapas saturs ir noklusējuma valodā, kuru lietotājs izvēlējās, iestatot ekrāna lasītāju. Ja lapas saturs nav noklusējuma valodā, iespējams, ekrāna lasītājs tekstu neatskaņos pareizi. [Uzziniet vairāk](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Elementā <html> nav atribūta [lang]"
+    "message": "Tagam `<html>` nav derīga atribūta `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Elementam <html> ir atribūts [lang]"
+    "message": "Tagam `<html>` ir atribūts `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Ja norādīsiet derīgu [BCP 47 valodu](https://www.w3.org/International/questions/qa-choosing-language-tags#question), ekrāna lasītāji pareizi atskaņos tekstu. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ja norādīsiet derīgu [BCP 47 valodu](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ), ekrāna lasītāji pareizi atskaņos tekstu. [Uzziniet vairāk](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Elementa <html> atribūtā [lang] nav norādīta derīga vērtība."
+    "message": "Tagam `<html>` nav derīgas vērtības tā atribūtam `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Elementa <html> atribūtā [lang] ir norādīta derīga vērtība"
+    "message": "Elementam `<html>` ir derīga tā atribūta `[lang]` vērtība"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informatīvajiem elementiem ir nepieciešams īss, aprakstošs alternatīvais teksts. Dekoratīvajiem elementiem alternatīvo atribūtu var atstāt tukšu. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informatīvajiem elementiem ir nepieciešams īss, aprakstošs alternatīvais teksts. Dekoratīvajiem elementiem alternatīvo atribūtu var atstāt tukšu. [Uzziniet vairāk](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Attēlu elementiem nav atribūtu [alt]"
+    "message": "Attēlu elementiem nav atribūtu `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Attēlu elementiem ir atribūti [alt]"
+    "message": "Attēlu elementiem ir atribūti `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Ja kā poga <input> tiek izmantots attēls, alternatīvais teksts var sniegt informāciju par pogas nozīmi lietotājiem, kuri izmanto ekrāna lasītāju. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Ja attēls tiek izmantots kā poga `<input>`, alternatīvais teksts var sniegt informāciju par pogas nozīmi lietotājiem, kuri izmanto ekrāna lasītāju. [Uzziniet vairāk](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Elementiem <input type=\"image\"> nav atribūta [alt] teksta"
+    "message": "Elementiem `<input type=\"image\">` nav teksta `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Elementiem <input type=\"image\"> ir atribūta [alt] teksts"
+    "message": "Elementi `<input type=\"image\">` ietver tekstu `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Ja norādīsiet iezīmes, palīgtehnoloģijas, piemēram, ekrāna lasītāji, varēs pareizi atskaņot veidlapu vadīklas. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Ja norādīsiet iezīmes, palīgtehnoloģijas, piemēram, ekrāna lasītāji, varēs pareizi atskaņot veidlapu vadīklas. [Uzziniet vairāk](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Veidlapu elementiem nav saistīto iezīmju"
@@ -201,16 +201,16 @@
     "message": "Veidlapu elementiem ir saistītas iezīmes"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Tabulā, kas tiek izmantota izkārtojumam, nav ieteicams iekļaut datu elementus, piemēram, elementus “th” vai “caption”, kā arī atribūtu “summary”, jo tā var mulsināt lietotājus, kuri izmanto ekrāna lasītājus. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Tabulā, kas tiek izmantota izkārtojumam, nav ieteicams iekļaut datu elementus, piemēram, elementus “th” vai “caption”, kā arī atribūtu “summary”, jo tā var mulsināt lietotājus, kuri izmanto ekrāna lasītājus. [Uzziniet vairāk](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Attēlojumam paredzētajos elementos <table> tiek izmantoti elementi <th>, <caption> vai atribūts [summary]."
+    "message": "Attēlojumam paredzētajos elementos `<table>` tiek izmantots atribūts `<th>`, `<caption>` vai `[summary]`"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Attēlojumam paredzētajos elementos <table> netiek izmantoti elementi <th>, <caption> vai atribūts [summary]."
+    "message": "Attēlojumam paredzētajos elementos `<table>` netiek izmantots atribūts `<th>`, `<caption>` vai `[summary]`"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Atšķirams, unikāls un aktivizējams saites teksts (un alternatīvais teksts attēliem, kas tiek izmantoti kā saites) nodrošina labākas navigācijas iespējas lietotājiem, kuri izmanto ekrāna lasītājus. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Atšķirams, unikāls un aktivizējams saites teksts (un alternatīvais teksts attēliem, kas tiek izmantoti kā saites) nodrošina labākas navigācijas iespējas lietotājiem, kuri izmanto ekrāna lasītājus. [Uzziniet vairāk](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Saitēm nav atšķirama nosaukuma"
@@ -219,103 +219,115 @@
     "message": "Saitēm ir atšķirams nosaukums"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Ekrāna lasītāji nolasa sarakstus īpašā veidā. Ja saraksta struktūra ir pareiza, tiek atvieglota satura atskaņošana ekrāna lasītājā. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Ekrāna lasītāji nolasa sarakstus īpašā veidā. Ja saraksta struktūra ir pareiza, tiek atvieglota satura atskaņošana ekrāna lasītājā. [Uzziniet vairāk](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Sarakstos ir ietverti elementi <li> un skripta atbalsta elementi (<script> un <template>) un papildu saturs."
+    "message": "Saraksti neietver tikai tos elementus `<li>` un skriptus, kas atbalsta elementus (`<script>` un `<template>`)"
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Sarakstos ir ietverti tikai elementi <li> un skripta atbalsta elementi (<script> un <template>)."
+    "message": "Saraksti ietver tikai elementus `<li>` un skriptus, kas atbalsta elementus (`<script>` un `<template>`)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Lai ekrāna lasītāji varētu pareizi atskaņot saraksta vienumus (<li>), tiem ir jābūt ietvertiem vecākelementos <ul> vai <ol>. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Lai ekrāna lasītāji varētu pareizi atskaņot saraksta vienumus (`<li>`), tiem ir jābūt ietvertiem vecākelementos `<ul>` vai `<ol>`. [Uzziniet vairāk](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Saraksta vienumi (<li>) nav ietverti vecākelementos <ul> vai <ol>."
+    "message": "Saraksta vienumi (`<li>`) nav ietverti vecākelementos `<ul>` vai `<ol>`"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Saraksta vienumi (<li>) ir ietverti vecākelementos <ul> vai <ol>"
+    "message": "Saraksta vienumi (`<li>`) ir ietverti vecākelementos `<ul>` vai `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Lietotāji negaida, ka lapa tiks automātiski atsvaidzināta, un tādējādi atkal tiks pāriets uz lapas augšdaļu. Tas var būt kaitinoši vai mulsinoši. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Lietotāji negaida, ka lapa tiks automātiski atsvaidzināta, un tādējādi atkal tiks pāriets uz lapas augšdaļu. Tas var būt kaitinoši vai mulsinoši. [Uzziniet vairāk](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokumentā tiek izmantots tags <meta http-equiv=\"refresh\">"
+    "message": "Dokumentā tiek izmantots metatags `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Dokumentā netiek izmantots tags <meta http-equiv=\"refresh\">"
+    "message": "Dokumentā netiek izmantots metatags “`<meta http-equiv=\"refresh\">`”"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Ja tālummaiņa ir atspējota, lietotājiem ar redzes traucējumiem, kuri izmanto ekrāna palielinājumu, ir grūtības piekļūt tīmekļa lapas saturam. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Ja tālummaiņa ir atspējota, lietotājiem ar redzes traucējumiem, kuri izmanto ekrāna palielinājumu, ir grūtības piekļūt tīmekļa lapas saturam. [Uzziniet vairāk](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "Elementā <meta name=\"viewport\"> tiek izmantots atribūts [user-scalable=\"no\"], vai atribūta [maximum-scale] vērtība ir mazāka par 5."
+    "message": "Parametrs `[user-scalable=\"no\"]` tiek lietots elementā `<meta name=\"viewport\">`, vai atribūts `[maximum-scale]` ir mazāks par 5"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "Elementā <meta name=\"viewport\"> netiek izmantots atribūts [user-scalable=\"no\"], un atribūta [maximum-scale] vērtība nav mazāka par 5."
+    "message": "Atribūts `[user-scalable=\"no\"]` netiek izmantots elementā `<meta name=\"viewport\">`, un atribūts `[maximum-scale]` nav mazāks par 5"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Ekrāna lasītāji nevar tulkot saturu, kas nav teksts. Ja elementiem “<object>” pievienosiet alternatīvo tekstu, ekrāna lasītāji lietotājiem varēs paziņot teksta nozīmi. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Ekrāna lasītāji nevar tulkot saturu, kas nav teksts. Ja elementiem `<object>` pievienosiet alternatīvo tekstu, ekrāna lasītāji varēs lietotājiem paziņot teksta nozīmi. [Uzziniet vairāk](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Elementiem <object> nav atribūta [alt] teksta"
+    "message": "Elementiem `<object>` nav teksta `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Elementiem <object> ir atribūta [alt] teksts"
+    "message": "Elementi `<object>` ietver tekstu `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Ja vērtība ir lielāka par “0”, navigācijas secība ir noteikta. Lai gan tehniski šis risinājums ir derīgs, bieži vien tas mulsina lietotājus, kuri izmanto palīgtehnoloģijas. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Ja vērtība ir lielāka par “0”, navigācijas secība ir noteikta. Lai gan tehniski šis risinājums ir derīgs, bieži vien tas mulsina lietotājus, kuri izmanto palīgtehnoloģijas. [Uzziniet vairāk](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Dažiem elementiem atribūta [tabindex] vērtība ir lielāka par 0"
+    "message": "Dažiem elementiem atribūta “`[tabindex]`” vērtība ir lielāka par 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Neviena elementa atribūta [tabindex] vērtība nav lielāka par 0"
+    "message": "Nevienam elementam nav atribūta `[tabindex]` vērtības, kas augstāka par 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Ekrāna lasītāju funkcijas atvieglo pārvietošanos tabulās. Ja elementa <table> šūnās, kas izmanto atribūtu “[headers]”, ir atsauces tikai uz citām šūnām tajā pašā tabulā, tiek nodrošināta labāka pieredze lietotājiem, kuri izmanto ekrāna lasītājus. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Ekrāna lasītāju funkcijas atvieglo pārvietošanos tabulās. Ja elementa `<td>` šūnās, kas izmanto atribūtu `[headers]`, ir atsauces tikai uz citām šūnām tajā pašā tabulā, tiek nodrošināta labāka pieredze lietotājiem, kuri izmanto ekrāna lasītājus. [Uzziniet vairāk](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Elementa <table> šūnās, kas izmanto atribūtu [headers], ir atsauces uz citām šūnām tajā pašā tabulā."
+    "message": "Elementa `<table>` šūnās, kas izmanto atribūtu `[headers]`, ir atsauces uz citām šūnām tajā pašā tabulā"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Elementa <table> šūnās, kas izmanto atribūtu [headers], ir atsauces tikai uz citām šūnām tajā pašā tabulā."
+    "message": "Elementa `<table>` šūnās, kas izmanto atribūtu `[headers]` ir atsauces tikai uz citām šūnām tajā pašā tabulā"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Ekrāna lasītāju funkcijas atvieglo pārvietošanos tabulās. Ja tabulu virsrakstos vienmēr ir atsauces uz citām šūnām, tas var nodrošināt labāku pieredzi lietotājiem, kuri izmanto ekrāna lasītājus. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Ekrāna lasītāju funkcijas atvieglo pārvietošanos tabulās. Ja tabulu virsrakstos vienmēr ir atsauces uz citām šūnām, tas var nodrošināt labāku pieredzi lietotājiem, kuri izmanto ekrāna lasītājus. [Uzziniet vairāk](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Elementiem <th> un elementiem ar atribūtu [role=\"columnheader\"/\"rowheader\"] nav datu šūnu, ko tie raksturo."
+    "message": "Elementi `<th>` un elementi ar atribūtu `[role=\"columnheader\"/\"rowheader\"]` neietver to aprakstītās datu šūnas"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Elementiem <th> un elementiem ar atribūtu [role=\"columnheader\"/\"rowheader\"] ir datu šūnas, ko tie raksturo."
+    "message": "Elementi `<th>` un elementi ar atribūtu `[role=\"columnheader\"/\"rowheader\"]` ietver to aprakstītās datu šūnas"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Ja elementos norādīsiet derīgu [BCP 47 valodu](https://www.w3.org/International/questions/qa-choosing-language-tags#question), ekrāna lasītājs pareizi atskaņos tekstu. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ja elementos norādīsiet derīgu [BCP 47 valodu](https://www.w3.org/International/questions/qa-choosing-language-tags#question), ekrāna lasītājs pareizi atskaņos tekstu. [Uzziniet vairāk](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Atribūtiem [lang] nav derīgu vērtību"
+    "message": "Atribūtiem `[lang]` nav derīgas vērtības"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Atribūtiem [lang] ir derīgas vērtības"
+    "message": "Atribūtiem `[lang]` ir derīga vērtība"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Ja videoklipam ir subtitri, nedzirdīgi lietotāji un lietotāji ar dzirdes traucējumiem varēs vieglāk piekļūt informācijai. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Ja videoklipam ir subtitri, nedzirdīgi lietotāji un lietotāji ar dzirdes traucējumiem varēs vieglāk piekļūt informācijai. [Uzziniet vairāk](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Elementos <video> nav elementu <track> ar atribūtu [kind=\"captions\"]."
+    "message": "Elementi `<video>` neietver elementu `<track>` ar parametru `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Elementos <video> ir ietverti elementi <track> ar atribūtu [kind=\"captions\"]"
+    "message": "Elementi `<video>` ietver elementu `<track>` ar parametru `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Audio aprakstos ir noderīga, videoklipos neiekļauta informācija, piemēram, sejas izteiksmes un ainas. [Uzziniet vairāk](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Audio aprakstos ir noderīga, videoklipos neiekļauta informācija, piemēram, sejas izteiksmes un ainas. [Uzziniet vairāk](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Elementos <video> nav elementu <track> ar atribūtu [kind=\"description\"]."
+    "message": "Elementi `<video>` neietver elementu `<track>` ar parametru `[kind=\"description\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Elementos <video> ir ietverti elementi <track> ar atribūtu [kind=\"description\"]"
+    "message": "Elementi `<video>` ietver elementu `<track>` ar parametru `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Lai iegūtu ideālu izskatu iOS ierīcē, lietotājiem pievienojot vietni sākuma ekrānam, definējiet atribūtu “apple-touch-icon”. Tam ir jānorāda uz necaurspīdīgu 192 pikseļu (vai 180 pikseļu) kvadrātveida PNG. [Uzziniet vairāk](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Netiek nodrošināts derīgs atribūts “`apple-touch-icon`”"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Atribūts “`apple-touch-icon-precomposed`” ir novecojis; ieteicams izmantot atribūtu “`apple-touch-icon`”."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Nodrošina derīgu atribūtu “`apple-touch-icon`”"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome paplašinājumi negatīvi ietekmē šīs lapas ielādes veiktspēju. Mēģiniet lapas pārbaudi veikt inkognito režīmā vai no Chrome profila bez paplašinājumiem."
@@ -330,7 +342,7 @@
     "message": "Kopējais centrālā procesora laiks"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Ieteicams samazināt laiku, kas tiek izmantots JS parsēšanai, kompilēšanai un izpildei. Iespējams, konstatēsiet, ka ir noderīgi izmantot mazākas JS lietderīgās slodzes. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Ieteicams samazināt laiku, kas tiek izmantots JS parsēšanai, kompilēšanai un izpildei. Iespējams, konstatēsiet, ka ir noderīgi izmantot mazākas JS lietderīgās slodzes. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "JavaScript izpildes laika samazināšana"
@@ -339,28 +351,28 @@
     "message": "JavaScript izpildes laiks"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Lieli GIF attēli nav efektīvi animēta satura rādīšanai. Animācijām ir ieteicams izmantot MPEG4/WebM video, bet statiskiem attēliem — PNG/WebP, nevis GIF, lai samazinātu tīkla lietojumu (baitos). [Uzzināt] vairāk(https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Lieli GIF attēli nav efektīvi animēta satura rādīšanai. Animācijām ieteicams izmantot MPEG4/WebM video, bet statiskiem attēliem — PNG/WebP, nevis GIF, lai samazinātu tīkla lietojumu (baitos). [Uzziniet vairāk](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)."
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Izmantojiet video failu formātus animētam saturam"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Lai samazinātu laiku līdz interaktivitātei, ārpus ekrāna un paslēptos attēlus ar lēnu ielādi ieteicams atlikt līdz visu svarīgo resursu ielādes pabeigšanai. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Lai samazinātu laiku līdz interaktivitātei, ārpus ekrāna attēlus un paslēptos attēlus ar lēnu ielādi ieteicams atlikt līdz visu svarīgo resursu ielādes pabeigšanai. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Ārpus ekrāna esošo attēlu atlikšana"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Resursi bloķē jūsu lapas pirmo satura atveidojumu. Ieteicams rādīt svarīgos JS/CSS iekļautā veidā un atteikties no visiem nesvarīgajiem JS/stiliem. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Resursi bloķē jūsu lapas pirmo satura atveidojumu. Ieteicams rādīt svarīgos JS/CSS iekļautā veidā un atteikties no visiem nesvarīgajiem JS/stiliem. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Samaziniet resursus, kas bloķē renderēšanu"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Lielas tīkla lietderīgās slodzes izmaksā lietotājiem īstu naudu un ir cieša saistītas ar ilgu ielādes laiku. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Lielas tīkla lietderīgās slodzes izmaksā lietotājiem īstu naudu un ir cieši saistītas ar ilgu ielādes laiku. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "Kopējais lielums bija {totalBytes, number, bytes} KB"
+    "message": "Kopējais lielums bija {totalBytes, number, bytes} KB."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Pārāk lielas tīkla lietderīgās slodzes nepieļaušana"
@@ -369,13 +381,13 @@
     "message": "Nepieļauj pārāk lielu tīkla lietderīgo slodzi"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Samazinot CSS failus, var samazināties tīkla lietderīgā slodze. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Samazinot CSS failus, var samazināties tīkla lietderīgā slodze. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Samaziniet CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Samazinot JavaScript failus, var samazināties lietderīgās slodzes apjomi un skriptu parsēšanas laiks. [Uzzināt vairāk](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Samazinot JavaScript failus, var samazināties lietderīgās slodzes apjomi un skriptu parsēšanas laiks. [Uzziniet vairāk](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "JavaScript·samazināšana"
@@ -393,7 +405,7 @@
     "message": "Noņemiet neizmantoto JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Iestatot ilgu kešatmiņas mūžu, lapas atkārtoti apmeklējumi varētu paātrināties. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Iestatot ilgu kešatmiņas mūžu, lapas atkārtoti apmeklējumi varētu paātrināties. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Atrasts 1 resurss}zero{Atrasti # resursi}one{Atrasts # resurss}other{Atrasti # resursi}}"
@@ -405,37 +417,88 @@
     "message": "Efektīvas kešatmiņas politikas izmantošana statiskiem elementiem"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Optimizēti attēli tiek ielādēti ātrāk un izmanto mazāku mobilo datu apjomu. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Optimizēti attēli tiek ielādēti ātrāk un izmanto mazāku mobilo datu apjomu. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Efektīva attēlu kodēšana"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Rādiet atbilstoša izmēra attēlus, lai tiktu izmantots mazāks mobilo datu apjoms un tiktu uzlabots ielādes laiks. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Rādiet atbilstoša izmēra attēlus, lai tiktu izmantots mazāks mobilo datu apjoms un tiktu uzlabots ielādes laiks. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Atbilstoša lieluma attēli"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Lai samazinātu kopējo tīkla lietojumu (baitos), iesakām izmantot saspiešanu (Gzip, Deflate or Brotli). [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Lai samazinātu kopējo tīkla lietojumu (baitos), ieteicams izmantot saspiešanu (Gzip, Deflate vai Brotli). [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Iespējojiet teksta saspiešanu"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Tādi attēlu formāti kā JPEG 2000, JPEG XR un WebP bieži ir veiksmīgāk saspiežami nekā PNG vai JPEG — tas nozīmē ātrāku lejupielādi un mazāku datu patēriņu. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Tādi attēlu formāti kā JPEG 2000, JPEG XR un WebP bieži ir veiksmīgāk saspiežami nekā PNG vai JPEG. Tas nozīmē ātrāku lejupielādi un mazāku datu patēriņu. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Rādiet attēlus nākamās paaudzes formātos"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Metrika “Kritisko pieprasījumu ķēdes” tālāk parāda, kuri resursi ir ielādēti ar augstāko prioritāti. Lai uzlabotu lapas ielādi, ieteicams samazināt ķēžu garumu, samazināt resursu lejupielādes apjomu vai atlikt nevajadzīgo resursu lejupielādi.[Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Metrika “Kritisko pieprasījumu ķēdes” tālāk parāda, kuri resursi ir ielādēti ar augstāko prioritāti. Lai uzlabotu lapas ielādi, ieteicams samazināt ķēžu garumu, samazināt resursu lejupielādes apjomu vai atlikt nevajadzīgo resursu lejupielādi. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Atrasta 1 ķēde}zero{Atrastas # ķēdes}one{Atrasta # ķēde}other{Atrastas # ķēdes}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Kritisko pieprasījumu dziļuma samazināšana"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Pārtraukšana/brīdinājums"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Rindiņa"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Novecojušas saskarnes API laika gaitā tiks noņemtas no pārlūkprogrammas. [Uzziniet vairāk](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Atrasts 1 brīdinājums}zero{Atrasti # brīdinājumi}one{Atrasts # brīdinājums}other{Atrasti # brīdinājumi}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Tiek izmantotas novecojušas saskarnes API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Nav atļautas novecojušas saskarnes API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Lietojumprogrammas kešatmiņa ir novecojusi. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Atrasts parametrs “{AppCacheManifest}”"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Tiek izmantota lietojumprogrammas kešatmiņa"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Netiek izmantota lietojumprogrammas kešatmiņa"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Ja norādāt DOCTYPE, pārlūkprogramma nevar pārslēgties uz saderības režīmu. Plašāku informāciju skatiet [MDN Web Docs lapā](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "DOCTYPE nosaukumam jābūt mazo burtu virknei “`html`”."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokumentam ir jāietver DOCTYPE."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Paredzamais publiskais ID būs tukša virkne."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Paredzamais sistēmas ID būs tukša virkne."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Lapai trūkst HTML DOCTYPE, tāpēc tiek aktivizēts saderības režīms"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Lapā ir HTML DOCTYPE"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elements"
@@ -447,7 +510,7 @@
     "message": "Vērtība"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Pārlūkprogrammas inženieri iesaka, lai lapā nebūtu vairāk par 1500 DOM elementiem. Ieteicams, lai koka dziļums nepārsniegtu 32 elementus un 60 bērnelementus/vecākelementus. Liels DOM elements var palielināt atmiņas lietojumu, izraisīt ilgākus [stila aprēķinus](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) un radīt dārgu [izkārtojuma plūduma sakārtošanu](https://developers.google.com/speed/articles/reflow). [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Pārlūkprogrammas inženieri iesaka, lai lapā nebūtu vairāk par 1500 DOM elementiem. Ieteicams, lai koka dziļums nepārsniegtu 32 elementus un 60 bērnelementus/vecākelementus. Liels DOM elements var palielināt atmiņas lietojumu, radīt ilgākus [stila aprēķinus](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) un izraisīt [izkārtojuma plūduma sakārtošanu](https://developers.google.com/speed/articles/reflow). [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 elements}zero{# elementu}one{# elements}other{# elementi}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Nepieļauj pārāk lielus DOM izmērus"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Mērķis"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Pievienojiet parametru `rel=\"noopener\"` vai `rel=\"noreferrer\"` jebkurām ārējām saitēm, lai uzlabotu veiktspēju un novērstu drošības ievainojamību. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Saites uz savstarpējās izcelsmes galamērķiem nav drošas"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Saites uz savstarpējās izcelsmes galamērķiem ir drošas"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Nevar noteikt enkura ({anchorHTML}) galamērķi. Ja to neizmantojat kā hipersaiti, apsveriet galamērķa noņemšanu (target=_blank)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Lietotājus mulsina un rada neuzticību vietnes, kas pieprasa viņu atrašanās vietu bez konteksta. Tā vietā ieteicams saistīt pieprasījumu ar lietotāja darbību. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Tiek pieprasīta ģeogrāfiskās atrašanās vietas noteikšanas atļauja lapas ielādei"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Netiek pieprasīta ģeogrāfiskās atrašanās vietas noteikšanas atļauja lapas ielādei"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versija"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Visas JavaScript priekšgalsistēmas bibliotēkas ir noteiktas šajā lapā."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Noteiktās JavaScript bibliotēkas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Lietotājiem, kuriem ir lēns savienojums, ārējie skripti, kas ir dinamiski ievadīti, izmantojot elementu “`document.write()`”, var ievērojami aizkavēt lapas ielādi. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Tiek izmantots elements “`document.write()`”"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Netiek izmantots elements “`document.write()`”"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Vislielākā nozīme"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Bibliotēkas versija"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Ievainojamības gadījumu skaits"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Dažos trešo pušu skriptos var būt zināma drošības ievainojamība, kuras uzbrucēji viegli identificē un izmanto. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Konstatēta 1 ievainojamība}zero{Konstatētas # ievainojamības}one{Konstatēta # ievainojamība}other{Konstatētas # ievainojamības}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Ietver JavaScript priekšgalsistēmas bibliotēkas ar zināmu drošības ievainojamību"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Augsts"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Zems"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Vidējs"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Nepieļauj JavaScript priekšgalsistēmas bibliotēkas ar zināmām drošības ievainojamībām"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Lietotājus mulsina un viņiem rada neuzticību vietnes, kas pieprasa sūtīt paziņojumus bez konteksta. Tā vietā ieteicams saistīt pieprasījumu ar lietotāja žestiem. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Tiek pieprasīta paziņojumu atļauja lapas ielādei"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Netiek pieprasīta paziņojumu atļauja lapas ielādei"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Nederīgi elementi"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Paroles ielīmēšanas novēršana neatbilst labai drošības politikai. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Neļauj lietotājiem ielīmēt paroles laukos"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Ļauj lietotājiem ielīmēt paroles laukos"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokols"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 piedāvā daudzas priekšrocības salīdzinājumā ar HTTP/1.1, tostarp binārās galvenes, multipleksēšanu un servera tiešu darbību (server push). [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 pieprasījums nav parādīts, izmantojot HTTP/2}zero{# pieprasījumi nav parādīti, izmantojot HTTP/2}one{# pieprasījums nav parādīts, izmantojot HTTP/2}other{# pieprasījumi nav parādīti, izmantojot HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Netiek izmantots protokols HTTP/2 visiem tā resursiem"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Tiek izmantots protokols HTTP/2 tā resursiem"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Llai uzlabotu savas lapas ritināšanas veiktspēju, ieteicams atzīmēt pieskārienu un peles ritentiņa notikumu uztvērējus kā “`passive`”. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Netiek izmantoti pasīvie klausītāji, lai uzlabotu ritināšanas veiktspēju"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Tiek izmantoti pasīvie klausītāji, lai uzlabotu ritināšanas veiktspēju"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Apraksts"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Konsolē reģistrētās kļūdas norāda uz neatrisinātām problēmām. Tās var rasties no tīkla pieprasījuma kļūmēm un citām pārlūkprogrammas problēmām."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Pārlūkprogrammas kļūdas tika reģistrētas konsolē"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Neviena pārlūkprogrammas kļūda nav reģistrēta konsolē"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Izmantojiet fonta rādīšanas CSS funkciju, lai nodrošinātu, ka lietotāji tīmekļa fontu ielādes laikā var redzēt tekstu. [Uzzināt vairāk](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Izmantojiet fonta rādīšanas CSS funkciju, lai lietotāji tīmekļa fontu ielādes laikā varētu redzēt tekstu. [Uzziniet vairāk](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Visa teksta redzamības nodrošināšana tīmekļa fonta ielādes laikā"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Tīmekļa fonta ielādes laikā viss teksts paliek redzams"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse nevarēja automātiski pārbaudīt šī URL fonta attēlojuma vērtību: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Malu attiecība (faktiskā)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Malu attiecība (attēlotā)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Attēla parādīšanas izmēriem jāatbilst dabiskajai malu attiecībai. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Tiek rādīti attēli ar nepareizu malu attiecību"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Tiek rādīti attēli ar pareizu malu attiecību"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Nederīga attēla lieluma informācija: {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Nedrošs URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Visas vietnes ir jāaizsargā ar protokolu HTTPS, pat ja tajās netiek apstrādāti sensitīvi dati. HTTPS neļauj iebrucējiem manipulēt vai pasīvi uztvert sakarus starp jūsu lietotni un lietotājiem, un tas ir HTTP/2 un daudzu jaunu tīmekļa platformu saskarņu API priekšnoteikums. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Noteikts 1 nedrošs pieprasījums}zero{Noteikti # nedroši pieprasījumi}one{Noteikts # nedrošs pieprasījums}other{Noteikti # nedroši pieprasījumi}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Netiek izmantots protokols HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Tiek izmantots protokols HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Ātra lapas ielāde, izmantojot mobilo datu tīklu, nodrošina labu pieredzi mobilo ierīču lietotājiem. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interaktīvs pēc {timeInMs, number, seconds} sekundēm"
+    "message": "Interaktīvais laiks: {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Interaktīvs simulētās mobilajās ierīcēs {timeInMs, number, seconds} sekunžu laikā"
+    "message": "Interaktīvs simulētā mobilajā tīklā {timeInMs, number, seconds} sekunžu laikā"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Lapas ielāde nav pietiekami ātra mobilajos tīklos"
@@ -510,19 +741,19 @@
     "message": "Paredzētais ievades latentums"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Metrika \"Pirmais satura marķējums\" atzīmē laiku, kad tiek marķēts pirmais teksts vai attēls. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Metrika \"Pirmais satura marķējums\" atzīmē laiku, kad tiek marķēts pirmais teksts vai attēls. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Pirmais saturīgais satura atveidojums"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "Metrika “Pirmā CPU dīkstāve” norāda laiku, kad lapas galvenais pavediens ir kļuvis pietiekami mazs, lai varētu apstrādāt ievadi. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "Metrika “Pirmā CPU dīkstāve” norāda laiku, kad lapas galvenais pavediens ir kļuvis pietiekami mazs, lai varētu apstrādāt ievadi. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Pirmā CPU dīkstāve"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Metrika “Pirmais nozīmīgais satura atveidojums” norāda, kad kļūst redzams lapas galvenais saturs. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Metrika “Pirmais nozīmīgais satura atveidojums” norāda, kad kļūst redzams lapas galvenais saturs. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Pirmais nozīmīgais satura atveidojums"
@@ -534,16 +765,22 @@
     "message": "Laiks līdz interaktivitātei"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Iespējamā pirmā ievades kavēšanās, ar ko jūsu lietotāji var saskarties, ir ilgākā uzdevuma ilgums milisekundēs."
+    "message": "Iespējamā maksimālā pirmās ievades aizkave, ar ko jūsu lietotāji var saskarties, ir ilgākā uzdevuma ilgums milisekundēs. [Uzziniet vairāk](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Maks. iespējamā pirmās ievades kavēšanās"
+    "message": "Maks. potenciālā pirmā ievades aizkave"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Metrika “Ātruma rādītājs” norāda, cik ātri tiek parādīts lapas saturs. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Ātruma rādītājs norāda, cik ātri tiek parādīts lapas saturs. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Ātruma rādītājs"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Visu laika periodu summa (no PSM līdz “Laiks līdz interaktivitātei”), kad uzdevuma ilgums pārsniedz 50 ms (izteikts milisekundēs)."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Kopējais bloķēšanas laiks"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Tīkla aprites laiks (RTT) spēcīgi ietekmē veiktspēju. Ja aprites laiks uz sākumpunktu ir augsts, tas norāda, ka serveru veiktspēja, kas atrodas tuvāk lietotājam, var tikt uzlabota. [Uzziniet vairāk](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,38 +794,59 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Servera aizmugursistēmas latentums"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Pārsniegts budžets"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Saglabājiet tīkla pieprasījumu daudzumu un lielumu zem mērķiem, kas noteikti sniegtajā izpildes budžetā. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 pieprasījums}zero{# pieprasījumi}one{# pieprasījums}other{# pieprasījumi}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Izpildes budžets"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Novirzīšana rada papildu aizkaves pirms lapas ielādes. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Novirzīšana rada papildu aizkaves pirms lapas ielādes. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Nepieļaujiet vairākas lapas novirzīšanas"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Lai iestatītu lapas resursu daudzuma un lieluma budžetus, pievienojiet failu budget.json. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 pieprasījums}zero{# pieprasījumi}one{# pieprasījums}other{# pieprasījumi}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Uzturiet nelielu pieprasījumu skaitu un mazu pārsūtīšanas failu lielumu"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Kanoniskās saites iesaka, kurus URL rādīt meklēšanas rezultātos. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Vairāki savā starpā konfliktējoši URL ({urlList})"
+    "message": "Vairāki konfliktējoši URL ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Norāda uz citu domēnu ({url})"
+    "message": "Norāda uz citu domēnu ({url})."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "Nederīgs URL ({url})"
+    "message": "Nederīgs URL ({url})."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Norāda uz citu atribūta “hreflang” atrašanās vietu ({url})"
+    "message": "Norāda uz citu atribūta “`hreflang`” atrašanās vietu ({url})."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "Atbilstošs URL ({url})"
+    "message": "Atbilstošs URL ({url})."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "Ekvivalenta satura lapas vietā norāda uz domēna saknes piekļuves URL (sākumlapu)"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokumentā nav derīgs atribūts “rel=canonical”"
+    "message": "Dokumentā nav derīga atribūta “`rel=canonical`”"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokumentā ir derīgs atribūts “rel=canonical”"
+    "message": "Dokumentam ir derīgs atribūts “`rel=canonical`”"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Fonta izmērs, kas ir mazāks par 12 pikseļiem, ir pārāk mazs, lai būtu salasāms, un mobilo ierīču lietotāji ir spiesti tuvināt tekstu, lai varētu to salasīt. Centieties, lai vairāk nekā 60% lapas teksta būtu vismaz 12 pikseļu vai lielāka izmēra. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
@@ -596,14 +854,11 @@
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} salasāms teksts"
   },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} teksta ir pārāk mazs fonta izmērs."
-  },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Teksts nav salasāms, jo mobilo ierīču ekrāniem nav optimizēts skatvietas metatags."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} teksta ir pārāk mazs fonta izmērs (pamatojoties uz {decimalProportionVisited, number, extendedPercent} paraugu)."
+    "message": "{decimalProportion, number, extendedPercent} ir pārāk mazs teksta izmērs (pamatojoties uz {decimalProportionVisited, number, extendedPercent} paraugu)."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Dokumentā netiek izmantoti salasāmi fonta izmēri"
@@ -612,13 +867,13 @@
     "message": "Dokumentā izmantoti salasāmi fonta izmēri"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Atribūta “hreflang” saites norāda meklētājprogrammām, kuru lapas versiju iekļaut meklēšanas rezultātu sarakstā attiecīgai valodai vai reģionam. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Atribūta “hreflang” saites norāda meklētājprogrammām, kuru lapas versiju iekļaut meklēšanas rezultātu sarakstā konkrētai valodai vai reģionam. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokumentā nav derīga atribūta “hreflang”"
+    "message": "Dokumentā nav derīga atribūta “`hreflang`”"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokumentā ir derīgs atribūts “hreflang”"
+    "message": "Dokumentam ir derīgs atribūts “`hreflang`”"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Lapas ar nesekmīgu HTTP statusa kodu var tikt indeksētas nepareizi. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -651,7 +906,7 @@
     "message": "Saitēm ir aprakstošs teksts"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Lai validētu strukturētos datus, palaidiet [strukturētu datu testēšanas rīku](https://search.google.com/structured-data/testing-tool/) un [strukturētu datu linteru](http://linter.structured-data.org/). [Uzziniet vairāk](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Lai validētu strukturētos datus, palaidiet [strukturētu datu testēšanas rīku](https://search.google.com/structured-data/testing-tool/) un rīku [Structured Data Linter](http://linter.structured-data.org/). [Uzziniet vairāk](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Strukturētie dati ir derīgi"
@@ -681,7 +936,7 @@
     "message": "Ja jūsu robots.txt fails ir nepareizi veidots, rāpuļprogrammas, iespējams, nevarēs saprast, kā esat gribējis, lai jūsu tīmekļa vietne tiktu pārmeklēta vai indeksēta."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "robots.txt pieprasījumam tika nosūtīts atpakaļ HTTP statuss: {statusCode}"
+    "message": "robots.txt pieprasījumam tika atgriezts HTTP statuss: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{Tika atrasta 1 kļūda}zero{Tika atrastas # kļūdas}one{Tika atrasta # kļūda}other{Tika atrastas # kļūdas}}"
@@ -699,7 +954,7 @@
     "message": "Interaktīvajiem elementiem, piemēram, pogām un saitēm, ir jābūt pietiekami lieliem (48 x 48 pikseļi), un tiem apkārt ir jābūt pietiekami daudz brīvas vietas, lai tiem varētu viegli pieskarties, neaizskarot citus elementus. [Uzziniet vairāk](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "{decimalProportion, number, percent} pieskārienu mērķu izmērs ir atbilstošs"
+    "message": "{decimalProportion, number, percent} pieskārienu mērķu izmērs ir atbilstošs."
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "Pieskārienu mērķu izmērs ir pārāk mazs, jo mobilo ierīču ekrāniem nav optimizēts skatvietas metatags"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Mērķis, kas pārklājas"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Izmērs"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Pieskārienu mērķis"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Pieskārienu mērķi ir pietiekami liela izmēra"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Galvenā pavediena laiks"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Trešā puse"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Trešās puses kods var ievērojami ietekmēt ielādes veiktspēju. Ierobežojiet lieko trešo pušu pakalpojumu sniedzēju skaitu un mēģiniet ielādēt trešās puses kodu pēc tam, kad jūsu lapa būs ielādēta. [Uzziniet vairāk](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Atrasta 1 trešā puse}zero{Atrastas # trešās puses}one{Atrasta # trešā puse}other{Atrastas # trešās puses}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Trešo pušu lietojums"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Metrika “Laiks līdz pirmajam baitam” norāda laiku, kad jūsu serveris nosūta atbildi. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "Metrika “Laiks līdz pirmajam baitam” norāda laiku, kad jūsu serveris nosūta atbildi. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Saknes dokumentam nepieciešamais laiks: {timeInMs, number, milliseconds} ms"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Ilgums"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Vārds"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Sākuma laiks"
   },
@@ -744,7 +1008,7 @@
     "message": "Veids"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Ieteicams pievienot lietotnei Lietotāju laika API, lai noteiktu lietotnes aktuālo veiktspēju lietotāju pamata darbības laikā. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Ieteicams pievienot lietotnei “Lietotāja laika API”, lai noteiktu lietotnes aktuālo veiktspēju lietotāju pamata darbības laikā. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 lietotāja laiks}zero{# lietotāju laiks}one{# lietotāja laiks}other{# lietotāju laiks}}"
@@ -753,19 +1017,19 @@
     "message": "Lietotāju laika atzīmes un mērījumi"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Elementam “{securityOrigin}” tika atrasta iepriekšējas pieslēgšanās saite, taču pārlūks to neizmantoja. Pārliecinieties, vai pareizi izmantojat atribūtu “crossorigin”."
+    "message": "Elementam “{securityOrigin}” tika atrasta iepriekšējas pieslēgšanās parametrs <link>, taču pārlūkprogramma to neizmantoja. Pārbaudiet, vai pareizi izmantojat atribūtu “`crossorigin`”."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Ieteicams pievienot iepriekš pieslēgtu vai DNS sākotnējo datu iegūšanas resursa norādes, lai izveidotu laicīgus savienojumus ar svarīgiem trešās puses sākumpunktiem. [Uzzināt vairāk](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Ieteicams pievienot iepriekš pieslēgtu vai DNS sākotnējo datu iegūšanas resursa norādes, lai izveidotu laicīgus savienojumus ar svarīgiem trešās puses sākumpunktiem. [Uzziniet vairāk](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Veiciet iepriekšēju pieslēgšanu obligātajiem sākumpunktiem"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Saitei “{preloadURL}” tika atrasta iepriekšēja ielādes saite, taču pārlūks to neizmantoja. Pārliecinieties, vai pareizi izmantojat atribūtu “crossorigin”."
+    "message": "Saitei “{preloadURL}” tika atrasts iepriekšējas ielādes parametrs <link>, taču pārlūkprogramma to neizmantoja. Pārbaudiet, vai pareizi izmantojat atribūtu “`crossorigin`”."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Ieteicams izmantot <link rel=preload>, lai noteiktu prioritāti tādu resursu iegūšanai, kas pašlaik lapas ielādē tiek pieprasīti vēlāk. [Uzzināt vairāk](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Ieteicams izmantot atribūtu `<link rel=preload>`, lai noteiktu prioritāti tādu resursu iegūšanai, kas pašlaik lapas ielādē tiek pieprasīti vēlāk. [Uzziniet vairāk](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Veiciet svarīgāko pieprasījumu iepriekšēju ielādi"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabulas un saraksti"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Paraugprakse"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Izpildes budžets nosaka jūsu vietnes veiktspējas standartus."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budžeti"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Plašāka informācija par jūsu lietojumprogrammas veiktspēju"
+    "message": "Plašāka informācija par jūsu lietojumprogrammas veiktspēju. Šie skaitļi [tieši neietekmē](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) veiktspējas rezultātu"
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostika"
@@ -840,7 +1113,7 @@
     "message": "Pirmā satura atveidojuma uzlabojumi"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Šīs optimizācijas var paātrināt lapas ielādi."
+    "message": "Šie ieteikumi var palīdzēt ātrāk ielādēt jūsu lapu. Tie [tieša veidā neietekmē](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) veiktspējas rezultātu."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Iespējas"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Kešatmiņas TTL vērtība"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Atrašanās vieta"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Vārds"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Pieprasījumi"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Resursu veids"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Lielums (KB)"
+    "message": "Izmērs"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Iztērētais laiks"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Pārsūtīto failu lielums"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potenciālais ietaupījums (KB)"
+    "message": "Potenciālie ietaupījumi"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potenciālais ietaupījums (ms)"
+    "message": "Potenciālie ietaupījumi"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Potenciālais ietaupījums: {wastedBytes, number, bytes} KB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Potenciālais ietaupījums: {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokuments"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Fonts"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Attēls"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Multivide"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Cits"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skripts"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stilu lapa"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Trešā puse"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Kopā"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Nevarēja reģistrēt lapas ielādes trasējumu. Lūdzu, vēlreiz palaidiet Lighthouse. ({errorCode})"
@@ -930,13 +1245,19 @@
     "message": "Gaidot sākotnējā atkļūdotāja protokola savienojumu, radās noildze."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Ielādējot lapu, Chrome neieguva ekrānuzņēmumus. Pārliecinieties, ka lapā ir redzams saturs, un pēc tam atkārtoti palaidiet Lighthouse. ({errorCode})"
+    "message": "Lapas ielādes laikā pārlūkprogramma Chrome nav apkopojusi nevienu ekrānuzņēmumu. Lūdzu, nodrošiniet, ka saturs ir redzams lapā, un pēc tam mēģiniet atkārtoti palaist Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS serveri nevarēja atrast norādīto domēnu."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Nepieciešamajam parametra “{artifactName}” vācējam radās kļūda: {errorMessage}."
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Radās iekšēja Chrome kļūda. Lūdzu, restartējiet Chrome un mēģiniet atkārtoti palaist Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Nepieciešamais parametra “{artifactName}” vācējs nedarbojās."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse nevarēja droši ielādēt jūsu pieprasīto lapu. Pārliecinieties, ka testējat pareizo URL un serveris pareizi reaģē uz visiem pieprasījumiem."
@@ -945,19 +1266,22 @@
     "message": "Lighthouse nevarēja droši ielādēt jūsu pieprasīto URL, jo lapa pārstāja reaģēt."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Jūsu norādītajam URL nav derīgu drošības akreditācijas datu. {securityMessages}"
+    "message": "Jūsu norādītajam URL nav derīga drošības sertifikāta. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Pārlūkprogramma Chrome neļāva ielādēt lapu ar iespiestu reklāmu. Nodrošiniet, ka pārbaudāt pareizo URL un ka serveris pareizi reaģē uz visiem pieprasījumiem."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Lighthouse nevarēja droši ielādēt jūsu pieprasīto lapu. Pārliecinieties, ka testējat pareizo URL un serveris pareizi reaģē uz visiem pieprasījumiem. (Detalizēta informācija: {errorDetails})"
+    "message": "Lighthouse nevarēja uzticami ielādēt jūsu pieprasīto lapu. Nodrošiniet, ka pārbaudāt pareizo URL un ka serveris pareizi reaģē uz visiem pieprasījumiem. (Detalizēta informācija: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Lighthouse nevarēja droši ielādēt jūsu pieprasīto lapu. Pārliecinieties, ka testējat pareizo URL un serveris pareizi reaģē uz visiem pieprasījumiem. (Statusa kods: {statusCode})"
+    "message": "Lighthouse nevarēja uzticami ielādēt jūsu pieprasīto lapu. Nodrošiniet, ka pārbaudāt pareizo URL un ka serveris pareizi reaģē uz visiem pieprasījumiem. (Statusa kods: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Lapas ielādei bija nepieciešams pārāk daudz laika. Lūdzu, izmantojiet pārskatā sniegtos ieteikumus, lai saīsinātu lapas ielādes laiku, un pēc tam atkārtoti palaidiet Lighthouse. ({errorCode})"
+    "message": "Lapas ielādei bija nepieciešams pārāk ilgs laiks. Lūdzu, izmantojiet pārskatā sniegtās iespējas, lai samazinātu lapas ielādes laiku, un pēc tam mēģiniet atkārtoti palaist Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "DevTools protokola atbildes gaidīšanai ir nepieciešams ilgāks laiks, nekā pieļaujams. (Metode: {protocolMethod})"
+    "message": "Gaidot DevTools protokola atbildi, ir pārsniegts atvēlētais laiks. (Veids: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "Resursu satura izgūšanai ir nepieciešams ilgāks laiks, nekā pieļaujams"
@@ -984,7 +1308,7 @@
     "message": "Laboratorijas dati"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "Pašreizējās lapas [Lighthouse](https://developers.google.com/web/tools/lighthouse/) analīze emulētā mobilajā tīklā. Vērtības ir aptuvenas un var atšķirties."
+    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) pašreizējās lapas analīze emulētajā mobilajā tīklā. Vērtības ir aptuvenas un var atšķirties."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Papildu vienumi manuālai pārbaudei"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Izvērst fragmentu"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Parādīt trešās puses resursus"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Radās problēmas, kas ietekmēja šo Lighthouse palaišanu:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Vērtības ir aptuvenas un var atšķirties."
+    "message": "Vērtības ir aptuvenas un var atšķirties. Veiktspējas rezultāts tiek [tiek pamatots tikai uz šīm metrikām](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Veiktās pārbaudes ar brīdinājumiem"
@@ -1023,7 +1350,7 @@
     "message": "Apsveriet iespēju augšupielādēt GIF attēlu pakalpojumā, kuru varēs izmantot, lai iegultu GIF attēlu kā HTML5 videoklipu."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Instalējiet [atliktās ielādes WordPress spraudni](https://wordpress.org/plugins/search/lazy+load/), kas sniedz iespēju atlikt jebkādus ārpus ekrāna esošus attēlus vai mainīt motīvu uz tādu, kurā šī funkcija tiek nodrošināta. Apsveriet arī iespēju izmantot [AMP spraudni](https://wordpress.org/plugins/amp/)."
+    "message": "Instalējiet [atliktās ielādes WordPress spraudni](https://wordpress.org/plugins/search/lazy+load/), kas sniedz iespēju atlikt jebkādus ārpus ekrāna esošus attēlus vai mainīt motīvu uz tādu, kurā šī funkcija tiek nodrošināta. Ieteicams izmantot arī [AMP spraudni](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "Ir vairāki WordPress spraudņi, kas var palīdzēt [iekļaut būtiskus līdzekļus](https://wordpress.org/plugins/search/critical+css/) vai [atlikt mazāk svarīgus resursus](https://wordpress.org/plugins/search/defer+css+javascript/). Ņemiet vērā, ka šo spraudņu nodrošinātā optimizācija var traucēt funkciju darbībai jūsu motīvā vai spraudņos, tādēļ, visticamāk, jums būs jāveic koda izmaiņas."
@@ -1038,27 +1365,27 @@
     "message": "Vairāki [WordPress spraudņi](https://wordpress.org/plugins/search/minify+css/) var paātrināt jūsu vietnes darbību, savienojot, samazinot un saspiežot stilus. Ja iespējams, varat arī veikt šo samazināšanu iepriekš izveides procesā."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Vairāki [WordPress spraudņi](https://wordpress.org/plugins/search/minify+javascript/) var paātrināt jūsu vietnes darbību, savienojot, samazinot un saspiežot jūsu skriptus. Ja iespējams, varat veikt šo samazināšanu jau iepriekš izveides procesā."
+    "message": "Vairāki [WordPress spraudņi](https://wordpress.org/plugins/search/minify+javascript/) var paātrināt jūsu vietnes darbību, savienojot, samazinot un saspiežot skriptus. Ja iespējams, varat veikt šo samazināšanu jau iepriekš izveides procesā."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Apsveriet iespēju samazināt vai mainīt to [WordPress spraudņu] skaitu (https://wordpress.org/plugins/), kuri ielādē neizmantotus CSS datus jūsu lapā. Lai identificētu spraudņus, kas pievieno liekus CSS datus, mēģiniet izpildīt [koda pārklājumu](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage), izmantojot Chrome DevTools. Saistīto motīvu/spraudni varat identificēt stila lapas vietrādī URL. Meklējiet spraudņus, kuriem sarakstā ir daudz stila lapu ar daudz sarkanām atzīmēm koda pārklājumā. Spraudnim ir jāievieto rindā stilu lapa tikai tad, ja tā faktiski tiek izmantota lapā."
+    "message": "Ieteicams samazināt vai mainīt tādu [WordPress spraudņu](https://wordpress.org/plugins/) skaitu, kuri ielādē nelietotu CSS kodu jūsu lapā. Lai identificētu spraudņus, kuri pievieno lieku CSS kodu, mēģiniet izpildīt [koda pārklājumu](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage), izmantojot Chrome DevTools. Saistīto motīvu/spraudni varat identificēt stila lapas vietrādī URL. Meklējiet spraudņus, kuriem sarakstā ir daudz stila lapu ar daudz sarkanām atzīmēm koda pārklājumā. Spraudnim ir jāievieto rindā stilu lapa tikai tad, ja tā faktiski tiek izmantota lapā."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Apsveriet iespēju samazināt vai mainīt tādu [WordPress spraudņu] skaitu, (https://wordpress.org/plugins/) kuri ielādē nelietotu JavaScript kodu jūsu lapā. Lai identificētu spraudņus, kuri pievieno lieku JS kodu, mēģiniet izpildīt [koda pārklājumu](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage), izmantojot Chrome DevTools. Saistīto motīvu/spraudni varat identificēt skripta vietrādī URL. Meklējiet spraudņus, kuriem sarakstā ir daudz skriptu ar daudz sarkanām atzīmēm koda pārklājumā. Spraudnim ir jāievieto rindā skripts tikai tad, ja tas faktiski tiek izmantots lapā."
+    "message": "Ieteicams samazināt vai mainīt tādu [WordPress spraudņu](https://wordpress.org/plugins/) skaitu, kuri ielādē nelietotu JavaScript kodu jūsu lapā. Lai identificētu spraudņus, kuri pievieno lieku JS kodu, mēģiniet izpildīt [koda pārklājumu](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage), izmantojot Chrome DevTools. Saistīto motīvu/spraudni varat identificēt skripta vietrādī URL. Meklējiet spraudņus, kuriem sarakstā ir daudz skriptu ar daudz sarkanām atzīmēm koda pārklājumā. Spraudnim ir jāievieto rindā skripts tikai tad, ja tas faktiski tiek izmantots lapā."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Uzziniet par [pārlūkprogrammas datu saglabāšanu kešatmiņā programmatūrā WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Apsveriet iespēju izmantot [attēlu optimizācijas WordPress spraudni](https://wordpress.org/plugins/search/optimize+images/), kas saspiež attēlus, vienlaikus saglabājot kvalitāti."
+    "message": "Ieteicams izmantot [attēlu optimizācijas WordPress spraudni](https://wordpress.org/plugins/search/optimize+images/), kas saspiež attēlus, vienlaikus saglabājot kvalitāti."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Augšupielādējiet attēlus tieši, izmantojot [multivides bibliotēku](https://codex.wordpress.org/Media_Library_Screen), lai nodrošinātu nepieciešamo attēlu lielumu pieejamību, un pēc tam ievietojiet attēlus no multivides bibliotēkas vai izmantojiet attēlu logrīku, lai nodrošinātu, ka tiek izmantoti optimāli attēlu lielumi (tostarp reaģējošām robežvērtībām paredzētie). Neizmantojiet pilna izmēra attēlus, ja to izmēri neatbilst to lietojumam. [Uzziniet vairāk](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Tieši augšupielādējiet attēlus, izmantojot [multivides bibliotēku](https://codex.wordpress.org/Media_Library_Screen), lai nodrošinātu nepieciešamo attēlu lielumu pieejamību. Pēc tam ievietojiet attēlus no multivides bibliotēkas vai izmantojiet attēlu logrīku, lai tiktu izmantoti optimāli attēlu lielumi (tostarp reaģējošām robežvērtībām paredzētie). Neizmantojiet `Full Size` attēlus, ja to izmēri neatbilst to lietojumam. [Uzziniet vairāk](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Varat iespējot teksta saspiešanu tīmekļa servera konfigurācijā."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Apsveriet iespēju izmantot [spraudni](https://wordpress.org/plugins/search/convert+webp/) vai pakalpojumu, kurā jūsu augšupielādētie attēli tiks automātiski pārveidoti optimālos formātos."
+    "message": "Ieteicams izmantot [spraudni](https://wordpress.org/plugins/search/convert+webp/) vai pakalpojumu, kurā jūsu augšupielādētie attēli tiks automātiski pārveidoti optimālos formātos."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/nl.json
+++ b/lighthouse-core/lib/i18n/locales/nl.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Met toegangstoetsen kunnen gebruikers snel de focus op een gedeelte van de pagina plaatsen. Voor correcte navigatie moet elke toegangstoets uniek zijn. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Met toegangstoetsen kunnen gebruikers snel de focus op een gedeelte van de pagina plaatsen. Voor correcte navigatie moet elke toegangstoets uniek zijn. [Meer informatie](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "'[accesskey]'-waarden zijn niet uniek"
+    "message": "`[accesskey]`-waarden zijn niet uniek"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "'[accesskey]'-waarden zijn uniek"
+    "message": "`[accesskey]`-waarden zijn uniek"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Elke ARIA-rol ondersteunt een specifieke subset van 'aria-*'-kenmerken. Als deze niet overeenkomen, zijn de 'aria-*'-kenmerken ongeldig. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Elke ARIA-`role` ondersteunt een specifieke subset van `aria-*`-kenmerken. Als deze verkeerd worden gekoppeld, worden de `aria-*`-kenmerken ongeldig. [Meer informatie](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "'[aria-*]'-kenmerken komen niet overeen met hun rollen"
+    "message": "`[aria-*]`-kenmerken komen niet overeen met hun rollen"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "'[aria-*]'-kenmerken komen overeen met hun rollen"
+    "message": "`[aria-*]`-kenmerken komen overeen met hun rollen"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Sommige ARIA-rollen hebben vereiste kenmerken die de status van het element beschrijven voor schermlezers. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Sommige ARIA-rollen hebben vereiste kenmerken die de status van het element beschrijven voor schermlezers. [Meer informatie](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "'[role]'-elementen bevatten niet alle vereiste '[aria-*]'-kenmerken"
+    "message": "`[role]`-elementen bevatten niet alle vereiste `[aria-*]`-kenmerken"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "'[role]'-elementen bevatten alle vereiste '[aria-*]'-kenmerken"
+    "message": "`[role]`-elementen bevatten alle vereiste `[aria-*]`-kenmerken"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Sommige bovenliggende ARIA-rollen moeten specifieke onderliggende rollen bevatten om de beoogde toegankelijkheidsfuncties uit te voeren. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Sommige bovenliggende ARIA-rollen moeten specifieke onderliggende rollen bevatten om de beoogde toegankelijkheidsfuncties uit te voeren. [Meer informatie](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Er ontbreken elementen met '[role]' waarvoor specifieke onderliggende '[role]'-elementen zijn vereist."
+    "message": "Er ontbreken elementen met `[role]` die specifieke onderliggende `[role]`-elementen vereisen."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Er zijn elementen met '[role]' aanwezig waarvoor specifieke onderliggende '[role]'-elementen zijn vereist"
+    "message": "Er zijn elementen met `[role]` aanwezig die specifieke onderliggende `[role]`-elementen vereisen."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Sommige onderliggende ARIA-rollen moeten zijn opgenomen in specifieke bovenliggende rollen om de beoogde toegankelijkheidsfuncties op de juiste manier uit te voeren. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Sommige onderliggende ARIA-rollen moeten zijn opgenomen in specifieke bovenliggende rollen om de beoogde toegankelijkheidsfuncties op de juiste manier uit te voeren. [Meer informatie](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "'[role]'-elementen zijn niet opgenomen in het vereiste bovenliggende element"
+    "message": "`[role]`-elementen zijn niet opgenomen in het vereiste bovenliggende element"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "'[role]'-elementen zijn opgenomen in het vereiste bovenliggende element"
+    "message": "`[role]`-elementen zijn opgenomen in het vereiste bovenliggende element"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA-rollen moeten geldige waarden hebben om hun beoogde toegankelijkheidsfuncties uit te voeren. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA-rollen moeten geldige waarden hebben om hun beoogde toegankelijkheidsfuncties uit te voeren. [Meer informatie](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "'[role]'-waarden zijn niet geldig"
+    "message": "`[role]`-waarden zijn niet geldig"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "'[role]'-waarden zijn geldig"
+    "message": "`[role]`-waarden zijn geldig"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "ARIA-kenmerken met ongeldige waarden kunnen niet worden geïnterpreteerd door hulptechnologieën, zoals schermlezers. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "ARIA-kenmerken met ongeldige waarden kunnen niet worden geïnterpreteerd door hulptechnologieën, zoals schermlezers. [Meer informatie](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "'[aria-*]'-kenmerken hebben geen geldige waarden"
+    "message": "`[aria-*]`-kenmerken hebben geen geldige waarden"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "'[aria-*]'-kenmerken hebben geldige waarden"
+    "message": "`[aria-*]`-kenmerken bevatten geldige waarden"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "ARIA-kenmerken met ongeldige namen kunnen niet worden geïnterpreteerd door hulptechnologieën, zoals schermlezers. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "ARIA-kenmerken met ongeldige namen kunnen niet worden geïnterpreteerd door hulptechnologieën, zoals schermlezers. [Meer informatie](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "'[aria-*]'-kenmerken zijn niet geldig of zijn verkeerd gespeld"
+    "message": "`[aria-*]`-kenmerken zijn niet geldig of zijn verkeerd gespeld"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "'[aria-*]'-kenmerken zijn geldig en niet verkeerd gespeld"
+    "message": "`[aria-*]`-kenmerken zijn geldig en niet verkeerd gespeld"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Ondertiteling zorgt ervoor dat audio-elementen kunnen worden gebruikt voor dove of slechthorende gebruikers. De ondertiteling biedt essentiële informatie zoals wie praat, wat de persoon zegt en andere niet-gesproken informatie. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Ondertiteling maakt audio-elementen bruikbaar voor doven en slechthorenden en geeft essentiële informatie zoals wie praat, wat de persoon zegt en andere niet-gesproken informatie. [Meer informatie](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Voor '<audio>'-elementen ontbreekt een '<track>'-element met '[kind=\"captions\"]'."
+    "message": "Voor `<audio>`-elementen ontbreekt een `<track>`-element met `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "'<audio>'-elementen bevatten een '<track>'-element met '[kind=\"captions\"]'"
+    "message": "`<audio>`-elementen bevatten een `<track>`-element met `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Mislukte elementen"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Wanneer een knop geen toegankelijke naam heeft, kondigen schermlezers deze aan als 'knop', waardoor de knop onbruikbaar wordt voor gebruikers die afhankelijk zijn van schermlezers. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Wanneer een knop geen toegankelijke naam heeft, kondigen schermlezers deze aan als 'knop', waardoor de knop onbruikbaar wordt voor gebruikers die afhankelijk zijn van schermlezers. [Meer informatie](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Knoppen hebben geen toegankelijke naam"
@@ -93,7 +93,7 @@
     "message": "Knoppen hebben een toegankelijke naam"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Als je manieren toevoegt om herhaalde content te omzeilen, kunnen toetsenbordgebruikers efficiënter navigeren op de pagina. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Als je manieren toevoegt om herhaalde content te omzeilen, kunnen toetsenbordgebruikers efficiënter navigeren op de pagina. [Meer informatie](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "De pagina bevat geen kop, link voor overslaan of herkenningspuntregio"
@@ -102,7 +102,7 @@
     "message": "De pagina bevat een kop, link voor overslaan of herkenningspuntregio"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Voor veel gebruikers is tekst met weinig contrast moeilijk of onmogelijk te lezen. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Voor veel gebruikers is tekst met weinig contrast moeilijk of onmogelijk te lezen. [Meer informatie](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "De contrastverhouding van achtergrond- en voorgrondkleuren is niet voldoende"
@@ -111,88 +111,88 @@
     "message": "De contrastverhouding van achtergrond- en voorgrondkleuren is voldoende"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Wanneer definitielijsten niet correct zijn opgemaakt, kunnen schermlezers verwarrende of onjuiste uitvoer produceren. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Wanneer definitielijsten niet juist zijn opgemaakt, kunnen schermlezers verwarrende of onjuiste uitvoer produceren. [Meer informatie](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "'<dl>'-elementen bevatten niet alleen correct geordende '<dt>'- en '<dd>'-groepen, '<script>'- of '<template>'-elementen."
+    "message": "`<dl>`-elementen bevatten niet alleen juist geordende `<dt>`- en `<dd>`-groepen, `<script>` of `<template>`-elementen."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "'<dl>'-elementen bevatten alleen correct geordende '<dt>'- en '<dd>'-groepen, '<script>'- of '<template>'-elementen."
+    "message": "`<dl>`-elementen bevatten alleen juist geordende`<dt>`- en `<dd>`-groepen,`<script>` of `<template>`-elementen."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Definitielijstitems ('<dt>' en '<dd>') moeten zijn verpakt in een bovenliggend '<dl>'-element om ervoor te zorgen dat schermlezers ze correct kunnen aankondigen. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Definitielijstitems (`<dt>` en `<dd>`) moeten zijn verpakt in een bovenliggend `<dl>`-element om ervoor te zorgen dat schermlezers ze juist kunnen aankondigen. [Meer informatie](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Definitielijstitems zijn niet verpakt in '<dl>'-elementen"
+    "message": "Definitielijstitems zijn verpakt in `<dl>`-elementen"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Definitielijstitems zijn verpakt in '<dl>'-elementen"
+    "message": "Definitielijstitems zijn verpakt in `<dl>`-elementen"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "De titel geeft gebruikers van een schermlezer een overzicht van de pagina. Gebruikers van een zoekmachine vertrouwen in hoge mate hierop om te bepalen of een pagina relevant is voor hun zoekopdracht. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "De titel geeft gebruikers van een schermlezer een overzicht van de pagina. Gebruikers van een zoekmachine vertrouwen in hoge mate hierop om te bepalen of een pagina relevant is voor hun zoekopdracht. [Meer informatie](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Document bevat geen '<title>'-element"
+    "message": "Document bevat geen `<title>`-element"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Document bevat een '<title>'-element"
+    "message": "Document bevat een `<title>`-element"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "De waarde van een id-kenmerk moet uniek zijn om te voorkomen dat andere instanties over het hoofd worden gezien door hulptechnologieën. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "De waarde van een id-kenmerk moet uniek zijn om te voorkomen dat andere instanties over het hoofd worden gezien door hulptechnologieën. [Meer informatie](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "De '[id]'-kenmerken op de pagina zijn niet uniek"
+    "message": "De `[id]`-kenmerken op de pagina zijn niet uniek"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "De '[id]'-kenmerken op de pagina zijn uniek"
+    "message": "De `[id]`-kenmerken op de pagina zijn uniek"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Gebruikers van een schermlezer zijn afhankelijk van frametitels die de content van de frames beschrijven. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Gebruikers van een schermlezer zijn afhankelijk van frametitels die de content van de frames beschrijven. [Meer informatie](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "'<frame>'- of '<iframe>'-elementen hebben geen titel"
+    "message": "`<frame>`- of `<iframe>`-elementen hebben geen titel"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "'<frame>'- of '<iframe>'-elementen hebben een titel"
+    "message": "`<frame>`- of `<iframe>`-elementen hebben een titel"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Als de pagina geen lang-kenmerk specificeert, neemt een schermlezer aan dat de pagina is geschreven in de standaardtaal die de gebruiker heeft gekozen toen de schermlezer werd ingesteld. Als de pagina niet in de standaardtaal is geschreven, kan de schermlezer de tekst van de pagina mogelijk niet correct aankondigen. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Als de pagina geen lang-kenmerk specificeert, neemt een schermlezer aan dat de pagina is geschreven in de standaardtaal die de gebruiker heeft gekozen toen de schermlezer werd ingesteld. Als de pagina niet in de standaardtaal is geschreven, kan de schermlezer de tekst van de pagina mogelijk niet juist aankondigen. [Meer informatie](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "'<html>'-element heeft geen '[lang]'-kenmerk"
+    "message": "`<html>`-element bevat geen `[lang]`-kenmerk"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "'<html>'-element heeft een '[lang]'-kenmerk"
+    "message": "`<html>`-element bevat een `[lang]`-kenmerk"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Als je een geldige [BCP 47-taal](https://www.w3.org/International/questions/qa-choosing-language-tags#question) opgeeft, zorg je ervoor dat schermlezers de tekst correct kunnen aankondigen. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Als je een geldige [BCP 47-taal](https://www.w3.org/International/questions/qa-choosing-language-tags#question) opgeeft, kunnen schermlezers de tekst juist aankondigen. [Meer informatie](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "'<html>'-element heeft geen geldige waarde voor het bijbehorende '[lang]'-kenmerk."
+    "message": "`<html>`-element bevat geen geldige waarde voor het `[lang]`-kenmerk."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "'<html>'-element heeft een geldige waarde voor het bijbehorende '[lang]'-kenmerk"
+    "message": "`<html>`-element bevat een geldige waarde voor het`[lang]`-kenmerk"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Voor informatieve elementen moet een korte, beschrijvende alternatieve tekst worden gebruikt. Decoratieve elementen kunnen worden genegeerd met een leeg alt-kenmerk. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Voor informatieve elementen moet een korte, beschrijvende alternatieve tekst worden gebruikt. Decoratieve elementen kunnen worden genegeerd met een leeg alt-kenmerk. [Meer informatie](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Afbeeldingselementen hebben geen '[alt]'-kenmerken"
+    "message": "Afbeeldingselementen hebben geen `[alt]`-kenmerken"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Afbeeldingselementen hebben '[alt]'-kenmerken"
+    "message": "Afbeeldingselementen bevatten `[alt]`-kenmerken"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Wanneer een afbeelding wordt gebruikt als '<input>'-knop en je hiervoor alternatieve tekst opgeeft, kunnen gebruikers van een schermlezer beter begrijpen wat het doel van de knop is. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Wanneer een afbeelding wordt gebruikt als `<input>`-knop en je hiervoor alternatieve tekst opgeeft, kunnen gebruikers van een schermlezer beter begrijpen wat het doel van de knop is. [Meer informatie](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "'<input type=\"image\">'-elementen hebben geen '[alt]'-tekst"
+    "message": "`<input type=\"image\">`-elementen bevatten geen `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "'<input type=\"image\">'-elementen hebben '[alt]'-tekst"
+    "message": "`<input type=\"image\">`-elementen bevatten `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Labels zorgen ervoor dat formulieropties correct worden aangekondigd door hulptechnologieën, zoals schermlezers. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Labels zorgen ervoor dat formulieropties juist worden aangekondigd door hulptechnologieën, zoals schermlezers. [Meer informatie](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Formulierelementen hebben geen bijbehorende labels"
@@ -201,16 +201,16 @@
     "message": "Formulierelementen hebben bijbehorende labels"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Een tabel die wordt gebruikt voor lay-outdoeleinden, mag geen gegevenselementen (zoals th- of caption-elementen of het summary-kenmerk) bevatten omdat dit verwarrend kan zijn voor gebruikers van een schermlezer. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Een tabel die wordt gebruikt voor lay-outdoeleinden, mag geen gegevenselementen (zoals th- of caption-elementen of het summary-kenmerk) bevatten omdat dit verwarrend kan zijn voor gebruikers van een schermlezer. [Meer informatie](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "In '<table>'-presentatie-elementen wordt het gebruik van '<th>', '<caption>' of het '[summary]'-kenmerk niet vermeden."
+    "message": "`<table>`-presentatie-elementen vermijden niet het gebruik van `<th>`, `<caption>` of het `[summary]`-kenmerk."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "In '<table>'-presentatie-elementen wordt het gebruik van '<th>', '<caption>' of het '[summary]'-kenmerk vermeden."
+    "message": "In `<table>`-presentatie-elementen wordt het gebruik van `<th>`, `<caption>` of het `[summary]`-kenmerk vermeden."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Met linktekst (en alternatieve tekst voor afbeeldingen, indien gebruikt als links) die herkenbaar en uniek is en waarop kan worden gefocust, verbeter je de navigatiefunctionaliteit voor gebruikers van een schermlezer. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Met linktekst (en alternatieve tekst voor afbeeldingen, indien gebruikt als links) die herkenbaar, uniek en focusbaar is, verbeter je de navigatiefunctionaliteit voor gebruikers van een schermlezer. [Meer informatie](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Links hebben geen herkenbare naam"
@@ -219,103 +219,115 @@
     "message": "Links hebben een herkenbare naam"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Schermlezers hebben een specifieke manier om lijsten aan te kondigen. Als je voor een correcte lijststructuur zorgt, wordt de uitvoer van schermlezers verbeterd. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Schermlezers hebben een specifieke manier om lijsten aan te kondigen. Met een juiste lijststructuur verbetert de uitvoer van schermlezers. [Meer informatie](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Lijsten bevatten niet alleen '<li>'-elementen en elementen voor scriptondersteuning ('<script>' en '<template>')."
+    "message": "Lijsten bevatten niet alleen `<li>`-elementen en elementen voor scriptondersteuning (`<script>` en `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Lijsten bevatten alleen '<li>'-elementen en elementen voor scriptondersteuning ('<script>' en '<template>')."
+    "message": "Lijsten bevatten alleen `<li>`-elementen en elementen voor scriptondersteuning (`<script>` en `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Voor schermlezers moeten lijstitems ('<li>') binnen een bovenliggende '<ul>' of '<ol>' worden geplaatst om correct te worden aangekondigd. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Voor schermlezers moeten lijstitems (`<li>`) binnen een bovenliggende `<ul>` of `<ol>` worden geplaatst om juist te worden aangekondigd. [Meer informatie](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Lijstitems ('<li>') zijn niet tussen bovenliggende '<ul>'- of '<ol>'-elementen geplaatst."
+    "message": "Lijstitems (`<li>`) zijn niet opgenomen in `<ul>` of bovenliggende `<ol>`-elementen."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Lijstitems ('<li>') zijn tussen bovenliggende '<ul>'- of '<ol>'-elementen geplaatst"
+    "message": "Lijstitems (`<li>`) zijn tussen bovenliggende `<ul>`- of `<ol>`-elementen geplaatst"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Gebruikers verwachten niet dat een pagina automatisch wordt vernieuwd. Als dit wel gebeurt, wordt de focus teruggezet op de bovenkant van de pagina. Dit kan vervelend of verwarrend zijn voor gebruikers. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Gebruikers verwachten niet dat een pagina automatisch wordt vernieuwd. Als dit wel gebeurt, wordt de focus teruggezet op de bovenkant van de pagina. Dit kan vervelend of verwarrend zijn voor gebruikers. [Meer informatie](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Het document maakt gebruik van '<meta http-equiv=\"refresh\">'"
+    "message": "Het document gebruikt `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Het document maakt geen gebruik van '<meta http-equiv=\"refresh\">'"
+    "message": "Het document gebruikt `<meta http-equiv=\"refresh\">` niet"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Het uitschakelen van de zoomfunctie is problematisch voor gebruikers met slecht zicht die afhankelijk zijn van schermvergroting om de content van een webpagina te zien. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Uitschakeling van de zoomfunctie is problematisch voor slechtzienden die afhankelijk zijn van schermvergroting om de content van een webpagina te zien. [Meer informatie](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "'[user-scalable=\"no\"]' wordt gebruikt in het '<meta name=\"viewport\">'-element of het '[maximum-scale]'-kenmerk is kleiner dan 5."
+    "message": "`[user-scalable=\"no\"]` wordt gebruikt in het `<meta name=\"viewport\">`-element of het `[maximum-scale]`-kenmerk is minder dan 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "'[user-scalable=\"no\"]' wordt niet gebruikt in het '<meta name=\"viewport\">'-element en het '[maximum-scale]'-kenmerk is niet kleiner dan 5."
+    "message": "`[user-scalable=\"no\"]` wordt niet gebruikt in het `<meta name=\"viewport\">`-element en het `[maximum-scale]`-kenmerk is niet minder dan 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Schermlezers kunnen geen andere content dan tekst vertalen. Als je alt-tekst aan '<object>'-elementen toevoegt, kunnen schermlezers de betekenis overbrengen aan gebruikers. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Schermlezers kunnen geen andere content dan tekst vertalen. Als je alt-tekst aan `<object>`-elementen toevoegt, kunnen schermlezers de betekenis overbrengen aan gebruikers. [Meer informatie](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "'<object>'-elementen hebben geen '[alt]'-tekst"
+    "message": "`<object>`-elementen bevatten geen `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "'<object>'-elementen hebben '[alt]'-tekst"
+    "message": "`<object>`-elementen bevatten `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Een waarde groter dan 0 impliceert een expliciete navigatievolgorde. Hoewel dit technisch geldig is, is dit vaak vervelend voor gebruikers die afhankelijk zijn van hulptechnologieën. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Een waarde groter dan 0 impliceert een expliciete navigatievolgorde. Hoewel dit technisch geldig is, is dit vaak vervelend voor gebruikers die afhankelijk zijn van hulptechnologieën. [Meer informatie](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Sommige elementen hebben een '[tabindex]'-waarde die groter is dan 0"
+    "message": "Sommige elementen hebben een `[tabindex]`-waarde die groter is dan 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Geen element dat een '[tabindex]'-waarde heeft die groter is dan 0"
+    "message": "Geen element dat een `[tabindex]`-waarde heeft die groter is dan 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Schermlezers hebben functies waarmee gemakkelijker kan worden genavigeerd in tabellen. Als je ervoor zorgt dat '<td>'-cellen die het '[headers]'-kenmerk gebruiken, alleen verwijzen naar andere cellen in dezelfde tabel, kun je de functionaliteit verbeteren voor gebruikers van een schermlezer. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Schermlezers hebben functies waarmee gemakkelijker kan worden genavigeerd in tabellen. Als je zorgt dat `<td>`-cellen die het `[headers]`-kenmerk gebruiken, alleen verwijzen naar andere cellen in dezelfde tabel, kun je de functionaliteit verbeteren voor gebruikers van een schermlezer. [Meer informatie](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Cellen in een '<table>'-element die het '[headers]'-kenmerk gebruiken, verwijzen naar andere cellen in dezelfde tabel."
+    "message": "Cellen in een `<table>`-element die het `[headers]`-kenmerk gebruiken, verwijzen naar andere cellen in dezelfde tabel."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Cellen in een '<table>'-element die het '[headers]'-kenmerk gebruiken, verwijzen alleen naar andere cellen in dezelfde tabel."
+    "message": "Cellen in een `<table>`-element die het `[headers]`-kenmerk gebruiken, verwijzen alleen naar andere cellen in diezelfde tabel."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Schermlezers hebben functies waarmee gemakkelijker kan worden genavigeerd in tabellen. Als je ervoor zorgt dat tabelheaders altijd verwijzen naar een bepaalde reeks cellen, kun je de functionaliteit verbeteren voor gebruikers van een schermlezer. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Schermlezers hebben functies waarmee gemakkelijker kan worden genavigeerd in tabellen. Als je zorgt dat tabelheaders altijd verwijzen naar een bepaalde reeks cellen, kun je de functionaliteit verbeteren voor gebruikers van een schermlezer. [Meer informatie](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "'<th>'-elementen en elementen met '[role=\"columnheader\"/\"rowheader\"]' bevatten niet de gegevenscellen die ze beschrijven."
+    "message": "`<th>`-elementen en elementen met `[role=\"columnheader\"/\"rowheader\"]` bevatten niet de gegevenscellen die ze beschrijven."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "'<th>'-elementen en elementen met '[role=\"columnheader\"/\"rowheader\"]' bevatten de gegevenscellen die ze beschrijven."
+    "message": "`<th>`-elementen en elementen met `[role=\"columnheader\"/\"rowheader\"]` bevatten de gegevenscellen die ze beschrijven."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Als je een geldige [BCP 47-taal](https://www.w3.org/International/questions/qa-choosing-language-tags#question) voor elementen opgeeft, zorg je ervoor dat de tekst correct wordt uitgesproken door een schermlezer. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Als je een geldige [BCP 47-taal](https://www.w3.org/International/questions/qa-choosing-language-tags#question) voor elementen opgeeft, kan de tekst juist wordt uitgesproken door een schermlezer. [Meer informatie](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "'[lang]'-kenmerken hebben geen geldige waarde"
+    "message": "`[lang]`-kenmerken hebben geen geldige waarde"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "'[lang]'-kenmerken hebben een geldige waarde"
+    "message": "`[lang]`-kenmerken bevatten een geldige waarde"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Wanneer een video een ondertiteling biedt, hebben dove of slechthorende gebruikers gemakkelijker toegang tot de bijbehorende informatie. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Video's met ondertiteling bieden doven en slechthorenden betere toegang tot de bijbehorende informatie. [Meer informatie](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "'<video>'-elementen bevatten geen '<track>'-element met '[kind=\"captions\"]'."
+    "message": "`<video>`-elementen bevatten geen `<track>`-element met `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "'<video>'-elementen bevatten een '<track>'-element met '[kind=\"captions\"]'"
+    "message": "`<video>`-elementen bevatten een `<track>`-element met `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Audiobeschrijvingen bieden relevante informatie over video's die dialoog niet kan bieden, zoals gezichtsuitdrukkingen en scènes. [Meer informatie](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Audiobeschrijvingen bieden relevante informatie over video's die dialoog niet kan bieden, zoals gezichtsuitdrukkingen en scènes. [Meer informatie](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "'<video>'-elementen bevatten geen '<track>'-element met '[kind=\"description\"]'."
+    "message": "`<video>`-elementen bevatten geen `<track>`-element met `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "'<video>'-elementen bevatten een '<track>'-element met '[kind=\"description\"]'"
+    "message": "`<video>`-elementen bevatten een `<track>`-element met `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Definieer voor een ideale weergave op iOS wanneer gebruikers toevoegen aan het startscherm een apple-touch-icon. Deze moet verwijzen naar een niet-transparante vierkante PNG van 192px (of 180px). [Meer informatie](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Geeft geen geldig `apple-touch-icon` op"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` is verouderd; `apple-touch-icon` krijgt de voorkeur."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Verstrekt een geldige `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome-extensies hadden een negatieve invloed op de laadprestaties van deze pagina. Controleer de pagina in de incognitomodus of via een Chrome-profiel zonder extensies."
@@ -330,7 +342,7 @@
     "message": "Totale CPU-tijd"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Overweeg minder tijd te besteden aan het parseren, compileren en uitvoeren van JS. Het leveren van kleinere JS-payloads kan hierbij helpen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Overweeg de tijd te verminderen die aan parseren, compileren en uitvoeren van JS wordt besteed. Het leveren van kleinere JS-payloads kan hierbij helpen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Verkort de JavaScript-uitvoeringstijd"
@@ -339,25 +351,25 @@
     "message": "JavaScript-uitvoeringstijd"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Grote gif's zijn niet efficiënt om content met animaties te leveren. Overweeg in plaats van gif's MPEG4-/WebM-video's voor animaties en PNG/WebP voor statische afbeeldingen en bespaar zo netwerkbytes. [Meer informatie](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Grote gif's zijn niet efficiënt om content met animaties te leveren. Overweeg het gebruik van MPEG4-/WebM-video's voor animaties en PNG/WebP voor statische afbeeldingen in plaats van gif's om netwerkbytes te besparen. [Meer informatie](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Gebruik video-indelingen voor content met animaties"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Overweeg afbeeldingen die niet in beeld zijn en verborgen afbeeldingen via 'lazy loading' te laden nadat alle kritieke bronnen zijn geladen om zo de tijd tot interactief te verlagen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Overweeg om afbeeldingen die niet in beeld zijn en verborgen afbeeldingen via 'lazy loading' te laden nadat alle kritieke bronnen zijn geladen om zo de tijd tot interactief te verlagen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Laad afbeeldingen die niet in beeld zijn nog niet"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Bronnen blokkeren de eerste weergave (FP) voor je pagina. Overweeg kritieke JS/css inline te leveren en alle niet-kritieke JS/stijlen uit te stellen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Bronnen blokkeren de eerste weergave (FP) voor je pagina. Overweeg kritieke JS/css inline te leveren en alle niet-kritieke JS/stijlen uit te stellen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Verwijder bronnen die de weergave blokkeren"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Grote netwerkpayloads kosten gebruikers veel geld en hebben vaak lange laadtijden. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Grote netwerkpayloads kosten gebruikers effectief geld en hebben vaak lange laadtijden. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Totale grootte was {totalBytes, number, bytes} KB"
@@ -369,19 +381,19 @@
     "message": "Vermijdt enorme netwerkpayloads"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Als je css-bestanden verkleint, kun je de omvang van netwerkpayloads verkleinen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Als je css-bestanden verkleint, kun je de omvang van netwerkpayloads verkleinen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Verklein de css"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Als je JavaScript-bestanden verkleint, kunnen de omvang van de payload en de parseringstijd van het script worden verkleind. [Meer informatie](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Als je JavaScript-bestanden verkleint, kunnen de omvang van de payload en de parseringstijd van het script worden verkleind. [Meer informatie](https://developers.google.com/speed/docs/insights/MinifyResources)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Verklein JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Verwijder overbodig geworden regels uit stylesheets en stel het laden van ongebruikte css uit voor content boven de vouw zodat er minder onnodige bytes worden verbruikt door netwerkactiviteit. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Verwijder overbodig geworden regels uit stylesheets en stel het laden van ongebruikte css uit voor content boven de vouw zodat er minder onnodige bytes worden verbruikt door netwerkactiviteit. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Ongebruikte css verwijderen"
@@ -393,7 +405,7 @@
     "message": "Verwijder ongebruikt JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Een lange levensduur voor het cachegeheugen kan herhaalde bezoeken aan je pagina versnellen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Een lange levensduur voor het cachegeheugen kan herhaalde bezoeken aan je pagina versnellen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 bron gevonden}other{# bronnen gevonden}}"
@@ -405,37 +417,88 @@
     "message": "Gebruikt een efficiënt cachebeleid voor statische items"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Geoptimaliseerde afbeeldingen worden sneller geladen en verbruiken minder mobiele data. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Geoptimaliseerde afbeeldingen worden sneller geladen en verbruiken minder mobiele data. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Codeer afbeeldingen op een efficiënte manier"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Lever afbeeldingen met het juiste formaat om mobiele data te besparen en de laadtijd te verbeteren. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Lever afbeeldingen met het juiste formaat om mobiele data te besparen en de laadtijd te verbeteren. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Geef afbeeldingen het juiste formaat"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Tekstgebaseerde bronnen moeten worden geleverd met compressie (gzip, deflate of brotli) om het totale aantal netwerkbytes te minimaliseren. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Tekstgebaseerde bronnen moeten worden geleverd met compressie (gzip, deflate of brotli) om het totale aantal netwerkbytes te minimaliseren. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Schakel tekstcompressie in"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Afbeeldingsindelingen zoals JPEG 2000, JPEG XR en WebP bieden vaak betere compressie dan PNG of JPEG. Dit resulteert in snellere downloads en minder dataverbruik. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Afbeeldingsindelingen zoals JPEG 2000, JPEG XR en WebP bieden vaak betere compressie dan PNG of JPEG. Dit resulteert in snellere downloads en minder dataverbruik. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Lever afbeeldingen in moderne indelingen"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "De onderstaande kritieke verzoekketens laten zien welke bronnen met een hoge prioriteit worden geladen. Overweeg de lengte van ketens te verkleinen, de downloadgrootte van bronnen te beperken of het downloaden van onnodige bronnen uit te stellen om de laadtijd van de pagina te verbeteren. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "De onderstaande kritieke verzoekketens laten zien welke bronnen met een hoge prioriteit worden geladen. Overweeg de lengte van ketens te verkleinen, de downloadgrootte van bronnen te beperken of het downloaden van onnodige bronnen uit te stellen om de laadtijd van de pagina te verbeteren. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 keten gevonden}other{# ketens gevonden}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimaliseer de diepte van kritieke verzoeken"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Beëindiging / Waarschuwing"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Lijn"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Beëindigde API's worden uiteindelijk verwijderd uit de browser. [Meer informatie](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 waarschuwing gevonden}other{# waarschuwingen gevonden}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Gebruikt beëindigde API's"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Vermijdt beëindigde API's"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Applicatiecache is beëindigd. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "'{AppCacheManifest}' gevonden"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Gebruikt applicatiecache"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Vermijdt applicatiecache"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Door een doctype op te geven, voorkom je dat de browser overschakelt naar de quirks-modus. Bekijk meer informatie op de [MDN Web Docs-pagina](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "De naam van het doctype moet de tekenreeks `html` in kleine letters zijn"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Document moet een doctype bevatten"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Verwachtte een lege tekenreeks voor publicId"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Verwachtte een lege tekenreeks voor systemId"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Pagina heeft geen html-doctype en activeert dus de quirks-modus"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Pagina bevat html-doctype"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
@@ -447,7 +510,7 @@
     "message": "Waarde"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Browser-engineers bevelen aan dat pagina's minder dan ~1500 DOM-elementen bevatten. De perfecte balans is een structuurdiepte van minder dan 32 elementen en minder dan 60 onderliggende/bovenliggende elementen. Een grote DOM kan ervoor zorgen dat het geheugengebruik toeneemt. Dit leidt tot langere [stijlberekeningen](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) en dure [dynamische lay-outaanpassingen](https://developers.google.com/speed/articles/reflow). [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Ontwikkelaars van browsers raden aan dat pagina's minder dan ~1.500 DOM-elementen bevatten. De ideale hoeveelheid bestaat uit vertakkingen met < 32 elementen en minder dan 60 onder-/bovenliggende elementen. Een grote DOM kan het geheugengebruik vergroten, en [stijlberekeningen](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) en kostbare [dynamische aanpassingen in de vormgeving](https://developers.google.com/speed/articles/reflow) veroorzaken. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 element}other{# elementen}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Vermijdt een overmatige grote DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Doel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Voeg `rel=\"noopener\"` of `rel=\"noreferrer\"` toe aan eventuele externe links om de prestaties te verbeteren en kwetsbaarheden in de beveiliging te voorkomen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Links naar cross-origin-bestemmingen zijn onveilig"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Links naar cross-origin-bestemmingen zijn veilig"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Kan geen bestemming bepalen voor ankeradvertentie ({anchorHTML}). Als deze niet wordt gebruikt als hyperlink, overweeg dan om target=_blank te verwijderen."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Gebruikers wantrouwen of raken in de war van sites die vragen om hun locatie zonder context. Overweeg het verzoek in plaats daarvan te koppelen aan gebruikershandelingen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Verzoekt om de geolocatierechten bij laden van pagina"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Vermijdt verzoeken om de geolocatierechten bij laden van pagina"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versie"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Alle front end JavaScript-bibliotheken op de pagina gedetecteerd."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Gedetecteerde JavaScript-bibliotheken"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Externe scripts die dynamisch worden geïnjecteerd via `document.write()` kunnen bij gebruikers met een langzame verbinding het laden van de pagina met tientallen seconden vertragen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Gebruikt `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Vermijdt `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Meest ernstig"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Bibliotheekversie"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Aantal kwetsbaarheden"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Sommige scripts van derden kunnen bekende beveiligingskwetsbaarheden bevatten die makkelijk te identificeren en door aanvallers te gebruiken zijn. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 kwetsbaarheid gedetecteerd}other{# kwetsbaarheden gedetecteerd}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Omvat front end JavaScript-bibliotheken met bekende beveiligingskwetsbaarheden"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Hoog"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Laag"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Normaal"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Vermijdt front end JavaScript-bibliotheken met bekende beveiligingskwetsbaarheden"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Gebruikers wantrouwen of raken in de war van sites die vragen om het versturen van meldingen zonder context. Overweeg het verzoek in plaats daarvan te koppelen aan gebruikersgebaren. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Verzoekt om de meldingsrechten bij laden van pagina"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Vermijdt verzoeken om de meldingsrechten bij laden van pagina"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Mislukte elementen"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Verhindering van het plakken van wachtwoorden ondermijnt een goed beveiligingsbeleid. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Voorkomt dat gebruikers kunnen plakken in wachtwoordvelden"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Laat gebruikers plakken in wachtwoordvelden"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 beschikt over veel voordelen ten opzichte van HTTP/1.1, waaronder binaire headers, multiplexing en serverpush. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 verzoek niet weergegeven via HTTP/2}other{# verzoeken niet weergegeven via HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Gebruikt HTTP/2 niet voor alle bronnen"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Gebruikt HTTP/2 voor de eigen bronnen"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Overweeg je touch- en event-listeners te markeren als `passive` om de scrollprestaties van je pagina te verbeteren. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Gebruikt geen passieve listeners om scrollprestaties te verbeteren"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Gebruikt passieve listeners voor de verbetering van de scrollprestaties"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Beschrijving"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Fouten die zijn gelogd op de console geven aan dat er onopgeloste problemen zijn. Deze kunnen afkomstig zijn van niet-uitgevoerde netwerkverzoeken en andere problemen met de browser."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Er zijn browserfouten gelogd op de console"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Er zijn geen browserfouten gelogd op de console"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Maak gebruik van de css-functie 'font-display' om ervoor te zorgen dat tekst zichtbaar is voor gebruikers terwijl weblettertypen worden geladen. [Meer informatie](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Maak gebruik van de css-functie 'font-display' om ervoor te zorgen dat tekst zichtbaar is voor gebruikers terwijl weblettertypen worden geladen. [Meer informatie](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Zorg ervoor dat tekst zichtbaar blijft tijdens het laden van weblettertypen"
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Alle tekst blijft zichtbaar tijdens het laden van weblettertypen"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse kan de waarde voor de lettertypeweergave niet automatisch controleren voor de volgende URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Beeldverhouding (werkelijk)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Beeldverhouding (weergegeven)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "De weergaveafmetingen van afbeeldingen moeten overeenkomen met de natuurlijke beeldverhouding. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Geeft afbeeldingen weer met een onjuiste beeldverhouding"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Geeft afbeeldingen weer met een juiste beeldverhouding"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Ongeldige informatie over afbeeldingsformaat {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Niet-beveiligde URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Alle sites moeten worden beschermd met HTTPS, zelfs sites die geen gevoelige gegevens verwerken. HTTPS voorkomt dat indringers de communicatie tussen je app en je gebruikers manipuleren of hier passief naar luisteren en is een vereiste voor HTTP/2 en veel nieuwe webplatform-API's. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 niet-beveiligd verzoek gevonden}other{# niet-beveiligde verzoeken gevonden}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Gebruikt geen HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Gebruikt HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Snel laden van een pagina via een mobiel netwerk zorgt voor een goede mobiele gebruikerservaring. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Snel laden van een pagina via een mobiel netwerk zorgt voor een goede mobiele gebruikerservaring. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interactief binnen {timeInMs, number, seconds} s"
+    "message": "Interactief na {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Interactief op gesimuleerd mobiel netwerk binnen {timeInMs, number, seconds} s"
@@ -504,79 +735,106 @@
     "message": "Primaire threadbewerkingen minimaliseren"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Geschatte wachttijd voor invoer is een schatting van hoelang het duurt voordat je app reageert op gebruikersinvoer (in milliseconden) gedurende de drukste periode van 5 seconden tijdens het laden van de pagina. Als de wachttijd langer dan 50 ms is, kunnen gebruikers je app als traag beschouwen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Geschatte wachttijd voor invoer is een schatting van de tijd die je app nodig heeft om te reageren op gebruikersinvoer (in milliseconden) gemeten voor de drukste periode van 5 seconden tijdens het laden van de pagina. Als de wachttijd langer dan 50 ms is, kunnen gebruikers je app als traag beschouwen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Geschatte invoerwachttijd"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "'Eerste weergave met content' (FCP) geeft het tijdstip aan waarop de eerste tekst of afbeelding wordt weergegeven. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "'Eerste tekenbewerking met content' (FCP) geeft het tijdstip aan waarop de eerste tekst of afbeelding wordt weergegeven. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Eerste weergave met content (FCP)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "'Eerste keer dat CPU inactief was' geeft de eerste keer aan dat de primaire thread van de pagina rustig genoeg was om invoer te verwerken. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "'Eerste keer dat CPU inactief was' geeft de eerste keer aan dat de primaire thread van de pagina rustig genoeg was om invoer te verwerken. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Eerste keer dat CPU inactief was"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "'Eerste nuttige weergave' (FMP) meet wanneer de primaire content van een pagina zichtbaar is. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "'Eerste nuttige weergave' (FMP) meet wanneer de primaire content van een pagina zichtbaar is. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Eerste nuttige weergave (FMP)"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Tijd tot interactief is de hoeveelheid tijd die nodig is voordat een pagina volledig interactief is. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Tijd tot interactief is de hoeveelheid tijd die nodig is voordat een pagina volledig interactief is. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Tijd tot interactief"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "De potentiële vertraging voor de eerste invoer die gebruikers kunnen ervaren, is de duur (in milliseconden) van de langste taak."
+    "message": "De maximale potentiële vertraging voor de eerste invoer die gebruikers kunnen ervaren, is de duur (in milliseconden) van de langste taak. [Meer informatie](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Max. potentiële vertraging voor eerste invoer"
+    "message": "Max. potentiële eerste invoervertraging"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Snelheidsindex laat zien hoe snel de content van een pagina zichtbaar is. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Snelheidsindex laat zien hoe snel de content van een pagina zichtbaar is. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Snelheidsindex"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Som van alle perioden tussen 'Eerste tekenbewerking met content' (FCP) en 'Tijd tot interactief', wanneer de taaklengte langer duurt dan 50 ms, aangegeven in milliseconden."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Totale geblokkeerde tijd"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Retourtijden (RTT) van netwerken hebben een grote invloed op de prestaties. Als de RTT naar een beginpunt hoog is, is dit een indicatie dat de prestaties van servers dichter bij de gebruiker kunnen worden verbeterd. [Meer informatie](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Retourtijden (RTT) van netwerken hebben een grote invloed op de prestaties. Een hoge RTT naar een beginpunt geeft aan dat de prestaties van servers dichter bij de gebruiker kunnen worden verbeterd. [Meer informatie](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Retourtijden van netwerk"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Serverwachttijden kunnen invloed hebben op webprestaties. Als de serverwachttijd van een beginpunt hoog is, is dit een indicatie dat de server overbelast is of slechte backend-prestaties levert. [Meer informatie](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Serverwachttijden kunnen invloed hebben op webprestaties. Als de serverwachttijd van een beginpunt hoog is, is dit een indicatie dat de server overbelast is of slechte backend-prestaties levert. [Meer informatie](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Wachttijden van server-backend"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Over het budget"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Houd de hoeveelheid en grootte van netwerkverzoeken onder de door het verstrekte prestatiebudget ingestelde doelen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 verzoek}other{# verzoeken}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Prestatiebudget"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Omleidingen zorgen voor extra vertraging voordat de pagina kan worden geladen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Omleidingen zorgen voor extra vertraging voordat de pagina kan worden geladen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Vermijd meerdere pagina-omleidingen"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Voeg een budget.json-bestand toe om budgetten in te stellen voor de hoeveelheid en grootte van paginabronnen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 verzoek}other{# verzoeken}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Houd het aantal verzoeken laag en de overdrachtsgrootte klein"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Canonieke links geven een suggestie voor welke URL moet worden weergegeven in de zoekresultaten. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Canonieke links geven een suggestie voor welke URL moet worden weergegeven in de zoekresultaten. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Meerdere conflicterende URL's ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Verwijst naar een ander domein ({url})"
+    "message": "Wijst naar een ander domein ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Ongeldige URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Verwijst naar een andere 'hreflang'-locatie ({url})"
+    "message": "Wijst naar een andere `hreflang`-locatie ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relatieve URL ({url})"
@@ -585,19 +843,16 @@
     "message": "Verwijst naar de root-URL van het domein (de homepage), in plaats van een equivalente pagina van de content"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Document bevat geen geldige 'rel=canonical'"
+    "message": "Document bevat geen geldig `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Document bevat een geldige 'rel=canonical'"
+    "message": "Document bevat een geldige `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Lettergrootten kleiner dan 12 pixels zijn te klein om leesbaar te zijn en zorgen ervoor dat mobiele bezoekers moeten 'knijpen om te zoomen' voordat ze de tekst kunnen lezen. Probeer om meer dan 60% van de paginatekst gelijk aan of groter dan 12 pixels te maken. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Lettergrootten kleiner dan 12 pixels zijn te klein om leesbaar te zijn en leiden ertoe dat mobiele bezoekers hun 'vingers moeten 'samenknijpen' om te zoomen voordat ze de tekst kunnen lezen. Probeer om meer dan 60% van de paginatekst gelijk aan of groter dan 12 pixels te maken. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} leesbare tekst"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} van tekst is te klein."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Tekst is onleesbaar omdat er geen kijkvenstermetatag is geoptimaliseerd voor mobiele schermen."
@@ -612,16 +867,16 @@
     "message": "Document gebruikt leesbare lettergrootten"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "hreflang-links laten zoekmachines weten welke versie van een pagina ze moeten vermelden in zoekresultaten voor een bepaalde taal of regio. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "hreflang-links laten zoekmachines weten welke versie van een pagina ze moeten vermelden in zoekresultaten voor een bepaalde taal of regio. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Document bevat geen geldige 'hreflang'"
+    "message": "Document bevat geen geldige `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Document bevat een geldige 'hreflang'"
+    "message": "Document bevat een geldige `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Pagina's met ongeldige HTTP-statuscodes worden mogelijk niet juist geïndexeerd. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Pagina's met ongeldige HTTP-statuscodes worden mogelijk niet juist geïndexeerd. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "Pagina bevat ongeldige HTTP-statuscode"
@@ -630,7 +885,7 @@
     "message": "Pagina bevat geldige HTTP-statuscode"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Zoekmachines kunnen je pagina's niet opnemen in zoekresultaten als de zoekmachines geen rechten hebben om ze te crawlen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Zoekmachines kunnen je pagina's niet opnemen in zoekresultaten als de zoekmachines geen rechten hebben om ze te crawlen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Pagina is geblokkeerd tegen indexeren"
@@ -639,7 +894,7 @@
     "message": "Pagina is niet geblokkeerd tegen indexeren"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Aan de hand van beschrijvende linktekst kunnen zoekmachines je content begrijpen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "Aan de hand van beschrijvende linktekst kunnen zoekmachines je content begrijpen. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 link gevonden}other{# links gevonden}}"
@@ -651,13 +906,13 @@
     "message": "Links bevatten beschrijvende tekst"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Voer de [Tool voor het testen van gestructureerde gegevens](https://search.google.com/structured-data/testing-tool/) en de [Linter voor gestructureerde gegevens](http://linter.structured-data.org/) uit om de gestructureerde gegevens te valideren. [Meer informatie](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Voer de [Tool voor het testen van gestructureerde gegevens](https://search.google.com/structured-data/testing-tool/) en de [Linter voor gestructureerde gegevens](http://linter.structured-data.org/) uit om gestructureerde gegevens te valideren. [Meer informatie](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "De gestructureerde gegevens zijn geldig"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Er kunnen metabeschrijvingen worden opgenomen in zoekresultaten voor een korte samenvatting van paginacontent. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Er kunnen metabeschrijvingen worden opgenomen in zoekresultaten voor een korte samenvatting van paginacontent. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/description)"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Beschrijvingstekst is leeg."
@@ -669,7 +924,7 @@
     "message": "Document bevat een metabeschrijving"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Zoekmachines kunnen content van plug-ins niet indexeren en veel apparaten beperken plug-ins of ondersteunen deze niet. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Zoekmachines kunnen content van plug-ins niet indexeren en veel apparaten beperken plug-ins of ondersteunen deze niet. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "Document gebruikt plug-ins"
@@ -696,7 +951,7 @@
     "message": "robots.txt is geldig"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Interactieve elementen, zoals knoppen en links, moeten groot genoeg zijn (48 x 48 pixels) en moeten voldoende ruimte eromheen hebben, zodat er makkelijk op getikt kan worden zonder dat andere elementen worden aangeraakt. [Meer informatie](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Interactieve elementen, zoals knoppen en links, moeten groot genoeg zijn (48 x 48 pixels) en moeten voldoende ruimte eromheen hebben, zodat er makkelijk op getikt kan worden zonder dat andere elementen worden aangeraakt. [Meer informatie](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} van de tikdoelen heeft een geschikt formaat"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Overlappend doel"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Formaat"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Tikdoel"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Tikdoelen hebben het juiste formaat"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Tijd van primaire thread"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Derden"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Code van derden kan van grote invloed zijn op de laadprestaties. Beperkt het aantal overbodige externe providers en probeer code van derden te laden nadat je pagina primair is geladen. [Meer informatie](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 derde gevonden}other{# derden gevonden}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Gebruik door derden"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "'Tijd tot eerste byte' identificeert het tijdstip waarop je server een reactie stuurt. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "'Tijd tot eerste byte' identificeert het tijdstip waarop je server een reactie stuurt. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Hoofddocument duurde {timeInMs, number, milliseconds} ms"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Duur"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Naam"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Begintijd"
   },
@@ -744,7 +1008,7 @@
     "message": "Type"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Overweeg je app te voorzien van de API voor gebruikerstiming om de daadwerkelijke prestaties van je app tijdens belangrijke gebruikerservaringen te meten. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Overweeg je app te voorzien van de API voor gebruikerstiming om de daadwerkelijke prestaties van je app tijdens belangrijke gebruikerservaringen te meten. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 gebruikerstiming}other{# gebruikerstimings}}"
@@ -753,19 +1017,19 @@
     "message": "Markeringen en metingen voor gebruikerstiming"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Er is een <link> voor vooraf verbinden gevonden voor '{securityOrigin}' maar deze is niet gebruikt door de browser. Controleer of je het 'crossorigin'-kenmerk correct gebruikt."
+    "message": "Er is een <link> voor vooraf verbinden gevonden voor {securityOrigin} maar is niet gebruikt door de browser. Controleer of je het `crossorigin`-kenmerk juist gebruikt."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Overweeg hints voor het vooraf verbinden of dns-prefetchen van bronnen toe te voegen om vroege verbindingen met belangrijke externe herkomsten tot stand te brengen. [Meer informatie](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Overweeg hints voor het vooraf verbinden of dns-prefetchen van bronnen toe te voegen om vroege verbindingen met belangrijke externe herkomsten tot stand te brengen. [Meer informatie](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Maak vooraf verbinding met vereiste herkomsten"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Er is een <link> voor vooraf laden gevonden voor '{preloadURL}' maar deze is niet gebruikt door de browser. Controleer of je het 'crossorigin'-kenmerk correct gebruikt."
+    "message": "Er is een <link> voor vooraf laden gevonden voor {preloadURL} maar deze is niet gebruikt door de browser. Controleer of je het `crossorigin`-kenmerk juist gebruikt."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Overweeg <link rel=preload> te gebruiken om prioriteit te geven aan het ophalen van bronnen die momenteel later tijdens het laden van de pagina worden opgehaald. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Overweeg `<link rel=preload>` te gebruiken om prioriteit te geven aan het ophalen van bronnen die momenteel later tijdens het laden van de pagina worden opgehaald. [Meer informatie](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Laad belangrijke verzoeken vooraf"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabellen en lijsten"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Praktische tips"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Prestatiebudgetten stellen normen in voor de prestaties van je site."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budgetten"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Meer informatie over de prestaties van je app."
+    "message": "Meer informatie over de prestaties van je app. Deze cijfers hebben geen [directe invloed](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) op de prestatiescore."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostische gegevens"
@@ -840,7 +1113,7 @@
     "message": "Verbeteringen voor eerste weergave"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Deze optimalisaties kunnen het laden van je pagina versnellen."
+    "message": "Deze suggesties kunnen helpen je pagina sneller te laden. Ze hebben geen [directe invloed](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) op de prestatiescore."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Aanbevelingen"
@@ -867,7 +1140,7 @@
     "message": "Geoptimaliseerd voor PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Deze controles zorgen ervoor dat je pagina is geoptimaliseerd voor positionering in zoekmachineresultaten. Er zijn aanvullende factoren waarop Lighthouse niet controleert, die van invloed kunnen zijn op je positie in de zoekresultaten. [Meer informatie](https://support.google.com/webmasters/answer/35769)."
+    "message": "Deze controles zorgen ervoor dat je pagina is geoptimaliseerd voor positionering in zoekmachineresultaten. Er zijn aanvullende factoren waarop Lighthouse niet controleert, die van invloed kunnen zijn op je positie in de zoekresultaten. [Meer informatie](https://support.google.com/webmasters/answer/35769)"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Voer deze extra validators op je site uit om aanvullende praktische tips voor SEO te controleren."
@@ -888,7 +1161,7 @@
     "message": "Crawlen en indexeren"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Zorg ervoor dat je pagina's geschikt zijn voor mobiele apparaten zodat gebruikers hun vingers niet hoeven samen te knijpen of hoeven te zoomen om de contentpagina's te lezen. [Meer informatie](https://developers.google.com/search/mobile-sites/)."
+    "message": "Zorg dat je pagina's geschikt zijn voor mobiele apparaten zodat gebruikers niet hun vingers hoeven samen te knijpen of moeten zoomen om de contentpagina's te lezen. [Meer informatie](https://developers.google.com/search/mobile-sites/)"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Geschikt voor mobiele apparaten"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Cache-TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Locatie"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Naam"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Verzoeken"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Brontype"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Grootte (KB)"
+    "message": "Formaat"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Bestede tijd"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Overdrachtgrootte"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potentiële besparing (KB)"
+    "message": "Potentiële besparingen"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potentiële besparing (ms)"
+    "message": "Potentiële besparingen"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Potentiële besparing van {wastedBytes, number, bytes} KB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Potentiële besparing van {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Document"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Lettertype"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Afbeelding"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Media"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Anders"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stylesheet"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Derden"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Totaal"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Er is een fout opgetreden bij het opnemen van het netwerkspoor voor het laden van je pagina. Voer Lighthouse opnieuw uit. ({errorCode})"
@@ -930,13 +1245,19 @@
     "message": "Time-out tijdens wachten op eerste verbinding met Debugger-protocol."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome heeft geen screenshots verzameld tijdens het laden van de pagina. Zorg ervoor dat er content zichtbaar is op de pagina en probeer daarna Lighthouse opnieuw uit te voeren. ({errorCode})"
+    "message": "Chrome heeft geen screenshots verzameld tijdens het laden van de pagina. Zorg dat er content zichtbaar is op de pagina en voer Lighthouse daarna opnieuw uit. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS-servers kunnen het opgegeven domein niet omzetten."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Er is een fout opgetreden in de vereiste {artifactName}-verzamelaar: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Er is een interne Chrome-fout opgetreden. Start Chrome opnieuw op en probeer Lighthouse nogmaals uit te voeren."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Vereiste {artifactName}-verzamelaar is niet uitgevoerd."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse kan de door jou aangevraagde pagina niet goed laden. Zorg ervoor dat je de juiste URL test en dat de server correct reageert op alle verzoeken."
@@ -945,16 +1266,19 @@
     "message": "Lighthouse kan de door jou aangevraagde URL niet goed laden omdat de pagina niet meer reageert."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "De URL die je hebt opgegeven, bevat geen geldige beveiligingsgegevens. {securityMessages}"
+    "message": "De URL die je hebt opgegeven, bevat geen geldig beveiligingscertificaat. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome heeft laden van pagina met interstitial voorkomen. Zorg dat je de juiste URL test en de server correct reageert op alle verzoeken."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Lighthouse kan de door jou aangevraagde pagina niet goed laden. Zorg ervoor dat je de juiste URL test en dat de server correct reageert op alle verzoeken. (Details: {errorDetails})"
+    "message": "Lighthouse kan de aangevraagde pagina niet goed laden. Zorg dat je de juiste URL test en de server correct reageert op alle verzoeken. (Details: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Lighthouse kan de door jou aangevraagde pagina niet goed laden. Zorg ervoor dat je de juiste URL test en dat de server correct reageert op alle verzoeken. (Statuscode: {statusCode})"
+    "message": "Lighthouse kan de aangevraagde pagina niet goed laden. Zorg dat je de juiste URL test en de server correct reageert op alle verzoeken. (Statuscode: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Het laden van je pagina duurde te lang. Volg de suggesties in het rapport om de laadtijd van je pagina te beperken. Probeer daarna Lighthouse opnieuw uit te voeren. ({errorCode})"
+    "message": "Het laden van je pagina duurde te lang. Volg de suggesties in het rapport om de laadtijd van je pagina te beperken. Voer Lighthouse daarna opnieuw uit. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "Tijdens het wachten op een reactie van het DevTools-protocol is de toegewezen tijd overschreden. (Methode: {protocolMethod})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Fragment uitvouwen"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Bronnen van derden weergeven"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Er zijn problemen opgetreden bij deze uitvoering van Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Waarden worden geschat en kunnen variëren."
+    "message": "Waarden worden geschat en kunnen variëren. De prestatiescore is [alleen gebaseerd op deze statistieken](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Geslaagd voor controles maar met waarschuwingen"
@@ -1026,7 +1353,7 @@
     "message": "Installeer een [WordPress-plug-in voor lazy loading](https://wordpress.org/plugins/search/lazy+load/) waarmee afbeeldingen die niet in beeld zijn, kunnen worden uitgesteld, of schakel over naar een thema met deze functionaliteit. Je kunt ook overwegen [de AMP-plug-in](https://wordpress.org/plugins/amp/) te gebruiken."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Er zijn enkele WordPress-plug-ins om [kritieke items inline te plaatsen](https://wordpress.org/plugins/search/critical+css/) of [minder belangrijke bronnen uit te stellen](https://wordpress.org/plugins/search/defer+css+javascript/). Bedenk wel dat de optimalisatie die deze plug-ins bieden, bepaalde functies van je thema of plug-ins kunnen verstoren. Het is daarom goed mogelijk dat je de code moet wijzigen."
+    "message": "Er zijn een aantal WordPress-plug-ins om [kritieke items inline te plaatsen](https://wordpress.org/plugins/search/critical+css/) of [minder belangrijke bronnen uit te stellen](https://wordpress.org/plugins/search/defer+css+javascript/). Bedenk wel dat de optimalisatie die deze plug-ins bieden, bepaalde functies van je thema of plug-ins kunnen verstoren. Het is daarom goed mogelijk dat je de code moet wijzigen."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Thema's, plug-ins en serverspecificaties zijn allemaal van invloed op de reactietijd van de server. Overweeg een thema te gebruiken dat beter is geoptimaliseerd, kies met zorg een optimalisatieplug-in en/of upgrade je server."
@@ -1035,16 +1362,16 @@
     "message": "Overweeg fragmenten te tonen in je postlijsten (bijvoorbeeld via de tag 'more'), zodat er per pagina minder posts worden weergegeven. Ook kun je lange posts verdelen over meerdere pagina's of een plug-in voor lazy loading van reacties gebruiken."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Er zijn enkele [WordPress-plug-ins](https://wordpress.org/plugins/search/minify+css/) die je site sneller kunnen maken door je stijlen in te korten, te verkleinen of te comprimeren. Indien mogelijk is het bovendien handig zulke verkleining al mee te nemen in het ontwerpproces."
+    "message": "Er zijn een aantal [WordPress-plug-ins](https://wordpress.org/plugins/search/minify+css/) die stijlen inkorten, verkleinen en comprimeren en je site sneller maken. Mogelijk kun je een ontwerpproces gebruiken dat deze verkleining van tevoren toepast."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Er zijn enkele [WordPress-plug-ins](https://wordpress.org/plugins/search/minify+javascript/) die je site sneller kunnen maken door je scripts in te korten, te verkleinen of te comprimeren. Indien mogelijk is het bovendien handig zulke verkleining al mee te nemen in het ontwerpproces."
+    "message": "Er zijn een aantal [WordPress-plug-ins](https://wordpress.org/plugins/search/minify+javascript/) die je site sneller kunnen maken door je scripts in te korten, te verkleinen of te comprimeren. Indien mogelijk is het bovendien handig zulke verkleining al mee te nemen in het ontwerpproces."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Overweeg gebruik te maken van minder of andere [WordPress-plug-ins](https://wordpress.org/plugins/) die ongebruikte css laden op je pagina. Probeer [codedekking](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) uit te voeren in Chrome DevTools als je plug-ins wilt identificeren die extra css toevoegen. Via de URL van de stylesheet kun je identificeren welk thema/welke plug-in verantwoordelijk is. Ga in de lijst op zoek naar plug-ins met veel stylesheets en veel rood in de codedekking. Een plug-in zou een stylesheet alleen in de wachtrij moeten plaatsen als deze daadwerkelijk wordt gebruikt op de pagina."
+    "message": "Overweeg gebruik te maken van minder of andere [WordPress-plug-ins](https://wordpress.org/plugins/) die ongebruikte css laden op je pagina. Voer [codedekking](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) uit in Chrome DevTools als je plug-ins wilt identificeren die extra css toevoegen. Via de URL van de stylesheet kun je identificeren welk thema/welke plug-in verantwoordelijk is. Ga in de lijst op zoek naar plug-ins met veel stylesheets en veel rood in de codedekking. Een plug-in zou een stylesheet alleen in de wachtrij moeten plaatsen als deze daadwerkelijk wordt gebruikt op de pagina."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Overweeg gebruik te maken van minder of andere [WordPress-plug-ins](https://wordpress.org/plugins/) die ongebruikte JavaScript laden op je pagina. Probeer [codedekking](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) uit te voeren in Chrome DevTools als je plug-ins wilt identificeren die extra JS toevoegen. Via de URL van het script kun je identificeren welk thema/welke plug-in verantwoordelijk is. Ga in de lijst op zoek naar plug-ins met veel scripts en veel rood in de codedekking. Een plug-in zou een script alleen in de wachtrij moeten plaatsen als het daadwerkelijk wordt gebruikt op de pagina."
+    "message": "Overweeg gebruik te maken van minder of andere [WordPress-plug-ins](https://wordpress.org/plugins/) die ongebruikt JavaScript laden op je pagina. Voer [codedekking](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) uit in Chrome DevTools als je plug-ins wilt identificeren die extra JS toevoegen. Via de URL van het script kun je identificeren welk thema/welke plug-in verantwoordelijk is. Ga in de lijst op zoek naar plug-ins met veel scripts en veel rood in de codedekking. Een plug-in zou een script alleen in de wachtrij moeten plaatsen als het daadwerkelijk wordt gebruikt op de pagina."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Lees meer over [browsercaching in WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
@@ -1053,7 +1380,7 @@
     "message": "Overweeg een [beeldoptimalisatieplug-in voor WordPress](https://wordpress.org/plugins/search/optimize+images/) te gebruiken om je afbeeldingen te comprimeren terwijl de beeldkwaliteit behouden blijft."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Upload afbeeldingen rechtstreeks via de [mediabibliotheek](https://codex.wordpress.org/Media_Library_Screen) om er zeker van te zijn dat de vereiste afbeeldingsformaten beschikbaar zijn. Voeg de afbeeldingen vervolgens in vanuit de mediabibliotheek. Ook kun je de afbeeldingswidget gebruiken om ervoor te zorgen dat de optimale afbeeldingsformaten worden gebruikt (inclusief voor responsieve breakpoints). Vermijd afbeeldingen op volledig formaat, tenzij de afmetingen geschikt zijn voor waar ze worden geplaatst. [Meer informatie](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Upload afbeeldingen rechtstreeks via de [mediabibliotheek](https://codex.wordpress.org/Media_Library_Screen) om er zeker van te zijn dat de vereiste afbeeldingsformaten beschikbaar zijn. Voeg de afbeeldingen vervolgens in vanuit de mediabibliotheek. Ook kun je de afbeeldingswidget gebruiken om ervoor te zorgen dat de optimale afbeeldingsformaten worden gebruikt (inclusief voor responsieve breakpoints). Vermijd `Full Size`-afbeeldingen, tenzij de afmetingen geschikt zijn voor waar ze worden geplaatst. [Meer informatie](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Je kunt tekstcompressie inschakelen bij je webserverinstellingen."

--- a/lighthouse-core/lib/i18n/locales/no.json
+++ b/lighthouse-core/lib/i18n/locales/no.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Med tilgangsnøkler kan brukere raskt fokusere på deler av siden. Hver tilgangsnøkkel må være unik for at navigeringen skal fungere riktig. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Med tilgangsnøkler kan brukere raskt fokusere på deler av siden. Hver tilgangsnøkkel må være unik for at navigeringen skal fungere riktig. [Finn ut mer](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "«[accesskey]»-verdier er ikke unike"
+    "message": "`[accesskey]`-verdier er ikke unike"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "«[accesskey]»-verdiene er unike"
+    "message": "`[accesskey]`-verdiene er unike"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Hver ARIA-«role» støtter en spesifikk undergruppe av «aria-*»-attributter. Manglende samsvar mellom disse gjør «aria-*»-attributtene ugyldige. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Hver ARIA-`role` støtter en spesifikk undergruppe av `aria-*`-attributter. Manglende samsvar mellom disse gjør `aria-*`-attributtene ugyldige. [Finn ut mer](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "«[aria-*]»-attributter samsvarer ikke med rollene sine"
+    "message": "`[aria-*]`-attributter samsvarer ikke med rollene sine"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "«[aria-*]»-attributtene samsvarer med rollene sine"
+    "message": "`[aria-*]`-attributtene samsvarer med rollene sine"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Noen ARIA-roller har obligatoriske attributter som beskriver elementenes tilstand for skjermlesere. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Noen ARIA-roller har obligatoriske attributter som beskriver elementenes tilstand for skjermlesere. [Finn ut mer](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "«[role]»-elementer har ikke alle de obligatoriske «[aria-*]»-attributtene"
+    "message": "`[role]`-elementer har ikke alle de obligatoriske `[aria-*]`-attributtene"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "«[role]»-elementene har alle de obligatoriske «[aria-*]»-attributtene"
+    "message": "`[role]`-elementene har alle de obligatoriske `[aria-*]`-attributtene"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Noen overordnede ARIA-roller må inneholde spesifikke underordnede roller for å utføre de tiltenkte tilgjengelighetsfunksjonene. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Noen overordnede ARIA-roller må inneholde spesifikke underordnede roller for å utføre de tiltenkte tilgjengelighetsfunksjonene. [Finn ut mer](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Det mangler elementer med «[role]» som krever spesifikke underordnede «[role]»-elementer."
+    "message": "Elementer med `[role]` som krever spesifikke underordnede `[role]`-elementer, mangler."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Det finnes elementer med «[role]» som krever spesifikke underordnede «[role]»-elementer"
+    "message": "Det finnes elementer med `[role]` som krever spesifikke underordnede `[role]`-elementer."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Noen underordnede ARIA-roller må ligge innenfor de spesifikke overordnede rollene for å utføre de tiltenkte tilgjengelighetsfunksjonene på riktig måte. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Noen underordnede ARIA-roller må ligge innenfor de spesifikke overordnede rollene for å utføre de tiltenkte tilgjengelighetsfunksjonene på riktig måte. [Finn ut mer](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "«[role]»-elementer ligger ikke i de obligatoriske overordnede elementene"
+    "message": "`[role]`-elementer ligger ikke i de obligatoriske overordnede elementene"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "«[role]»-elementer ligger ikke i de relaterte obligatoriske overordnede elementene"
+    "message": "`[role]`-elementer ligger i de obligatoriske overordnede elementene"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA-roller må ha gyldige verdier for å utføre de tiltenkte tilgjengelighetsfunksjonene. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA-roller må ha gyldige verdier for å utføre de tiltenkte tilgjengelighetsfunksjonene. [Finn ut mer](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "«[role]»-verdier er ikke gyldige"
+    "message": "`[role]`-verdiene er ikke gyldige"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "«[role]»-verdiene er gyldige"
+    "message": "`[role]`-verdiene er gyldige"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Assisterende teknologi, for eksempel skjermlesere, kan ikke tolke ARIA-attributter med ugyldige verdier. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Assisterende teknologi, for eksempel skjermlesere, kan ikke tolke ARIA-attributter med ugyldige verdier. [Finn ut mer](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "«[aria-*]»-attributter har ikke gyldige verdier"
+    "message": "`[aria-*]`-attributter har ikke gyldige verdier"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "«[aria-*]»-attributtene har gyldige verdier"
+    "message": "`[aria-*]`-attributtene har gyldige verdier"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Assisterende teknologi, som skjermlesere, kan ikke tolke ARIA-attributter med ugyldige navn. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Assisterende teknologi, som skjermlesere, kan ikke tolke ARIA-attributter med ugyldige navn. [Finn ut mer](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "«[aria-*]»-attributter er ugyldige eller feilstavet"
+    "message": "`[aria-*]`-attributter er ugyldige eller feilstavet"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "«[aria-*]»-attributtene er gyldige og ikke feilstavet"
+    "message": "`[aria-*]`-attributtene er gyldige og ikke feilstavet"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Når du inkluderer teksting, kan døve og hørselshemmede brukere også dra nytte av lydelementer, siden de får se kritisk informasjon, for eksempel om hvem som snakker, hva de sier, og annen informasjon som ikke er talerelatert. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Når du inkluderer teksting, kan døve og hørselshemmede brukere også dra nytte av lydelementer, siden de får se kritisk informasjon, for eksempel om hvem som snakker, hva de sier, og annen informasjon som ikke er talerelatert. [Finn ut mer](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "«<audio>»-elementer mangler et «<track>»-element med «[kind=\"captions\"]»."
+    "message": "`<audio>`-elementer mangler et `<track>`-element med `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "«<audio>»-elementene inneholder et «<track>»-element med «[kind=\"captions\"]»"
+    "message": "`<audio>`-elementer inneholder et `<track>`-element med `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Elementer som ikke besto kontrollen"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Når knapper ikke har tilgjengelige navn, beskriver skjermlesere dem som «knapp». Dermed er de ubrukelige for brukere som er avhengige av skjermlesere. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Når knapper ikke har tilgjengelige navn, beskriver skjermlesere dem som «knapp». Dermed er de ubrukelige for brukere som er avhengige av skjermlesere. [Finn ut mer](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Knapper har ikke tilgjengelige navn"
@@ -93,7 +93,7 @@
     "message": "Knappene har tilgjengelige navn"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Hvis du legger til måter å hoppe over repeterende innhold på, kan tastaturbrukere navigere mer effektivt på siden. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Hvis du legger til måter å hoppe over repeterende innhold på, kan tastaturbrukere navigere mer effektivt på siden. [Finn ut mer](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Siden mangler overskrift, landemerkeregion eller link for å hoppe over innhold"
@@ -102,7 +102,7 @@
     "message": "Siden inneholder en overskrift, en landemerkeregion eller en link for å hoppe over innhold"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Tekst med lav kontrast er vanskelig eller umulig å lese for mange brukere. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Tekst med lav kontrast er vanskelig eller umulig å lese for mange brukere. [Finn ut mer](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Kontrastforholdet mellom bakgrunns- og forgrunnsfarger er ikke tilstrekkelig."
@@ -111,88 +111,88 @@
     "message": "Kontrastforholdet mellom bakgrunns- og forgrunnsfargene er tilstrekkelig"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Når definisjonslister ikke er riktig kodet, kan resultatene fra skjermlesere bli forvirrende eller unøyaktige. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Når definisjonslister ikke er riktig kodet, kan resultatene fra skjermlesere bli forvirrende eller unøyaktige. [Finn ut mer](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "«<dl>»-elementer inneholder ikke bare velordnede «<dt>»- og «<dd>»-grupper og «<script>»- eller «<template>»-elementer."
+    "message": "`<dl>`-elementer inneholder ikke bare velordnede `<dt>`- og `<dd>`-grupper og `<script>`- eller `<template>`-elementer."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "«<dl>»-elementene inneholder bare velordnede «<dt>»- og «<dd>»-grupper og «<script>»- eller «<template>»-elementer."
+    "message": "`<dl>`-elementene inneholder bare velordnede `<dt>`- og `<dd>`-grupper og `<script>`- eller `<template>`-elementer."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Elementer i definisjonslister («<dt>» og «<dd>») må være omsluttet av et overordnet «<dl>»-element for å sørge for at skjermlesere kan lese dem opp riktig. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Elementer i definisjonslister (`<dt>` og `<dd>`) må være omsluttet av et overordnet `<dl>`-element for å sørge for at skjermlesere kan lese dem opp riktig. [Finn ut mer](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Elementer i definisjonslister er ikke omsluttet av «<dl>»-elementer"
+    "message": "Elementer i definisjonslister er ikke omsluttet av `<dl>`-elementer"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Elementene i definisjonslister er omsluttet av «<dl>»-elementer"
+    "message": "Elementene i definisjonslister er omsluttet av `<dl>`-elementer"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Tittelen gir brukere av skjermlesere oversikt over siden, og søkemotorbrukere er svært avhengige av den for å avgjøre om siden er relevant for søket deres. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Tittelen gir brukere av skjermlesere oversikt over siden, og søkemotorbrukere er svært avhengige av den for å avgjøre om siden er relevant for søket deres. [Finn ut mer](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokumentet har ikke noe «<title>»-element"
+    "message": "Dokumentet har ikke noe `<title>`-element"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokumentet har et «<title>»-element"
+    "message": "Dokumentet har et `<title>`-element"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "ID-attributter må ha unike verdier for å unngå at andre forekomster blir oversett av assisterende teknologi. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "ID-attributter må ha unike verdier for å unngå at andre forekomster blir oversett av assisterende teknologi. [Finn ut mer](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "«[id]»-attributter på siden er ikke unike"
+    "message": "`[id]`-attributter på siden er ikke unike"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "«[id]»-attributtene på siden er unike"
+    "message": "`[id]`-attributtene på siden er unike"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Brukere av skjermlesere er avhengige av titler for «frame»- og «iframe»-elementer for å forstå innholdet i dem. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Brukere av skjermlesere er avhengige av titler for «frame»/«iframe»-elementer for å forstå innholdet i dem. [Finn ut mer](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "«<frame>»- eller «<iframe>»-elementer mangler tittel"
+    "message": "`<frame>`- eller `<iframe>`-elementer mangler tittel"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "«<frame>»- eller «<iframe>»-elementene har en tittel"
+    "message": "`<frame>`- og `<iframe>`-elementer har titler"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Hvis en side ikke angir noe «lang»-attributt, antar skjermlesere at siden er på standardspråket som brukeren valgte ved konfigurering av skjermleseren. Hvis siden ikke faktisk er på standardspråket, kan det hende skjermleseren leser teksten på siden feil. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Hvis en side ikke angir noe «lang»-attributt, antar skjermlesere at siden er på standardspråket brukeren valgte ved konfigurering av skjermleseren. Hvis siden ikke faktisk er på standardspråket, kan det hende skjermleseren leser teksten på siden feil. [Finn ut mer](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "«<html>»-elementet har ikke noe «[lang]»-attributt"
+    "message": "`<html>`-elementet har ikke noe gyldig `[lang]`-attributt"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "«<html>»-elementet har et «[lang]»-attributt"
+    "message": "`<html>`-elementet har et `[lang]`-attributt"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Ved å angi et gyldig [BCP 47-språk](https://www.w3.org/International/questions/qa-choosing-language-tags#question) hjelper du skjermlesere med å lese opp teksten riktig. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ved å angi et gyldig [BCP 47-språk](https://www.w3.org/International/questions/qa-choosing-language-tags#question) hjelper du skjermlesere med å lese opp teksten riktig. [Finn ut mer](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "«<html>»-elementet har ingen gyldig verdi for «[lang]»-attributtet."
+    "message": "`<html>`-elementet har ikke noen gyldig verdi for `[lang]`-attributtet."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "«<html>»-elementet har en gyldig verdi for «[lang]»-attributtet sitt"
+    "message": "`<html>`-elementet har en gyldig verdi for `[lang]`-attributtet"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informative elementer bør ta sikte på korte og beskrivende alternative tekster. Dekorative elementer kan ignoreres med tomme alt-attributter. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informative elementer bør ta sikte på korte og beskrivende alternative tekster. Dekorative elementer kan ignoreres med tomme alt-attributter. [Finn ut mer](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Bildeelementer har ikke «[alt]»-attributter"
+    "message": "Bildeelementer har ikke `[alt]`-attributter"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Bildeelementene har «[alt]»-attributter"
+    "message": "Bildeelementene har `[alt]`-attributter"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Når et bilde brukes som «<input>»-knapp, bør du oppgi en alternativ tekst som hjelper brukere av skjermlesere med å forstå hva knappen er til. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Når et bilde brukes som `<input>`-knapp, bør du oppgi en alternativ tekst som hjelper brukere av skjermlesere med å forstå hva knappen er til. [Finn ut mer](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "«<input type=\"image\">»-elementer har ikke «[alt]»-tekst"
+    "message": "`<input type=\"image\">`-elementer har ikke `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "«<input type=\"image\">»-elementene har «[alt]»-tekst"
+    "message": "`<input type=\"image\">`-elementer har `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Etiketter sørger for at skjemakontroller leses opp på riktig måte av assisterende teknologi, som skjermlesere. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Etiketter sørger for at skjemakontroller leses opp på riktig måte av assisterende teknologi, som skjermlesere. [Finn ut mer](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Skjemaelementer har ikke tilknyttede etiketter"
@@ -201,16 +201,16 @@
     "message": "Skjemaelementene har tilknyttede etiketter"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Tabeller som brukes til layoutformål, skal ikke inneholde dataelementer, som th-elementer, caption-elementer eller summary-attributtet, da disse kan skape en forvirrende opplevelse for brukere av skjermlesere. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Tabeller som brukes til layoutformål, skal ikke inneholde dataelementer, som th-elementer, caption-elementer eller summary-attributtet, da disse kan skape en forvirrende opplevelse for brukere av skjermlesere. [Finn ut mer](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Presentasjonsmessige «<table>»-elementer unngår ikke bruk av «<th>», «<caption>» eller «[summary]»-attributtet."
+    "message": "Presentasjonsmessige `<table>`-elementer unngår ikke å bruke `<th>`, `<caption>` eller `[summary]`-attributtet."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Presentasjonsmessige «<table>»-elementer unngår bruk av «<th>», «<caption>» og «[summary]»-attributtet."
+    "message": "Presentasjonsmessige `<table>`-elementer unngår å bruke `<th>`, `<caption>` og `[summary]`-attributtet."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Når du bruker linktekst (og alternativ tekst for bilder som brukes som linker) som er tydelig, unik og mulig å sette fokus på, blir navigeringsopplevelsen bedre for brukere av skjermlesere. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Når du bruker linktekst (og alternativ tekst for bilder som brukes som linker) som er tydelig, unik og mulig å sette fokus på, blir navigeringsopplevelsen bedre for brukere av skjermlesere. [Finn ut mer](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Linker har ikke tydelige navn"
@@ -219,103 +219,115 @@
     "message": "Linkene har tydelige navn"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Skjermlesere har en spesifikk måte å lese opp lister på. Du kan øke kvaliteten på resultatene fra skjermlesere ved å bruke en god listestruktur. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Skjermlesere har en spesifikk måte å lese opp lister på. Du kan øke kvaliteten på resultatene fra skjermlesere ved å bruke en god listestruktur. [Finn ut mer](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Lister inneholder ikke kun «<li>»-elementer og elementer som støtter skript («<script>» og «<template>»)."
+    "message": "Lister inneholder ikke kun `<li>`-elementer og elementer som støtter skript (`<script>` og `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Listene inneholder bare «<li>»-elementer og elementer som støtter skript («<script>» og «<template>»)."
+    "message": "Listene inneholder bare `<li>`-elementer og elementer som støtter skript (`<script>` og `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Skjermlesere krever at listeelementer («<li>») ligger i et overordnet «<ul>»- eller «<ol>»-element – ellers kan de ikke leses opp på riktig måte. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Skjermlesere krever at listeelementer (`<li>`) ligger i et overordnet `<ul>`- eller `<ol>`-element – ellers kan de ikke leses opp på riktig måte. [Finn ut mer](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Listeelementer («<li>») ligger ikke i overordnede «<ul>»- eller «<ol>»-elementer."
+    "message": "Listeelementer (`<li>`) ligger ikke i overordnede `<ul>`- eller `<ol>`-elementer."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Listeelementene («<li>») ligger i overordnede «<ul>»- eller «<ol>»-elementer"
+    "message": "Listeelementene (`<li>`) ligger i overordnede `<ul>`- eller `<ol>`-elementer"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Brukere forventer ikke at sider oppdateres automatisk. Hvis det skjer, flyttes dessuten fokuset tilbake til toppen av siden. Dette kan føre til en frustrerende eller forvirrende brukeropplevelse. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Brukere forventer ikke at sider oppdateres automatisk, så hvis dette skjer, flyttes fokuset tilbake til toppen av siden. Dette kan føre til frustrasjon eller forvirring. [Finn ut mer](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokumentet bruker «<meta http-equiv=\"refresh\">»"
+    "message": "Dokumentet bruker `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Dokumentet bruker ikke «<meta http-equiv=\"refresh\">»"
+    "message": "Dokumentet bruker ikke `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Deaktivering av zoom er problematisk for brukere med nedsatt synsevne som har behov for å forstørre skjermen for å se innholdet på nettsider skikkelig. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Deaktivering av zoom er problematisk for brukere med nedsatt synsevne som har behov for å forstørre skjermen for å se innholdet på nettsider. [Finn ut mer](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "«[user-scalable=\"no\"]» brukes i «<meta name=\"viewport\">»-elementet, eller «[maximum-scale]»-attributtet er mindre enn 5."
+    "message": "`[user-scalable=\"no\"]` brukes i `<meta name=\"viewport\">`-elementet, eller `[maximum-scale]`-attributtet er mindre enn 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "«[user-scalable=\"no\"]» brukes ikke i «<meta name=\"viewport\">»-elementet, og «[maximum-scale]»-attributtet er ikke mindre enn 5."
+    "message": "`[user-scalable=\"no\"]` brukes ikke i `<meta name=\"viewport\">`-elementet, og `[maximum-scale]`-attributtet er ikke mindre enn 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Skjermlesere kan ikke oversette innhold som ikke er tekst. Ved å legge til alternativ tekst i «<object>»-elementer hjelper du skjermlesere med å formidle mening til brukerne. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Skjermlesere kan ikke oversette innhold som ikke er tekst. Ved å legge til alternativ tekst i `<object>`-elementer hjelper du skjermlesere med å formidle mening til brukerne. [Finn ut mer](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "«<object>»-elementer har ikke «[alt]»-tekst"
+    "message": "`<object>`-elementer har ikke `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "«<object>»-elementene har «[alt]»-tekst"
+    "message": "`<object>`-elementer har `[alt]`-tekst"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Større verdier enn 0 antyder en eksplisitt navigeringsrekkefølge. Selv om dette teknisk sett er gyldig, kan det ofte være frustrerende for brukere som er avhengige av assisterende teknologi. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Større verdier enn 0 antyder en eksplisitt navigeringsrekkefølge. Selv om dette teknisk sett er gyldig, kan det ofte være frustrerende for brukere som er avhengige av assisterende teknologi. [Finn ut mer](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Noen elementer har en «[tabindex]»-verdi som er større enn 0"
+    "message": "Noen elementer har en `[tabindex]`-verdi som er større enn 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Ingen elementer har en «[tabindex]»-verdi som er større enn 0"
+    "message": "Ingen elementer har en `[tabindex]`-verdi som er større enn 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Skjermlesere har funksjonalitet som gjør det enklere å navigere i tabeller. Ved å sørge for at «<td>»-celler som bruker «[headers]»-attributtet, kun refererer til andre celler i den samme tabellen, kan du gjøre opplevelsen bedre for brukere av skjermlesere. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Skjermlesere har funksjonalitet som gjør det enklere å navigere i tabeller. Ved å sørge for at `<td>`-celler som bruker `[headers]`-attributtet, kun refererer til andre celler i den samme tabellen, kan du gjøre opplevelsen bedre for brukere av skjermlesere. [Finn ut mer](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Celler som er en del av et «<table>»-element og bruker «[headers]»-attributtet, refererer til andre celler i den samme tabellen."
+    "message": "Celler som er en del av et `<table>`-element og bruker `[headers]`-attributtet, refererer bare til andre celler i den samme tabellen."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Celler som er en del av et «<table>»-element og bruker «[headers]»-attributtet, refererer bare til andre celler i den samme tabellen."
+    "message": "Celler som er en del av et `<table>`-element som bruker `[headers]`-attributtet, refererer bare til andre celler i den samme tabellen."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Skjermlesere har funksjonalitet som gjør det enklere å navigere i tabeller. Ved å sørge for at tabelloverskrifter alltid refererer til spesifikke cellesett, kan du gjøre opplevelsen bedre for brukere av skjermlesere. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Skjermlesere har funksjonalitet som gjør det enklere å navigere i tabeller. Ved å sørge for at tabelloverskrifter alltid refererer til spesifikke cellesett, kan du gjøre opplevelsen bedre for brukere av skjermlesere. [Finn ut mer](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "«<th>»-elementer og elementer med «[role=\"columnheader\"/\"rowheader\"]» har ikke datacellene de beskriver."
+    "message": "`<th>`-elementer og elementer med `[role=\"columnheader\"/\"rowheader\"]` har ikke datacellene de beskriver."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "«<th>»-elementene og elementene med «[role=\"columnheader\"/\"rowheader\"]» har datacellene de beskriver."
+    "message": "`<th>`-elementene og elementene med `[role=\"columnheader\"/\"rowheader\"]` har datacellene de beskriver."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Ved å angi et gyldig [BCP 47-språk](https://www.w3.org/International/questions/qa-choosing-language-tags#question) i elementer bidrar du til at skjermlesere leser opp teksten riktig. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Ved å angi et gyldig [BCP 47-språk](https://www.w3.org/International/questions/qa-choosing-language-tags#question) i elementer bidrar du til at skjermlesere leser opp teksten riktig. [Finn ut mer](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "«[lang]»-attributter mangler en gyldig verdi"
+    "message": "`[lang]`-attributter mangler gyldige verdier"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "«[lang]»-attributtene har en gyldig verdi"
+    "message": "`[lang]`-attributtene har gyldige verdier"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Når videoer har teksting, blir det lettere for døve og hørselhemmede brukere å få med seg informasjonen i dem. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Når videoer har teksting, blir det lettere for døve og hørselshemmede brukere å få med seg informasjonen i dem. [Finn ut mer](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "«<video>»-elementer inneholder ikke noe «<track>»-element med «[kind=\"captions\"]»."
+    "message": "`<video>`-elementer mangler et `<track>`-element med `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "«<video>»-elementene inneholder et «<track>»-element med «[kind=\"captions\"]»"
+    "message": "`<video>`-elementer inneholder et `<track>`-element med `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Lydbeskrivelser gir relevant videoinformasjon som dialog ikke kan formidle, for eksempel ansiktsuttrykk og scener. [Finn ut mer](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Lydbeskrivelser gir relevant videoinformasjon som dialog ikke kan formidle, for eksempel ansiktsuttrykk og scener. [Finn ut mer](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "«<video>»-elementer mangler et «<track>»-element med «[kind=\"description\"]»."
+    "message": "`<video>`-elementer mangler et `<track>`-element med `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "«<video>»-elementene inneholder et «<track>»-element med «[kind=\"description\"]»"
+    "message": "`<video>`-elementer inneholder et `<track>`-element med `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "For å oppnå det ideelle utseendet på iOS når brukere legger til appen på startskjermen, definer et apple-touch-icon. Det må peke til et ugjennomsiktig, kvadratisk PNG-bilde med sidelengde på 192 (eller 180) piksler. [Finn ut mer](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Har ikke noe gyldig `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` er utdatert – `apple-touch-icon` foretrekkes."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Har et gyldig `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome-utvidelser gjør innlastingen av denne siden tregere. Prøv å revidere siden i inkognitomodus eller fra en Chrome-profil uten utvidelser."
@@ -330,7 +342,7 @@
     "message": "Total CPU-tid"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Vurder å redusere tiden som brukes til parsing, kompilering og kjøring i JS. Levering av mindre JS-nyttelaster kan bidra til dette. [Finn ut mer] (https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Vurder å redusere tiden som brukes til parsing, kompilering og kjøring av JavaScript. Levering av mindre JS-ressurser kan bidra til dette. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Reduser JavaScript-kjøretiden"
@@ -339,7 +351,7 @@
     "message": "JavaScript-kjøretid"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Store GIF-er er mindre effektive for levering av animert innhold. I stedet for GIF bør du vurdere bruk av MPEG4/WebM-videoer for animasjon og PNG/WebP for statiske bilder, da dette belaster nettverket mindre. [Finn ut mer] (https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Store GIF-er er mindre effektive for visning av animert innhold. I stedet for GIF bør du vurdere å bruke MPEG4/WebM-videoer for animasjon og PNG/WebP for statiske bilder, da dette belaster nettverket mindre. [Finn ut mer](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Bruk videoformat for animert innhold"
@@ -351,13 +363,13 @@
     "message": "Utsett bilder utenfor skjermen"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Ressurser blokkerer den første opptegningen av siden din. Vurder å levere kritisk JS/CSS innebygd og utsette all JS / alle stiler som ikke er kritiske. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Ressurser blokkerer første opptegning (FP) av siden. Vurder å levere kritisk JS/CSS innebygd og utsette all JS/CSS som ikke er kritisk. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Eliminer ressurser som blokkerer gjengivelse"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Store nettverksressurser koster brukerne mer og er hovedgrunnen til lange innlastingstider. [Finn ut mer] (https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Store nettverksressurser koster brukerne ekte penger og er hovedgrunnen til lange innlastingstider. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Den totale størrelsen var {totalBytes, number, bytes} kB"
@@ -375,7 +387,7 @@
     "message": "Forminsk CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Forminsking av JavaScript-filer kan redusere nyttelaststørrelser og parsetiden for skript. [Finn ut mer](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Forminskede JavaScript-filer kan redusere mengden data som må overføres, og parsetiden for skript. [Finn ut mer](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Forminsk JavaScript"
@@ -393,7 +405,7 @@
     "message": "Fjern ubrukt JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "En lang bufferlevetid kan øke antall gjentatte besøk på siden din. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "En lang bufferlevetid kan gjøre at gjentatte besøk på siden din går raskere. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 ressurs funnet}other{# ressurser funnet}}"
@@ -405,19 +417,19 @@
     "message": "Bruker effektive buffer-retningslinjer på statiske ressurser"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Optimaliserte bilder lastes inn raskere og bruker mindre mobildata [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Optimaliserte bilder lastes inn raskere og bruker mindre mobildata. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Effektiviser omgjøring av bilder til kode"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Vis bilder som har passende størrelse, for å spare mobildata og få kortere innlastingstid. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Vis bilder som har passende størrelse, for å spare mobildata og redusere innlastingstiden. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Velg riktige bildestørrelser"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Tekstbaserte ressurser bør leveres komprimert (gzip, deflate eller brotli) for å minimerer antall byte gjennom nettverket. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Tekstbaserte ressurser bør leveres komprimert (gzip, deflate eller brotli) for å minimere antall byte som sendes over nettverket. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Aktiver tekstkomprimering"
@@ -429,13 +441,64 @@
     "message": "Bruk nyere bildeformater"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "De kritiske forespørselskjedene nedenfor viser hvilke ressurser som er utstedt med høy prioritet. Vurder å redusere lengden på kjedene, redusere nedlastingsstørrelsen på ressurser eller utsette nedlasting av unødvendige ressurser for å bedre sideinnlastingen. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "De kritiske forespørselskjedene nedenfor viser hvilke ressurser som lastes inn med høy prioritet. Vurder å redusere lengden på kjedene, redusere nedlastingsstørrelsen på ressursene eller utsette nedlasting av unødvendige ressurser for å bedre sideinnlastingen. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 kjede funnet}other{# kjeder funnet}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimer dybden på kritiske forespørsler"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Avvikling/varsel"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Linje"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Avviklede API-er kommer etter hvert til å bli fjernet fra nettleseren. [Finn ut mer](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 varsel er funnet}other{# varsler er funnet}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Bruker avviklede API-er"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Unngår å bruke avviklede API-er"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Programbufferen er avviklet. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Fant «{AppCacheManifest}»"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Bruker programbufferen"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Unngår å bruke programbufferen"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Ved å angi en doctype forhindrer du nettleseren fra å bytte til modus for bred kompatibilitet. Les mer på [MDN Web Docs-siden](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Doctype-navnet må være strengen `html` med små bokstaver"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokumentet må ha en doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Forventet at publicId skulle være en tom streng"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Forventet at systemId skulle være en tom streng"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Siden har ikke HTML som doctype og utløser derfor modus for bred kompatibilitet."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Siden har HTML som doctype"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
@@ -447,7 +510,7 @@
     "message": "Verdi"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Nettlesereksperter anbefaler at sider inneholder mindre enn ca. 1500 DOM-elementer. Den perfekte verdien er en tredybde på mindre enn 32 elementer og mindre enn 60 underordnede/overordnede elementer. En stor DOM-struktur kan øke minnebruken, føre til at [stilberegninger](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) tar lengre tid, og forårsake kostbare [gjenoppbygginger av sidevisningen](https://developers.google.com/speed/articles/reflow). [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Nettleseringeniører anbefaler å ha mindre enn 1500 DOM-elementer på nettsider. Ideelt bør treet være mindre enn 32 elementer dypt, og det bør være færre enn 60 underordnede/overordnede elementer. Store DOM-er kan øke minnebruken, forårsake lengre [stilberegninger](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) og utløse kostbare [dynamiske tilpasninger av layouten](https://developers.google.com/speed/articles/reflow). [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 element}other{# elementer}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Unngå for stor DOM-struktur"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Mål"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Legg til `rel=\"noopener\"` eller `rel=\"noreferrer\"` i eksterne linker for å øke ytelsen og forhindre sikkerhetssårbarheter. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Linker til opphavsuavhengige destinasjoner er utrygge"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Linker til opphavsuavhengige destinasjoner er trygge"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Kunne ikke avgjøre destinasjonen for ankeret ({anchorHTML}). Hvis ankeret ikke brukes som hyperlink, vurder å fjerne target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Brukere er mistroiske overfor eller blir forvirret av nettsteder som spør om posisjonen deres uten kontekst. Vurder å knytte forespørselen opp mot en brukerhandling i stedet. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Spør om geolokaliseringstillatelsen ved sideinnlasting"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Unngår å spørre om geolokaliseringstillatelsen ved sideinnlasting"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versjon"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Alle JavaScript-grensesnittsbiblioteker som ble funnet på siden."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "JavaScript-biblioteker som ble oppdaget"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "For brukere som har trege tilkoblinger, kan eksterne skript som injiseres dynamisk via `document.write()`, forsinke sideinnlastingen med flere titalls sekunder. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Bruker `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Unngår `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Høyeste alvorlighetsgrad"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Bibliotekversjon"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Antall sårbarheter"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Noen tredjepartsskript kan inneholde kjente sikkerhetssårbarheter som enkelt kan identifiseres og utnyttes av angripere. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 sårbarhet er oppdaget}other{# sårbarheter er oppdaget}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Inkluderer JavaScript-grensesnittsbiblioteker med kjente sikkerhetssårbarheter"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Høy"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Lav"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Middels"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Unngår JavaScript-grensesnittsbiblioteker med kjente sikkerhetssårbarheter"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Brukere er mistroiske overfor eller blir forvirret av nettsteder som spør om å få sende varsler uten kontekst. Vurder å knytte forespørselen opp mot brukerbevegelser i stedet. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Spør om varseltillatelsen ved sideinnlasting"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Unngår å spørre om varseltillatelsen ved sideinnlasting"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elementer som ikke besto kontrollen"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Å hindre brukere i å lime inn passord underminerer gode retningslinjer for sikkerhet. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Forhindrer brukere fra å lime inn i passordfelt"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Brukerne kan lime inn i passordfelt"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokoll"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 har mange fordeler sammenlignet med HTTP/1.1, blant annet binære headers, multipleksing og aktiv meldingslevering fra tjener. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 forespørsel ble ikke vist via HTTP/2}other{# forespørsler ble ikke vist via HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Bruker ikke HTTP/2 for alle ressursene"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Bruker HTTP/2 til sine egne ressurser"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Vurder å markere aktivitetslytterne for berøring og musehjul som `passive` for å oppnå bedre ytelse ved rulling på siden. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Bruker ikke passive lyttere for å oppnå bedre ytelse ved rulling på siden"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Bruker passive lyttere for å oppnå bedre ytelse ved rulling på siden"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Beskrivelse"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Feil som loggføres i konsollen, tyder på uløste problemer. De kan stamme fra mislykkede nettverksforespørsler og andre nettleserproblemer."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Nettleserfeil ble loggført i konsollen"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Ingen nettleserfeil ble loggført i konsollen"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Bruk CSS-funksjonen font-display til å forsikre deg om at brukerne ser teksten mens skrifttypen for nettet lastes inn. [Finn ut mer](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Bruk CSS-funksjonen font-display til å forsikre deg om at brukerne ser teksten mens skrifttypene for nettet lastes inn. [Finn ut mer](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Sørg for at teksten forblir synlig under innlasting av skrifttyper for nettet"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "All tekst forblir synlig under innlasting av skrifttype for nettet"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse kunne ikke automatisk kontrollere verdien av font-display for denne nettadressen: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Høyde/bredde-forhold (faktisk)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Høyde/bredde-forhold (vist)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Visningsstørrelsen for bilder bør samsvare med det naturlige høyde/bredde-forholdet. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Viser bilder med feil høyde/bredde-forhold"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Viser bilder med riktig høyde/bredde-forhold"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Ugyldig informasjon om bildestørrelse – {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Utrygg nettadresse"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Alle nettsteder bør være beskyttet med HTTPS, selv de som ikke håndterer sensitive opplysninger. HTTPS forhindrer inntrengere fra å tukle med eller lytte passivt til kommunikasjonen mellom appen din og brukerne dine og er en forutsetning for å kunne bruke HTTP/2 og mange nye nettplattform-API-er. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 utrygg forespørsel er funnet}other{# utrygge forespørsler er funnet}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Bruker ikke HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Bruker HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Når sider lastes inn raskt over mobilnettverk, gir det en god brukeropplevelse på mobilenheter. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Siden ble interaktiv etter {timeInMs, number, seconds} s"
+    "message": "Interaktiv etter {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Siden ble interaktiv på simulert mobilnettverk etter {timeInMs, number, seconds} s"
+    "message": "Siden ble interaktiv på det simulerte mobilnettverket etter {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Siden lastes ikke inn raskt nok over mobilnettverk"
@@ -534,16 +765,22 @@
     "message": "Tid til interaktiv"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Den potensielle første inndataforsinkelsen som brukerne dine kan oppleve, er varigheten (i millisekunder) av den lengste oppgaven."
+    "message": "Den maksimale potensielle forsinkelsen for første inndata som brukerne dine kan oppleve, er varigheten (i millisekunder) av den lengste oppgaven. [Finn ut mer](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Størst mulige FID"
+    "message": "Maks forsinkelse for første inndata"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Hastighetsindeksen viser hvor raskt innhold på en side blir synlig. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Hastighetsindeksen viser hvor raskt innholdet på siden blir synlig. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Hastighetsindeks"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Summen av alle tidsperiodene mellom første innholdsrike opptegning (FCP) og tid til interaktiv, når oppgavelengden har overskredet 50 ms, uttrykt i millisekunder."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Total blokkeringstid"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Rundturstidene (RTT) for nettverket har stor innvirkning på ytelsen. Hvis RTT-en til et bestemt opprinnelsessted er høy, tyder det på at tjenere som befinner seg nærmere brukeren, muligens kan gi bedre ytelse. [Finn ut mer](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,11 +794,32 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Forsinkelser i tjenerdelen"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Over budsjett"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Sørg for at antall nettverksforespørsler og størrelsen på disse er lavere enn målene som er angitt i det aktuelle ytelsesbudsjettet. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 forespørsel}other{# forespørsler}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Ytelsesbudsjett"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Viderekoblinger fører til flere forsinkelser før siden kan lastes inn. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Unngå flere viderekoblinger av siden"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "For å angi budsjetter for antall sideressurser og størrelsen på disse, legg til en budget.json-fil. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 forespørsel}other{# forespørsler}} • {byteCount, number, bytes} kB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Minimer antall forespørsler og størrelsen på overføringer"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Kanoniske linker foreslår hvilken nettadresse som skal vises i søkeresultater. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
@@ -576,7 +834,7 @@
     "message": "Ugyldig nettadresse ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Peker til en annen «hreflang»-plassering ({url})"
+    "message": "Peker til en annen `hreflang`-plassering ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relativ nettadresse ({url})"
@@ -585,19 +843,16 @@
     "message": "Peker til domenets rotadresse (startsiden) i stedet for en tilsvarende side med innhold"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokumentet har ikke noe gyldig «rel=canonical»-element"
+    "message": "Dokumentet har ikke noe gyldig `rel=canonical`-element"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokumentet har et gyldig «rel=canonical»-element"
+    "message": "Dokumentet har en gyldig `rel=canonical`-link"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Skriftstørrelser på mindre enn 12 px er for små til å være leselige og gjør at besøkende på mobil må «klype for å zoome» for å klare å lese teksten. Prøv å sørge for at mer enn 60 % av teksten på siden er 12 px eller større. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "{decimalProportion, number, extendedPercent} av teksten er leselig"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} av teksten er for liten."
+    "message": "{decimalProportion, number, extendedPercent} lesbar tekst"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Teksten er uleselig fordi det ikke er noen viewport-metatag som er optimalisert for mobilskjermer."
@@ -615,10 +870,10 @@
     "message": "hreflang-linker forteller søkemotorer hvilken sideversjon som skal føres opp i søkeresultatene for bestemte språk eller regioner. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokumentet har ikke noe gyldig «hreflang»-attributt"
+    "message": "Dokumentet har ikke noe gyldig `hreflang`-attributt"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokumentet har et gyldig «hreflang»-attributt"
+    "message": "Dokumentet har et gyldig `hreflang`-attributt"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Sider med HTTP-statuskoder som indikerer mislykkede forespørsler, indekseres kanskje ikke skikkelig. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Overlappende trykkbart element"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Størrelse"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Trykkbart element"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Trykkbare elementer er store nok"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Tid i hovedtråden"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Tredjepart"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Tredjepartskode kan ha betydelig innvirkning på hvor lang tid det tar å laste inn siden. Begrens antallet overflødige tredjepartsleverandører, og prøv å laste inn tredjepartskode etter at siden for det meste er ferdig innlastet. [Finn ut mer](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 tredjepart er funnet}other{# tredjeparter er funnet}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Tredjepartsbruk"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Tid til første byte identifiserer tidspunktet da tjeneren sendte et svar. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Varighet"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Navn"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Starttid"
   },
@@ -744,7 +1008,7 @@
     "message": "Type"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Vurder å utstyre appen din med User Timing API for å måle appens reelle ytelse under viktige brukeropplevelser. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Vurder å utstyre appen din med brukertiming-API-et for å måle appens reelle ytelse under viktige brukeropplevelser. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{ 1 brukertiming}other{# brukertiminger}}"
@@ -753,19 +1017,19 @@
     "message": "User Timing – merker og intervaller"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Det ble funnet en <link> for forhåndstilkobling for «{securityOrigin}», men denne ble ikke brukt av nettleseren. Kontrollér at du bruker «crossorigin»-attributtet riktig."
+    "message": "Det ble funnet en <link> for forhåndstilkobling for {securityOrigin}, men denne ble ikke brukt av nettleseren. Kontrollér at du bruker `crossorigin`-attributtet riktig."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Vurder å legge til ressurshint (preconnect eller dns-prefetch) for å opprette tidlige tilkoblinger til viktige tredjepartsplasseringer. [Finn ut mer] (https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Vurder å legge til ressurshint (preconnect eller dns-prefetch) for å opprette tidlige tilkoblinger til viktige tredjepartsplasseringer. [Finn ut mer](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Opprett forhåndstilkobling til nødvendige domenenavn"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Det ble funnet en <link> for forhåndsinnlasting for «{preloadURL}», men denne ble ikke brukt av nettleseren. Kontrollér at du bruker «crossorigin»-attributtet riktig."
+    "message": "Det ble funnet en <link> for forhåndsinnlasting for {preloadURL}, men denne ble ikke brukt av nettleseren. Kontrollér at du bruker `crossorigin`-attributtet riktig."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Vurder bruk av <link rel=preload> for å prioritere henting av ressurser som for øyeblikket er forespurt senere i sideinnlastingen. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Vurder å bruke `<link rel=preload>` for å prioritere henting av ressurser som for øyeblikket blir forespurt senere i sideinnlastingen. [Finn ut mer](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Forhåndsinnlast (preload) nøkkelforespørsler"
@@ -792,7 +1056,7 @@
     "message": "Disse kontrollene fremhever muligheter til [å gjøre nettprogrammet ditt mer tilgjengelig](https://developers.google.com/web/fundamentals/accessibility). Kun et utvalg av tilgjengelighetsproblemer kan oppdages automatisk, så du bør teste manuelt i tillegg."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Disse elementene tar for seg områder som ikke kan dekkes av automatiske testverktøy. Finn ut mer i veiledningen vår om [å utføre tilgjengelighetsgjennomganger](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Disse punktene tar for seg områder som ikke kan dekkes av automatiske testverktøy. Finn ut mer i veiledningen vår om [å utføre tilgjengelighetsgjennomganger](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Tilgjengelighet"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabeller og lister"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Gode fremgangsmåter"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Ytelsesbudsjetter angir standarder for ytelsen på nettstedet."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budsjetter"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Mer informasjon om ytelsen til appen din."
+    "message": "Mer informasjon om ytelsen til appen din. Disse tallene har ingen [direkte innvirkning](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) på ytelsespoengsummen."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostikk"
@@ -840,7 +1113,7 @@
     "message": "Forbedringer av første opptegning"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Disse optimaliseringene kan gjøre sideinnlastingen raskere."
+    "message": "Disse forslagene kan bidra til at siden lastes inn raskere. De har ingen [direkte innvirkning](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) på ytelsespoengsummen."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Muligheter"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Buffer-TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Posisjon"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Navn"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Forespørsler"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Ressurstype"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Størrelse (kB)"
+    "message": "Størrelse"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Brukt tid"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Overføringsstørrelse"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "Nettadresse"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potensielle besparelser (kB)"
+    "message": "Potensielle besparelser"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potensielle besparelser (ms)"
+    "message": "Potensielle besparelser"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Potensielle besparelser på {wastedBytes, number, bytes} kB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "Potensiell besparelse på {wastedMs, number, milliseconds} ms"
+    "message": "Potensielle besparelser på {wastedMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Skrifttype"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Bilde"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Medier"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Annet"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skript"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stilark"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Tredjepart"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Totalt"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Noe gikk galt med sporingsregistreringen for sideinnlastingen. Kjør Lighthouse på nytt. ({errorCode})"
@@ -930,13 +1245,19 @@
     "message": "Tidsavbrudd under venting på første tilkobling fra feilsøkingsprogramprotokollen."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome samlet ingen skjermdumper under innlasting av siden. Sørg for at det er synlig innhold på siden, og prøv deretter å kjøre Lighthouse på nytt. ({errorCode})"
+    "message": "Chrome samlet ingen skjermdumper under innlasting av siden. Sørg for at det finnes synlig innhold på siden, og prøv deretter å kjøre Lighthouse på nytt. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS-tjenerne kunne ikke oversette domenet du oppga."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Den obligatoriske {artifactName}-samleren støtte på en feil: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Det oppsto en intern Chrome-feil. Start Chrome på nytt, og prøv å kjøre Lighthouse igjen."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Den obligatoriske {artifactName}-samleren ble ikke kjørt."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse kunne ikke laste inn den forespurte siden på en pålitelig måte. Sjekk at du tester riktig nettadresse, og at tjeneren svarer ordentlig på alle forespørsler."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse kunne ikke laste inn den forespurte nettadressen på en pålitelig måte, fordi siden sluttet å svare."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Nettadressen du oppga, har ikke gyldig sikkerhetslegitimasjon. {securityMessages}"
+    "message": "Nettadressen du oppga, har ikke noe gyldig sikkerhetssertifikat. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome forhindret siden fra å lastes inn og viste en interstitial-skjerm i stedet. Sjekk at du tester riktig nettadresse, og at tjeneren svarer ordentlig på alle forespørsler."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse kunne ikke laste inn den forespurte siden på en pålitelig måte. Sjekk at du tester riktig nettadresse, og at tjeneren svarer ordentlig på alle forespørsler. (Detaljer: {errorDetails})"
@@ -984,7 +1308,7 @@
     "message": "Prøvefunksjonsdata"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) – analyse av den nåværende siden på et emulert mobilnettverk. Verdiene er anslått og kan variere."
+    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/)-analyse av den nåværende siden på et emulert mobilnettverk. Verdiene er anslått og kan variere."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Tilleggselementer for manuell kontroll"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Vis fragment"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Vis tredjepartsressurser"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Det oppsto problemer som påvirker denne kjøringen av Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Verdiene er anslått og kan variere."
+    "message": "Verdiene er anslått og kan variere. Ytelsespoengsummen er [kun basert på disse verdiene](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Revisjoner som er bestått, men med advarsler"
@@ -1053,7 +1380,7 @@
     "message": "Vurder å bruke et [WordPress-programtillegg for bildeoptimalisering](https://wordpress.org/plugins/search/optimize+images/) som komprimerer bildene uten at det går ut over kvaliteten."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Last opp bilder direkte gjennom [mediebiblioteket](https://codex.wordpress.org/Media_Library_Screen) for å sikre at de nødvendige bildestørrelsene er tilgjengelige, og sett dem deretter inn fra mediebiblioteket eller bruk bildemodulen for å sikre at de optimale bildestørrelsene brukes (inkludert dem som brukes for responsive stoppunkter). Unngå å bruke bilder i full størrelse med mindre dimensjonene er tilstrekkelige for bruksområdet. [Finn ut mer](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Last opp bilder direkte gjennom [mediebiblioteket](https://codex.wordpress.org/Media_Library_Screen) for å sikre at de nødvendige bildestørrelsene er tilgjengelige, og sett dem deretter inn fra mediebiblioteket eller bruk bildemodulen for å sikre at de optimale bildestørrelsene brukes (inkludert dem som brukes for responsive stoppunkter). Unngå å bruke `Full Size`-bilder med mindre størrelsen er tilstrekkelig for bruksområdet. [Finn ut mer](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Du kan slå på tekstkomprimering i oppsettet av nettjeneren."

--- a/lighthouse-core/lib/i18n/locales/pl.json
+++ b/lighthouse-core/lib/i18n/locales/pl.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Klawisze dostępu umożliwiają szybkie ustawienie fokusu na określonej części strony. Aby nawigacja działała dobrze, każdy klawisz dostępu musi być unikalny. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Klawisze dostępu umożliwiają szybkie ustawienie fokusu na określonej części strony. Aby nawigacja działała dobrze, każdy klawisz dostępu musi być unikalny. [Więcej informacji](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Wartości atrybutu [accesskey] nie są unikalne"
+    "message": "Wartości `[accesskey]` nie są unikalne"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Wartości [accesskey] są unikalne"
+    "message": "Wartości `[accesskey]` są unikalne"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Każda „rola” ARIA obsługuje podzbiór atrybutów „aria-*”. Niezgodność powoduje, że atrybuty „aria-*” stają się nieprawidłowe. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Każda `role` ARIA obsługuje podzbiór atrybutów `aria-*`. Brak ich dopasowania skutkuje niepoprawnością atrybutów `aria-*`. [Więcej informacji](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Atrybuty [aria-*] nie pasują do swoich ról"
+    "message": "Atrybuty `[aria-*]` nie pasują do swoich ról"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Atrybuty [aria-*] odpowiadają swoim rolom"
+    "message": "Atrybuty `[aria-*]` odpowiadają swoim rolom"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Niektóre role ARIA mają atrybuty wymagane, które opisują stan elementu na potrzeby czytników ekranu. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Niektóre role ARIA mają atrybuty wymagane, które opisują stan elementu na potrzeby czytników ekranu. [Więcej informacji](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Elementy z atrybutem [role] nie mają wszystkich wymaganych atrybutów [aria-*]"
+    "message": "Elementy z atrybutem `[role]` nie mają wszystkich wymaganych atrybutów `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Elementy z atrybutem [role] mają wszystkie wymagane atrybuty [aria-*]"
+    "message": "Elementy `[role]` mają wszystkie wymagane atrybuty `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Niektóre role nadrzędne ARIA muszą zawierać określone role podrzędne, by poprawnie realizować funkcje ułatwień dostępu. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Niektóre role nadrzędne ARIA muszą zawierać określone role podrzędne, by poprawnie realizować funkcje ułatwień dostępu. [Więcej informacji](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Elementy z atrybutem [role] wymagają elementów podrzędnych z określonym atrybutem [role], których brak."
+    "message": "Elementy z atrybutem `[role]` wymagają elementów podrzędnych z określonym atrybutem `[role]`, których brak."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Obecne są elementy z atrybutem [role], które wymagają elementów podrzędnych z określonym atrybutem [role]"
+    "message": "Obecne są elementy z atrybutem `[role]`, które wymagają elementów podrzędnych z określonym atrybutem `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Niektóre role podrzędne ARIA muszą znajdować się wewnątrz określonych ról nadrzędnych, by poprawnie realizować funkcje ułatwień dostępu. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Niektóre role podrzędne ARIA muszą znajdować się wewnątrz określonych ról nadrzędnych, by poprawnie realizować funkcje ułatwień dostępu. [Więcej informacji](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Elementy [role] nie znajdują się wewnątrz wymaganych elementów nadrzędnych"
+    "message": "Elementy `[role]` nie znajdują się wewnątrz wymaganych elementów nadrzędnych"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Elementy z atrybutami [role] znajdują się wewnątrz wymaganych elementów nadrzędnych"
+    "message": "Elementy `[role]` znajdują się wewnątrz wymaganych elementów nadrzędnych"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Role ARIA muszą mieć prawidłowe wartości, by poprawnie realizować funkcje ułatwień dostępu. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Role ARIA muszą mieć prawidłowe wartości, by poprawnie realizować funkcje ułatwień dostępu. [Więcej informacji](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Wartości atrybutów [role] są nieprawidłowe"
+    "message": "Wartości `[role]` są nieprawidłowe"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Wartości [role] są prawidłowe"
+    "message": "Wartości `[role]` są prawidłowe"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Technologie wspomagające, takie jak czytniki ekranu, nie potrafią interpretować atrybutów ARIA o nieprawidłowej wartości. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Technologie wspomagające, takie jak czytniki ekranu, nie potrafią interpretować atrybutów ARIA o nieprawidłowej wartości. [Więcej informacji](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Atrybuty [aria-*] nie mają prawidłowych wartości"
+    "message": "Atrybuty `[aria-*]` nie mają prawidłowych wartości"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Atrybuty [aria-*] mają prawidłowe wartości"
+    "message": "Atrybuty `[aria-*]` mają prawidłowe wartości"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Technologie wspomagające, takie jak czytniki ekranu, nie potrafią interpretować atrybutów ARIA o nieprawidłowych nazwach. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Technologie wspomagające, takie jak czytniki ekranu, nie potrafią interpretować atrybutów ARIA o nieprawidłowych nazwach. [Więcej informacji](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Atrybuty [aria-*] są nieprawidłowe lub są w nich literówki"
+    "message": "Atrybuty `[aria-*]` są nieprawidłowe lub są w nich literówki"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Atrybuty [aria-*] są prawidłowe i nie ma w nich literówek"
+    "message": "Atrybuty `[aria-*]` są prawidłowe i nie ma w nich literówek"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Dzięki napisom z elementów audio mogą korzystać osoby niesłyszące i słabosłyszące. Napisy zawierają ważne informacje na przykład o tym, kto i co mówi, a także informacje niedotyczące mowy. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Dzięki napisom z elementów audio mogą korzystać osoby niesłyszące i słabosłyszące. Napisy zawierają ważne informacje na przykład o tym, kto i co mówi, a także informacje niedotyczące mowy. [Więcej informacji](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Elementy <audio> nie zawierają elementu <track> z atrybutem [kind=\"captions\"]."
+    "message": "Elementy `<audio>` nie mają elementu `<track>` z atrybutem `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Elementy <audio> zawierają element <track> z atrybutem [kind=\"captions\"]"
+    "message": "Elementy `<audio>` zawierają element `<track>` z atrybutem `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Nieprawidłowe elementy"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Gdy przycisk nie ma nazwy na potrzeby ułatwień dostępu, czytniki ekranu określają go jako „przycisk”, przez co jest on bezużyteczny dla ich użytkowników. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Gdy przycisk nie ma nazwy na potrzeby ułatwień dostępu, czytniki ekranu określają go jako „przycisk”, przez co jest on bezużyteczny dla ich użytkowników. [Więcej informacji](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Przyciski nie mają nazw dostępnych dla czytników ekranu"
@@ -93,7 +93,7 @@
     "message": "Przyciski mają nazwy dostępne dla czytników ekranu"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Dodanie sposobu na ominięcie powtarzających się treści ułatwia nawigację na stronie za pomocą klawiatury. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Dodanie sposobu na ominięcie powtarzających się treści ułatwia nawigację na stronie za pomocą klawiatury. [Więcej informacji](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Strona nie zawiera nagłówka, linku pomijającego ani regionu orientacyjnego"
@@ -102,7 +102,7 @@
     "message": "Strona zawiera nagłówek, link pomijający lub region orientacyjny"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Wielu użytkowników ma problemy z czytaniem tekstu o niskim kontraście. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Wielu użytkowników ma problemy z czytaniem tekstu o niskim kontraście. [Więcej informacji](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Kolory tła i pierwszego planu mają niewystarczający współczynnik kontrastu."
@@ -111,88 +111,88 @@
     "message": "Kolory tła i pierwszego planu mają wystarczający współczynnik kontrastu"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Gdy listy definicji nie mają właściwej struktury, czytniki ekranu mogą odczytywać je niedokładnie lub błędnie. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Gdy listy definicji nie mają właściwej struktury, czytniki ekranu mogą odczytywać je niedokładnie lub błędnie. [Więcej informacji](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Elementy <dl> nie zawierają tylko właściwie uporządkowanych grup elementów <dt> i <dd> oraz elementów <script> lub <template>."
+    "message": "Elementy `<dl>` nie zawierają tylko właściwie uporządkowanych grup elementów `<dt>` i `<dd>` oraz elementów `<script>` lub `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Elementy <dl> zawierają tylko właściwie uporządkowane grupy elementów <dt> i <dd> oraz elementy <script> lub <template>."
+    "message": "Elementy `<dl>` zawierają tylko właściwie uporządkowane grupy elementów `<dt>` i `<dd>` oraz elementy `<script>` lub `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Elementy listy definicji (<dt> i <dd>) muszą znajdować się wewnątrz nadrzędnego elementu <dl>, by czytniki ekranu mogły je poprawnie odczytać. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Elementy listy definicji (`<dt>` i `<dd>`) muszą znajdować się wewnątrz nadrzędnego elementu `<dl>`, by mogły je poprawnie odczytać czytniki ekranu. [Więcej informacji](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Elementy listy definicji nie znajdują się wewnątrz elementów <dl>"
+    "message": "Elementy listy definicji nie znajdują się wewnątrz elementów `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Elementy listy definicji znajdują się wewnątrz elementów <dl>"
+    "message": "Elementy listy definicji znajdują się wewnątrz elementów `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Tytuł informuje użytkowników czytnika ekranu o ogólnej zawartości strony, a użytkownicy wyszukiwarki mogą dowiedzieć się z niego, czy strona zawiera szukane informacje. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Tytuł informuje użytkowników czytnika ekranu o ogólnej zawartości strony, a użytkownicy wyszukiwarki mogą dowiedzieć się z niego, czy strona zawiera szukane informacje. [Więcej informacji](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokument nie ma elementu <title>"
+    "message": "W dokumencie nie ma elementu `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokument ma element <title>"
+    "message": "Dokument zawiera element `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Wartość atrybutu id musi być unikalna, by inne wystąpienia nie zostały pominięte przez technologie wspomagające. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Wartość atrybutu id musi być unikalna, by inne wystąpienia nie zostały pominięte przez technologie wspomagające. [Więcej informacji](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Atrybuty [id] na stronie nie są unikalne"
+    "message": "Atrybuty `[id]` na stronie nie są unikalne"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Atrybuty [id] na stronie są unikalne"
+    "message": "Atrybuty `[id]` na stronie są unikalne"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Tytuły ramek służą użytkownikom czytników ekranu jako opisy zawartości ramek. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Tytuły ramek służą użytkownikom czytników ekranu jako opisy zawartości ramek. [Więcej informacji](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Elementy <frame> lub <iframe> bez tytułu"
+    "message": "Element `<frame>` lub `<iframe>` nie ma tytułu"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Elementy <frame> i <iframe> mają tytuły"
+    "message": "Elementy `<frame>` i `<iframe>` mają tytuł"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Jeśli strona nie ma atrybutu lang, czytnik ekranu przyjmuje, że strona jest w języku domyślnym, który użytkownik wybrał podczas konfigurowania czytnika. Jeśli strona nie jest w języku domyślnym, czytnik ekranu może niepoprawnie wymawiać tekst strony. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Jeśli strona nie ma atrybutu lang, czytnik ekranu przyjmuje, że strona jest w języku domyślnym, który użytkownik wybrał podczas konfigurowania czytnika. Jeśli strona nie jest w języku domyślnym, czytnik ekranu może niepoprawnie wymawiać tekst strony. [Więcej informacji](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Element <html> nie ma atrybutu [lang]"
+    "message": "Element `<html>` nie ma atrybutu `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Element <html> ma atrybut [lang]"
+    "message": "Element `<html>` ma atrybut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Określenie prawidłowego [języka BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) pomaga czytnikom ekranu prawidłowo wymawiać tekst. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Określenie prawidłowego [języka BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) pomaga czytnikom ekranu prawidłowo wymawiać tekst. [Więcej informacji](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Element <html> nie ma prawidłowej wartości atrybutu [lang]."
+    "message": "Element `<html>` nie ma prawidłowej wartości atrybutu `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Element <html> ma prawidłową wartość atrybutu [lang]"
+    "message": "Element `<html>` ma prawidłową wartość atrybutu `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Elementy informacyjne powinny mieć krótki, opisowy tekst zastępczy. Elementy dekoracyjne można zignorować, podając pusty atrybut alt. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Elementy informacyjne powinny mieć krótki, opisowy tekst zastępczy. Elementy dekoracyjne można zignorować, podając pusty atrybut alt. [Więcej informacji](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Elementy graficzne nie mają atrybutów [alt]"
+    "message": "Elementy graficzne nie mają atrybutów `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Elementy graficzne mają atrybuty [alt]"
+    "message": "Elementy graficzne mają atrybuty `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Gdy jako przycisk <input> używany jest obraz, warto dodać tekst zastępczy, by ułatwić użytkownikom czytnika ekranu zrozumienie, do czego służy ten przycisk. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Gdy jako przycisk `<input>` używany jest obraz, warto dodać tekst zastępczy, by ułatwić użytkownikom czytnika ekranu zrozumienie, do czego służy ten przycisk. [Więcej informacji](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Elementy <input type=\"image\"> nie mają tekstu [alt]"
+    "message": "Elementy `<input type=\"image\">` nie mają tekstu `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Elementy <input type=\"image\"> mają atrybut [alt] z tekstem"
+    "message": "Elementy `<input type=\"image\">` mają tekst `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Etykiety zapewniają prawidłowe odczytywanie kontrolek formularzy przez technologie wspomagające takie jak czytniki ekranu. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Etykiety zapewniają prawidłowe odczytywanie kontrolek formularzy przez technologie wspomagające takie jak czytniki ekranu. [Więcej informacji](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Z elementami formularzy nie są powiązane etykiety"
@@ -201,16 +201,16 @@
     "message": "Z elementami formularzy są powiązane etykiety"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Tabela używana do tworzenia układu nie powinna zawierać elementów danych, takich jak elementy th czy caption albo atrybut summary, ponieważ mogą one utrudniać korzystanie z czytnika ekranu. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Tabela używana do tworzenia układu nie powinna zawierać elementów danych, takich jak elementy th czy caption albo atrybut summary, ponieważ mogą one utrudniać korzystanie z czytnika ekranu. [Więcej informacji](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "W prezentacyjnych elementach <table> są używane elementy <th> lub <caption> albo atrybut [summary]."
+    "message": "W prezentacyjnych elementach `<table>` są używane elementy `<th>` lub `<caption>` albo atrybut `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "W prezentacyjnych elementach <table> nie są używane elementy <th> lub <caption> albo atrybut [summary]."
+    "message": "W prezentacyjnych elementach `<table>` nie są używane elementy `<th>` i `<caption>` ani atrybut `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Tekst linków (i tekst zastępczy obrazów używanych jako linki), który jest charakterystyczny, unikalny i możliwy do wybrania, ułatwia nawigację użytkownikom czytników ekranu. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Tekst linków (i tekst zastępczy obrazów używanych jako linki), który jest charakterystyczny, unikalny i możliwy do wybrania, ułatwia nawigację użytkownikom czytników ekranu. [Więcej informacji](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Linki nie mają wyróżniających je nazw"
@@ -219,103 +219,115 @@
     "message": "Linki mają wyróżniające je nazwy"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Czytniki ekranu odczytują listy w specjalny sposób. Właściwa struktura list pomaga czytnikom poprawnie odczytać tekst. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Czytniki ekranu odczytują listy w specjalny sposób. Właściwa struktura list pomaga czytnikom poprawnie odczytać tekst. [Więcej informacji](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Listy nie zawierają tylko elementów <li> i elementów skryptowych (<script> i <template>)."
+    "message": "Listy nie zawierają tylko elementów `<li>` i elementów skryptowych (`<script>` i `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Listy zawierają tylko elementy <li> i elementy skryptowe (<script> i <template>)."
+    "message": "Listy zawierają tylko elementy `<li>` i elementy skryptowe (`<script>` i `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Elementy list (<li>) muszą być zawarte w elementach nadrzędnych <ul> lub <ol>, by czytniki ekranu mogły je poprawnie odczytać. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Elementy list (`<li>`) muszą być zawarte w elementach nadrzędnych `<ul>` lub `<ol>`, by czytniki ekranu mogły je poprawnie odczytać. [Więcej informacji](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Elementy listy (<li>) nie znajdują się wewnątrz elementów nadrzędnych <ul> lub <ol>."
+    "message": "Elementy list (`<li>`) nie znajdują się wewnątrz elementów nadrzędnych `<ul>` lub `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Elementy list (<li>) znajdują się wewnątrz elementów nadrzędnych <ul> lub <ol>"
+    "message": "Elementy list (`<li>`) znajdują się wewnątrz elementów nadrzędnych `<ul>` lub `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Użytkownicy nie spodziewają się automatycznego odświeżania strony – powoduje ono powrót fokusu na początek strony. Może to dezorientować i irytować użytkowników. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Użytkownicy nie spodziewają się automatycznego odświeżania strony – powoduje ono powrót fokusu na jej początek. Może to dezorientować i irytować użytkowników. [Więcej informacji](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokument używa <meta http-equiv=\"refresh\">"
+    "message": "Dokument używa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "W dokumencie nie jest używany element <meta http-equiv=\"refresh\">"
+    "message": "Dokument nie używa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Wyłączenie powiększania to problem dla użytkowników niedowidzących, którzy muszą korzystać z powiększenia ekranu, by dobrze widzieć zawartość stron internetowych. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Wyłączenie powiększania to problem dla użytkowników niedowidzących, którzy muszą korzystać z powiększenia ekranu, by dobrze widzieć zawartość stron internetowych. [Więcej informacji](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "W elemencie <meta name=\"viewport\"> jest używany atrybut [user-scalable=\"no\"] albo atrybut [maximum-scale] ma wartość mniejszą niż 5."
+    "message": "W elemencie `<meta name=\"viewport\">` jest używany atrybut `[user-scalable=\"no\"]` lub atrybut `[maximum-scale]` ma wartość mniejszą niż 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "Atrybut [user-scalable=\"no\"] nie jest używany w elemencie <meta name=\"viewport\">, a atrybut [maximum-scale] ma wartość nie mniejszą niż 5."
+    "message": "W elemencie `<meta name=\"viewport\">` nie jest używany atrybut `[user-scalable=\"no\"]`, a atrybut `[maximum-scale]` ma wartość nie mniejszą niż 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Czytniki ekranu nie potrafią tłumaczyć treści innych niż tekst. Dodanie do elementów <object> tekstu zastępczego pomaga czytnikom ekranu w przekazywaniu użytkownikom właściwego znaczenia. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Czytniki ekranu nie potrafią tłumaczyć treści innych niż tekst. Dodanie do elementów `<object>` tekstu zastępczego pomaga czytnikom ekranu w przekazywaniu użytkownikom właściwego znaczenia. [Więcej informacji](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Elementy <object> nie mają tekstu [alt]"
+    "message": "Elementy `<object>` nie mają tekstu `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Elementy <object> mają tekst [alt]"
+    "message": "Elementy `<object>` mają tekst `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Wartość większa niż 0 implikuje określoną wprost kolejność nawigacji. Chociaż takie rozwiązanie jest technicznie poprawne, często powoduje frustrację użytkowników technologii wspomagających. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Wartość większa niż 0 implikuje określoną wprost kolejność nawigacji. Chociaż takie rozwiązanie jest technicznie poprawne, często powoduje frustrację użytkowników technologii wspomagających. [Więcej informacji](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Niektóre elementy mają atrybut [tabindex] o wartości większej niż 0"
+    "message": "Niektóre elementy mają atrybut `[tabindex]` o wartości większej niż 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Żaden element nie ma wartości atrybutu [tabindex] większej niż 0"
+    "message": "Żaden element nie ma wartości atrybutu `[tabindex]` większej niż 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Czytniki ekranu mają funkcje, które ułatwiają nawigację w tabelach. Gdy komórki <td> używające atrybutu [headers] odwołują się tylko do innych komórek w tej samej tabeli, użytkownicy czytników ekranu mogą wygodniej korzystać z tabel. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Czytniki ekranu mają funkcje, które ułatwiają nawigację w tabelach. Gdy komórki `<td>` używające atrybutu `[headers]` odwołują się tylko do innych komórek w tej samej tabeli, użytkownicy czytników ekranu mogą wygodniej korzystać z tabel. [Więcej informacji](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Komórki elementu <table>, które używają atrybutu [headers], odwołują się do innych komórek tej samej tabeli."
+    "message": "Komórki w elemencie `<table>`, które używają atrybutu `[headers]`, odwołują się do innych komórek w tej samej tabeli."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Komórki elementu <table>, które używają atrybutu [headers], odwołują się tylko do innych komórek tej samej tabeli."
+    "message": "Komórki w elemencie `<table>`, które używają atrybutu `[headers]`, odwołują się tylko do innych komórek w tej samej tabeli."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Czytniki ekranu mają funkcje, które ułatwiają nawigację w tabelach. Gdy nagłówki tabel zawsze odwołują się do jakiegoś zbioru komórek, użytkownicy czytników ekranu mogą wygodniej korzystać z tabel. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Czytniki ekranu mają funkcje, które ułatwiają nawigację w tabelach. Gdy nagłówki tabel zawsze odwołują się do jakiegoś zbioru komórek, użytkownicy czytników ekranu mogą wygodniej korzystać z tabel. [Więcej informacji](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Nie istnieją komórki danych opisywane przez elementy <th> i elementy z atrybutem [role=\"columnheader\"/\"rowheader\"]."
+    "message": "Nie istnieją komórki danych opisywane przez elementy `<th>` i elementy z atrybutem `[role=\"columnheader\"/\"rowheader\"]`."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Istnieją komórki danych opisywane przez elementy <th> i elementy z atrybutem [role=\"columnheader\"/\"rowheader\"]."
+    "message": "Istnieją komórki danych opisywane przez elementy `<th>` i elementy z atrybutem `[role=\"columnheader\"/\"rowheader\"]`."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Określenie prawidłowego [języka BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) elementów pomaga zapewnić prawidłową wymowę tekstu przez czytnik ekranu. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Określenie prawidłowego [języka BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) elementów pomaga zapewnić prawidłową wymowę tekstu przez czytnik ekranu. [Więcej informacji](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Atrybuty [lang] nie mają prawidłowej wartości"
+    "message": "Atrybuty `[lang]` nie mają prawidłowej wartości"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Atrybuty [lang] mają prawidłową wartość"
+    "message": "Atrybuty `[lang]` mają prawidłową wartość"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Filmy z napisami są bardziej dostępne dla osób niesłyszących i niedosłyszących. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Filmy z napisami są bardziej dostępne dla osób niesłyszących i niedosłyszących. [Więcej informacji](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Elementy <video> nie zawierają elementu <track> z atrybutem [kind=\"captions\"]."
+    "message": "Elementy `<video>` nie zawierają elementu `<track>` z atrybutem `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Elementy <video> zawierają element <track> z atrybutem [kind=\"captions\"]"
+    "message": "Elementy `<video>` zawierają element `<track>` z atrybutem `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Audiodeskrypcja dostarcza ważnych informacji, których nie ma w dialogach – na przykład o wyrazie twarzy i scenerii. [Więcej informacji](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Audiodeskrypcja dostarcza ważnych informacji, których nie ma w dialogach – na przykład o wyrazie twarzy i scenerii. [Więcej informacji](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Elementy <video> nie zawierają elementu <track> z atrybutem [kind=\"description\"]."
+    "message": "Elementy `<video>` nie zawierają elementu `<track>` z atrybutem `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Elementy <video> zawierają element <track> z atrybutem [kind=\"description\"]"
+    "message": "Elementy `<video>` zawierają element `<track>` z atrybutem `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Aby witryna dobrze prezentowała się na iOS po dodaniu jej do ekranu głównego, określ atrybut apple-touch-icon. Musi on wskazywać kwadratowy obraz PNG o rozmiarze 192 (lub 180) pikseli bez przezroczystości. [Więcej informacji](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Nie dostarcza prawidłowego atrybutu `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Atrybut `apple-touch-icon-precomposed` jest przestarzały. Preferowany jest `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Dostarcza prawidłowy atrybut `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Rozszerzenia Chrome pogorszyły szybkość ładowania tej strony. Przeprowadź audyt strony w trybie incognito lub w profilu Chrome bez rozszerzeń."
@@ -345,13 +357,13 @@
     "message": "Użyj formatów wideo dla animacji"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Rozważ opóźnione (leniwe) ładowanie obrazów ukrytych i znajdujących się poza ekranem dopiero po zakończeniu ładowania wszystkich zasobów kluczowych, by skrócić czas do pełnej interaktywności. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
+    "message": "Aby skrócić czas do pełnej interaktywności, warto skorzystać z leniwego ładowania. Dzięki temu najpierw będą ładowane wszystkie zasoby kluczowe, a dopiero potem obrazy ukryte i znajdujące się poza ekranem. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Odłóż ładowanie obrazów poza ekranem"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Zasoby blokują pierwsze wyrenderowanie strony. Rozważ umieszczenie krytycznego kodu JS/CSS w kodzie strony i opóźnienie ładowania wszystkich niekrytycznych plików JS i stylów. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
+    "message": "Zasoby blokują pierwsze wyrenderowanie strony. Sugerujemy umieszczenie krytycznego kodu JS/CSS w kodzie strony i opóźnienie ładowania wszystkich niekrytycznych plików JS i stylów. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Wyeliminuj zasoby blokujące renderowanie"
@@ -381,7 +393,7 @@
     "message": "Minifikuj JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Usuń nieużywane reguły z arkuszy stylów i opóźnij ładowanie kodu CSS, który nie jest używany w części strony widocznej na ekranie bez przewijania, by zmniejszyć ilość danych niepotrzebnie przesyłanych w sieci. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Usuń nieużywane reguły z arkuszy stylów i opóźnij ładowanie kodu CSS, który nie jest używany w części strony widocznej na ekranie bez przewijania, by zmniejszyć ilość danych niepotrzebnie przesyłanych w sieci. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Usuń nieużywany kod CSS"
@@ -393,7 +405,7 @@
     "message": "Usuń nieużywany JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Długi czas przechowywania w pamięci podręcznej może przyspieszyć ponowne otwarcie strony. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
+    "message": "Długi czas przechowywania w pamięci podręcznej może przyśpieszyć ponowne otwarcie strony. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Znaleziono 1 zasób}few{Znaleziono # zasoby}many{Znaleziono # zasobów}other{Znaleziono # zasobu}}"
@@ -411,7 +423,7 @@
     "message": "Użyj efektywnego kodowania obrazów"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Wyświetlaj obrazy o odpowiednim rozmiarze, by oszczędzać komórkową transmisję danych i przyspieszyć ładowanie. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
+    "message": "Wyświetlaj obrazy o odpowiednim rozmiarze, by oszczędzać komórkową transmisję danych i przyśpieszyć ładowanie. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Zmień rozmiar obrazów"
@@ -423,19 +435,70 @@
     "message": "Włącz kompresję tekstu"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Formaty obrazów, takie jak JPEG 2000, JPEG XR i WebP, często dają lepszą kompresję niż PNG czy JPEG, co przekłada się na szybsze pobieranie i mniejsze wykorzystanie danych. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/webp)"
+    "message": "Takie formaty obrazów jak JPEG 2000, JPEG XR i WebP często zapewniają lepszą kompresję niż PNG czy JPEG, co przekłada się na szybsze pobieranie i mniejsze wykorzystanie danych. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Wyświetlaj obrazy w formatach nowej generacji"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Poniższe łańcuchy żądań krytycznych pokazują zasoby ładowane z wysokim priorytetem. Aby przyspieszyć ładowanie strony, możesz skrócić łańcuchy, zmniejszyć rozmiar pobieranych zasobów lub opóźnić pobieranie zasobów, które nie są niezbędne. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
+    "message": "Poniższe łańcuchy żądań krytycznych pokazują zasoby ładowane z wysokim priorytetem. Aby przyśpieszyć ładowanie strony, możesz skrócić łańcuchy, zmniejszyć rozmiar pobieranych zasobów lub opóźnić pobieranie zasobów, które nie są niezbędne. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Znaleziono 1 łańcuch}few{Znaleziono # łańcuchy}many{Znaleziono # łańcuchów}other{Znaleziono # łańcucha}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Zminimalizuj głębię żądań krytycznych"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Wycofanie/ostrzeżenie"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Wiersz"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Wycofane interfejsy API zostaną w przyszłości usunięte z przeglądarki. [Więcej informacji](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Znaleziono 1 ostrzeżenie}few{Znaleziono # ostrzeżenia}many{Znaleziono # ostrzeżeń}other{Znaleziono # ostrzeżenia}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Używa wycofanych interfejsów API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Nie używa wycofanych interfejsów API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Pamięć podręczna aplikacji jest wycofana. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Znaleziono „{AppCacheManifest}”"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Używa pamięci podręcznej aplikacji"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Nie używa pamięci podręcznej aplikacji"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Podanie doctype zapobiega przełączaniu przeglądarki w tryb osobliwości. Więcej informacji znajdziesz na [stronie dokumentacji MDN](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Nazwa doctype musi być ciągiem małych liter `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokument musi zawierać element doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Oczekiwano pustego ciągu w polu publicId"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Oczekiwano pustego ciągu w polu systemId"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Strona nie zawiera elementu HTML doctype, przez co aktywuje tryb osobliwości"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Strona ma element HTML doctype"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
@@ -447,7 +510,7 @@
     "message": "Wartość"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Twórcy przeglądarek zalecają, by strony zawierały mniej niż około 1500 elementów DOM. Optymalne jest drzewo o głębokości mniejszej niż 32 elementy i zawierające mniej niż 60 elementów podrzędnych/nadrzędnych. Duży DOM może zwiększyć wykorzystanie pamięci, wydłużyć [obliczanie stylów](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) i powodować kosztowne [przeformatowanie układu](https://developers.google.com/speed/articles/reflow). [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
+    "message": "Twórcy przeglądarek zalecają, by strony zawierały mniej niż około 1500 elementów DOM. Optymalne jest drzewo o głębokości mniejszej niż 32 elementy i zawierające mniej niż 60 elementów podrzędnych/nadrzędnych. Duży DOM może zwiększyć wykorzystanie pamięci, wydłużyć [obliczanie stylów](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) i powodować kosztowne [przeformatowania układu](https://developers.google.com/speed/articles/reflow). [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 element}few{# elementy}many{# elementów}other{# elementu}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Unika zbyt dużego DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Cel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Dodaj `rel=\"noopener\"` lub `rel=\"noreferrer\"` do wszystkich linków zewnętrznych, by przyśpieszyć działanie i zapobiec lukom w zabezpieczeniach. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Linki do innych witryn są niebezpieczne"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Linki do innych witryn są bezpieczne"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Nie można ustalić miejsca docelowego dla kotwicy ({anchorHTML}). Jeśli nie jest używana jako hiperlink, sugerujemy usunięcie target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Witryny, które bez kontekstu pytają o zgodę na dostęp do lokalizacji, nie budzą zaufania użytkowników lub ich dezorientują. Sugerujemy powiązanie wyświetlenia tej prośby z działaniem użytkownika. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Pyta o zgodę na geolokalizację podczas wczytywania strony"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Nie pyta o zgodę na geolokalizację podczas wczytywania strony"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Wersja"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Wszystkie wykryte na stronie biblioteki JavaScript interfejsu użytkownika."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Wykryte biblioteki JavaScript"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "W przypadku wolnego połączenia sieciowego skrypty zewnętrzne dodawane dynamicznie przy użyciu `document.write()` mogą opóźnić wczytanie strony o dziesiątki sekund. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Używa `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Nie używa `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Najwyższy poziom zagrożenia"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Wersja biblioteki"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Liczba luk w zabezpieczeniach"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Niektóre skrypty spoza witryny mogą mieć znane luki w zabezpieczeniach, które mogą łatwo odkryć i wykorzystać hakerzy. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Wykryto 1 lukę w zabezpieczeniach}few{Wykryto # luki w zabezpieczeniach}many{Wykryto # luk w zabezpieczeniach}other{Wykryto # luki w zabezpieczeniach}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Używa bibliotek JavaScript interfejsu użytkownika, które mają znane luki w zabezpieczeniach"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Wysoki"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Niski"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Średni"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Nie używa bibliotek JavaScript interfejsu użytkownika, które mają znane luki w zabezpieczeniach"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Witryny, które bez kontekstu pytają o zgodę na wyświetlanie powiadomień, nie budzą zaufania użytkowników lub ich dezorientują. Sugerujemy powiązanie wyświetlenia tej prośby z gestami użytkownika. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Pyta o zgodę na wyświetlanie powiadomień podczas wczytywania strony"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Nie pyta o zgodę na wyświetlanie powiadomień podczas wczytywania strony"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Nieprawidłowe elementy"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Uniemożliwianie wklejania haseł jest sprzeczne z dobrymi zasadami bezpieczeństwa. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Uniemożliwia wklejanie tekstu w polach haseł"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Pozwala wklejać tekst w polach haseł"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokół"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ma wiele funkcji niedostępnych w HTTP/1.1, m.in. nagłówki binarne, multipleksowanie i komunikaty push z serwera. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 żądanie nieprzesłane przez HTTP/2}few{# żądania nieprzesłane przez HTTP/2}many{# żądań nieprzesłanych przez HTTP/2}other{# żądania nieprzesłanego przez HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Nie używa HTTP/2 dla żadnych swoich zasobów"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Używa HTTP/2 dla własnych zasobów"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Proponujemy oznaczenie detektorów zdarzeń dotyku i kółka myszy jako `passive`, by poprawić działanie przewijania strony. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Nie używa pasywnych detektorów do poprawy działania przewijania"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Używa pasywnych detektorów do poprawy działania przewijania"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Opis"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Błędy zarejestrowane w konsoli wskazują nierozwiązane problemy. Mogą być spowodowane nieudanymi żądaniami sieciowymi i innymi problemami w przeglądarce."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Błędy przeglądarki zostały zarejestrowane w konsoli"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "W konsoli nie zostały zarejestrowane żadne błędy przeglądarki"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Użyj funkcji CSS „font-display”, by zapewnić widoczność tekstu dla użytkownika podczas ładowania czcionek internetowych. [Więcej informacji](https://developers.google.com/web/updates/2016/02/font-display)"
   },
@@ -476,8 +671,44 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Cały tekst pozostaje widoczny podczas ładowania czcionek internetowych"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse nie udało się automatycznie sprawdzić wartości font-display dla tego adresu URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Współczynnik proporcji (rzeczywisty)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Współczynnik proporcji (wyświetlany)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Wymiary wyświetlanego obrazu muszą odpowiadać naturalnemu współczynnikowi proporcji. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Wyświetla obrazy o niepoprawnym współczynniku proporcji"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Wyświetla obrazy o poprawnym współczynniku proporcji"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Nieprawidłowa informacja o rozmiarze obrazu {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Niezabezpieczony URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Wszystkie witryny powinny być zabezpieczone przy użyciu HTTPS – również te, które nie obsługują danych wrażliwych. HTTPS uniemożliwia intruzom modyfikowanie i podsłuchiwanie komunikacji między aplikacją a użytkownikami. HTTP/2 i liczne nowe interfejsy API platformy WWW wymagają używania HTTPS. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Wykryto 1 niezabezpieczone żądanie}few{Wykryto # niezabezpieczone żądania}many{Wykryto # niezabezpieczonych żądań}other{Wykryto # niezabezpieczonego żądania}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Nie używa HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Używa HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Szybkie wczytywanie stron przez sieć komórkową zapewnia dobre wrażenia użytkowników telefonów. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Szybkie wczytywanie stron przez sieć komórkową zapewnia dobre wrażenia użytkowników telefonów. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
     "message": "Interaktywna po {timeInMs, number, seconds} s"
@@ -504,7 +735,7 @@
     "message": "Minimalizuje aktywność głównego wątku"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Szacowane opóźnienie reakcji (Estimated Input Latency) jest szacunkowym czasem (w milisekundach), po którym aplikacja reaguje na działanie użytkownika w trakcie najbardziej intensywnego, pięciosekundowego okresu ładowania strony. Jeśli opóźnienie jest większe niż 50 ms, użytkownicy mogą uznać aplikację za powolną. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Szacowane opóźnienie reakcji (Estimated Input Latency) jest szacunkowym czasem (w milisekundach), po którym aplikacja reaguje na działanie użytkownika w trakcie najbardziej intensywnego, pięciosekundowego okresu ładowania strony. Jeśli opóźnienie jest większe niż 50 ms, użytkownicy mogą uznać aplikację za powolną. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Szacowane opóźnienie reakcji"
@@ -516,7 +747,7 @@
     "message": "Pierwsze wyrenderowanie treści"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "CPU bezczynny po raz pierwszy oznacza czas, gdy wątek główny jest po raz pierwszy na tyle mało obciążony, że może obsługiwać działania użytkownika. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
+    "message": "CPU bezczynny po raz pierwszy oznacza czas, gdy wątek główny na stronie jest po raz pierwszy na tyle mało obciążony, że może obsługiwać działania użytkownika. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "CPU bezczynny po raz pierwszy"
@@ -528,16 +759,16 @@
     "message": "Pierwsze wyrenderowanie elementu znaczącego"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Czas do pełnej interaktywności to czas, po którym strona staje się w pełni interaktywna. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Czas do pełnej interaktywności to czas, po którym strona staje się w pełni interaktywna. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Czas do pełnej interaktywności"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Potencjalne opóźnienie pierwszej reakcji (First Input Delay), którego mogą doświadczyć użytkownicy, to czas wykonywania (w milisekundach) najdłuższego zadania."
+    "message": "Maksymalne opóźnienie przy pierwszym działaniu, którego mogą doświadczyć użytkownicy, to czas wykonywania (w milisekundach) najdłuższego zadania. [Więcej informacji](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Maksymalne potencjalne opóźnienie pierwszej reakcji (FID)"
+    "message": "Maks. potencjalne opóźnienie przy 1. działaniu"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Indeks szybkości wskazuje, jak szybko strona zapełnia się widocznymi treściami. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
@@ -545,17 +776,35 @@
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Indeks szybkości"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Wyrażona w milisekundach suma wszystkich okresów czasu między pierwszym wyrenderowaniem treści a czasem do pełnej interaktywności, gdy długość zadania przekroczyła 50 ms."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Łączny czas zablokowania"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Czas błądzenia w sieci (RTT) ma duży wpływ na szybkość działania. Jeśli RTT do źródła jest duży, serwery znajdujące się bliżej użytkownika mogą przyspieszyć działanie. [Więcej informacji](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Czas błądzenia w sieci (RTT) ma duży wpływ na szybkość działania. Jeśli RTT do źródła jest duży, serwery znajdujące się bliżej użytkownika mogą przyśpieszyć działanie. [Więcej informacji](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Czasy błądzenia w sieci (Network Round Trip Times)"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Opóźnienie serwera może wpływać na szybkość stron internetowych. Jeśli opóźnienie serwera źródłowego jest duże, serwer może być przeciążony lub mieć mało wydajny backend. [Więcej informacji](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Opóźnienie serwera może wpływać na szybkość stron internetowych. Jeśli opóźnienie serwera źródłowego jest duże, serwer może być przeciążony lub mieć mało wydajny backend. [Więcej informacji](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Opóźnienia backendu serwera"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Przekroczenie budżetu"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Liczba ani rozmiar żądań sieciowych nie mogą przekraczać wartości określonych przez podany budżet wydajności. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 żądanie}few{# żądania}many{# żądań}other{# żądania}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Budżet wydajności"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Przekierowania wprowadzają dodatkowe opóźnienia przed rozpoczęciem ładowania strony. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
@@ -563,11 +812,20 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Unikaj wielokrotnych przekierowań"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Aby określić budżety dla liczby i rozmiaru zasobów strony, dodaj plik budget.json. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 żądanie}few{# żądania}many{# żądań}other{# żądania}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Liczba żądań i ilość przesyłanych danych powinny być małe"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Linki kanoniczne sugerują URL, który ma być pokazywany w wynikach wyszukiwania. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Linki kanoniczne sugerują URL, który ma być pokazywany w wynikach wyszukiwania. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Wiele adresów URL będących w konflikcie ({urlList})"
+    "message": "Niezgodne ze sobą adresy URL ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "Wskazuje inną domenę ({url})"
@@ -576,7 +834,7 @@
     "message": "Nieprawidłowy URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Wskazuje inną lokalizację „hreflang” ({url})"
+    "message": "Wskazuje inną lokalizację `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Względny URL ({url})"
@@ -585,19 +843,16 @@
     "message": "Wskazuje główny URL domeny (stronę główną) zamiast odpowiedniej strony z treścią"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokument nie ma prawidłowego atrybutu „rel=canonical”"
+    "message": "Dokument nie zawiera prawidłowego atrybutu `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokument ma prawidłowy atrybut „rel=canonical”"
+    "message": "Dokument ma prawidłowy atrybut `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Na urządzeniach mobilnych czcionka o rozmiarze mniejszym niż 12 pikseli jest nieczytelna, dlatego użytkownicy muszą powiększać ekran, by odczytać tekst. Ponad 60% tekstu na stronie powinno mieć rozmiar co najmniej 12 pikseli. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Na urządzeniach mobilnych czcionka o rozmiarze mniejszym niż 12 pikseli jest nieczytelna, dlatego użytkownicy muszą powiększać ekran, by odczytać tekst. Ponad 60% tekstu na stronie powinno mieć rozmiar co najmniej 12 pikseli. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} czytelnego tekstu"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} tekstu jest zbyt małe."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Tekst jest nieczytelny z powodu braku metatagu viewport zoptymalizowanego na potrzeby ekranów telefonów."
@@ -612,16 +867,16 @@
     "message": "W dokumencie używane są czytelne rozmiary czcionek"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Linki hreflang informują wyszukiwarki, którą wersję strony pokazywać w wynikach wyszukiwania dla danego języka lub regionu. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Linki hreflang informują wyszukiwarki, którą wersję strony pokazywać w wynikach wyszukiwania dla danego języka lub regionu. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokument nie ma prawidłowego atrybutu „hreflang”"
+    "message": "Dokument nie ma prawidłowego atrybutu `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokument ma prawidłowy atrybut „hreflang”"
+    "message": "Dokument ma prawidłowy atrybut `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Strony z kodem stanu HTTP oznaczającym niepowodzenie mogą nie być indeksowane poprawnie. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Strony z kodem stanu HTTP oznaczającym niepowodzenie mogą nie być indeksowane poprawnie. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "Strona ma kod stanu HTTP oznaczający niepowodzenie"
@@ -630,7 +885,7 @@
     "message": "Strona ma kod stanu HTTP oznaczający powodzenie"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Wyszukiwarki nie mogą umieszczać Twoich stron w wynikach wyszukiwania, jeśli nie mają uprawnień, by je indeksować. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Wyszukiwarki nie mogą umieszczać Twoich stron w wynikach wyszukiwania, jeśli nie mają uprawnień, by je indeksować. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Zablokowano indeksowanie strony"
@@ -639,7 +894,7 @@
     "message": "Indeksowanie strony nie jest zablokowane"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Opisowy tekst linków ułatwia wyszukiwarkom zrozumienie zawartości stron. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "Opisowy tekst linków ułatwia wyszukiwarkom zrozumienie zawartości stron. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{Znaleziono 1 link}few{Znaleziono # linki}many{Znaleziono # linków}other{Znaleziono # linku}}"
@@ -651,13 +906,13 @@
     "message": "Linki mają tekst opisowy"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Uruchom [Narzędzie do testowania uporządkowanych danych](https://search.google.com/structured-data/testing-tool/) i narzędzie [Structured Data Linter](http://linter.structured-data.org/), by sprawdzić uporządkowane dane. [Więcej informacji](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Uruchom [Narzędzie do testowania uporządkowanych danych](https://search.google.com/structured-data/testing-tool/) i narzędzie [Structured Data Linter](http://linter.structured-data.org/), by sprawdzić uporządkowane dane. [Więcej informacji](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Uporządkowane dane są prawidłowe"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Metaopis można umieścić w wynikach wyszukiwania, by krótko podsumować zawartość strony. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Metaopis można umieścić w wynikach wyszukiwania, by krótko podsumować zawartość strony. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/description)"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Tekst opisu jest pusty."
@@ -669,7 +924,7 @@
     "message": "Dokument ma metaopis"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Wyszukiwarki nie potrafią indeksować treści z wtyczek, a wiele urządzeń nie obsługuje wtyczek lub ogranicza ich działanie. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Wyszukiwarki nie potrafią indeksować treści z wtyczek, a wiele urządzeń nie obsługuje wtyczek lub ogranicza ich działanie. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "Dokument używa wtyczek"
@@ -696,7 +951,7 @@
     "message": "Plik robots.txt jest prawidłowy"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Elementy interaktywne, takie jak przyciski i linki, powinny być dostatecznie duże (48 x 48 pikseli) i mieć wokół siebie odpowiednią ilość miejsca, by można było je łatwo dotknąć, nie zahaczając o inne elementy. [Więcej informacji](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Elementy interaktywne, takie jak przyciski i linki, powinny być dostatecznie duże (48 x 48 pikseli) i mieć wokół siebie odpowiednią ilość miejsca, by można było je łatwo dotknąć, nie zahaczając o inne elementy. [Więcej informacji](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} elementów dotykowych ma odpowiednią wielkość"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Pokrywające się elementy dotykowe"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Rozmiar"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Element dotykowy"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Elementy dotykowe mają odpowiednią wielkość"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Czas w wątku głównym"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Dostawca zewnętrzny"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Kod spoza witryny może znacznie spowalniać wczytywanie stron. Ogranicz liczbę zewnętrznych dostawców kodu i spróbuj wczytywać kod spoza witryny dopiero po zakończeniu wczytywania podstawowej strony. [Więcej informacji](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Znaleziono 1 zasób kodu spoza witryny}few{Znaleziono # zasoby kodu spoza witryny}many{Znaleziono # zasobów kodu spoza witryny}other{Znaleziono # zasobu kodu spoza witryny}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Używanie kodu spoza witryny"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Czas do pierwszego bajtu oznacza czas wysłania odpowiedzi przez serwer. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
+    "message": "Czas do pierwszego bajta oznacza czas wysłania odpowiedzi przez serwer. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Czas odpowiedzi głównego dokumentu: {timeInMs, number, milliseconds} ms"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Czas trwania"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nazwa"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Czas rozpoczęcia"
@@ -753,7 +1017,7 @@
     "message": "Znaczniki i odcinki Czasu działań użytkownika"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Znaleziono element <link> wcześniejszego połączenia dla „{securityOrigin}”, który nie jest używany przez przeglądarkę. Sprawdź, czy poprawnie używasz atrybutu „crossorigin”."
+    "message": "Znaleziono element <link> wcześniejszego połączenia dla „{securityOrigin}”, który nie jest używany przez przeglądarkę. Sprawdź, czy poprawnie używasz atrybutu `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Rozważ dodanie wskazówek „preconnect” lub „dns-prefetch”, by wcześniej nawiązać połączenia z ważnymi źródłami w innych domenach. [Więcej informacji](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
@@ -762,10 +1026,10 @@
     "message": "Wcześniej nawiąż połączenia z wymaganymi źródłami"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Znaleziono element <link> wstępnego wczytywania dla „{preloadURL}”, który nie jest używany przez przeglądarkę. Sprawdź, czy poprawnie używasz atrybutu „crossorigin”."
+    "message": "Znaleziono element <link> wstępnego wczytywania dla „{preloadURL}”, który nie jest używany przez przeglądarkę. Sprawdź, czy poprawnie używasz atrybutu `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Pomyśl o użyciu deklaracji <link rel=preload>, by szybciej pobierały się zasoby, które są obecnie żądane na dalszym etapie ładowania strony. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/preload)"
+    "message": "Pomyśl o użyciu deklaracji `<link rel=preload>`, by szybciej pobierały się zasoby, które są obecnie żądane na dalszym etapie ładowania strony. [Więcej informacji](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Załaduj wstępnie kluczowe żądania"
@@ -789,7 +1053,7 @@
     "message": "Sprawdzone metody"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Te testy wskazują możliwości [poprawy ułatwień dostępu Twojej aplikacji internetowej](https://developers.google.com/web/fundamentals/accessibility). Ponieważ wykryć automatycznie można tylko część problemów z ułatwieniami dostępu, wskazane jest przeprowadzenie testów ręcznych."
+    "message": "Te testy wskazują możliwości [poprawy ułatwień dostępu Twojej aplikacji internetowej](https://developers.google.com/web/fundamentals/accessibility). Ponieważ wykryć automatycznie można tylko część problemów z ułatwieniami dostępu, wskazane jest przeprowadzenie też testów ręcznych."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "Te pozycje dotyczą obszarów, których narzędzie do testów automatycznych nie może zbadać. Więcej informacji w naszym przewodniku po [prowadzeniu przeglądu ułatwień dostępu](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabele i listy"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Sprawdzone metody"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Budżety wydajności są podstawą do określania standardów wydajności witryny."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budżety"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Więcej informacji o wydajności aplikacji."
+    "message": "Więcej informacji o wydajności aplikacji. Te liczby nie mają [bezpośredniego wpływu](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) na wyniki Wydajność."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostyka"
@@ -840,7 +1113,7 @@
     "message": "Ulepszenia pierwszego renderowania"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Te optymalizacje mogą przyspieszyć ładowanie stron."
+    "message": "Te sugestie mogą pomóc przyśpieszyć wczytywanie strony. Nie mają one [bezpośredniego wpływu na](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) wynik Wydajność."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Możliwości"
@@ -867,7 +1140,7 @@
     "message": "Optymalizacja dla PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Te testy sprawdzają, czy strona jest zoptymalizowana pod kątem rankingu wyników wyszukiwarki. Na ranking mogą wpływać inne czynniki, których Lighthouse nie sprawdza. [Więcej informacji](https://support.google.com/webmasters/answer/35769)."
+    "message": "Te testy sprawdzają, czy strona jest zoptymalizowana pod kątem rankingu wyników wyszukiwarki. Na ranking mogą wpływać inne czynniki, których Lighthouse nie sprawdza. [Więcej informacji](https://support.google.com/webmasters/answer/35769)"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Uruchom te dodatkowe walidatory w swojej witrynie, by skontrolować więcej sprawdzonych metod SEO."
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Czas przechowywania danych w pamięci podręcznej"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Lokalizacja"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nazwa"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Żądania"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Typ zasobu"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Rozmiar (KB)"
+    "message": "Rozmiar"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Spędzony czas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Rozmiar przesłanych danych"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potencjalne oszczędności (KB)"
+    "message": "Potencjalne oszczędności"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potencjalne oszczędności (ms)"
+    "message": "Potencjalne oszczędności"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Potencjalna oszczędność: {wastedBytes, number, bytes} KB"
+    "message": "Potencjalne przyspieszenie o {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Potencjalne przyspieszenie o {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Czcionka"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Obraz"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Multimedia"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Inne"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skrypt"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Arkusz stylów"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Zewnętrzne"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Razem"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Podczas rejestrowania śladu wczytywania strony wystąpił błąd. Uruchom Lighthouse ponownie. ({errorCode})"
@@ -930,22 +1245,31 @@
     "message": "Upłynął czas oczekiwania na wstępne połączenie z Protokołem debugującym."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Podczas wczytywania strony w Chrome nie zostały utworzone zrzuty ekranu. Zapewnij widoczność treści na stronie, a następnie ponownie uruchom Lighthouse. ({errorCode})"
+    "message": "Podczas wczytywania strony w Chrome nie zostały utworzone zrzuty ekranu. Zapewnij widoczność treści na stronie, a potem uruchom Lighthouse jeszcze raz. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Serwery DNS nie potrafiły ustalić adresu podanej domeny."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Wystąpił błąd wymaganego elementu zbierającego {artifactName}: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Wystąpił wewnętrzny błąd Chrome. Uruchom ponownie Chrome, a następnie Lighthouse."
   },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Wymagany element zbierający {artifactName} nie został uruchomiony."
+  },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
-    "message": "Lighthouse nie udało się całkowicie wczytać żądanej strony. Upewnij się, że testujesz właściwy URL, a serwer poprawnie odpowiada na wszystkie żądania."
+    "message": "Narzędziu Lighthouse nie udało się całkowicie wczytać żądanej strony. Upewnij się, że testujesz właściwy URL, a serwer poprawnie odpowiada na wszystkie żądania."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedHung": {
-    "message": "Lighthouse nie udało się całkowicie wczytać żądanego URL-a, ponieważ strona przestała odpowiadać."
+    "message": "Narzędziu Lighthouse nie udało się całkowicie wczytać żądanego URL-a, ponieważ strona przestała odpowiadać."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Brak poprawnych danych logowania dla podanego adresu URL. {securityMessages}"
+    "message": "Podany URL nie ma prawidłowego certyfikatu bezpieczeństwa. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Przeglądarka Chrome zablokowała wczytywanie strony i wyświetliła komunikat pełnoekranowy. Upewnij się, że testujesz właściwy URL, a serwer poprawnie odpowiada na wszystkie żądania."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse nie udało się całkowicie wczytać żądanej strony. Upewnij się, że testujesz właściwy URL, a serwer poprawnie odpowiada na wszystkie żądania. (Szczegóły: {errorDetails})"
@@ -954,7 +1278,7 @@
     "message": "Lighthouse nie udało się całkowicie wczytać żądanej strony. Upewnij się, że testujesz właściwy URL, a serwer poprawnie odpowiada na wszystkie żądania. (Kod stanu: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Wczytywanie strony trwało zbyt długo. Skorzystaj z możliwości przyspieszenia wczytywania strony podanych w raporcie, a następnie ponownie uruchom Lighthouse. ({errorCode})"
+    "message": "Wczytywanie strony trwało zbyt długo. Skorzystaj z możliwości przyspieszenia wczytywania strony podanych w raporcie, a następnie uruchom Lighthouse jeszcze raz. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "Przekroczono przydzielony czas oczekiwania na odpowiedź protokołu DevTools. (Metoda: {protocolMethod})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Rozwiń fragment"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Pokaż zasoby zewnętrzne"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Podczas tego uruchomienia Lighthouse wystąpiły problemy:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Wartości są szacunkowe i mogą się zmieniać."
+    "message": "Wartości są szacunkowe i mogą się zmieniać. Wynik wydajności jest [oparty tylko na tych danych](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Audyty zaliczone z ostrzeżeniami"
@@ -1023,7 +1350,7 @@
     "message": "Możesz przesłać plik GIF do usługi, która umożliwi umieszczanie go jako pliku wideo HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Zainstaluj [wtyczkę WordPress opóźniającą ładowanie](https://wordpress.org/plugins/search/lazy+load/), która umożliwia odłożenie ładowania obrazów niewyświetlanych na ekranie, albo wybierz motyw, który ma tę funkcję. Warto też skorzystać z [wtyczki AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Zainstaluj [wtyczkę WordPress leniwego ładowania](https://wordpress.org/plugins/search/lazy+load/), która umożliwia odłożenie ładowania obrazów niewyświetlanych na ekranie, albo wybierz motyw, który ma tę funkcję. Warto też skorzystać z [wtyczki AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "Jest wiele wtyczek WordPress, które mogą pomóc Ci [umieścić w tekście najważniejsze zasoby](https://wordpress.org/plugins/search/critical+css/) lub [opóźnić wczytywanie mniej ważnych zasobów](https://wordpress.org/plugins/search/defer+css+javascript/). Pamiętaj, że optymalizacje dostarczane przez te wtyczki mogą uszkodzić funkcje Twojego motywu lub innych wtyczek i konieczne może być wprowadzenie zmian w kodzie."
@@ -1035,30 +1362,30 @@
     "message": "Korzystne może być wyświetlanie fragmentów na liście postów (np. przy użyciu tagu more), zmniejszenie liczby postów wyświetlanych na danej stronie, podział długich postów na kilka stron lub użycie wtyczki umożliwiającej opóźnione wczytywanie komentarzy."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Kilka [wtyczek WordPress](https://wordpress.org/plugins/search/minify+css/) może przyspieszyć działanie strony dzięki konkatenacji, minifikacji i kompresji stylów. Jeśli masz taką możliwość, warto też użyć procesu tworzenia, by od razu przeprowadzić minifikację."
+    "message": "Kilka [wtyczek WordPress](https://wordpress.org/plugins/search/minify+css/) może przyśpieszyć działanie strony dzięki konkatenacji, minifikacji i kompresji stylów. Jeśli masz taką możliwość, warto też użyć procesu tworzenia, by od razu przeprowadzić minifikację."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Kilka [wtyczek WordPress](https://wordpress.org/plugins/search/minify+javascript/) może przyspieszyć działanie strony dzięki konkatenacji, minifikacji i kompresji skryptów. Jeśli masz taką możliwość, warto też użyć procesu tworzenia, by od razu przeprowadzić minifikację."
+    "message": "Kilka [wtyczek WordPress](https://wordpress.org/plugins/search/minify+javascript/) może przyśpieszyć działanie strony dzięki konkatenacji, minifikacji i kompresji skryptów. Jeśli masz taką możliwość, użyj też procesu tworzenia, by od razu przeprowadzić minifikację."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Dobrym rozwiązaniem może być ograniczenie liczby [wtyczek WordPress](https://wordpress.org/plugins/) wczytujących na stronie nieużywany kod CSS albo zmiana tych wtyczek na inne. Aby zidentyfikować wtyczki, które dodają nieistotny kod CSS, uruchom [zasięg kodu](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) w Chrome DevTools. Możesz zidentyfikować taki motyw/wtyczkę w adresie URL arkusza stylów. Szukaj wtyczek, które mają na liście wiele arkuszy stylów z dużą ilością czerwonego koloru w zasięgu kodu. Wtyczka powinna umieszczać arkusz stylów w kolejce, tylko jeśli rzeczywiście jest on używany na stronie."
+    "message": "Dobrym rozwiązaniem może być ograniczenie liczby [wtyczek WordPressa](https://wordpress.org/plugins/) wczytujących na stronie nieużywany kod CSS albo zmiana tych wtyczek na inne. Aby zidentyfikować wtyczki, które dodają nieistotny kod CSS, uruchom [zasięg kodu](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) w Chrome DevTools. Możesz zidentyfikować taki motyw/wtyczkę w adresie URL arkusza stylów. Szukaj wtyczek, które mają na liście wiele arkuszy stylów z dużą ilością czerwonego koloru w zasięgu kodu. Wtyczka powinna umieszczać arkusz stylów w kolejce tylko wtedy, gdy rzeczywiście jest on używany na stronie."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Dobrym rozwiązaniem może być ograniczenie liczby [wtyczek WordPress](https://wordpress.org/plugins/) wczytujących na stronie nieużywany kod JacaScript albo zmiana tych wtyczek na inne. Aby zidentyfikować wtyczki, które dodają nieistotny kod JS, uruchom [zasięg kodu](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) w Chrome DevTools. Możesz zidentyfikować taki motyw/wtyczkę w adresie URL skryptu. Szukaj wtyczek, które mają na liście wiele skryptów z dużą ilością czerwonego koloru w zasięgu kodu. Wtyczka powinna umieszczać skrypt w kolejce, tylko jeśli rzeczywiście jest on używany na stronie."
+    "message": "Dobrym rozwiązaniem może być ograniczenie liczby [wtyczek WordPressa](https://wordpress.org/plugins/) wczytujących na stronie nieużywany kod JavaScript albo zmiana tych wtyczek na inne. Aby zidentyfikować wtyczki, które dodają nieistotny kod JS, uruchom [zasięg kodu](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) w Chrome DevTools. Możesz zidentyfikować taki motyw/wtyczkę w adresie URL skryptu. Szukaj wtyczek, które mają na liście wiele skryptów z dużą ilością czerwonego koloru w zasięgu kodu. Wtyczka powinna umieszczać skrypt w kolejce, tylko jeśli rzeczywiście jest on używany na stronie."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Dowiedz się więcej o [pamięci podręcznej przeglądarki w WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Dowiedz się więcej o [pamięci podręcznej przeglądarki w WordPressie](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "Pomocna może być [wtyczka WordPress do optymalizacji obrazów](https://wordpress.org/plugins/search/optimize+images/), która kompresuje obrazy, zachowując ich jakość."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Przesyłaj obrazy bezpośrednio przez [bibliotekę multimediów](https://codex.wordpress.org/Media_Library_Screen), by mieć pewność, że wymagane rozmiary obrazów są dostępne, a następnie wstawiaj je z biblioteki multimediów lub używaj widżetu obrazów, by zapewnić użycie optymalnych rozmiarów obrazów (także w dynamicznych punktach przerwania). Unikaj używania obrazów w „pełnym rozmiarze”, chyba że wymiary są adekwatne do danego zastosowania. [Dowiedz się więcej](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Przesyłaj obrazy bezpośrednio przez [bibliotekę multimediów](https://codex.wordpress.org/Media_Library_Screen), by mieć pewność, że wymagane rozmiary obrazów są dostępne, a następnie wstawiaj je z biblioteki multimediów lub używaj widżetu obrazów, by zapewnić użycie optymalnych rozmiarów obrazów (także w dynamicznych punktach przerwania). Unikaj używania obrazów `Full Size`, chyba że wymiary są adekwatne do danego zastosowania. [Więcej informacji](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Możesz włączyć kompresję tekstu w konfiguracji swojego serwera WWW."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Możesz skorzystać z [wtyczki](https://wordpress.org/plugins/search/convert+webp/) lub usługi, która będzie automatycznie konwertować przesłane obrazy do optymalnych formatów."
+    "message": "Możesz skorzystać z [wtyczki](https://wordpress.org/plugins/search/convert+webp/) lub usługi, która będzie automatycznie konwertować przesłane obrazy do optymalnych formatów."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/pt-PT.json
+++ b/lighthouse-core/lib/i18n/locales/pt-PT.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "As chaves de acesso permitem que os utilizadores se concentrem rapidamente numa parte da página. Para uma navegação adequada, cada chave de acesso tem de ser exclusiva. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "As chaves de acesso permitem que os utilizadores se concentrem rapidamente numa parte da página. Para uma navegação adequada, cada chave de acesso tem de ser exclusiva. [Saiba mais](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Os valores \"[accesskey]\" não são exclusivos"
+    "message": "Os valores `[accesskey]` não são exclusivos"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Os valores \"[accesskey]\" são exclusivos"
+    "message": "Os valores `[accesskey]` são exclusivos"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Cada \"role\" ARIA suporta um subconjunto específico de atributos \"aria-*\". Retirar a correspondência destes elementos invalida os atributos \"aria-*\". [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Cada ARIA `role` suporta um subconjunto específico de atributos `aria-*`. A não correspondência destes invalida os atributos `aria-*`. [Saiba mais](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Os atributos \"[aria-*]\" não correspondem às respetivas funções"
+    "message": "Os atributos `[aria-*]` não correspondem às respetivas funções"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Os atributos \"[aria-*]\" correspondem às respetivas funções"
+    "message": "Os atributos `[aria-*]` correspondem às respetivas funções"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Algumas funções ARIA têm atributos obrigatórios que descrevem o estado do elemento para os leitores de ecrã. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Algumas funções ARIA têm atributos obrigatórios que descrevem o estado do elemento para os leitores de ecrã. [Saiba mais](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Os \"[role]\"s não têm todos os atributos \"[aria-*]\" obrigatórios"
+    "message": "Os `[role]`s não têm todos os atributos `[aria-*]` obrigatórios"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Os \"[role]\"s têm todos os atributos \"[aria-*]\" obrigatórios"
+    "message": "Os `[role]`s têm todos os atributos `[aria-*]` obrigatórios"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Algumas funções superiores ARIA têm de conter funções secundárias específicas para desempenhar as respetivas funções de acessibilidade previstas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Algumas funções superiores ARIA têm de conter funções secundárias específicas para desempenhar as respetivas funções de acessibilidade previstas. [Saiba mais](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Os elementos com \"[role]\" que exigem \"[role]\"s secundários específicos estão em falta"
+    "message": "Os elementos com `[role]` que exigem `[role]`s secundários específicos estão em falta."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Os elementos com \"[role]\" que exigem \"[role]\"s secundários específicos estão presentes"
+    "message": "Os elementos com `[role]` que exigem `[role]`s secundários específicos estão presentes"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Algumas funções secundárias ARIA têm de ser contidas por funções superiores específicas para desempenharem adequadamente as respetivas funções de acessibilidade pretendidas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Algumas funções secundárias ARIA têm de ser contidas por funções superiores específicas para desempenharem adequadamente as respetivas funções de acessibilidade pretendidas. [Saiba mais](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Os \"[role]\"s não são contidos pelo respetivo elemento superior obrigatório"
+    "message": "Os `[role]`s não são contidos pelo respetivo elemento superior obrigatório"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Os \"[role]\"s são contidos pelo respetivo elemento superior obrigatório"
+    "message": "Os `[role]`s são contidos pelo respetivo elemento superior obrigatório"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "As funções ARIA têm de possuir valores válidos para desempenhar as funções de acessibilidade previstas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "As funções ARIA têm de possuir valores válidos para desempenhar as funções de acessibilidade previstas. [Saiba mais](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Os valores \"[role]\" não são válidos"
+    "message": "Os valores `[role]` não são válidos"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Os valores \"[role]\" são válidos"
+    "message": "Os valores `[role]` são válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "As tecnologias de assistência, que incluem os leitores de ecrã, não conseguem interpretar atributos ARIA com valores inválidos. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "As tecnologias de assistência, que incluem os leitores de ecrã, não conseguem interpretar atributos ARIA com valores inválidos. [Saiba mais](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Os atributos \"[aria-*]\" não têm valores válidos"
+    "message": "Os atributos `[aria-*]` não têm valores válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Os atributos \"[aria-*]\" têm valores válidos"
+    "message": "Os atributos `[aria-*]` têm valores válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "As tecnologias de assistência, que incluem os leitores de ecrã, não conseguem interpretar atributos ARIA com nomes inválidos. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "As tecnologias de assistência, que incluem os leitores de ecrã, não conseguem interpretar atributos ARIA com nomes inválidos. [Saiba mais](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Os atributos \"[aria-*]\" não são válidos ou têm erros ortográficos"
+    "message": "Os atributos `[aria-*]` não são válidos ou têm erros ortográficos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Os atributos \"[aria-*]\" são válidos e não têm erros ortográficos"
+    "message": "Os atributos `[aria-*]` são válidos e não têm erros ortográficos"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "As legendas tornam os elementos áudio utilizáveis para os utilizadores surdos ou com problemas de audição, ao facultar informações essenciais, como quem está a falar, o que está a dizer e outras informações não verbais. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "As legendas tornam os elementos áudio utilizáveis para os utilizadores surdos ou com problemas de audição, ao facultar informações essenciais, como quem está a falar, o que está a dizer e outras informações não verbais. [Saiba mais](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Os elementos \"<audio>\" têm um elemento \"<track>\" em falta com \"[kind=\"captions\"]\"."
+    "message": "Os elementos `<audio>` têm um elemento `<track>` em falta com `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Os elementos \"<audio>\" contêm um elemento \"<track>\" com \"[kind=\"captions\"]\""
+    "message": "Os elementos `<audio>` contêm um elemento `<track>` com `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Elementos reprovados"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Quando um botão não tem um nome acessível, os leitores de ecrã anunciam-no como \"botão\", tornando-o inutilizável para os utilizadores que dependem de leitores de ecrã. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Quando um botão não tem um nome acessível, os leitores de ecrã anunciam-no como \"botão\", tornando-o inutilizável para os utilizadores que dependem de leitores de ecrã. [Saiba mais](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Os botões não têm um nome acessível"
@@ -93,7 +93,7 @@
     "message": "Os botões têm um nome acessível"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Adicionar formas de ignorar conteúdo repetitivo permite que os utilizadores com teclado naveguem na página de forma mais eficiente. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Adicionar formas de ignorar conteúdo repetitivo permite que os utilizadores com teclado naveguem na página de forma mais eficiente. [Saiba mais](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "A página não contém um título, um link para ignorar ou uma região de ponto de referência"
@@ -102,7 +102,7 @@
     "message": "A página contém um título, um link para ignorar ou uma região de ponto de referência"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "O texto de baixo contraste é difícil ou impossível de ler para muitos utilizadores. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "O texto de baixo contraste é difícil ou impossível de ler para muitos utilizadores. [Saiba mais](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "As cores de primeiro e de segundo plano não têm uma relação de contraste suficiente"
@@ -111,88 +111,88 @@
     "message": "As cores de segundo plano e de primeiro plano têm uma relação de contraste suficiente"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Quando as listas de definição não estão devidamente marcadas, os leitores de ecrã podem produzir um resultado confuso ou impreciso. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Quando as listas de definição não estão devidamente marcadas, os leitores de ecrã podem produzir um resultado confuso ou impreciso. [Saiba mais](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Os \"<dl>\"'s não contêm grupos de \"<dt>\" e \"<dd>\" apenas devidamente ordenados, nem elementos \"<script>\" ou \"<template>\"."
+    "message": "Os `<dl>`s não contêm grupos de `<dt>` e `<dd>` apenas devidamente ordenados, nem elementos `<script>` ou `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Os \"<dl>\"s contêm grupos de \"<dt>\" e \"<dd>\" apenas devidamente ordenados, bem como elementos \"<script>\" ou \"<template>\""
+    "message": "Os `<dl>` contêm grupos de `<dt>` e `<dd>` bem como elementos `<script>` ou `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Os itens de lista de definição (\"<dt>\" e \"<dd>\") têm de estar unidos num elemento \"<dl>\" superior de modo a garantir que os leitores de ecrã os possam anunciar adequadamente. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Os itens de lista de definição (`<dt>` e `<dd>`) têm de estar unidos num elemento `<dl>` superior de modo a garantir que os leitores de ecrã os possam anunciar adequadamente. [Saiba mais](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Os itens de lista de definição não estão unidos em elementos \"<dl>\""
+    "message": "Os itens de lista de definição não estão unidos em elementos `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Os itens de lista de definição estão unidos em elementos \"<dl>\""
+    "message": "Os itens de lista de definição estão unidos em elementos `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "O título proporciona aos utilizadores de leitores de ecrã uma vista geral da página, sendo que os utilizadores de motores de pesquisa dependem dele para determinar se uma página é relevante para a respetiva pesquisa. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "O título proporciona aos utilizadores de leitores de ecrã uma vista geral da página, sendo que os utilizadores de motores de pesquisa dependem dele para determinar se uma página é relevante para a respetiva pesquisa. [Saiba mais](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "O documento não tem um elemento \"<title>\""
+    "message": "O documento não tem um elemento `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "O documento tem um elemento \"<title>\""
+    "message": "O documento tem um elemento `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "O valor de um atributo id tem de ser exclusivo para evitar que outras instâncias sejam ignoradas pelas tecnologias de assistência. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "O valor de um atributo id tem de ser exclusivo para evitar que outras instâncias sejam ignoradas pelas tecnologias de assistência. [Saiba mais](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Os atributos \"[id]\" na página não são exclusivos"
+    "message": "Os atributos `[id]` na página não são exclusivos"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Os atributos \"[id]\" na página são exclusivos"
+    "message": "Os atributos `[id]` na página são exclusivos"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Os utilizadores com leitores de ecrã dependem dos títulos de frames para descrever o conteúdo dos frames. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Os utilizadores com leitores de ecrã dependem dos títulos de frames para descrever o conteúdo dos frames. [Saiba mais](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Os elementos \"<frame>\" ou \"<iframe>\" não têm um título"
+    "message": "Os elementos `<frame>` ou `<iframe>` não têm um título"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Os elementos \"<frame>\" ou \"<iframe>\" têm um título"
+    "message": "Os elementos `<frame>` ou `<iframe>` têm um título"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Se uma página não especificar um atributo lang, um leitor de ecrã parte do princípio de que a página está no idioma predefinido que o utilizador escolheu quando configurou o leitor de ecrã. Se a página não estiver realmente no idioma predefinido, o leitor de ecrã pode não anunciar corretamente o texto da página. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Se uma página não especificar um atributo lang, um leitor de ecrã parte do princípio de que a página está no idioma predefinido que o utilizador escolheu quando configurou o leitor de ecrã. Se a página não estiver realmente no idioma predefinido, o leitor de ecrã pode não anunciar corretamente o texto da página. [Saiba mais](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "O elemento \"<html>\" não tem um atributo \"[lang]\""
+    "message": "O elemento `<html>` não tem um atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "O elemento \"<html>\" tem um atributo \"[lang]\""
+    "message": "O elemento `<html>` tem um atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Especificar um [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido ajuda os leitores de ecrã a anunciar texto adequadamente. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Especificar um idioma [BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido ajuda os leitores de ecrã a anunciar texto adequadamente. [Saiba mais](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "O elemento \"<html>\" não tem um valor válido no respetivo atributo \"[lang]\"."
+    "message": "O elemento `<html>` tem um valor válido para o respetivo atributo `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "O elemento \"<html>\" tem um valor válido para o respetivo atributo \"[lang]\""
+    "message": "O elemento `<html>` tem um valor válido para o respetivo atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Os elementos informativos devem procurar incluir texto curto, descritivo e alternativo. Os elementos decorativos podem ser ignorados com um atributo alternativo vazio. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Os elementos informativos devem procurar incluir texto curto, descritivo e alternativo. Os elementos decorativos podem ser ignorados com um atributo alternativo vazio. [Saiba mais](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Os elementos de imagem não têm atributos \"[alt]\""
+    "message": "Os elementos de imagem não têm atributos `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Os elementos de imagem têm atributos \"[alt]\""
+    "message": "Os elementos de imagem têm atributos `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Quando uma imagem está a ser utilizada como um botão \"<input>\", facultar texto alternativo pode ajudar os utilizadores com leitores de ecrã a compreender a finalidade do botão. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Quando uma imagem está a ser utilizada como um botão `<input>`, facultar texto alternativo pode ajudar os utilizadores com leitores de ecrã a compreender a finalidade do botão. [Saiba mais](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Os elementos \"<input type=\"image\">\" não têm texto \"[alt]\""
+    "message": "Os elementos `<input type=\"image\">` não têm texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Os elementos \"<input type=\"image\">\" têm texto \"[alt]\""
+    "message": "Os elementos `<input type=\"image\">` têm texto de `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "As etiquetas garantem que os controlos de formulários são anunciados adequadamente pelas tecnologias de assistência, que incluem os leitores de ecrã. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "As etiquetas garantem que os controlos de formulários são anunciados adequadamente pelas tecnologias de assistência, que incluem os leitores de ecrã. [Saiba mais](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Os elementos de formulário não têm etiquetas associadas"
@@ -201,16 +201,16 @@
     "message": "Os elementos de formulário têm etiquetas associadas"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Uma tabela utilizada para esquemas não deve incluir elementos de dados, como os elementos th ou de legenda ou o atributo resumo, porque esta situação pode criar uma experiência confusa para os utilizadores com leitores de ecrã. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Uma tabela utilizada para esquemas não deve incluir elementos de dados, como os elementos th ou de legenda ou o atributo resumo, porque esta situação pode criar uma experiência confusa para os utilizadores com leitores de ecrã. [Saiba mais](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Os elementos \"<table>\" de apresentação não evitam a utilização de \"<th>\", \"<caption>\" nem do atributo \"[summary]\"."
+    "message": "Os elementos `<table>` de apresentação não evitam a utilização de `<th>`, `<caption>` nem do atributo `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Os elementos \"<table>\" de apresentação evitam a utilização de \"<th>\", \"<caption>\" ou do atributo \"[summary]\""
+    "message": "Os elementos `<table>` de apresentação evitam a utilização de `<th>`, `<caption>` ou do atributo `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "O texto de link (e texto alternativo para imagens, quando utilizado como link) que seja percetível, exclusivo e ajustável melhora a experiência de navegação dos utilizadores de leitores de ecrã. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "O texto de link (e texto alternativo para imagens, quando utilizado como link) que seja percetível, exclusivo e ajustável melhora a experiência de navegação dos utilizadores de leitores de ecrã. [Saiba mais](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Os links não têm um nome percetível"
@@ -219,103 +219,115 @@
     "message": "Os links têm um nome percetível"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Os leitores de ecrã têm uma forma específica de anunciar listas. Garantir uma estrutura de listas adequada é benéfico para o resultado do leitor de ecrã. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Os leitores de ecrã têm uma forma específica de anunciar listas. Garantir uma estrutura de listas adequada é benéfico para o resultado do leitor de ecrã. [Saiba mais](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "As listas não contêm apenas elementos \"<li>\" e elementos de suporte de script (\"<script>\" e \"<template>\")"
+    "message": "As listas não contêm apenas elementos `<li>` e elementos de suporte de script (`<script>` e `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "As listas contêm apenas elementos \"<li>\" e elementos de suporte de script (\"<script>\" e \"<template>\")"
+    "message": "As listas contêm apenas elementos `<li>` e elementos de suporte de script (`<script>` e `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Os leitores de ecrã necessitam que os itens de lista (\"<li>\") sejam contidos num \"<ul>\" ou \"<ol>\" superior para serem adequadamente anunciados. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Os leitores de ecrã necessitam que os itens de lista (`<li>`) sejam contidos num `<ul>` ou `<ol>` superior para serem adequadamente anunciados. [Saiba mais](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Os itens de lista (\"<li>\") não estão incluídos nos elementos superiores \"<ul>\" ou \"<ol>\""
+    "message": "Os itens de lista (`<li>`) não estão incluídos nos elementos superiores `<ul>` ou `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Os itens da lista (\"<li>\") estão incluídos nos elementos superiores \"<ul>\" ou \"<ol>\""
+    "message": "Os itens de lista (`<li>`) estão incluídos nos elementos superiores `<ul>` ou `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Os utilizadores não esperam que uma página seja atualizada automaticamente e, se tal acontecer, vai desviar o foco para a parte superior da página. Esta situação pode criar uma experiência frustrante ou confusa. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Os utilizadores não esperam que uma página se atualize automaticamente e, se tal acontecer, vai desviar o foco para a parte superior da página. Esta situação pode criar uma experiência frustrante ou confusa. [Saiba mais](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "O documento utiliza \"<meta http-equiv=\"refresh\">\""
+    "message": "O documento utiliza `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "O documento não utiliza \"<meta http-equiv=\"refresh\">\""
+    "message": "O documento não utiliza `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Desativar o zoom é problemático para os utilizadores com visão reduzida que dependem da ampliação do ecrã para ver adequadamente o conteúdo de uma página Web. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Desativar o zoom é problemático para os utilizadores com visão reduzida que dependem da ampliação do ecrã para ver adequadamente o conteúdo de uma página Web. [Saiba mais](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "O \"[user-scalable=\"no\"]\" é utilizado no elemento \"<meta name=\"viewport\">\" ou o atributo \"[maximum-scale]\" é inferior a 5"
+    "message": "O `[user-scalable=\"no\"]` é utilizado no elemento `<meta name=\"viewport\">` ou o atributo `[maximum-scale]` é inferior a 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "\"[user-scalable=\"no\"]\" não é utilizado no elemento \"<meta name=\"viewport\">\" e o atributo \"[maximum-scale]\" não é inferior a 5."
+    "message": "O `[user-scalable=\"no\"]` não é utilizado no elemento `<meta name=\"viewport\">` e o atributo `[maximum-scale]` não é inferior a 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Os leitores de ecrã não conseguem traduzir conteúdo que não seja de texto. Adicionar texto alternativo a elementos \"<object>\" ajuda os leitores de ecrã a transmitir significado aos utilizadores. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Os leitores de ecrã não conseguem traduzir conteúdo que não seja de texto. Adicionar texto alternativo a elementos `<object>` ajuda os leitores de ecrã a transmitir significado aos utilizadores. [Saiba mais](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Os elementos \"<object>\" não têm texto \"[alt]\""
+    "message": "Os elementos `<object>` não têm texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Os elementos \"<object>\" têm texto \"[alt]\""
+    "message": "Os elementos `<object>` têm texto de `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Um valor superior a 0 implica uma ordenação de navegação explícita. Embora seja tecnicamente válida, esta situação costuma criar experiências frustrantes para os utilizadores que dependem de tecnologias de assistência. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Um valor superior a 0 implica uma ordenação de navegação explícita. Embora seja tecnicamente válida, esta situação costuma criar experiências frustrantes para os utilizadores que dependem de tecnologias de assistência. [Saiba mais](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Alguns elementos têm um valor \"[tabindex]\" superior a 0"
+    "message": "Alguns elementos têm um valor `[tabindex]` superior a 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Nenhum elemento tem um valor \"[tabindex]\" superior a 0"
+    "message": "Nenhum elemento tem um valor `[tabindex]` superior a 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Os leitores de ecrã têm funcionalidades para facilitar a navegação em tabelas. Garantir que as células \"<td>\" que utilizam o atributo \"[headers]\" apenas referenciam outras células na mesma tabela pode melhorar a experiência para os utilizadores com leitores de ecrã. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Os leitores de ecrã têm funcionalidades para facilitar a navegação em tabelas. Garantir que as células `<td>` que utilizam o atributo `[headers]` apenas referenciam outras células na mesma tabela pode melhorar a experiência para os utilizadores com leitores de ecrã. [Saiba mais](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "As células num elemento \"<table>\" que utilizam o atributo \"[headers]\" referem-se a outras células dessa mesma tabela."
+    "message": "As células num elemento `<table>` que utilizam o atributo `[headers]` referem-se a outras células dessa mesma tabela."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "As células num elemento \"<table>\" que utilizam o atributo \"[headers]\" apenas referenciam outras células dessa mesma tabela."
+    "message": "As células num elemento `<table>` que utilizam o atributo `[headers]` apenas referenciam outras células dessa mesma tabela."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Os leitores de ecrã têm funcionalidades para facilitar a navegação em tabelas. Garantir que os cabeçalhos de tabelas referenciam sempre algum conjunto de células pode melhorar a experiência dos utilizadores com leitores de ecrã. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Os leitores de ecrã têm funcionalidades para facilitar a navegação em tabelas. Garantir que os cabeçalhos de tabelas referenciam sempre algum conjunto de células pode melhorar a experiência dos utilizadores com leitores de ecrã. [Saiba mais](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Os elementos \"<th>\" e os elementos com \"[role=\"columnheader\"/\"rowheader\"]\" não têm as células de dados que descrevem"
+    "message": "Os elementos `<th>` e os elementos com `[role=\"columnheader\"/\"rowheader\"]` não têm as células de dados que descrevem."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Os elementos \"<th>\" e os elementos com \"[role=\"columnheader\"/\"rowheader\"]\" têm as células de dados que descrevem"
+    "message": "Os elementos `<th>` e os elementos com `[role=\"columnheader\"/\"rowheader\"]` têm as células de dados que descrevem."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Especificar um [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido em elementos ajuda a garantir que o texto é pronunciado corretamente por um leitor de ecrã. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Especificar um idioma [BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido para elementos ajuda a garantir que o texto é pronunciado corretamente por um leitor de ecrã. [Saiba mais](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Os atributos \"[lang]\" não têm um valor válido"
+    "message": "Os atributos `[lang]` não têm um valor válido"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Os atributos \"[lang]\" têm um valor válido"
+    "message": "Os atributos `[lang]` têm um valor válido"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Quando um vídeo oferece uma legenda, é mais fácil para os utilizadores surdos e com problemas de audição aceder às informações. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Quando um vídeo oferece uma legenda, é mais fácil para os utilizadores surdos e com problemas de audição aceder às informações. [Saiba mais](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Os elementos \"<video>\" não contêm um elemento \"<track>\" com \"[kind=\"captions\"]\"."
+    "message": "Os elementos `<video>` não contêm um elemento `<track>` com `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Os elementos \"<video>\" contêm um elemento \"<track>\" com \"[kind=\"captions\"]\""
+    "message": "Os elementos `<video>` contêm um elemento `<track>` com `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "As descrições de áudio proporcionam informações relevantes que os diálogos não conseguem proporcionar nos vídeos, como expressões faciais e cenas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "As descrições de áudio proporcionam informações relevantes que os diálogos não conseguem proporcionar nos vídeos, como expressões faciais e cenas. [Saiba mais](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Os elementos \"<video>\" não contêm um elemento \"<track>\" com \"[kind=\"description\"]\""
+    "message": "Os elementos `<video>` não contêm um elemento `<track>` com `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Os elementos \"<video>\" contêm um elemento \"<track>\" com \"[kind=\"description\"]\""
+    "message": "Os elementos `<video>` contêm um elemento `<track>` com `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Defina um ícone Apple Touch para obter um aspeto ideal no iOS quando os utilizadores adicionam elementos ao ecrã principal. Deve apontar para um PNG quadrado não transparente de 192px (ou 180px). [Saiba mais](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Não fornece um `apple-touch-icon` válido"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "O `apple-touch-icon-precomposed` está desatualizado; recomendamos o `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Fornece um `apple-touch-icon` válido"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "As extensões do Chrome afetam negativamente o desempenho de carregamento desta página. Experimente efetuar uma auditoria à página no modo de navegação anónima ou com um perfil do Chrome sem extensões."
@@ -339,7 +351,7 @@
     "message": "Tempo de execução de JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Os GIFs grandes são ineficientes para publicar conteúdo animado. Para poupar bytes de rede, considere utilizar vídeos MPEG4/WebM para animações e ficheiros PNG/WebP para imagens estáticas em vez de GIFs. [Saiba mais](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)."
+    "message": "Os GIFs grandes são ineficientes para publicação de conteúdo animado. Para poupar bytes de rede, considere utilizar vídeos MPEG4/WebM para animações e ficheiros PNG/WebP para imagens estáticas em vez de GIFs. [Saiba mais](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Utilize formatos de vídeo para conteúdo animado"
@@ -351,7 +363,7 @@
     "message": "Adie as imagens não visíveis"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "O primeiro preenchimento da sua página está a ser bloqueado por recursos. Considere publicar JS/CSS críticos inline e adiar todos os JS/estilos não críticos. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Os recursos estão a bloquear o primeiro preenchimento da página. Considere publicar JS/CSS críticos inline e adiar todos os JS/estilos não críticos. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Elimine recursos que bloqueiam o processamento"
@@ -360,7 +372,7 @@
     "message": "Os grandes payloads de rede têm custos reais para os utilizadores e estão fortemente correlacionados com tempos de carregamento demorados. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "O tamanho total foi de {totalBytes, number, bytes} KB"
+    "message": "O tamanho total era {totalBytes, number, bytes} KB."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Evite enormes payloads de rede"
@@ -393,7 +405,7 @@
     "message": "Remova o JavaScript não utilizado"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Uma duração total longa da cache pode acelerar as visitas repetidas à sua página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Uma longa duração total da cache pode acelerar as visitas repetidas à sua página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 recurso encontrado}other{# recursos encontrados}}"
@@ -429,13 +441,64 @@
     "message": "Publique imagens em formatos de última geração"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "As Cadeias de pedidos críticos abaixo apresentam os recursos que são carregados com uma prioridade elevada. Pondere reduzir o comprimento das cadeias, reduzir o tamanho de transferência dos recursos ou adiar a transferência de recursos desnecessários para melhorar o carregamento da página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "As Cadeias de pedidos críticos abaixo apresentam os recursos que são carregados com uma prioridade elevada. Considere reduzir o tamanho das cadeias, reduzir o tamanho de transferência dos recursos ou adiar a transferência de recursos desnecessários para melhorar o carregamento de página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 cadeia encontrada}other{# cadeias encontradas}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Reduza a profundidade de pedidos críticos"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Descontinuação/aviso"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Linha"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "As APIs descontinuadas serão eventualmente removidas do navegador. [Saiba mais](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 aviso encontrado}other{# avisos encontrados}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Utiliza APIs descontinuadas"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Evita APIs descontinuadas"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "A cache da aplicação foi descontinuada. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" encontrado"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Utiliza a cache da aplicação"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Evita a cache da aplicação"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Especificar um doctype impede que o navegador mude para o modo quirks. Saiba mais na [página MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "O nome do doctype deve ser a string `html` minúscula"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "O documento deve conter um doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Era esperado que o PublicId fosse uma string vazia"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Era esperado que o SystemId fosse uma string vazia."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "A página não possui o doctype HTML, o que faz com que o modo quirks seja acionado"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "A página possui o doctype HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elemento"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Evita um tamanho excessivo do DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Alvo"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Adicione `rel=\"noopener\"` ou `rel=\"noreferrer\"` a quaisquer links externos para melhorar o desempenho e prevenir vulnerabilidades de segurança. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Os links para destinos de origem cruzada não são seguros"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Os links para destinos de origem cruzada são seguros"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Não é possível determinar o destino da âncora ({anchorHTML}). Se não for utilizado como uma hiperligação, considere remover o target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Os utilizadores desconfiam ou ficam confusos perante os sites que solicitam a sua localização sem contexto. Em vez disso, considere associar o pedido a uma ação do utilizador. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Solicita a autorização de geolocalização no carregamento da página"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Evita a solicitação da autorização de geolocalização no carregamento da página"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versão"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Todas as bibliotecas de interface JavaScript detetadas na página."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Bibliotecas JavaScript detetadas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "No caso de utilizadores com ligações lentas, os scripts externos inseridos dinamicamente através de `document.write()` podem atrasar o carregamento da página em dezenas de segundos. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Utiliza `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Evita `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Gravidade mais alta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Versão da biblioteca"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Contagem de vulnerabilidades"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Alguns scripts de terceiros podem conter vulnerabilidades de segurança conhecidas que são facilmente identificadas e exploradas pelos atacantes. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 vulnerabilidade detetada}other{# vulnerabilidades detetadas}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Inclui bibliotecas de interface JavaScript com vulnerabilidades de segurança conhecidas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Alto"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Baixo"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Médio"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Evita bibliotecas de interface JavaScript com vulnerabilidades de segurança conhecidas"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Os utilizadores desconfiam ou ficam confusos perante os sites que solicitam o envio de notificações sem contexto. Em vez disso, considere associar o pedido aos gestos do utilizador. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Solicita a autorização de notificações no carregamento da página"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Evita a solicitação da autorização de notificações no carregamento da página"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elementos reprovados"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Impedir a colagem de palavras-passe compromete o cumprimento de uma política de segurança adequada. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Impede que os utilizadores colem conteúdo nos campos de palavra-passe"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Permite que os utilizadores colem nos campos de palavra-passe"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocolo"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "O HTTP/2 oferece muitas vantagens em relação ao HTTP/1.1, incluindo cabeçalhos binários, multiplexação e push de servidor. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 pedido não publicado através de HTTP/2}other{# pedidos não publicados através de HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Não utiliza o HTTP/2 para todos os respetivos recursos"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Utiliza HTTP/2 para os seus próprios recursos"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Considere marcar os seus event listeners de toque e roda como `passive` para melhorar o desempenho de deslocamento da sua página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Não utiliza ouvintes passivos para melhorar o desempenho do deslocamento"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Utiliza ouvintes passivos para melhorar o desempenho do deslocamento"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Descrição"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Os erros registados na consola indicam problemas não resolvidos. Estes podem ser provenientes de falhas de pedidos de rede e outras questões do navegador."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Os erros do navegador foram registados na consola"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Nenhum erro do navegador registado na consola"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Tire partido da funcionalidade CSS de apresentação de tipos de letra para garantir que o texto é visível para o utilizador enquanto os tipos de letra para Websites são carregados. [Saiba mais](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -475,6 +670,42 @@
   },
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Todo o texto permanece visível durante os carregamentos de tipos de letra para Websites"
+  },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "O Lighthouse não conseguiu verificar automaticamente o valor de apresentação de tipos de letra para o seguinte URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Proporção (atual)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Formato (apresentado)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "As dimensões de apresentação das imagens devem corresponder à proporção natural. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Apresenta imagens com uma proporção incorreta"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Apresenta imagens com uma proporção correta"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Informações inválidas de dimensionamento de imagens {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL inseguro"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Todos os sites devem ser protegidos com HTTPS, mesmo aqueles que não lidam com dados confidenciais. O HTTPS evita que os intrusos adulterem ou escutem passivamente as comunicações entre a sua aplicação e os seus utilizadores, e é um pré-requisito para o HTTP/2 e muitas novas APIs de plataformas Web. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 pedido inseguro encontrado}other{# pedidos inseguros encontrados}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Não utiliza HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Utiliza HTTPS"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Um rápido carregamento da página numa rede móvel assegura uma boa experiência do utilizador móvel. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
@@ -534,16 +765,22 @@
     "message": "Tempo até à interação"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "O Primeiro atraso de entrada potencial que pode afetar os utilizadores é a duração, em milissegundos, da tarefa mais longa."
+    "message": "O máximo potencial do primeiro atraso de entrada que pode afetar os utilizadores é a duração, em milissegundos, da tarefa mais longa. [Saiba mais](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID máximo potencial"
+    "message": "Máximo potencial de primeiro atraso de entrada"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "A métrica Índice de velocidade apresenta a rapidez de preenchimento visível dos conteúdos de uma página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Índice de velocidade"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "A soma de todos os períodos de tempo entre o FCP e o Tempo até à interação, quando a duração da tarefa é superior a 50 ms, expressa em milissegundos."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Tempo de bloqueio total"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Os tempos de ida e volta da rede (RTT) têm um grande impacto no desempenho. Se o RTT para uma origem for elevado, é uma indicação de que os servidores mais próximos do utilizador podem melhorar o desempenho. [Saiba mais](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,11 +794,32 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latências de back-end do servidor"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Superior ao orçamento"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Mantenha a quantidade e o tamanho dos pedidos de rede abaixo dos alvos estabelecidos pelo orçamento de desempenho fornecido. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 pedido}other{# pedidos}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Orçamento de desempenho"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "A auditoria Redirecionamentos introduz atrasos adicionais antes do carregamento da página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Evite vários redirecionamentos de página"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Adicione um ficheiro budget.json para definir orçamentos para a quantidade e tamanho dos recursos da página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 pedido}other{# pedidos}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Mantenha a contagem dos pedidos baixa e os tamanhos de transferência pequenos"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Os links canónicos sugerem o URL a apresentar nos resultados da pesquisa. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
@@ -576,7 +834,7 @@
     "message": "URL inválido ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Aponta para outra localização de \"hreflang\" ({url})"
+    "message": "Aponta para outra localização `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "URL relativo ({url})"
@@ -585,19 +843,16 @@
     "message": "Aponta para o URL raiz do domínio (a página inicial), em vez de uma página de conteúdo equivalente."
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "O documento não tem um valor \"rel=canonical\" válido"
+    "message": "O documento não tem um `rel=canonical` válido"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "O documento tem um valor \"rel=canonical\" válido"
+    "message": "O documento tem um `rel=canonical` válido"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Os tamanhos de tipo de letra inferiores a 12 px são demasiado pequenos para serem legíveis e requerem que os visitantes de dispositivos móveis \"juntem os dedos para aumentar o zoom” para conseguirem ler. Tente ter > 60% de texto da página ≥ 12 px. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} de texto legível"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} do texto é demasiado pequeno."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "O texto é ilegível porque não existe nenhuma metatag de área visível otimizada para ecrãs de dispositivos móveis."
@@ -615,10 +870,10 @@
     "message": "Os links hreflang indicam aos motores de pesquisa a versão de uma página que devem apresentar nos resultados da pesquisa para um determinado idioma ou região. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "O documento não tem um valor \"hreflang\" válido"
+    "message": "O documento não tem um `hreflang` válido"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "O documento tem um valor \"hreflang\" válido"
+    "message": "O documento tem um `hreflang` válido"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "As páginas com códigos de estado HTTP não executados com êxito podem não ser indexadas corretamente. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -681,7 +936,7 @@
     "message": "Se o ficheiro robots.txt estiver mal formado, os motores de rastreio podem não conseguir compreender como pretende que o seu Website seja rastreado ou indexado."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "O pedido de robots.txt devolveu o estado de HTTP: {statusCode}"
+    "message": "O pedido de robots.txt devolveu o seguinte estado de HTTP: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{1 erro encontrado}other{# erros encontrados}}"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Alvo sobreposto"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Tamanho"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Alvo tátil"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Os alvos táteis estão dimensionados corretamente"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Tempo do thread principal"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Terceiros"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "O código de terceiros pode afetar significativamente o desempenho de carregamento. Limite o número de fornecedores terceiros redundantes e tente carregar o código de terceiros após a conclusão do carregamento da sua página. [Saiba mais](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 terceiro encontrado}other{# terceiros encontrados}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Utilização de terceiros"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "A auditoria Tempo até ao primeiro byte indica o tempo de envio de uma resposta pelo seu servidor. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Duração"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nome"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Hora de início"
   },
@@ -744,7 +1008,7 @@
     "message": "Tipo"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Pondere a possibilidade de complementar a sua aplicação com a API Tempos do utilizador para analisar o desempenho da aplicação no mundo real durante as principais experiências do utilizador. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Pondere a possibilidade de complementar a sua aplicação com a API Tempos do utilizador para analisar o desempenho real da aplicação durante as principais experiências do utilizador. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 tempo do utilizador}other{# tempos do utilizador}}"
@@ -753,7 +1017,7 @@
     "message": "Marcas e medições de Tempos do utilizador"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Foi encontrado um <link> de pré-ligação para \"{securityOrigin}\", mas este não foi utilizado pelo navegador. Confirme se está a utilizar o atributo \"crossorigin\" adequadamente."
+    "message": "Foi encontrado um <link> de pré-ligação para \"{securityOrigin}\", mas este não foi utilizado pelo navegador. Confirme se está a utilizar o atributo `crossorigin` adequadamente."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Considere adicionar instruções para recursos de pré-ligação ou de obtenção prévia de DNS para estabelecer ligações antecipadamente a origens de terceiros importantes. [Saiba mais](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Efetue a pré-ligação às origens necessárias"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Foi encontrado um <link> de pré-carregamento para \"{preloadURL}\", mas este não foi utilizado pelo navegador. Confirme se está a utilizar o atributo \"crossorigin\" adequadamente."
+    "message": "Foi encontrado um <link> de pré-carregamento para \"{preloadURL}\", mas este não foi utilizado pelo navegador. Confirme se está a utilizar o atributo `crossorigin` adequadamente."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Considere utilizar <link rel=preload> para dar prioridade à obtenção de recursos que são atualmente solicitados mais tarde no carregamento de página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Considere utilizar `<link rel=preload>` para dar prioridade à obtenção de recursos que são atualmente solicitados mais tarde no carregamento de página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Pré-carregue pedidos-chave"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabelas e listas"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Práticas recomendadas"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Os orçamentos de desempenho definem padrões para o desempenho do seu site."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Orçamentos"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Mais informações sobre o desempenho da sua aplicação."
+    "message": "Mais informações sobre o desempenho da sua aplicação. Estes números não [afetam diretamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) a pontuação de desempenho."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnósticos"
@@ -840,7 +1113,7 @@
     "message": "Melhorias no primeiro preenchimento"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Estas otimizações podem acelerar o carregamento da sua página."
+    "message": "Estas sugestões podem ajudar a sua página a ser carregada mais rapidamente. As mesmas não [afetam diretamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) a pontuação de desempenho."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Oportunidades"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL da cache"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Localização"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nome"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Pedidos"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Tipo de recurso"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Tamanho (KB)"
+    "message": "Tamanho"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Tempo gasto"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Tamanho da transferência"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Poupança potencial (KB)"
+    "message": "Poupança potencial"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Poupança potencial (ms)"
+    "message": "Poupança potencial"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Poupança potencial de {wastedBytes, number, bytes} KB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Poupança potencial de {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Documento"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Tipo de letra"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Imagem"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Multimédia"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Outro"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} seg"
+    "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Folha de estilos"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Terceiros"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Total"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Ocorreu um erro ao registar o rastreio durante o carregamento da sua página. Volte a executar o Lighthouse. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Os servidores DNS não conseguiram resolver o domínio fornecido."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "O coletor {artifactName} obrigatório encontrou o seguinte erro: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Ocorreu um erro interno do Chrome. Reinicie o Chrome e experimente executar novamente o Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "O coletor {artifactName} obrigatório não foi executado."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "O Lighthouse não conseguiu carregar com fiabilidade a página que solicitou. Certifique-se de que está a testar o URL correto e que o servidor está a responder adequadamente a todos os pedidos."
@@ -945,7 +1266,10 @@
     "message": "O Lighthouse não conseguiu carregar com fiabilidade o URL que solicitou porque a página deixou de responder."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "O URL que facultou não tem credenciais de segurança válidas. {securityMessages}"
+    "message": "O URL que forneceu não tem um certificado de segurança válido. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "O Chrome impediu o carregamento da página com um anúncio intercalar. Certifique-se de que está a testar o URL correto e que o servidor está a responder adequadamente a todos os pedidos."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "O Lighthouse não conseguiu carregar com fiabilidade a página que solicitou. Certifique-se de que está a testar o URL correto e que o servidor está a responder adequadamente a todos os pedidos. (Detalhes: {errorDetails})"
@@ -984,7 +1308,7 @@
     "message": "Dados laboratoriais"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) análise da página atual numa rede móvel emulada. Os valores são estimativas, pelo que podem variar."
+    "message": "A análise do [Lighthouse](https://developers.google.com/web/tools/lighthouse/) da página atual numa rede móvel emulada. Os valores são o resultado de uma estimativa e podem variar."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Itens adicionais a verificar manualmente"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Expandir fragmento"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Mostrar recursos de terceiros"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Ocorreram problemas que afetaram esta execução do Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Os valores são estimados e podem variar."
+    "message": "Os valores são o resultado de uma estimativa e podem variar. A pontuação de desempenho é [baseada apenas nestas métricas](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "As auditorias foram concluídas com êxito, mas com avisos"
@@ -1035,25 +1362,25 @@
     "message": "Considere mostrar excertos nas suas listas de publicações (por exemplo, através da etiqueta de mais), reduzir o número de publicações apresentadas numa determinada página, dividir as publicações longas em várias páginas ou utilizar um plug-in para tornar o carregamento de comentários lento."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Há vários [plug-ins do WordPress](https://wordpress.org/plugins/search/minify+css/) que podem acelerar o seu site ao concatenar, reduzir e comprimir os seus estilos. Poderá ainda utilizar um processo de criação para proceder previamente à redução se possível."
+    "message": "Um número de [plug-ins do WordPress](https://wordpress.org/plugins/search/minify+css/) pode acelerar o seu site ao concatenar, reduzir e comprimir os seus estilos. Poderá ainda utilizar um processo de criação para proceder previamente à redução se possível."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
     "message": "Um número de [plug-ins do WordPress](https://wordpress.org/plugins/search/minify+javascript/) pode acelerar o seu site ao concatenar, reduzir e comprimir os seus scripts. Poderá ainda utilizar um processo de criação para proceder previamente à redução se possível."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Considere reduzir ou mudar o número de [plug-ins do WordPress](https://wordpress.org/plugins/) que carregam CSS não utilizadas na sua página. Para identificar plug-ins que estejam a adicionar CSS estranhas, experimente realizar a [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) nas DevTools do Chrome. Pode identificar o tema/plug-in responsável a partir do URL da folha de estilos. Esteja atento a plug-ins que tenham muitas folhas de estilo na lista com muito vermelho na cobertura do código. Um plug-in só deve ter uma folha de estilos na fila de espera se esta for realmente utilizada na página."
+    "message": "Considere reduzir ou mudar o número de [plug-ins do WordPress](https://wordpress.org/plugins/) que carregam CSS não utilizadas na sua página. Para identificar plug-ins que estejam a adicionar CSS não reconhecido, experimente realizar a [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) nas DevTools do Chrome. Pode identificar o tema/plug-in responsável a partir do URL da folha de estilos. Esteja atento a plug-ins que tenham muitas folhas de estilo na lista com muito vermelho na cobertura do código. Um plug-in só deve ter uma folha de estilos na fila de espera se esta for realmente utilizada na página."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Considere reduzir ou mudar o número de [plug-ins do WordPress](https://wordpress.org/plugins/) que carregam JavaScript não utilizado na sua página. Para identificar plug-ins que estejam a adicionar JS estranho, experimente realizar a [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) nas DevTools do Chrome. Pode identificar o tema/plug-in responsável a partir do URL do script. Esteja atento a plug-ins que tenham muitos scripts na lista com muito vermelho na cobertura do código. Um plug-in só deve ter um script na fila de espera se este for realmente utilizado na página."
+    "message": "Considere reduzir ou mudar o número de [plug-ins do WordPress](https://wordpress.org/plugins/) que carregam JavaScript não utilizado na sua página. Para identificar plug-ins que estejam a adicionar JS não reconhecido, experimente realizar a [cobertura de código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) nas DevTools do Chrome. Pode identificar o tema/plug-in responsável a partir do URL do script. Esteja atento a plug-ins que tenham muitos scripts na lista com muito vermelho na cobertura do código. Um plug-in só deve ter um script na fila de espera se este for realmente utilizado na página."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Leia sobre [Colocação do navegador em cache no WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Considere utilizar um [plug-in do WordPress de otimização da imagem](https://wordpress.org/plugins/search/optimize+images/) que comprime as imagens, ao mesmo tempo que mantém a qualidade."
+    "message": "Considere utilizar um [plug-in do WordPress de otimização da imagem](https://wordpress.org/plugins/search/optimize+images/) que comprima as imagens, ao mesmo tempo que mantém a qualidade."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Carregue imagens diretamente a partir da [biblioteca de multimédia](https://codex.wordpress.org/Media_Library_Screen) para garantir que estão disponíveis os tamanhos de imagem necessários e, em seguida, introduza-as a partir da biblioteca de multimédia ou utilize o widget de imagens para garantir que são utilizados os tamanhos ideais das imagens (incluindo as referentes a breakpoints adaptáveis). Evite utilizar imagens de \"tamanho original\", a menos que as dimensões sejam adequadas à utilização. [Saiba mais](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Carregue imagens diretamente a partir da [biblioteca de multimédia](https://codex.wordpress.org/Media_Library_Screen) para garantir que estão disponíveis os tamanhos de imagem necessários e, em seguida, introduza-as a partir da biblioteca de multimédia ou utilize o widget de imagens para garantir que são utilizados os tamanhos ideais das imagens (incluindo as referentes a breakpoints adaptáveis). Evite utilizar imagens de `Full Size`, a menos que as dimensões sejam adequadas à utilização. [Saiba mais](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Pode ativar a compressão de texto na configuração do servidor Web."

--- a/lighthouse-core/lib/i18n/locales/pt.json
+++ b/lighthouse-core/lib/i18n/locales/pt.json
@@ -1,15 +1,15 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "As chaves de acesso permitem ao usuário focar rapidamente determinada parte da página. Para haver uma navegação adequada, cada chave de acesso precisa ser única. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "As chaves de acesso permitem ao usuário focar rapidamente determinada parte da página. Para haver uma navegação adequada, cada chave de acesso precisa ser única. [Saiba mais](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
     "message": "Os valores de `[accesskey]` não são únicos"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Os valores de `[accesskey]` são únicos"
+    "message": "Valores de `[accesskey]` são exclusivos"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Cada função ARIA é compatível com um subconjunto específico de atributos \"aria-*\". Desfazer a correspondência entre eles invalida os atributos \"aria-*\". [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Cada `role` ARIA é compatível com um subconjunto específico de atributos `aria-*`. A falta de correspondência entre eles invalida os atributos `aria-*`. [Saiba mais](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
     "message": "Os atributos `[aria-*]` não correspondem às próprias funções"
@@ -18,7 +18,7 @@
     "message": "Os atributos `[aria-*]` correspondem às próprias funções"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Algumas funções ARIA têm atributos obrigatórios que descrevem o estado do elemento para leitores de tela. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Algumas funções ARIA têm atributos obrigatórios que descrevem o estado do elemento para leitores de tela. [Saiba mais](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
     "message": "`[role]`s não têm todos os atributos `[aria-*]` obrigatórios"
@@ -27,16 +27,16 @@
     "message": "`[role]`s têm todos os atributos `[aria-*]` obrigatórios"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Algumas funções ARIA mães precisam ter funções filhas específicas para cumprir as tarefas de acessibilidade pretendidas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Algumas funções ARIA mães precisam ter funções filhas específicas para cumprir as tarefas de acessibilidade pretendidas. [Saiba mais](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Os elementos com `[role]` que exigem `[role]`s filhos específicos estão ausentes."
+    "message": "Os elementos com `[role]` que exigem `[role]`s filhos específicos não estão presentes."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
     "message": "Os elementos com `[role]` que exigem `[role]`s filhos específicos estão presentes"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Algumas funções ARIA filhas precisam fazer parte das funções mães específicas para cumprir as tarefas de acessibilidade pretendidas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Algumas funções ARIA filhas precisam fazer parte das funções mães específicas para cumprir as tarefas de acessibilidade pretendidas. [Saiba mais](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
     "message": "`[role]`s não fazem parte do elemento pai obrigatório"
@@ -45,7 +45,7 @@
     "message": "`[role]`s fazem parte do elemento pai obrigatório"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "As funções ARIA precisam ter valores válidos para que realizem as tarefas de acessibilidade pretendidas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "As funções ARIA precisam ter valores válidos para que realizem as tarefas de acessibilidade pretendidas. [Saiba mais](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
     "message": "Os valores de `[role]` não são válidos"
@@ -54,7 +54,7 @@
     "message": "Os valores de `[role]` são válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Tecnologias assistivas, como leitores de tela, não conseguem interpretar atributos ARIA com valores inválidos. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Tecnologias assistivas, como leitores de tela, não conseguem interpretar atributos ARIA com valores inválidos. [Saiba mais](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
     "message": "Os atributos `[aria-*]` não têm valores válidos"
@@ -63,19 +63,19 @@
     "message": "Os atributos `[aria-*]` têm valores válidos"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "As tecnologias assistivas, como leitores de tela, não conseguem interpretar atributos ARIA com nomes inválidos. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "As tecnologias assistivas, como leitores de tela, não conseguem interpretar atributos ARIA com nomes inválidos. [Saiba mais](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Os atributos `[aria-*]` não são válidos ou contêm erros ortográficos"
+    "message": "Os atributos `[aria-*]` não são válidos nem contêm erros de ortografia"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
     "message": "Os atributos `[aria-*]` são válidos e não contêm erros de ortografia"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "As legendas tornam os elementos de áudio úteis para pessoas surdas ou deficientes auditivas, disponibilizando informações essenciais, como quem está falando, o que a pessoa está dizendo e outras informações não relacionadas à fala. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "As legendas tornam os elementos de áudio úteis para pessoas surdas ou deficientes auditivas, disponibilizando informações essenciais, como quem está falando, o que a pessoa está dizendo e outras informações não relacionadas à fala. [Saiba mais](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Os elementos `<audio>` não têm um elemento `<track>` com `[kind=\"captions\"]`."
+    "message": "Os elementos `<audio>` estão sem um elemento `<track>` com `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
     "message": "Os elementos `<audio>` contêm um elemento `<track>` com `[kind=\"captions\"]`"
@@ -84,7 +84,7 @@
     "message": "Elementos com falha"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Quando um botão não tem um nome acessível, os leitores de tela o enunciam como \"botão\", o que o torna inútil para usuários que dependem desses leitores. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Quando um botão não tem um nome acessível, os leitores de tela o enunciam como \"botão\", o que o inutiliza para usuários que dependem desses leitores. [Saiba mais](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Os botões não têm um nome acessível"
@@ -93,7 +93,7 @@
     "message": "Os botões têm um nome acessível"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Adicionar maneiras de ignorar conteúdo repetido permite ao usuário do teclado navegar pela página com mais eficiência. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "A adição de maneiras de ignorar conteúdo repetido permite ao usuário do teclado navegar pela página com mais eficiência. [Saiba mais](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "A página não contém um cabeçalho, link de salto ou região de ponto de referência"
@@ -102,7 +102,7 @@
     "message": "A página contém um título, um link de salto ou uma região de ponto de referência"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Para muitos usuários, é difícil ou impossível ler textos com baixo contraste. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Para muitos usuários, é difícil ou impossível ler textos com baixo contraste. [Saiba mais](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "As cores de primeiro e segundo plano não têm uma taxa de contraste suficiente."
@@ -111,16 +111,16 @@
     "message": "As cores de primeiro e segundo plano têm uma taxa de contraste suficiente"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Quando listas de definição não são marcadas corretamente, os leitores de tela podem produzir resultados confusos ou imprecisos. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Quando listas de definição não são marcadas corretamente, os leitores de tela podem produzir resultados confusos ou imprecisos. [Saiba mais](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "`<dl>`s não contêm apenas grupos `<dt>` e `<dd>` e elementos `<script>` ou `<template>` adequadamente organizados."
+    "message": "`<dl>`s não contêm apenas grupos `<dt>` e `<dd>` devidamente organizados e elementos `<script>` ou `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "`<dl>`s contêm apenas grupos `<dt>` e `<dd>` e elementos `<script>` ou `<template>` adequadamente organizados."
+    "message": "`<dl>`s contêm apenas os grupos `<dt>` e `<dd>` devidamente organizados ou os elementos `<script>` ou `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Os itens da lista de definição (\"<dt>\" e \"<dd>\") precisam ficar unidos em um elemento \"<dl>\" pai para garantir que os leitores de tela consigam enunciá-los corretamente. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Os itens da lista de definição (`<dt>` e `<dd>`) precisam ficar unidos em um elemento `<dl>` pai para garantir que os leitores de tela consigam enunciá-los corretamente. [Saiba mais](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
     "message": "Os itens da lista de definição não estão unidos em elementos `<dl>`"
@@ -129,7 +129,7 @@
     "message": "Os itens da lista de definição estão unidos em elementos `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "O título oferece ao usuário do leitor de tela uma visão geral da página, além de ser extremamente útil para que os usuários de mecanismos de pesquisa determinem se uma página é relevante à pesquisa deles. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "O título oferece ao usuário do leitor de tela uma visão geral da página, além de ser extremamente útil para que os usuários de mecanismos de pesquisa determinem se uma página é relevante à pesquisa deles. [Saiba mais](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "O documento não tem um elemento `<title>`"
@@ -138,16 +138,16 @@
     "message": "O documento tem um elemento `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "O valor de um atributo id precisa ser único para evitar que outras instâncias sejam ignoradas por tecnologias assistivas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "O valor de um atributo \"id\" precisa ser único para evitar que outras instâncias sejam ignoradas por tecnologias assistivas. [Saiba mais](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Os atributos `[id]`da página não são únicos"
+    "message": "Os atributos `[id]` da página não são únicos"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
     "message": "Os atributos `[id]` da página são únicos"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Os usuários de leitores de tela utilizam títulos para descrever o conteúdo de frames. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Os usuários de leitores de tela utilizam títulos para descrever o conteúdo de frames. [Saiba mais](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "Os elementos `<frame>` ou `<iframe>` não têm um título"
@@ -156,7 +156,7 @@
     "message": "Os elementos `<frame>` ou `<iframe>` têm um título"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Se uma página não especificar um atributo lang, o leitor de tela presumirá que a página está no idioma padrão que o usuário escolheu ao configurar esse leitor. Se a página não estiver no idioma padrão, o leitor de tela poderá ler o texto dela incorretamente. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Se uma página não especificar um atributo lang, o leitor de tela presumirá que a página está no idioma padrão que o usuário escolheu ao configurar esse leitor. Se a página não estiver no idioma padrão, o leitor de tela poderá ler o texto dela incorretamente. [Saiba mais](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
     "message": "O elemento `<html>` não tem um atributo `[lang]`"
@@ -165,7 +165,7 @@
     "message": "O elemento `<html>` tem um atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Especificar um [idioma BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido ajuda os leitores de tela a enunciar o texto corretamente. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "A especificação de um [idioma BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido ajuda os leitores de tela a enunciar o texto corretamente. [Saiba mais](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
     "message": "O elemento `<html>` não tem um valor válido para o atributo `[lang]`."
@@ -174,7 +174,7 @@
     "message": "O elemento `<html>` tem um valor válido para o atributo `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "O texto dos elementos informativos precisa ser alternativo, breve e descritivo. Os elementos decorativos podem ser ignorados com um atributo alternativo vazio. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "O texto dos elementos informativos precisa ser alternativo, breve e descritivo. Os elementos decorativos podem ser ignorados com um atributo alternativo vazio. [Saiba mais](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
     "message": "Os elementos de imagem não têm atributos `[alt]`"
@@ -183,7 +183,7 @@
     "message": "Os elementos de imagem têm atributos `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Quando uma imagem for usada como um botão \"<input>\", fornecer um texto alternativo pode ajudar os usuários do leitor de tela a entender a finalidade do botão. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Quando uma imagem for usada como um botão `<input>`, a oferta de texto alternativo poderá ajudar o usuário do leitor de tela a entender a finalidade do botão. [Saiba mais](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "Os elementos `<input type=\"image\">` não têm texto `[alt]`"
@@ -192,7 +192,7 @@
     "message": "Os elementos `<input type=\"image\">` têm texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "As etiquetas garantem que os controles de formulário sejam enunciados corretamente por tecnologias assistivas, como leitores de tela. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "As etiquetas garantem que os controles de formulário sejam enunciados corretamente por tecnologias assistivas, como leitores de tela. [Saiba mais](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Os elementos de formulário não têm etiquetas associadas"
@@ -201,7 +201,7 @@
     "message": "Os elementos de formulário têm etiquetas associadas"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Não inclua elementos de dados, como os elementos \"th\" ou \"caption\", nem o atributo \"summary\" em uma tabela utilizada para fins de layout, já que isso pode gerar uma experiência confusa para os usuários de leitores de telas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Não inclua elementos de dados, como os elementos \"th\" ou \"caption\", nem o atributo \"summary\" em uma tabela utilizada para fins de layout, já que isso pode gerar uma experiência confusa para os usuários de leitores de telas. [Saiba mais](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
     "message": "Os elementos `<table>` de apresentação não evitam o uso de `<th>`, `<caption>` ou do atributo `[summary]`."
@@ -210,7 +210,7 @@
     "message": "Os elementos `<table>` de apresentação evitam o uso de `<th>`, `<caption>` ou do atributo `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Textos de link (e textos alternativos de imagens, quando utilizados como links) compreensíveis, únicos e focalizáveis melhoram a experiência de navegação para usuários de leitores de tela. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Textos de link (e textos alternativos de imagens, quando utilizados como link) compreensíveis, únicos e focalizáveis melhoram a experiência de navegação para usuários de leitores de tela. [Saiba mais](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Os links não têm um nome compreensível"
@@ -219,43 +219,43 @@
     "message": "Os links têm um nome compreensível"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Os leitores de tela têm uma maneira específica de enunciar listas. Garantir uma estrutura de lista adequada melhora os resultados do leitor de tela. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Os leitores de tela têm uma maneira específica de enunciar listas. Uma estrutura de lista adequada melhora os resultados do leitor de tela. [Saiba mais](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
     "message": "As listas não contêm apenas elementos `<li>` e elementos compatíveis com script (`<script>` e `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "As listas contêm apenas elementos `<li>` e elementos compatíveis com script (`<script>` e `<template>`)."
+    "message": "As listas contêm somente elementos `<li>` e elementos compatíveis com script (`<script>` e `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Os itens de lista (\"<li>\") precisam estar em um \"<ul>\" ou \"<ol>\" pai para que os leitores de tela os enunciem corretamente. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Os leitores de tela exigem que os itens de lista (`<li>`) estejam contidos em um `<ul>` ou `<ol>` pai para serem enunciados corretamente. [Saiba mais](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Os itens de lista (`<li>`) não estão nos elementos pais `<ul>` ou `<ol>`."
+    "message": "Os itens de lista (`<li>`) não estão contidos nos elementos pai `<ul>` ou `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Os itens de lista (`<li>`) estão nos elementos pais `<ul>` ou `<ol>`"
+    "message": "Os itens de lista (`<li>`) estão contidos nos elementos pai `<ul>` ou `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Os usuários não esperam que a página seja atualizada automaticamente, o que moveria o foco novamente para a parte superior dela. Isso pode causar uma experiência confusa ou frustrante. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "O usuário não espera a atualização automática da página, o que move o foco novamente para a parte superior dela. Isso pode causar uma experiência confusa ou frustrante. [Saiba mais](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "O documento utiliza `<meta http-equiv=\"refresh\">`"
+    "message": "O documento usa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "O documento não utiliza `<meta http-equiv=\"refresh\">`"
+    "message": "O documento não usa `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "A desativação do zoom gera problemas para usuários com baixa visão que utilizam a ampliação de tela para enxergar corretamente o conteúdo de uma página da Web. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "A desativação do zoom gera problemas para usuários com baixa visão que utilizam a ampliação de tela para enxergar corretamente o conteúdo de uma página da Web. [Saiba mais](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "`[user-scalable=\"no\"]` é utilizado no elemento `<meta name=\"viewport\">`, ou o atributo `[maximum-scale]` é inferior a 5."
+    "message": "`[user-scalable=\"no\"]` é usado no elemento `<meta name=\"viewport\">` ou o atributo `[maximum-scale]` é menor que 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "`[user-scalable=\"no\"]` não é usado no elemento `<meta name=\"viewport\">`, e o atributo `[maximum-scale]` não é inferior a 5."
+    "message": "`[user-scalable=\"no\"]` não é usado no elemento `<meta name=\"viewport\">`, e o atributo `[maximum-scale]` não é menor que 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Os leitores de tela não traduzem conteúdo não textual. Adicionar um texto alternativo aos elementos \"<object>\" ajuda os leitores de tela a transmitir mensagens corretas aos usuários. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Os leitores de tela não traduzem conteúdo não textual. A adição de texto alternativo aos elementos `<object>` ajuda os leitores de tela a transmitir o significado para os usuários. [Saiba mais](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "Os elementos `<object>` não têm texto `[alt]`"
@@ -264,7 +264,7 @@
     "message": "Os elementos `<object>` têm texto `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Um valor maior que 0 indica uma ordem explícita de navegação. Embora tecnicamente válido, isso costuma gerar experiências frustrantes para os usuários que utilizam tecnologias assistivas. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Um valor maior que 0 indica uma ordem explícita de navegação. Embora tecnicamente válido, isso costuma gerar experiências frustrantes para os usuários que utilizam tecnologias assistivas. [Saiba mais](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "Alguns elementos têm um valor de `[tabindex]` maior que 0"
@@ -273,25 +273,25 @@
     "message": "Nenhum elemento tem um valor de `[tabindex]` maior que 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Os leitores de tela têm recursos para facilitar a navegação em tabelas. Garantir que as células \"<td>\" que utilizam o atributo \"[headers]\" se refiram apenas às demais células da mesma tabela pode melhorar a experiência dos usuários de leitores de tela. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Os leitores de tela têm recursos para facilitar a navegação em tabelas. Para melhorar a experiência dos usuários de leitores de tela, as células `<td>` que usam o atributo `[headers]` precisam referenciar apenas outras células na mesma tabela. [Saiba mais](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "As células em um elemento `<table>` que utilizam o atributo `[headers]` referem-se às demais células dessa mesma tabela."
+    "message": "As células de um elemento `<table>` que usa o atributo `[headers]` se referem às outras células dessa mesma tabela."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "As células de um elemento `<table>` que utilizam o atributo `[headers]` só se referem às demais células dessa mesma tabela."
+    "message": "As células em um elemento `<table>` que usam o atributo `[headers]` se referem apenas às outras células da mesma tabela."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Os leitores de tela têm recursos para facilitar a navegação em tabelas. Garantir que os cabeçalhos das tabelas se refiram sempre a alguns conjuntos de células pode melhorar a experiência dos usuários de leitores de tela. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Os leitores de tela têm recursos para facilitar a navegação em tabelas. Garantir que os cabeçalhos das tabelas se refiram sempre a alguns conjuntos de células pode melhorar a experiência dos usuários de leitores de tela. [Saiba mais](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Os elementos `<th>` e os elementos com `[role=\"columnheader\"/\"rowheader\"]` não têm células de dados descritas."
+    "message": "Os elementos `<th>` e os elementos com `[role=\"columnheader\"/\"rowheader\"]` não têm as células de dados descritas."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Os elementos `<th>` e os elementos com `[role=\"columnheader\"/\"rowheader\"]` têm células de dados descritas."
+    "message": "Os elementos `<th>` e os elementos com `[role=\"columnheader\"/\"rowheader\"]` têm as células de dados descritas."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Especificar um [idioma BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido nos elementos ajuda a garantir que o texto seja pronunciado corretamente pelo leitor de tela. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "A especificação de um [idioma BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) válido nos elementos ajuda a garantir que o texto seja pronunciado corretamente pelo leitor de tela. [Saiba mais](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
     "message": "Os atributos `[lang]` não têm um valor válido"
@@ -300,7 +300,7 @@
     "message": "Os atributos `[lang]` têm um valor válido"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Quando um vídeo é acompanhado de legendas, as pessoas surdas e deficientes auditivas têm mais facilidade para acessar as informações dele. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Quando um vídeo é acompanhado de legendas, as pessoas surdas e deficientes auditivas têm mais facilidade para acessar as informações dele. [Saiba mais](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
     "message": "Os elementos `<video>` não contêm um elemento `<track>` com `[kind=\"captions\"]`."
@@ -309,13 +309,25 @@
     "message": "Os elementos `<video>` contêm um elemento `<track>` com `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "As descrições de áudio fornecem informações importantes que não podem ser transmitidas por meio do diálogo nos vídeos, por exemplo, expressões faciais e cenários. [Saiba mais](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "As descrições de áudio trazem informações importantes que não podem ser transmitidas por meio do diálogo nos vídeos, por exemplo, expressões faciais e cenários. [Saiba mais](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
     "message": "Os elementos `<video>` não contêm um elemento `<track>` com `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
     "message": "Os elementos `<video>` contêm um elemento `<track>` com `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Para ter uma exibição ideal no iOS quando o usuário adiciona itens à tela inicial, defina um apple-touch-icon. Ele precisa apontar para um PNG quadrado não transparente de 192 px (ou 180 px). [Saiba mais](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Não oferece um `apple-touch-icon` válido"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` está desatualizado. Use `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Disponibiliza um `apple-touch-icon` válido"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "As extensões do Chrome afetaram negativamente o desempenho de carregamento desta página. Tente fazer a auditoria da página no modo de navegação anônima ou em um perfil do Chrome sem extensões."
@@ -330,7 +342,7 @@
     "message": "Tempo total de CPU"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Reduza o tempo gasto com análise, compilação e execução de JS. Você perceberá que exibir payloads de JS menores ajuda a fazer isso. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Diminua o tempo gasto na análise, compilação e execução de JS. Você perceberá que exibir payloads de JS menores ajuda a fazer isso. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Reduza o tempo de execução de JavaScript"
@@ -339,25 +351,25 @@
     "message": "Tempo de execução de JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "GIFs grandes são ineficazes para exibir conteúdo animado. Use vídeos MPEG4/WebM para animações e PNG/WebP para imagens estáticas em vez de GIF, para economizar bytes de rede. [Saiba mais](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "GIFs grandes não são eficientes para exibir conteúdo animado. Use vídeos MPEG4/WebM para animações e PNG/WebP para imagens estáticas em vez de GIF para economizar bytes de rede. [Saiba mais](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Use formatos de vídeo para conteúdo animado"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Use o carregamento lento para imagens fora da tela e ocultas depois que todos os recursos críticos já estiverem carregados, para reduzir o tempo necessário até que a página se torne interativa. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "A fim de reduzir o tempo para interação da página, faça o carregamento lento de imagens fora da tela e ocultas quando todos os recursos críticos já estiverem carregados. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Adie imagens fora da tela"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Alguns recursos estão bloqueando o primeiro aparecimento da sua página. Considere exibir JS/CSS crítico inline e adiar todos os JS/estilos não críticos. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Os recursos estão bloqueando a primeira exibição da sua página. Exiba JS/CSS crítico inline e adie todos os JS/estilos não críticos. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Elimine recursos que impedem a renderização"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Grandes payloads de rede geram custos para os usuários e estão altamente relacionados a tempos maiores de carregamento. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Grandes payloads de rede geram custos para o usuário e estão diretamente relacionados a tempos de carregamento maiores. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "O tamanho total foi de {totalBytes, number, bytes} KB"
@@ -381,7 +393,7 @@
     "message": "Reduza o JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Remova as regras inativas das folhas de estilo e adie o carregamento de CSS não usado para conteúdo acima da dobra para reduzir o consumo desnecessário de bytes da atividade de rede. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Remova as regras inativas das folhas de estilo e adie o carregamento de CSS não usado para conteúdo acima da dobra, a fim de reduzir o consumo desnecessário de bytes da atividade da rede. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Remova CSS não utilizado"
@@ -411,31 +423,82 @@
     "message": "Codifique as imagens com eficiência"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Disponibilize imagens de tamanho adequado para economizar dados da rede celular e melhorar o tempo de carregamento. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Veicule imagens que tenham o tamanho adequado para economizar dados da rede celular e melhorar o tempo de carregamento. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Defina um tamanho adequado para as imagens"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Os recursos baseados em texto precisam ser disponibilizados com compactação (gzip, deflate ou brotli) para reduzir o total de bytes da rede. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Os recursos baseados em texto precisam ser veiculados com compactação (gzip, deflate ou brotli) para minimizar o total de bytes da rede. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Ative a compactação de texto"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Formatos de imagem como JPEG 2000, JPEG XR e WebP geralmente resultam em uma compactação melhor em comparação a PNG ou JPEG, o que significa downloads mais rápidos e menor consumo de dados. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Formatos de imagem como JPEG 2000, JPEG XR e WebP geralmente oferecem uma melhor compactação do que PNG ou JPEG, o que significa downloads mais rápidos e menor consumo de dados. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Disponibilize imagens em formatos de última geração"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "As redes de solicitações críticas abaixo mostram os recursos carregados com alta prioridade. Reduza o tamanho das redes ao diminuir o tamanho do download dos recursos ou ao adiar o download de recursos desnecessários para melhorar o carregamento de página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "As cadeias de solicitação críticas abaixo mostram quais recursos são carregados com prioridade alta. Diminua o tamanho das cadeias, reduza o tamanho do download de recursos ou adie o download de recursos desnecessários para melhorar o carregamento de página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 rede encontrada}one{# rede encontrada}other{# redes encontradas}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Reduza a profundidade de solicitações críticas"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Suspensão de uso/aviso"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Linha"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "As APIs obsoletas acabarão sendo removidas do navegador. [Saiba mais](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 aviso encontrado}one{# aviso encontrado}other{# avisos encontrados}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Utiliza APIs obsoletas"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Evita APIs obsoletas"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "O cache de aplicativo está obsoleto. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" encontrado"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Usa cache de aplicativo"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Evita o cache de aplicativo"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "A especificação de um doctype evita que o navegador alterne para o modo quirks. Leia mais na [página do MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "O nome do doctype precisa ser o `html` da string em letra minúscula"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "O documento precisa conter um doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "O ID público deveria ser uma string vazia"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "O ID do sistema deveria ser uma string vazia"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "A página não tem o doctype HTML e, assim, aciona o modo quirks"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "A página tem o doctype HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Elemento"
@@ -447,7 +510,7 @@
     "message": "Valor"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Os engenheiros de navegador recomendam que as páginas tenham menos de 1.500 elementos DOM, aproximadamente. O ideal é uma profundidade de árvore com menos de 32 elementos e menos de 60 elementos filhos/pais. Um DOM grande pode aumentar o uso da memória, causar [cálculos de estilo mais longos](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) e produzir [reflows de layout de alto custo](https://developers.google.com/speed/articles/reflow). [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Os engenheiros do navegador recomendam páginas com menos de ~1.500 elementos DOM. A posição ideal é uma profundidade de árvore com menos de 32 elementos e menos de 60 elementos filhos/pais. Um DOM grande pode aumentar o uso da memória, causar [cálculos de estilo](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) mais longos e produzir [reflows de layout](https://developers.google.com/speed/articles/reflow) dispendiosos. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 elemento}one{# elemento}other{# elementos}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Evita DOM de tamanho excessivo"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Destino"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Adicione `rel=\"noopener\"` ou `rel=\"noreferrer\"` a qualquer link externo para melhorar o desempenho e evitar vulnerabilidades de segurança. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Links para destinos de origem cruzada não são seguros"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Links para destinos de origem cruzada são seguros"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Não é possível determinar o destino do item fixo ({anchorHTML}). Se não for usado como um hiperlink, remova target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Os usuários não confiam ou ficam confusos com sites que solicitam a localização sem contexto. Vincule a solicitação a uma ação do usuário. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Solicita a permissão de geolocalização no carregamento de página"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Evita o pedido da permissão de geolocalização no carregamento de página"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versão"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Todas as bibliotecas JavaScript de front-end detectadas na página."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Bibliotecas JavaScript detectadas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Para usuários em conexões lentas, os scripts externos injetados dinamicamente via `document.write()` podem atrasar o carregamento de página em dezenas de segundos. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Usa `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Evita `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Maior gravidade"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Versão da biblioteca"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Contagem de vulnerabilidades"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Alguns scripts de terceiros podem conter vulnerabilidades de segurança conhecidas, facilmente identificadas e exploradas por invasores. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 vulnerabilidade detectada}one{# vulnerabilidade detectada}other{# vulnerabilidades detectadas}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Inclui bibliotecas JavaScript de front-end com vulnerabilidades de segurança conhecidas"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Alto"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Baixo"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Médio"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Evita bibliotecas JavaScript de front-end com vulnerabilidades de segurança conhecidas"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Os usuários não confiam ou ficam confusos com sites que solicitam o envio de notificações sem contexto. Vincule a solicitação a gestos do usuário. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Solicita a permissão de notificação no carregamento de página"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Evita o pedido da permissão de notificação no carregamento de página"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elementos com falha"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Impedir a colagem da senha prejudica a política de boa segurança. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Evita que o usuário cole nos campos de senha"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Permite que o usuário cole nos campos de senha"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocolo"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 oferece muitos benefícios com relação ao HTTP/1.1, incluindo cabeçalhos binários, multiplexação e push do servidor. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 solicitação não veiculada via HTTP/2}one{# solicitação não veiculada via HTTP/2}other{# solicitações não veiculadas via HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Não utiliza HTTP/2 para todos os recursos"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Usa HTTP/2 para os próprios recursos"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Marque os listeners de eventos de toque e rolagem como `passive` para melhorar o desempenho de rolagem da página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Não utiliza listeners passivos para melhorar o desempenho de rolagem"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Utiliza listeners passivos para melhorar o desempenho de rolagem"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Descrição"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Os erros registrados no console indicam problemas não resolvidos. Eles podem ocorrer devido a falhas de solicitação de rede e outras questões relacionadas ao navegador."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Erros do navegador foram registrados no console"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Nenhum erro do navegador registrado no console"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Use o recurso CSS de exibição de fonte para garantir que o texto possa ser visto pelo usuário enquanto as webfonts são carregadas. [Saiba mais](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Todo o texto continua visível durante o carregamento da webfont"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "O Lighthouse não conseguiu verificar automaticamente o valor de exibição da fonte para o seguinte URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Proporção (real)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Proporção (exibida)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "As dimensões de exibição da imagem devem corresponder à proporção. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Exibe imagens com a proporção incorreta"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Exibe imagens com a proporção correta"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Informações inválidas para tamanho de imagem {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL não seguro"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Todos os sites devem ser protegidos com HTTPS, mesmo aqueles que não lidam com dados confidenciais. O HTTPS evita que invasores falsifiquem ou escutem passivamente a comunicação entre o app e o usuário, além de ser um pré-requisito para HTTP/2 e muitas novas APIs para plataforma da Web. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 solicitação não segura encontrada}one{# solicitação não segura encontrada}other{# solicitações não seguras encontradas}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Não utiliza HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Utiliza HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Um carregamento de página rápido em uma rede celular garante uma boa experiência do usuário em dispositivos móveis. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interativo em {timeInMs, number, seconds} s"
+    "message": "Interativa em {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Interativo em rede móvel simulada em {timeInMs, number, seconds} s"
+    "message": "Interativa na rede móvel simulada em {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "A velocidade de carregamento da página não é suficiente em redes móveis"
@@ -504,58 +735,76 @@
     "message": "Minimiza o trabalho da thread principal"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "A latência de entrada é uma estimativa do tempo que seu app leva para responder à atividade do usuário, em milésimos de segundo, durante a janela de carregamento de página mais movimentada de cinco segundos. Se a latência for superior a 50 ms, o usuário poderá notar lentidão no aplicativo. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "\"Latência de entrada estimada\" é uma estimativa de quanto tempo o app leva para responder à entrada do usuário, em milésimos de segundo, durante a janela de carregamento de página mais movimentada de cinco segundos. Se a latência for maior que 50 ms, o usuário poderá notar lentidão no app. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Latência de entrada estimada"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "A primeira exibição de conteúdo marca o momento em que o primeiro texto ou imagem é disponibilizado. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "\"Primeira exibição de conteúdo\" marca o momento em que o primeiro texto ou imagem é disponibilizado. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Primeiro aparecimento com conteúdo"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "\"Primeira CPU ociosa\" marca a primeira vez que a thread principal da página fica silenciosa o suficiente para lidar com a entrada. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "\"Primeira CPU ociosa\" marca a primeira vez que o thread principal da página fica silencioso o suficiente para lidar com a entrada. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Primeira CPU ociosa"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "\"Primeira exibição importante\" marca o momento em que o conteúdo principal de uma página se torna visível. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "\"Primeira exibição significativa\" marca o momento em que o conteúdo principal de uma página se torna visível. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Primeira exibição importante"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "O tempo para interação da página é o período necessário para que ela fique totalmente interativa. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "\"Tempo para interação da página\" é o período necessário para que ela fique totalmente interativa. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Tempo até ficar interativa"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "A potencial latência de entrada que seus usuários notariam seria a duração, em milésimos de segundo, da tarefa mais longa."
+    "message": "A possível latência máxima na primeira entrada que seus usuários notariam seria a duração, em milésimos de segundo, da tarefa mais longa. [Saiba mais](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Potencial máx. de 1º atraso de entrada"
+    "message": "Possível latência máxima na primeira entrada"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "O Índice de velocidade mostra a rapidez com que o conteúdo de uma página é preenchido visivelmente. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "\"Índice de velocidade\" mostra a rapidez com que o conteúdo de uma página é preenchido visivelmente. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Índice de velocidade"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Soma de todos os períodos entre \"FCP\" e \"Tempo para interação da página\", quando a duração da tarefa ultrapassa 50 ms, expressa em milésimos de segundo."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Tempo total de bloqueio"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "O tempo de retorno (RTT, na sigla em inglês) da rede tem um grande impacto no desempenho. Se o RTT para uma origem for alto, isso é uma indicação de que os servidores mais próximos do usuário poderiam melhorar o desempenho. [Saiba mais](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "O tempo de retorno (RTT, na sigla em inglês) da rede tem um grande impacto no desempenho. Se o RTT para uma origem é alto, significa que os servidores mais próximos do usuário poderiam melhorar o desempenho. [Saiba mais](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Tempos de retorno da rede"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Latências do servidor podem afetar o desempenho na Web. Se a latência do servidor de uma origem for alta, isso é uma indicação de que ele está sobrecarregado ou o back-end tem desempenho fraco. [Saiba mais](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "As latências de servidor podem afetar o desempenho na Web. Se a latência do servidor de uma origem for alta, isso indica que ele está sobrecarregado ou que o back-end apresenta um desempenho ruim. [Saiba mais](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latências do back-end do servidor"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Acima do orçamento"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Mantenha a quantidade e o tamanho de solicitações de rede de acordo com os destinos definidos pelo orçamento de desempenho informado. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 solicitação}one{# solicitação}other{# solicitações}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Orçamento de desempenho"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Os redirecionamentos causam mais atrasos antes do carregamento da página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
@@ -563,11 +812,20 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Evite redirecionamentos múltiplos de página"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Para definir orçamentos para a quantidade e o tamanho dos recursos da página, adicione um arquivo budget.json. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 solicitação}one{# solicitação}other{# solicitações}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Mantenha as contagens de solicitações baixas e os tamanhos de transferência pequenos"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Os links canônicos sugerem o URL a ser exibido nos resultados da pesquisa. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Vários URLs conflitantes ({urlList})"
+    "message": "Vários URLs com conflito ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "Aponta para um domínio diferente ({url})"
@@ -576,7 +834,7 @@
     "message": "URL inválido ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Aponta para outro local de \"hreflang\" ({url})"
+    "message": "Aponta para outro local de `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "URL relativo ({url})"
@@ -585,25 +843,22 @@
     "message": "Aponta para o URL raiz do domínio (a página inicial), em vez de uma página de conteúdo equivalente"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "O documento não tem um \"rel=canonical\" válido"
+    "message": "O documento não tem um `rel=canonical` válido"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "O documento tem um \"rel=canonical\" válido"
+    "message": "O documento tem um `rel=canonical` válido"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Fontes menores do que 12 px não são legíveis e exigem que os visitantes de dispositivos móveis façam um gesto de pinça para aumentar o zoom e conseguir ler. Faça o possível para ter mais de 60% do texto da página com pelo menos 12 px. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Fontes menores que 12 px não são legíveis e exigem que os visitantes que utilizam dispositivos móveis façam um gesto de pinça para aumentar o zoom e conseguir ler. Faça o possível para ter mais de 60% do texto da página com pelo menos 12 px. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} do texto legível"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} do texto é muito pequeno."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "O texto é ilegível porque não há nenhuma metatag de janela de visualização otimizada para telas de dispositivos móveis."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} do texto é muito pequeno (baseado em uma amostra de {decimalProportionVisited, number, extendedPercent})."
+    "message": "{decimalProportion, number, extendedPercent} do texto é muito pequeno (com base na amostra de {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "O documento não usa tamanhos de fonte legíveis"
@@ -612,13 +867,13 @@
     "message": "O documento usa tamanhos de fonte legíveis"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Os links hreflang informam aos mecanismos de pesquisa qual versão de uma página deve ser listada nos resultados para um determinado idioma ou região. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Os links hreflang informam aos mecanismos de pesquisa qual versão de uma página deve ser listada nos resultados de pesquisa para um determinado idioma ou região. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "O documento não tem um \"hreflang\" válido"
+    "message": "O documento não tem um `hreflang` válido"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "O documento tem um \"hreflang\" válido"
+    "message": "O documento tem um `hreflang` válido"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "As páginas com falha no código de status HTTP talvez não sejam indexadas corretamente. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -630,7 +885,7 @@
     "message": "A página tem um código de status HTTP bem-sucedido"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Os mecanismos de pesquisa não poderão incluir suas páginas nos resultados se não tiverem permissão para rastreá-los. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Os mecanismos de pesquisa não poderão incluir suas páginas nos resultados se não tiverem permissão para rastreá-las. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "A página está bloqueada para indexação"
@@ -639,7 +894,7 @@
     "message": "A página não está bloqueada para indexação"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Texto com link descritivo ajuda os mecanismos de pesquisa a entenderem o conteúdo. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "O texto com link descritivo ajuda os mecanismos de pesquisa a entender o conteúdo. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 link encontrado}one{# link encontrado}other{# links encontrados}}"
@@ -651,7 +906,7 @@
     "message": "Os links têm texto descritivo"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Execute a [Ferramenta de teste de dados estruturados](https://search.google.com/structured-data/testing-tool/) e o [Structured Data Linter](http://linter.structured-data.org/) para validar os dados estruturados. [Saiba mais](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Execute a [Ferramenta de teste de dados estruturados](https://search.google.com/structured-data/testing-tool/) e a [Structured Data Linter](http://linter.structured-data.org/) para validar os dados estruturados. [Saiba mais](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Os dados estruturados são válidos"
@@ -681,7 +936,7 @@
     "message": "Se o arquivo robots.txt for inválido, os rastreadores talvez não consigam entender como você quer que seu site seja rastreado ou indexado."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "solicitação de robots.txt retornou o status HTTP: {statusCode}"
+    "message": "A solicitação de robots.txt retornou o status HTTP: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{1 erro encontrado}one{# erro encontrado}other{# erros encontrados}}"
@@ -696,7 +951,7 @@
     "message": "robots.txt é válido"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Os elementos interativos, como botões e links, precisam ser grandes o suficiente (48x48 px) e ter espaço suficiente ao redor para poderem ser tocados sem sobreposição com outros elementos. [Saiba mais](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Os elementos interativos, como botões e links, precisam ser grandes o bastante (48x48 px) e ter espaço suficiente ao redor para poderem ser tocados sem sobreposição com outros elementos. [Saiba mais](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} de áreas de toque dimensionadas corretamente"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Área com sobreposição"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Tamanho"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Área de toque"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "As áreas de toque estão dimensionadas corretamente"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Tempo na linha de execução principal"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Terceiros"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Código de terceiros pode afetar significativamente o desempenho de carregamento. Limite o número de provedores terceiros redundantes e carregue o código de terceiros depois que a página tiver sido carregada. [Saiba mais](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 terceiro encontrado}one{# terceiro encontrado}other{# terceiros encontrados}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Uso de terceiros"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "\"Tempo até o primeiro byte\" identifica o momento em que seu servidor envia uma resposta. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "\"Tempo até o primeiro byte\" identifica o momento em que o servidor envia uma resposta. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "O documento raiz levou {timeInMs, number, milliseconds} ms"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Duração"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nome"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Horário de início"
   },
@@ -744,7 +1008,7 @@
     "message": "Tipo"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Instrumente seu app com a User Timing API para medir o desempenho real do app durante as principais experiências do usuário. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Instrumente seu app com a API User Timing para avaliar o desempenho real do app durante as principais experiências do usuário. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 velocidade do usuário}one{# velocidade do usuário}other{# velocidades do usuário}}"
@@ -762,10 +1026,10 @@
     "message": "Pré-conecte às origens necessárias"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Um <link> de pré-carregamento foi encontrado para \"{preloadURL}\", mas não foi usado pelo navegador. Verifique se você está usando o atributo \"crossorigin\" corretamente."
+    "message": "Um <link> de pré-carregamento foi encontrado para \"{preloadURL}\", mas não foi usado pelo navegador. Verifique se você está usando o atributo `crossorigin` corretamente."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Use <link rel=preload> para priorizar a busca posterior de recursos solicitados atualmente no carregamento de página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Use `<link rel=preload>` para priorizar a busca de recursos que, no momento, são solicitados posteriormente no carregamento de página. [Saiba mais](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Pré-carregue as principais solicitações"
@@ -789,10 +1053,10 @@
     "message": "Práticas recomendadas"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Essas verificações destacam oportunidades para [melhorar a acessibilidade do seu app da Web](https://developers.google.com/web/fundamentals/accessibility). Apenas um subconjunto de problemas de acessibilidade pode ser automaticamente detectado, portanto, os testes manuais também são incentivados."
+    "message": "Essas verificações destacam oportunidades para [melhorar a acessibilidade do seu app da Web](https://developers.google.com/web/fundamentals/accessibility). Somente um subconjunto de problemas de acessibilidade pode ser detectado automaticamente, portanto, testes manuais também devem ser realizados."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Esses itens se referem a áreas que uma ferramenta de teste automatizada não pode cobrir. Saiba mais no nosso guia sobre [como conduzir uma revisão de acessibilidade](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Esses itens se referem a áreas que uma ferramenta de teste automatizada não pode cobrir. Saiba mais no nosso guia sobre [como realizar uma avaliação de acessibilidade](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Acessibilidade"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabelas e listas"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Práticas recomendadas"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Os orçamentos de desempenho definem padrões para o desempenho do seu site."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Orçamentos"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Mais informações sobre o desempenho do seu aplicativo."
+    "message": "Mais informações sobre o desempenho do seu aplicativo. Esses números não [afetam diretamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) o índice de desempenho."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnóstico"
@@ -840,7 +1113,7 @@
     "message": "Melhorias do primeiro aparecimento"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Essas otimizações podem acelerar o carregamento de página."
+    "message": "Essas sugestões podem ajudar a acelerar o carregamento de página. Elas não [afetam diretamente](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) o índice de desempenho."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Oportunidades"
@@ -867,7 +1140,7 @@
     "message": "Otimizado para PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Essas verificações garantem que sua página seja otimizada para a classificação dos resultados dos mecanismos de pesquisa. Existem fatores adicionais que o Lighthouse não verifica e que podem afetar a classificação da pesquisa. [Saiba mais](https://support.google.com/webmasters/answer/35769)."
+    "message": "Essas verificações garantem que sua página seja otimizada para a classificação dos resultados dos mecanismos de pesquisa. Existem outros fatores que o Lighthouse não verifica e que podem afetar a classificação da pesquisa. [Saiba mais](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Execute estes validadores adicionais no seu site para verificar mais práticas recomendadas de SEO."
@@ -888,7 +1161,7 @@
     "message": "Rastreamento e indexação"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Suas páginas precisam ser otimizadas para dispositivos móveis para que os usuários não tenham que usar gestos de pinça ou zoom para ler o conteúdo. [Saiba mais](https://developers.google.com/search/mobile-sites/)."
+    "message": "Suas páginas precisam ser compatíveis com dispositivos móveis, para que o usuário não tenha que usar gestos de pinça ou zoom para ler o conteúdo. [Saiba mais](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Otimizada para dispositivos móveis"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Cache TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Localização"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nome"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Solicitações"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Tipo de recurso"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Tamanho (KB)"
+    "message": "Tamanho"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Tempo gasto"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Tamanho da transferência"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Possível economia (KB)"
+    "message": "Possível economia"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Possível economia (ms)"
+    "message": "Possível economia"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Possível economia de {wastedBytes, number, bytes} KB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Possível economia de {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Documento"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Fonte"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Imagem"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Mídia"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Outro"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Folha de estilo"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Terceiros"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Total"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Ocorreu um erro com a gravação dos rastros no carregamento de página. Execute o Lighthouse novamente. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Os servidores DNS não resolveram o domínio fornecido."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "O coletor {artifactName} obrigatório encontrou um erro: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Ocorreu um erro interno do Chrome. Reinicie o Chrome e tente executar o Lighthouse novamente."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "O coletor {artifactName} obrigatório não foi executado."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "O Lighthouse não carregou de maneira confiável a página solicitada. Verifique se você está testando o URL correto e se o servidor está respondendo de forma adequada a todas as solicitações."
@@ -945,7 +1266,10 @@
     "message": "O Lighthouse não carregou de maneira confiável o URL solicitado, porque a página parou de responder."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "O URL informado não tem credenciais de segurança válidas. {securityMessages}"
+    "message": "O URL informado não tem um certificado de segurança válido. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "O Chrome impediu o carregamento da página com um intersticial. Verifique se você está testando o URL correto e se o servidor está respondendo de forma adequada a todas as solicitações."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "O Lighthouse não carregou de maneira confiável a página solicitada. Verifique se você está testando o URL correto e se o servidor está respondendo de forma adequada a todas as solicitações. (Detalhes: {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Expandir snippet"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Mostrar recursos de terceiros"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Alguns problemas afetaram esta execução do Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Os valores são estimados e podem variar."
+    "message": "Os valores são estimados e podem variar. O índice de desempenho [se baseia somente nessas métricas](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Passou nas auditorias, mas como avisos"
@@ -1023,10 +1350,10 @@
     "message": "Faça upload do seu GIF para um serviço que o disponibilizará para incorporação como um vídeo HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Instale um [plug-in lazy-load do WordPress](https://br.wordpress.org/plugins/search/lazy+load/), que permite adiar imagens fora da tela, ou alterne para um tema que ofereça essa funcionalidade. Também recomendamos o uso do [plug-in AMP](https://br.wordpress.org/plugins/amp/)."
+    "message": "Instale um [plug-in de carregamento lento do WordPress](https://wordpress.org/plugins/search/lazy+load/), que permite adiar imagens fora da tela, ou alterne para um tema que ofereça essa funcionalidade. Também recomendamos o uso do [plug-in de AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Existem vários plug-ins do WordPress que podem ajudar você a [aplicar inline a recursos essenciais](https://br.wordpress.org/plugins/search/critical+css/) ou [adiar recursos menos importantes](https://br.wordpress.org/plugins/search/defer+css+javascript/). As otimizações oferecidas por esses plug-ins podem corromper os recursos do seu tema ou dos seus plug-ins, então é provável que você precise fazer alterações no código."
+    "message": "Existem vários plug-ins do WordPress que podem ajudar você a [aplicar inline a recursos essenciais](https://wordpress.org/plugins/search/critical+css/) ou [adiar recursos menos importantes](https://wordpress.org/plugins/search/defer+css+javascript/). As otimizações oferecidas por esses plug-ins podem corromper os recursos do tema ou dos seus plug-ins, então é provável que você precise fazer alterações no código."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Todas as especificações de servidor, temas e plug-ins contribuem para o tempo de resposta do servidor. Recomendamos que você use um tema mais otimizado, selecionando cuidadosamente um plug-in de otimização e/ou fazendo upgrade do seu servidor."
@@ -1035,30 +1362,30 @@
     "message": "Recomendamos que você mostre trechos nas suas listas de postagem (por exemplo, por meio da tag \"mais\"), reduza o número de postagens exibidas em uma determinada página, divida suas postagens longas em várias páginas ou use um plug-in para aplicar lazy-load nos comentários."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Vários [plug-ins do WordPress](https://br.wordpress.org/plugins/search/minify+css/) podem acelerar seu site por meio da concatenação, diminuição e compactação dos seus estilos. Você também pode usar um processo de criação para fazer essa redução antecipadamente, se possível."
+    "message": "Vários [plug-ins do WordPress](https://wordpress.org/plugins/search/minify+css/) podem acelerar seu site concatenando, reduzindo e compactando seus estilos. Você também pode usar um processo de compilação para fazer essa redução antecipadamente, se possível."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Vários [plug-ins do WordPress](https://br.wordpress.org/plugins/search/minify+javascript/) podem acelerar seu site por meio da concatenação, redução e compactação dos seus scripts. Você também pode usar um processo de criação para fazer essa redução antecipadamente, se possível."
+    "message": "Vários [plug-ins do WordPress](https://wordpress.org/plugins/search/minify+javascript/) podem acelerar seu site concatenando, reduzindo e compactando seus scripts. Você também pode usar um processo de compilação para fazer essa redução antecipadamente, se possível."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Recomendamos que você reduza ou alterne o número de [plug-ins do WordPress](https://br.wordpress.org/plugins/) que carregam CSS não utilizado na sua página. Para identificar plug-ins que estão adicionando CSS externo, tente executar a [cobertura do código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) no Chrome DevTools. Você pode identificar o tema/plug-in responsável a partir do URL da folha de estilo. Procure plug-ins que tenham muitas folhas de estilo na lista, apresentando um nível alto de vermelho na cobertura do código. Um plug-in só deverá colocar uma folha de estilo na fila se ela for realmente utilizada na página."
+    "message": "Reduza ou troque o número de [plug-ins do WordPress](https://wordpress.org/plugins/) que carregam CSS não utilizado na sua página. Para identificar plug-ins que estão adicionando CSS externo, execute a [cobertura do código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) no Chrome DevTools. Você pode identificar o tema/plug-in responsável a partir do URL da folha de estilo. Procure plug-ins que tenham muitas folhas de estilo na lista, apresentando um nível alto de vermelho na cobertura do código. Um plug-in só deverá colocar uma folha de estilo na fila se ela for realmente utilizada na página."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Recomendamos que você reduza ou alterne o número de [plug-ins do WordPress](https://br.wordpress.org/plugins/) que carregam JavaScript não utilizado na sua página. Para identificar plug-ins que estão adicionando JS externo, tente executar a [cobertura do código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) no Chrome DevTools. Você pode identificar o tema/plug-in responsável a partir do URL do script. Procure plug-ins que tenham muitos scripts na lista, apresentando um nível alto de vermelho na cobertura do código. Um plug-in só deverá colocar um script na fila se ele for realmente usado na página."
+    "message": "Reduza ou troque o número de [plug-ins do WordPress](https://wordpress.org/plugins/) que carregam JavaScript não utilizado na sua página. Para identificar plug-ins que estão adicionando JS externo, execute a [cobertura do código](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) no Chrome DevTools. Você pode identificar o tema/plug-in responsável a partir do URL do script. Procure plug-ins que tenham muitos scripts na lista, apresentando um nível alto de vermelho na cobertura do código. Um plug-in só deverá colocar um script na fila se ele for realmente usado na página."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Leia mais sobre o [processo de cache do navegador no WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching) (link em inglês)."
+    "message": "Leia sobre o [Processo de cache do navegador no WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Recomendamos que você use um [plug-in do WordPress para otimização de imagens](https://br.wordpress.org/plugins/search/optimize+images/), que compacta suas imagens mantendo a qualidade delas."
+    "message": "Use um [plug-in do WordPress para otimização de imagens](https://wordpress.org/plugins/search/optimize+images/), que as compacta sem afetar a qualidade."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Faça upload de imagens diretamente por meio da [biblioteca de mídia](https://codex.wordpress.org/Media_Library_Screen) (link em inglês) para garantir que os tamanhos de imagem necessários estejam disponíveis. Depois, insira-os na biblioteca de mídia ou use o widget de imagem para garantir que os tamanhos ideais sejam usados (incluindo aqueles para os pontos de interrupção responsivos). Só use imagens em \"Tamanho grande\" se as dimensões forem adequadas para isso. [Saiba mais](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size) (link em inglês)."
+    "message": "Faça upload de imagens diretamente por meio da [biblioteca de mídia](https://codex.wordpress.org/Media_Library_Screen) para garantir que os tamanhos de imagem necessários estejam disponíveis. Depois, insira-os na biblioteca de mídia ou use o widget de imagem para garantir que os tamanhos ideais sejam usados (incluindo aqueles para os pontos de interrupção responsivos). Evite usar imagens `Full Size`, a não ser que as dimensões sejam adequadas para uso. [Saiba mais](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Você pode ativar a compactação de texto na configuração do servidor da Web."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Recomendamos que você use um [plug-in](https://br.wordpress.org/plugins/search/convert+webp/) ou um serviço que converterá automaticamente suas imagens enviadas para os formatos ideais."
+    "message": "Use um [plug-in](https://wordpress.org/plugins/search/convert+webp/) ou serviço que converta automaticamente as imagens enviadas nos formatos ideais."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/ro.json
+++ b/lighthouse-core/lib/i18n/locales/ro.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Tastele de acces permit utilizatorilor să focalizeze rapid o parte a paginii. Pentru o navigare corectă, fiecare tastă de acces trebuie să fie unică. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Tastele de acces permit utilizatorilor să focalizeze rapid o parte a paginii. Pentru o navigare corectă, fiecare tastă de acces trebuie să fie unică. [Află mai multe](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Valorile „[accesskey]” nu sunt unice"
+    "message": "Valorile `[accesskey]` nu sunt unice"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Valorile „[accesskey]” sunt unice"
+    "message": "Valorile `[accesskey]`sunt unice"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Fiecare „rol” ARIA acceptă un anumit subset de atribute „aria-*”. Nepotrivirea acestora anulează atributele „aria-*”. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Fiecare `role` ARIA acceptă un anumit subset de atribute `aria-*`. Nepotrivirea acestora anulează atributele `aria-*`. [Află mai multe](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Atributele „[aria-*]” nu se potrivesc cu rolul lor"
+    "message": "Atributele `[aria-*]` nu se potrivesc cu rolurile"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Atributele „[aria-*]” se potrivesc cu rolurile lor"
+    "message": "Atributele `[aria-*]` se potrivesc cu rolurile"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Unele roluri ARIA au atribute obligatorii care descriu starea elementului cititoarelor de ecrane. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Unele roluri ARIA au atribute obligatorii care descriu starea elementului cititoarelor de ecrane. [Află mai multe](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Rolurile „[role]” nu au atributele „[aria-*]” obligatorii"
+    "message": "`[role]` nu au toate atributele `[aria-*]` necesare"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Rolurile „[role]” au toate atributele „[aria-*]” obligatorii"
+    "message": "`[role]` au toate atributele `[aria-*]` obligatorii"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Unele roluri ARIA principale trebuie să conțină roluri secundare specifice pentru a-și îndeplini funcțiile de accesibilitate pentru care au fost concepute. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Unele roluri ARIA principale trebuie să conțină roluri secundare specifice pentru a-și îndeplini funcțiile de accesibilitate pentru care au fost concepute. [Află mai multe](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Elementele cu „[role]” care necesită roluri secundare specifice „[role]” lipsesc."
+    "message": "Lipsesc elementele cu `[role]` care necesită anumite `[role]` de elemente secundare."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Elementele cu „[role]” care necesită roluri secundare specifice „[role]” sunt prezente"
+    "message": "Elementele cu `[role]` care necesită anumite elemente secundare `[role]` sunt prezente"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Unele roluri ARIA secundare trebuie să fie conținute de roluri principale specifice pentru a-și îndeplini corect funcțiile de accesibilitate pentru care au fost concepute. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Unele roluri ARIA secundare trebuie să fie conținute de roluri principale specifice pentru a-și îndeplini corect funcțiile de accesibilitate pentru care au fost concepute. [Află mai multe](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Rolurile „[role]” nu sunt conținute de elementul lor principal obligatoriu"
+    "message": "`[role]` nu sunt conținute de elementul părinte impus"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Rolurile „[role]” sunt conținute de elementul lor principal obligatoriu"
+    "message": "`[role]` sunt conținute de elementul părinte impus"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Rolurile ARIA trebuie să aibă valori valide pentru a-și îndeplini funcțiile de accesibilitate pentru care au fost concepute. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Rolurile ARIA trebuie să aibă valori valide pentru a-și îndeplini funcțiile de accesibilitate pentru care au fost concepute. [Află mai multe](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Valorile „[role]” nu sunt valide"
+    "message": "Valorile `[role]` nu sunt valide"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Valorile „[role]” sunt valide"
+    "message": "Valorile `[role]` sunt valide"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Tehnologiile care asigură asistență, precum cititoarele de ecran, nu pot interpreta atributele ARIA cu valori nevalide. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Tehnologiile care asigură asistență, precum cititoarele de ecran, nu pot interpreta atributele ARIA cu valori nevalide. [Află mai multe](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Atributele „[aria-*]” nu au valori valide"
+    "message": "Atributele `[aria-*]` nu au valori valide"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Atributele „[aria-*]” au valori valide"
+    "message": "Atributele `[aria-*]` au valori valide"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Tehnologiile care oferă asistență, precum cititoarele de ecran, nu pot interpreta atributele ARIA cu nume nevalide. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Tehnologiile care oferă asistență, precum cititoarele de ecran, nu pot interpreta atributele ARIA cu nume nevalide. [Află mai multe](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Atributele „[aria-*]” nu sunt valide sau sunt scrise greșit"
+    "message": "Atributele `[aria-*]` sunt nevalide sau scrise greșit"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Atributele „[aria-*]” sunt valide și nu sunt scrise greșit"
+    "message": "Atributele `[aria-*]` sunt valide și nu sunt scrise greșit"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Subtitrările fac ca elementele audio să poată fi folosite de utilizatorii surzi sau cu dizabilități de auz, furnizând informații esențiale, precum cine vorbește, ce spune și alte informații care nu sunt legate de vorbire. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Subtitrările fac ca elementele audio să poată fi folosite de utilizatorii surzi sau cu dizabilități de auz, furnizând informații esențiale, precum cine vorbește, ce spune și alte informații care nu sunt legate de vorbire. [Află mai multe](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Elementelor „<audio>” le lipsesc un element „<track>” cu „[kind=\"captions\"]”."
+    "message": "Elementele `<audio>` au un element `<track>` cu `[kind=\"captions\"]` lipsă."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Elementele „<audio>” conțin un element „<track>” cu „[kind=\"captions\"]”"
+    "message": "Elementele `<audio>` conțin un element `<track>` cu `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Elemente cu probleme"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Când un buton nu are un nume accesibil, cititoarele de ecran îl anunță ca „buton”, făcându-l inutil pentru utilizatorii care se bazează pe cititoarele de ecran. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Când un buton nu are un nume accesibil, cititoarele de ecran îl anunță ca „buton”, făcându-l inutil pentru utilizatorii care se bazează pe cititoarele de ecran. [Află mai multe](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Butoanele nu au un nume accesibil"
@@ -93,7 +93,7 @@
     "message": "Butoanele au un nume accesibil"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Dacă adaugi modalități de a ocoli conținutul repetitiv, utilizatorii tastaturii vor naviga pe pagină mai eficient. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Dacă adaugi modalități de a ocoli conținutul repetitiv, utilizatorii tastaturii vor naviga pe pagină mai eficient. [Află mai multe](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Această pagină nu conține un titlu, un link de închidere sau o regiune de reper"
@@ -102,7 +102,7 @@
     "message": "Pagina conține un titlu, un link de închidere sau o regiune de reper"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Textul cu un contrast redus este dificil sau imposibil de citit pentru mulți utilizatori. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Textul cu un contrast redus este dificil sau imposibil de citit pentru mulți utilizatori. [Află mai multe](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Culorile din fundal și din prim-plan nu au un raport de contrast suficient."
@@ -111,88 +111,88 @@
     "message": "Culorile din fundal și din prim-plan au un raport de contrast suficient"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Când listele de definiții nu sunt marcate corect, cititoarele de ecran pot produce un rezultat confuz sau inexact. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Când listele de definiții nu sunt marcate corect, cititoarele de ecran pot produce un rezultat derutant sau inexact. [Află mai multe](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Elementele „<dl>” nu conțin numai grupuri „<dt>” și „<dd>” ordonate corect, elemente „<script>” sau „<template>”."
+    "message": "`<dl>` nu conțin doar grupurile `<dt>` și `<dd>` ordonate corect, `<script>` sau elementele `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Elementele „<dl>” conțin doar grupuri „<dt>” și „<dd>” ordonate corect, elemente „<script>” sau „<template>”."
+    "message": "`<dl>` conțin doar grupurile `<dt>` și `<dd>` ordonate corect, `<script>` sau elemente `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Elementele din lista de definiții („<dt>” și „<dd>”) trebuie grupate într-un element principal „<dl>” pentru a asigura că cititoarele de ecran le pot anunța corect. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Elementele din lista de definiții (`<dt>` și `<dd>`) trebuie grupate într-un element principal `<dl>` pentru a se asigura că cititoarele de ecran le pot anunța corect. [Află mai multe](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Elementele din lista de definiții nu sunt grupate în elemente „<dl>”"
+    "message": "Elementele din lista de definiții nu sunt incluse în elementele `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Elementele din lista de definiție sunt grupate în elemente „<dl>”"
+    "message": "Elementele din lista de definiții sunt incluse în elementele `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Titlul oferă utilizatorilor cititorului de ecran o prezentare generală a paginii, iar utilizatorii motoarelor de căutare se bazează în principal pe titlu pentru a determina dacă o pagină este relevantă pentru căutarea lor. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Titlul le oferă utilizatorilor de cititoare de ecran o prezentare generală a paginii, iar utilizatorii de motoare de căutare îl folosesc intensiv pentru a stabili dacă o pagină este relevantă pentru căutarea lor. [Află mai multe](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Documentul nu are un element „<title>”"
+    "message": "Documentul nu are un element `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Documentul are un element „<title>”"
+    "message": "Documentul are un element `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Valoarea unui atribut ID trebuie să fie unică pentru a preveni omiterea altor instanțe de tehnologiile care asigură asistență. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Valoarea unui atribut ID trebuie să fie unică pentru a preveni omiterea altor instanțe de tehnologiile care asigură asistență. [Află mai multe](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Atributele „[id]” de pe pagină nu sunt unice"
+    "message": "Atributele `[id]` de pe pagină nu sunt unice"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Atributele „[id]” de pe pagină sunt unice"
+    "message": "Atributele `[id]` de pe pagină sunt unice"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Utilizatorii cititoarelor de ecran se bazează pe titlurile cadrelor pentru a descrie conținutul cadrelor. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Utilizatorii cititoarelor de ecran se bazează pe titlurile cadrelor pentru a descrie conținutul cadrelor. [Află mai multe](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Elementele „<frame>” sau „<iframe>” nu au un titlu"
+    "message": "Elementele `<frame>` sau `<iframe>` nu au un titlu"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Elementele „<frame>” sau „<iframe>” au un titlu"
+    "message": "Elementele `<frame>` sau `<iframe>` au un titlu"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Dacă o pagină nu specifică un atribut de limbă, un cititor de ecran presupune că pagina este în limba prestabilită pe care utilizatorul a ales-o când a configurat cititorul de ecran. Dacă pagina nu este în limba prestabilită, atunci cititorul de ecran este posibil să nu citească corect textul paginii. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Dacă o pagină nu specifică un atribut de limbă, cititorul de ecran presupune că pagina este în limba prestabilită pe care utilizatorul a ales-o când a configurat cititorul de ecran. Dacă pagina nu este în limba prestabilită, atunci cititorul de ecran este posibil să nu citească corect textul paginii. [Află mai multe](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Elementul „<html>” nu are un atribut „[lang]”"
+    "message": "Elementul `<html>` nu are un atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Elementul „<html>” are un atribut „[lang]”"
+    "message": "Elementul `<html>` are un atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Indicarea unei etichete de [limbă BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valide ajută cititoarele de ecran să anunțe corect textul. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Indicarea unei etichete de [limbă BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valide ajută cititoarele de ecran să anunțe corect textul. [Află mai multe](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Elementul „<html>” nu are o valoare validă pentru atributul său „[lang]”."
+    "message": "Elementul `<html>` nu are o valoare validă pentru atributul `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Elementul „<html>” are o valoare validă pentru atributul său „[lang]”"
+    "message": "Elementul `<html>` are o valoare validă pentru atributul `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Elementele informative ar trebui să conțină texte alternative descriptive scurte. Elementele decorative pot fi ignorate cu un atribut Alt gol. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Elementele informative ar trebui să conțină texte alternative descriptive scurte. Elementele decorative pot fi ignorate cu un atribut Alt gol. [Află mai multe](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Elementele imaginii nu au atribute „[alt]”"
+    "message": "Elementele imaginii nu au atribute `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Elementele imaginii au atribute „[alt]”"
+    "message": "Elementele imagine au atribute `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Când o imagine este folosită ca buton „<input>”, furnizarea unui text alternativ poate ajuta utilizatorii cititorului de ecran să înțeleagă scopul butonului. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Când o imagine este folosită ca buton `<input>`, furnizarea unui text alternativ poate ajuta utilizatorii cititorului de ecran să înțeleagă scopul butonului. [Află mai multe](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Elementele „<input type=\"image\">” nu au text „[alt]”"
+    "message": "Elementele `<input type=\"image\">` nu au text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Elementele „<input type=\"image\">” au text „[alt]”"
+    "message": "Elementele `<input type=\"image\">` au text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Etichetele asigură că opțiunile formularelor sunt anunțate corect de tehnologiile care asigură asistență, precum cititoarele de ecran. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Etichetele asigură că opțiunile formularelor sunt anunțate corect de tehnologiile care asigură asistență, precum cititoarele de ecran. [Află mai multe](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Elementele formularului nu au etichete asociate"
@@ -201,16 +201,16 @@
     "message": "Elementele formularului au etichete asociate"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Un tabel care este folosit pentru aspect nu ar trebui să includă elemente de date, precum elementele th sau de subtitrare sau atributul rezumat, deoarece poate crea confuzie pentru utilizatorii cititoarelor de ecran. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Un tabel care este folosit pentru aspect nu ar trebui să includă elemente de date, precum elementele th sau de subtitrare sau atributul rezumat, deoarece poate crea confuzie pentru utilizatorii cititoarelor de ecran. [Află mai multe](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Elementele „<table>” de prezentare nu evită să folosească atributele „<th>”, „<caption>” sau „[summary]”."
+    "message": "Elementele `<table>` de prezentare nu evită folosirea `<th>`, `<caption>` sau a atributului `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Elementele „<table>” de prezentare evită să folosească atributul „<th>”, „<caption>” sau „[summary]”."
+    "message": "Elementele `<table>` de prezentare evită să folosească `<th>`, `<caption>` sau atributul `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Textul linkurilor (și textul alternativ pentru imagini, când sunt folosite ca linkuri) care se poate distinge, unic și pe care se poate focaliza, îmbunătățește navigarea pentru utilizatorii de cititoare de ecran. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Textul linkurilor (și textul alternativ pentru imagini, când sunt folosite ca linkuri) care se poate distinge, unic și pe care se poate focaliza, îmbunătățește navigarea pentru utilizatorii de cititoare de ecran. [Află mai multe](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Linkurile nu au un nume care se poate distinge"
@@ -219,103 +219,115 @@
     "message": "Linkurile au un nume care se poate distinge"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Cititoarele de ecran au un anumit mod de anunțare a listelor. Asigurarea unei structuri corecte a listei îmbunătățește rezultatele cititorului de ecran. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Cititoarele de ecran au un anumit mod de anunțare a listelor. Asigurarea unei structuri corecte a listei îmbunătățește rezultatele cititorului de ecran. [Află mai multe](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Listele nu conțin numai elemente „<li>” și elemente care susțin scriptul („<script>” și „<template>”)."
+    "message": "Listele nu conțin doar elemente `<li>` și elemente pe care se bazează scriptul (`<script>` și `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Listele conțin numai elemente „<li>” și elemente care susțin scriptul („<script>” și „<template>”)."
+    "message": "Listele conțin doar elemente `<li>` și elemente pe care se bazează scriptul (`<script>` și `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Cititoarele de ecran necesită ca elementele din listă („<li>”) să fie conținute într-un element principal „<ul>” sau „<ol>” pentru a fi anunțate corect. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Cititoarele de ecran necesită ca elementele din listă (`<li>`) să fie conținute într-un element principal `<ul>` sau `<ol>` pentru a fi anunțate corect. [Află mai multe](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Elementele din listă („<li>”) nu sunt conținute în elemente principale „<ul>” sau „<ol>”."
+    "message": "Elementele din listă (`<li>`) nu sunt incluse în elementele principale `<ul>` sau `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Elementele din listă („<li>”) sunt conținute în elementele principale „<ul>” sau „<ol>”"
+    "message": "Elementele din listă (`<li>`) sunt conținute în elementele principale `<ul>` sau `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Utilizatorii nu se așteaptă ca o pagină să se actualizeze automat, iar dacă ei actualizează, focalizarea se va muta din nou în partea de sus a paginii. Acest lucru poate crea frustrare sau confuzie. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Utilizatorii nu se așteaptă ca o pagină să se actualizeze automat, iar dacă ei actualizează, focalizarea se va muta din nou în partea de sus a paginii. Acest lucru poate crea frustrare sau confuzie. [Află mai multe](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Documentul folosește „<meta http-equiv=\"refresh\">”"
+    "message": "Documentul folosește `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Documentul nu folosește „<meta http-equiv=\"refresh\">”"
+    "message": "Documentul nu folosește `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Dezactivarea măririi sau micșorării este o problemă pentru utilizatorii cu vedere slabă, care se bazează pe mărirea ecranului pentru a vedea bine conținutul unei pagini web. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Dezactivarea măririi sau micșorării este o problemă pentru utilizatorii cu vedere slabă, care se bazează pe mărirea ecranului pentru a vedea bine conținutul unei pagini web. [Află mai multe](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "„[user-scalable=\"no\"]” se folosește în elementul „<meta name=\"viewport\">” sau atributul „[maximum-scale]” este mai mic decât 5."
+    "message": "`[user-scalable=\"no\"]` este folosit în elementul `<meta name=\"viewport\">` sau atributul `[maximum-scale]` este mai mic decât 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "„[user-scalable=\"no\"]” nu este folosit în elementul „<meta name=\"viewport\">”, iar atributul „[maximum-scale]” nu este mai mic decât 5."
+    "message": "`[user-scalable=\"no\"]` nu se folosește în elementul `<meta name=\"viewport\">` și atributul `[maximum-scale]` nu este mai mic decât 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Cititoarele de ecran nu pot traduce conținut în alt format decât text. Adăugarea de text alternativ la elementele „<object>” ajută cititoarele de ecran să transmită utilizatorilor înțelesul. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Cititoarele de ecran nu pot traduce conținut în alt format decât text. Adăugarea de text alternativ la elementele `<object>` ajută cititoarele de ecran să le transmită utilizatorilor înțelesul. [Află mai multe](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Elementele „<object>” nu au text „[alt]”"
+    "message": "Elementele `<object>` nu au text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Elementele „<object>” au text „[alt]”"
+    "message": "Elementele `<object>` au text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "O valoare mai mare decât 0 implică o ordine explicită de navigare. Deși valid din punct de vedere tehnic, acest lucru creează adesea frustrări utilizatorilor care se bazează pe tehnologii care oferă asistență. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "O valoare mai mare decât 0 implică o ordine explicită de navigare. Deși valid din punct de vedere tehnic, acest lucru creează adesea frustrări utilizatorilor care se bazează pe tehnologii care oferă asistență. [Află mai multe](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Unele elemente au o valoare „[tabindex]” mai mare decât 0"
+    "message": "Unele elemente au o valoare `[tabindex]` mai mare decât 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Niciun element nu are o valoare „[tabindex]” mai mare de 0"
+    "message": "Niciun element nu are o valoare `[tabindex]` mai mare decât 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Cititoarele de ecran au funcții care facilitează navigarea în tabele. Dacă se asigură că celulele „<td>” care folosesc atributul „[headers]” se referă numai la alte celule din același tabel, se poate îmbunătăți experiența pentru utilizatorii de cititoare de ecran. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Cititoarele de ecran au funcții care facilitează navigarea în tabele. Dacă se asigură că celulele `<td>` care folosesc atributul `[headers]` se referă doar la alte celule din același tabel, se poate îmbunătăți experiența pentru utilizatorii de cititoare de ecran. [Află mai multe](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Celulele dintr-un element „<table>”, care folosesc atributul „[headers]”, se referă la alte celule ale aceluiași tabel."
+    "message": "Celulele dintr-un element `<table>` care folosesc atributul `[headers]` se referă la alte celule ale aceluiași tabel."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Celulele dintr-un element „<table>” care folosesc atributul „[headers]” se referă numai la alte celule din același tabel."
+    "message": "Celulele dintr-un element `<table>` care folosesc atributul `[headers]` se referă doar la alte celule ale aceluiași tabel."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Cititoarele de ecran au funcții care facilitează navigarea în tabele. Dacă se asigură că antetele tabelelor se referă întotdeauna la unele seturi de celule, se poate îmbunătăți experiența pentru utilizatorii de cititoare de ecran. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Cititoarele de ecran au funcții care facilitează navigarea în tabele. Dacă se asigură că antetele tabelelor se referă întotdeauna la unele seturi de celule, se poate îmbunătăți experiența pentru utilizatorii de cititoare de ecran. [Află mai multe](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Elementele „<th>” și elementele cu „[role=\"columnheader\"/\"rowheader\"]” nu au celulele de date pe care le descriu."
+    "message": "Elementele `<th>` și elementele cu `[role=\"columnheader\"/\"rowheader\"]` nu au celule de date pe care să le descrie."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Elementele „<th>” și elementele cu „[role=\"columnheader\"/\"rowheader\"]” au celulele de date pe care le descriu."
+    "message": "Elementele `<th>` și elementele cu `[role=\"columnheader\"/\"rowheader\"]` au celule de date pe care le descriu."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Indicarea unei etichete de [limbă BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valide la elemente ajută la pronunțarea corectă a textului de un cititor de ecran. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Indicarea unei etichete de [limbă BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) valide la elemente ajută la pronunțarea corectă a textului de un cititor de ecran. [Află mai multe](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Atributele „[lang]” nu au o valoare validă"
+    "message": "Atributele `[lang]` nu au o valoare validă"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Atributele „[lang]” au o valoare validă"
+    "message": "Atributele `[lang]` au o valoare validă"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Când un videoclip are subtitrare, este mai simplu pentru utilizatorii surzi și cu dizabilități de auz să îi acceseze informațiile. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Când un videoclip are subtitrare, este mai simplu pentru utilizatorii surzi și cu dizabilități de auz să îi acceseze informațiile. [Află mai multe](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Elementele „<video>” nu conțin un element „<track>” cu „[kind=\"captions\"]”."
+    "message": "Elementele `<video>` nu conțin un element `<track>` cu `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Elementele „<video>” conțin un element „<track>” cu „[kind=\"captions\"]”"
+    "message": "Elementele `<video>` conțin un element `<track>` cu `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Descrierile audio oferă informații relevante pentru videoclipuri pe care dialogul nu le poate oferi, precum scene și expresii faciale. [Află mai multe](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Descrierile audio oferă informații relevante pentru videoclipuri pe care dialogul nu le poate oferi, precum scene și expresii faciale. [Află mai multe](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Elementele „<video>” nu conțin un element „<track>” cu „[kind=\"description\"]”."
+    "message": "Elementele `<video>` nu conțin un element `<track>` cu `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Elementele „<video>” conțin un element „<track>” cu „[kind=\"description\"]”"
+    "message": "Elementele `<video>` conțin un element `<track>` cu `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Pentru un aspect ideal în iOS atunci când utilizatori o adaugă în ecranul de pornire, definiți o pictogramă apple-touch. Aceasta trebuie să indice spre un PNG pătrat netransparent, de 192 px (sau 180 px). [Află mai multe](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Nu oferă o `apple-touch-icon` validă"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` este învechit; se preferă `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Oferă o `apple-touch-icon` validă"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Extensiile Chrome au afectat performanța de încărcare a acestei pagini. Încearcă să auditezi pagina în modul incognito sau dintr-un profil Chrome fără extensii."
@@ -345,7 +357,7 @@
     "message": "Folosește formate video pentru conținut animat"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Poți încărca lent imaginile ascunse sau pe cele din afara ecranului după ce toate resursele esențiale s-au încărcat, pentru a micșora durata până la interactivitate. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Poți încărca lent imaginile ascunse sau pe cele din afara ecranului după ce toate resursele esențiale s-au încărcat, pentru a micșora timpul până la interactivitate. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Amână imaginile din afara ecranului"
@@ -360,7 +372,7 @@
     "message": "Sarcinile mari de rețea îi costă pe utilizatori și sunt corelate cu timpi de încărcare îndelungați. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "Dimensiunea totală a fost de {totalBytes, number, bytes} KB"
+    "message": "Dimensiunea totală a fost de {totalBytes, number, bytes} KB"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Evită sarcinile uriașe de rețea"
@@ -417,7 +429,7 @@
     "message": "Dimensionează corect imaginile"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Înainte de difuzare, resursele bazate pe text trebuie comprimate (gzip, deflate sau brotli) pentru a minimiza numărul total de byți în rețea. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Resursele bazate pe text trebuie comprimate (gzip, deflate sau brotli) pentru a minimiza numărul total de byți în rețea. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Activează comprimarea textului"
@@ -429,13 +441,64 @@
     "message": "Difuzează imagini în formate moderne"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Lanțurile de solicitări esențiale de mai jos îți arată ce resurse sunt încărcate cu prioritate ridicată. Poți să reduci lungimea lanțurilor, să reduci dimensiunea de descărcare a resurselor sau să amâni descărcarea de resurse inutile pentru a îmbunătăți încărcarea paginilor. [Află mai multe] (https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Lanțurile de solicitări esențiale de mai jos îți arată ce resurse sunt încărcate cu prioritate ridicată. Poți să reduci lungimea lanțurilor, să reduci dimensiunea de descărcare a resurselor sau să amâni descărcarea de resurse inutile pentru a îmbunătăți încărcarea paginilor. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{un lanț găsit}few{# lanțuri găsite}other{# de lanțuri găsite}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Redu profunzimea solicitărilor esențiale"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Renunțare la dezvoltare/Avertisment"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Rând"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "API-urile învechite vor fi eliminate, în final, din browser. [Află mai multe](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{A fost identificat un avertisment}few{Au fost identificate # avertismente}other{Au fost identificate # de avertismente}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Folosește API-uri învechite"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Evită API-urile învechite"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Memoria cache a aplicației este învechită. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Am găsit „{AppCacheManifest}”"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Folosește memoria cache de aplicație"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Evită memoria cache a aplicației"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Specificarea unui doctype împiedică browserul să treacă la modul caracteristici speciale. Citește mai multe pe [pagina MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Numele doctype trebuie să fie șirul cu litere mici `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Documentul trebuie să conțină un doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Se aștepta ca publicId să fie un șir gol"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Se aștepta ca systemId să fie un șir gol"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Pagina nu are doctype HTML, așadar declanșează modul caracteristici speciale"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Pagina are doctype HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
@@ -447,7 +510,7 @@
     "message": "Valoare"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Specialiștii în browsere recomandă ca paginile să conțină mai puțin de ~1.500 de elemente DOM. Ideal este ca arborele să aibă o profunzime mai mică de 32 de elemente și mai puțin de 60 de elemente principale/subordonate. Un DOM mare poate crește folosirea memoriei, poate produce [calcule de stil] (https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) mai lungi și [rearanjări ale aspectului](https://developers.google.com/speed/articles/reflow) costisitoare. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Specialiștii în browsere recomandă ca paginile să conțină mai puțin de ~1.500 de elemente DOM. Ideal este ca arborele să aibă o profunzime mai mică de 32 de elemente și mai puțin de 60 de elemente principale/subordonate. Un DOM mare poate crește folosirea memoriei, poate produce [calcule de stil](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) mai lungi și [rearanjări ale aspectului](https://developers.google.com/speed/articles/reflow) costisitoare. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 element}few{# elemente}other{# de elemente}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Evită o dimensiune DOM excesivă"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Obiectiv"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Adaugă `rel=\"noopener\"` sau `rel=\"noreferrer\"` la orice linkuri externe pentru a îmbunătăți rezultatele și a preveni vulnerabilitățile de securitate. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Linkurile spre destinații cu mai multe origini sunt nesigure"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Linkurile spre destinații cu mai multe origini sunt sigure"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Nu se poate determina destinația pentru ancora ({anchorHTML}). Dacă nu se folosește ca hyperlink, elimină target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Utilizatorii nu au încredere sau sunt derutați de site-urile care le solicită locația fără context. Asociază solicitarea cu o acțiune a utilizatorilor. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Solicită permisiunea de localizare geografică la încărcarea paginii"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Evită solicitarea permisiunii de localizare geografică la încărcarea paginii"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Versiune"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Toate bibliotecile JavaScript front-end detectate pe pagină."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Biblioteci JavaScript detectate"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Pentru utilizatorii cu conexiuni lente, scripturile externe injectate dinamic prin `document.write()` pot întârzia încărcarea paginilor cu zeci de secunde. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Utilizări `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Evită `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Cea mai mare severitate"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Versiunea bibliotecii"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Numărul de vulnerabilități"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Unele scripturi terță parte pot conține vulnerabilități de securitate cunoscute, ușor de identificat și de exploatat de atacatori. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{O vulnerabilitate detectată}few{# vulnerabilități detectate}other{# de vulnerabilități detectate}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Include bibliotecile JavaScript front-end cu vulnerabilități de securitate cunoscute"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Înaltă"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Redusă"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Medie"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Evită bibliotecile JavaScript front-end cu vulnerabilități de securitate cunoscute"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Utilizatorii nu au încredere sau sunt derutați de site-urile care solicită să trimită notificări fără context. Asociază solicitarea cu gesturile utilizatorilor. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Solicită permisiunea de notificare la încărcarea paginii"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Evită solicitarea permisiunii de notificare la încărcarea paginii"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elemente cu probleme"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Împiedicarea inserării parolelor subminează buna politică de securitate. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Împiedică utilizatorii să insereze în câmpurile pentru parole"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Permite-le utilizatorilor să insereze în câmpurile pentru parole"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protocol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 oferă multe beneficii față de HTTP/1.1, inclusiv antete binare, anunțuri multiplex și tehnologie push pentru server. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{O solicitare nu a fost difuzată prin HTTP/2}few{# solicitări nu au fost difuzate prin HTTP/2}other{# de solicitări nu au fost difuzate prin HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Nu folosește HTTP/2 pentru toate resursele"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Folosește HTTP/2 pentru propriile sale resurse"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Poți marca funcțiile de procesare a evenimentelor prin atingere sau derulare `passive` pentru a îmbunătăți capacitatea de derulare a paginii. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Nu folosește ascultători pasivi pentru a îmbunătăți performanța la derulare"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Folosește ascultători pasivi pentru a îmbunătăți performanța la derulare"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Descriere"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Erorile înregistrate pe consolă indică probleme nerezolvate Acestea pot fi provocate de erorile de solicitare din rețea și de alte probleme ale browserului."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "S-au înregistrat erori de browser pe consolă"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Nu s-a înregistrat nicio eroare de browser pe consolă"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Poți folosi funcția CSS de afișare a fonturilor pentru a verifica dacă textul este vizibil pentru utilizatori în timp ce se încarcă fonturile web. [Află mai multe](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Tot textul rămâne vizibil în timpul încărcării fonturilor web"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse nu a putut verifica automat valoarea de afișare a fonturilor pentru următoarea adresă URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Raport de dimensiuni (real)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Raport de dimensiuni (afișat)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Dimensiunile de afișare a imaginilor trebuie să se potrivească raportului natural de dimensiuni. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Afișează imaginile cu rapoarte de dimensiuni incorecte"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Afișează imaginile cu rapoarte de dimensiuni corecte"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Informații nevalide privind dimensiunea imaginilor {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Adresă URL nesigură"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Toate site-urile trebuie protejate cu HTTPS, chiar și cele care nu gestionează date sensibile. HTTPS împiedică persoanele străine să modifice sau să asculte pasiv comunicațiile dintre aplicația ta și utilizatori, fiind o cerință obligatorie pentru HTTP/2 și multe API-uri noi pentru platformele web. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{S-a găsit o solicitare nesigură}few{S-au găsit # solicitări nesigure}other{S-au găsit # de solicitări nesigure}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Nu folosește HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Folosește HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "O încărcare rapidă a paginii într-o rețea celulară asigură o experiență bună a utilizatorului pe mobil. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interactivă la {timeInMs, number, seconds} s"
+    "message": "Interactiv la {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Interactivă pe rețeaua mobilă simulată la {timeInMs, number, seconds} s"
@@ -534,16 +765,22 @@
     "message": "Timpul până la interactivitate"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Posibila amânare a primei comenzi cu care utilizatorii se pot confrunta este durata, în milisecunde, a celei mai lungi activități."
+    "message": "Timpul maxim potențial de la prima interacțiune cu care utilizatorii se pot confrunta este durata, în milisecunde, a celei mai lungi activități. [Află mai multe](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID potențial maxim"
+    "message": "Timpul maxim potențial de la prima interacțiune"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Indexul de viteză arată cât de repede se completează vizibil conținutul unei pagini. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Index de viteză"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Suma tuturor perioadelor de timp dintre FCP și Timpul până la interactivitate, când lungimea activității a depășit 50 ms, exprimate în milisecunde."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Durata totală de blocare"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Durata pingului în rețea (RTT) are impact important asupra performanței. Dacă RTT către o origine este mare, înseamnă că serverele mai apropiate de utilizator pot îmbunătăți performanța. [Află mai multe](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -552,58 +789,76 @@
     "message": "Durata pingului în rețea"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Latențele serverului pot influența performanța pe web. Dacă latența serverului unei origini este mare, înseamnă că serverul este supraîncărcat sau are performanțe slabe în backend. [Află mai multe](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Latențele serverului pot influența rezultatele pe web. Dacă latența serverului unei origini este mare, înseamnă că serverul este supraîncărcat sau are performanțe slabe în backend. [Află mai multe](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latențe ale backendului serverului"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Peste buget"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Păstrează cantitatea și dimensiunea solicitărilor din rețea sub obiectivele stabilite de bugetul de performanță solicitat. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{O solicitare}few{# solicitări}other{# de solicitări}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Buget de performanță"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Redirecționările introduc întârzieri suplimentare înainte ca pagina să se poată încărca. [Află mai multe] (https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Redirecționările introduc întârzieri suplimentare înainte ca pagina să se poată încărca. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Evită mai multe redirecționări ale paginii"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Ca să setezi bugetele pentru cantitatea și dimensiunea resurselor de pagină, adaugă un fișier budget.json. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{O solicitare}few{# solicitări}other{# de solicitări}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Păstrează numărul de solicitări scăzut și dimensiunea transferurilor redusă"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Linkurile canonice sugerează care adresă URL să se afișeze în rezultatele căutării. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Adrese URL multiple în conflict ({urlList})"
+    "message": "Mai multe adrese URL incompatibile ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Direcționează către un alt domeniu ({url})"
+    "message": "Indică spre alt domeniu ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Adresă URL nevalidă ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Direcționează către o altă locație „hreflang” ({url})"
+    "message": "Indică spre altă locație `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "Adresă URL relativă ({url})"
+    "message": "Adresa URL relativă ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "Direcționează către adresa URL a rădăcinii domeniului (pagina principală), nu către o pagină de conținut echivalentă"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Documentul nu are un link „rel=canonical” valid"
+    "message": "Documentul nu are un `rel=canonical` valid"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Documentul are un link „rel=canonical” valid"
+    "message": "Documentul are un `rel=canonical` valid"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Dimensiunile fontului mai mici de 12 pixeli sunt prea mici pentru a putea fi citite, iar utilizatorii de dispozitive mobile trebuie să „ciupească pentru zoom” pentru a citi. Încearcă să ai peste 60% din textul paginii cu font ≥12px. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Dimensiunile fontului mai mici de 12 pixeli sunt prea mici pentru a putea fi citite, iar utilizatorii de dispozitive mobile trebuie să „ciupească pentru zoom” pentru a citi. Încearcă să ai peste 60 % din textul paginii cu font ≥12 px. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "{decimalProportion, number, extendedPercent} text lizibil"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} din text este prea mic."
+    "message": "Text lizibil {decimalProportion, number, extendedPercent}"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Textul nu este lizibil deoarece nu există nicio metaetichetă viewport optimizată pentru ecranele dispozitivelor mobile."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} din text este prea mic (pe baza mostrei de {decimalProportionVisited, number, extendedPercent})."
+    "message": "{decimalProportion, number, extendedPercent} din text este prea mic (pornind de la un eșantion de {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Documentul nu folosește dimensiuni de fonturi lizibile"
@@ -615,10 +870,10 @@
     "message": "Linkurile hreflang spun motoarelor de căutare ce versiune a unei pagini să înregistreze în rezultatele căutării pentru o limbă sau regiune dată. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Documentul nu are un atribut „hreflang” valid"
+    "message": "Document nu are un `hreflang` valid"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Documentul are un atribut „hreflang” valid"
+    "message": "Documentul are un `hreflang` valid"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Este posibil ca paginile cu Coduri de stare HTTP nefuncționale să nu fie indexate corect. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -630,7 +885,7 @@
     "message": "Pagina are Cod de stare HTTP funcțional"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Motoarele de căutare nu pot include paginile în rezultatele căutării dacă nu au permisiunea de a fi accesate cu crawlere. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Motoarele de căutare nu pot include paginile în rezultatele căutării dacă nu au permisiunea de a le accesa cu crawlere. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Indexarea este blocată pentru pagină"
@@ -681,7 +936,7 @@
     "message": "Dacă fișierul robots.txt este deteriorat, este posibil ca aplicațiile crawler să nu poată înțelege cum vrei să fie site-ul tău accesat cu crawlere sau indexat."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "Cererile pentru robots.txt au returnat starea HTTP: {statusCode}"
+    "message": "Cererea pentru robots.txt a returnat starea HTTP: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{A fost identificată o eroare}few{Au fost identificate # erori}other{Au fost identificate # de erori}}"
@@ -696,7 +951,7 @@
     "message": "Fișierul robots.txt este valid"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Elementele interactive, precum butoanele și linkurile, trebuie să fie suficient de mari (48x48px) și să aibă suficient spațiu în jurul lor, pentru a fi ușor de atins, fără a se suprapune peste alte elemente. [Află mai multe](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Elementele interactive, precum butoanele și linkurile, trebuie să fie suficient de mari (48x48 px) și să aibă suficient spațiu în jurul lor, pentru a fi ușor de atins, fără a se suprapune peste alte elemente. [Află mai multe](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} direcționări ale atingerilor au mărimea corectă"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Direcționarea se suprapune"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Dimensiune"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Direcționarea atingerii"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Direcționările atingerilor sunt dimensionate corect"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Durata pentru firul principal"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Terță parte"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Codul terță parte poate influența semnificativ performanța de încărcare. Limitează numărul de furnizori terță parte redundanți și încearcă să încarce cod terță parte după ce pagina a terminat încărcarea de bază. [Află mai multe](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{S-a găsit o terță parte}few{S-au găsit # terțe părți}other{S-au găsit # de terțe părți}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Utilizarea terță parte"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Timpul până la primul byte identifică timpul în care serverul trimite un răspuns. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Durată"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Nume"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Ora de începere"
@@ -753,7 +1017,7 @@
     "message": "Mărci și dimensiuni pentru Duratele utilizărilor"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "S-a găsit un <link> de conectare anticipată pentru „{securityOrigin}”, dar nu a fost folosit de browser. Verifică dacă folosești corect atributul „crossorigin”."
+    "message": "Un <link> preconectat a fost găsit pentru „{securityOrigin}”, dar nu a fost folosit de browser. Verifică dacă folosești corect atributul `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Poți adăuga indicii de resurse de preconectare sau dns-prefetch pentru a stabili conexiuni inițiale cu originile terță parte importante. [Află mai multe](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Preconectează la originile necesare"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Un <link> preîncărcat a fost găsit pentru „{preloadURL}”, dar nu a fost folosit de browser. Verifică dacă folosești corect atributul „crossorigin”."
+    "message": "Un <link> preîncărcat a fost găsit pentru „{preloadURL}”, dar nu a fost folosit de browser. Verifică dacă folosești corect atributul `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Poți folosi <link rel=preload> ca să acorzi prioritate preluării resurselor care sunt momentan solicitate mai târziu la încărcarea paginii. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Poți folosi `<link rel=preload>` ca să acorzi prioritate preluării resurselor care sunt momentan solicitate mai târziu la încărcarea paginii. [Află mai multe](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Preîncarcă solicitările importante"
@@ -789,10 +1053,10 @@
     "message": "Cele mai bune practici"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Aceste verificări evidențiază oportunitățile pentru a [îmbunătăți accesibilitatea aplicației web](https://developers.google.com/web/fundamentals/accessibility). Doar un subset de probleme de accesibilitate pot fi detectate automat, astfel încât se recomandă și testarea automată."
+    "message": "Aceste verificări evidențiază oportunitățile pentru a [îmbunătăți accesibilitatea aplicației web](https://developers.google.com/web/fundamentals/accessibility). Doar un subset de probleme de accesibilitate pot fi detectate automat, astfel încât se recomandă și testarea manuală."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Aceste elemente se adresează zonelor pe care un instrument de testare automată nu le poate acoperi. Află mai multe în ghidul nostru despre [realizarea unei evaluări a accesibilității](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Aceste elemente se adresează zonelor pe care un instrument de testare automată nu le poate acoperi. Află mai multe din ghidul nostru despre [realizarea unei evaluări a accesibilității](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Accesibilitate"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabele și liste"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Cele mai bune practici"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Bugetele de performanță stabilesc standarde pentru performanța site-ului."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Bugete"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Mai multe informații despre performanța aplicației tale."
+    "message": "Mai multe informații despre performanța aplicației tale. Numerele nu [influențează direct](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) Scorul de performanță."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnosticare"
@@ -840,7 +1113,7 @@
     "message": "Îmbunătățirile pentru prima redare"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Aceste optimizări pot accelera încărcarea paginii."
+    "message": "Aceste sugestii îți pot face pagina să se încarce mai repede. Ele nu [influențează direct](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) scorul de performanță."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Oportunități"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL cache"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Locație"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Nume"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Solicitări"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Tip de resursă"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Dimensiune (KB)"
+    "message": "Dimensiune"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Timp petrecut"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Dimensiunea transferului"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "Adresa URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Economii potențiale (KB)"
+    "message": "Economii potențiale"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Economii potențiale (ms)"
+    "message": "Economii potențiale"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Poți economisi {wastedBytes, number, bytes} KB"
@@ -917,26 +1205,59 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Poți economisi {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Document"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Font"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Imagine"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Media"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Altele"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Script"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
   },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Foaie de stil"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Terță parte"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Total"
+  },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "A apărut o eroare la înregistrarea urmei încărcării paginii. Te rugăm să rulezi din nou Lighthouse. ({errorCode})"
+    "message": "A apărut o eroare la înregistrarea urmei de la încărcarea paginii. Rulează din nou Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Timpul a expirat așteptând conexiunea inițială la protocolul Debugger."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome nu a colectat nicio captură de ecran în timpul încărcării paginii. Asigură-te că există conținut vizibil pe pagină, apoi încearcă să rulezi din nou Lighthouse. ({errorCode})"
+    "message": "Chrome nu a colectat capturi de ecran în timpul încărcării paginii. Asigură-te că există conținut vizibil în pagină și încearcă să rulezi din nou Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Serverele DNS nu au putut rezolva domeniul furnizat."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Colectorul de {artifactName} obligatorii a întâmpinat o eroare: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "A apărut o eroare Chrome internă. Repornește Chrome și încearcă să rulezi din nou Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Colectorul {artifactName} obligatoriu nu a rulat."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse nu a putut încărca în mod sigur pagina solicitată. Asigură-te că testezi adresa URL corectă și că serverul răspunde corect la toate solicitările."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse nu a putut încărca în mod sigur adresa URL solicitată, deoarece pagina nu mai răspunde."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Adresa URL furnizată nu are date de conectare de securitate valide. {securityMessages}"
+    "message": "Adresa URL furnizată nu are un certificat de securitate valid. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome a împiedicat încărcarea paginii cu un interstițial. Asigură-te că testezi adresa URL corectă și că serverul răspunde corect la toate solicitările."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse nu a putut încărca în mod sigur pagina solicitată. Asigură-te că testezi adresa URL corectă și că serverul răspunde corect la toate solicitările. (Detalii: {errorDetails})"
@@ -954,10 +1278,10 @@
     "message": "Lighthouse nu a putut încărca în mod sigur pagina solicitată. Asigură-te că testezi adresa URL corectă și că serverul răspunde corect la toate solicitările. (Cod de stare: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Încărcarea paginii a durat prea mult. Urmărește oportunitățile din raport pentru a reduce durata de încărcare a paginii, apoi încearcă să rulezi din nou Lighthouse. ({errorCode})"
+    "message": "Încărcarea paginii a durat prea mult. Urmează recomandările din raport pentru a reduce durata de încărcare a paginii, apoi încearcă din nou să rulezi Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "Așteptarea răspunsului protocolului DevTools a depășit timpul alocat. (Metodă: {protocolMethod})"
+    "message": "Așteptarea răspunsului la protocolul DevTools a depășit timpul alocat. (Metoda: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "Preluarea conținutului resursei a depășit timpul alocat"
@@ -984,7 +1308,7 @@
     "message": "Datele testului"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "Analiza în [Lighthouse](https://developers.google.com/web/tools/lighthouse/) a paginii actuale pe o rețea mobilă emulată. Valorile sunt estimate și pot varia."
+    "message": "Analiza în [Lighthouse](https://developers.google.com/web/tools/lighthouse/) a paginii actuale cu o rețea mobilă simulată. Valorile sunt estimate și pot varia."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Elemente suplimentare de verificat manual"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Extinde fragmentul"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Afișează resursele terță parte"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Au apărut probleme care au afectat această rulare Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Valorile sunt estimate și pot varia."
+    "message": "Valorile sunt estimate și pot varia. Scorul de performanță [se bazează doar pe aceste valori](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Auditări trecute, dar cu avertismente"
@@ -1023,7 +1350,7 @@
     "message": "Îți recomandăm să încarci GIF-ul într-un serviciu care îl va pune dispoziție pentru încorporare ca videoclip HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Instalează un [plugin WordPress de încărcare lentă](https://wordpress.org/plugins/search/lazy+load/) care oferă capacitatea de a amâna imaginile din afara ecranului sau schimbă-ți tema cu una care oferă acea funcție. Îți recomandăm să folosești și [pluginul AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Instalează un [plugin WordPress de încărcare lentă](https://wordpress.org/plugins/search/lazy+load/) care oferă capacitatea de a amâna imaginile din afara ecranului sau schimbă-ți tema cu una care oferă acea funcție. Îți recomandăm [pluginul AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "Există o serie de pluginuri Wordpress care te pot ajuta să [activezi inline elementele critice](https://wordpress.org/plugins/search/critical+css/) sau să [amâni resurse mai puțin importante](https://wordpress.org/plugins/search/defer+css+javascript/). Atenție, optimizările oferite de aceste pluginuri pot să întrerupă funcțiile temei sau pluginurilor tale, astfel încât este posibil să trebuiască să modifici codul."
@@ -1035,10 +1362,10 @@
     "message": "Îți recomandăm să afișezi extrase în listele postărilor tale (de exemplu, prin intermediul filei Mai multe), reducând numărul de postări afișate pe o anumită pagină, împărțind postările lungi pe mai multe pagini sau folosind un plugin pentru a încărca lent comentariile."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "O serie de [pluginuri WordPress](https://wordpress.org/plugins/search/minify+css/) îți pot accelera site-ul concatenând, minimizând și comprimând stilurile. Ai putea să folosești și un proces de design pentru a face minimizarea în avans, dacă este posibil."
+    "message": "Mai multe [pluginuri WordPress](https://wordpress.org/plugins/search/minify+css/) îți pot accelera site-ul prin concatenarea, minimizarea și comprimarea stilurilor. Ai putea să folosești și un proces de design pentru a face minimizarea în avans, dacă este posibil."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "O serie de [pluginuri WordPress](https://wordpress.org/plugins/search/minify+javascript/) îți pot accelera site-ul concatenând, minimizând și comprimând scripturile. Ai putea să folosești și un proces de design pentru a face minimizarea în avans, dacă este posibil."
+    "message": "Mai multe [pluginuri WordPress](https://wordpress.org/plugins/search/minify+javascript/) îți pot accelera site-ul prin concatenarea, minimizarea și comprimarea scripturilor. Ai putea să folosești și un proces de design pentru a face minimizarea în avans, dacă este posibil."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
     "message": "Îți recomandăm să reduci sau să schimbi numărul de [pluginuri WordPress](https://wordpress.org/plugins/) care încarcă CSS nefolosit în pagină. Ca să identifici pluginurile care adaugă conținut CSS neesențial, încearcă să rulezi [acoperirea codului](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) în Chrome DevTools. Poți identifica tema/pluginul responsabil din adresa URL a foii de stil. Caută pluginuri care au multe foi de stil în listă cu mult roșu în bara acoperirii codului. Un plugin ar trebui să pună în coadă o foaie de stil numai dacă este într-adevăr folosită în pagină."
@@ -1053,7 +1380,7 @@
     "message": "Îți recomandăm să folosești un [plugin WordPress de optimizare a imaginii](https://wordpress.org/plugins/search/optimize+images/) care comprimă imaginile, păstrând calitatea."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Încarcă imaginile direct prin [biblioteca de media](https://codex.wordpress.org/Media_Library_Screen) pentru a te asigura că sunt disponibile dimensiunile de imagine necesare, apoi inserează-le din biblioteca de media sau folosește widgetul de imagine pentru a te asigura că sunt folosite dimensiunile de imagine necesare (inclusiv cele pentru punctele de întrerupere adaptabile). Evită să folosești imagini cu „dimensiune completă”, cu excepția cazului în care dimensiunile sunt adecvate pentru utilizare. [Află mai multe](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Încarcă imaginile direct prin [biblioteca de media](https://codex.wordpress.org/Media_Library_Screen) pentru a te asigura că sunt disponibile dimensiunile de imagine necesare, apoi inserează-le din biblioteca de media sau folosește widgetul de imagine pentru a te asigura că se folosesc dimensiunile de imagine optime (inclusiv cele pentru punctele de întrerupere adaptabile). Evită să folosești imagini `Full Size`, cu excepția cazului în care dimensiunile sunt adecvate pentru utilizare. [Află mai multe](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Poți activa comprimarea textului în configurarea serverului web."

--- a/lighthouse-core/lib/i18n/locales/ru.json
+++ b/lighthouse-core/lib/i18n/locales/ru.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Ключи доступа позволяют быстро перейти к нужной части страницы. Каждый из них должен быть уникальным. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Ключи доступа позволяют быстро перейти к нужной части страницы. Каждый из них должен быть уникальным. [Подробнее…](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Значения атрибута [accesskey] не уникальны"
+    "message": "Значения атрибута `[accesskey]` не уникальны"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Значения [accesskey] уникальны"
+    "message": "`[accesskey]`: значения уникальны"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Для каждой роли ARIA предусмотрен определенный набор атрибутов aria-*. Неверно присвоенные атрибуты будут недействительны. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Каждая `role` ARIA поддерживает определенный набор атрибутов `aria-*`. Неверно присвоенные атрибуты `aria-*` будут недействительны. [Подробнее…](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Атрибуты [aria-*] не соответствуют указанным для них ролям"
+    "message": "Атрибуты `[aria-*]` не соответствуют своим ролям"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Атрибуты [aria-*] соответствуют указанным для них ролям"
+    "message": "Атрибуты `[aria-*]` соответствуют своим ролям"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "С некоторыми ролями ARIA необходимо использовать атрибуты, описывающие состояние элемента для программ чтения с экрана. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "К некоторым ролям ARIA требуется добавить атрибуты, описывающие состояние элемента для программ чтения с экрана. [Подробнее…](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Для элементов с атрибутом [role] заданы не все необходимые атрибуты [aria-*]"
+    "message": "Для элементов с атрибутом `[role]` заданы не все необходимые атрибуты `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Для элементов с атрибутом [role] заданы все необходимые атрибуты [aria-*]"
+    "message": "У элементов `[role]` есть все необходимые атрибуты `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Некоторые элементы с ролями ARIA должны содержать определенные дочерние роли, иначе связанные с ними функции будут работать неправильно. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Некоторые родительские элементы с ролями ARIA должны содержать определенные дочерние роли, иначе связанные с ними функции специальных возможностей будут работать неправильно. [Подробнее…](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Отсутствуют элементы с атрибутом [role], для которых необходимы дочерние элементы с определенными атрибутами [role]"
+    "message": "Отсутствуют элементы с атрибутом `[role]`, для которых необходимы дочерние элементы с определенными атрибутами `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Элементы с атрибутом [role], для которых необходимы дочерние элементы с определенными атрибутами [role], присутствуют"
+    "message": "Элементы с атрибутом `[role]`, для которых необходимы дочерние элементы с определенными атрибутами `[role]`, присутствуют"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Некоторые элементы с ролями ARIA должны содержаться в определенных родительских ролях, иначе связанные с ними функции будут работать неправильно. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Некоторые дочерние элементы с ролями ARIA должны содержаться внутри определенных родительских элементов, иначе связанные с ними функции специальных возможностей будут работать неправильно. [Подробнее…](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Элементы с атрибутом [role] содержатся не в тех родительских элементах"
+    "message": "Элементы с атрибутом `[role]` не содержатся в своих родительских элементах"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Элементы с атрибутом [role] содержатся в необходимых для них родительских элементах"
+    "message": "Элементы с атрибутом `[role]` содержатся в своих родительских элементах"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Значения ролей ARIA должны быть действительными, иначе связанные с ними функции будут работать неправильно. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Значения ролей ARIA должны быть действительными, иначе связанные с ними функции будут работать неправильно. [Подробнее…](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Значения атрибутов [role] недействительны"
+    "message": "Присутствуют недействительные значения атрибутов `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Значения атрибутов [role] действительны"
+    "message": "Недействительные значения атрибутов `[role]` отсутствуют"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Программы чтения с экрана не могут распознать атрибуты ARIA с недействительными значениями. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Программы чтения с экрана не могут распознавать атрибуты ARIA с недействительными значениями. [Подробнее…](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Значения атрибутов [aria-*] недействительны"
+    "message": "У атрибутов `[aria-*]` недействительные значения"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Значения атрибутов [aria-*] действительны"
+    "message": "Недействительные значения атрибутов `[aria-*]` отсутствуют"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Программы чтения с экрана не могут распознавать атрибуты ARIA с недействительными названиями. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Программы чтения с экрана не могут интерпретировать атрибуты ARIA с недействительными названиями. [Подробнее…](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Атрибуты [aria-*] недействительны или указаны с ошибками"
+    "message": "Атрибуты `[aria-*]` недействительны или указаны с ошибками"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Атрибуты [aria-*] действительны и не содержат ошибок"
+    "message": "Атрибуты `[aria-*]` действительны и написаны без ошибок"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Чтобы ваш аудиоконтент был доступен людям с нарушениями слуха, добавьте субтитры. В них можно включить описания сцен, у которых нет звукового сопровождения. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Чтобы ваш аудиоконтент был доступен людям с нарушениями слуха, добавьте субтитры. В них можно включить описания сцен, у которых нет звукового сопровождения. [Подробнее…](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Элементы <audio> не содержат элемент <track> с параметром [kind=\"captions\"]"
+    "message": "Элементы `<audio>` не содержат элемент `<track>` с атрибутом `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Элементы <audio> содержат элемент <track> с параметром [kind=\"captions\"]"
+    "message": "Элементы `<audio>` содержат элемент `<track>` с атрибутом `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
-    "message": "Неподходящие элементы"
+    "message": "Элементы, не прошедшие проверку"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Если у кнопки нет названия, доступного программам чтения с экрана, пользователи услышат слово \"кнопка\", но не поймут, для чего она нужна. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Если у кнопки нет названия, доступного программам чтения с экрана, пользователи услышат слово \"кнопка\", но не поймут, для чего она нужна. [Подробнее…](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Названия кнопок недоступны программам чтения с экрана"
@@ -93,7 +93,7 @@
     "message": "Названия кнопок доступны программам чтения с экрана"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Чтобы пользователям было проще перемещаться по странице с помощью клавиатуры, добавьте возможность пропускать повторяющийся контент. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Чтобы пользователям было проще перемещаться по странице с помощью клавиатуры, добавьте возможность пропускать повторяющийся контент. [Подробнее…](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "На странице отсутствует заголовок, ссылка для пропуска или указание региона"
@@ -102,7 +102,7 @@
     "message": "Страница содержит заголовок, ссылку для пропуска контента или указание региона"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Многие пользователи не разбирают или плохо видят текст с низкой контрастностью. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Многие пользователи не могут разобрать или не видят текст с низкой контрастностью. [Подробнее…](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Цвета фона и переднего плана недостаточно контрастны"
@@ -111,88 +111,88 @@
     "message": "Цвета фона и переднего плана достаточно контрастны"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Если списки определений размечены некорректно, программы чтения с экрана могут озвучивать их неправильно. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Если в структуре списков определений есть ошибки, программы чтения с экрана могут неправильно их озвучивать. [Подробнее…](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Некоторые группы <dt> и <dd>, а также элементы <script> или <template> указаны в тегах <dl> в неправильном порядке"
+    "message": "Элементы `<dt>`, `<dd>`, `<script>` и `<template>` расположены внутри элементов `<dl>` в неправильном порядке"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Группы <dt> и <dd>, а также элементы <script> или <template> указаны в тегах <dl> в нужном порядке"
+    "message": "Элементы `<dt>`, `<dd>`, `<script>` и `<template>` расположены внутри элементов `<dl>` в нужном порядке"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Чтобы программы чтения с экрана правильно озвучивали список определений, его элементы (<dt> и <dd>) должны быть размещены внутри родительского элемента <dl>. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Чтобы программы чтения с экрана правильно озвучивали элементы списков определений `<dt>` и `<dd>`, они должны располагаться внутри родительского элемента `<dl>`. [Подробнее…](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Элементы для списков определений не размещены внутри элементов <dl>"
+    "message": "Элементы списков определений не расположены внутри элементов `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Элементы для списков определений размещены внутри элементов <dl>"
+    "message": "Элементы списков определений расположены внутри элементов `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Элемент title нужен для того, чтобы программы чтения с экрана могли озвучивать название страницы. Также он появляется в результатах поиска и позволяет определять, соответствует ли сайт запросу. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Элемент title нужен для того, чтобы программы чтения с экрана могли озвучивать название страницы. Также он появляется в результатах поиска и позволяет определять, соответствует ли сайт запросу. [Подробнее…](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "В документе отсутствует элемент <title>"
+    "message": "В документе нет элемента `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "В документе есть элемент <title>"
+    "message": "Документ содержит элемент `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Значение атрибута id должно быть уникальным, так как программы для людей с ограниченными возможностями могут игнорировать повторяющиеся идентификаторы. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Значение атрибута id должно быть уникальным, так как программы для людей с ограниченными возможностями могут игнорировать повторяющиеся идентификаторы. [Подробнее…](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Атрибуты [id] на странице не уникальны"
+    "message": "Атрибуты `[id]` не уникальны на этой странице"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Атрибуты [id] на странице уникальны"
+    "message": "Атрибуты `[id]` уникальны на этой странице"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Чтобы программы чтения с экрана могли описывать содержимое фреймов, у каждого из них должно быть название (атрибут title). [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Чтобы программы чтения с экрана могли описывать содержимое фреймов, для каждого из них должен быть указан атрибут title. [Подробнее…](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "У элементов <frame> или <iframe> отсутствует атрибут title"
+    "message": "Для элементов `<frame>` или `<iframe>` не указан атрибут title"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Для элементов <frame> или <iframe> задан атрибут title"
+    "message": "У элементов `<frame>` и `<iframe>` есть атрибут title"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Если для страницы не указан атрибут lang, программа чтения с экрана предполагает, что текст приведен на языке по умолчанию, выбранном пользователем при установке программы. Если текст написан на другом языке, он может озвучиваться некорректно. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Если для страницы не указан атрибут lang, программа чтения с экрана предполагает, что текст приведен на языке по умолчанию, выбранном пользователем при установке программы. Если текст написан на другом языке, он может озвучиваться некорректно. [Подробнее…](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Для элемента <html> не задан атрибут [lang]"
+    "message": "Для элемента `<html>` не задан атрибут `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Для элемента <html> задан атрибут [lang]"
+    "message": "Элемент `<html>` содержит атрибут `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Чтобы программы чтения с экрана могли правильно озвучивать текст, укажите корректный [языковой тег BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question). [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Чтобы программы чтения с экрана правильно озвучивали текст, укажите действительный [языковой тег BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question). [Подробнее…](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Для элемента <html> указано недействительное значение атрибута [lang]"
+    "message": "В элементе `<html>` нет действительного значения для атрибута `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Для элемента <html> указано действительное значение атрибута [lang]"
+    "message": "Для элемента `<html>` указано действительное значение атрибута `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "В информационных элементах должен содержаться короткий и ясный альтернативный текст. Если элемент декоративный, то атрибут alt для него можно оставить пустым. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "В информационных элементах должен содержаться короткий и ясный альтернативный текст. Если элемент декоративный, то атрибут alt для него можно оставить пустым. [Подробнее…](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Для элементов с изображениями не заданы атрибуты [alt]"
+    "message": "Для элементов изображений не заданы атрибуты `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Для элементов с изображениями заданы атрибуты [alt]"
+    "message": "У элементов изображений есть атрибут `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Если для кнопки в теге <input> используется изображение, добавьте альтернативный текст, описывающий назначение этой кнопки для программ чтения с экрана. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Если в элементе `<input>` в качестве кнопки используется изображение, добавьте альтернативный текст, описывающий назначение этой кнопки для программ чтения с экрана. [Подробнее…](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Элементы <input type=\"image\"> не содержат атрибут [alt]"
+    "message": "Атрибут `[alt]` задан не для всех элементов `<input type=\"image\">`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Элементы <input type=\"image\"> содержат атрибут [alt]"
+    "message": "Элементы `<input type=\"image\">` содержат атрибут `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Чтобы программы чтения с экрана могли озвучивать элементы формы, добавьте ярлыки. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Ярлыки нужны для того, чтобы программы чтения с экрана могли правильно озвучивать элементы управления формой. [Подробнее…](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Элементам формы не присвоены соответствующие ярлыки"
@@ -201,16 +201,16 @@
     "message": "Элементам формы присвоены соответствующие ярлыки"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "В таблице, предназначенной для дизайна, не должны содержаться элементы данных, например теги th, caption и атрибут summary: они могут создать трудности для тех, кто использует программы чтения с экрана. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "В таблице, используемой в качестве основы дизайна веб-страницы, не должны содержаться элементы данных, например th, caption или атрибут summary, так как они могут создать трудности для тех, кто использует программы чтения с экрана. [Подробнее…](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "В описательных элементах <table> используется тег <th>, <caption> или атрибут [summary]"
+    "message": "В элементах `<table>` с атрибутом role=\"presentation\" используются элементы `<th>` и `<caption>` или атрибут `[summary]`"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "В описательных элементах <table> не используются теги <th> и <caption> или атрибут [summary]"
+    "message": "В элементах `<table>` с атрибутом role=\"presentation\" не используются элементы `<th>` и `<caption>` или атрибут `[summary]`"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Текст ссылок, как и альтернативный текст для изображений-ссылок, должен быть различимым для программ чтения с экрана, уникальным и доступным для выбора с помощью таких программ. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Текст ссылок (как и альтернативный текст для изображений, используемых в качестве ссылок) должен быть уникальным, фокусируемым и доступным для программ чтения с экрана. [Подробнее…](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Текст ссылок неразличим для программ чтения с экрана"
@@ -219,103 +219,115 @@
     "message": "Текст ссылок различим для программ чтения с экрана"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Списки должны быть размечены определенным образом, иначе программы чтения с экрана могут озвучивать их неправильно. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Используйте правильную структуру кода при верстке списков, иначе программы чтения с экрана будут неправильно их озвучивать. [Подробнее…](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "В списках обнаружены данные, которые не являются элементами <li>, <script> и <template>"
+    "message": "В списках содержатся другие элементы, помимо элементов `<li>` и элементов поддержки скрипта (`<script>` и `<template>`)"
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "В списках содержатся только элементы <li>, <script> и <template>"
+    "message": "В списках содержатся только элементы `<li>` и элементы поддержки скрипта (`<script>` и `<template>`)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Чтобы программы чтения с экрана правильно озвучивали списки, их элементы (<li>) должны содержаться в родительских элементах <ul> или <ol>. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Чтобы программы чтения с экрана правильно озвучивали списки, элементы `<li>` должны располагаться внутри родительских элементов `<ul>` или `<ol>`. [Подробнее…](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Элементы списка (<li>) не содержатся в родительских элементах <ul> или <ol>"
+    "message": "Элементы списка `<li>` не содержатся в родительских элементах `<ul>` или `<ol>`"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Элементы списка (<li>) содержатся в родительских элементах <ul> или <ol>"
+    "message": "Элементы списка `<li>` расположены внутри родительских элементов `<ul>` или `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Когда страница обновляется автоматически, фокус программ для чтения с экрана возвращается в ее верхнюю часть. Это может раздражать пользователей и мешать их работе. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Когда страница обновляется автоматически, фокус, используемый программами для чтения с экрана, перемещается в верхнюю часть. Это может раздражать пользователей и мешать их работе. [Подробнее…](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "В документе используется метатег <meta http-equiv=\"refresh\">"
+    "message": "В документе используется метатег `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "В документе не используется метатег <meta http-equiv=\"refresh\">"
+    "message": "В документе не используется метатег `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Не отключайте масштабирование: эта функция помогает слабовидящим пользователям читать информацию на страницах. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Не отключайте масштабирование: эта функция помогает слабовидящим пользователям читать информацию на веб-страницах. [Подробнее…](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "Параметр [user-scalable=\"no\"] используется в элементе <meta name=\"viewport\">, или значение атрибута [maximum-scale] меньше 5"
+    "message": "Атрибут `[user-scalable=\"no\"]` используется в элементе `<meta name=\"viewport\">` или значение атрибута `[maximum-scale]` меньше 5"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "Параметр [user-scalable=\"no\"] не используется в элементе <meta name=\"viewport\">, а значение атрибута [maximum-scale] не меньше 5"
+    "message": "Атрибут `[user-scalable=\"no\"]` не используется в элементе `<meta name=\"viewport\">`, и значение атрибута `[maximum-scale]` больше или равно 5"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Чтобы программы чтения с экрана могли озвучивать содержимое элементов <object>, добавьте для этих элементов альтернативный текст. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Чтобы программы чтения с экрана могли озвучивать содержимое элементов `<object>`, добавьте к ним атрибут alt. [Подробнее…](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Элементы <object> не содержат атрибут [alt]"
+    "message": "Атрибут `[alt]` задан не для всех элементов `<object>`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Элементы <object> содержат атрибут [alt]"
+    "message": "Элементы `<object>` содержат атрибут `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Значение больше 0 подразумевает определенный порядок навигации. Это может создавать трудности для пользователей с ограниченными возможностями. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Значение больше 0 подразумевает определенный порядок навигации. Это может создавать трудности для пользователей с ограниченными возможностями. [Подробнее…](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Для некоторых элементов значение [tabindex] больше 0"
+    "message": "Для некоторых элементов значение `[tabindex]` больше 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Ни в одном элементе значение [tabindex] не превышает 0"
+    "message": "Нет элементов со значением атрибута `[tabindex]` выше 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Чтобы пользователям было проще перемещаться по таблицам с помощью программ чтения с экрана, убедитесь, что ячейки в тегах <td> с атрибутом [headers] ссылаются только на другие ячейки в той же таблице. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Чтобы пользователям было проще перемещаться по таблицам с помощью программ чтения с экрана, убедитесь, что ячейки в элементах `<td>` с атрибутом `[headers]` ссылаются только на другие ячейки в той же таблице. [Подробнее…](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ячейки таблицы из элемента <table>, использующие атрибут [headers], ссылаются на другие ячейки той же таблицы"
+    "message": "Ячейки внутри элемента `<table>`, в которых используется атрибут `[headers]`, не ссылаются на другие ячейки той же таблицы"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Ячейки таблицы из элемента <table>, использующие атрибут [headers], ссылаются только на другие ячейки той же таблицы"
+    "message": "Ячейки внутри элемента `<table>`, в которых используется атрибут `[headers]`, ссылаются на другие ячейки той же таблицы"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Чтобы пользователям было проще перемещаться по таблицам с помощью программ чтения с экрана, убедитесь, что все заголовки в таблицах ссылаются на набор ячеек. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Чтобы пользователям было проще перемещаться по таблицам с помощью программ чтения с экрана, убедитесь, что все заголовки в таблицах ссылаются на определенный набор ячеек. [Подробнее…](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "В тегах <th> и элементах с параметром [role=\"columnheader\"/\"rowheader\"] нет описываемых ими ячеек с данными"
+    "message": "В элементах `<th>` и элементах с атрибутом `[role=\"columnheader\"/\"rowheader\"]` нет описываемых ими ячеек с данными"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "В тегах <th> и элементах с параметром [role=\"columnheader\"/\"rowheader\"] есть описываемые ими ячейки с данными"
+    "message": "В элементах `<th>` и элементах с атрибутом `[role=\"columnheader\"/\"rowheader\"]` есть описываемые ими ячейки с данными"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Чтобы программы чтения с экрана правильно озвучивали текст, укажите для элементов корректный [языковой тег BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question). [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Чтобы программы чтения с экрана правильно озвучивали текст, укажите для элементов корректный [языковой тег BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question). [Подробнее…](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Значения атрибутов [lang] недействительны"
+    "message": "Присутствуют недействительные значения атрибутов `[lang]`"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Значения атрибутов [lang] действительны"
+    "message": "Недействительные значения атрибутов `[lang]` отсутствуют"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Чтобы информация, озвучиваемая в видео, была доступна людям с нарушениями слуха, добавьте субтитры. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Чтобы информация, озвучиваемая в видео, была доступна людям с нарушениями слуха, добавьте субтитры. [Подробнее…](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Элементы <video> не содержат элемент <track> с параметром [kind=\"captions\"]"
+    "message": "Элементы `<video>` не содержат элемент `<track>` с атрибутом `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Элементы <video> содержат элемент <track> с параметром [kind=\"captions\"]"
+    "message": "Элементы `<video>` содержат элемент `<track>` с атрибутом `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Благодаря звуковым описаниям к видео слабовидящие пользователи могут узнавать, что происходит на экране в сценах без аудиосопровождения. [Подробнее…](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Благодаря звуковым описаниям к видео слабовидящие пользователи могут узнавать, что происходит на экране в сценах без аудиосопровождения. [Подробнее…](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Элементы <video> не содержат элемент <track> с параметром [kind=\"description\"]"
+    "message": "Элементы `<video>` не содержат элемент `<track>` с атрибутом `[kind=\"description\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Элементы <video> содержат элемент <track> с параметром [kind=\"description\"]"
+    "message": "Элементы `<video>` содержат элемент `<track>` с атрибутом `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Чтобы оптимизировать добавление сайта на главный экран для пользователей iOS, задайте значение для атрибута apple-touch-icon. Он должен указывать на непрозрачное квадратное PNG-изображение размером 192 пикс. (или 180 пикс.) по каждой стороне. [Подробнее…](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Не содержит действительный атрибут `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Атрибут `apple-touch-icon-precomposed` устарел. Используйте атрибут `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Содержит действительный атрибут `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Расширения Chrome замедляют загрузку этой страницы. Попробуйте использовать режим инкогнито или профиль Chrome без расширений."
@@ -330,7 +342,7 @@
     "message": "Общее процессорное время"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Рекомендуем сократить время на анализ, компиляцию и выполнение скриптов JS. Для этого вы можете уменьшить размер фрагментов кода JS. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Рекомендуем сократить время на анализ, компиляцию и выполнение скриптов JS. Для этого вы можете уменьшить размер фрагментов кода JS. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Сократите время выполнения кода JavaScript"
@@ -339,25 +351,25 @@
     "message": "Время выполнения кода JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Большие GIF-файлы – неэффективный способ представления анимации. Чтобы сэкономить трафик в сети, используйте видео в формате MPEG4/WebM для анимированного контента и изображения в формате PNG/WebP – для статического. [Подробнее…](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Анимированный контент неэффективно загружать в виде больших GIF-файлов. Чтобы сэкономить сетевой трафик, используйте формат видео MPEG4/WebM для анимированного контента и формат изображений PNG/WebP – для статического. [Подробнее…](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Используйте видеоформаты для анимированного контента"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Чтобы уменьшить время до начала взаимодействия, рекомендуем использовать принцип lazy loading для скрытых изображений после того, как все важные ресурсы будут загружены. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Чтобы уменьшить время загрузки для взаимодействия, рекомендуем настроить отложенную загрузку скрытых изображений. Тогда основные ресурсы сайта будут загружаться в первую очередь. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Отложите загрузку скрытых изображений"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Некоторые ресурсы препятствуют загрузке контента страницы. Рекомендуем настроить загрузку необходимых ресурсов JS/CSS в первую очередь и отложить загрузку остальных ресурсов. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Некоторые ресурсы блокируют первую отрисовку страницы. Рекомендуем встроить критическую часть данных JS/CSS в код HTML и отложить загрузку остальных ресурсов. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Устраните ресурсы, блокирующие отображение"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Чрезмерная нагрузка на сеть стоит пользователям реальных денег и может стать причиной долгого ожидания при работе в Интернете. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Чрезмерная нагрузка на сеть стоит пользователям реальных денег и может стать причиной долгого ожидания при работе в Интернете. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Общий размер достиг {totalBytes, number, bytes} КБ"
@@ -369,19 +381,19 @@
     "message": "Предотвращение чрезмерной нагрузки на сеть"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Уменьшение CSS-файлов может сократить нагрузку на сеть. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Уменьшив файлы CSS, вы можете сократить объем полезной сетевой нагрузки. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Уменьшите размер кода CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Уменьшение файлов JavaScript может сократить размер фрагментов кода и время анализа скриптов. [Подробнее…](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Уменьшив файлы JavaScript, вы можете сократить объем полезной нагрузки и время анализа скриптов. [Подробнее…](https://developers.google.com/speed/docs/insights/MinifyResources)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Уменьшите размер кода JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Чтобы сократить расход трафика, удалите ненужные правила из таблиц стилей и отложите загрузку кода CSS, который не используется в верхней части страницы. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Чтобы сократить расход трафика, удалите ненужные правила из таблиц стилей и отложите загрузку кода CSS, который не используется в верхней части страницы. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/unused-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Удалите неиспользуемый код CSS"
@@ -393,7 +405,7 @@
     "message": "Удалите неиспользуемый код JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Длительное время хранения кеша может ускорить загрузку при повторных посещениях страницы. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Благодаря долгому времени хранения кеша страница может быстрее загружаться при повторных посещениях. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Найден 1 ресурс}one{Найден # ресурс}few{Найдено # ресурса}many{Найдено # ресурсов}other{Найдено # ресурса}}"
@@ -405,37 +417,88 @@
     "message": "Настройка правил эффективного использования кеша для статических объектов"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Оптимизированные изображения загружаются быстрее и расходуют меньше мобильных данных. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Оптимизированные изображения загружаются быстрее и меньше расходуют мобильный трафик. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Настройте эффективную кодировку изображений"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Чтобы сэкономить мобильные данные и ускорить загрузку, настройте подходящий размер изображений на странице. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Чтобы сэкономить мобильный трафик и ускорить загрузку страницы, следите за тем, чтобы размеры ваших изображений соответствовали требованиям. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Настройте подходящий размер изображений"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Чтобы уменьшить расход трафика в сети, рекомендуем использовать сжатие для текстовых ресурсов (gzip, deflate или brotli). [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Чтобы уменьшить расход сетевого трафика, рекомендуем сжимать текстовые ресурсы (gzip, deflate или brotli). [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Включите сжатие текста"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Для изображений в форматах JPEG 2000, JPEG XR и WebP используется более эффективное сжатие, поэтому они загружаются быстрее и потребляют меньше трафика, чем изображения PNG и JPEG. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Форматы JPEG 2000, JPEG XR и WebP обеспечивают более эффективное сжатие по сравнению с PNG или JPEG, поэтому такие изображения загружаются быстрее и потребляют меньше трафика. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Используйте современные форматы изображений"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Приведенные ниже цепочки критических запросов показывают, какие ресурсы загружаются с высоким приоритетом. Чтобы ускорить загрузку страниц, рекомендуем сократить длину цепочек, уменьшить размер скачиваемых ресурсов или отложить скачивание ненужных ресурсов. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Приведенные ниже цепочки критических запросов показывают, какие ресурсы загружаются с высоким приоритетом. Чтобы ускорить загрузку страниц, рекомендуем сократить длину цепочек, уменьшить размер скачиваемых ресурсов или отложить скачивание ненужных ресурсов. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Найдена 1 цепочка}one{Найдена # цепочка}few{Найдено # цепочки}many{Найдено # цепочек}other{Найдено # цепочки}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Сократите глубину вложенности критических запросов"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Прекращение поддержки / предупреждение"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Строка"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Рано или поздно устаревшие API будут удалены из браузера. [Подробнее…](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Обнаружено 1 предупреждение}one{Обнаружено # предупреждение}few{Обнаружено # предупреждения}many{Обнаружено # предупреждений}other{Обнаружено # предупреждения}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "На странице используются устаревшие API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Устаревшие API не используются"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Application Cache больше не поддерживается. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Обнаружен манифест {AppCacheManifest}"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Используется Application Cache"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Application Cache не используется"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Если для страницы указан элемент DOCTYPE, браузер не будет переключаться в режим совместимости. Подробнее [о DOCTYPE](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)…"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "В качестве названия элемента DOCTYPE нужно указать `html` строчными буквами."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Необходимо добавить элемент DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Поле publicId содержит данные"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Поле systemId содержит данные"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Активирован режим совместимости, так как на странице отсутствует элемент DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Тип страницы (DOCTYPE): HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Элемент"
@@ -447,7 +510,7 @@
     "message": "Значение"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Разработчики браузеров рекомендуют размещать на странице не более 1500 элементов DOM. Наилучшие показатели: глубина дерева – менее 32 элементов, количество дочерних и родительских элементов – менее 60. Сложная структура DOM может увеличить использование памяти, замедлить [вычисление стилей](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) и повысить затраты на [компоновку шаблонов](https://developers.google.com/speed/articles/reflow). [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
+    "message": "Разработчики браузеров рекомендуют размещать на странице не более 1500 элементов DOM. Оптимальные показатели: глубина дерева – менее 32 элементов, количество дочерних и родительских элементов – менее 60. Сложная структура DOM может привести к использованию большего объема памяти, замедлить [вычисление стилей](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) и увеличить затраты на [компоновку шаблонов](https://developers.google.com/speed/articles/reflow). [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 элемент}one{# элемент}few{# элемента}many{# элементов}other{# элемента}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Сокращение размера структуры DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Атрибут target"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Добавьте атрибут `rel=\"noopener\"` или `rel=\"noreferrer\"` ко всем внешним ссылкам, чтобы повысить производительность и избежать уязвимостей в защите. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Ссылки на сторонние ресурсы небезопасны"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Ссылки на сторонние ресурсы безопасны"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Не удалось определить целевой якорь ({anchorHTML}). Если элемент не используется в качестве гиперссылки, попробуйте удалить атрибут target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Пользователи с подозрением относятся к сайтам, которые беспричинно запрашивают доступ к их местоположению. Мы рекомендуем связать этот запрос с определенными действиями пользователя. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Разрешение на определение местоположения запрашивается при загрузке страницы"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Разрешение на определение местоположения не запрашивается при загрузке страницы"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Версия"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Все клиентские библиотеки JavaScript, обнаруженные на странице."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Обнаруженные библиотеки JavaScript"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Использование метода `document.write()` для динамической подгрузки внешних скриптов может значительно замедлять загрузку страницы для пользователей с низкой скоростью подключения. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Используется метод `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Метод `document.write()` не используется"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Максимальная степень опасности"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Версия библиотеки"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Количество уязвимостей"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Некоторые сторонние скрипты содержат известные уязвимости, которые легко могут быть обнаружены и использованы злоумышленниками. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Обнаружена 1 уязвимость}one{Обнаружена # уязвимость}few{Обнаружено # уязвимости}many{Обнаружено # уязвимостей}other{Обнаружено # уязвимости}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Содержит клиентские библиотеки JavaScript с известными уязвимостями"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Высокая"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Низкая"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Средняя"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Не содержит клиентские библиотеки JavaScript с известными уязвимостями"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Пользователи с подозрением относятся к сайтам, которые беспричинно запрашивают разрешение на отправку уведомлений. Мы рекомендуем связать этот запрос с определенными жестами пользователя. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Разрешение на отправку уведомлений запрашивается при загрузке страницы"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Разрешение на отправку уведомлений не запрашивается при загрузке страницы"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Элементы, запрещающие вставку из буфера обмена"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Запрет на вставку пароля из буфера обмена отрицательно сказывается на безопасности пользователей. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Вставка пароля из буфера обмена запрещена"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Вставка пароля из буфера обмена разрешена"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Протокол"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "Протокол HTTP/2 отличается от HTTP/1.1 массой преимуществ, включая бинарность, мультиплексирование запросов, а также возможность отправки данных по инициативе сервера. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 запрос не передан через HTTP/2}one{# запрос не передан через HTTP/2}few{# запроса не передано через HTTP/2}many{# запросов не передано через HTTP/2}other{# запроса не передано через HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Не использует протокол HTTP/2 для всех ресурсов"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Протокол HTTP/2 используется для собственных ресурсов"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Чтобы повысить производительность при прокрутке страницы, используйте флаг `passive` для прослушивателей событий прикосновения и колеса мыши. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Пассивные прослушиватели событий не используются для улучшения производительности при прокрутке"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Пассивные прослушиватели событий используются для улучшения производительности при прокрутке"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Описание"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Ошибки, записанные в журнале консоли, указывают на нерешенные проблемы. Это могут быть невыполненные сетевые запросы и другие сбои в работе браузера."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Ошибки браузера занесены в журнал консоли"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "В журнале консоли нет ошибок браузера"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Чтобы пользователь мог видеть текст, пока веб-шрифты не загрузились, используйте функцию отображения шрифтов CSS. [Подробнее…](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Используйте свойство CSS font-display, чтобы пользователи могли видеть текст во время загрузки веб-шрифтов. [Подробнее…](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Настройте показ всего текста во время загрузки веб-шрифтов"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Показ всего текста во время загрузки веб-шрифтов"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Сервису Lighthouse не удалось автоматически проверить значение font-display для следующего URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Соотношение сторон (фактическое)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Соотношение сторон (отображаемое)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Размеры отображаемого изображения должны соответствовать нормальному соотношению сторон. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Присутствуют изображения с некорректным соотношением сторон"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Отсутствуют изображения с некорректным соотношением сторон"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Недействительные данные о размере изображения {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Небезопасный URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Все сайты (даже если они не обрабатывают конфиденциальные данные) должны быть защищены протоколом HTTPS. Он обеспечивает защиту от взлома и не позволяет посторонним узнавать, как пользователи взаимодействуют с приложением. Кроме того, использование этого протокола обязательно при работе с версией HTTP/2 и многими новыми API для веб-платформ. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Обнаружен 1 небезопасный запрос}one{Обнаружен # небезопасный запрос}few{Обнаружено # небезопасных запроса}many{Обнаружено # небезопасных запросов}other{Обнаружено # небезопасного запроса}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Протокол HTTPS не используется"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Используется протокол HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Если страницы будут быстро загружаться по мобильной сети, сайтом будет удобно пользоваться с телефона или планшета. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Если страницы будут быстро загружаться по мобильной сети, сайтом станет удобно пользоваться на телефоне или планшете. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Отклик за {timeInMs, number, seconds} сек."
+    "message": "Станица интерактивна через {timeInMs, number, seconds} сек."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Отклик по мобильной сети достигается за {timeInMs, number, seconds} сек."
+    "message": "Страница интерактивна в эмулированной мобильной сети через {timeInMs, number, seconds} сек."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Страницы загружаются через мобильную сеть недостаточно быстро"
@@ -504,106 +735,130 @@
     "message": "Минимизация работы в основном потоке"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Предполагаемое время задержки при вводе показывает время в миллисекундах, которое занимает реакция приложения на действия пользователя в течение самых занятых 5 сек. загрузки страницы. Если это время превышает 50 мс, пользователям может показаться, что ваше приложение работает с задержками. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Примерное время задержки при вводе показывает время в миллисекундах, через которое приложение реагирует на действия пользователя в течение самых активных 5 секунд загрузки страницы. Если это время превышает 50 мс, пользователям может показаться, что ваше приложение работает слишком медленно. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Приблизительное время задержки при вводе"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Первая отрисовка контента – показатель, который определяет интервал времени между началом загрузки страницы и появлением первого изображения или блока текста. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Первая отрисовка контента – показатель, который определяет интервал времени между началом загрузки страницы и появлением первого изображения или блока текста. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Время загрузки первого контента"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "Этот параметр показывается время, в которое основной поток страницы становится достаточно свободен для обработки ручного ввода. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "Время окончания работы ЦП – время, когда на странице становится возможной обработка пользовательского ввода. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Время окончания работы ЦП"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Этот параметр показывает время, по истечении которого становится виден основной контент страницы. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Первая значимая отрисовка – показатель, определяющий интервал времени между началом загрузки страницы и появлением основного контента. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Время загрузки достаточной части контента"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Время загрузки для взаимодействия – это время, в течение которого страница становится полностью готова к взаимодействию с пользователем. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Время загрузки для взаимодействия – это время, в течение которого страница становится полностью готова к взаимодействию с пользователем. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)"
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Время загрузки для взаимодействия"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Потенциальная задержка после первого ввода (FID) показывает максимальное время выполнения задачи в миллисекундах"
+    "message": "Максимальная потенциальная задержка после первого ввода показывает время выполнения самой длительной задачи в миллисекундах. [Подробнее…](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Максимальная потенциальная задержка FID"
+    "message": "Макс. потенц. задержка после первого ввода"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Индекс скорости загрузки показывает, насколько быстро контент страницы становится доступен для просмотра. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Индекс скорости загрузки показывает, как быстро на странице появляется контент. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Индекс скорости загрузки"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Общее время в миллисекундах между первой отрисовкой контента и временем загрузки для взаимодействия, когда скорость выполнения задач превышала 50 мс"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Общее время блокировки"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Время прохождения сигнала сети (RTT) напрямую влияет на производительность сайта. Высокое время прохождения сигнала означает, что серверы расположены слишком далеко от пользователя и сайт будет работать медленнее. [Подробнее…](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Время прохождения сигнала сети (RTT) напрямую влияет на производительность сайта. Высокое время прохождения сигнала означает, что серверы расположены слишком далеко от пользователя и сайт будет работать медленнее. [Подробнее…](https://hpbn.co/primer-on-latency-and-bandwidth/)"
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Время прохождения сигнала сети"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Задержки со стороны сервера могут влиять на скорость загрузки страниц. Высокое время отклика означает, что сервер перегружен или имеет низкую производительность. [Подробнее…](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Задержки со стороны сервера могут влиять на скорость загрузки страниц. Высокое время реакции сервера говорит о его перегруженности или недостаточной производительности. [Подробнее…](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Задержка со стороны сервера"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Сверх бюджета"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Следите за тем, чтобы количество и размер сетевых запросов соответствовали целям, установленным в бюджете производительности. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 запрос}one{# запрос}few{# запроса}many{# запросов}other{# запроса}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Бюджет производительности"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Переадресация может стать причиной дополнительной задержки при загрузке страницы. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Переадресации могут стать причиной дополнительных задержек при загрузке страницы. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Избегайте большого количества переадресаций"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Чтобы установить бюджет для количества и размера ресурсов на странице, добавьте файл budget.json. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 запрос}one{# запрос}few{# запроса}many{# запросов}other{# запроса}} • {byteCount, number, bytes} КБ"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Постарайтесь уменьшить количество запросов и размеры передаваемых данных"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Ссылки с атрибутом rel=canonical будут показаны в результатах поиска. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Ссылки с атрибутом rel=\"canonical\" будут показаны в результатах поиска. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Конфликтующие URL ({urlList})."
+    "message": "Несколько конфликтующих URL ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "URL ведет на другой домен ({url})."
+    "message": "Указывает на другой домен ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "URL недействителен ({url})."
+    "message": "Недопустимый URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "URL ведет на другую версию страницы с атрибутом hreflang ({url})."
+    "message": "Указывает на другое расположение атрибута `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "Относительный URL ({url})."
+    "message": "Относительный URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "Каноническая ссылка ведет на корневой URL домена, а не на соответствующую страницу с контентом."
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Документ содержит недействительный атрибут rel=canonical"
+    "message": "В документе нет действительного атрибута `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Документ содержит действительный атрибут rel=canonical"
+    "message": "Для документа указан действительный атрибут `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Если вы хотите, чтобы текст легко читался, размер шрифта должен составлять не менее 12 пикс. В противном случае пользователям мобильных устройств придется масштабировать страницу для чтения. Желательно, чтобы более 60 % текста на странице было написано шрифтом размером не менее 12 пикс. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Если вы хотите, чтобы текст легко читался, размер шрифта должен составлять не менее 12 пикс. В противном случае пользователям мобильных устройств придется масштабировать страницу для чтения. В идеале на странице должно быть более 60 % текста высотой не менее 12 пикс. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} текста можно легко прочитать"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} текста слишком маленького размера."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Слишком мелкий текст. Настройте область просмотра для экранов мобильных устройств с помощью метатега viewport."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} текста слишком маленького размера (проанализировано {decimalProportionVisited, number, extendedPercent} текста на странице)."
+    "message": "{decimalProportion, number, extendedPercent} текста набрано слишком мелким шрифтом (на основе образца размером {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "В документе используются шрифты слишком маленького размера"
@@ -612,16 +867,16 @@
     "message": "В документе используются шрифты оптимального размера"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Добавьте на страницу элементы link с атрибутом hreflang. Тогда в результатах поиска будут представлены те версии ваших страниц, которые лучше всего подходят для языка и региона пользователя. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Добавьте на страницу элементы link с атрибутом hreflang. Тогда в результатах поиска будут представлены те версии ваших страниц, которые лучше всего подходят для языка и региона пользователя. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "В документе нет действительного атрибута hreflang"
+    "message": "В документе нет действительного атрибута `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Документ содержит действительный атрибут hreflang"
+    "message": "Для документа указан действительный атрибут `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Индексация страниц с недействительным кодом статуса HTTP может быть нарушена. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Индексация страниц с недействительным кодом статуса HTTP может быть нарушена. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "Код статуса HTTP недействителен"
@@ -630,7 +885,7 @@
     "message": "Код статуса HTTP действителен"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Разрешите поисковым системам сканировать ваши страницы, чтобы они могли появляться в результатах поиска. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Поисковые системы не смогут включать ваши страницы в результаты поиска, если вы не предоставите разрешение на сканирование. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/indexing)"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Страница недоступна для индексации"
@@ -639,7 +894,7 @@
     "message": "Страница доступна для индексации"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Добавьте описания ссылок, чтобы поисковые системы лучше распознавали ваш контент. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "Добавьте к ссылкам текстовые описания, чтобы поисковые системы лучше распознавали ваш контент. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)"
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{Найдена 1 ссылка}one{Найдена # ссылка}few{Найдено # ссылки}many{Найдено # ссылок}other{Найдено # ссылки}}"
@@ -651,13 +906,13 @@
     "message": "У ссылок есть описания"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Воспользуйтесь [инструментом для проверки структурированных данных](https://search.google.com/structured-data/testing-tool/), а также [инструментом для их анализа](http://linter.structured-data.org/). [Подробнее…](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Для тестирования структурированных данных воспользуйтесь [инструментом проверки](https://search.google.com/structured-data/testing-tool/) и [инструментом Structured Data Linter](http://linter.structured-data.org/). [Подробнее…](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Структурированные данные действительны"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Метаописания содержат общие сведения о контенте страницы и могут быть показаны в результатах поиска. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Метаописания содержат общие сведения о контенте страницы и могут быть показаны в результатах поиска. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/description)"
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Отсутствует описание."
@@ -669,7 +924,7 @@
     "message": "В документе есть метаописание"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "Поисковые системы не могут индексировать плагины. К тому же на многих устройствах использование плагинов ограничено или не поддерживается. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "Поисковые системы не могут индексировать содержимое плагинов. К тому же на многих устройствах использование плагинов ограничено или не поддерживается. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/plugins)"
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "В документе используются плагины"
@@ -681,7 +936,7 @@
     "message": "Если файл robots.txt поврежден, поисковые роботы могут не распознать ваши инструкции по сканированию или индексации сайта."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "Код статуса HTTP для файла robots.txt: {statusCode}"
+    "message": "Код статуса HTTP, полученный в ответ на запрос файла robots.txt: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{Обнаружена 1 ошибка}one{Обнаружена # ошибка}few{Обнаружено # ошибки}many{Обнаружено # ошибок}other{Обнаружено # ошибки}}"
@@ -696,10 +951,10 @@
     "message": "Файл robots.txt действителен"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Интерактивные элементы, такие как кнопки и ссылки, должны быть достаточно крупными (48 x 48 пикс.) и не должны быть расположены рядом друг с другом. Тогда пользователям будет удобно нажимать на них. [Подробнее…](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Интерактивные элементы, такие как кнопки и ссылки, должны быть достаточно крупными (48 x 48 пикс.) и располагаться на достаточном расстоянии друг от друга. Тогда пользователям будет удобно нажимать на них. [Подробнее…](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "{decimalProportion, number, percent} интерактивных элементов оптимального размера."
+    "message": "Размеры {decimalProportion, number, percent} интерактивных элементов соответствуют требованиям."
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "Слишком маленькие интерактивные элементы. Настройте область просмотра для экранов мобильных устройств с помощью метатега viewport."
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Частичное совпадение элементов"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Размер"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Интерактивный элемент"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Размер интерактивных элементов оптимален"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Время выполнения в основном потоке"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Сторонний поставщик"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Сторонний код может сильно замедлить загрузку страниц сайта. Рекомендуем использовать только самые необходимые сторонние ресурсы и сделать так, чтобы они загружались в последнюю очередь. [Подробнее…](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Обнаружен 1 сторонний фрагмент кода}one{Обнаружен # сторонний фрагмент кода}few{Обнаружено # сторонних фрагмента кода}many{Обнаружено # сторонних фрагментов кода}other{Обнаружено # стороннего фрагмента кода}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Сторонний код"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Время до получения первого байта показывает задержку, после которой с вашего сервера отправляется ответ на запрос. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "Время до первого байта – показатель, который определяет интервал времени между отправкой запроса и ответом вашего сервера. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Загрузка корневого документа заняла {timeInMs, number, milliseconds} мс"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Длительность"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Название"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Время начала"
   },
@@ -744,7 +1008,7 @@
     "message": "Тип"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Используйте User Timing API, чтобы измерить реальную производительность своего приложения во время ключевых моментов взаимодействия с пользователями. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Используйте User Timing API, чтобы измерить реальную производительность своего приложения во время ключевых моментов взаимодействия с пользователями. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 временная метка}one{# временная метка}few{# временные метки}many{# временных меток}other{# временной метки}}"
@@ -753,19 +1017,19 @@
     "message": "Метки и промежутки пользовательского времени"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Для {securityOrigin} найдена ссылка типа preconnect, но она не использовалась браузером. Убедитесь, что атрибут crossorigin задан правильно."
+    "message": "Для страницы {securityOrigin} найден элемент <link> с атрибутом rel=\"preconnect\", но он не использовался браузером. Проверьте значение атрибута `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Чтобы быстро устанавливать соединение с необходимыми сторонними доменами, рекомендуем добавить ресурсные подсказки preconnect или dns-prefetch. [Подробнее…](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Чтобы быстро устанавливать соединение с необходимыми сторонними источниками, рекомендуем добавить ресурсные подсказки preconnect или dns-prefetch. [Подробнее…](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Используйте предварительное подключение к необходимым доменам"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Для {preloadURL} найдена ссылка типа preload, но она не использовалась браузером. Убедитесь, что атрибут crossorigin задан правильно."
+    "message": "Для страницы {preloadURL} найден элемент <link> с атрибутом rel=\"preload\", но он не использовался браузером. Проверьте значение атрибута `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Чтобы загружать требуемые ресурсы в порядке приоритета, вам следует использовать <link rel=предварительную загрузку>. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Чтобы основные ресурсы загружались в первую очередь, используйте для них элемент `<link rel=preload>`. [Подробнее…](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Настройте предварительную загрузку ключевых запросов"
@@ -789,10 +1053,10 @@
     "message": "Рекомендации"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Узнайте, какие трудности могут возникнуть у людей с ограниченными возможностями при использовании вашего сайта, и [сделайте его доступнее для таких пользователей](https://developers.google.com/web/fundamentals/accessibility). Рекомендуем также провести ручную проверку, так как не все проблемы могут быть выявлены автоматически."
+    "message": "Узнайте, какие трудности могут возникнуть у людей с ограниченными возможностями при использовании вашего веб-приложения, и [сделайте его доступнее](https://developers.google.com/web/fundamentals/accessibility). Тестирование вручную поможет выявить проблемы доступности, которые не были обнаружены автоматически."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Ручная проверка позволяет охватить области, которые невозможно просканировать автоматически. Чтобы узнать больше, ознакомьтесь с нашим [руководством по проверке специальных возможностей](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Ручная проверка позволяет охватить области, которые невозможно протестировать автоматически. Подробнее [о проверке специальных возможностей](https://developers.google.com/web/fundamentals/accessibility/how-to-review)…"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Специальные возможности"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Таблицы и списки"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Рекомендации"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "В бюджете производительности устанавливаются нормы для производительности вашего сайта."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Бюджет"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Подробная информация о производительности вашего приложения."
+    "message": "Подробная информация о производительности вашего приложения. Эти цифры не влияют на показатель производительности [напрямую](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Диагностика"
@@ -840,7 +1113,7 @@
     "message": "Уменьшение времени загрузки контента"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Эти действия по оптимизации могут ускорить загрузку страницы."
+    "message": "Эти рекомендации могут помочь вам ускорить загрузку страницы. Они не влияют на показатель производительности [напрямую](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Оптимизация"
@@ -867,7 +1140,7 @@
     "message": "Соответствие рекомендациям для PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Эти проверки позволяют оптимизировать сайт для успешной индексации поисковыми системами. Lighthouse проверяет не все факторы, которые могут повлиять на позицию сайта в результатах поиска. [Подробнее…](https://support.google.com/webmasters/answer/35769)."
+    "message": "Эти проверки позволяют оптимизировать сайт для успешной индексации поисковыми системами. Lighthouse проверяет не все факторы, которые могут повлиять на позицию сайта в результатах поиска. [Подробнее…](https://support.google.com/webmasters/answer/35769)"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Проверьте, соответствует ли ваш сайт рекомендациям по поисковой оптимизации (SEO), с помощью этих дополнительных сервисов."
@@ -888,7 +1161,7 @@
     "message": "Сканирование и индексирование"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Убедитесь, что ваши страницы оптимизированы для мобильных устройств, чтобы пользователям не приходилось менять масштаб страниц или подстраивать их под размер экрана. [Подробнее…](https://developers.google.com/search/mobile-sites/)."
+    "message": "Убедитесь, что ваши страницы оптимизированы для мобильных устройств, чтобы пользователям не приходилось менять масштаб страниц или подстраивать их под размер экрана. [Подробнее…](https://developers.google.com/search/mobile-sites/)"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Оптимизация для мобильных устройств"
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Время жизни кеша"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Расположение"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Название"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Запросы"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Тип ресурса"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Размер (КБ)"
+    "message": "Размер"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Потраченное время"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Объем переданных данных"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Потенциальная экономия данных (КБ)"
+    "message": "Потенциальная экономия"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Потенциальная экономия времени (мс)"
+    "message": "Потенциальная экономия"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Потенциальная экономия данных: {wastedBytes, number, bytes} КБ"
+    "message": "Потенциальная экономия – {wastedBytes, number, bytes} КБ"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "Потенциальная экономия времени: {wastedMs, number, milliseconds} мс"
+    "message": "Потенциальная экономия – {wastedMs, number, milliseconds} мс"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Документ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Шрифт"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Изображение"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Медиа"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} мс"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Другой"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Скрипт"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} сек."
   },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Таблица стилей"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Сторонний"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Всего"
+  },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "При записи трассировки для вашей страницы произошла ошибка. Перезапустите Lighthouse. Код ошибки: {errorCode}."
+    "message": "При записи трассировки для вашей страницы произошла ошибка. Перезапустите Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Превышено время ожидания для первичного соединения с протоколом отладчика."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "При загрузке страницы в Chrome не были сделаны скриншоты. Проверьте, есть ли на странице видимый контент, и перезапустите Lighthouse. Код ошибки: {errorCode}."
+    "message": "При загрузке страницы в Chrome не были сделаны скриншоты. Проверьте, есть ли на странице видимый контент, и перезапустите Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS-серверам не удалось определить IP-адрес по указанному домену."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "При сборе данных ресурса {artifactName} произошла ошибка ({errorMessage})."
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Произошла внутренняя ошибка. Перезапустите Chrome и Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Не удалось собрать данные ресурса {artifactName}."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Не удалось загрузить страницу. Убедитесь, что URL введен правильно и сервер отвечает на все запросы."
@@ -945,16 +1266,19 @@
     "message": "Не удалось загрузить URL, так как страница не отвечает."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Учетные данные для указанного URL недействительны. {securityMessages}"
+    "message": "Сертификат безопасности для указанного URL недействителен ({securityMessages})."
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Браузер Chrome остановил загрузку страницы с межстраничным объявлением. Убедитесь, что URL введен правильно и сервер отвечает на все запросы."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Не удалось загрузить страницу. Убедитесь, что URL введен правильно и сервер отвечает на все запросы. Подробности: {errorDetails}."
+    "message": "Не удалось загрузить страницу. Убедитесь, что URL введен правильно и сервер отвечает на все запросы. Подробнее: {errorDetails}."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
     "message": "Не удалось загрузить страницу. Убедитесь, что URL введен правильно и сервер отвечает на все запросы. Код статуса: {statusCode}."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Страница загружалась слишком долго. Уменьшите время загрузки, выполнив рекомендации из отчета, а затем перезапустите Lighthouse. Код ошибки: {errorCode}."
+    "message": "Страница загружалась слишком долго. Уменьшите время загрузки, выполнив рекомендации из отчета, а затем перезапустите Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "Истекло время ожидания ответа от протокола DevTools. Метод: {protocolMethod}."
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Развернуть фрагмент"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Показывать сторонние ресурсы"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Во время работы Lighthouse возникли следующие проблемы:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Значения приблизительные и могут изменяться."
+    "message": "Значения приблизительные и могут изменяться. Уровень производительности рассчитывается [только на основании этих показателей](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Пройденные проверки с предупреждениями"
@@ -1023,10 +1350,10 @@
     "message": "Используйте сервисы, которые позволяют встраивать GIF-файлы на страницы сайта в формате видео HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Установите [плагин WordPress для отложенной загрузки изображений](https://wordpress.org/plugins/search/lazy+load/) или подберите тему, которая поддерживает такую возможность. Это позволит системе загружать скрытые изображения позже. Мы также рекомендуем использовать [плагин AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Чтобы отложить загрузку скрытых страниц, установите [плагин WordPress](https://wordpress.org/plugins/search/lazy+load/) или подберите тему, которая поддерживает такую возможность. Мы также рекомендуем [плагин AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Используйте плагины, которые позволяют [в первую очередь загружать критически важные ресурсы](https://wordpress.org/plugins/search/critical+css/) или [откладывать загрузку менее важных](https://wordpress.org/plugins/search/defer+css+javascript/). Обратите внимание, что такие плагины могут привести к сбоям в работе других используемых вами тем или плагинов. Не исключено, что вам потребуется внести изменения в код."
+    "message": "Используйте плагины WordPress, которые позволяют [встроить критическую часть данных](https://wordpress.org/plugins/search/critical+css/) или [отложить загрузку менее важных ресурсов](https://wordpress.org/plugins/search/defer+css+javascript/). Обратите внимание, что такие плагины могут привести к сбоям в работе других используемых вами тем или плагинов. Не исключено, что вам потребуется внести изменения в код."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Темы, плагины и спецификации сервера – все это влияет на время ответа сервера. Советуем найти более подходящую тему, тщательно подобрать плагин для оптимизации и/или обновить сервер."
@@ -1035,25 +1362,25 @@
     "message": "Мы рекомендуем включить показ только начального фрагмента записей (например, с помощью тега More). Вы также можете сократить количество записей на одной странице, разбить длинные записи на несколько страниц или использовать отложенную загрузку комментариев."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Увеличьте скорость загрузки страниц сайта с помощью [плагинов WordPress](https://wordpress.org/plugins/search/minify+css/), которые позволяют объединять, уменьшать и сжимать стили. Рекомендуем использовать такие плагины на этапе сборки."
+    "message": "Ускорьте загрузку сайта с помощью [плагинов WordPress](https://wordpress.org/plugins/search/minify+css/), которые позволяют объединять, уменьшать и сжимать стили. Рекомендуем использовать такие плагины на этапе сборки."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Увеличьте скорость загрузки страниц сайта с помощью [плагинов WordPress](https://wordpress.org/plugins/search/minify+javascript/), которые позволяют объединять, уменьшать и сжимать скрипты. Рекомендуем использовать такие плагины на этапе сборки."
+    "message": "Ускорьте загрузку сайта с помощью [плагинов WordPress](https://wordpress.org/plugins/search/minify+javascript/), которые позволяют объединять, уменьшать и сжимать скрипты. Рекомендуем использовать такие плагины на этапе сборки."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Рекомендуем заменить или удалить [плагины WordPress](https://wordpress.org/plugins/), которые загружают неиспользуемый код CSS на странице сайта. Чтобы найти такие плагины, запустите [анализ покрытия кода](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) в Инструментах разработчика Chrome. Определить нужный плагин или тему можно по URL таблицы стилей. Обращайте внимание на плагины с большим количеством таблиц стилей, в которых при анализе покрытия кода преобладает красный цвет. Таблица стилей должна попадать в очередь, только если она используется на странице."
+    "message": "Рекомендуем заменить или удалить [плагины WordPress](https://wordpress.org/plugins/), которые загружают неиспользуемый код CSS на вашей странице. Чтобы найти такие плагины, запустите [анализ покрытия кода](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) в инструментах разработчика Chrome. Определить нужный плагин или тему можно по URL таблицы стилей. Обращайте внимание на плагины с большим количеством таблиц стилей, в которых при анализе покрытия кода преобладает красный цвет. Таблица стилей должна попадать в очередь, только если она используется на странице."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Рекомендуем заменить или удалить некоторые [плагины WordPress](https://wordpress.org/plugins/), которые загружают неиспользуемый код JavaScript на странице сайта. Чтобы найти такие плагины, запустите [анализ покрытия кода](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) в Инструментах разработчика Chrome. Определить нужный плагин или тему можно по URL скрипта. Обращайте внимание на плагины с большим количеством скриптов, в которых при анализе покрытия кода преобладает красный цвет. Скрипт должен попадать в очередь, только если он используется на странице."
+    "message": "Рекомендуем заменить или удалить [плагины WordPress](https://wordpress.org/plugins/), которые загружают неиспользуемый код JavaScript на вашей странице. Чтобы найти такие плагины, запустите [анализ покрытия кода](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) в инструментах разработчика Chrome. Определить нужный плагин или тему можно по URL скрипта. Обращайте внимание на плагины с большим количеством скриптов, в которых при анализе покрытия кода преобладает красный цвет. Скрипт должен попадать в очередь, только если он используется на странице."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Узнайте больше [о кешировании в браузере на платформе WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Подробнее [о кешировании в браузере на платформе WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)…"
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "Чтобы сжимать изображения без потери качества, используйте [специальный плагин WordPress](https://wordpress.org/plugins/search/optimize+images/)."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Чтобы проверить размер изображений, загрузите их в [Библиотеку файлов](https://codex.wordpress.org/Media_Library_Screen). С помощью виджета или из библиотеки вы сможете вставить на страницу изображения оптимального размера, который также будет соответствовать контрольным точкам для отзывчивого дизайна. Старайтесь не размещать изображения в полном размере, за исключением тех случаев, когда он соответствует необходимому. [Подробнее…](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
+    "message": "Чтобы привести размеры ваших изображений в соответствие с требованиями, загрузите их в [библиотеку файлов](https://codex.wordpress.org/Media_Library_Screen). Затем вставьте их на сайт прямо из библиотеки или используйте виджет изображений. Таким образом вы сможете обеспечить оптимальный размер изображений (в том числе для контрольных точек адаптивного дизайна). Старайтесь не использовать для изображения значение `Full Size` без особой необходимости. [Подробнее…](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Включить сжатие текста можно в настройках веб-сервера."

--- a/lighthouse-core/lib/i18n/locales/sk.json
+++ b/lighthouse-core/lib/i18n/locales/sk.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Prístupové klávesy umožňujú používateľom rýchlejšie vybrať časť stránky. Každý prístupový kláves musí byť jedinečný, aby navigácia fungovala správne. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)"
+    "message": "Prístupové klávesy umožňujú používateľom rýchlejšie vybrať časť stránky. Každý prístupový kláves musí byť jedinečný, aby navigácia správne fungovala. [Ďalšie informácie](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Hodnoty atribútu [accesskey] nie sú jedinečné"
+    "message": "Hodnoty `[accesskey]` nie sú jedinečné"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Hodnoty atribútu [accesskey] sú jedinečné"
+    "message": "Počet jedinečných hodnôt: `[accesskey]`"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Každá rola ARIA podporuje konkrétnu podmnožinu atribútov aria-*. Atribúty aria-* použité pre nesprávnu rolu sú neplatné. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)"
+    "message": "Každá značka ARIA `role` podporuje konkrétnu podmnožinu atribútov `aria-*`. Ak ich pomiešate, znehodnotia sa atribúty `aria-*`. [Ďalšie informácie](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Atribúty [aria-*] sa nezhodujú so svojimi rolami"
+    "message": "Atribúty `[aria-*]` nezodpovedajú svojim rolám"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Atribúty [aria-*] sa zhodujú so svojimi rolami"
+    "message": "Atribúty `[aria-*]` zodpovedajú svojim rolám"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Niektoré roly ARIA majú povinné atribúty, ktoré čítačkám obrazovky opisujú stav prvku. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)"
+    "message": "Niektoré roly ARIA majú povinné atribúty, ktoré čítačkám obrazovky opisujú stav prvku. [Ďalšie informácie](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Prvky s atribútom [role] nemajú všetky povinné atribúty [aria-*]"
+    "message": "Roly `[role]` nemajú všetky požadované atribúty `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Prvky s atribútom [role] obsahujú všetky povinné atribúty [aria-*]"
+    "message": "Roly `[role]` majú všetky požadované atribúty `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Niektoré nadradené roly ARIA musia obsahovať určité podradené roly, aby poskytovali správne funkcie dostupnosti. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)"
+    "message": "Ak majú poskytovať správne funkcie dostupnosti, musia niektoré nadradené roly ARIA obsahovať určité podradené roly. [Ďalšie informácie](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "V prvkoch s atribútom [role], ktoré by mali obsahovať podradené prvky s určitými atribútmi [role], tieto podradené prvky chýbajú."
+    "message": "Chýbajú prvky s rolou `[role]`, ktoré vyžadujú konkrétne podradené roly `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "V prvkoch s atribútom [role], ktoré by mali obsahovať podradené prvky s určitými atribútmi [role], sú tieto podradené prvky prítomné"
+    "message": "Prvky s rolou `[role]`, ktoré vyžadujú konkrétne podradené roly `[role]`, sú prítomné."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Niektoré podriadené roly ARIA musia byť obsiahnuté v konkrétnych nadradených rolách, aby poskytovali správne funkcie dostupnosti. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)"
+    "message": "Ak majú niektoré podradené roly ARIA poskytovať správne funkcie dostupnosti, musia byť obsiahnuté v konkrétnych nadradených rolách. [Ďalšie informácie](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Prvky s atribútom [role] nie sú umiestnené v požadovanom nadradenom prvku"
+    "message": "Roly `[role]` sa nenachádzajú v požadovanom nadradenom prvku"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Prvky s atribútmi [role] sú umiestnené v požadovanom nadradenom prvku"
+    "message": "Roly `[role]` sa nachádzajú v požadovanom nadradenom prvku"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Ak majú roly ARIA vykonávať zamýšľané funkcie dostupnosti, musia mať platné hodnoty. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)"
+    "message": "Ak majú roly ARIA vykonávať zamýšľané funkcie dostupnosti, musia mať platné hodnoty. [Ďalšie informácie](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Hodnoty atribútov [role] nie sú platné"
+    "message": "Hodnoty `[role]` nie sú platné"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Hodnoty atribútu [role] sú platné"
+    "message": "Hodnoty `[role]` sú platné"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Asistenčné technológie, ako sú čítačky obrazovky, nedokážu interpretovať atribúty ARIA s neplatnými hodnotami. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)"
+    "message": "Asistenčné technológie, ako sú čítačky obrazovky, nedokážu interpretovať atribúty ARIA s neplatnými hodnotami. [Ďalšie informácie](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Atribúty [aria-*] neobsahujú platné hodnoty"
+    "message": "Atribúty `[aria-*]` nemajú platné hodnoty"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Atribúty [aria-*] obsahujú platné hodnoty"
+    "message": "Atribúty `[aria-*]` majú platné hodnoty"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Asistenčné technológie, ako sú čítačky obrazovky, nedokážu interpretovať atribúty ARIA s neplatnými názvami. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)"
+    "message": "Asistenčné technológie, ako sú čítačky obrazovky, nedokážu interpretovať atribúty ARIA s neplatnými názvami. [Ďalšie informácie](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Atribúty [aria-*] nie sú platné alebo obsahujú preklepy"
+    "message": "Atribúty `[aria-*]` nie sú platné ani neobsahujú preklepy"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Atribúty [aria-*] sú platné a neobsahujú preklepy"
+    "message": "Atribúty `[aria-*]` sú platné a neobsahujú preklepy"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Titulky sprístupňujú nepočujúcim a sluchovo postihnutým používateľom zvukové prvky pomocou dôležitých informácií, napríklad údajov o tom, kto hovorí, čo hovorí a ďalších informácií nesúvisiacich s rečou. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)"
+    "message": "Titulky sprístupňujú nepočujúcim a sluchovo postihnutým používateľom zvukové prvky pomocou dôležitých informácií, napríklad údajov o tom, kto hovorí, čo hovorí a ďalších informácií nesúvisiacich s rečou. [Ďalšie informácie](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Prvky <audio> neobsahujú prvok <track> s atribútom [kind=\"captions\"]."
+    "message": "Prvkom `<audio>` chýba prvok `<track>` s titulkami `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Prvky <audio> obsahujú prvok <track> s atribútom [kind=\"captions\"]"
+    "message": "Prvky `<audio>` obsahujú prvok `<track>` s titulkami `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
-    "message": "Prvky, ktoré zlyhali"
+    "message": "Prvky s chybami"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Keď tlačidlo nemá dostupný názov, čítačky obrazovky ho oznamujú ako „tlačidlo“, takže je pre používateľov v podstate nanič. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)"
+    "message": "Keď tlačidlo nemá dostupný názov, čítačky obrazovky ho oznamujú ako „tlačidlo“, takže je pre používateľov v podstate nanič. [Ďalšie informácie](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Tlačidlá nemajú dostupný názov"
@@ -93,7 +93,7 @@
     "message": "Tlačidlá majú dostupný názov"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Keď pridáte možnosti, ako obísť opakujúci sa obsah, umožníte tým efektívnejšiu navigáciu na stránke pomocou klávesnice. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)"
+    "message": "Keď pridáte možnosti, ako obísť opakujúci sa obsah, umožníte tým efektívnejšiu navigáciu na stránke pomocou klávesnice. [Ďalšie informácie](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Stránka neobsahuje hlavičku, odkaz na preskočenie či orientačný bod regióna."
@@ -102,7 +102,7 @@
     "message": "Stránka obsahuje hlavičku, odkaz na preskočenie alebo orientačný bod regiónu"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Mnohí používatelia majú problémy s čítaním textu s nízkym kontrastom, prípadne to vôbec nedokážu. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)"
+    "message": "Mnohí používatelia majú problémy s čítaním textu s nízkym kontrastom, prípadne to vôbec nedokážu. [Ďalšie informácie](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Farby pozadia a popredia nemajú dostatočný kontrastný pomer."
@@ -111,88 +111,88 @@
     "message": "Farby pozadia a popredia majú dostatočný kontrastný pomer"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Keď zoznamy definícií nie sú správne označené, čítačky obrazovky môžu generovať mätúci alebo nepresný výstup. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)"
+    "message": "Keď zoznamy definícií nie sú správne označené, čítačky obrazovky môžu generovať mätúci alebo nepresný výstup. [Ďalšie informácie](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Prvky <dl> neobsahujú iba správne zoradené skupiny prvkov <dt> a <dd> či prvky <script> alebo <template>."
+    "message": "`<dl>` neobsahuje iba správne usporiadané skupiny `<dt>` a `<dd>`, prvky `<script>` alebo `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Prvky <dl> obsahujú iba správne zoradené skupiny <dt> a <dd> či prvky <script> alebo <template>."
+    "message": "`<dl>` obsahuje iba správne usporiadané skupiny `<dt>` a `<dd>`, prvky `<script>` alebo `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Položky zoznamu definícií (<dt> a <dd>) musia byť zabalené v nadradenom prvku <dl>, aby ich čítačky obrazovky dokázali správne oznamovať. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)"
+    "message": "Položky zoznamu definícií (`<dt>` a `<dd>`) musia byť zabalené v nadradenom prvku `<dl>`, aby ich čítačky obrazovky dokázali správne oznamovať. [Ďalšie informácie](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Položky zoznamu definícií nie sú zabalené v prvkoch <dl>"
+    "message": "Položky zoznamu definícií nie sú zabalené v prvkoch `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Položky zoznamu definícií sú zabalené v prvkoch <dl>"
+    "message": "Položky zoznamu definícií sú zabalené v prvkoch `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Názov poskytuje používateľom čítačiek obrazovky prehľadné informácie o stránke a používatelia vyhľadávačov sa podľa neho rozhodujú, či je stránka pre ich vyhľadávanie relevantná. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Názov poskytuje používateľom čítačiek obrazovky prehľadné informácie o stránke a používatelia vyhľadávačov sa podľa neho rozhodujú, či je stránka pre ich vyhľadávanie relevantná. [Ďalšie informácie](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokument neobsahuje prvok <title>"
+    "message": "Dokument nemá prvok `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokument obsahuje prvok <title>"
+    "message": "Dokument má prvok `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Hodnota atribútu ID musí byť jedinečná, aby asistenčné technológie neprehliadli ďalšie výskyty. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)"
+    "message": "Hodnota atribútu ID musí byť jedinečná, aby asistenčné technológie neprehliadli ďalšie výskyty. [Ďalšie informácie](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Atribúty [id] použité na stránke nie sú jedinečné"
+    "message": "Atribúty `[id]` na stránke nie sú jedinečné"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Atribúty [id] použité na stránke sú jedinečné"
+    "message": "Atribúty `[id]` na stránke sú jedinečné"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Používatelia čítačiek obrazovky zistia obsah rámcov pomocou ich názvov. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)"
+    "message": "Používatelia čítačiek obrazovky zistia obsah rámcov pomocou ich názvov. [Ďalšie informácie](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Prvky <frame> a <iframe> nemajú atribút title"
+    "message": "Prvky `<frame>` alebo `<iframe>` nemajú názov"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Prvok <frame> alebo <iframe> obsahuje názov"
+    "message": "Prvok `<frame>` alebo `<iframe>` má názov"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Ak stránka neuvádza atribút lang, čítačka obrazovky predpokladá, že je v predvolenom jazyku, ktorý používateľ zvolil pri nastavovaní čítačky obrazovky. Ak stránka v skutočnosti nie je v predvolenom jazyku, čítačka obrazovky nemusí jej text prečítať správne. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)"
+    "message": "Ak stránka neuvádza atribút lang, čítačka obrazovky predpokladá, že je v predvolenom jazyku vybranom používateľom pri nastavovaní čítačky obrazovky. Ak stránka v skutočnosti nie je v predvolenom jazyku, čítačka obrazovky nemusí jej text prečítať správne. [Ďalšie informácie](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Prvok <html> nemá atribút [lang]"
+    "message": "Prvok `<html>` nemá atribút `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Prvok <html> má atribút [lang]"
+    "message": "Prvok `<html>` má atribút `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Ak je uvedený platný [jazyk BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), čítačkám obrazovky to pomôže správne oznamovať text. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)"
+    "message": "Ak je uvedený platný [jazyk BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), čítačkám obrazovky to pomôže správne oznamovať text. [Ďalšie informácie](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Prvok <html> nemá platnú hodnotu atribútu [lang]."
+    "message": "Prvok `<html>` nemá platnú hodnotu pre atribút `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Prvok <html> obsahuje platnú hodnotu atribútu [lang]"
+    "message": "Prvok `<html>` má platnú hodnotu pre svoj atribút `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informatívne prvky by mali mať krátky popisný alternatívny text. Dekoratívne prvky je možné ignorovať pomocou prázdneho atribútu alt. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)"
+    "message": "Informatívne prvky by mali mať krátky popisný alternatívny text. Dekoratívne prvky je možné ignorovať pomocou prázdneho atribútu alt. [Ďalšie informácie](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Prvky obrázkov nemajú atribúty [alt]"
+    "message": "Prvky obrázkov nemajú atribúty `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Prvky obrázkov majú atribúty [alt]"
+    "message": "Prvky obrázka majú atribúty `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Keď je ako tlačidlo <input> použitý obrázok, uvedenie alternatívneho textu môže pomôcť používateľom čítačky obrazovky pochopiť účel tlačidla. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)"
+    "message": "Keď je ako tlačidlo `<input>` použitý obrázok, uvedenie alternatívneho textu môže pomôcť používateľom čítačky obrazovky pochopiť účel tlačidla. [Ďalšie informácie](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Prvky <input type=\"image\"> nemajú text [alt]"
+    "message": "Prvky `<input type=\"image\">` nemajú text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Prvky <input type=\"image\"> majú text [alt]"
+    "message": "Prvky `<input type=\"image\">` majú text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Štítky zaisťujú, aby asistenčné technológie (napríklad čítačky obrazovky) správne oznamovali ovládacie prvky formulárov. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)"
+    "message": "Štítky zaisťujú, aby asistenčné technológie (napríklad čítačky obrazovky) správne oznamovali ovládacie prvky formulárov. [Ďalšie informácie](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Prvky formulárov nemajú priradené štítky"
@@ -201,16 +201,16 @@
     "message": "K prvkom formulára sú priradené štítky"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Tabuľka používaná na vytvorenie rozloženia by nemala obsahovať údajové prvky, ako sú prvky th a caption, prípadne atribút summary, pretože by ste tým mohli zmiasť používateľov čítačiek obrazovky. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)"
+    "message": "Tabuľka používaná na vytvorenie rozloženia by nemala obsahovať údajové prvky, ako sú prvky th a caption, prípadne atribút summary, pretože by ste tým mohli zmiasť používateľov čítačiek obrazovky. [Ďalšie informácie](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Prezentačné tabuľky (<table>) používajú prvky <th> a <caption> alebo atribút [summary]."
+    "message": "Prezentačné prvky `<table>` nepoužívajú atribút `<th>`, `<caption>` alebo `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Prezentačné tabuľky (<table>) nepoužívajú prvky <th> a <caption> ani atribút [summary]."
+    "message": "Prezentačné prvky `<table>` nepoužívajú atribút `<th>`, `<caption>` ani `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Rozpoznateľný, jedinečný a zamerateľný text odkazu (a alternatívny text pre obrázky, ktoré sa používajú ako odkazy) zlepšuje navigáciu pomocou čítačky obrazovky. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)"
+    "message": "Rozpoznateľný, jedinečný a zamerateľný text odkazu (a alternatívny text pre obrázky, ktoré sa používajú ako odkazy) zlepšuje navigáciu pomocou čítačky obrazovky. [Ďalšie informácie](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Odkazy nemajú rozpoznateľné názvy"
@@ -219,103 +219,115 @@
     "message": "Odkazy majú rozpoznateľné názvy"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Čítačky obrazovky oznamujú zoznamy špeciálnym spôsobom. Použitím správnej štruktúry zoznamu pomôžete čítačkám obrazovky s výstupom. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)"
+    "message": "Čítačky obrazovky oznamujú zoznamy špeciálnym spôsobom. Použitím správnej štruktúry zoznamu pomôžete čítačkám obrazovky s výstupom. [Ďalšie informácie](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Zoznamy majú aj iný obsah ako prvky <li> a prvky s podporou skriptu (<script> a <template>)."
+    "message": "Zoznamy neobsahujú iba prvky `<li>` a prvky podporujúce skript (`<script>` a `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Zoznamy obsahujú iba prvky <li> a prvky s podporou skriptu (<script> a <template>)."
+    "message": "Zoznamy obsahujú iba prvky `<li>` a prvky podporujúce skript (`<script>` a `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Položky zoznamu (`<li>`) sa musia nachádzať v nadradenom prvku <ul> alebo <ol>, aby ich mohli čítačky obrazovky správne oznámiť. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)"
+    "message": "Položky zoznamu (`<li>`) sa musia nachádzať v nadradenom prvku `<ul>` alebo `<ol>`, aby ich dokázali čítačky obrazovky správne oznámiť. [Ďalšie informácie](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Položky zoznamov (<li>) nie sú vložené v nadradených prvkoch <ul> a <ol>."
+    "message": "Položky zoznamu (`<li>`) sa nenachádzajú v nadradených prvkoch `<ul>` ani `<ol>`"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Položky zoznamu (<li>) sú umiestnené v nadradených prvkoch <ul> alebo <ol>"
+    "message": "Položky zoznamu (`<li>`) sa nachádzajú v nadradených prvkoch `<ul>` alebo `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Používatelia neočakávajú, že sa stránka bude automaticky obnovovať. Pri automatickom obnovení sa zameranie vráti späť na začiatok stránky. Na používateľov to môže pôsobiť nepríjemne alebo mätúco. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)"
+    "message": "Používatelia neočakávajú, že sa stránka bude automaticky obnovovať. Pri automatickom obnovení sa zameranie vráti späť na začiatok stránky. Na používateľov to môže pôsobiť nepríjemne alebo mätúco. [Ďalšie informácie](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "V dokumente je použitá značka <meta http-equiv=\"refresh\">"
+    "message": "Dokument používa metaznačku `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "V dokumente nie je použitá značka <meta http-equiv=\"refresh\">"
+    "message": "Dokument nepoužíva `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Deaktivácia približovania spôsobuje problémy slabozrakým používateľom, ktorí pri čítaní obsahu webovej stránky využívajú priblíženie obrazovky. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)"
+    "message": "Deaktivácia približovania spôsobuje problémy slabozrakým používateľom, ktorí pri čítaní obsahu webovej stránky využívajú priblíženie obrazovky. [Ďalšie informácie](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "V prvku <meta name=\"viewport\"> je použitý atribút [user-scalable=\"no\"], prípadne je hodnota atribútu [maximum-scale] menšia ako 5."
+    "message": "`[user-scalable=\"no\"]` sa nepoužíva v prvku `<meta name=\"viewport\">` alebo hodnota atribútu `[maximum-scale]` je nižšia ako 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "V prvku <meta name=\"viewport\"> nie je použitý atribút [user-scalable=\"no\"] a hodnota atribútu [maximum-scale] nie je menšia než 5."
+    "message": "`[user-scalable=\"no\"]` sa nepoužíva v prvku `<meta name=\"viewport\">` a atribút `[maximum-scale]` nie je menší ako 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Čítačky obrazovky nedokážu preložiť iný obsah ako text. Keď k prvkom <object> pridáte alternatívny text, pomôžete tým čítačkám obrazovky sprostredkovať používateľom význam. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)"
+    "message": "Čítačky obrazovky nedokážu preložiť netextový obsah. Pridaním alternatívneho textu k prvkom `<object>` pomôžete čítačkám obrazovky sprostredkovať používateľom význam. [Ďalšie informácie](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Prvky <object> nemajú text [alt]"
+    "message": "Prvky `<object>` nemajú text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Prvky <object> majú text [alt]"
+    "message": "Prvky `<object>` majú text `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Hodnota väčšia ako 0 označuje explicitné usporiadanie navigácie. Hoci je to technicky platné riešenie, často vedie k nepríjemným skúsenostiam používateľov, ktorí sa spoliehajú na asistenčné technológie. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)"
+    "message": "Hodnota väčšia ako 0 označuje explicitné usporiadanie navigácie. Hoci je to technicky platné riešenie, často vedie k nepríjemným skúsenostiam používateľov, ktorí potrebujú asistenčné technológie. [Ďalšie informácie](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Niektoré prvky majú hodnotu [tabindex] vyššiu ako 0"
+    "message": "Niektoré prvky majú hodnotu `[tabindex]` vyššiu ako 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Žiadny prvok nemá hodnotu [tabindex] väčšiu ako 0"
+    "message": "Žiadny prvok nemá hodnotu `[tabindex]` vyššiu ako 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Čítačky obrazovky majú funkcie, ktoré zjednodušujú prehliadanie tabuliek. Keď zaistíte, aby bunky <td> s atribútom [headers] odkazovali iba na bunky v rovnakej tabuľke, môžete tým používateľom čítačiek obrazovky zjednodušiť prehliadanie. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)"
+    "message": "Čítačky obrazovky majú funkcie, ktoré zjednodušujú prehliadanie tabuliek. Keď zaistíte, aby bunky `<td>` s atribútom `[headers]` odkazovali iba na bunky v rovnakej tabuľke, môžete tým používateľom čítačiek obrazovky zjednodušiť prehliadanie. [Ďalšie informácie](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Bunky v prvku <table> s atribútom [headers] odkazujú na iné bunky v rovnakej tabuľke."
+    "message": "Bunky v prvku `<table>`, ktoré používajú atribút `[headers]`, odkazujú na ďalšie bunky v rovnakej tabuľke."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Bunky v prvku <table>, ktoré používajú atribút [headers], odkazujú iba na bunky v rovnakej tabuľke."
+    "message": "Bunky v prvku `<table>`, ktoré používajú atribút `[headers]`, odkazujú iba na ďalšie bunky v rovnakej tabuľke."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Čítačky obrazovky majú funkcie, ktoré zjednodušujú prehliadanie tabuliek. Dojem používateľov čítačiek obrazovky môžete vylepšiť tým, že hlavičky tabuliek budú odkazovať na určitú skupinu buniek. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)"
+    "message": "Čítačky obrazovky majú funkcie, ktoré zjednodušujú prehliadanie tabuliek. Dojem používateľov čítačiek obrazovky môžete vylepšiť tým, že hlavičky tabuliek budú odkazovať na určitú skupinu buniek. [Ďalšie informácie](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Prvky <th> a prvky s atribútom [role=\"columnheader\"/\"rowheader\"] nemajú údajové bunky, ktoré opisujú."
+    "message": "Prvky `<th>` a prvky s rolou `[role=\"columnheader\"/\"rowheader\"]` nemajú bunky s údajmi, ktoré opisujú."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Prvky <th> a prvky s atribútom [role=\"columnheader\"/\"rowheader\"] majú údajové bunky, ktoré opisujú."
+    "message": "Prvky `<th>` a prvky s rolou `[role=\"columnheader\"/\"rowheader\"]` majú bunky s údajmi, ktoré opisujú."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Ak je uvedený platný [jazyk BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), pomôže to zaistiť, aby čítačky obrazovky text čítali správne. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)"
+    "message": "Ak je v prvkoch uvedený platný [jazyk BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), pomôže to zaistiť, aby čítačky obrazovky čítali text správne. [Ďalšie informácie](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Atribúty [lang] nemajú platnú hodnotu"
+    "message": "Atribúty `[lang]` nemajú platnú hodnotu"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Atribúty [lang] obsahujú platnú hodnotu"
+    "message": "Atribúty `[lang]` majú platnú hodnotu"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Keď má video k dispozícii titulky, nepočujúci a sluchovo postihnutí používatelia jednoduchšie získajú informácie vo videu. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)"
+    "message": "Keď má video k dispozícii titulky, nepočujúci a sluchovo postihnutí používatelia jednoduchšie získajú informácie vo videu. [Ďalšie informácie](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Prvky <video> neobsahujú prvok <track> s atribútom [kind=\"captions\"]."
+    "message": "Prvky `<video>` neobsahujú prvok `<track>` s titulkami `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Prvky <video> obsahujú prvok <track> s atribútom [kind=\"captions\"]"
+    "message": "Prvky `<video>` obsahujú prvok `<track>` s titulkami `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Zvukové popisy pridávajú k videám relevantné informácie, napríklad o výrazoch tváre a scénach, ktoré nedokážu poskytnúť dialógy. [Ďalšie informácie](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)"
+    "message": "Zvukové popisy pridávajú k videám relevantné informácie, napríklad o výrazoch tváre a scénach, ktoré dialógy neposkytujú. [Ďalšie informácie](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Prvky <video> neobsahujú prvok <track> s atribútom [kind=\"description\"]."
+    "message": "Prvky `<video>` neobsahujú prvok `<track>` s titulkami `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Prvky <video> obsahujú prvok <track> s atribútom [kind=\"description\"]"
+    "message": "Prvky `<video>` obsahujú prvok `<track>` s titulkami `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Ak chcete zaistiť ideálny vzhľad stránky v systéme iOS, keď si ju používatelia pridajú na plochu, definujte ikonu apple-touch-icon. Musí odkazovať na nepriehľadný štvorcový obrázok PNG s veľkosťou 192 px (alebo 180 px). [Ďalšie informácie](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Neposkytuje platnú ikonu `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Prvok `apple-touch-icon-precomposed` je zastaraný, preferuje sa `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Poskytuje platnú ikonu `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Rozšírenia pre Chrome negatívne ovplyvnili výkonnosť načítania tejto stránky. Skúste stránku skontrolovať v režime inkognito alebo profile Chrome bez rozšírení."
@@ -330,7 +342,7 @@
     "message": "Celkový čas využitia procesora"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Zvážte skrátenie času stráveného analýzou, zostavovaním a spustením JavaScriptu. Možno vám s tým pomôže zobrazovanie menších prenášaných dát JavaScriptu. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Zvážte skrátenie času stráveného analýzou, zostavovaním a spustením JavaScriptu. Možno vám s tým pomôže zobrazovanie menších prenášaných dát JavaScriptu. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Skráťte čas spustenia JavaScriptu"
@@ -339,25 +351,25 @@
     "message": "Čas spustenia JavaScriptu"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Veľké GIFy nie sú vhodné na zobrazovanie animovaného obsahu. Namiesto nich odporúčame použiť videá MPEG4/WebM pre animácie a PNG/WebP pre statické obrázky, aby ste ušetrili spotrebu bajtov v sieti. [Ďalšie informácie](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Veľké gify nie sú vhodné na zobrazovanie animovaného obsahu. Namiesto nich odporúčame použiť videá MPEG4/WebM pre animácie a PNG/WebP pre statické obrázky, aby ste ušetrili spotrebu bajtov v sieti. [Ďalšie informácie](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Pre animovaný obsah použite formáty videa"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Zvážte oneskorené načítanie obrázkov, ktoré sú mimo obrazovky alebo skryté, a to až po dokončení načítania všetkých podstatných zdrojov, čím skrátite čas do interaktívneho vykreslenia. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Zvážte oneskorené načítanie obrázkov, ktoré sú mimo obrazovky alebo skryté, a to až po dokončení načítania všetkých podstatných zdrojov, čím skrátite čas do interaktívneho vykreslenia. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Oddiaľte načítanie obrázkov mimo obrazovky"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Zdroje blokujú prvé vyfarbenie stránky. Zvážte zobrazovanie podstatných JavaScriptov alebo šablón CSS v texte a oddialenie všetkých nepodstatných JavaScriptov alebo štýlov. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Zdroje blokujú prvé vykreslenie stránky. Zvážte zobrazovanie podstatných JavaScriptov alebo šablón CSS v texte a oddialenie všetkých nepodstatných JavaScriptov alebo štýlov. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Odstráňte zdroje blokujúce vykreslenie"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Veľké sieťové prenosy dát stoja používateľov mnoho peňazí a často sú spájané s dlhými časmi načítania. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Veľké sieťové prenosy dát stoja používateľov mnoho peňazí a často sú spájané s dlhými časmi načítania. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Celková veľkosť bola {totalBytes, number, bytes} KB"
@@ -369,13 +381,13 @@
     "message": "Zabráni nadmerným sieťovým prenosom dát"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Minifikáciou súborov šablón CSS môžete znížiť veľkosti sieťových prenosov dát. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Minifikáciou súborov šablón CSS môžete znížiť veľkosti sieťových prenosov dát. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Minifikujte súbory CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "Minifikáciou súborov JavaScriptu môžete znížiť veľkosti prenášaných dát a čas analýzy skriptu. [Ďalšie informácie](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "Minifikáciou súborov JavaScriptu môžete znížiť veľkosti prenášaných dát a čas analýzy skriptu. [Ďalšie informácie](https://developers.google.com/speed/docs/insights/MinifyResources)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "Minifikujte JavaScript"
@@ -393,7 +405,7 @@
     "message": "Odstráňte nepoužívaný JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Dlhá životnosť vyrovnávacej pamäte môže urýchliť opakované návštevy stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Dlhá životnosť vyrovnávacej pamäte môže zrýchliť opakované návštevy stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Našiel sa 1 zdroj}few{Našli sa # zdroje}many{# resources found}other{Našlo sa # zdrojov}}"
@@ -405,37 +417,88 @@
     "message": "Používa účinné pravidlá ukladania do vyrovnávacej pamäte pre statické podklady"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "Optimalizované obrázky sa načítavajú rýchlejšie a spotrebúvajú menej mobilných dát. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "Optimalizované obrázky sa načítavajú rýchlejšie a spotrebúvajú menej mobilných dát. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "Účinne zakódujte obrázky"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Zobrazujte obrázky s primeranou veľkosťou, čím ušetríte mobilné dáta a skrátite čas načítania. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Zobrazujte obrázky s primeranou veľkosťou, čím ušetríte mobilné dáta a skrátite čas načítania. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Nastavte primeranú veľkosť obrázkov"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Textové zdroje by sa mali zobrazovať komprimované (gzip, deflate alebo brotli), aby sa minimalizovala celková spotreba bajtov v sieti. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Textové zdroje by sa mali zobrazovať komprimované (gzip, deflate alebo brotli), aby sa minimalizovala celková spotreba bajtov v sieti. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Povoľte kompresiu textu"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Formáty obrázka, napríklad JPEG 2000, JPEG XR a WebP, zvyčajne poskytujú lepšiu kompresiu než PNG alebo JPEG, čo znamená rýchlejšie sťahovanie a nižšiu spotrebu dát. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Formáty obrázka, napríklad JPEG 2000, JPEG XR a WebP, zvyčajne poskytujú lepšiu kompresiu než PNG alebo JPEG, čo znamená rýchlejšie sťahovanie a nižšiu spotrebu dát. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/webp)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Zobrazujte obrázky vo formátoch ďalšej generácie"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Reťazce podstatných žiadostí uvedené nižšie znázorňujú, ktoré zdroje sú načítané s vysokou prioritou. Zvážte skrátenie dĺžky reťazcov, aby ste znížili veľkosť sťahovaných zdrojov, alebo odložte sťahovanie nepotrebných zdrojov, čím zlepšíte načítanie stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Reťazce podstatných žiadostí uvedené nižšie znázorňujú, ktoré zdroje sú načítané s vysokou prioritou. Zvážte skrátenie dĺžky reťazcov, aby ste znížili veľkosť sťahovaných zdrojov, alebo odložte sťahovanie nepotrebných zdrojov, čím zlepšíte načítanie stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Našiel sa 1 reťazec}few{Našli sa # reťazce}many{# chains found}other{Našlo sa # reťazcov}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minimalizujte hĺbku podstatných žiadostí"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Ukončenie podpory / upozornenie"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Riadok"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Rozhrania API s ukončenou podporou budú nakoniec z prehliadača odstránené. [Ďalšie informácie](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Zistilo sa 1 upozornenie}few{Zistili sa # upozornenia}many{# warnings found}other{Zistilo sa # upozornení}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Používa rozhrania API s ukončenou podporou"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Nepoužíva rozhrania API s ukončenou podporou"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Podpora vyrovnávacej pamäte aplikácie je ukončená. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Našiel sa prvok {AppCacheManifest}"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Používa vyrovnávaciu pamäť aplikácie"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Nepoužíva vyrovnávaciu pamäť aplikácie"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Špecifikovaním prvku doctype zabránite prechodu prehliadača do režimu kompatibility. Ďalšie informácie nájdete na [stránke MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)."
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Názov prvku doctype musí byť reťazec `html` s malými písmenami"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokument musí obsahovať prvok doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Očakávalo sa, že publicId bude prázdny reťazec"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Očakávalo sa, že systemId bude prázdny reťazec"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Stránke chýba prvok HTML doctype, preto spúšťa režim kompatibility"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Stránka obsahuje prvok HTML doctype"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Prvok"
@@ -447,7 +510,7 @@
     "message": "Hodnota"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Programátori prehliadača odporúčajú, aby stránky obsahovali menej ako ~1 500 prvkov DOM. Optimálna hodnota je hĺbka stromovej štruktúry menšia ako 32 prvkov a menej ako 60 podradených či nadradených prvkov. Veľký prvok DOM môže zvýšiť spotrebu pamäte, predĺžiť [výpočty štýlov](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) a spôsobiť nákladné [preformátovania rozložení](https://developers.google.com/speed/articles/reflow). [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Programátori prehliadača odporúčajú, aby stránky obsahovali menej ako ~1 500 prvkov DOM. Optimálna hodnota je hĺbka stromovej štruktúry menšia ako 32 prvkov a menej ako 60 podradených či nadradených prvkov. Veľký prvok DOM môže zvýšiť spotrebu pamäte, predĺžiť [výpočty štýlov](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) a spôsobiť nákladné [preformátovania rozložení](https://developers.google.com/speed/articles/reflow). [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 prvok}few{# prvky}many{# elements}other{# prvkov}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Zabráni použitiu nadmerne veľkého prvku DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Cieľ"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Ak chcete zlepšiť výkonnosť a zabrániť chybám zabezpečenia, pridajte k ľubovoľným externým odkazom prvok `rel=\"noopener\"` alebo `rel=\"noreferrer\"`. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Odkazy na destinácie typu cross origin nie sú bezpečné"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Odkazy na destinácie typu cross origin sú bezpečné"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Nepodarilo sa zistiť cieľ ukotvenia ({anchorHTML}). Ak sa nepoužíva ako hypertextový odkaz, zvážte odstránenie prvku target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Používatelia nedôverujú webom, ktoré požadujú ich polohu bez kontextu, alebo ich považujú za mätúce. Zvážte namiesto toho spojenie žiadosti s akciou používateľa. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Požaduje povolenie na geolokáciu pri načítaní stránky"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Nepožaduje povolenie na geolokáciu pri načítaní stránky"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Verzia"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Na stránke boli zistené všetky JavaScriptové knižnice klientskeho rozhrania."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Zistené knižnice JavaScriptu"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "V prípade používateľov s pomalým pripojením môžu externé skripty, ktoré sú dynamicky vložené prostredníctvom funkcie `document.write()`, oneskoriť načítavanie stránky o desiatky sekúnd. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Používa `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Nepoužíva `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Najzávažnejšie"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Verzia knižnice"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Počet chýb zabezpečenia"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Niektoré skripty tretích strán môžu obsahovať chyby zabezpečenia, ktoré dokážu útočníci ľahko rozpoznať a zneužiť. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Bola zistená 1 chyba zabezpečenia}few{Boli zistené # chyby zabezpečenia}many{# vulnerabilities detected}other{Bolo zistených # chýb zabezpečenia}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Zahrnuje JavaScriptové knižnice v klientskom rozhraní so známymi chybami zabezpečenia"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Vysoká"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Nízka"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Stredné"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Nepoužíva v klientskom rozhraní knižnice JavaScriptov so známymi chybami zabezpečenia"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Používatelia nedôverujú webom, ktoré požadujú odosielanie upozornení bez kontextu, alebo ich považujú za mätúce. Zvážte namiesto toho spojenie žiadosti s gestami používateľa. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Požaduje povolenie na upozornenie pri načítaní stránky"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Nepožaduje povolenie na upozornenie pri načítaní stránky"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Prvky s chybami"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Ak zakážete prilepovanie hesiel, zhoršíte kvalitu zabezpečenia. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Zabráňte používateľom prilepovať do polí pre heslá"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Umožnite používateľom prilepovať do polí pre heslá"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ponúka oproti HTTP/1.1 mnoho výhod vrátane binárnych hlavičiek, multiplexovania a technológie push na strane servera. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 žiadosť nebola odoslaná cez HTTP/2}few{# žiadosti neboli odoslané cez HTTP/2}many{# requests not served via HTTP/2}other{# žiadostí nebolo odoslaných cez HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Nepoužíva HTTP/2 pre všetky svoje zdroje"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Používa HTTP/2 pre svoje vlastné zdroje"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Odporúčame zmeniť prijímače udalostí aktivovaných dotykom alebo kolieskom myši na `passive`, čím zlepšíte výkonnosť posúvania stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Nepoužíva pasívne prijímače na zlepšenie posúvania"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Používa pasívne prijímače na zlepšenie posúvania"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Popis"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Chyby zaznamenané do konzoly označujú nevyriešené problémy. Môžu pochádzať zo zlyhaní žiadostí siete a ďalších problémov prehliadača."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Chyby prehliadača boli zaznamenané do konzoly"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Do konzoly neboli zaznamenané žiadne chyby prehliadača"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Využite funkciu CSS zobrazenia písma, ktorá pomôže zaistiť, aby bol text viditeľný používateľom počas načítavania webfontov. [Ďalšie informácie](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Využite funkciu CSS zobrazenia písma, ktorá pomôže zaistiť, aby používatelia videli text počas načítavania webfontov. [Ďalšie informácie](https://developers.google.com/web/updates/2016/02/font-display)"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Zaistite, aby text zostal počas načítania webfontov viditeľný"
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Všetok text zostane počas načítania webfontov viditeľný"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Nástroj Lighthouse nedokázal automaticky skontrolovať hodnotu zobrazenia písma na nasledujúcej webovej adrese: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Pomer strán (skutočný)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Pomer strán (zobrazený)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Rozmery zobrazenia obrázka by mali zodpovedať prirodzenému pomeru strán. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Zobrazuje obrázky s nesprávnym pomerom strán"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Zobrazuje obrázky so správnym pomerom strán"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Neplatné informácie o veľkosti obrázka {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Nezabezpečená webová adresa"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Všetky weby by mali byť zabezpečené protokolom HTTPS, dokonca aj tie, ktoré nespracúvajú citlivé údaje. HTTPS bráni útočníkom narušovať komunikáciu medzi vašou aplikáciou a používateľmi alebo ju pasívne odpočúvať, a je podmienkou pre HTTP/2 a mnoho nových rozhraní API webových platforiem. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Bola zistená 1 nezabezpečená žiadosť}few{Boli zistené # nezabezpečené žiadosti}many{# insecure requests found}other{Bolo zistených # nezabezpečených žiadostí}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Nepoužíva HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Používa HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Rýchle načítanie stránky cez mobilnú sieť zaisťuje dobrý dojem používateľov mobilných zariadení. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interaktívna v čase {timeInMs, number, seconds} s"
+    "message": "Interaktívna po {timeInMs, number, seconds} s"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Interaktívna v simulovanej mobilnej sieti v čase {timeInMs, number, seconds} s"
@@ -510,19 +741,19 @@
     "message": "Odhadovaná latencia vstupu"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Prvé obsahové vyfarbenie označuje čas, za ktorý je vyfarbený prvý text alebo obrázok. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Prvé vykreslenie obsahu označuje čas, za ktorý je vykreslený prvý text alebo obrázok. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Prvé obsahové vyfarbenie"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "Prvá nečinnosť procesora označuje, kedy je hlavné vlákno stránky prvýkrát dostatočne nečinné na spracovanie vstupu. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "Prvá nečinnosť procesora označuje, kedy je hlavné vlákno stránky prvýkrát dostatočne nečinné na spracovanie vstupu. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Prvá nečinnosť procesora"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Prvé účelné vyfarbenie meria, kedy je hlavný obsah stránky viditeľný. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Prvé zmysluplné vykreslenie meria, kedy je hlavný obsah stránky viditeľný. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Prvé účelné vyfarbenie"
@@ -534,16 +765,22 @@
     "message": "Čas do interaktívneho vykreslenia"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Potenciálne oneskorenie prvého vstupu, ktoré sa u vašich používateľov môže vyskytnúť, je trvanie najdlhšej úlohy (v milisekundách)."
+    "message": "Maximálne potenciálne oneskorenie prvého vstupu, ktoré sa u vašich používateľov môže vyskytnúť, je trvanie najdlhšej úlohy (v milisekundách). [Ďalšie informácie](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
     "message": "Max. potenc. oneskorenie prvého vstupu"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Index rýchlosti znázorňuje, za aký čas sa viditeľne doplní obsah stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Index rýchlosti znázorňuje, za aký čas sa viditeľne doplní obsah stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Index rýchlosti"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Súčet všetkých časových období medzi prvým vykreslením obsahu a časom do interaktivity, kedy dĺžka úlohy presiahla 50 ms (vyjadrený v milisekundách)."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Celkový čas blokovania"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Časy vrátenia žiadostí v rámci siete majú veľký vplyv na výkonnosť. Ak je čas vrátenia žiadostí v rámci siete k pôvodnému zdroju vysoký, znamená to, že servery umiestnené bližšie k používateľovi by mohli zlepšiť výkonnosť. [Ďalšie informácie](https://hpbn.co/primer-on-latency-and-bandwidth/)"
@@ -552,22 +789,43 @@
     "message": "Časy vrátania žiadostí v rámci siete"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Výkonnosť webu môžu ovplyvniť latencie serverov. Ak je latencia zdrojového servera vysoká, znamená to, že je preťažený alebo má slabú výkonnosť. [Ďalšie informácie](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
+    "message": "Výkonnosť webu môžu ovplyvniť latencie servera. Ak je latencia zdrojového servera vysoká, znamená to, že je preťažený alebo má slabú výkonnosť. [Ďalšie informácie](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Latencie na strane servera"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Cez rozpočet"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Udržujte množstvo a veľkosť žiadostí siete pod cieľovými hodnotami stanovenými poskytnutým rozpočtom výkonnosti. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 žiadosť}few{# žiadosti}many{# requests}other{# žiadostí}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Rozpočet výkonnosti"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Presmerovania spôsobujú ďalšie oneskorenia pri načítavaní stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Presmerovania spôsobujú ďalšie oneskorenia pri načítavaní stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Vyhnite sa viacnásobným presmerovaniam stránky"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Ak chcete nastaviť rozpočty pre množstvo a veľkosť zdrojov stránky, pridajte súbor budget.json. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 žiadosť}few{# žiadosti}many{# requests}other{# žiadostí}} • {byteCount, number, bytes} kB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Udržiavajte nízke počty žiadostí a malé veľkosti prenosov"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Kanonické odkazy navrhujú, ktorá webová adresa by sa mala zobraziť vo výsledkoch vyhľadávania. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Viacero konfliktných webových adries ({urlList})"
+    "message": "Viacero kolidujúcich webových adries ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "Odkazuje na inú doménu ({url})"
@@ -576,7 +834,7 @@
     "message": "Neplatná webová adresa ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Odkazuje na iné miesto hreflang ({url})"
+    "message": "Odkazuje na iné umiestnenie `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relatívna webová adresa ({url})"
@@ -585,10 +843,10 @@
     "message": "Odkazuje na koreňovú webovú adresu domény (domovskú stránku), a nie na ekvivalentnú stránku s obsahom"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokument nemá platný odkaz rel=canonical"
+    "message": "Dokument nemá platný odkaz `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokument má platný odkaz rel=canonical"
+    "message": "Dokument má platný odkaz `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Veľkosti písma menšie ako 12 px sú príliš malé na to, aby boli čitateľné, a nútia používateľov mobilných zariadení, aby si ich priblížili stiahnutím prstov. Zaistite, aby viac ako 60 % textu na stránke malo veľkosť ≥ 12 px. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)"
@@ -596,14 +854,11 @@
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} čitateľného textu"
   },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} príliš malého textu."
-  },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Text nie je čitateľný, pretože neexistuje žiadna metaznačka oblasti zobrazenia optimalizovaná pre mobilné obrazovky."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} príliš malého textu (na základe {decimalProportionVisited, number, extendedPercent} vzorky)."
+    "message": "Určitá časť textu ({decimalProportion, number, extendedPercent}) je príliš malá (na základe vzorky {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Dokument nepoužíva čitateľné veľkosti písma"
@@ -615,13 +870,13 @@
     "message": "Odkazy hreflang informujú vyhľadávače, akú verziu stránky by mali uviesť vo výsledkoch vyhľadávania pre daný jazyk alebo oblasť. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/hreflang)"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokument nemá platný atribút hreflang"
+    "message": "Dokument nemá platný atribút `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokument má platný atribút hreflang"
+    "message": "Dokument má platný odkaz `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Stránky s neúspešným stavovým kódom HTTP sa nemusia správne indexovať. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
+    "message": "Stránky s neúspešnými stavovými kódmi HTTP sa nemusia správne indexovať. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)"
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "Stránka má neúspešný stavový kód HTTP"
@@ -696,7 +951,7 @@
     "message": "Súbor robots.txt je platný"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Interaktívne prvky, ako sú tlačidlá a odkazy, by mali byť dostatočne veľké (48 × 48 px) s dostatkom voľného miesta okolo, aby sa na ne dalo ľahko klepnúť a neprekrývali ďalšie prvky. [Ďalšie informácie](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
+    "message": "Interaktívne prvky, ako sú tlačidlá a odkazy, by mali byť dostatočne veľké (48 × 48 px) a mať okolo seba dostatočné voľné miesto, aby sa na ne dalo ľahko klepnúť a neprekrývali ďalšie prvky. [Ďalšie informácie](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} cieľových oblastí s vhodnou veľkosťou"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Prekrývajúce sa cieľové oblasti"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Veľkosť"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Cieľová oblasť klepnutia"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Cieľové oblasti klepnutia majú vhodnú veľkosť"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Čas hlavného vlákna"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Tretia strana"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Kód tretích strán môže výrazne ovplyvniť výkonnosť načítavania. Obmedzte počet nadbytočných poskytovateľov tretích strán a skúste načítavať kód tretích strán po dokončení načítavania stránky. [Ďalšie informácie](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Bola zistená 1 tretia strana}few{Boli zistené # tretie strany}many{# Third-Parties Found}other{Bolo zistených # tretích strán}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Využívanie tretích strán"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Čas do prvého bajtu určuje čas, za ktorý váš server odošle odpoveď. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "Čas do prvého bajtu určuje čas, za ktorý váš server odošle odpoveď. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Hlavný dokument trval {timeInMs, number, milliseconds} ms"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Trvanie"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Názov"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Čas začatia"
   },
@@ -744,7 +1008,7 @@
     "message": "Typ"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Zvážte vybavenie aplikácie rozhraním User Timing API a odmerajte tak skutočnú výkonnosť svojej aplikácie počas kľúčových dojmov používateľov. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Odporúčame do aplikácie implementovať rozhranie User Timing API, ktoré umožňuje odmerať jej skutočnú výkonnosť počas udalostí kľúčových pre dojem používateľov. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/user-timing)"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 trvanie aktivít používateľov}few{# trvania aktivít používateľov}many{# user timings}other{# trvaní aktivít používateľov}}"
@@ -753,19 +1017,19 @@
     "message": "Značky a merania trvania aktivít používateľov"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Našiel sa prvok <link> predbežného pripojenia zdroja {securityOrigin}, prehliadač ho však nepoužil. Skontrolujte, či atribút crossorigin používate správne."
+    "message": "Pre atribút {securityOrigin} sa našiel odkaz predpripojenia <link>, prehliadač ho však nepoužil. Skontrolujte, či atribút `crossorigin` používate správne."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Zvážte pridanie indikátorov zdrojov predbežného pripojenia alebo predbežného načítania DNS, ktoré vám pomôžu zriadiť predbežné pripojenia k dôležitým zdrojom tretích strán. [Ďalšie informácie](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Zvážte pridanie indikátorov zdrojov predbežného pripojenia alebo predbežného načítania DNS, ktoré vám pomôžu zriadiť predbežné pripojenia k dôležitým zdrojom tretích strán. [Ďalšie informácie](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Nastavte predbežné pripojenie k požadovaným zdrojom"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Pre atribút {preloadURL} sa našiel odkaz <link> predbežného načítania, prehliadač ho však nepoužil. Skontrolujte, či atribút crossorigin používate správne."
+    "message": "Pre atribút {preloadURL} sa našiel odkaz <link> prednačítania, prehliadač ho však nepoužil. Skontrolujte, či atribút `crossorigin` používate správne."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Zvážte použitie funkcie <link rel=preload>, čím uprednostníte načítanie zdrojov, o ktoré sa momentálne žiada v neskoršej fáze načítania stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Zvážte použitie funkcie `<link rel=preload>`, čím uprednostníte načítanie zdrojov momentálne požadovaných v neskoršej fáze načítania stránky. [Ďalšie informácie](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Predbežne načítavajte kľúčové žiadosti"
@@ -789,7 +1053,7 @@
     "message": "Osvedčené postupy"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Tieto kontroly zvýrazňujú možnosti, ako [zlepšiť dostupnosť vašej webovej aplikácie](https://developers.google.com/web/fundamentals/accessibility). Automaticky je možné zistiť iba podmnožinu problémov s dostupnosťou, preto sa odporúča ručné testovanie."
+    "message": "Tieto kontroly zvýrazňujú možnosti [zlepšenia dostupnosti vašej webovej aplikácie](https://developers.google.com/web/fundamentals/accessibility). Automaticky je možné zistiť iba podmnožinu problémov s dostupnosťou, preto sa odporúča ručné testovanie."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "Tieto položky sa zaoberajú oblasťami, ktoré automatické testovanie nemôže obsiahnuť. Ďalšie informácie získate v [sprievodcovi vykonávaním kontroly dostupnosti](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabuľky a zoznamy"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Osvedčené postupy"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Rozpočty výkonnosti sú štandardy výkonnosti vášho webu."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Rozpočty"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Ďalšie informácie o výkonnosti vašej aplikácie"
+    "message": "Ďalšie informácie o výkonnosti vašej aplikácie. Tieto hodnoty [priamo ovplyvňujú](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) skóre výkonnosti."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostika"
@@ -840,7 +1113,7 @@
     "message": "Vylepšenia prvého vyfarbenia"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Týmito optimalizáciami môžete zrýchliť načítanie stránky."
+    "message": "Tieto návrhy môžu pomôcť s rýchlejším načítavaním vašej stránky. [Neovplyvňujú priamo](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) skóre výkonnosti."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Príležitosti"
@@ -888,7 +1161,7 @@
     "message": "Prehľadávanie a indexovanie"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Upravte svoje stránky pre mobilné zariadenia, aby používatelia pri čítaní ich obsahu nemuseli sťahovať prsty alebo približovať. [Ďalšie informácie](https://developers.google.com/search/mobile-sites/)."
+    "message": "Upravte svoje stránky pre mobilné zariadenia, aby používatelia pri čítaní ich obsahu nemuseli sťahovať prsty ani približovať. [Ďalšie informácie](https://developers.google.com/search/mobile-sites/)"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Vhodné pre mobilné zariadenia"
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL vyrovnávacej pamäte"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Umiestnenie"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Názov"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Žiadosti"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Typ zdroja"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Veľkosť (KB)"
+    "message": "Veľkosť"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Strávený čas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Veľkosť prenosu"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "Webová adresa"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potenciálna úspora (KB)"
+    "message": "Potenciálna úspora"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potenciálna úspora (ms)"
+    "message": "Potenciálna úspora"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Potenciálna úspora: {wastedBytes, number, bytes} KB"
+    "message": "Potenciálna úspora: {wastedBytes, number, bytes} kB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Potenciálna úspora: {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Písmo"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Obrázok"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Médiá"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Iné"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skript"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
   },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Šablóna štýlu"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Tretia strana"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Celkovo"
+  },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Pri zaznamenávaní stopy načítania stránky sa vyskytla chyba. Spustite nástroj Lighthouse znova. ({errorCode})"
+    "message": "Pri zaznamenávaní stopy načítania stránky sa vyskytol problém. Znova spustite Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Časový limit čaká na počiatočné pripojenie protokolu ladiaceho nástroja."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome pri načítaní stránky nezískal žiadne snímky obrazovky. Skontrolujte, či je na stránke viditeľný nejaký obsah, a potom nástroj Lighthouse skúste spustiť znova. ({errorCode})"
+    "message": "Chrome počas načítavania stránky nevytvoril žiadne snímky obrazovky. Skontrolujte, či je na stránke viditeľný obsah, a potom skúste znova spustiť Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Servery DNS nedokázali rozpoznať poskytnutú doménu."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "V súvislosti s požadovaným zberačom {artifactName} sa vyskytla chyba: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Vyskytla sa interná chyba Chromu. Reštartujte Chrome a skúste nástroj Lighthouse spustiť znova."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Požadovaný zberač {artifactName} nebol spustený."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Nástroj Lighthouse nedokázal spoľahlivo načítať požadovanú stránku. Skontrolujte, či testujete správnu webovú adresu a či server správne odpovedá na všetky žiadosti."
@@ -945,19 +1266,22 @@
     "message": "Nástroj Lighthouse nedokázal spoľahlivo načítať webovú adresu, pretože stránka prestala reagovať."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Poskytnutá webová adresa nemá platné bezpečnostné poverenia. {securityMessages}"
+    "message": "Poskytnutá webová adresa nemá platný bezpečnostný certifikát. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome zabránil načítaniu stránky s intersticiálnou reklamou. Skontrolujte, či testujete správnu webovú adresu a server správne reaguje na všetky žiadosti."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Nástroj Lighthouse nedokázal spoľahlivo načítať požadovanú stránku. Skontrolujte, či testujete správnu webovú adresu a či server správne odpovedá na všetky žiadosti. (Podrobnosti: {errorDetails})"
+    "message": "Nástroj Lighthouse nedokázal spoľahlivo načítať požadovanú stránku. Skontrolujte, či testujete správnu webovú adresu a server správne reaguje na všetky žiadosti. (Podrobnosti: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Nástroj Lighthouse nedokázal spoľahlivo načítať požadovanú stránku. Skontrolujte, či testujete správnu webovú adresu a či server správne odpovedá na všetky žiadosti. (Kód stavu: {statusCode})"
+    "message": "Nástroj Lighthouse nedokázal spoľahlivo načítať požadovanú stránku. Skontrolujte, či testujete správnu webovú adresu a server správne reaguje na všetky žiadosti. (Kód stavu: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Načítanie stránky trvalo príliš dlho. Podľa návrhov v prehľade skráťte trvanie načítania stránky a potom nástroj Lighthouse skúste spustiť znova. ({errorCode})"
+    "message": "Načítanie stránky trvalo príliš dlho. Riaďte sa príležitosťami v prehľade a skráťte tak načítavanie stránky. Potom skúste Lighthouse znova spustiť. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "Pri čakaní na odpoveď protokolu DevTools bol prekročený pridelený čas. (Metóda: {protocolMethod})"
+    "message": "Čakanie na odpoveď protokolu DevTools presiahlo pridelený čas. (Metóda: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "Pri načítaní obsahu zdroja bol prekročený pridelený čas"
@@ -984,7 +1308,7 @@
     "message": "Údaje laboratória"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "Analýza aktuálnej stránky pomocou nástroja [Lighthouse](https://developers.google.com/web/tools/lighthouse/) v emulovanej mobilnej sieti. Hodnoty sú odhadované a môžu sa líšiť."
+    "message": "Analýza aktuálnej stránky v emulovanej mobilnej sieti nástrojom [Lighthouse](https://developers.google.com/web/tools/lighthouse/). Hodnoty sú odhady, ktoré sa môžu líšiť."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Ďalšie položky na manuálnu kontrolu"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Rozbaliť útržok"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Zobrazovať zdroje tretích strán"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Vyskytli sa problémy ovplyvňujúce funkčnosť nástroja Lighthouse:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Hodnoty sú odhady, ktoré sa môžu líšiť."
+    "message": "Hodnoty sú odhady, ktoré sa môžu líšiť. Skóre výkonnosti je [založené iba na týchto metrikách](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Úspešne absolvované kontroly, ale s upozorneniami"
@@ -1038,13 +1365,13 @@
     "message": "Niekoľko [doplnkov WordPress](https://wordpress.org/plugins/search/minify+css/) môže váš web zrýchliť konkatenáciou, minifikáciou a komprimáciou štýlov. Ak je to možné, tiež odporúčame túto minifikáciu vykonať vopred pomocou procesu zostavy."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Niekoľko [doplnkov WordPress](https://wordpress.org/plugins/search/minify+javascript/) môže váš web zrýchliť konkatenáciou, minifikáciou a komprimáciou skriptov. Ak je to možné, tiež odporúčame túto minifikáciu vykonať vopred pomocou procesu zostavy."
+    "message": "Niekoľko [doplnkov WordPress](https://wordpress.org/plugins/search/minify+javascript/) môže váš web zrýchliť konkatenáciou, minifikáciou a komprimáciou skriptov. Ak je to možné, odporúčame túto minifikáciu vykonať vopred pomocou procesu zostavy."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Zvážte zníženie alebo prepnutie počtu [doplnkov WordPress](https://wordpress.org/plugins/) načítavajúcich nepoužívané šablóny CSS na stránke. Na identifikáciu doplnkov pridávajúcich externé šablóny CSS skúste spustiť funkciu [zahrnutia v kóde](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) v nástroji Chrome DevTools. Príslušný motív alebo doplnok môžete identifikovať pomocou webovej adresy danej šablóny štýlov. Nájdite doplnky, ktoré majú v zozname mnoho šablón štýlov s veľkým počtom červených hodnôt vo funkcii zahrnutia v kóde. Doplnok by nemal šablónu štýlov zaradiť do poradia, keď sa používa na stránke."
+    "message": "Zvážte zníženie alebo prepnutie počtu [doplnkov WordPress](https://wordpress.org/plugins/) načítavajúcich nepoužívané šablóny CSS na stránke. Na identifikáciu doplnkov pridávajúcich externé šablóny CSS skúste spustiť funkciu [zahrnutia v kóde](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) v nástroji Chrome DevTools. Príslušný motív alebo doplnok môžete identifikovať pomocou webovej adresy danej šablóny štýlov. Nájdite doplnky, ktoré majú v zozname mnoho šablón štýlov s veľkým počtom červených hodnôt vo funkcii zahrnutia v kóde. Doplnok by mal šablónu štýlov zaradiť do poradia iba vtedy, keď sa používa na stránke."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Zvážte zníženie alebo prepnutie počtu [doplnkov WordPress](https://wordpress.org/plugins/) načítavajúcich nepoužívaný JavaScript na stránke. Na identifikáciu doplnkov pridávajúcich externý JavaScript skúste použiť funkciu [zahrnutia v kóde](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) v nástroji Chrome DevTools. Príslušný motív alebo doplnok môžete identifikovať pomocou webovej adresy daného skriptu. Nájdite doplnky, ktoré majú v zozname mnoho skriptov s veľkým počtom červených hodnôt vo funkcii zahrnutia v kóde. Doplnok by nemal skript zaradiť do poradia, keď sa používa na stránke."
+    "message": "Zvážte zníženie alebo prepnutie počtu [doplnkov WordPress](https://wordpress.org/plugins/) načítavajúcich nepoužívaný JavaScript na stránke. Doplnky pridávajúce externý JavaScript skúste identifikovať pomocou funkcie [zahrnutia v kóde](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) v nástroji Chrome DevTools. Príslušný motív alebo doplnok môžete identifikovať pomocou webovej adresy daného skriptu. Nájdite doplnky, ktoré majú v zozname mnoho skriptov s veľkým počtom červených hodnôt vo funkcii zahrnutia v kóde. Doplnok by nemal skript zaradiť do poradia, keď sa používa na stránke."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Prečítajte si o [ukladaní obsahu do vyrovnávacej pamäte prehliadača na webe WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
@@ -1053,7 +1380,7 @@
     "message": "Zvážte použitie [doplnku WordPress na optimalizáciu obrázkov](https://wordpress.org/plugins/search/optimize+images/), ktorý skomprimuje obrázky, ale zachová ich kvalitu."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Nahrajte obrázky priamo prostredníctvom [knižnice médií](https://codex.wordpress.org/Media_Library_Screen), čím zaistíte dostupnosť ich požadovaných veľkostí. Potom ich vložte z knižnice médií alebo zaistite použitie optimálnych veľkostí obrázkov pomocou ich miniaplikácií (vrátane tých, ktoré sú určené pre responzívne zlomové body). Obrázky v plnej veľkosti použite iba vtedy, keď sú dané rozmery vhodné na použitie. [Ďalšie informácie](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Nahrajte obrázky priamo prostredníctvom [knižnice médií](https://codex.wordpress.org/Media_Library_Screen), čím zaistíte dostupnosť ich požadovaných veľkostí. Potom ich vložte z knižnice médií alebo zaistite použitie optimálnych veľkostí obrázkov pomocou ich miniaplikácií (vrátane tých, ktoré sú určené pre responzívne zlomové body). Obrázky s veľkosťou `Full Size` použite iba vtedy, keď sú dané rozmery vhodné na použitie. [Ďalšie informácie](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "V konfigurácii webového servera môžete povoliť kompresiu textu."

--- a/lighthouse-core/lib/i18n/locales/sl.json
+++ b/lighthouse-core/lib/i18n/locales/sl.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Tipke za dostop uporabnikom omogočajo hiter izbor dela strani. Za ustrezno pomikanje mora biti vsaka tipka za dostop drugačna. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Tipke za dostop uporabnikom omogočajo hiter izbor dela strani. Za ustrezno pomikanje mora biti vsaka tipka za dostop drugačna. [Več o tem](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Vrednosti »[accesskey]« niso enolične"
+    "message": "Vrednosti `[accesskey]` niso enolične"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Vrednosti za »[accesskey]« so enolične"
+    "message": "Vrednosti `[accesskey]` so enolične"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Vsaka vloga »role« ARIA podpira določen podniz atributov »aria-*«. Če pride do neujemanja vlog, postanejo atributi »aria-*« neveljavni. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Vsak element ARIA `role` podpira določen podniz atributov `aria-*`. Če se ne ujemajo, so atributi `aria-*` razveljavljeni. [Več o tem](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Atributi »[aria-*]« se ne ujemajo z vlogami"
+    "message": "Atributi `[aria-*]` se ne ujemajo z vlogami"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Atributi »[aria-*]« se ujemajo s svojimi vlogami"
+    "message": "Atributi `[aria-*]` se ujemajo s svojimi vlogami"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Nekatere vloge ARIA imajo zahtevane atribute, ki opišejo stanje elementa bralnikom zaslona. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Nekatere vloge ARIA imajo zahtevane atribute, ki opišejo stanje elementa bralnikom zaslona. [Več o tem](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Vloge »[role]« nimajo vseh zahtevanih atributov »[aria-*]«"
+    "message": "Vloge `[role]` nimajo vseh zahtevanih atributov `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Vloge »[role]« imajo vse zahtevane atribute »[aria-*]«"
+    "message": "Vloge `[role]` imajo vse zahtevane atribute `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Nekatere nadrejene vloge ARIA morajo zaradi ustreznega izvajanja funkcij za ljudi s posebnimi potrebami vsebovati določene podrejene vloge. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Nekatere nadrejene vloge ARIA morajo zaradi ustreznega izvajanja funkcij za ljudi s posebnimi potrebami vsebovati določene podrejene vloge. [Več o tem](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Ni elementov z vlogo »[role]«, ki zahtevajo določene podrejene vloge »[role]«."
+    "message": "Elementi z vlogo `[role]`, ki zahtevajo določene podrejene vloge `[role]`, manjkajo."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Elementi z vlogo »[role]«, ki zahtevajo določene podrejene vloge »[role]«, so prisotni"
+    "message": "Elementi z vlogo `[role]`, ki zahtevajo določene podrejene vloge `[role]`, so prisotni"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Nekatere podrejene vloge ARIA morajo biti zaradi ustreznega izvajanja funkcij za ljudi s posebnimi potrebami vsebovane v določenih nadrejenih vlogah. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Nekatere podrejene vloge ARIA morajo biti zaradi ustreznega izvajanja funkcij za ljudi s posebnimi potrebami vsebovane v določenih nadrejenih vlogah. [Več o tem](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Vloge »[role]« niso vsebovane v zahtevanem nadrejenem elementu"
+    "message": "Vloge `[role]` niso vsebovane v zahtevanem nadrejenem elementu"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Vloge »[role]« so vsebovane v zahtevanem nadrejenem elementu"
+    "message": "Vloge `[role]` so vsebovane v zahtevanem nadrejenem elementu"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Vloge ARIA morajo imeti veljavne vrednosti, če želite, da bodo izvajale želene funkcije za ljudi s posebnimi potrebami. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Vloge ARIA morajo imeti veljavne vrednosti, če želite, da bodo izvajale želene funkcije za ljudi s posebnimi potrebami. [Več o tem](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Vrednosti »[role]« niso veljavne"
+    "message": "Vrednosti `[role]` niso veljavne"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Vrednosti »[role]« so veljavne"
+    "message": "Vrednosti `[role]` so veljavne"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Pomožne tehnologije, kot so bralniki zaslona, ne morejo tolmačiti atributov ARIA z neveljavnimi vrednostmi. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Pomožne tehnologije, kot so bralniki zaslona, ne morejo tolmačiti atributov ARIA z neveljavnimi vrednostmi. [Več o tem](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Atributi »[aria-*]« nimajo veljavnih vrednosti"
+    "message": "Atributi `[aria-*]` nimajo veljavnih vrednosti"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Atributi »[aria-*]« imajo veljavne vrednosti"
+    "message": "Atributi `[aria-*]` imajo veljavne vrednosti"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Pomožne tehnologije, kot so bralniki zaslona, ne morejo tolmačiti atributov ARIA z neveljavnimi imeni. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Pomožne tehnologije, kot so bralniki zaslona, ne morejo tolmačiti atributov ARIA z neveljavnimi imeni. [Več o tem](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Atributi »[aria-*]« so neveljavni ali napačno črkovani"
+    "message": "Atributi `[aria-*]` so neveljavni ali napačno črkovani"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Atributi »[aria-*]« so veljavni in niso napačno črkovani"
+    "message": "Atributi `[aria-*]` so veljavni in niso napačno črkovani"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Podnapisi poskrbijo, da so zvočni elementi uporabni za gluhe ali slušno prizadete tako, da zagotavljajo ključne informacije, na primer, kdo govori, kaj govori in druge neverbalne informacije. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Podnapisi poskrbijo, da so zvočni elementi uporabni za gluhe ali slušno prizadete tako, da zagotavljajo ključne informacije, na primer, kdo govori, kaj govori in druge neverbalne informacije. [Več o tem](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Elementi »<audio>« nimajo elementa »<track>« s podnapisi »[kind=\"captions\"]«."
+    "message": "Elementi `<audio>` nimajo elementa `<track>` s podnapisi `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Elementi »<audio>« vsebujejo element »<track>« s podnapisi »[kind=\"captions\"]«"
+    "message": "Elementi `<audio>` vsebujejo element `<track>` s podnapisi `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Neuspešni elementi"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Če gumb nima dostopnega imena, ga bralniki zaslona predstavijo kot »gumb«, s čimer je neuporaben za uporabnike, ki se zanašajo na bralnike zaslona. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Če gumb nima dostopnega imena, ga bralniki zaslona predstavijo kot »gumb«, s čimer je neuporaben za uporabnike, ki se zanašajo na bralnike zaslona. [Več o tem](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Gumbi nimajo dostopnega imena"
@@ -93,7 +93,7 @@
     "message": "Gumbi imajo dostopna imena"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Če dodate načine, s katerimi je mogoče zaobiti ponavljajočo se vsebino, uporabnikom s tipkovnico omogočite učinkovitejše pomikanje po strani. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Če dodate načine, s katerimi je mogoče zaobiti ponavljajočo se vsebino, uporabnikom s tipkovnico omogočite učinkovitejše pomikanje po strani. [Več o tem](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Stran ne vsebuje naslova, povezave za preskok ali območja z mejnikom"
@@ -102,7 +102,7 @@
     "message": "Stran vsebuje naslov, povezavo za preskok ali območje z mejnikom"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Besedilo z nizkim kontrastom številni uporabniki težko preberejo ali ga sploh ne morejo prebrati. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Besedilo z nizkim kontrastom številni uporabniki težko preberejo ali ga sploh ne morejo prebrati. [Več o tem](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Barve ozadja in ospredja nimajo zadostnega kontrastnega razmerja."
@@ -111,88 +111,88 @@
     "message": "Barve ozadja in ospredja imajo zadostno kontrastno razmerje"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Če seznami opredelitev niso ustrezno označeni, lahko bralniki zaslona izgovorijo nejasno ali netočno vsebino. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Če seznami opredelitev niso ustrezno označeni, lahko bralniki zaslona izgovorijo nejasno ali netočno vsebino. [Več o tem](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Elementi »<dl>« ne vsebujejo samo ustrezno razvrščenih skupin »<dt>« in »<dd>«, skripta »<script>« ali elementov »<template>«."
+    "message": "Elementi `<dl>` ne vsebujejo samo ustrezno razvrščenih skupin `<dt>` in `<dd>`, skripta `<script>` ali elementov `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Elementi »<dl>« vsebujejo samo ustrezno razvrščene skupine »<dt>« in »<dd>«, skript »<script>« ali elemente »<template>«."
+    "message": "Elementi `<dl>` vsebujejo samo ustrezno razvrščene skupine `<dt>` in `<dd>`, skript `<script>` ali elemente `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Elementi seznamov opredelitev (»<dt>« in »<dd>«) morajo biti zaradi zagotavljanja, da jih lahko bralniki zaslona ustrezno predstavijo, oviti z nadrejenim elementom »<dl>«. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Elementi seznamov opredelitev (`<dt>` in `<dd>`) morajo biti zaradi zagotavljanja, da jih lahko bralniki zaslona ustrezno predstavijo, oviti z nadrejenim elementom `<dl>`. [Več o tem](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Elementi seznamov opredelitev niso oviti z elementi »<dl>«"
+    "message": "Elementi seznamov opredelitev niso oviti z elementi `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Elementi seznamov opredelitev so oviti z elementi »<dl>«"
+    "message": "Elementi seznamov opredelitev so oviti z elementi `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Naslov uporabnikom bralnikov zaslona zagotavlja pregled strani, uporabniki iskalnikov pa se nanašajo nanj pri določanju, ali je stran pomembna za njihovo iskanje. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Naslov uporabnikom bralnikov zaslona zagotavlja pregled strani, uporabniki iskalnikov pa se nanašajo nanj pri določanju, ali je stran pomembna za njihovo iskanje. [Več o tem](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokument nima elementa »<title>«"
+    "message": "Dokument nima elementa `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokument ima element »<title>«"
+    "message": "Dokument ima element `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Vrednost atributa ID-ja mora biti enolična, če želite preprečiti, da bi pomožne tehnologije spregledale druge primerke. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Vrednost atributa ID-ja mora biti enolična, če želite preprečiti, da bi pomožne tehnologije spregledale druge primerke. [Več o tem](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Atributi »[id]« na strani niso enolični"
+    "message": "Atributi `[id]` na strani niso enolični"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Atributi »[id]« so enolični"
+    "message": "Atributi `[id]` na strani so enolični"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Uporabniki bralnikov zaslona se zanašajo, da jim vsebino okvirjev opišejo naslovi okvirjev. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Uporabniki bralnikov zaslona se zanašajo, da jim vsebino okvirjev opišejo naslovi okvirjev. [Več o tem](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Elementi »<frame>« ali »<iframe>« nimajo naslova"
+    "message": "Elementi `<frame>` ali `<iframe>` nimajo naslova"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Elementi »<frame>« ali »<iframe>« imajo naslov"
+    "message": "Elementi `<frame>` ali `<iframe>` imajo naslov"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Če stran ne določi atributa »lang«, bralnik zaslona predvideva, da je stran v privzetem jeziku, ki ga je uporabnik izbral pri nastavljanju bralnika zaslona. Če stran ni v privzetem jeziku, bralnik zaslona morda ne bo pravilno predstavil besedila na strani. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Če stran ne določi atributa »lang«, bralnik zaslona predvideva, da je stran v privzetem jeziku, ki ga je uporabnik izbral pri nastavljanju bralnika zaslona. Če stran ni v privzetem jeziku, bralnik zaslona morda ne bo pravilno predstavil besedila na strani. [Več o tem](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Element »<html>« nima atributa »[lang]«"
+    "message": "Element `<html>` nima atributa `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Element »<html>« ima atribut »[lang]«"
+    "message": "Element `<html>` ima atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Če določite veljaven jezik [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question), pomagate bralnikom zaslona ustrezno predstaviti besedilo. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Če določite veljaven [jezik BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), pomagate bralnikom zaslona ustrezno predstaviti besedilo [Več o tem](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Element »<html>« nima veljavne vrednosti za atribut »[lang]«."
+    "message": "Element `<html>` nima veljavne vrednosti za atribut `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Element »<html>« ima veljavno vrednost za atribut »[lang]«"
+    "message": "Element `<html>` ima veljavno vrednost za svoj atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informativni elementi naj imajo kratko, opisno nadomestno besedilo. Okrasne elemente je mogoče prezreti s praznim nadomestnim atributom. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informativni elementi naj imajo kratko, opisno nadomestno besedilo. Okrasne elemente je mogoče prezreti s praznim nadomestnim atributom. [Več o tem](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Elementi slik nimajo atributov »[alt]«"
+    "message": "Elementi slik nimajo atributov `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Elementi slik imajo nadomestne atribute »[alt]«"
+    "message": "Elementi slik imajo atribute `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Če se kot gumb »<input>« uporablja slika, lahko z navajanjem nadomestnega besedila uporabnikom bralnikov zaslona pomagate razumeti namen gumba. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Če se kot gumb `<input>` uporablja slika, lahko z navajanjem nadomestnega besedila uporabnikom bralnikov zaslona pomagate razumeti namen gumba. [Več o tem](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Elementi »<input type=\"image\">« nimajo nadomestnega besedila »[alt]«"
+    "message": "Elementi `<input type=\"image\">` nimajo besedila `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Elementi »<input type=\"image\">« imajo nadomestno besedilo »[alt]«"
+    "message": "Elementi `<input type=\"image\">` imajo besedilo `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Oznake zagotavljajo, da pomožne tehnologije, na primer bralniki zaslona, ustrezno predstavijo kontrolnike za obrazce. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Oznake zagotavljajo, da pomožne tehnologije, na primer bralniki zaslona, ustrezno predstavijo kontrolnike za obrazce. [Več o tem](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Elementi obrazcev nimajo povezanih oznak"
@@ -201,16 +201,16 @@
     "message": "Elementi obrazcev imajo povezane oznake"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Tabela, ki se uporablja za namene postavitve, ne sme vsebovati podatkovnih elementov, na primer elementov »th« oziroma podnapisov ali atributa povzetka, ker lahko to privede do zavajajoče izkušnje za uporabnike bralnikov zaslona. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Tabela, ki se uporablja za namene postavitve, ne sme vsebovati podatkovnih elementov, na primer elementov »th« oziroma podnapisov ali atributa povzetka, ker lahko to privede do zavajajoče izkušnje za uporabnike bralnikov zaslona. [Več o tem](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Elementi predstavitvene razpredelnice »<table>« se ne izogibajo uporabi atributa »<th>«, »<caption>« ali »[summary]«."
+    "message": "Elementi predstavitvene razpredelnice `<table>` se ne izogibajo uporabi atributa `<th>`, `<caption>` ali `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Elementi predstavitvene razpredelnice »<table>« se izogibajo uporabi atributa »<th>«, »<caption>« ali »[summary]«."
+    "message": "Elementi predstavitvene razpredelnice `<table>` se izogibajo uporabi atributa `<th>`, `<caption>` ali `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Besedilo za povezavo (in nadomestno besedilo za slike, kadar so uporabljene kot povezave), ki je prepoznavno in edinstveno ter ga je mogoče izbrati, uporabnikom bralnikov zaslona zagotavlja boljšo izkušnjo pomikanja. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Besedilo za povezavo (in nadomestno besedilo za slike, kadar so uporabljene kot povezave), ki je prepoznavno in edinstveno ter ga je mogoče izbrati, uporabnikom bralnikov zaslona zagotavlja boljšo izkušnjo pomikanja. [Več o tem](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Povezave nimajo prepoznavnega imena"
@@ -219,103 +219,115 @@
     "message": "Povezave imajo prepoznavno ime"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Bralniki zaslona predstavljajo sezname na poseben način. Če želite doprinesti h kakovostnejši izgovorjavi bralnikov zaslona, poskrbite za ustrezno strukturo seznamov. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Bralniki zaslona predstavljajo sezname na poseben način. Če želite doprinesti h kakovostnejši izgovorjavi bralnikov zaslona, poskrbite za ustrezno strukturo seznamov. [Več o tem](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Seznami ne vsebujejo samo elementov »<li>« in elementov, ki podpirajo skripte (»<script>« in »<template>«)."
+    "message": "Seznami ne vsebujejo samo elementov `<li>` in elementov, ki podpirajo skripte (`<script>` in `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Seznami vsebujejo samo elemente »<li>« in elemente, ki podpirajo skripte (»<script>« in »<template>«)."
+    "message": "Seznami vsebujejo samo elemente `<li>` in elemente, ki podpirajo skripte (`<script>` in `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Bralniki zaslona zahtevajo, da so elementi seznamov (»<li>«) vsebovani v nadrejenih elementih »<ul>« ali »<ol>«, da jih lahko ustrezno predstavijo. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Bralniki zaslona zahtevajo, da so elementi seznamov (`<li>`) vsebovani v nadrejenih elementih `<ul>` ali `<ol>`, da jih lahko ustrezno predstavijo. [Več o tem](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Elementi seznamov (»<li>«) niso vsebovani v nadrejenih elementih »<ul>« ali »<ol>«."
+    "message": "Elementi seznamov (`<li>`) niso vsebovani v nadrejenih elementih `<ul>` ali `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Elementi seznamov (»<li>«) so vsebovani v nadrejenih elementih »<ul>« ali »<ol>«"
+    "message": "Elementi seznamov (`<li>`) so vsebovani v nadrejenih elementih `<ul>` ali `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Uporabniki ne pričakujejo samodejne osvežitve strani. Če se to zgodi, se izbira pomakne nazaj na vrh strani. To lahko privede do zoprne ali zavajajoče izkušnje. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Uporabniki ne pričakujejo samodejne osvežitve strani. Če se to zgodi, se izbira pomakne nazaj na vrh strani. To lahko privede do zoprne ali zavajajoče izkušnje. [Več o tem](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokument uporablja »<meta http-equiv=\"refresh\">«"
+    "message": "Dokument uporablja `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Dokument ne uporablja oznake »<meta http-equiv=\"refresh\">«"
+    "message": "Dokument ne uporablja `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Onemogočanje povečave/pomanjšave je težavno za slabovidne uporabnike, ki se zanašajo na povečavo zaslona, da lahko ustrezno vidijo vsebino spletne strani. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Onemogočanje povečave/pomanjšave je težavno za slabovidne uporabnike, ki se zanašajo na povečavo zaslona, da lahko ustrezno vidijo vsebino spletne strani. [Več o tem](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "Lastnosti prilagajanja velikosti »[user-scalable=\"no\"]« se uporabljajo v elementu »<meta name=\"viewport\">« ali pa je atribut »[maximum-scale]« manjši od 5."
+    "message": "Lastnosti prilagajanja velikosti `[user-scalable=\"no\"]` se uporabljajo v elementu `<meta name=\"viewport\">` ali pa je atribut `[maximum-scale]` manjši od 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "Lastnosti prilagajanja velikosti »[user-scalable=\"no\"]« se ne uporabljajo v elementu »<meta name=\"viewport\">« in atribut »[maximum-scale]« ni manjši od 5."
+    "message": "Lastnosti prilagajanja velikosti `[user-scalable=\"no\"]` se ne uporabljajo v elementu `<meta name=\"viewport\">` in atribut `[maximum-scale]` ni manjši od 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Bralniki zaslona ne morejo prevesti vsebine, ki ni besedilna. Če elementom »<object>« dodate nadomestno besedilo, bralnikom zaslona pomagate prenesti pomen uporabnikom. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Bralniki zaslona ne morejo prevesti vsebine, ki ni besedilna. Če elementom `<object>` dodate nadomestno besedilo, bralnikom zaslona pomagate prenesti pomen uporabnikom. [Več o tem](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Elementi »<object>« nimajo nadomestnega besedila »[alt]«"
+    "message": "Elementi `<object>` nimajo besedila `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Elementi »<object>« imajo nadomestno besedilo »[alt]«"
+    "message": "Elementi `<object>` imajo besedilo `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Vrednost, večja od 0, kaže na izrecno razporeditev pomikanja. Čeprav je načeloma veljavna, pogosto vodi v zoprne izkušnje za uporabnike, ki se zanašajo na pomožne tehnologije. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Vrednost, večja od 0, kaže na izrecno razporeditev pomikanja. Čeprav je načeloma veljavna, pogosto vodi v zoprne izkušnje za uporabnike, ki se zanašajo na pomožne tehnologije. [Več o tem](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Nekateri elementi imajo vrednost za »[tabindex]«, večjo od 0"
+    "message": "Nekateri elementi imajo vrednost za `[tabindex]` večjo od 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Noben element nima večje vrednosti za »[tabindex]« od 0"
+    "message": "Noben element nima večje vrednosti za `[tabindex]` od 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Bralniki zaslona imajo funkcije za preprostejše pomikanje po razpredelnicah. Če zagotovite, da se celice »<td>«. ki uporabljajo atribut »[headers]«, nanašajo samo na druge celice v isti razpredelnici, lahko izboljšate izkušnjo za uporabnike bralnikov zaslona. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Bralniki zaslona imajo funkcije za preprostejše pomikanje po razpredelnicah. Če zagotovite, da se celice `<td>`, ki uporabljajo atribut `[headers]`, nanašajo samo na druge celice v isti razpredelnici, lahko izboljšate izkušnjo za uporabnike bralnikov zaslona. [Več o tem](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Celice v elementu »<table>«, ki uporabljajo atribut »[headers]«, se nanašajo na druge celice v isti razpredelnici."
+    "message": "Celice v elementu `<table>`, ki uporabljajo atribut `[headers]`, se nanašajo samo na druge celice v isti razpredelnici."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Celice v elementu »<table>«, ki uporabljajo atribut »[headers]«, se nanašajo samo na druge celice v isti razpredelnici."
+    "message": "Celice v elementu `<table>`, ki uporabljajo atribut `[headers]`, se nanašajo samo na druge celice v isti razpredelnici."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Bralniki zaslona imajo funkcije za preprostejše pomikanje po razpredelnicah. Če zagotovite, da se glave razpredelnic vedno nanašajo na določen nabor celic, lahko izboljšate izkušnjo za uporabnike bralnikov zaslona. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Bralniki zaslona imajo funkcije za preprostejše pomikanje po razpredelnicah. Če zagotovite, da se glave razpredelnic vedno nanašajo na določen nabor celic, lahko izboljšate izkušnjo za uporabnike bralnikov zaslona. [Več o tem](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Elementi »<th>« in elementi z glavami »[role=\"columnheader\"/\"rowheader\"]« nimajo podatkovnih celic, ki jih opisujejo."
+    "message": "Elementi `<th>` in elementi z glavami `[role=\"columnheader\"/\"rowheader\"]` nimajo podatkovnih celic, ki jih opisujejo."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Elementi »<th>« in elementi z glavami »[role=\"columnheader\"/\"rowheader\"]« imajo podatkovne celice, ki jih opisujejo."
+    "message": "Elementi `<th>` in elementi z glavami `[role=\"columnheader\"/\"rowheader\"]` imajo podatkovne celice, ki jih opisujejo."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Če za elemente določite veljaven jezik [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question), pomagate zagotoviti, da bralnik zaslona pravilno izgovori besedilo. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Če za elemente določite veljaven [jezik BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), pomagate zagotoviti, da bralnik zaslona pravilno izgovori besedilo. [Več o tem](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Atributi »[lang]« nimajo veljavne vrednosti"
+    "message": "Atributi `[lang]` nimajo veljavne vrednosti"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Atributi »[lang]« imajo veljavno vrednost"
+    "message": "Atributi `[lang]` imajo veljavno vrednost"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Če ima videoposnetek dodan podnapis, lahko gluhi in slušno prizadeti uporabniki preprosteje dostopajo do informacij, ki jih podaja. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Če ima videoposnetek dodan podnapis, lahko gluhi in slušno prizadeti uporabniki preprosteje dostopajo do informacij, ki jih podaja. [Več o tem](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Elementi »<video>« ne vsebujejo elementa »<track>« s podnapisi »[kind=\"captions\"]«."
+    "message": "Elementi `<video>` ne vsebujejo elementa `<track>` z opisom `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Elementi »<video>« vsebujejo element »<track>« s podnapisi »[kind=\"captions\"]«"
+    "message": "Elementi `<video>` vsebujejo element `<track>` s podnapisi `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Zvočni opisi zagotavljajo pomembne informacije glede videoposnetkov, ki jih sam dialog ne more, na primer opisujejo obrazne izraze in prizore. [Več o tem](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Zvočni opisi zagotavljajo pomembne informacije glede videoposnetkov, ki jih sam dialog ne more, na primer opisujejo obrazne izraze in prizore. [Več o tem](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Elementi »<video>« ne vsebujejo elementa »<track>« z opisom »[kind=\"description\"]«."
+    "message": "Elementi `<video>` ne vsebujejo elementa `<track>` z opisom `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Elementi »<video>« vsebujejo element »<track>« z opisom »[kind=\"description\"]«"
+    "message": "Elementi `<video>` vsebujejo element `<track>` s podnapisi `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Za idealen prikaz v iOSu, ko uporabniki dodajo na začetni zaslon, določite apple-touch-icon. Kazati mora na neprosojno kvadratno datoteko PNG velikosti 192 (ali 180) slikovnih pik. [Več o tem](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Ne vsebuje veljavne vrednosti `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` je zastarel; prednostni je `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Vsebuje veljavno vrednost `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Razširitve za Chrome so negativno vplivale na nalaganje te strani. Poskusite pregledati to stran v načinu brez beleženja zgodovine ali v profilu za Chrome brez razširitev."
@@ -330,7 +342,7 @@
     "message": "Skupni čas CPE"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Razmislite o skrajšanju časa, ki ga porabite za razčlenjevanje, prevajanje in izvajanje JavaScripta. Ugotovili boste, da vam lahko pri tem pomaga dostavljanje manjših paketov koristne vsebine JavaScript. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Razmislite o skrajšanju časa, ki ga porabite za razčlenjevanje, prevajanje in izvajanje JavaScripta. Ugotovili boste, da vam lahko pri tem morda pomaga dostavljanje manjših paketov koristne vsebine JavaScript. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Skrajšajte čas izvajanja JavaScripta"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Zmanjšajte globino kritičnih zahtev"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Zastaranje/opozorilo"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Vrstica"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Zastareli API-ji bodo sčasoma odstranjeni iz brskalnika. [Več o tem](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Najdeno je bilo 1 opozorilo}one{Najdeno je bilo # opozorilo}two{Najdeni sta bili # opozorili}few{Najdena so bila # opozorila}other{Najdenih je bilo # opozoril}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Uporablja zastarele API-je"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Izogiba se zastarelim API-jem"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Predpomnilnik aplikacij je zastarel. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Najdeno – »{AppCacheManifest}«"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Uporablja predpomnilnik aplikacij"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Izogiba se predpomnilniku aplikacij"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Če določite doctype, brskalnik ne more preklopiti v način »quirks«. Preberite več na [strani MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Ime doctype mora biti niz z majhnimi črkami `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokument mora vsebovati doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Pričakovano je bilo, da je publicid prazen niz"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Pričakovano je bilo, da je systemid prazen niz"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Stran nima HTML-doctype, zato se sproži način »quirks«"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Stran ima HTML-doctype"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
   },
@@ -447,7 +510,7 @@
     "message": "Vrednost"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Inženirji za brskalnike priporočajo, da strani vsebujejo manj kot približno 1500 elementov DOM. Idealna vrednost je globina drevesa z manj kot 32 elementi in manj kot 60 podrejenimi/nadrejenimi elementi. Velik DOM lahko povzroči povečano uporabo pomnilnika, daljše [slogovne izračune](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) in drage [prilagoditve postavitve](https://developers.google.com/speed/articles/reflow). [Preberite več o tem](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Inženirji za brskalnike priporočajo, da strani vsebujejo manj kot približno 1500 elementov DOM. Idealna vrednost je globina drevesa z manj kot 32 elementi in manj kot 60 podrejenimi/nadrejenimi elementi. Velik DOM lahko povzroči povečano uporabo pomnilnika, daljše [slogovne izračune](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) in drage [prilagoditve postavitve](https://developers.google.com/speed/articles/reflow). [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 element}one{# element}two{# elementa}few{# elementi}other{# elementov}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Izogiba se prekomerni velikosti DOM-a"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Cilj"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Zunanjim povezavam dodajte `rel=\"noopener\"` ali `rel=\"noreferrer\"` zaradi izboljšanja delovanja in preprečevanja varnostnih ranljivosti. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Povezave do ciljev iz več izvorov niso varne"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Povezave do ciljev iz več izvorov so varne"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Ni mogoče določiti cilja za sidro ({anchorHTML}). Če se ne uporablja kot hiperpovezava, lahko odstranite target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Uporabniki so nezaupljivi do spletnih mest oziroma jih begajo spletna mesta, ki zahtevajo njihovo lokacijo brez konteksta. Razmislite o tem, da bi zahtevo povezali z uporabniškim dejanjem. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Zahteva dovoljenje za geolokacijo pri nalaganju strani"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Ne zahteva dovoljenja za geolokacijo pri nalaganju strani"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Različica"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Vse knjižnice JavaScript vmesnikov, zaznane na strani."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Zaznane knjižnice JavaScript"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Pri uporabnikih s počasnimi povezavami lahko zunanji skripti, dinamično vstavljeni prek `document.write()`, zakasnijo nalaganje strani za več deset sekund. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Uporablja `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Se izogiba `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Največja resnost"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Različica knjižnice"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Štetje ranljivosti"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Nekateri skripti drugih ponudnikov morda vsebujejo znane varnostne ranljivosti, ki jih napadalci lahko preprosto prepoznajo in izkoristijo. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Zaznana je bila 1 ranljivost}one{Zaznana je bila # ranljivost}two{Zaznani sta bili # ranljivosti}few{Zaznane so bile # ranljivosti}other{Zaznanih je bilo # ranljivosti}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Vključuje knjižniceJavaScript vmesnikov z znanimi varnostnimi ranljivostmi"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Visoka"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Nizka"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Srednja"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Izogiba se knjižnicam JavaScript vmesnikov z znanimi varnostnimi ranljivostmi"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Uporabniki so nezaupljivi do spletnih mest oziroma jih begajo spletna mesta, ki zahtevajo pošiljanje obvestil brez konteksta. Razmislite o tem, da bi zahtevo povezali z uporabniškimi potezami. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Zahteva dovoljenje za obvestila pri nalaganju strani"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Ne zahteva dovoljenja za obvestila pri nalaganju strani"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Neuspešni elementi"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Preprečevanje lepljenja gesel omeji dober pravilnik o varnosti. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Uporabnikom preprečuje lepljenje v polja za gesla"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Uporabnikom omogoča lepljenje v polja za gesla"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ima več prednosti pred HTTP/1.1, vključno z binarnimi glavami, multipleksiranjem in potisnimi sredstvi iz strežnika. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 zahteva ni bila poslana prek HTTP/2}one{# zahteva ni bila poslana prek HTTP/2}two{# zahtevi nista bili poslani prek HTTP/2}few{# zahteve niso bile poslane prek HTTP/2}other{# zahtev ni bilo poslanih prek HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Ne uporablja HTTP/2 za vsa svoja sredstva"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Uporablja HTTP/2 za svoja sredstva"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Posluševalnike dogodkov dotika in kolesca lahko označite kot `passive` zaradi izboljšanja delovanja pomikanja na strani. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Ne uporablja pasivnih poslušalcev za izboljšanje delovanja pomikanja"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Uporablja pasivne poslušalce za izboljšanje delovanja pomikanja"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Opis"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Napake, zabeležene v konzoli, označujejo nerazrešene težave. Te so lahko posledica neuspešnih omrežnih zahtev in drugih težav z brskalnikom."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Napake brskalnika so bile zabeležene v konzoli"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "V konzoli ni bila zabeležena nobena napaka brskalnika"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Izkoristite funkcijo CSS-ja za prikaz pisave, s čimer poskrbite, da je med nalaganjem spletne pisave besedilo vidno uporabnikom. [Več o tem](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -475,6 +670,42 @@
   },
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Vse besedilo ostaja vidno med nalaganjem spletne pisave"
+  },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Orodje Lighthouse ni utegnilo samodejno preveriti vrednosti font-display za naslednji URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Razmerje stranic (dejansko)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Razmerje stranic (prikazano)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Mere prikaza slike se morajo ujemati z naravnim razmerjem stranic. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Prikazuje slike z nepravilnim razmerjem stranic"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Prikazuje slike s pravilnim razmerjem stranic"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Neveljavni podatki o velikosti slike {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL zahtev, ki niso varne"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Vsa spletna mesta morajo biti zaščitena s HTTPS, tudi tista, ki nimajo opravka z občutljivimi podatki. HTTPS vsiljivcem preprečuje manipuliranje s komunikacijami ali pasivno poslušanje komunikacij med aplikacijo in uporabniki ter je pogoj za HTTP/2 in veliko novih API-jev za spletna okolja. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Najdena je bila 1 zahteva, ki ni varna}one{Najdena je bila # zahteva, ki ni varna}two{Najdeni sta bili # zahtevi, ki nista varni}few{Najdene so bile # zahteve, ki niso varne}other{Najdenih je bilo # zahtev, ki niso varne}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Ne uporablja HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Uporablja HTTPS"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Hitro nalaganje strani prek mobilnega omrežja zagotavlja dobro uporabniško izkušnjo pri uporabi mobilnih naprav. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
@@ -534,16 +765,22 @@
     "message": "Čas do interaktivnosti"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Potencialna zakasnitev prvega vnosa, na katero lahko uporabniki naletijo, je trajanje (v ms) najdaljšega opravila."
+    "message": "Največja potencialna zakasnitev od prvega vnosa, na katero lahko uporabniki naletijo, je trajanje (v ms) najdaljšega opravila. [Več o tem](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Najv. potencialna zakasnitev prvega vnosa"
+    "message": "Najv. potencial. zakasn. od prvega vnosa"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Indeks hitrosti prikazuje, kako hitro je vsebina strani vidno izpolnjena. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Indeks hitrosti"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Skupek vseh časovnih obdobij med FCP-jem in časom do interaktivnosti, ko je dolžina opravila presegla 50 ms, izražena v milisekundah."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Skupni čas blokiranja"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Omrežni časi povratnega potovanja (RTT) imajo velik vpliv na učinkovitost delovanja. Če je RTT do izvora velik, to kaže na to, da bi lahko strežniki bližje uporabniku izboljšali učinkovitost delovanja. [Več o tem](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,17 +794,38 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Zakasnitve strežnikovega zaledja"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Prek proračuna"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Količino in velikosti omrežnih zahtev imejte pod cilji, ki so nastavljeni z navedenim proračunom za uspešnost. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 zahteva}one{# zahteva}two{# zahtevi}few{# zahteve}other{# zahtev}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Proračun za uspešnost"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Preusmeritve vnašajo dodatne zakasnitve nalaganja strani. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Izogibajte se preusmeritvam na več strani"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Če želite nastaviti proračune za količino in velikost sredstev strani, dodajte datoteko budget.json. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 zahteva}one{# zahteva}two{# zahtevi}few{# zahteve}other{# zahtev}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Število zahtev naj bo majhno in prenosi naj ne bodo preveliki"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Kanonične povezave predlagajo, kateri URL naj bo prikazan v rezultatih iskanja. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Več URL-jev je v sporu ({urlList})"
+    "message": "Več URL-jev v sporu ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "Kaže na drugo domeno ({url})"
@@ -576,7 +834,7 @@
     "message": "Neveljaven URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Kaže na drugo lokacijo »hreflang« ({url})"
+    "message": "Kaže na drugo lokacijo `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relativni URL ({url})"
@@ -585,19 +843,16 @@
     "message": "Kaže na korenski URL domene (domačo stran), namesto na enakovredno stran z vsebino"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokument nima veljavne povezave »rel=canonical«"
+    "message": "Dokument nima veljavne povezave `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokument ima veljavno povezavo »rel=canonical«"
+    "message": "Dokument ima veljaven atribut `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Velikosti pisave, manjše od 12 slikovnih pik, so premajhne,. da bi bile berljive, zato morajo obiskovalci z mobilnimi napravami s potezo razširjanja prstov na zaslonu povečati strani, da bi jih lahko prebrali. Poskušajte zagotoviti, da bo več kot 60 % besedila na strani velikosti, ki ni manjša od 12 slikovnih pik. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Velikosti pisave, manjše od 12 slikovnih pik, so premajhne, da bi bile berljive, zato morajo obiskovalci z mobilnimi napravami s potezo razširjanja prstov na zaslonu povečati strani, da bi jih lahko prebrali. Poskušajte zagotoviti, da bo več kot 60 % besedila na strani velikosti, ki ni manjša od 12 slikovnih pik. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} berljivega besedila"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} besedila je premajhnega."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Besedilo je neberljivo, ker ni metaoznake »viewport«, optimizirane za zaslone mobilnih naprav."
@@ -615,10 +870,10 @@
     "message": "Povezave hreflang iskalnikom povedo, katero različico strani naj prikažejo v rezultatih iskanja za določen jezik ali regijo. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokument nima veljavnega atributa »hreflang«"
+    "message": "Dokument nima veljavnega atributa `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokument ima veljaven atribut »hreflang«"
+    "message": "Dokument ima veljaven atribut `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Strani z neuspešnimi kodami stanja HTTP morda ne bodo pravilno indeksirane. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Prekrivajoči se cilj"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Velikost"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Cilj za dotik"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Cilji za dotikanje so ustrezne velikosti"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Čas glavne niti"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Drugi ponudniki"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Koda drugega ponudnika lahko znatno vpliva na učinkovitost nalaganja. Omejite število odvečnih drugih ponudnikov in poskusite naložiti kodo drugega ponudnika, ko je stran prvenstveno končala nalaganje. [Več o tem](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Najden je bil 1 drug ponudnik}one{Najden je bil # drug ponudnik}two{Najdena sta bila # druga ponudnika}few{Najdeni so bili # drugi ponudniki}other{Najdenih je bilo # drugih ponudnikov}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Uporaba drugih ponudnikov"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "»Čas do prvega bajta« navaja čas, v katerem vaš strežnik pošlje odziv. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "Korenski dokument je terjal {timeInMs, number, milliseconds} ms"
+    "message": "Korenski dokument je terjal {timeInMs, number, milliseconds} ms"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "Skrajšajte odzivne čase strežnika (TTFB)"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Trajanje"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Ime"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Začetni čas"
@@ -753,7 +1017,7 @@
     "message": "Oznake in merjenja trajanj izvedbe uporabniških dogodkov"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Povezava <link> za vnaprejšnje povezovanje je bila najdena za »{securityOrigin}«, vendar je brskalnik ni uporabil. Preverite, ali pravilno uporabljate atribut »crossorigin«."
+    "message": "Povezava <link> za vnaprejšnje povezovanje je bila najdena za »{securityOrigin}«, vendar je brskalnik ni uporabil. Preverite, ali pravilno uporabljate atribut `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Razmislite o dodajanju namigov za sredstva za vnaprejšnje povezovanje ali vnaprejšnji prenos DNS-ja zaradi vzpostavljanja zgodnjih povezav s pomembnimi izvori tretjih oseb. [Več o tem](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Vnaprej se povežite z zahtevanimi izvori"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Najden je bil element <link> za »{preloadURL}«, vendar ga brskalnik ni uporabil. Preverite, ali pravilno uporabljate atribut »crossorigin«."
+    "message": "Najden je bil element <link> za »{preloadURL}«, vendar ga brskalnik ni uporabil. Preverite, ali pravilno uporabljate atribut `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Razmislite o uporabi oznake <link rel=preload> za dodeljevanje višje stopnje prednosti pri pridobivanju sredstev, ki so trenutno zahtevana pri nadaljnjem nalaganju strani. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Razmislite o uporabi oznake `<link rel=preload>` za dodeljevanje višje stopnje prednosti pri pridobivanju sredstev, ki so trenutno zahtevana pri nadaljnjem nalaganju strani. [Več o tem](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Vnaprej nalagajte ključne zahteve"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabele in seznami"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Najboljši postopki"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Proračuni za uspešnost postavljajo standarde za uspešnost spletnega mesta."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Proračuni"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Več informacij o delovanju aplikacije."
+    "message": "Več informacij o delovanju aplikacije. Te številke [neposredno ne vplivajo](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) na rezultat uspešnosti."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostika"
@@ -840,7 +1113,7 @@
     "message": "Izboljšave prvega barvanja"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Te optimizacije lahko pospešijo nalaganje strani."
+    "message": "Ti predlogi lahko pomagajo pri hitrejšem nalaganju strani. [Neposredno ne vplivajo](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) na rezultat uspešnosti."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Priložnosti"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL predpomnjenja"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Lokacija"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Ime"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Zahteve"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Vrsta sredstva"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Velikost (KB)"
+    "message": "Velikost"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Porabljeni čas"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Velikost prenosa"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Morebitni prihranek (KB)"
+    "message": "Morebitni prihranki"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Morebitni prihranki (ms)"
+    "message": "Morebitni prihranki"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "{wastedBytes, number, bytes} KB morebitnega prihranka"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "{wastedMs, number, milliseconds} ms morebitnega prihranka"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Pisava"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Slika"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Predstavnost"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Drugo"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skript"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Slogovna datoteka"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Drugi ponudniki"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Skupno"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Pri snemanju sledi ob nalaganju strani je prišlo do napake. Znova zaženite Lighthouse. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Strežnikom DNS ni uspelo razrešiti navedene domene."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "V zahtevanem zbiralniku {artifactName} je prišlo do napake: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Prišlo je do notranje napake Chroma. Znova zaženite Chrome in poskusite znova zagnati Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Zahtevani zbiralnik {artifactName} se ni izvedel."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Orodje Lighthouse ni utegnilo zanesljivo naložiti zahtevane strani. Poskrbite, da preizkušate pravilen URL in da se strežnik ustrezno odziva na vse zahteve."
@@ -945,7 +1266,10 @@
     "message": "Orodje Lighthouse ni utegnilo zanesljivo naložiti zahtevanega URL-ja, ker se je stran nehala odzivati."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Navedeni URL nima veljavnih varnostnih poverilnic. {securityMessages}"
+    "message": "Navedeni URL nima veljavnega varnostnega potrdila. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome je preprečil nalaganje strani z vrinjenim zaslonom. Poskrbite, da preizkušate pravilen URL in da se strežnik ustrezno odziva na vse zahteve."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Orodje Lighthouse ni utegnilo zanesljivo naložiti zahtevane strani. Poskrbite, da preizkušate pravilen URL in da se strežnik ustrezno odziva na vse zahteve. (Podrobnosti: {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Razširi delček"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Prikaži sredstva drugih ponudnikov"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Na to izvedbo storitve Lighthouse so vplivale težave:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Vrednosti so ocenjene in lahko odstopajo."
+    "message": "Vrednosti so ocenjene in lahko odstopajo. Rezultat uspešnosti [temelji samo na teh meritvah](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Pregledi so bili uspešno opravljeni, vendar z opozorili"
@@ -1023,7 +1350,7 @@
     "message": "Razmislite o tem, da bi GIF naložili v storitev, prek katere bo na voljo za vdelavo kot videposnetek v obliki HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Namestite [vtičnik za postopno nalaganje za WordPress](https://wordpress.org/plugins/search/lazy+load/), ki omogoča odlog nalaganja slik, ki niso na zaslonu, ali preidite na temo, ki ponuja to funkcijo. Razmislite tudi o uporabi [vtičnika AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Namestite [vtičnik za postopno nalaganje za WordPress](https://wordpress.org/plugins/search/lazy+load/) ki omogoča odlog nalaganja slik, ki niso na zaslonu, ali preidite na temo, ki ponuja to funkcijo. Razmislite tudi o uporabi [vtičnika AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "Na voljo je več vtičnikov za WordPress, ki vam lahko pomagajo [uvrstiti nujna sredstva](https://wordpress.org/plugins/search/critical+css/) ali [odložiti manj pomembna sredstva](https://wordpress.org/plugins/search/defer+css+javascript/). Upoštevajte, da lahko optimizacije, ki jih ponujajo ti vtičniki, pokvarijo delovanje funkcij vaših tem ali vtičnikov, zato boste verjetno morali spremeniti kodo."
@@ -1035,10 +1362,10 @@
     "message": "Razmislite o tem, da bi na seznamih objav prikazali izvlečke (npr. z oznako »more«), zmanjšali število objav, prikazanih na posamezni strani, daljše objave razdelili na več strani ali uporabili vtičnik za odloženo nalaganje komentarjev."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Na voljo je več [vtičnikov za WordPress](https://wordpress.org/plugins/search/minify+css/), ki lahko s sestavljanjem, pomanjševanjem in stiskanjem slogov pospešijo vaše spletno mesto. Po možnosti uporabite tudi postopek gradnje, ki to pomanjševanje izvede vnaprej."
+    "message": "Na voljo je več [vtičnikov za WordPress](https://wordpress.org/plugins/search/minify+css/) ki lahko s sestavljanjem, pomanjševanjem in stiskanjem slogov pospešijo vaše spletno mesto. Po možnosti uporabite tudi postopek gradnje, ki to pomanjševanje izvede vnaprej."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Na voljo je več [vtičnikov za WordPress](https://wordpress.org/plugins/search/minify+javascript/), ki lahko s sestavljanjem, pomanjševanjem in stiskanjem skriptov pospešijo vaše spletno mesto. Po možnosti uporabite tudi postopek gradnje, ki to pomanjševanje izvede vnaprej."
+    "message": "Na voljo je več [vtičnikov za WordPress](https://wordpress.org/plugins/search/minify+javascript/), ki lahko s sestavljanjem, pomanjševanjem in stiskanjem slogov pospešijo vaše spletno mesto. Po možnosti uporabite tudi postopek gradnje, ki to pomanjševanje izvede vnaprej."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
     "message": "Razmislite o tem, da bi zmanjšali ali spremenili število [vtičnikov za WordPress](https://wordpress.org/plugins/), ki na vaši strani nalagajo neuporabljen CSS. Če želite ugotoviti, kateri vtičniki dodajo zunanji CSS, poskušajte z orodji Chrome DevTools izvesti [pokritost kode](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage). Ustrezen vtičnik/temo lahko ugotovite na podlagi URL-ja datoteke s slogi. Bodite pozorni na vtičnike, ki imajo na seznamu mnogo datotek s slogi, ki imajo v pokritosti kode veliko rdeče obarvanega območja. Datoteka s slogi naj bo v čakalni vrsti vtičnika samo, če je dejansko uporabljena na strani."
@@ -1053,7 +1380,7 @@
     "message": "Razmislite o tem, da bi uporabili [vtičnik za optimizacijo slik za WordPress](https://wordpress.org/plugins/search/optimize+images/), ki slike stisne, a ohrani kakovost."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Slike naložite neposredno prek [predstavnostne knjižnice](https://codex.wordpress.org/Media_Library_Screen) in tako zagotovite, da so na voljo potrebne velikosti slik. Nato jih vstavite iz predstavnostne knjižnice ali uporabite slikovni pripomoček, da zagotovite uporabo optimalnih velikosti slik (vključno s tistimi za odzivne prekinitvene točke). Izogibajte se slikam polne velikosti, razen če so mere primerne za njihovo uporabo. [Preberite več o tem](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Slike naložite neposredno prek [predstavnostne knjižnice](https://codex.wordpress.org/Media_Library_Screen) in tako zagotovite, da so na voljo potrebne velikosti slik. Nato jih vstavite iz predstavnostne knjižnice ali uporabite slikovni pripomoček, da zagotovite uporabo optimalnih velikosti slik (vključno s tistimi za odzivne prekinitvene točke). Izogibajte se slikam `Full Size`, razen če so mere primerne za njihovo uporabo. [Več o tem](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Stiskanje besedila lahko omogočite v konfiguraciji spletnega strežnika."

--- a/lighthouse-core/lib/i18n/locales/sr-Latn.json
+++ b/lighthouse-core/lib/i18n/locales/sr-Latn.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Tasteri za pristup omogućavaju korisnicima da brzo fokusiraju deo stranice. Da bi navigacija bila odgovarajuća, svaki taster za pristup mora da bude jedinstven. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Tasteri za pristup omogućavaju korisnicima da brzo fokusiraju deo stranice. Da bi navigacija radila ispravno, svaki taster za pristup mora da bude jedinstven. [Saznajte više](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Vrednosti za „[accesskey]“ nisu jedinstvene"
+    "message": "Vrednosti za `[accesskey]` nisu jedinstvene"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Vrednosti za „[accesskey]“ su jedinstvene"
+    "message": "Vrednosti za `[accesskey]` su jedinstvene"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Svaka ARIA uloga „role“ podržava određeni podskup atributa „aria-*“. Ako se ne podudaraju, atributi „aria-*“ biće poništeni. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Svaki ARIA element „`role`“ podržava određeni podskup atributa „`aria-*`“. Ako se ovi elementi ne podudaraju, atributi „`aria-*`“ će biti nevažeći. [Saznajte više](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Atributi „[aria-*]“ se ne podudaraju sa svojim ulogoma"
+    "message": "Atributi `[aria-*]` se ne podudaraju sa svojim ulogama"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Atributi „[aria-*]“ se podudaraju sa svojim ulogama"
+    "message": "Atributi `[aria-*]` se podudaraju sa svojim ulogama"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Pojedine ARIA uloge imaju obavezne atribute koji status elementa opisuju čitačima ekrana. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Pojedine ARIA uloge imaju obavezne atribute koji status elementa opisuju čitačima ekrana. [Saznajte više](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Uloge „[role]“ nemaju sve obavezne atribute „[aria-*]“"
+    "message": "Uloge `[role]` nemaju sve obavezne atribute `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Uloge „[role]“ imaju sve obavezne atribute „[aria-*]“"
+    "message": "Uloge `[role]` imaju sve obavezne atribute `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Pojedine nadređene ARIA uloge moraju da obuhvataju određene podređene uloge da bi pravilno obavljale namenjene funkcije pristupačnosti. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Pojedine nadređene ARIA uloge moraju da obuhvataju određene podređene uloge da bi pravilno obavljale namenjene funkcije pristupačnosti. [Saznajte više](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Nedostaju elementi sa ulogom „[role]“ koji zahtevaju određenu podređenu ulogu „[role]“."
+    "message": "Nedostaju elementi sa ulogom `[role]` koji zahtevaju određenu podređenu ulogu `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Prisutni su elementi sa ulogom „[role]“ koji zahtevaju određenu podređenu ulogu „[role]“"
+    "message": "Prisutni su elementi sa ulogom `[role]` koji zahtevaju određenu podređenu ulogu `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Pojedine podređene ARIA uloge moraju da budu obuhvaćene određenim nadređenim ulogama da bi pravilno obavljale namenjene funkcije pristupačnosti. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Pojedine podređene ARIA uloge moraju da budu obuhvaćene određenim nadređenim ulogama da bi pravilno obavljale namenjene funkcije pristupačnosti. [Saznajte više](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Uloge „[role] nisu obuhvaćene svojim obaveznim nadređenim elementom"
+    "message": "Uloge `[role]` nisu obuhvaćene svojim obaveznim nadređenim elementom"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Uloge „[role]“ obuhvaćene su svojim obaveznim nadređenim elementom"
+    "message": "Uloge `[role]` su obuhvaćene svojim obaveznim nadređenim elementom"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Vrednosti ARIA uloga moraju da budu važeće da bi pravilno obavljale namenjene funkcije pristupačnosti. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Vrednosti ARIA uloga moraju da budu važeće da bi pravilno obavljale namenjene funkcije pristupačnosti. [Saznajte više](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Vrednosti za „[role]“ nisu važeće"
+    "message": "Vrednosti za `[role]` nisu važeće"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Vrednosti za „[role]“ su važeće"
+    "message": "Vrednosti za `[role]` su važeće"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Tehnologije za pomoć osobama sa invaliditetom, poput čitača ekrana, ne mogu da interpretiraju ARIA atribute sa nevažećim vrednostima. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Tehnologije za pomoć osobama sa invaliditetom, poput čitača ekrana, ne mogu da interpretiraju ARIA atribute sa nevažećim vrednostima. [Saznajte više](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Vrednost atributa „[aria-*]“ nije važeća"
+    "message": "Vrednosti atributa `[aria-*]` nisu važeće"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Vrednosti atributa „[aria-*]“ su važeće"
+    "message": "Vrednosti atributa `[aria-*]` su važeće"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Tehnologije za pomoć osobama sa invaliditetom, poput čitača ekrana, ne mogu da interpretiraju ARIA atribute sa nevažećim nazivima. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Tehnologije za pomoć osobama sa invaliditetom, poput čitača ekrana, ne mogu da interpretiraju ARIA atribute sa nevažećim nazivima. [Saznajte više](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Atributi „[aria-*]“ nisu važeći ili su pogrešno napisani"
+    "message": "Atributi `[aria-*]` nisu važeći ili su pogrešno napisani"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Atributi „[aria-*]“ su važeći i nisu pogrešno napisani"
+    "message": "Atributi `[aria-*]` su važeći i nisu pogrešno napisani"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Titlovi omogućavaju da gluvi korisnici ili korisnici sa oštećenjem sluha koriste audio elemente, čime se pružaju važne informacije, na primer, informacije o tome koja osoba govori, šta govori, kao i druge informacije koje nisu vezane za govor. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Titlovi omogućavaju da gluvi korisnici ili korisnici sa oštećenjem sluha koriste audio elemente, čime se pružaju važne informacije, na primer, informacije o tome koja osoba govori, šta govori, kao i druge informacije koje nisu vezane za govor. [Saznajte više](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Elementima „<audio>“ nedostaje element „<track>“ sa atributom „[kind=\"captions\"]“."
+    "message": "Elementima `<audio>` nedostaje element `<track>` sa atributom `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Elementi „<audio>“ obuhvataju element „<track>“ sa atributom „[kind=\"captions\"]“"
+    "message": "Elementi `<audio>` sadrže element `<track>` sa atributom `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Elementi koji nisu prošli proveru"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Kada dugme nema naziv prilagođen funkciji pristupačnosti, čitači ekrana ga najavljuju kao „dugme“, pa korisnici koji se oslanjaju na čitače ekrana ne mogu da ga koriste. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Kada dugme nema naziv prilagođen funkciji pristupačnosti, čitači ekrana ga najavljuju kao „dugme“, pa korisnici koji se oslanjaju na čitače ekrana ne mogu da ga koriste. [Saznajte više](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Dugmad nema nazive prilagođene funkcijama pristupačnosti"
@@ -93,7 +93,7 @@
     "message": "Dugmad ima nazive prilagođene funkcijama pristupačnosti"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Kada se dodaju načini za zaobilaženje, sadržaj koji se ponavlja omogućava da se korisnici tastature efikasnije kreću kroz stranicu. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Kada se dodaju načini za zaobilaženje sadržaja koji se ponavlja, korisnici tastature mogu efikasnije da se kreću po stranici. [Saznajte više](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Stranica ne obuhvata naslov, link za preskakanje niti region orijentira"
@@ -102,7 +102,7 @@
     "message": "Stranica obuhvata naslov, link za preskakanje ili region orijentira"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Mnogi korisnici veoma teško čitaju tekst sa malim kontrastom ili uopšte ne mogu da ga čitaju. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Mnogi korisnici veoma teško čitaju tekst sa malim kontrastom ili uopšte ne mogu da ga čitaju. [Saznajte više](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Boje u pozadini i u prvom planu nemaju zadovoljavajući odnos kontrasta."
@@ -111,88 +111,88 @@
     "message": "Boje u pozadini i u prvom planu imaju zadovoljavajući odnos kontrasta"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Kada liste definicija nisu pravilno označene, čitači ekrana mogu da pružaju zbunjujući ili netačan izlaz. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Kada liste definicija nisu pravilno označene, čitači ekrana mogu da pružaju zbunjujući ili netačan izlaz. [Saznajte više](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "„<dl>“ ne sadrži samo pravilno naručene grupe „<dt>“ i „<dd>“, elemente „<script>“ ili „<template>“."
+    "message": "`<dl>` ne sadrži samo pravilno naručene grupe `<dt>` i `<dd>`, elemente `<script>` ili `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "„<dl>“ sadrži samo pravilno naručene grupe „<dt>“ i „<dd>“, elemente „<script>“ ili „<template>“."
+    "message": "`<dl>` sadrži samo pravilno naručene grupe`<dt>` i `<dd>`, elemente `<script>` ili `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Stavke liste definicija („<dt>“ i „<dd>“) moraju da budu upakovane u nadređeni element „<dl>“ da bi čitači ekrana mogli da ih pravilno čitaju. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Stavke liste definicija (`<dt>` i `<dd>`) moraju da budu upakovane u nadređeni element`<dl>` da bi čitači ekrana mogli da ih pravilno čitaju. [Saznajte više](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Stavke liste definicija nisu upakovane u elemente „<dl>“"
+    "message": "Stavke liste definicija su upakovane u elemente `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Stavke liste definicija su upakovane u elemente „<dl>“"
+    "message": "Stavke liste definicija su upakovane u elemente`<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Naslov korisnicima čitača ekrana pruža pregled stranice, a korisnici pretraživača se na njega oslanjaju da bi utvrdili da li je stranica relevantna za njihovu pretragu. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Naslov korisnicima čitača ekrana pruža pregled stranice, a korisnici pretraživača se na njega oslanjaju da bi utvrdili da li je stranica relevantna za njihovu pretragu. [Saznajte više](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokument nema element „<title>“"
+    "message": "Dokument nema element `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokument ima element „<title>“"
+    "message": "Dokument ima element `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Vrednost atributa ID mora da bude jedinstvena da bi se sprečilo da tehnologije za pomoć osobama sa invaliditetom propuste druge instance. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Vrednost atributa ID mora da bude jedinstvena da bi se sprečilo da tehnologije za pomoć osobama sa invaliditetom propuste druge instance. [Saznajte više](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Atributi „[id]“ na stranici nisu jedinstveni"
+    "message": "Atributi `[id]` na stranici nisu jedinstveni"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Atributi „[id]“ na stranici su jedinstveni"
+    "message": "Atributi `[id]` na stranici su jedinstveni"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Korisnici čitača ekrana oslanjaju se na naslove okvira da bi se opisao sadržaj okvira. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Korisnici čitača ekrana očekuju od naslova okvira da im opišu sadržaj okvira. [Saznajte više](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Ne postoji naslov elementa „<frame>“ ili „<iframe>“"
+    "message": "Elementi `<frame>` ili `<iframe>` nemaju naslov"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Elementi „<frame>“ ili „<iframe>“ imaju naslov"
+    "message": "Elementi `<frame>` ili `<iframe>` imaju naslov"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Ako za stranicu nije naveden atribut za jezik, čitač ekrana pretpostavlja da je stranica na podrazumevanom jeziku koji je korisnik odabrao tokom podešavanja čitača ekrana. Ako stranica zapravo nije na podrazumevanom jeziku, čitač ekrana možda neće pravilno čitati tekst sa stranice. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Ako za stranicu nije naveden atribut za jezik, čitač ekrana pretpostavlja da je stranica na podrazumevanom jeziku koji je korisnik odabrao tokom podešavanja čitača ekrana. Ako stranica zapravo nije na podrazumevanom jeziku, čitač ekrana možda neće pravilno čitati tekst sa stranice. [Saznajte više](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Element „<html>“ nema atribut „[lang]“"
+    "message": "Element `<html>` nema atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Element „<html>“ ima atribut „[lang]“"
+    "message": "Element `<html>` ima atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Navođenjem važećeg koda [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) omogućava se da čitač ekrana pravilno čita tekst. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Navođenjem važećeg koda [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) omogućava se da čitač ekrana pravilno čita tekst. [Saznajte više](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Element „<html>“ nema važeću vrednost za svoj atribut „[lang]“."
+    "message": "Element `<html>` nema važeću vrednost za svoj atribut `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Element „<html>“ ima važeću vrednost za atribut „[lang]“"
+    "message": "Element `<html>` ima važeću vrednost za svoj atribut `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Informativni elementi treba da sadrže kratki, opisni alternativni tekst. Dekorativni elementi mogu da se zanemare pomoću praznog alt atributa. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Informativni elementi treba da sadrže kratki, opisni alternativni tekst. Dekorativni elementi mogu da se zanemare praznim atributom alt. [Saznajte više](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Elementi slike nemaju atribute „[alt]“"
+    "message": "Elementi slike nemaju atribute `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Elementi slika imaju atribute „[alt]“"
+    "message": "Elementi slika imaju atribute `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Kada se slika koristi kao dugme „<input>“, navođenje alternativnog teksta može da pomogne korisnicima da razumeju svrhu dugmeta. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Kada se slika koristi kao dugme `<input>`, navođenje alternativnog teksta može da pomogne korisnicima da razumeju svrhu dugmeta. [Saznajte više](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Elementi „<input type=\"image\">“ nemaju tekst „[alt]“"
+    "message": "Elementi `<input type=\"image\">` ne sadrže tekst `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Elementi „<input type=\"image\">“ imaju tekst „[alt]“"
+    "message": "Elementi `<input type=\"image\">` sadrže tekst `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Oznake omogućavaju da tehnologije za pomoć osobama sa invaliditetom, poput čitača ekrana, pravilno najavljuju kontrole obrazaca. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Oznake omogućavaju da tehnologije za pomoć osobama sa invaliditetom, poput čitača ekrana, pravilno najavljuju kontrole obrazaca. [Saznajte više](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Elementi obrazaca nemaju povezane oznake"
@@ -201,16 +201,16 @@
     "message": "Elementi obrazaca imaju povezane oznake"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Tabela koja se koristi u svrhe rasporeda ne treba da obuhvata elemente podataka, kao što su elementi th ili titl ili atribut rezimea, jer to može da zbuni korisnike čitača ekrana. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Tabela koja se koristi u svrhe rasporeda ne treba da obuhvata elemente podataka, kao što su elementi th ili titl ili atribut rezimea jer to može da zbuni korisnike čitača ekrana. [Saznajte više](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Prezentacioni elementi „<table>“ ne izbegavaju upotrebu atributa „<th>“, „<caption>“ ili „[summary]“."
+    "message": "Prezentacioni elementi `<table>` ne izbegavaju upotrebu atributa `<th>`, `<caption>` ili `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Prezentacioni elementi „<table>“ izbegavaju upotrebu atributa „<th>“, „<caption>“ ili „[summary]“."
+    "message": "Prezentacioni elementi `<table>` izbegavaju upotrebu atributa `<th>`, `<caption>` ili `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Tekst linka (i alternativni tekst za slike kada se koristi za linkove) koji je prepoznatljiv, jedinstven i može da se fokusira olakšava kretanje za korisnike čitača ekrana. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Tekst linka (i alternativni tekst za slike kada se koristi za linkove) koji je prepoznatljiv, jedinstven i može da se fokusira olakšava kretanje za korisnike čitača ekrana. [Saznajte više](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Naziv linkova ne može da se prepozna"
@@ -219,103 +219,115 @@
     "message": "Naziv linkova može da se prepozna"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Čitači ekrana čitaju liste na poseban način. Pravilna struktura liste olakšava razumevanje čitača ekrana. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Čitači ekrana čitaju liste na poseban način. Pravilna struktura liste olakšava razumevanje čitača ekrana. [Saznajte više](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Liste ne sadrže isključivo elemente „<li>“ i elemente koje podržavaju skripte („<script>“ i „<template>“)."
+    "message": "Liste ne sadrže isključivo elemente `<li>` i elemente koji podržavaju skripte (`<script>` i`<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Liste sadrže isključivo elemente „<li>“ i elemente koje podržavaju skripte („<script>“ i „<template>“)."
+    "message": "Liste sadrže isključivo elemente `<li>` i elemente koji podržavaju skripte (`<script>` i `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Čitači ekrana zahtevaju da stavke liste („<li>“) budu obuhvaćene nadređenim elementima „<ul>“ ili „<ol>“ da bi mogle da se pravilno čitaju. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Čitači ekrana zahtevaju da stavke liste (`<li>`) budu obuhvaćene nadređenim elementima `<ul>` ili `<ol>` da bi mogle da se pravilno čitaju. [Saznajte više](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Stavke liste („<li>“) nisu obuhvaćene nadređenim elementima „<ul>“ ili „<ol>“."
+    "message": "Stavke liste (`<li>`) nisu obuhvaćene nadređenim elementima`<ul>` ili `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Stavke liste („<li>“) su obuhvaćene nadređenim elementima „<ul>“ ili „<ol>“"
+    "message": "Stavke liste (`<li>`) su obuhvaćene nadređenim elementima `<ul>` ili `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Korisnici ne očekuju da se stranica automatski osvežava i time se fokus premešta na početak stranice. To može da frustrira ili zbunjuje korisnike. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Korisnici ne očekuju da se stranica automatski osvežava i time se fokus premešta na početak stranice. To može da frustira ili zbunjuje korisnike. [Saznajte više](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Dokument koristi „<meta http-equiv=\"refresh\">“"
+    "message": "Dokument koristi metaoznaku `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Dokument ne koristi „<meta http-equiv=\"refresh\">“"
+    "message": "Dokument ne koristi metaoznaku `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Onemogućavanje zumiranja predstavlja problem za slabovide korisnike koji se oslanjaju na uvećavanje prikaza ekrana da bi mogli da vide sadržaj veb-stranice. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Onemogućavanje zumiranja predstavlja problem za slabovide korisnike koji se oslanjaju na uvećavanje prikaza ekrana da bi mogli da vide sadržaj veb-stranice. [Saznajte više](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "„[user-scalable=\"no\"]“ se koristi u elementu „<meta name=\"viewport\">“ ili je vrednost atributa „[maximum-scale]“ manja od 5."
+    "message": "`[user-scalable=\"no\"]` se koristi u elementu `<meta name=\"viewport\">` ili je vrednost atributa `[maximum-scale]` manja od 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "„[user-scalable=\"no\"]“ se ne koristi u elementu „<meta name=\"viewport\">“, a vrednost atributa „[maximum-scale]“ nije manja od 5."
+    "message": "`[user-scalable=\"no\"]` se ne koristi u elementu `<meta name=\"viewport\">`, a vrednost atributa `[maximum-scale]` nije manja od 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Čitači ekrana ne mogu da prevode sadržaj koji nije tekst. Dodavanje alt teksta elementima „<object>“ omogućava da čitači ekrana lakše prenesu značenje korisnicima. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Čitači ekrana ne mogu da prevode sadržaj koji nije tekst. Dodavanje alt teksta elementima `<object>` omogućava da čitači ekrana lakše prenesu značenje korisnicima. [Saznajte više](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Elementi „<object>“ nemaju tekst „[alt]“"
+    "message": "Elementi `<object>` ne sadrže tekst `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Elementi „<object>“ imaju tekst „[alt]“"
+    "message": "Elementi `<object>` sadrže tekst `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Vrednost veća od 0 označava eksplicitno naručivanje navigacije. Iako je tehnički ispravno, to često frustrira korisnike koji se oslanjaju na tehnologije za pomoć osobama sa invaliditetom. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Vrednost veća od 0 označava eksplicitno naručivanje navigacije. Iako je tehnički ispravno, to često frustrira korisnike koji se oslanjaju na tehnologije za pomoć osobama sa invaliditetom. [Saznajte više](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Neki elementi imaju vrednost za „[tabindex]“ koja je veća od 0"
+    "message": "Neki elementi imaju vrednost za `[tabindex]` koja je veća od 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Vrednost nijednog elementa „[tabindex]“ nije veća od 0"
+    "message": "Vrednost nijednog elementa `[tabindex]` nije veća od 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Čitači ekrana imaju funkcije koje olakšavaju kretanje kroz tabele. Ako se pobrinete da se ćelije „<td>“ koje koriste atribut „[headers]“ odnose samo na druge ćelije u istoj tabeli, možete da poboljšate doživljaj za korisnike čitača ekrana. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Čitači ekrana imaju funkcije koje olakšavaju kretanje kroz tabele. Ako se pobrinete da se ćelije `<td>` koje koriste atribut `[headers]` odnose samo na druge ćelije u istoj tabeli, možete da poboljšate doživljaj za korisnike čitača ekrana. [Saznajte više](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ćelije u elementu „<table>“ koje koriste atribut „[headers]“ odnose se na druge ćelije u toj istoj tabeli."
+    "message": "Ćelije u elementu `<table>` koje koriste atribut `[headers]` odnose se na druge ćelije u toj istoj tabeli."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Ćelije u elementu „<table>“ koje koriste atribut „[headers]“ odnose se samo na druge ćelije u toj istoj tabeli."
+    "message": "Ćelije u elementu `<table>` koje koriste atribut `[headers]` odnose se samo na druge ćelije u toj istoj tabeli."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Čitači ekrana imaju funkcije koje olakšavaju kretanje kroz tabele. Ako se pobrinete da se naslovi tabela uvek odnose na neku grupu ćelija, možete da poboljšate doživljaj za korisnike čitača ekrana. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Čitači ekrana imaju funkcije koje olakšavaju kretanje kroz tabele. Ako se pobrinete da se naslovi tabela uvek odnose na neku grupu ćelija, možete da poboljšate doživljaj za korisnike čitača ekrana. [Saznajte više](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Elementi „<th>“ i elementi sa atributom „[role=\"columnheader\"/\"rowheader\"]“ nemaju ćelije sa podacima koje opisuju."
+    "message": "Elementi `<th>` i elementi sa atributom`[role=\"columnheader\"/\"rowheader\"]` nemaju ćelije sa podacima koje opisuju."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Elementi „<th>“ i elementi sa atributom „[role=\"columnheader\"/\"rowheader\"]“ imaju ćelije sa podacima koje opisuju."
+    "message": "Elementi `<th>` i elementi sa atributom `[role=\"columnheader\"/\"rowheader\"]` imaju ćelije sa podacima koje opisuju."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Navođenjem važećeg koda [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) u elementima omogućava se da čitač ekrana pravilno čita tekst. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Navođenjem važećeg koda [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) u elementima omogućava se da čitač ekrana pravilno čita tekst. [Saznajte više](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Vrednost atributa „[lang]“ nije važeća"
+    "message": "Vrednost atributa `[lang]` nije važeća"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Vrednost atributa „[lang]“ je važeća"
+    "message": "Atributi `[lang]` imaju važeću vrednost"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Kada je dostupan titl za video, gluvi korisnici i oni sa oštećenjem sluha lakše mogu da pristupaju informacijama koje video obuhvata. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Kada je dostupan titl za video, gluvi korisnici i oni sa oštećenjem sluha lakše mogu da pristupaju informacijama koje video obuhvata. [Saznajte više](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Elementi „<video>“ ne obuhvataju element „<track>“ sa atributom „[kind=\"captions\"]“."
+    "message": "Elementi `<video>` ne obuhvataju element `<track>` sa atributom `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Elementi „<video>“ obuhvataju element „<track>“ sa atributom „[kind=\"captions\"]“"
+    "message": "Elementi `<video>` sadrže element `<track>` sa atributom `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Audio opisi pružaju relevantne informacije za video snimke koje dijalog ne može da pruži, poput izraza lica i scena. [Saznajte više](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Audio opisi pružaju relevantne informacije za video snimke koje dijalog ne može, poput izraza lica i scena. [Saznajte više](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Elementi „<video>“ ne obuhvataju element „<track>“ sa atributom „[kind=\"description\"]“."
+    "message": "Elementi `<video>` ne obuhvataju element `<track>` sa atributom `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Elementi „<video>“ obuhvataju element „<track>“ sa atributom „[kind=\"description\"]“"
+    "message": "Elementi `<video>` sadrže element `<track>` sa atributom `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Da bi izgled na iOS-u bio idealan kada korisnici dodaju nešto na početni ekran, definišite ikonu „apple-touch-icon“. Ona mora da usmerava na netransparentni kvadratni PNG od 192 piksela (ili 180 piksela). [Saznajte više](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Ne pruža važeći atribut `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Atribut `apple-touch-icon-precomposed` je zastareo; preporučuje se `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Pruža važeći atribut `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Dodaci za Chrome su negativno uticali na brzinu učitavanja ove stranice. Probajte da proverite stranicu u režimu bez arhiviranja ili sa Chrome profila bez dodataka."
@@ -330,7 +342,7 @@
     "message": "Ukupno CPU vreme"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Razmislite o tome da smanjite vreme potrebno za raščlanjivanje, kompajliranje i izvršavanje JS datoteka. Prikazivanje manjih JS resursa će vam možda pomoći u tome. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Preporučujemo vam da smanjite vreme potrebno za raščlanjivanje, kompajliranje i izvršavanje JS datoteka. Prikazivanje manjih JS resursa će vam možda pomoći u tome. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Smanjite vreme izvršavanja JavaScript datoteka"
@@ -339,19 +351,19 @@
     "message": "Vreme izvršavanja JavaScript-a"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Veliki GIF-ovi nisu korisni za prikazivanje animiranog sadržaja. Razmislite o tome da umesto GIF-ova koristite MPEG4/WebM video snimke za animacije i PNG/WebP za statične slike da biste uštedeli mrežne podatke. [Saznajte više](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Veliki GIF-ovi nisu korisni za prikazivanje animiranog sadržaja. Preporučujemo vam da umesto GIF-ova koristite MPEG4/WebM video snimke za animacije i PNG/WebP za statične slike da biste uštedeli mrežne podatke. [Saznajte više](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Koristite video formate za animirani sadržaj"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Razmislite o tome da odložite učitavanje slika van ekrana i skrivenih slika dok se svi veoma važni resursi ne učitaju kako biste smanjili vreme do početka interakcije. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Preporučujemo vam da odložite učitavanje slika van ekrana i skrivenih slika dok se svi veoma važni resursi ne učitaju kako biste smanjili vreme do početka interakcije. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Odložite slike van ekrana"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Resursi blokiraju prvo prikazivanje stranice. Razmislite o tome da prikazujete sve važne JS/CSS datoteke u tekstu i da odložite sve JS datoteke/stilove koji nisu toliko važni. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Resursi blokiraju prvo prikazivanje stranice. Preporučujemo vam da prikazujete sve važne JS/CSS datoteke u tekstu i da odložite sve JS datoteke/stilove koji nisu toliko važni. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Eliminišite resurse koji blokiraju prikazivanje"
@@ -423,19 +435,70 @@
     "message": "Omogućite kompresiju teksta"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Formati slika kao što su JPEG 2000, JPEG XR i WebP često pružaju bolju kompresiju nego PNG ili JPEG, što znači brža preuzimanja i manju potrošnju podataka. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Formati slika kao što su JPEG 2000, JPEG XR i WebP često pružaju bolju kompresiju nego PNG ili JPEG, što podrazumeva brža preuzimanja i manju potrošnju podataka. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Prikazujte slike u formatima sledeće generacije"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Lanci veoma važnih zahteva u nastavku vam prikazuju koji resursi se učitavaju sa visokim prioritetom. Razmislite o tome da smanjite dužinu lanaca, da smanjite veličinu preuzimanja za resurse ili da odložite preuzimanje resursa koji nisu neophodni radi bržeg učitavanja stranice. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Lanci veoma važnih zahteva u nastavku vam prikazuju koji resursi se učitavaju sa visokim prioritetom. Preporučujemo vam da smanjite dužinu lanaca, da smanjite veličinu preuzimanja za resurse ili da odložite preuzimanje resursa koji nisu neophodni radi bržeg učitavanja stranice. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Pronađen je 1 lanac}one{Pronađen je # lanac}few{Pronađena su # lanca}other{Pronađeno je # lanaca}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Smanjite broj veoma važnih zahteva"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Zastarelo/upozorenje"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Red"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Zastareli API-ji će na kraju biti uklonjeni iz pregledača. [Saznajte više](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Otkriveno je 1 upozorenje}one{Otkriveno je # upozorenje}few{Otkrivena su # upozorenja}other{Otkriveno je # upozorenja}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Koristi zastarele API-je"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Izbegava zastarele API-je"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Keš aplikacije je zastareo. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Pronađeno je „{AppCacheManifest}“"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Koristi keš aplikacije"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Izbegava keš aplikacije"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Navođenjem doctype-a sprečava se prelazak na arhajski režim pregledača. Pročitajte više na [stranici MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Naziv za doctype mora da bude string napisan malim slovima `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokument mora da sadrži doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Očekivani publicId će biti prazan string"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Očekivani systemId će biti prazan string"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Stranici nedostaje HTML doctype, pa se aktivira arhajski režim"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Stranica ima HTML doctype"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Izbegava preveliku veličinu DOM-a"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Cilj"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Dodajte `rel=\"noopener\"` ili`rel=\"noreferrer\"` svim spoljnim linkovima da biste poboljšali učinak i sprečili bezbednosne propuste. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Linkovi do odredišta iz drugih izvora nisu bezbedni"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Linkovi do odredišta iz drugih izvora su bezbedni"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Nije moguće odrediti odredište za tekst linka ({anchorHTML}). Ako se ne koristi kao hiperlink, preporučujemo vam da uklonite target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Korisnici nemaju poverenja u sajtove koji traže njihovu lokaciju bez konteksta ili ih takvi sajtovi zbunjuju. Preporučujemo vam da umesto toga povežete zahtev sa radnjom koju obavlja korisnik. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Traži dozvolu za geolociranje pri učitavanju stranice"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Izbegavajte traženje dozvole za geolociranje pri učitavanju stranice"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Verzija"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Sve korisničke JavaScript datoteke otkrivene na ovoj stranici."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Otkrivene su JavaScript biblioteke"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Ako korisnici imaju spore veze, spoljne skripte koje se dinamički ubacuju pomoću atributa `document.write()` mogu da odlože učitavanje stranice za desetine sekundi. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Koristi `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Izbegava atribut `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Najviši nivo ozbiljnosti"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Verzija biblioteke"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Broj propusta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Neke nezavisne skripte mogu da obuhvataju poznate bezbednosne propuste koje napadači mogu lako da prepoznaju i iskoriste. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Otkriven je 1 propust}one{Otkriven je # propust}few{Otkrivena su # propusta}other{Otkriveno je # propusta}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Obuhvata korisničke JavaScript datoteke sa poznatim bezbednosnim propustima"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Visoka"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Niska"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Srednja"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Izbegava korisničke JavaScript datoteke sa poznatim bezbednosnim propustima"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Korisnici nemaju poverenja u sajtove koji traže dozvolu za slanje obaveštenja bez konteksta ili ih takvi sajtovi zbunjuju. Preporučujemo vam da umesto toga povežete zahtev sa pokretima korisnika. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Traži dozvolu za obaveštenja pri učitavanju stranice"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Izbegavajte traženje dozvole za obaveštenja pri učitavanju stranice"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Elementi koji nisu prošli proveru"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Sprečavanje lepljenja lozinke narušava dobre smernice za bezbednost. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Sprečava korisnike da nalepe vrednost u polja za lozinke"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Dozvoljava korisnicima da nalepe vrednost u polja za lozinke"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ima brojne prednosti u odnosu na HTTP/1.1, uključujući binarna zaglavlja, multipleksiranje i serverski puš. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 zahtev nije isporučen preko protokola HTTP/2}one{# zahtev nije isporučen preko protokola HTTP/2}few{# zahteva nisu isporučena preko protokola HTTP/2}other{# zahteva nije isporučeno preko protokola HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Ne koristi HTTP/2 za sve svoje resurse"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Koristi HTTP/2 za svoje resurse"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Preporučujemo vam da pasivne obrađivače događaja označite kao `passive` da biste poboljšali rezultate pomeranja. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Ne koristite pasivne obrađivače da biste poboljšali učinak pomeranja"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Koristite pasivne obrađivače da biste poboljšali učinak pomeranja"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Opis"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Greške evidentirane u konzoli ukazuju na nerešene probleme. One su rezultat neuspelih mrežnih zahteva i drugih problema u vezi sa pregledačem."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Greške pregledača su evidentirane u konzoli"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Nijedna greška pregledača nije evidentirana u konzoli"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Iskoristite CSS funkciju za prikaz fontova da biste bili sigurni da korisnik može da vidi tekst dok se veb-fontovi učitavaju. [Saznajte više](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Sav tekst ostaje vidljiv tokom učitavanja veb-fontova"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse nije uspeo da automatski proveri vrednost za prikaz fontova za sledeći URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Razmera (stvarna)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Razmera (prikazana)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Dimenzije prikaza slike treba da se podudaraju sa prirodnom razmerom. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Prikazuje slike sa pogrešnom razmerom"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Prikazuje slike sa tačnom razmerom"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Nevažeće informacije o veličini slike {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Nebezbedan URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Svi sajtovi treba da budu zaštićeni HTTPS-om, čak i oni koji ne obrađuju osetljive podatke. HTTPS sprečava uljeze da neovlašćeno pristupaju komunikaciji između aplikacije i korisnika ili da je pasivno slušaju. On je preduslov za HTTP/2 i API-je brojnih novih veb-platformi. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Pronađen je 1 nebezbedan zahtev}one{Pronađen je # nebezbedan zahtev}few{Pronađena su # nebezbedna zahteva}other{Pronađeno je # nebezbednih zahteva}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Ne koristi HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Koristi HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Brzo učitavanje stranice preko mobilne mreže obezbeđuje dobar doživljaj korisnicima mobilnih uređaja. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Interaktivna za {timeInMs, number, seconds} sek"
+    "message": "Interaktivno za {timeInMs, number, seconds} sek"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Interaktivna na simuliranoj mobilnoj mreži za {timeInMs, number, seconds} sek"
@@ -534,16 +765,22 @@
     "message": "Vreme početka interakcije"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Potencijalno kašnjenje prvog unosa koje može da se desi korisnicima je trajanje najdužeg zadatka u milisekundama."
+    "message": "Maksimalno potencijalno kašnjenje prvog unosa koje može da se desi korisnicima je trajanje najdužeg zadatka u milisekundama. [Saznajte više](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Najveće potencijalno kašnjenje prvog unosa"
+    "message": "Maks. potencijalno kašnjenje prvog prikaza"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Indeks brzine prikazuje koliko brzo sadržaj stranice postaje vidljiv za korisnike. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Indeks brzine"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Zbir svih perioda između FCP-a i vremena do početka interakcije, kada zadatak traje duže od 50 ms, izraženo u milisekundama."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Ukupno vreme blokiranja"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Trajanja povratnog puta (RTT) mreže znatno utiču na učinak. Ako je trajanje povratnog puta do početne lokacije veliko, to znači da bi serveri koji su bliži korisniku mogli da poboljšaju učinak. [Saznajte više](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,26 +794,47 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Pozadinska kašnjenja servera"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Premašuje cilj"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Zahteve za količinu i veličinu mreže održavajte ispod granica određenih ciljevima za učinak. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 zahtev}one{# zahtev}few{# zahteva}other{# zahteva}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Cilj za učinak"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Preusmeravanja dovode do dodatnih kašnjenja pre učitavanja stranice. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Izbegavajte višestruka preusmeravanja stranice"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Da biste podesili ciljeve za količinu i veličinu resursa stranice, dodajte datoteku budget.json file. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 zahtev}one{# zahtev}few{# zahteva}other{# zahteva}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Omogući da broj zahteva i veličine prenosa budu mali"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Kanonički linkovi predlažu koji URL treba prikazati u rezultatima pretrage. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Kanonički linkovi predlažu koji URL treba da se prikaže u rezultatima pretrage. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Više neusaglašenih URL-ova ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Usmerava na neki drugi domen ({url})"
+    "message": "Usmerava ka drugom domenu ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Nevažeći URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Usmerava na drugu „hreflang“ lokaciju ({url})"
+    "message": "Usmerava na drugu `hreflang` lokaciju ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relativni URL ({url})"
@@ -585,25 +843,22 @@
     "message": "Usmerava na osnovni URL domena (početnu stranicu), umesto ekvivalentne stranice sadržaja"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokument nema važeću vrednost „rel=canonical“"
+    "message": "Dokument nema važeću vrednost `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokument ima važeću vrednost „rel=canonical“"
+    "message": "Dokument ima važeći atribut `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Veličine fontova ispod 12 piksela su premale da bi bile čitljive i zbog njih korisnici na mobilnim uređajima moraju da „skupe prste radi zumiranja“ kako bi mogli da čitaju sadržaj. Potrudite se da >60% teksta stranice bude ≥12 piksela. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Veličine fontova ispod 12 piksela su premale da bi bile čitljive i zbog njih korisnici na mobilnim uređajima moraju da „zumiraju prstima“ kako bi mogli da čitaju sadržaj. Potrudite se da >60% teksta stranice bude ≥12 piksela. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} čitljivog teksta"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "Deo teksta ({decimalProportion, number, extendedPercent}) je premali."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Tekst nije čitljiv jer ne postoji metaoznaka oblasti prikaza koja je optimizovana za ekrane na mobilnim uređajima."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "Deo teksta je premali ({decimalProportion, number, extendedPercent}) (na osnovu uzorka od {decimalProportionVisited, number, extendedPercent})."
+    "message": "{decimalProportion, number, extendedPercent} teksta je premalo (na osnovu uzorka od {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Dokument ne koristi čitljive veličine fontova"
@@ -615,10 +870,10 @@
     "message": "Linkovi hreflang obaveštavaju pretraživače koju verziju stranice treba da navedu u rezultatima pretrage za dati jezik ili region. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokument nema važeći atribut „hreflang“"
+    "message": "Dokument nema važeći atribut `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokument ima važeći atribut „hreflang“"
+    "message": "Dokument ima važeći atribut `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Stranice sa neuspešnim HTTP kodovima statusa možda neće biti pravilno indeksirane. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -699,7 +954,7 @@
     "message": "Interaktivni elementi poput dugmadi i linkova treba da budu dovoljno veliki (48×48 piksela) i da imaju dovoljno prostora oko sebe da bi bilo lako da se dodirnu bez preklapanja sa drugim elementima. [Saznajte više](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "Deo ciljeva dodirivanja ({decimalProportion, number, percent}) ima odgovarajuću veličinu"
+    "message": "{decimalProportion, number, percent} ciljeva dodirivanja ima odgovarajuću veličinu"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "Ciljevi dodirivanja su premali jer ne postoji metaoznaka oblasti prikaza koja je optimizovana za ekrane na mobilnim uređajima"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Cilj koji se preklapa"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Veličina"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Cilj dodirivanja"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Ciljevi dodirivanja imaju odgovarajuću veličinu"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Vreme glavne niti"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Nezavisni dobavljač"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Kôd nezavisnog dobavljača može značajno da utiče na učinak učitavanja. Ograničite broj suvišnih nezavisnih dobavljača usluge i probajte da učitate kôd nezavisnog dobavljača kada stranica primarno završi sa učitavanjem. [Saznajte više](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Pronađen je 1 nezavisni}one{Pronađen je # nezavisni}few{Pronađena su # nezavisna}other{Pronađeno je # nezavisnih}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Nezavisna upotreba"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Vreme prvog odgovora određuje vreme u koje server šalje odgovor. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Trajanje"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Naziv"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Vreme početka"
   },
@@ -744,7 +1008,7 @@
     "message": "Tip"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Razmislite o tome da opremite aplikaciju API-jem za vreme korisnika da biste izmerili učinak aplikacije u realnom svetu tokom ključnih korisničkih doživljaja. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Preporučujemo vam da opremite aplikaciju API-jem za vreme korisnika da biste izmerili učinak aplikacije u realnom svetu tokom ključnih korisničkih doživljaja. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 vreme korisnika}one{# vreme korisnika}few{# vremena korisnika}other{# vremena korisnika}}"
@@ -753,19 +1017,19 @@
     "message": "Oznake i mere Vremena korisnika"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Povezivanje unapred <link> je pronađeno za „{securityOrigin}“, ali ga pregledač nije upotrebio. Proverite da li pravilno koristite atribut „crossorigin“."
+    "message": "Povezivanje unapred <link> je pronađeno za „{securityOrigin}“, ali ga pregledač nije upotrebio. Proverite da li pravilno koristite atribut `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Razmislite o tome da dodate savete za resurse za povezivanje unapred ili pripremu učitavanja DNS-a kako biste uspostavili rane veze sa važnim izvorima trećih strana. [Saznajte više](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Preporučujemo vam da dodate savete za resurse za povezivanje unapred ili pripremu učitavanja DNS-a kako biste uspostavili rane veze sa važnim izvorima trećih strana. [Saznajte više](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Povežite se unapred sa potrebnim izvorima"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Predučitavanje <link> je pronađeno za „{preloadURL}“, ali ga pregledač nije upotrebio. Proverite da li pravilno koristite atribut „crossorigin“."
+    "message": "Predučitavanje <link> je pronađeno za „{preloadURL}“, ali ga pregledač nije upotrebio. Proverite da li pravilno koristite atribut `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Razmislite o tome da koristite <link rel=preload> kako biste kasnije tokom učitavanja stranice dali prioritet preuzimanju resursa koji se trenutno traže. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Preporučujemo vam da koristite `<link rel=preload>` kako biste kasnije tokom učitavanja stranice dali prioritet preuzimanju resursa koji se trenutno traže. [Saznajte više](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Unapred učitajte najvažnije zahteve"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabele i liste"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Najbolje prakse"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Ciljevima za učinak određuju se standardi za učinak sajta."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Ciljevi"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Više informacija o učinku aplikacije."
+    "message": "Više informacija o učinku aplikacije. Ovi brojevi ne [utiču direktno](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) na ocenu učinka."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Dijagnostika"
@@ -840,7 +1113,7 @@
     "message": "Poboljšanja prvog prikazivanja"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Ove optimizacije mogu da ubrzaju učitavanje stranice."
+    "message": "Ovi predlozi mogu da vam pomognu da se stranica učitava brže. Ne [utiču direktno](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) na ocenu učinka."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Mogućnosti"
@@ -888,7 +1161,7 @@
     "message": "Popisivanje i indeksiranje"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Proverite da li su stranice prilagođene mobilnim uređajima da korisnici ne bi morali da skupljaju prste ili uvećavaju prikaz kako bi čitali stranice sa sadržajem. [Saznajte više](https://developers.google.com/search/mobile-sites/)."
+    "message": "Uverite se da su stranice prilagođene mobilnim uređajima da korisnici ne bi morali da umanjuju ili uvećavaju prikaz kako bi čitali stranice sa sadržajem. [Saznajte više](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Prilagođeno mobilnim uređajima"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Vreme preživljavanja keša"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Lokacija"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Naziv"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Zahtevi"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Tip resursa"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Veličina (kB)"
+    "message": "Veličina"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Provedeno vreme"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Veličina prenosa"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potencijalna ušteda (kB)"
+    "message": "Potencijalna ušteda"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potencijalna ušteda (ms)"
+    "message": "Potencijalna ušteda"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Potencijalna ušteda od {wastedBytes, number, bytes} kB"
+    "message": "Potencijalna ušteda od {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Potencijalna ušteda od {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Font"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Slika"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Mediji"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Drugo"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skripta"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} sek"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Opis stila"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Nezavisni resursi"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Ukupno"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Došlo je do greške pri evidentiranju traga tokom učitavanja stranice. Ponovo pokrenite Lighthouse. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS serveri nisu mogli da razreše navedeni domen."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Prikupljač za obavezni resurs {artifactName} je naišao na grešku: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Došlo je do interne greške u Chrome-u. Ponovo pokrenite Chrome i probajte da ponovo pokrenete Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Prikupljač za obavezni resurs {artifactName} se nije pokrenuo."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse nije uspeo da pouzdano učita stranicu koju ste zahtevali. Uverite se da testirate odgovarajući URL i da server pravilno odgovara na sve zahteve."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse nije uspeo da pouzdano učita URL koji ste zahtevali jer je stranica prestala da reaguje."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "URL koji ste naveli nema važeće bezbednosne akreditive. {securityMessages}"
+    "message": "URL koji ste naveli nema važeći bezbednosni sertifikat. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome je sprečio učitavanje stranice sa tranzitivnim oglasom. Uverite se da testirate odgovarajući URL i da server pravilno odgovara na sve zahteve."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse nije uspeo da pouzdano učita stranicu koju ste zahtevali. Uverite se da testirate odgovarajući URL i da server pravilno odgovara na sve zahteve. (Detalji: {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Proširi fragment"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Prikaži nezavisne resurse"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Bilo je izvesnih problema koji su uticali na ovo pokretanje Lighthouse-a:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Vrednosti predstavljaju procene i mogu da variraju."
+    "message": "Vrednosti predstavljaju procene i mogu da variraju. Ocena učinka se [zasniva samo na ovim pokazateljima](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Provere sa zadovoljavajućom ocenom koje sadrže upozorenja"
@@ -1053,7 +1380,7 @@
     "message": "Preporučujemo da koristite [WordPress dodatnu komponentu za optimizaciju slika](https://wordpress.org/plugins/search/optimize+images/) koja komprimuje slike bez gubitka kvaliteta."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Otpremajte slike direktno pomoću [biblioteke medija](https://codex.wordpress.org/Media_Library_Screen) da biste se uverili da su dostupne obavezne veličine slika, pa ih umetnite u biblioteku medija ili koristite vidžet stranice da biste se uverili da se koriste optimalne veličine slika (uključujući one za prelomne tačke koje se odazivaju). Izbegavajte korišćenje slika „pune veličine“ ako dimenzije nisu adekvatne za njihovo korišćenje. [Saznajte više](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Otpremajte slike direktno pomoću [biblioteke medija](https://codex.wordpress.org/Media_Library_Screen) da biste se uverili da su dostupne obavezne veličine slika, pa ih umetnite u biblioteku medija ili koristite vidžet stranice da biste se uverili da se koriste optimalne veličine slika (uključujući one za prelomne tačke koje se odazivaju). Izbegavajte korišćenje slika `Full Size` ako dimenzije nisu adekvatne za njihovo korišćenje. [Saznajte više](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Možete da omogućite komprimovanje teksta u konfiguraciji veb-servera."

--- a/lighthouse-core/lib/i18n/locales/sr.json
+++ b/lighthouse-core/lib/i18n/locales/sr.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Тастери за приступ омогућавају корисницима да брзо фокусирају део странице. Да би навигација била одговарајућа, сваки тастер за приступ мора да буде јединствен. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Тастери за приступ омогућавају корисницима да брзо фокусирају део странице. Да би навигација радила исправно, сваки тастер за приступ мора да буде јединствен. [Сазнајте више](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Вредности за „[accesskey]“ нису јединствене"
+    "message": "Вредности за `[accesskey]` нису јединствене"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Вредности за „[accesskey]“ су јединствене"
+    "message": "Вредности за `[accesskey]` су јединствене"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Свака ARIA улога „role“ подржава одређени подскуп атрибута „aria-*“. Ако се не подударају, атрибути „aria-*“ биће поништени. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Сваки ARIA елемент „`role`“ подржава одређени подскуп атрибута „`aria-*`“. Ако се ови елементи не подударају, атрибути „`aria-*`“ ће бити неважећи. [Сазнајте више](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Атрибути „[aria-*]“ се не подударају са својим улогома"
+    "message": "Атрибути `[aria-*]` се не подударају са својим улогама"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Атрибути „[aria-*]“ се подударају са својим улогама"
+    "message": "Атрибути `[aria-*]` се подударају са својим улогама"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Поједине ARIA улоге имају обавезне атрибуте који статус елемента описују читачима екрана. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Поједине ARIA улоге имају обавезне атрибуте који статус елемента описују читачима екрана. [Сазнајте више](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Улоге „[role]“ немају све обавезне атрибуте „[aria-*]“"
+    "message": "Улоге `[role]` немају све обавезне атрибуте `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Улоге „[role]“ имају све обавезне атрибуте „[aria-*]“"
+    "message": "Улоге `[role]` имају све обавезне атрибуте `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Поједине надређене ARIA улоге морају да обухватају одређене подређене улоге да би правилно обављале намењене функције приступачности. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Поједине надређене ARIA улоге морају да обухватају одређене подређене улоге да би правилно обављале намењене функције приступачности. [Сазнајте више](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Недостају елементи са улогом „[role]“ који захтевају одређену подређену улогу „[role]“."
+    "message": "Недостају елементи са улогом `[role]` који захтевају одређену подређену улогу `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Присутни су елементи са улогом „[role]“ који захтевају одређену подређену улогу „[role]“"
+    "message": "Присутни су елементи са улогом `[role]` који захтевају одређену подређену улогу `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Поједине подређене ARIA улоге морају да буду обухваћене одређеним надређеним улогама да би правилно обављале намењене функције приступачности. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Поједине подређене ARIA улоге морају да буду обухваћене одређеним надређеним улогама да би правилно обављале намењене функције приступачности. [Сазнајте више](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Улоге „[role] нису обухваћене својим обавезним надређеним елементом"
+    "message": "Улоге `[role]` нису обухваћене својим обавезним надређеним елементом"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Улоге „[role]“ обухваћене су својим обавезним надређеним елементом"
+    "message": "Улоге `[role]` су обухваћене својим обавезним надређеним елементом"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Вредности ARIA улога морају да буду важеће да би правилно обављале намењене функције приступачности. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Вредности ARIA улога морају да буду важеће да би правилно обављале намењене функције приступачности. [Сазнајте више](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Вредности за „[role]“ нису важеће"
+    "message": "Вредности за `[role]` нису важеће"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Вредности за „[role]“ су важеће"
+    "message": "Вредности за `[role]` су важеће"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Технологије за помоћ особама са инвалидитетом, попут читача екрана, не могу да интерпретирају ARIA атрибуте са неважећим вредностима. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Технологије за помоћ особама са инвалидитетом, попут читача екрана, не могу да интерпретирају ARIA атрибуте са неважећим вредностима. [Сазнајте више](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Вредност атрибута „[aria-*]“ није важећа"
+    "message": "Вредности атрибута `[aria-*]` нису важеће"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Вредности атрибута „[aria-*]“ су важеће"
+    "message": "Вредности атрибута `[aria-*]` су важеће"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Технологије за помоћ особама са инвалидитетом, попут читача екрана, не могу да интерпретирају ARIA атрибуте са неважећим називима. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Технологије за помоћ особама са инвалидитетом, попут читача екрана, не могу да интерпретирају ARIA атрибуте са неважећим називима. [Сазнајте више](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Атрибути „[aria-*]“ нису важећи или су погрешно написани"
+    "message": "Атрибути `[aria-*]` нису важећи или су погрешно написани"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Атрибути „[aria-*]“ су важећи и нису погрешно написани"
+    "message": "Атрибути `[aria-*]` су важећи и нису погрешно написани"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Титлови омогућавају да глуви корисници или корисници са оштећењем слуха користе аудио елементе, чиме се пружају важне информације, на пример, информације о томе која особа говори, шта говори, као и друге информације које нису везане за говор. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Титлови омогућавају да глуви корисници или корисници са оштећењем слуха користе аудио елементе, чиме се пружају важне информације, на пример, информације о томе која особа говори, шта говори, као и друге информације које нису везане за говор. [Сазнајте више](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Елементима „<audio>“ недостаје елемент „<track>“ са атрибутом „[kind=\"captions\"]“."
+    "message": "Елементима `<audio>` недостаје елемент `<track>` са атрибутом `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Елементи „<audio>“ обухватају елемент „<track>“ са атрибутом „[kind=\"captions\"]“"
+    "message": "Елементи `<audio>` садрже елемент `<track>` са атрибутом `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Елементи који нису прошли проверу"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Када дугме нема назив прилагођен функцији приступачности, читачи екрана га најављују као „дугме“, па корисници који се ослањају на читаче екрана не могу да га користе. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Када дугме нема назив прилагођен функцији приступачности, читачи екрана га најављују као „дугме“, па корисници који се ослањају на читаче екрана не могу да га користе. [Сазнајте више](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Дугмад нема називе прилагођене функцијама приступачности"
@@ -93,7 +93,7 @@
     "message": "Дугмад има називе прилагођене функцијама приступачности"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Када се додају начини за заобилажење, садржај који се понавља омогућава да се корисници тастатуре ефикасније крећу кроз страницу. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Када се додају начини за заобилажење садржаја који се понавља, корисници тастатуре могу ефикасније да се крећу по страници. [Сазнајте више](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Страница не обухвата наслов, линк за прескакање нити регион оријентира"
@@ -102,7 +102,7 @@
     "message": "Страница обухвата наслов, линк за прескакање или регион оријентира"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Многи корисници веома тешко читају текст са малим контрастом или уопште не могу да га читају. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Многи корисници веома тешко читају текст са малим контрастом или уопште не могу да га читају. [Сазнајте више](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Боје у позадини и у првом плану немају задовољавајући однос контраста."
@@ -111,88 +111,88 @@
     "message": "Боје у позадини и у првом плану имају задовољавајући однос контраста"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Када листе дефиниција нису правилно означене, читачи екрана могу да пружају збуњујући или нетачан излаз. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Када листе дефиниција нису правилно означене, читачи екрана могу да пружају збуњујући или нетачан излаз. [Сазнајте више](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "„<dl>“ не садржи само правилно наручене групе „<dt>“ и „<dd>“, елементе „<script>“ или „<template>“."
+    "message": "`<dl>` не садржи само правилно наручене групе `<dt>` и `<dd>`, елементе `<script>` или `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "„<dl>“ садржи само правилно наручене групе „<dt>“ и „<dd>“, елементе „<script>“ или „<template>“."
+    "message": "`<dl>` садржи само правилно наручене групе`<dt>` и `<dd>`, елементе `<script>` или `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Ставке листе дефиниција („<dt>“ и „<dd>“) морају да буду упаковане у надређени елемент „<dl>“ да би читачи екрана могли да их правилно читају. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Ставке листе дефиниција (`<dt>` и `<dd>`) морају да буду упаковане у надређени елемент`<dl>` да би читачи екрана могли да их правилно читају. [Сазнајте више](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Ставке листе дефиниција нису упаковане у елементе „<dl>“"
+    "message": "Ставке листе дефиниција су упаковане у елементе `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Ставке листе дефиниција су упаковане у елементе „<dl>“"
+    "message": "Ставке листе дефиниција су упаковане у елементе`<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Наслов корисницима читача екрана пружа преглед странице, а корисници претраживача се на њега ослањају да би утврдили да ли је страница релевантна за њихову претрагу. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Наслов корисницима читача екрана пружа преглед странице, а корисници претраживача се на њега ослањају да би утврдили да ли је страница релевантна за њихову претрагу. [Сазнајте више](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Документ нема елемент „<title>“"
+    "message": "Документ нема елемент `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Документ има елемент „<title>“"
+    "message": "Документ има елемент `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Вредност атрибута ИД мора да буде јединствена да би се спречило да технологије за помоћ особама са инвалидитетом пропусте друге инстанце. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Вредност атрибута ИД мора да буде јединствена да би се спречило да технологије за помоћ особама са инвалидитетом пропусте друге инстанце. [Сазнајте више](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Атрибути „[id]“ на страници нису јединствени"
+    "message": "Атрибути `[id]` на страници нису јединствени"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Атрибути „[id]“ на страници су јединствени"
+    "message": "Атрибути `[id]` на страници су јединствени"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Корисници читача екрана ослањају се на наслове оквира да би се описао садржај оквира. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Корисници читача екрана очекују од наслова оквира да им опишу садржај оквира. [Сазнајте више](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Не постоји наслов елемента „<frame>“ или „<iframe>“"
+    "message": "Елементи `<frame>` или `<iframe>` немају наслов"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Елементи „<frame>“ или „<iframe>“ имају наслов"
+    "message": "Елементи `<frame>` или `<iframe>` имају наслов"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Ако за страницу није наведен атрибут за језик, читач екрана претпоставља да је страница на подразумеваном језику који је корисник одабрао током подешавања читача екрана. Ако страница заправо није на подразумеваном језику, читач екрана можда неће правилно читати текст са странице. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Ако за страницу није наведен атрибут за језик, читач екрана претпоставља да је страница на подразумеваном језику који је корисник одабрао током подешавања читача екрана. Ако страница заправо није на подразумеваном језику, читач екрана можда неће правилно читати текст са странице. [Сазнајте више](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Елемент „<html>“ нема атрибут „[lang]“"
+    "message": "Елемент `<html>` нема атрибут `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Елемент „<html>“ има атрибут „[lang]“"
+    "message": "Елемент `<html>` има атрибут `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Навођењем важећег кода [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) омогућава се да читач екрана правилно чита текст. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Навођењем важећег кода [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) омогућава се да читач екрана правилно чита текст. [Сазнајте више](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Елемент „<html>“ нема важећу вредност за свој атрибут „[lang]“."
+    "message": "Елемент `<html>` нема важећу вредност за свој атрибут `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Елемент „<html>“ има важећу вредност за атрибут „[lang]“"
+    "message": "Елемент `<html>` има важећу вредност за свој атрибут `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Информативни елементи треба да садрже кратки, описни алтернативни текст. Декоративни елементи могу да се занемаре помоћу празног alt атрибута. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Информативни елементи треба да садрже кратки, описни алтернативни текст. Декоративни елементи могу да се занемаре празним атрибутом alt. [Сазнајте више](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Елементи слике немају атрибуте „[alt]“"
+    "message": "Елементи слике немају атрибуте `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Елементи слика имају атрибуте „[alt]“"
+    "message": "Елементи слика имају атрибуте `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Када се слика користи као дугме „<input>“, навођење алтернативног текста може да помогне корисницима да разумеју сврху дугмета. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Када се слика користи као дугме `<input>`, навођење алтернативног текста може да помогне корисницима да разумеју сврху дугмета. [Сазнајте више](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Елементи „<input type=\"image\">“ немају текст „[alt]“"
+    "message": "Елементи `<input type=\"image\">` не садрже текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Елементи „<input type=\"image\">“ имају текст „[alt]“"
+    "message": "Елементи `<input type=\"image\">` садрже текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Ознаке омогућавају да технологије за помоћ особама са инвалидитетом, попут читача екрана, правилно најављују контроле образаца. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Ознаке омогућавају да технологије за помоћ особама са инвалидитетом, попут читача екрана, правилно најављују контроле образаца. [Сазнајте више](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Елементи образаца немају повезане ознаке"
@@ -201,16 +201,16 @@
     "message": "Елементи образаца имају повезане ознаке"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Табела која се користи у сврхе распореда не треба да обухвата елементе података, као што су елементи th или титл или атрибут резимеа, јер то може да збуни кориснике читача екрана. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Табела која се користи у сврхе распореда не треба да обухвата елементе података, као што су елементи th или титл или атрибут резимеа јер то може да збуни кориснике читача екрана. [Сазнајте више](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Презентациони елементи „<table>“ не избегавају употребу атрибута „<th>“, „<caption>“ или „[summary]“."
+    "message": "Презентациони елементи `<table>` не избегавају употребу атрибута `<th>`, `<caption>` или `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Презентациони елементи „<table>“ избегавају употребу атрибута „<th>“, „<caption>“ или „[summary]“."
+    "message": "Презентациони елементи `<table>` избегавају употребу атрибута `<th>`, `<caption>` или `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Текст линка (и алтернативни текст за слике када се користи за линкове) који је препознатљив, јединствен и може да се фокусира олакшава кретање за кориснике читача екрана. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Текст линка (и алтернативни текст за слике када се користи за линкове) који је препознатљив, јединствен и може да се фокусира олакшава кретање за кориснике читача екрана. [Сазнајте више](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Назив линкова не може да се препозна"
@@ -219,103 +219,115 @@
     "message": "Назив линкова може да се препозна"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Читачи екрана читају листе на посебан начин. Правилна структура листе олакшава разумевање читача екрана. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Читачи екрана читају листе на посебан начин. Правилна структура листе олакшава разумевање читача екрана. [Сазнајте више](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Листе не садрже искључиво елементе „<li>“ и елементе које подржавају скрипте („<script>“ и „<template>“)."
+    "message": "Листе не садрже искључиво елементе `<li>` и елементе који подржавају скрипте (`<script>` и`<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Листе садрже искључиво елементе „<li>“ и елементе које подржавају скрипте („<script>“ и „<template>“)."
+    "message": "Листе садрже искључиво елементе `<li>` и елементе који подржавају скрипте (`<script>` и `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Читачи екрана захтевају да ставке листе („<li>“) буду обухваћене надређеним елементима „<ul>“ или „<ol>“ да би могле да се правилно читају. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Читачи екрана захтевају да ставке листе (`<li>`) буду обухваћене надређеним елементима `<ul>` или `<ol>` да би могле да се правилно читају. [Сазнајте више](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Ставке листе („<li>“) нису обухваћене надређеним елементима „<ul>“ или „<ol>“."
+    "message": "Ставке листе (`<li>`) нису обухваћене надређеним елементима`<ul>` или `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Ставке листе („<li>“) су обухваћене надређеним елементима „<ul>“ или „<ol>“"
+    "message": "Ставке листе (`<li>`) су обухваћене надређеним елементима `<ul>` или `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Корисници не очекују да се страница аутоматски освежава и тиме се фокус премешта на почетак странице. То може да фрустрира или збуњује кориснике. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Корисници не очекују да се страница аутоматски освежава и тиме се фокус премешта на почетак странице. То може да фрустира или збуњује кориснике. [Сазнајте више](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Документ користи „<meta http-equiv=\"refresh\">“"
+    "message": "Документ користи метаознаку `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Документ не користи „<meta http-equiv=\"refresh\">“"
+    "message": "Документ не користи метаознаку `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Онемогућавање зумирања представља проблем за слабовиде кориснике који се ослањају на увећавање приказа екрана да би могли да виде садржај веб-странице. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Онемогућавање зумирања представља проблем за слабовиде кориснике који се ослањају на увећавање приказа екрана да би могли да виде садржај веб-странице. [Сазнајте више](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "„[user-scalable=\"no\"]“ се користи у елементу „<meta name=\"viewport\">“ или је вредност атрибута „[maximum-scale]“ мања од 5."
+    "message": "`[user-scalable=\"no\"]` се користи у елементу `<meta name=\"viewport\">` или је вредност атрибута `[maximum-scale]` мања од 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "„[user-scalable=\"no\"]“ се не користи у елементу „<meta name=\"viewport\">“, а вредност атрибута „[maximum-scale]“ није мања од 5."
+    "message": "`[user-scalable=\"no\"]` се не користи у елементу `<meta name=\"viewport\">`, а вредност атрибута `[maximum-scale]` није мања од 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Читачи екрана не могу да преводе садржај који није текст. Додавање alt текста елементима „<object>“ омогућава да читачи екрана лакше пренесу значење корисницима. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Читачи екрана не могу да преводе садржај који није текст. Додавање alt текста елементима `<object>` омогућава да читачи екрана лакше пренесу значење корисницима. [Сазнајте више](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Елементи „<object>“ немају текст „[alt]“"
+    "message": "Елементи `<object>` не садрже текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Елементи „<object>“ имају текст „[alt]“"
+    "message": "Елементи `<object>` садрже текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Вредност већа од 0 означава експлицитно наручивање навигације. Иако је технички исправно, то често фрустрира кориснике који се ослањају на технологије за помоћ особама са инвалидитетом. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Вредност већа од 0 означава експлицитно наручивање навигације. Иако је технички исправно, то често фрустрира кориснике који се ослањају на технологије за помоћ особама са инвалидитетом. [Сазнајте више](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Неки елементи имају вредност за „[tabindex]“ која је већа од 0"
+    "message": "Неки елементи имају вредност за `[tabindex]` која је већа од 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Вредност ниједног елемента „[tabindex]“ није већа од 0"
+    "message": "Вредност ниједног елемента `[tabindex]` није већа од 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Читачи екрана имају функције које олакшавају кретање кроз табеле. Ако се побринете да се ћелије „<td>“ које користе атрибут „[headers]“ односе само на друге ћелије у истој табели, можете да побољшате доживљај за кориснике читача екрана. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Читачи екрана имају функције које олакшавају кретање кроз табеле. Ако се побринете да се ћелије `<td>` које користе атрибут `[headers]` односе само на друге ћелије у истој табели, можете да побољшате доживљај за кориснике читача екрана. [Сазнајте више](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ћелије у елементу „<table>“ које користе атрибут „[headers]“ односе се на друге ћелије у тој истој табели."
+    "message": "Ћелије у елементу `<table>` које користе атрибут `[headers]` односе се на друге ћелије у тој истој табели."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Ћелије у елементу „<table>“ које користе атрибут „[headers]“ односе се само на друге ћелије у тој истој табели."
+    "message": "Ћелије у елементу `<table>` које користе атрибут `[headers]` односе се само на друге ћелије у тој истој табели."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Читачи екрана имају функције које олакшавају кретање кроз табеле. Ако се побринете да се наслови табела увек односе на неку групу ћелија, можете да побољшате доживљај за кориснике читача екрана. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Читачи екрана имају функције које олакшавају кретање кроз табеле. Ако се побринете да се наслови табела увек односе на неку групу ћелија, можете да побољшате доживљај за кориснике читача екрана. [Сазнајте више](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Елементи „<th>“ и елементи са атрибутом „[role=\"columnheader\"/\"rowheader\"]“ немају ћелије са подацима које описују."
+    "message": "Елементи `<th>` и елементи са атрибутом`[role=\"columnheader\"/\"rowheader\"]` немају ћелије са подацима које описују."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Елементи „<th>“ и елементи са атрибутом „[role=\"columnheader\"/\"rowheader\"]“ имају ћелије са подацима које описују."
+    "message": "Елементи `<th>` и елементи са атрибутом `[role=\"columnheader\"/\"rowheader\"]` имају ћелије са подацима које описују."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Навођењем важећег кода [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) у елементима омогућава се да читач екрана правилно чита текст. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Навођењем важећег кода [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) у елементима омогућава се да читач екрана правилно чита текст. [Сазнајте више](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Вредност атрибута „[lang]“ није важећа"
+    "message": "Вредност атрибута `[lang]` није важећа"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Вредност атрибута „[lang]“ је важећа"
+    "message": "Атрибути `[lang]` имају важећу вредност"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Када је доступан титл за видео, глуви корисници и они са оштећењем слуха лакше могу да приступају информацијама које видео обухвата. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Када је доступан титл за видео, глуви корисници и они са оштећењем слуха лакше могу да приступају информацијама које видео обухвата. [Сазнајте више](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Елементи „<video>“ не обухватају елемент „<track>“ са атрибутом „[kind=\"captions\"]“."
+    "message": "Елементи `<video>` не обухватају елемент `<track>` са атрибутом `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Елементи „<video>“ обухватају елемент „<track>“ са атрибутом „[kind=\"captions\"]“"
+    "message": "Елементи `<video>` садрже елемент `<track>` са атрибутом `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Аудио описи пружају релевантне информације за видео снимке које дијалог не може да пружи, попут израза лица и сцена. [Сазнајте више](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Аудио описи пружају релевантне информације за видео снимке које дијалог не може, попут израза лица и сцена. [Сазнајте више](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Елементи „<video>“ не обухватају елемент „<track>“ са атрибутом „[kind=\"description\"]“."
+    "message": "Елементи `<video>` не обухватају елемент `<track>` са атрибутом `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Елементи „<video>“ обухватају елемент „<track>“ са атрибутом „[kind=\"description\"]“"
+    "message": "Елементи `<video>` садрже елемент `<track>` са атрибутом `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Да би изглед на iOS-у био идеалан када корисници додају нешто на почетни екран, дефинишите икону „apple-touch-icon“. Она мора да усмерава на нетранспарентни квадратни PNG од 192 пиксела (или 180 пиксела). [Сазнајте више](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Не пружа важећи атрибут `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Атрибут `apple-touch-icon-precomposed` је застарео; препоручује се `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Пружа важећи атрибут `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Додаци за Chrome су негативно утицали на брзину учитавања ове странице. Пробајте да проверите страницу у режиму без архивирања или са Chrome профила без додатака."
@@ -330,7 +342,7 @@
     "message": "Укупно CPU време"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Размислите о томе да смањите време потребно за рашчлањивање, компајлирање и извршавање JS датотека. Приказивање мањих JS ресурса ће вам можда помоћи у томе. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Препоручујемо вам да смањите време потребно за рашчлањивање, компајлирање и извршавање JS датотека. Приказивање мањих JS ресурса ће вам можда помоћи у томе. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Смањите време извршавања JavaScript датотека"
@@ -339,19 +351,19 @@
     "message": "Време извршавања JavaScript-а"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Велики GIF-ови нису корисни за приказивање анимираног садржаја. Размислите о томе да уместо GIF-ова користите MPEG4/WebM видео снимке за анимације и PNG/WebP за статичне слике да бисте уштедели мрежне податке. [Сазнајте више](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Велики GIF-ови нису корисни за приказивање анимираног садржаја. Препоручујемо вам да уместо GIF-ова користите MPEG4/WebM видео снимке за анимације и PNG/WebP за статичне слике да бисте уштедели мрежне податке. [Сазнајте више](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Користите видео формате за анимирани садржај"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Размислите о томе да одложите учитавање слика ван екрана и скривених слика док се сви веома важни ресурси не учитају како бисте смањили време до почетка интеракције. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Препоручујемо вам да одложите учитавање слика ван екрана и скривених слика док се сви веома важни ресурси не учитају како бисте смањили време до почетка интеракције. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Одложите слике ван екрана"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Ресурси блокирају прво приказивање странице. Размислите о томе да приказујете све важне JS/CSS датотеке у тексту и да одложите све JS датотеке/стилове који нису толико важни. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Ресурси блокирају прво приказивање странице. Препоручујемо вам да приказујете све важне JS/CSS датотеке у тексту и да одложите све JS датотеке/стилове који нису толико важни. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Елиминишите ресурсе који блокирају приказивање"
@@ -423,19 +435,70 @@
     "message": "Омогућите компресију текста"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Формати слика као што су JPEG 2000, JPEG XR и WebP често пружају бољу компресију него PNG или JPEG, што значи бржа преузимања и мању потрошњу података. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Формати слика као што су JPEG 2000, JPEG XR и WebP често пружају бољу компресију него PNG или JPEG, што подразумева бржа преузимања и мању потрошњу података. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Приказујте слике у форматима следеће генерације"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Ланци веома важних захтева у наставку вам приказују који ресурси се учитавају са високим приоритетом. Размислите о томе да смањите дужину ланаца, да смањите величину преузимања за ресурсе или да одложите преузимање ресурса који нису неопходни ради бржег учитавања странице. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Ланци веома важних захтева у наставку вам приказују који ресурси се учитавају са високим приоритетом. Препоручујемо вам да смањите дужину ланаца, да смањите величину преузимања за ресурсе или да одложите преузимање ресурса који нису неопходни ради бржег учитавања странице. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Пронађен је 1 ланац}one{Пронађен је # ланац}few{Пронађена су # ланца}other{Пронађено је # ланаца}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Смањите број веома важних захтева"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Застарело/упозорење"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Ред"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Застарели API-ји ће на крају бити уклоњени из прегледача. [Сазнајте више](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Откривено је 1 упозорење}one{Откривено је # упозорење}few{Откривена су # упозорења}other{Откривено је # упозорења}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Користи застареле API-је"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Избегава застареле API-је"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Кеш апликације је застарео. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Пронађено је „{AppCacheManifest}“"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Користи кеш апликације"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Избегава кеш апликације"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Навођењем doctype-а спречава се прелазак на архајски режим прегледача. Прочитајте више на [страници MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Назив за doctype мора да буде стринг написан малим словима `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Документ мора да садржи doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Очекивани publicId ће бити празан стринг"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Очекивани systemId ће бити празан стринг"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Страници недостаје HTML doctype, па се активира архајски режим"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Страница има HTML doctype"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Елемент"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Избегава превелику величину DOM-а"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Циљ"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Додајте `rel=\"noopener\"` или`rel=\"noreferrer\"` свим спољним линковима да бисте побољшали учинак и спречили безбедносне пропусте. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Линкови до одредишта из других извора нису безбедни"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Линкови до одредишта из других извора су безбедни"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Није могуће одредити одредиште за текст линка ({anchorHTML}). Ако се не користи као хиперлинк, препоручујемо вам да уклоните target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Корисници немају поверења у сајтове који траже њихову локацију без контекста или их такви сајтови збуњују. Препоручујемо вам да уместо тога повежете захтев са радњом коју обавља корисник. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Тражи дозволу за геолоцирање при учитавању странице"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Избегавајте тражење дозволе за геолоцирање при учитавању странице"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Верзија"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Све корисничке JavaScript датотеке откривене на овој страници."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Откривене су JavaScript библиотеке"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Ако корисници имају споре везе, спољне скрипте које се динамички убацују помоћу атрибута `document.write()` могу да одложе учитавање странице за десетине секунди. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Користи `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Избегава атрибут `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Највиши ниво озбиљности"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Верзија библиотеке"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Број пропуста"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Неке независне скрипте могу да обухватају познате безбедносне пропусте које нападачи могу лако да препознају и искористе. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Откривен је 1 пропуст}one{Откривен је # пропуст}few{Откривена су # пропуста}other{Откривено је # пропуста}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Обухвата корисничке JavaScript датотеке са познатим безбедносним пропустима"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Висока"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Ниска"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Средња"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Избегава корисничке JavaScript датотеке са познатим безбедносним пропустима"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Корисници немају поверења у сајтове који траже дозволу за слање обавештења без контекста или их такви сајтови збуњују. Препоручујемо вам да уместо тога повежете захтев са покретима корисника. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Тражи дозволу за обавештења при учитавању странице"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Избегавајте тражење дозволе за обавештења при учитавању странице"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Елементи који нису прошли проверу"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Спречавање лепљења лозинке нарушава добре смернице за безбедност. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Спречава кориснике да налепе вредност у поља за лозинке"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Дозвољава корисницима да налепе вредност у поља за лозинке"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Протокол"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 има бројне предности у односу на HTTP/1.1, укључујући бинарна заглавља, мултиплексирање и серверски пуш. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 захтев није испоручен преко протокола HTTP/2}one{# захтев није испоручен преко протокола HTTP/2}few{# захтева нису испоручена преко протокола HTTP/2}other{# захтева није испоручено преко протокола HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Не користи HTTP/2 за све своје ресурсе"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Користи HTTP/2 за своје ресурсе"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Препоручујемо вам да пасивне обрађиваче догађаја означите као `passive` да бисте побољшали резултате померања. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Не користите пасивне обрађиваче да бисте побољшали учинак померања"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Користите пасивне обрађиваче да бисте побољшали учинак померања"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Опис"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Грешке евидентиране у конзоли указују на нерешене проблеме. Оне су резултат неуспелих мрежних захтева и других проблема у вези са прегледачем."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Грешке прегледача су евидентиране у конзоли"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Ниједна грешка прегледача није евидентирана у конзоли"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Искористите CSS функцију за приказ фонтова да бисте били сигурни да корисник може да види текст док се веб-фонтови учитавају. [Сазнајте више](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Сав текст остаје видљив током учитавања веб-фонтова"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse није успео да аутоматски провери вредност за приказ фонтова за следећи URL: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Размера (стварна)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Размера (приказана)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Димензије приказа слике треба да се подударају са природном размером. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Приказује слике са погрешном размером"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Приказује слике са тачном размером"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Неважеће информације о величини слике {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Небезбедан URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Сви сајтови треба да буду заштићени HTTPS-ом, чак и они који не обрађују осетљиве податке. HTTPS спречава уљезе да неовлашћено приступају комуникацији између апликације и корисника или да је пасивно слушају. Он је предуслов за HTTP/2 i API-је бројних нових веб-платформи. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Пронађен је 1 небезбедан захтев}one{Пронађен је # небезбедан захтев}few{Пронађена су # небезбедна захтева}other{Пронађено је # небезбедних захтева}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Не користи HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Користи HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Брзо учитавање странице преко мобилне мреже обезбеђује добар доживљај корисницима мобилних уређаја. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Интерактивна за {timeInMs, number, seconds} сек"
+    "message": "Интерактивно за {timeInMs, number, seconds} сек"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Интерактивна на симулираној мобилној мрежи за {timeInMs, number, seconds} сек"
@@ -534,16 +765,22 @@
     "message": "Време почетка интеракције"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Потенцијално кашњење првог уноса које може да се деси корисницима је трајање најдужег задатка у милисекундама."
+    "message": "Максимално потенцијално кашњење првог уноса које може да се деси корисницима је трајање најдужег задатка у милисекундама. [Сазнајте више](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Највеће потенцијално кашњење првог уноса"
+    "message": "Макс. потенцијално кашњење првог приказа"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Индекс брзине приказује колико брзо садржај странице постаје видљив за кориснике. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Индекс брзине"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Збир свих периода између FCP-а и времена до почетка интеракције, када задатак траје дуже од 50 ms, изражено у милисекундама."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Укупно време блокирања"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Трајања повратног пута (RTT) мреже знатно утичу на учинак. Ако је трајање повратног пута до почетне локације велико, то значи да би сервери који су ближи кориснику могли да побољшају учинак. [Сазнајте више](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,26 +794,47 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Позадинска кашњења сервера"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Премашује циљ"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Захтеве за количину и величину мреже одржавајте испод граница одређених циљевима за учинак. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 захтев}one{# захтев}few{# захтева}other{# захтева}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Циљ за учинак"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Преусмеравања доводе до додатних кашњења пре учитавања странице. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Избегавајте вишеструка преусмеравања странице"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Да бисте подесили циљеве за количину и величину ресурса странице, додајте датотеку budget.json file. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 захтев}one{# захтев}few{# захтева}other{# захтева}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Омогући да број захтева и величине преноса буду мали"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "Канонички линкови предлажу који URL треба приказати у резултатима претраге. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
+    "message": "Канонички линкови предлажу који URL треба да се прикаже у резултатима претраге. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Више неусаглашених URL-ова ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Усмерава на неки други домен ({url})"
+    "message": "Усмерава ка другом домену ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Неважећи URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Усмерава на другу „hreflang“ локацију ({url})"
+    "message": "Усмерава на другу `hreflang` локацију ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Релативни URL ({url})"
@@ -585,25 +843,22 @@
     "message": "Усмерава на основни URL домена (почетну страницу), уместо еквивалентне странице садржаја"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Документ нема важећу вредност „rel=canonical“"
+    "message": "Документ нема важећу вредност `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Документ има важећу вредност „rel=canonical“"
+    "message": "Документ има важећи атрибут `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "Величине фонтова испод 12 пиксела су премале да би биле читљиве и због њих корисници на мобилним уређајима морају да „скупе прсте ради зумирања“ како би могли да читају садржај. Потрудите се да >60% текста странице буде ≥12 пиксела. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "Величине фонтова испод 12 пиксела су премале да би биле читљиве и због њих корисници на мобилним уређајима морају да „зумирају прстима“ како би могли да читају садржај. Потрудите се да >60% текста странице буде ≥12 пиксела. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} читљивог текста"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "Део текста ({decimalProportion, number, extendedPercent}) је премали."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Текст није читљив јер не постоји метаознака области приказа која је оптимизована за екране на мобилним уређајима."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "Део текста је премали ({decimalProportion, number, extendedPercent}) (на основу узорка од {decimalProportionVisited, number, extendedPercent})."
+    "message": "{decimalProportion, number, extendedPercent} текста је премало (на основу узорка од {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Документ не користи читљиве величине фонтова"
@@ -615,10 +870,10 @@
     "message": "Линкови hreflang обавештавају претраживаче коју верзију странице треба да наведу у резултатима претраге за дати језик или регион. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Документ нема важећи атрибут „hreflang“"
+    "message": "Документ нема важећи атрибут `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Документ има важећи атрибут „hreflang“"
+    "message": "Документ има важећи атрибут `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Странице са неуспешним HTTP кодовима статуса можда неће бити правилно индексиране. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -699,7 +954,7 @@
     "message": "Интерактивни елементи попут дугмади и линкова треба да буду довољно велики (48×48 пиксела) и да имају довољно простора око себе да би било лако да се додирну без преклапања са другим елементима. [Сазнајте више](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "Део циљева додиривања ({decimalProportion, number, percent}) има одговарајућу величину"
+    "message": "{decimalProportion, number, percent} циљева додиривања има одговарајућу величину"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "Циљеви додиривања су премали јер не постоји метаознака области приказа која је оптимизована за екране на мобилним уређајима"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Циљ који се преклапа"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Величина"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Циљ додиривања"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Циљеви додиривања имају одговарајућу величину"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Време главне нити"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Независни добављач"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Кôд независног добављача може значајно да утиче на учинак учитавања. Ограничите број сувишних независних добављача услуге и пробајте да учитате кôд независног добављача када страница примарно заврши са учитавањем. [Сазнајте више](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Пронађен је 1 независни}one{Пронађен је # независни}few{Пронађена су # независна}other{Пронађено је # независних}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Независна употреба"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Време првог одговора одређује време у које сервер шаље одговор. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Трајање"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Назив"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Време почетка"
   },
@@ -744,7 +1008,7 @@
     "message": "Тип"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Размислите о томе да опремите апликацију API-јем за време корисника да бисте измерили учинак апликације у реалном свету током кључних корисничких доживљаја. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Препоручујемо вам да опремите апликацију API-јем за време корисника да бисте измерили учинак апликације у реалном свету током кључних корисничких доживљаја. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 време корисника}one{# време корисника}few{# времена корисника}other{# времена корисника}}"
@@ -753,19 +1017,19 @@
     "message": "Ознаке и мере Времена корисника"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Повезивање унапред <link> је пронађено за „{securityOrigin}“, али га прегледач није употребио. Проверите да ли правилно користите атрибут „crossorigin“."
+    "message": "Повезивање унапред <link> је пронађено за „{securityOrigin}“, али га прегледач није употребио. Проверите да ли правилно користите атрибут `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Размислите о томе да додате савете за ресурсе за повезивање унапред или припрему учитавања DNS-а како бисте успоставили ране везе са важним изворима трећих страна. [Сазнајте више](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Препоручујемо вам да додате савете за ресурсе за повезивање унапред или припрему учитавања DNS-а како бисте успоставили ране везе са важним изворима трећих страна. [Сазнајте више](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Повежите се унапред са потребним изворима"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Предучитавање <link> је пронађено за „{preloadURL}“, али га прегледач није употребио. Проверите да ли правилно користите атрибут „crossorigin“."
+    "message": "Предучитавање <link> је пронађено за „{preloadURL}“, али га прегледач није употребио. Проверите да ли правилно користите атрибут `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Размислите о томе да користите <link rel=preload> како бисте касније током учитавања странице дали приоритет преузимању ресурса који се тренутно траже. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Препоручујемо вам да користите `<link rel=preload>` како бисте касније током учитавања странице дали приоритет преузимању ресурса који се тренутно траже. [Сазнајте више](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Унапред учитајте најважније захтеве"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Табеле и листе"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Најбоље праксе"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Циљевима за учинак одређују се стандарди за учинак сајта."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Циљеви"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Више информација о учинку апликације."
+    "message": "Више информација о учинку апликације. Ови бројеви не [утичу директно](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) на оцену учинка."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Дијагностика"
@@ -840,7 +1113,7 @@
     "message": "Побољшања првог приказивања"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Ове оптимизације могу да убрзају учитавање странице."
+    "message": "Ови предлози могу да вам помогну да се страница учитава брже. Не [утичу директно](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) на оцену учинка."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Могућности"
@@ -888,7 +1161,7 @@
     "message": "Пописивање и индексирање"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Проверите да ли су странице прилагођене мобилним уређајима да корисници не би морали да скупљају прсте или увећавају приказ како би читали странице са садржајем. [Сазнајте више](https://developers.google.com/search/mobile-sites/)."
+    "message": "Уверите се да су странице прилагођене мобилним уређајима да корисници не би морали да умањују или увећавају приказ како би читали странице са садржајем. [Сазнајте више](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Прилагођено мобилним уређајима"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Време преживљавања кеша"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Локација"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Назив"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Захтеви"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Тип ресурса"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Величина (kB)"
+    "message": "Величина"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Проведено време"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Величина преноса"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Потенцијална уштеда (kB)"
+    "message": "Потенцијална уштеда"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Потенцијална уштеда (ms)"
+    "message": "Потенцијална уштеда"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Потенцијална уштеда од {wastedBytes, number, bytes} kB"
+    "message": "Потенцијална уштеда од {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Потенцијална уштеда од {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Документ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Фонт"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Слика"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Медији"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Друго"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Скрипта"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} сек"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Опис стила"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Независни ресурси"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Укупно"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Дошло је до грешке при евидентирању трага током учитавања странице. Поново покрените Lighthouse. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS сервери нису могли да разреше наведени домен."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Прикупљач за обавезни ресурс {artifactName} је наишао на грешку: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Дошло је до интерне грешке у Chrome-у. Поново покрените Chrome и пробајте да поново покренете Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Прикупљач за обавезни ресурс {artifactName} се није покренуо."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse није успео да поуздано учита страницу коју сте захтевали. Уверите се да тестирате одговарајући URL и да сервер правилно одговара на све захтеве."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse није успео да поуздано учита URL који сте захтевали јер је страница престала да реагује."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "URL који сте навели нема важеће безбедносне акредитиве. {securityMessages}"
+    "message": "URL који сте навели нема важећи безбедносни сертификат. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome је спречио учитавање странице са транзитивним огласом. Уверите се да тестирате одговарајући URL и да сервер правилно одговара на све захтеве."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse није успео да поуздано учита страницу коју сте захтевали. Уверите се да тестирате одговарајући URL и да сервер правилно одговара на све захтеве. (Детаљи: {errorDetails})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Прошири фрагмент"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Прикажи независне ресурсе"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Било је извесних проблема који су утицали на ово покретање Lighthouse-а:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Вредности представљају процене и могу да варирају."
+    "message": "Вредности представљају процене и могу да варирају. Оцена учинка се [заснива само на овим показатељима](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Провере са задовољавајућом оценом које садрже упозорења"
@@ -1053,7 +1380,7 @@
     "message": "Препоручујемо да користите [WordPress додатну компоненту за оптимизацију слика](https://wordpress.org/plugins/search/optimize+images/) која компримује слике без губитка квалитета."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Отпремајте слике директно помоћу [библиотеке медија](https://codex.wordpress.org/Media_Library_Screen) да бисте се уверили да су доступне обавезне величине слика, па их уметните у библиотеку медија или користите виџет странице да бисте се уверили да се користе оптималне величине слика (укључујући оне за преломне тачке које се одазивају). Избегавајте коришћење слика „пуне величине“ ако димензије нису адекватне за њихово коришћење. [Сазнајте више](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Отпремајте слике директно помоћу [библиотеке медија](https://codex.wordpress.org/Media_Library_Screen) да бисте се уверили да су доступне обавезне величине слика, па их уметните у библиотеку медија или користите виџет странице да бисте се уверили да се користе оптималне величине слика (укључујући оне за преломне тачке које се одазивају). Избегавајте коришћење слика `Full Size` ако димензије нису адекватне за њихово коришћење. [Сазнајте више](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Можете да омогућите компримовање текста у конфигурацији веб-сервера."

--- a/lighthouse-core/lib/i18n/locales/sv.json
+++ b/lighthouse-core/lib/i18n/locales/sv.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Med åtkomsttangenter kan användaren snabbt flytta fokus till en viss del av sidan. Ingen åtkomsttangent får användas flera gånger om navigeringen ska fungera ordentligt. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Med åtkomsttangenter kan användaren snabbt flytta fokus till en viss del av sidan. Ingen åtkomsttangent får användas flera gånger om navigeringen ska fungera ordentligt. [Läs mer](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Alla värden på [accesskey] är inte unika"
+    "message": "Alla värden på `[accesskey]` är inte unika"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Alla värden på [accesskey] är unika"
+    "message": "`[accesskey]` värden är unika"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "ARIA-roller har stöd för ett visst antal attribut av typen aria-*. Attributen av typen aria-* fungerar inte om de blandas ihop. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Varje ARIA-`role` har stöd för ett visst antal attribut av typen `aria-*`. Om dessa inte överensstämmer blir attributen av typen `aria-*` ogiltiga. [Läs mer](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Alla attribut av typen [aria-*] stämmer inte med elementets roll"
+    "message": "Alla attribut av typen `[aria-*]` stämmer inte med elementets roll"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Attributen av typen [aria-*] stämmer med elementets roll"
+    "message": "Attributen av typen `[aria-*]` stämmer med elementets roll"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Vissa ARIA-roller har obligatoriska attribut som beskriver elementets tillstånd för skärmläsare. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Vissa ARIA-roller har obligatoriska attribut som beskriver elementets tillstånd för skärmläsare. [Läs mer](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Vissa element med attributet [role] har inte alla obligatoriska attribut av typen [aria-*]"
+    "message": "Vissa element med attributet `[role]` har inte alla obligatoriska attribut av typen `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Alla element med [role]-attribut har alla obligatoriska attribut av typen [aria-*]"
+    "message": "Alla element med `[role]`-attribut har alla obligatoriska attribut av typen `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Vissa överordnade element med ARIA-attributet role måste ha vissa underordnade element med role för att hjälpmedlen ska fungera som avsett. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Vissa överordnade element med ARIA-attributet role måste ha vissa underordnade element med role för att hjälpmedlen ska fungera som avsett. [Läs mer](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Obligatoriska underordnade element med [role] saknas för vissa element med [role]-attribut."
+    "message": "Vissa obligatoriska underordnade element med `[role]` saknas för element med `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Inga obligatoriska underordnade element med [role] saknas för element med [role]"
+    "message": "Alla obligatoriska underordnade element med `[role]` används för element med `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Vissa underordnade element med ARIA-attributet role måste ha ett bestämt överordnat element med role för att hjälpmedlen ska fungera som avsett. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Vissa underordnade element med ARIA-attributet role måste ha ett bestämt överordnat element med role för att hjälpmedlen ska fungera som avsett. [Läs mer](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Det finns element med [role]-attribut utan ett obligatoriskt överordnat element"
+    "message": "Det finns element med `[role]`-attribut utan ett obligatoriskt överordnat element"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Rätt överordnat element används för alla element med [role]-attribut"
+    "message": "Rätt överordnat element används för alla element med `[role]`-attribut"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Alla ARIA-rollattribut måste ha giltiga värden om de ska fungera som avsett med hjälpmedlen. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Alla ARIA-rollattribut måste ha giltiga värden om de ska fungera som avsett med hjälpmedlen. [Läs mer](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Vissa [role]-värden är inte giltiga"
+    "message": "Vissa `[role]`-värden är inte giltiga"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Alla [role]-värden är giltiga"
+    "message": "Alla `[role]`-värden är giltiga"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Skärmläsare och andra hjälpmedel kan inte tolka ARIA-attribut med ogiltiga värden. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Skärmläsare och andra hjälpmedel kan inte tolka ARIA-attribut med ogiltiga värden. [Läs mer](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Alla attribut av typen [aria-*] har inte ett giltigt värde"
+    "message": "Alla attribut av typen `[aria-*]` har inte ett giltigt värde"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Alla attribut av typen [aria-*] har giltiga värden"
+    "message": "Alla attribut av typen `[aria-*]` har giltiga värden"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Skärmläsare och andra hjälpmedel kan inte tolka ARIA-attribut med ogiltiga namn. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Skärmläsare och andra hjälpmedel kan inte tolka ARIA-attribut med ogiltiga namn. [Läs mer](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Det finns ogiltiga eller felstavade attribut av typen [aria-*]"
+    "message": "Vissa attribut av typen `[aria-*]` är ogiltiga eller felstavade"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Alla attribut av typen [aria-*] är giltiga och rättstavade"
+    "message": "Alla attribut av typen `[aria-*]` är giltiga och rättstavade"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Textningen ger döva och hörselskadade viktig information om vem som talar, vad de säger och andra ljud som inte är tal. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Textningen ger döva och hörselskadade viktig information om vem som talar, vad de säger och andra ljud som inte är tal. [Läs mer](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Alla <audio>-element har inte ett underordnat <track>-element med [kind=\"captions\"]"
+    "message": "Alla `<audio>`-element har inte ett underordnat `<track>`-element med `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Alla <audio>-element har ett underordnat <track>-element med [kind=\"captions\"]"
+    "message": "Alla `<audio>`-element innehåller ett `<track>`-element med `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Element med fel"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Utan ett igenkännligt namn läses knappen upp som ”knapp” av skärmläsarna. Det gör knappen oanvändbar för den som behöver använda en skärmläsare. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Utan ett igenkännligt namn läses knappen upp som ”knapp” av skärmläsarna. Det gör knappen oanvändbar för den som behöver använda en skärmläsare. [Läs mer](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Vissa knappar har inte namn som hjälpmedlen kan använda"
@@ -93,7 +93,7 @@
     "message": "Alla knappar har namn som hjälpmedlen kan använda"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Om du lägger till ett sätt att hoppa över innehåll som upprepas går det att navigera effektivare på sidan för den som använder tangentbordet. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Om du lägger till ett sätt att hoppa över innehåll som upprepas går det att navigera effektivare på sidan för den som använder tangentbordet. [Läs mer](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Sidan saknar rubrik, överhoppningslänk eller landmärkesområde"
@@ -102,7 +102,7 @@
     "message": "Sidan har en rubrik, en överhoppningslänk eller ett landmärkesområde"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Text med låg kontrast blir svårläst eller oläslig för många användare. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Text med låg kontrast blir svårläst eller oläslig för många användare. [Läs mer](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Kontrasten mellan bakgrundsfärg och förgrundsfärg är inte tillräckligt stor."
@@ -111,88 +111,88 @@
     "message": "Kontrasten mellan bakgrundsfärg och förgrundsfärg är tillräckligt stor"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Om en definitionslista inte har märkts upp korrekt kan den läsas upp på ett missvisande eller felaktigt sätt av skärmläsare. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Om en definitionslista inte har märkts upp korrekt kan den läsas upp på ett missvisande eller felaktigt sätt av skärmläsare. [Läs mer](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Alla <dl>-element har inte <dt>- och <dd>-grupper, <script>- eller <template>-element i rätt ordning."
+    "message": "Det finns `<dl>`-element som inte enbart består av `<dt>`- och `<dd>`-grupper i rätt ordning, `<script>`- och `<template>`-element."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Alla <dl>-element har <dt>- och <dd>-grupper, <script>- eller <template>-element i rätt ordning."
+    "message": "Alla `<dl>`-element består enbart av `<dt>`- och `<dd>`-grupper i rätt ordning, `<script>`- eller `<template>`-element."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Alla listposter i definitionslistor (<dt> och <dd>) måste ha överordnade <dl>-element så att de kan presenteras korrekt med skärmläsare. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Alla poster i definitionslistor (`<dt>` och `<dd>`) måste ha överordnade `<dl>`-element så att de kan presenteras korrekt av skärmläsare. [Läs mer](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Vissa poster i definitionslistor har inte bäddats in i <dl>-element"
+    "message": "Vissa poster i definitionslistor har inte bäddats in i `<dl>`-element"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Alla poster i definitionslistor har bäddats in i <dl>-element"
+    "message": "Alla poster i definitionslistor har bäddats in i `<dl>`-element"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Titeln ger den som använder skärmläsare en uppfattning om vad sidan handlar om. Dessutom fyller sidtiteln en viktig funktion i sökmotorer när användarna väljer ut sidor som verkar vara relevanta för sökningen. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Titeln ger den som använder skärmläsare en uppfattning om vad sidan handlar om. Dessutom fyller sidtiteln en viktig funktion i sökmotorer när användarna väljer ut sidor som verkar vara relevanta för sökningen. [Läs mer](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokumentet saknar <title>-element"
+    "message": "Dokumentet har inget `<title>`-element"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokumentet har ett <title>-element"
+    "message": "Dokumentet har ett `<title>`-element"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Alla id-attribut måste ha unika värden. Hjälpmedelstekniken skulle annars hoppa över dubblettförekomsterna av ett värde. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Alla id-attribut måste ha unika värden. Hjälpmedelstekniken skulle annars hoppa över dubblettförekomsterna av ett värde. [Läs mer](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Alla [id]-attribut på sidan är inte unika"
+    "message": "Alla `[id]`-attribut på sidan är inte unika"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Alla [id]-attribut på sidan är unika"
+    "message": "Alla `[id]`-attribut på sidan är unika"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Med en skärmläsare behövs namn på ramarna som beskriver vad ramen innehåller. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Med en skärmläsare behövs namn på ramarna som beskriver vad ramen innehåller. [Läs mer](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Vissa <frame>- eller <iframe>-element saknar namn"
+    "message": "Vissa `<frame>`- eller `<iframe>`-element saknar titel"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Alla <frame>- eller <iframe>-element har namn"
+    "message": "Alla `<frame>`- eller `<iframe>`-element har en titel"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Om inget lang-attribut har angetts för en sida används skärmläsarens standardspråk, det vill säga det språk som användaren valde när skärmläsaren konfigurerades. Om sidan inte är på det språket kanske texten inte läses upp korrekt. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Om inget lang-attribut har angetts för en sida används skärmläsarens standardspråk, det vill säga det språk som användaren valde när skärmläsaren konfigurerades. Om sidan inte är på det språket kanske texten inte läses upp korrekt. [Läs mer](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "<html>-elementet har inget [lang]-attribut"
+    "message": "`<html>`-elementet har inget `[lang]`-attribut"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "<html>-elementet har ett [lang]-attribut"
+    "message": "`<html>`-elementet har ett `[lang]`-attribut"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Om du anger ett giltigt [språk enligt BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) kan texten uttalas korrekt av skärmläsare. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Om du anger ett giltigt [språk enligt BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) kan texten uttalas korrekt av skärmläsare. [Läs mer](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "<html>-elementets [lang]-attribut har inte ett giltigt värde."
+    "message": "`<html>`-elementets `[lang]`-attribut har inte ett giltigt värde."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "<html>-elementets [lang]-attribut har ett giltigt värde"
+    "message": "`<html>`-elementets `[lang]`-attribut har ett giltigt värde"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Element med informativ funktion bör ha en kort, beskrivande alternativtext. Element som bara har estetisk funktion kan ignoreras genom att alt-attributet lämnas tomt. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Element med informativ funktion bör ha en kort, beskrivande alternativtext. Element som bara har estetisk funktion kan ignoreras genom att alt-attributet lämnas tomt. [Läs mer](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Vissa bildelement har inte [alt]-attribut"
+    "message": "Alla bildelement har inte `[alt]`-attribut"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Alla bildelement har [alt]-attribut"
+    "message": "Alla bildelement har `[alt]`-attribut"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Om du anger en alternativ text när en bild används som <input>-knapp blir det lättare för användare med skärmläsare att förstå hur knappen används. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Om du anger en alternativ text när en bild används som `<input>`-knapp blir det lättare för användare med skärmläsare att förstå hur knappen används. [Läs mer](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Alla element av typen <input type=\"image\"> har inte [alt]-text"
+    "message": "Vissa `<input type=\"image\">`-element saknar `[alt]`-text"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Alla element av typen <input type=\"image\"> har [alt]-text"
+    "message": "Alla `<input type=\"image\">`-element har `[alt]`-text"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Etiketterna gör att de olika delarna av ett formulär kan presenteras korrekt för användare med skärmläsare eller andra hjälpmedel. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Etiketterna gör att de olika delarna av ett formulär kan presenteras korrekt för användare med skärmläsare eller andra hjälpmedel. [Läs mer](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Vissa formulärelement har inte etiketter"
@@ -201,16 +201,16 @@
     "message": "Alla formulärelement har etiketter"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "I en tabell som används i layoutsyfte ska det inte finnas dataelement som th eller caption eller attributet summary, eftersom det kan bli missvisande för den som använder skärmläsare. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "I en tabell som används i layoutsyfte ska det inte finnas dataelement som th eller caption eller attributet summary, eftersom det kan bli missvisande för den som använder skärmläsare. [Läs mer](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Det finns <table>-element som används i layoutsyfte (role=\"presentation\" eller \"none\") men ändå har <th>- eller <caption>-element eller [summary]-attribut. Detta bör undvikas."
+    "message": "Det finns `<table>`-element som används i layoutsyfte men som ändå har `<th>`- eller `<caption>`-element eller `[summary]`-attribut, vilket bör undvikas."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Inga <th>- eller <caption>-element eller [summary]-attribut förekommer i <table>-element som används i layoutsyfte (dvs med role=\"presentation\" eller \"none\")."
+    "message": "Inga `<th>`- eller `<caption>`-element eller `[summary]`-attribut förekommer i `<table>`-element som används i layoutsyfte."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Det blir enklare att navigera för den som använder en skärmläsare om alla länktexter (och alternativtexter för alla bilder som används som länkar) är igenkännliga, unika och möjliga att flytta fokus till. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Det blir enklare att navigera för den som använder en skärmläsare om alla länktexter (och alternativtexter för alla bilder som används som länkar) är igenkännliga, unika och möjliga att flytta fokus till. [Läs mer](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Vissa länkar har inte ett igenkännligt namn"
@@ -219,103 +219,115 @@
     "message": "Alla länkar har igenkännliga namn"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Listor presenteras på ett särskilt sätt av skärmläsare. Med rätt liststruktur kan skärmläsarna ge rätt information. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Listor presenteras på ett särskilt sätt av skärmläsare. Med rätt liststruktur kan skärmläsarna ge rätt information. [Läs mer](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Vissa listor innehåller inte enbart <li>-element eller stödelement för skript (<script> och <template>)."
+    "message": "Listor innehåller inte enbart `<li>`-element och stödelement för skript (`<script>` och `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Alla listor innehåller enbart <li>-element eller stödelement för skript (<script> och <template>)."
+    "message": "Alla listor innehåller enbart `<li>`-element eller stödelement för skript (`<script>` och `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "För att skärmläsare ska kunna läsa listor ordentligt måste listobjekt (<li>) placeras i en överordnad <ul> eller <ol>. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Alla listposter (`<li>`) måste ha ett överordnat `<ul>`- eller `<ol>`-element för att kunna presenteras korrekt av skärmläsare. [Läs mer](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Vissa listposter (<li>) saknar ett överordnat <ul>- eller <ol>-element."
+    "message": "Vissa listposter (`<li>`) saknar ett överordnat `<ul>`- eller `<ol>`-element."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Alla listposter (<li>) har ett överordnat <ul>- eller <ol>-element"
+    "message": "Alla listposter (`<li>`) har ett överordnat `<ul>`- eller `<ol>`-element"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Användarna förväntar sig inte att en sida ska uppdateras automatiskt, och när det händer flyttas fokus tillbaka till sidans början. Det kan vara både frustrerande och förvirrande. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Användarna förväntar sig inte att en sida ska uppdateras automatiskt, och när det händer flyttas fokus tillbaka till sidans början. Det kan vara både frustrerande och förvirrande. [Läs mer](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "<meta http-equiv=\"refresh\"> används i dokumentet"
+    "message": "`<meta http-equiv=\"refresh\">` används i dokumentet"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "<meta http-equiv=\"refresh\"> används inte i dokumentet"
+    "message": "`<meta http-equiv=\"refresh\">` används inte i dokumentet"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Att inaktivera förstoring leder till problem för användare med nedsatt syn, som behöver skärmförstoring för att kunna se webbsidan ordentligt. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Att inaktivera förstoring leder till problem för användare med nedsatt syn, som behöver skärmförstoring för att kunna se webbsidan ordentligt. [Läs mer](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "[user-scalable=\"no\"] används i elementet <meta name=\"viewport\"> och värdet på attributet [maximum-scale] är mindre än 5."
+    "message": "`[user-scalable=\"no\"]` används i elementet `<meta name=\"viewport\">`, eller också är värdet på attributet `[maximum-scale]` mindre än 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "[user-scalable=\"no\"] används inte i elementet <meta name=\"viewport\"> och värdet på attributet [maximum-scale] är inte mindre än 5."
+    "message": "`[user-scalable=\"no\"]` används inte i elementet `<meta name=\"viewport\">` och attributet `[maximum-scale]` är inte mindre än 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "En skärmläsare kan inte tolka innehåll som inte är text. Om du lägger till alt-text i <object>-elementen kan skärmläsarna förmedla ett meningsfullt innehåll till användaren. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "En skärmläsare kan inte tolka innehåll som inte är text. Om du lägger till alt-text i `<object>`-elementen kan skärmläsarna förmedla ett meningsfullt innehåll till användaren. [Läs mer](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Alla <object>-element har inte [alt]-text"
+    "message": "Vissa `<object>`-element saknar `[alt]`-text"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Alla <object>-element har [alt]-text"
+    "message": "Alla `<object>`-element har `[alt]`-text"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Med värden större än noll anges en explicit ordningsföljd för navigeringen. Även om detta inte är fel rent tekniskt leder det ofta till en frustrerande upplevelse för den som är beroende av tekniska hjälpmedel. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Med värden större än noll anges en explicit ordningsföljd för navigeringen. Även om detta inte är fel rent tekniskt leder det ofta till en frustrerande upplevelse för den som är beroende av tekniska hjälpmedel. [Läs mer](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Det finns elementet med ett [tabindex]-värde som är större än 0"
+    "message": "Det finns element med ett `[tabindex]`-värde som är större än 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Det finns inga elementet med ett [tabindex]-värde som är större än 0"
+    "message": "Det finns inga element med ett `[tabindex]`-värde som är större än 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Skärmläsare har funktioner som gör det enklare att navigera i tabeller. Sidan fungerar bättre för den som använder skärmläsare om attributet [headers] i <td>-celler bara refererar till andra celler i samma tabell. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Skärmläsare har funktioner som gör det enklare att navigera i tabeller. Sidan fungerar bättre för den som använder skärmläsare om attributet `[headers]` i `<td>`-celler bara refererar till andra celler i samma tabell. [Läs mer](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Det finns celler i ett <table>-element där attributet [headers] inte hänvisar till andra celler i samma tabell."
+    "message": "Det finns celler i ett `<table>`-element där attributet `[headers]` inte hänvisar till andra celler i samma tabell."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "I alla celler i ett <table>-element där attributet [headers] används hänvisar det till andra celler i samma tabell."
+    "message": "I alla celler i ett `<table>`-element där attributet `[headers]` används hänvisar det till andra celler i samma tabell."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Skärmläsare har funktioner som gör det enklare att navigera i tabeller. Det fungerar bättre för den som använder skärmläsare om det inte finns några tabellrubriker som hänger i luften utan att referera till några dataceller. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Skärmläsare har funktioner som gör det enklare att navigera i tabeller. Det fungerar bättre för den som använder skärmläsare om det inte finns några tabellrubriker som hänger i luften utan att referera till några dataceller. [Läs mer](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Vissa <th>-element och element med [role=\"columnheader\" eller \"rowheader\"] står inte som rubrik för några dataceller."
+    "message": "Vissa `<th>`-element och element med `[role=\"columnheader\"/\"rowheader\"]` står inte som rubrik för några dataceller."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Alla <th>-element och element med [role=\"columnheader\" eller \"rowheader\"] står som rubriker för andra dataceller."
+    "message": "Alla `<th>`-element och element med `[role=\"columnheader\"/\"rowheader\"]` står som rubriker för andra dataceller."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Om du anger ett giltigt [språk enligt BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) för elementen uttalas texten korrekt av skärmläsare. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Om du anger ett giltigt [språk enligt BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) för elementen uttalas texten korrekt av en skärmläsare. [Läs mer](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Det finns [lang]-attribut som inte har ett giltigt värde"
+    "message": "Vissa `[lang]`-attribut har inte ett giltigt värde"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Alla [lang]-attribut har ett giltigt värde"
+    "message": "Alla `[lang]`-attribut har ett giltigt värde"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Det blir lättare för döva och hörselskadade att ta del av en video som är textad. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Det blir lättare för döva och hörselskadade att ta del av en video som är textad. [Läs mer](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Alla <video>-element har inte ett underordnat <track>-element med [kind=\"captions\"]."
+    "message": "Alla `<video>`-element har inte ett underordnat `<track>`-element med `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Alla <video>-element har ett underordnat <track>-element med [kind=\"captions\"]"
+    "message": "Alla `<video>`-element innehåller ett `<track>`-element med `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Upplästa beskrivningar ger viktig information om videon som inte framgår av dialogen, t.ex. ansiktsuttryck och naturvyer. [Läs mer](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Upplästa beskrivningar ger viktig information om videon som inte framgår av dialogen, t.ex. ansiktsuttryck och naturvyer. [Läs mer](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Alla <video>-element har inte ett underordnat <track>-element med [kind=\"description\"]."
+    "message": "Alla `<video>`-element har inte ett underordnat `<track>`-element med `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Alla <video>-element har ett underordnat <track>-element med [kind=\"description\"]"
+    "message": "Alla `<video>`-element innehåller ett `<track>`-element med `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Definiera en apple-touch-ikon för att få bästa möjliga utseende i iOS. Den måste peka på en icke-transparent, kvadratisk PNG med sidan 192 pixlar (eller 180 pixlar). [Läs mer](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Anger inte ett giltigt `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Attributet `apple-touch-icon-precomposed` är inaktuellt. `apple-touch-icon` är att föredra."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Anger en giltig `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Inläsningen av den här sidan påverkas negativt av tillägg i Chrome. Testa att granska sidan i inkognitoläge eller med en Chrome-profil utan tillägg."
@@ -339,7 +351,7 @@
     "message": "Körningstid för JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Stora GIF-bilder är ett ineffektivt sätt att visa animationer på. I stället för GIF kan du använda videor i MPEG4-/WebM-format för animationer och PNG-/WebP-format för statiska bilder, vilket minskar antalet byte som skickas via nätverket. [Läs mer](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Stora GIF-filer är inte ett effektivt sätt att visa animerat innehåll. I stället för GIF kan du använda videor i MPEG4-/WebM-format för animationer och PNG-/WebP-format för statiska bilder. Då minskar antalet byte som skickas via nätverket. [Läs mer](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Använd videoformat för animationer"
@@ -351,7 +363,7 @@
     "message": "Skjut upp inläsningen av bilder som inte visas på skärmen"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Den första uppritningen av sidan på skärmen blockeras av resurser. Infoga nödvändig JS-/CSS-kod direkt på sidan och skjut upp inläsningen av JS-kod/formatmallar som är mindre viktiga. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Resurser blockerar sidans första rendering. Infoga nödvändig JS-/CSS-kod direkt på sidan och skjut upp inläsningen av JS-kod/formatmallar som är mindre viktiga. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Ta bort resurser som blockerar renderingen"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Minska antalet steg i viktiga orderkedjor"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Utfasning/varning"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Rad"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Utfasade API:er tas bort från webbläsaren efter hand. [Läs mer](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 varning hittades}other{# varningar hittades}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Utfasade API:er används"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Utfasade API:er undviks"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Programmets cacheminne är utfasat. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "{AppCacheManifest} hittades"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Använder programmets cacheminne"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Undviker programcache"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "En doctype förhindrar att webbläsaren byter till quirks-läge. Läs mer på [sidan MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Doctype-namnet måste vara strängen `html` i gemener"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Dokument måste innehålla en doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "publicId förväntades vara en tom sträng"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "systemId förväntades vara en tom sträng"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Sidan har inte HTML som doctype, vilket aktiverar quirks-läge"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Sidan har HTML som doctype"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element"
   },
@@ -447,7 +510,7 @@
     "message": "Antal"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Webbläsarutvecklare rekommenderar att en sidas DOM ska ha färre än ca 1 500 element. Ett träd där djupet är mindre än 32 element och det finns högst 60 underordnade/överordnade element är idealiskt. Stora DOM-träd kan medföra ökad minnesförbrukning, längre [formatmallsberäkningar] (https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) och resurskrävande [omflödning av layouten] (https://developers.google.com/speed/articles/reflow). [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Webbutvecklare rekommenderar att sidor innehåller mindre än 1500 DOM-element. Det bästa är ett träddjup med mindre än 32 element och högst 60 underordnade/överordnade element. En stor DOM kan öka minnesförbrukningen, förlänga [formatberäkningarna](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) och producera kostsamma [flödesuppdateringar för layouten](https://developers.google.com/speed/articles/reflow). [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 element}other{# element}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Undviker ett onödigt stort DOM-träd"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Mål"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Lägg till `rel=\"noopener\"` eller `rel=\"noreferrer\"` i alla externa länkar för att förbättra prestanda och säkerhet. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Länkar till mål med korsursprung är osäkra"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Länkar till mål med korsursprung är säkra"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Det går inte att fastställa målet för ankaret ({anchorHTML}). Det kan vara bra att ta bort target=_blank om det inte används som hyperlänk."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Användare blir misstänksamma eller förvirrade av webbplatser som ber om åtkomst till deras plats utan sammanhang. Det kan vara bättre att koppla förfrågan till något användaren gör. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Begär åtkomst till geografisk plats vid sidinläsning"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Undviker att begära åtkomst till geografisk plats vid sidinläsning"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Version"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Alla JavaScript-bibliotek på klientsidan har identifierats på den här sidan."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "JavaScript-bibliotek har identifierats"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "För användare med långsam anslutning kan externa skript som infogas dynamiskt via `document.write()` fördröja sidinläsningen med tiotals sekunder. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "`document.write()` används"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "`document.write()` undviks"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Högsta allvarlighetsgrad"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Biblioteksversion"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Antal säkerhetsbrister"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Vissa skript från tredje part kan innehålla kända säkerhetsproblem som är lätta att identifiera och utnyttja för angripare. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 säkerhetsbrist har identifierats}other{# säkerhetsbrister har identifierats}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Innehåller JavaScript-bibliotek på klientsidan med kända säkerhetsbrister"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Hög"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Låg"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Medelstor"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Undviker JavaScript-bibliotek med kända säkerhetsproblem på klientsidan"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Användare blir misstänksamma eller förvirrade av webbplatser som ber om åtkomst att skicka aviseringar utan sammanhang. Det kan vara bättre att koppla förfrågan till rörelser. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Begär aviseringsbehörighet vid sidinläsning"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Undviker att begära aviseringsbehörighet vid sidinläsning"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Element med fel"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Att förhindra att lösenord klistras in underminerar en bra säkerhetspolicy. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Användarna tillåts inte att klistra in i lösenordsfält"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Användarna tillåts klistra in i lösenordsfält"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokoll"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ger många fördelar jämfört med HTTP/1.1, inklusive binära rubriker, multiplexning och server push. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 begäran visades inte via HTTP/2}other{# begäranden visades inte via HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Använder inte HTTP/2 för alla resurser"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Använder HTTP/2 för egna resurser"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Det kan vara bra att märka dina händelselyssnare för tryck och hjul som `passive` för att förbättra sidans rullningsfunktion. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Passiva lyssnare används inte för att förbättra rullningsprestanda"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Passiva lyssnare används för att förbättra rullningsprestanda"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Beskrivning"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Fel som loggats i konsolen indikerar olösta problem. De kan bero på fel i nätverksbegäranden och andra webbläsarproblem."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Webbläsarfel loggades i konsolen"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Inga webbläsarfel loggades i konsolen"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Använd funktionen font-display i CSS så att texten är synlig för användaren medan webbteckensnitten läses in. [Läs mer](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -475,6 +670,42 @@
   },
   "lighthouse-core/audits/font-display.js | title": {
     "message": "All text förblir synlig medan webbteckensnitten läses in"
+  },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse kunde inte kontrollera värdet för teckensnittsvisning automatiskt för följande webbadress: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Bildproportioner (faktiska)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Bildproportioner (visade)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Bildens visningsformat ska matcha de naturliga proportionerna. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Visar bilder med felaktiga bildproportioner"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Bilder visas med korrekta bildproportioner"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Ogiltig information om bildstorlek {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Osäker webbadress"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Alla webbplatser ska skyddas med HTTPS, även de som inte hanterar känslig data. HTTPS förhindrar att inkräktare påverkar eller passivt avlyssnar kommunikationen mellan din app och dina användare, och är ett krav för HTTP/2 och många nya API:er för webbplattformar. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 osäker begäran hittades}other{# osäkra begäranden hittades}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Använder inte HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Använder HTTPS"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Snabb sidinläsning i mobila nätverk ger en bra upplevelse för mobila användare. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
@@ -504,25 +735,25 @@
     "message": "Minskar arbetsbelastningen på modertråden"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "En uppskattning av hur lång tid (i millisekunder) det tar innan appen svarar på användarens inmatning under den mest aktiva femsekundersperioden av sidinläsningen. Om latensen är högre än 50 ms kan användarna uppfatta det som att appen laggar. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Uppskattad inmatningslatens är en uppskattning av hur lång tid (i millisekunder) det tar innan appen svarar på användarens inmatning under den mest aktiva femsekundersperioden av sidinläsningen. Om latensen är högre än 50 ms kan användarna uppfatta appen som seg. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Beräknad inmatningslatens"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Första innehållsrendering anger tidpunkten när den första texten eller bilden ritades upp. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Första innehållsrenderingen anger när den första texten eller bilden ritades upp. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Första uppritningen av innehåll"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "Första CPU-avbrottet anger tidpunkten då sidans modertråd först blev inaktiv nog att hantera indata. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "Första CPU-avbrottet anger när sidans modertråd först blev inaktiv nog att hantera indata. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "Första CPU-inaktivitet"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Första meningsfulla skärmuppritningen anger när sidans primära innehåll var synligt. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Första användbara renderingen anger när sidans primära innehåll blev synligt. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Första meningsfulla skärmuppritningen"
@@ -534,16 +765,22 @@
     "message": "Tid till interaktivt tillstånd"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Den potentiella fördröjningen vid första indata som användarna kan få är längden på den längsta uppgiften i millisekunder."
+    "message": "Den högsta potentiella fördröjningen vid första indata som användarna kan få är längden på den längsta uppgiften i millisekunder. [Läs mer](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Maximal potentiell fördröjning vid första indata"
+    "message": "Högsta potentiella fördröjning till första inmatningen"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Sidans hastighetsindex visar hur snabbt sidan fylls med synligt innehåll. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Hastighetsindexet visar hur snabbt en sida fylls med synligt innehåll. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Hastighetsindex"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Summan av alla tidsperioder mellan FCP och Tid till interaktivt tillstånd när uppgiftstiden överskred 50 ms, uttryckt i millisekunder."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Total blockeringstid"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Nätverkets RTT-tider (Round Trip Times) har stor inverkan på prestanda. Om RTT-tiden till ett ursprung är för hög tyder det på att servrar närmare användaren skulle kunna förbättra prestanda. [Läs mer](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,17 +794,38 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Serverlatens"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Över budget"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Håll antal och storlek för nätverksbegäranden under de mål som anges i den angivna prestandabudgeten. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 begäran}other{# begäranden}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Prestandabudget"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Omdirigeringar medför en ytterligare fördröjning innan sidan kan läsas in. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Undvik upprepade omdirigeringar"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Lägg till en budget.json-fil för att ange budget för kvantitet och storlek på sidresurser. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 begäran}other{# begäranden}} • {byteCount, number, bytes} kB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Begränsa antalet begäranden och storleken på överföringar"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Kanoniska länkar föreslår vilka webbadresser som ska visas i sökresultat. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Flera webbadresser i konflikt ({urlList})"
+    "message": "Flera webbadresser som står i konflikt ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "Pekar på en annan domän ({url})"
@@ -576,7 +834,7 @@
     "message": "Ogiltig webbadress ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Pekar på en annan hreflang-plats ({url})"
+    "message": "Pekar på en annan `hreflang`-plats ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Relativ webbadress ({url})"
@@ -585,19 +843,16 @@
     "message": "Pekar på domänens rotadress (startsidan) i stället för motsvarande sida med innehåll"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Dokumentet har ingen giltig länk med rel=canonical"
+    "message": "Dokumentet har ingen giltig länk med `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Dokumentet har en giltig länk med rel=canonical"
+    "message": "Dokumentet har ett giltigt `rel=canonical`-värde"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Teckenstorlekar under 12 pixlar är för små för att kunna läsas och kräver att mobila användare zoomar genom att nypa för att kunna läsa. Försök ha minst 60 % av texten i 12 pixlar eller mer. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} läslig text"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} av texten är för liten."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Text är oläslig eftersom det inte finns någon metatagg för visningsområde som är optimerad för mobila skärmar."
@@ -612,13 +867,13 @@
     "message": "Dokumentet har läsliga teckenstorlekar"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "hreflang informerar sökmotorer om vilken version av en sida de ska visa i sökresultatet för ett visst språk eller område. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "hreflang-länkar informerar sökmotorer om vilken version av en sida de ska visa i sökresultatet för ett visst språk eller område. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Dokumentet har inte ett giltigt hreflang-värde"
+    "message": "Dokumentet har inte ett giltigt `hreflang`-värde"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Dokumentet har ett giltigt hreflang-värde"
+    "message": "Dokumentet har ett giltigt `hreflang`-värde"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Sidor med HTTP-statuskoder som indikerar att begäran misslyckades kanske inte indexeras korrekt. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -639,7 +894,7 @@
     "message": "Sidan är inte blockerad från indexering"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Beskrivande länktext hjälper sökmotorer att förstå ditt innehåll. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "Beskrivande länktext hjälper sökmotorer att förstå innehållet. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 länk hittades}other{# länkar hittades}}"
@@ -710,14 +965,26 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Överlappande tryckmål"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Storlek"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Tryckmål"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Tryckmål har lämplig storlek"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Tid för huvudtråd"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Tredje part"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Kod från tredje part kan påverka inläsningsprestandan betydligt. Begränsa antalet överflödiga tredjepartsleverantörer och testa att låta tredjepartskod läsas in efter att sidans huvudinnehåll har lästs in helt. [Läs mer](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 tredje part hittades}other{# tredje parter hittades}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Tredjepartsanvändning"
   },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Mätvärdet Tid till första byte anger när servern svarade. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Varaktighet"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Namn"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Starttid"
@@ -753,7 +1017,7 @@
     "message": "User Timing API – tidsstämplar och mått"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Ett <link>-element för föranslutning till {securityOrigin} hittades men ignorerades av webbläsaren. Kontrollera att attributet crossorigin används korrekt."
+    "message": "Ett <link>-element för föranslutning till {securityOrigin} hittades men ignorerades av webbläsaren. Kontrollera att attributet `crossorigin` används korrekt."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Lägg till signaler för förhandsanslutning eller DNS-förhandshämtning så att viktiga anslutningar till tredje part upprättas tidigt. [Läs mer](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Föranslut till obligatoriska källor"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "En <link> för förinläsning hittades för {preloadURL} men den användes inte av webbläsaren. Kontrollera att attributet crossorigin används korrekt."
+    "message": "En <link> för förinläsning hittades för {preloadURL} men den användes inte av webbläsaren. Kontrollera att attributet `crossorigin` används korrekt."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Prioritera upp resurser som för närvarande hämtas senare under sidinläsningen med <link rel=preload>. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Det kan vara bra att använda `<link rel=preload>` för att prioritera hämtning av resurser som kommer att begäras senare i sidinläsningen. [Läs mer](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Läs in viktiga resurser i förväg"
@@ -792,7 +1056,7 @@
     "message": "Dessa kontroller visar möjligheter att [förbättra tillgängligheten för din webbapp](https://developers.google.com/web/fundamentals/accessibility). Alla tillgänglighetsproblem kan inte identifieras automatiskt. Du bör därför även testa manuellt."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "Dessa punkter beskriver områden som inte kan testas automatiskt. Läs mer i vår handbok om att [granska tillgängligheten](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "Dessa punkter beskriver områden som inte kan testas automatiskt. Läs mer i vår guide om att [granska tillgängligheten](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Tillgänglighet"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tabeller och listor"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Bästa metoder"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Prestandabudget anger standard för webbplatsens prestanda."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budgetar"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Mer information om appens prestanda."
+    "message": "Mer information om appens prestanda. Värdena påverkar inte prestandapoängen [direkt](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostik"
@@ -840,7 +1113,7 @@
     "message": "Förbättringar av första skärmuppritningen"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "De här optimeringarna kan göra inläsningen av sidan snabbare."
+    "message": "Dessa förslag kan hjälpa sidan att läsas in snabbare. De påverkar inte prestandavärdet [direkt](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Möjligheter"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Lagringstid i cacheminnet"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Plats"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Namn"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Begäranden"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Resurstyp"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Storlek (kB)"
+    "message": "Storlek"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Tid som använts"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Överföringsstorlek"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "Webbadress"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Möjlig databesparing (kB)"
+    "message": "Möjlig besparing"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Möjlig tidsbesparing (ms)"
+    "message": "Möjlig besparing"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Möjlig databesparing: {wastedBytes, number, bytes} kB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Möjlig tidsbesparing: {wastedMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Dokument"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Teckensnitt"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Bild"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Media"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Annat"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Skript"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} s"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Formatmall"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Tredje part"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Totalt"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "Ett fel uppstod när spårningen skulle registreras för sidinläsningen. Kör Lighthouse igen. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Uppslagningen av den angivna domänen misslyckades på DNS-servern."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "En obligatorisk {artifactName}-insamlare påträffade ett fel: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Ett internt fel har uppstått i Chrome. Starta om Chrome och testa att köra Lighthouse igen."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "En {artifactName}-samlare som krävs kördes inte."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Det gick inte att läsa in den begärda sidan i Lighthouse. Kontrollera att du testar rätt webbadress och att servern svarar korrekt."
@@ -945,10 +1266,13 @@
     "message": "Det gick inte att läsa in den begärda webbadressen med Lighthouse eftersom sidan slutade svara."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Det finns inga giltiga användaruppgifter för den angivna webbadressen. {securityMessages}"
+    "message": "Den webbadress du angav har inget giltigt säkerhetscertifikat. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome förhindrade sidhämtning med en mellansidesannons. Kontrollera att du testar rätt webbadress och att servern svarar korrekt."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Det gick inte att läsa in den begärda sidan i Lighthouse. Kontrollera att du testar rätt webbadress och att servern svarar korrekt. (Information: {errorDetails})"
+    "message": "Det gick inte att läsa in den begärda sidan i Lighthouse. Kontrollera att du testar rätt webbadress och att servern svarar korrekt. (Mer information: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
     "message": "Det gick inte att läsa in den begärda sidan i Lighthouse. Kontrollera att du testar rätt webbadress och att servern svarar korrekt. (Statuskod: {statusCode})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Utöka utdrag"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Visa resurser från tredje part"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Problem uppstod med den här körningen av Lighthouse."
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Värdena är uppskattningar och kan variera."
+    "message": "Värdena är uppskattningar och kan variera. Prestandapoängen [baseras enbart på dessa mätvärden](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Godkänd i granskningarna men med varningar"
@@ -1026,7 +1353,7 @@
     "message": "Installera en [WordPress-plugin för lat inläsning](https://wordpress.org/plugins/search/lazy+load/) som ger möjlighet att skjuta upp inläsningen av bilder som inte visas på skärmen, eller byt till ett tema som har den funktionen. Du kan även använda [AMP-pluginmodulen](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Det finns ett antal pluginmoduler för WordPress som kan hjälpa dig att [lägga in kritiska tillgångar direkt på sidan](https://wordpress.org/plugins/search/critical+css/) eller [skjuta upp inläsningen av mindre viktiga resurser](https://wordpress.org/plugins/search/defer+css+javascript/). Tänk på att optimeringarna som dessa pluginmoduler gör kan leda till att funktioner i teman eller andra pluginmoduler slutar fungera, så du kan behöva ändra i koden."
+    "message": "Det finns ett antal pluginmoduler för WordPress som kan hjälpa dig att [lägga till kritiska tillgångar direkt på sidan](https://wordpress.org/plugins/search/critical+css/) eller [skjuta upp inläsningen av mindre viktiga resurser](https://wordpress.org/plugins/search/defer+css+javascript/). Tänk på att optimeringarna som dessa pluginmoduler gör kan leda till att funktioner i teman eller andra pluginmoduler slutar fungera, så du kan behöva ändra i koden."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Serverns svarstider påverkas av teman, pluginmoduler och serverns prestanda. Du kan använda ett mer optimerat tema, välja en optimeringsplugin och/eller uppgradera servern."
@@ -1035,10 +1362,10 @@
     "message": "Du kan visa utdrag i inläggslistan (t.ex. via en more-tagg), minska antalet inlägg på sidan, dela upp långa inlägg på flera sidor eller använda en plugin som läser in kommentarer med lat inläsning."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Det finns ett antal [pluginmoduler för WordPress](https://wordpress.org/plugins/search/minify+css/) som kan göra webbplatsen snabbare genom att sammanfoga, minifiera och komprimera formatmallar. Du kan också göra minifieringen direkt i konstruktionsfasen om möjligt."
+    "message": "Det finns ett antal [pluginmoduler för WordPress](https://wordpress.org/plugins/search/minify+css/) som kan göra webbplatsen snabbare genom att sammanfoga, minifiera och komprimera skript. Du kan också göra minifieringen direkt i konstruktionsfasen om möjligt."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Det finns ett antal [pluginmoduler för WordPress](https://wordpress.org/plugins/search/minify+javascript/) som kan göra webbplatsen snabbare genom att sammanfoga, minifiera och komprimera skript. Du kan också göra minifieringen direkt i konstruktionsfasen om möjligt."
+    "message": "Ett antal [pluginmoduler för WordPress](https://wordpress.org/plugins/search/minify+javascript/) kan göra webbplatsen snabbare genom att sammanfoga, minifiera och komprimera skript. Du kan också göra minifieringen direkt i konstruktionsfasen om möjligt."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
     "message": "Du kan minska antalet [WordPress-pluginmoduler](https://wordpress.org/plugins/) som läser in CSS som inte används på sidan, eller byta ut dem. Testa fliken för [kodtäckning](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) i Chromes utvecklarverktyg om du vill se vilka pluginmoduler som lägger till överflödig CSS. Du ser på CSS-formatmallens webbadress vilket tema eller vilken plugin som koden kommer från. Titta efter pluginmoduler med många CSS-formatmallar på listan där en stor del av stapeln är röd. En plugin ska bara ställa en formatmall i kö för inläsning om den faktiskt används på sidan."
@@ -1050,15 +1377,15 @@
     "message": "Läs mer om [cachelagring i webbläsaren och WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Du kan använda en [WordPress-plugin för bildoptimering](https://wordpress.org/plugins/search/optimize+images/) som komprimerar bilderna utan att göra avkall på kvaliteten."
+    "message": "Du kan använda en [WordPress-plugin för bildoptimering](https://wordpress.org/plugins/search/optimize+images/) som komprimerar dina bilder utan att göra avkall på kvaliteten."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Säkerställ att de bildstorlekar som krävs finns tillgängliga genom att ladda upp bilderna direkt via [mediebiblioteket](https://codex.wordpress.org/Media_Library_Screen) och infoga dem sedan från mediebiblioteket eller med bildwidgeten, så att de optimala bildstorlekarna används (även för brytpunkterna för responsiv design). Undvik fullstora bilder, såvida de inte har mått som passar där bilderna ska användas. [Läs mer](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Säkerställ att de bildstorlekar som krävs finns tillgängliga genom att ladda upp bilderna direkt via [mediebiblioteket](https://codex.wordpress.org/Media_Library_Screen) och infoga dem sedan från mediebiblioteket eller med bildwidgeten, så att de optimala bildstorlekarna används (även för brytpunkterna för responsiv design). Undvik att använda `Full Size`-bilder såvida de inte har mått som passar där bilderna ska användas. [Läs mer](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Du kan aktivera textkomprimering i webbserverns konfiguration."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Du kan använda en [plugin](https://wordpress.org/plugins/search/convert+webp/) eller tjänst som konverterar uppladdade bilder till optimalt format automatiskt."
+    "message": "Det kan vara bra att använda en [plugin](https://wordpress.org/plugins/search/convert+webp/) eller tjänst som automatiskt konverterar uppladdade bilder till optimalt format."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/ta.json
+++ b/lighthouse-core/lib/i18n/locales/ta.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "பயனர்கள் பக்கத்தின் ஒரு பகுதிக்கு விரைவாகச் செல்ல அணுகல் விசைகள் உதவும். சரியாகச் செல்வதற்கு, ஒவ்வொரு அணுகல் விசையும் தனித்துவமானதாக இருக்க வேண்டும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "பக்கத்தின் ஏதேனும் ஒரு பகுதிக்கு விரைவாகச் செல்ல அணுகல் விசைகளைப் பயனர்கள் பயன்படுத்தலாம். சரியாகச் செல்வதற்கு, ஒவ்வொரு அணுகல் விசையும் தனித்துவமானதாக இருக்க வேண்டும். [மேலும் அறிக](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "`[accesskey]` மதிப்புகள் பிரத்யேகமானவை அல்ல"
+    "message": "`[accesskey]` மதிப்புகள் பிரத்தியேகமானவையாக இல்லை"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "`[accesskey]` மதிப்புகள் பிரத்யேகமானவையாக உள்ளன"
+    "message": "`[accesskey]` மதிப்புகள் தனித்துவமாக உள்ளன"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "ஒவ்வொரு ARIA `role` உம் குறிப்பிட்ட `aria-*` பண்புக்கூறுகளின் துணைத்தொகுப்பை ஆதரிக்கும். இவை பொருந்தவில்லை எனில் `aria-*` பண்புக்கூறுகள் செல்லுபடியாகாது. [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "ஒவ்வொரு ARIA `role` நியமனமும் `aria-*` பண்புக்கூறுகளின் குறிப்பிட்ட துணைத்தொகுப்பை ஆதரிக்கும். பொருந்தாதபட்சத்தில் `aria-*` பண்புக்கூறுகள் செல்லுபடியாகாதவையாகும். [மேலும் அறிக](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "`[aria-*]` பண்புக்கூறுகள் தங்கள் பங்களிப்புகளுடன் பொருந்தவில்லை"
+    "message": "`[aria-*]` பண்புக்கூறுகள் அவற்றின் பங்களிப்புகளுடன் பொருந்தவில்லை"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "`[aria-*]` பண்புக்கூறுகள் தங்களுடைய பங்களிப்புகளுடன் பொருந்துகின்றன"
+    "message": "`[aria-*]` பண்புக்கூறுகள் அவற்றின் பங்களிப்புகளுடன் பொருந்துகின்றன"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "சில ARIA பங்களிப்புகளில் ஸ்க்ரீன் ரீடர்களுக்கு உறுப்பின் நிலையை விவரிக்கும் தேவையான பண்புக்கூறுகள் உள்ளன. [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "சில ARIA பங்களிப்புகளில் ஸ்க்ரீன் ரீடர்களுக்கு உறுப்பின் நிலையை விவரிக்கத் தேவையான பண்புக்கூறுகள் உள்ளன. [மேலும் அறிக](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "`[role]`களுக்குத் தேவையான அனைத்து `[aria-*]` பண்புக்கூறுகளும் இல்லை"
+    "message": "`[role]`கள் தேவையான அனைத்து `[aria-*]` பண்புக்கூறுகளையும் கொண்டிருக்கவில்லை"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "`[role]`களில் தேவையான அனைத்து `[aria-*]` பண்புக்கூறுகளும் உள்ளன"
+    "message": "தேவையான அனைத்து `[aria-*]` பண்புக்கூறுகளும் `[role]`களில் உள்ளன"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "சில ARIA முதல்நிலைப் பங்களிப்புகள், அவற்றுக்கான அணுகல்தன்மைச் செயல்பாடுகளைச் செய்ய, குறிப்பிட்ட உபநிலைப் பங்களிப்புகளைக் கொண்டிருக்க வேண்டும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "சில ARIA முதல்நிலைப் பங்களிப்புகள், அவற்றுக்கான அணுகல்தன்மை செயல்பாடுகளை செய்ய, குறிப்பிட்ட உபநிலைப் பங்களிப்புகளைக் கொண்டிருக்க வேண்டும். [மேலும் அறிக](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "குறிப்பிட்ட உபநிலை `[role]`கள் தேவையான `[role]` உறுப்புகள் விடுபட்டுள்ளன."
+    "message": "குறிப்பிட்ட உபநிலை `[role]`கள் தேவையான `[role]` உடனுள்ள உறுப்புகள் விடுபட்டுள்ளன."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "குறிப்பிட்ட உபநிலை `[role]`கள் தேவைப்படும் `[role]`கள் உள்ளன"
+    "message": "குறிப்பிட்ட உபநிலை `[role]`களுக்குத் தேவையான உறுப்புகளுடன் இருக்கும் `[role]`கள் இருக்கின்றன"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "சில ARIA உபநிலைப் பங்களிப்புகள் அவற்றுக்கான அணுகல்தன்மைச் செயல்பாடுகளைச் சரியாகச் செய்வதற்கு, குறிப்பிட்ட முதல்நிலைப் பங்களிப்புகளில் இருக்க வேண்டும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "சில ARIA உபநிலைப் பங்களிப்புகள் அவற்றுக்கான அணுகல்தன்மை செயல்பாடுகளை சரியாக செய்ய, குறிப்பிட்ட முதல்நிலைப் பங்களிப்புகளில் இருக்க வேண்டும். [மேலும் அறிக](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "`[role]`கள் தங்களுக்குத் தேவையான முதல்நிலை உறுப்புக்குள் இல்லை"
+    "message": "`[role]`கள் அவற்றுக்குத் தேவையான முதல்நிலை உறுப்புக்குள் இல்லை"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "`[role]கள் அவற்றுக்குத் தேவையான முதல்நிலை உறுப்பிற்குள் உள்ளன"
+    "message": "`[role]`கள் அவற்றுக்குத் தேவையான முதல்நிலை உறுப்புகளால் கட்டுப்படுத்தப்பட்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA பங்களிப்புகள் தங்களுக்கான அணுகல்தன்மைச் செயல்பாடுகளைச் செய்வதற்கு, அவற்றுக்குச் செல்லுபடியாகும் மதிப்புகள் இருக்க வேண்டும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA பங்களிப்புகள் தங்களுக்கான அணுகல்தன்மை செயல்பாடுகளை செய்ய அவற்றில் செல்லுபடியாகும் மதிப்புகள் இருக்க வேண்டும். [மேலும் அறிக](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "`[role]` மதிப்புகள் செல்லுபடியாகவில்லை"
+    "message": "`[role]` செல்லுபடியாகாத மதிப்புகளைக் கொண்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "`[role]` மதிப்புகள் செல்லுபடியாகின்றன"
+    "message": "`[role]` செல்லுபடியாகும் மதிப்புகளைக் கொண்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "செல்லுபடியாகாத மதிப்புகள் உள்ள ARIA பண்புக்கூறுகளை ஸ்க்ரீன் ரீடர்கள் போன்ற உதவிகரமான தொழில்நுட்பங்களால் புரிந்துகொள்ள இயலாது. [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "செல்லுபடியாகாத மதிப்புகள் உள்ள ARIA பண்புக்கூறுகளை ஸ்க்ரீன் ரீடர்கள் போன்ற உதவிகரமான தொழில்நுட்பங்களால் புரிந்துகொள்ள இயலாது. [மேலும் அறிக](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "`[aria-*]` உறுப்புகளுக்குச் செல்லுபடியாகும் மதிப்புகள் இல்லை"
+    "message": "`[aria-*]` பண்புக்கூறுகள் செல்லுபடியாகும் மதிப்புகளைக் கொண்டிருக்கவில்லை"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "`[aria-*]` பண்புக்கூறுகளில் செல்லுபடியாகும் மதிப்புகள் உள்ளன"
+    "message": "`[aria-*]` பண்புக்கூறுகள் செல்லுபடியாகும் மதிப்புகளைக் கொண்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "செல்லுபடியாகாத பெயர்கள் உள்ள ARIA பண்புக்கூறுகளை ஸ்க்ரீன் ரீடர்கள் போன்ற உதவிகரமான தொழில்நுட்பங்களால் புரிந்துகொள்ள இயலாது. [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "செல்லுபடியாகாத பெயர்கள் உள்ள ARIA பண்புக்கூறுகளை ஸ்க்ரீன் ரீடர்கள் போன்ற உதவிகரமான தொழில்நுட்பங்களால் புரிந்துகொள்ள இயலாது. [மேலும் அறிக](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "`[aria-*]` பண்புக்கூறுகள் செல்லுபடியாகவில்லை அல்லது தவறாக உள்ளிடப்பட்டுள்ளன"
+    "message": "`[aria-*]` பண்புக்கூறுகள் செல்லுபடியாகாத மதிப்புகளைக் கொண்டுள்ளன அல்லது தவறாக உள்ளிடப்பட்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "`[aria-*]` பண்புக்கூறுகள் செல்லுபடியாகின்றன மற்றும் சரியாக உள்ளிடப்பட்டுள்ளன"
+    "message": "`[aria-*]` பண்புக்கூறுகள் செல்லுபடியாகும் மதிப்புகளைக் கொண்டுள்ளன, மேலும் அவை சரியாக உள்ளிடப்பட்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "வசனங்களில் காதுகேளாத அல்லது செவித்திறன் குறைவான பயனர்களின் வசதிக்காக யார் என்ன பேசுகிறார்கள் மற்றும் பேச்சல்லாத பிற தகவல்கள் போன்ற முக்கியமான தகவல்களை வழங்குவதன் மூலம் ஆடியோ உறுப்புகளைப் பயனுள்ளதாக்கலாம். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "வசனங்களில் காது கேளாதோர், செவித்திறன் குறைவானவர்கள் வசதிக்காக யார் என்ன பேசுகிறார்கள் என்பதையும் பேச்சல்லாத பிற தகவல்கள் போன்ற முக்கியமான தகவல்களையும் வழங்குவதன் மூலம் ஆடியோ உறுப்புகளைப் பயனுள்ளதாக்கலாம். [மேலும் அறிக](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "`<audio>` உறுப்புகளில் `[kind=\"captions\"]` உள்ள `<track>` உறுப்பு இல்லை."
+    "message": "`<audio>` உறுப்புகளில் `[kind=\"captions\"]` உடன் இருக்கும்`<track>` உறுப்பு ஒன்று விடுபட்டுள்ளது."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "`<audio>` உறுப்புகள், `[kind=\"captions\"]` உள்ள `<track>` உறுப்பைக் கொண்டுள்ளன"
+    "message": "`[kind=\"captions\"]` உடன் `<track>` உறுப்பைக் கொண்டிருக்கும் `<audio>` உறுப்புகள்"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "தோல்வியுற்ற உறுப்புகள்"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "ஒரு பட்டனுக்குத் தெளிவான பெயர் இல்லை என்றால் ஸ்க்ரீன் ரீடர்கள் அதை \"பட்டன்\" என அறிவிக்கும், இது ஸ்க்ரீன் ரீடர்களைப் பயன்படுத்தும் பயனர்களுக்கு உதவியாக இருக்காது. [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "ஒரு பட்டனுக்குத் தெளிவான பெயர் இல்லையெனில் ஸ்க்ரீன் ரீடர்கள் அதை \"பட்டன்\" என அறிவிக்கும், இது ஸ்க்ரீன் ரீடர்களைப் பயன்படுத்தும் பயனர்களுக்கு உதவியாக இருக்காது. [மேலும் அறிக](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "பட்டன்களுக்குத் தெளிவான பெயர் இல்லை"
@@ -93,7 +93,7 @@
     "message": "பட்டன்களுக்கு ஸ்க்ரீன் ரீடர்களால் படிக்கக்கூடிய பெயர்கள் உள்ளன"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "திரும்பத்திரும்ப வரும் உள்ளடக்கத்தை மீறிச் செல்லும் வழிகளைச் சேர்த்தால், பக்கத்தைக் கீபோர்டுப் பயனர்கள் மேலும் திறனுள்ள வகையில் கையாள முடியும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "திரும்பத்திரும்ப வரும் உள்ளடக்கத்தை மீறி செல்லும் வழிகளை சேர்த்தால், பக்கத்தைக் கீபோர்டுப் பயனர்கள் மேலும் திறனுள்ள வகையில் கையாள முடியும். [மேலும் அறிக](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "பக்கத்தில் தலைப்பு, தவிர்ப்பு இணைப்பு அல்லது இட அடையாள மண்டலம் இல்லை"
@@ -102,7 +102,7 @@
     "message": "பக்கத்தில் தலைப்பு, தவிர்ப்பு இணைப்பு அல்லது இட அடையாள மண்டலம் உள்ளது"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "குறைவான ஒளி மாறுபாடுள்ள உரையைப் படிப்பதற்குப் பெரும்பாலான பயனர்களுக்குக் கடினமாகவோ இயலாததாகவோ இருக்கும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "பெரும்பாலான பயனர்களால் குறைவான ஒளி மாறுபாடுள்ள உரையைப் படிக்க இயலாது அல்லது கடினமாக இருக்கும். [மேலும் அறிக](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "பின்னணி, முன்னணி நிறங்களுக்குப் போதுமான ஒளி மாறுபாடு விகிதம் இல்லை."
@@ -111,25 +111,25 @@
     "message": "பின்னணி, முன்னணி நிறங்கள் போதுமான ஒளி மாறுபாட்டு விகிதத்தைக் கொண்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "வரையறைப் பட்டியல்கள் சரியாகக் குறிக்கப்படவில்லை எனில், ஸ்க்ரீன் ரீடர்கள் குழப்பமான அல்லது துல்லியமற்ற வெளியீட்டை தரக்கூடும்.\n [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "வரையறைப் பட்டியல்கள் சரியாகக் குறிக்கப்படவில்லை எனில் ஸ்க்ரீன் ரீடர்கள் குழப்பமான அல்லது துல்லியமற்ற வெளியீட்டைத் தரக்கூடும். [மேலும் அறிக](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "`<dl>`கள் சரியாக வரிசைப்படுத்தப்பட்ட `<dt>` மற்றும் `<dd>` குழுக்கள், `<script>` அல்லது `<template>` உறுப்புகளை மட்டும் கொண்டிருக்கவில்லை."
+    "message": "சரியாக வரிசைப்படுத்தப்பட்ட `<dt>`, `<dd>` குழுக்கள், `<script>` அல்லது `<template>` உறுப்புகள் மட்டுமல்லாது வேறு வகைகளையும் `<dl>` கொண்டுள்ளது."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "`<dl>`களில் சரியாக வரிசைப்படுத்தப்பட்ட `<dt>` மற்றும் `<dd>` குழுக்கள், `<script>` அல்லது `<template>` உறுப்புகள் மட்டுமே உள்ளன."
+    "message": "`<dl>`கள் முறையாக வரிசைப்படுத்தப்பட்ட `<dt>`, `<dd>` குழுக்களையும் `<script>` அல்லது `<template>` உறுப்புகளையும் மட்டுமே கொண்டிருக்கும்."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "வரையறைப் பட்டியல் உறுப்புகளை (`<dt>` மற்றும் `<dd>`) ஸ்க்ரீன் ரீடர்கள் சரியாகப் படிப்பதற்கு, அவை ஒரு முதல்நிலை `<dl>` உறுப்பில் உட்பொதிக்கப்பட்டிருக்க வேண்டும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "விளக்கப்பட்டியலில் உள்ளவற்றை (`<dt>`,`<dd>`) ஸ்க்ரீன் ரீடர்கள் சரியாகப் படிக்க அவை ஒரு முதல்நிலை `<dl>` உறுப்பில் சேர்க்கப்பட்டிருக்க வேண்டும். [மேலும் அறிக](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "வரையறைப் பட்டியல் உறுப்புகள் `<dl>` உறுப்புகளுக்குள் உட்பொதிக்கப்படவில்லை"
+    "message": "விளக்கப்பட்டியலில் உள்ளவை`<dl>` உறுப்புகளில் சேர்க்கப்படவில்லை"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "வரையறைப் பட்டியல் உறுப்புகள் `<dl>` உறுப்புகளில் உட்பொதிக்கப்பட்டுள்ளன"
+    "message": "விளக்கப் பட்டியலில் உள்ளவை`<dl>` உறுப்புகளில் சேர்க்கப்பட்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "தலைப்பு, அந்தப் பக்கத்தைப் பற்றிய அறிமுகத்தை ஸ்க்ரீன் ரீடர் பயனர்களுக்கு வழங்குகிறது, தேடல் இன்ஜின் பயனர்கள் தங்களுடைய தேடலுடன் பக்கம் பொருந்துகின்றதா என்பதைத் தீர்மானிக்க அதைப் பெரிதும் நம்பியுள்ளனர். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "தலைப்பானது அந்தப் பக்கத்தைப் பற்றிய மேலோட்ட விவரங்களை ஸ்க்ரீன் ரீடர் பயனர்களுக்கு வழங்குகிறது, தேடல் இன்ஜின் பயனர்கள் தங்களுடைய தேடலுடன் பக்கம் பொருந்துகின்றதா என்பதைத் தீர்மானிக்க அதைப் பெரிதும் நம்பியுள்ளனர். [மேலும் அறிக](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "ஆவணத்தில் `<title>` உறுப்பு இல்லை"
@@ -138,16 +138,16 @@
     "message": "ஆவணத்தில் `<title>` உறுப்பு உள்ளது"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "உதவிகரமான தொழில்நுட்பங்களால் நேர்வுகள் புறக்கணிக்கப்படுவதைத் தடுக்க, ஐடி பண்புக்கூறின் மதிப்பு தனித்துவமானதாக இருக்க வேண்டும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "உதவிகரமான தொழில்நுட்பங்களால் நேர்வுகள் புறக்கணிக்கப்படுவதைத் தடுக்க, ஐடி பண்புக்கூறின் மதிப்பு பிரத்தியேகமானவையாக இருக்க வேண்டும். [மேலும் அறிக](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "பக்கத்திலுள்ள `[id]` பண்புக்கூறுகள் பிரத்யேகமானவையாக இல்லை"
+    "message": "பக்கத்திலுள்ள `[id]` பண்புக்கூறுகள் பிரத்தியேகமானவையாக இல்லை"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "பக்கத்தில் உள்ள `[id]` பண்புக்கூறுகள் பிரத்யேகமானவையாக உள்ளன"
+    "message": "பக்கத்தில் உள்ள `[id]` பண்புக்கூறுகள் பிரத்தியேகமானவை"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "ஃபிரேம்களில் உள்ள உள்ளடக்கங்களை விவரிப்பதற்கு, அவற்றின் தலைப்பை ஸ்க்ரீன் ரீடர் பயனர்கள் சார்ந்துள்ளனர். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "ஃபிரேம்களில் உள்ளவற்றை விவரிக்க அவற்றின் தலைப்பை ஸ்க்ரீன் ரீடர் பயனர்கள் சார்ந்துள்ளனர். [மேலும் அறிக](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "`<frame>` அல்லது `<iframe>` உறுப்புகளுக்குத் தலைப்பு இல்லை"
@@ -156,43 +156,43 @@
     "message": "`<frame>` அல்லது `<iframe>` உறுப்புகளுக்குத் தலைப்பு உள்ளது"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "மொழிப் பண்புக்கூறைப் பக்கம் குறிப்பிடவில்லை என்றால், ஸ்க்ரீன் ரீடரை அமைக்கும்போது பயனர் தேர்வுசெய்த மொழியையே பக்கத்தின் இயல்பு மொழியாக ஸ்க்ரீன் ரீடர் கருதும். இயல்பு மொழியில் பக்கம் இல்லையென்றால், பக்கத்தின் உரையை ஸ்க்ரீன் ரீடர் சரியாகப் படிக்காமல் போகக்கூடும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "ஒரு பக்கமானது மொழியின் பண்புக்கூறைக் குறிப்பிடவில்லை எனில் ஸ்க்ரீன் ரீடரை அமைக்கும்போது பயனர் தேர்வுசெய்த மொழியையே பக்கத்தின் இயல்பு மொழியாக ஸ்க்ரீன் ரீடர் கருதும். இயல்பு மொழியில் பக்கம் இல்லை எனில் பக்கத்தின் உரையை ஸ்க்ரீன் ரீடர் சரியாக வாசிக்க முடியாமல் போகக்கூடும். [மேலும் அறிக](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "`<html>` உறுப்பில் `[lang]` பண்புக்கூறு இல்லை"
+    "message": "`<html>` உறுப்பில்`[lang]` பண்புக்கூறு இல்லை"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "`<html>` உறுப்பில் `[lang]` பண்புக்கூறு உள்ளது"
+    "message": "`<html>` உறுப்பானது`[lang]` பண்புக்கூறைக் கொண்டுள்ளது"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "செல்லுபடியாகும் [BCP 47 language]ஐ (https://www.w3.org/International/questions/qa-choosing-language-tags#question) குறிப்பிட்டால், அது உரையை ஸ்க்ரீன் ரீடர் சரியாகப் படிப்பதற்கு உதவியாக இருக்கும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "செல்லுபடியாகும் [BCP 47 மொழியைக்](https://www.w3.org/International/questions/qa-choosing-language-tags#question) குறிப்பிட்டால், உரையை ஸ்க்ரீன் ரீடர்கள் சரியாகப் படிக்க அது உதவியாக இருக்கும். [மேலும் அறிக](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "`<html>` உறுப்பில் அதன் `[lang]` பண்புக்கூறுக்குச் செல்லுபடியாகும் மதிப்பு இல்லை."
+    "message": "`<html>` உறுப்பில் அதன்`[lang]` பண்புக்கூறுக்கான செல்லுபடியாகும் மதிப்பு இல்லை."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "`<html>` உறுப்பில் அதன் `[lang]` பண்புக்கூறுக்குச் செல்லுபடியாகும் மதிப்பு உள்ளது"
+    "message": "`<html>` உறுப்பில் அதன்`[lang]` பண்புக்கூறுக்கான செல்லுபடியாகும் மதிப்பு உள்ளது"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "தகவல் உறுப்புகள் சுருக்கமான, விளக்கமான மாற்று உரையைக் கொண்டிருக்க வேண்டும். அலங்கார உறுப்புகளில் காலியான மாற்றுப் பண்புக்கூறு இருக்கலாம். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "தகவல் உறுப்புகள் சுருக்கமான, விளக்கமான மாற்று உரையைக் கொண்டிருக்க வேண்டும். அலங்கார உறுப்புகளில் காலியான மாற்றுப் பண்புக்கூறு இருக்கலாம். [மேலும் அறிக](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "பட உறுப்புகளுக்கு `[alt]` பண்புக்கூறுகள் இல்லை"
+    "message": "பட உறுப்புகளில் `[alt]` பண்புக்கூறுகள் இல்லை"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "பட உறுப்புகளுக்கு `[alt]` பண்புக்கூறுகள் உள்ளன"
+    "message": "பட உறுப்புகள் `[alt]` பண்புக்கூறுகளைக் கொண்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "`<input>` பட்டனாக ஒரு படம் பயன்படுத்தப்படும்போது, அந்த பட்டனுக்கான மாற்று உரையை வழங்கினால், அதன் செயல்பாட்டை ஸ்க்ரீன் ரீடர் பயனர்கள் புரிந்துகொள்ள உதவியாக இருக்கும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "`<input>` பட்டனாக ஒரு படத்தைப் பயன்படுத்தும்போது அந்த பட்டனுக்கான மாற்று உரையை வழங்குவது அதன் செயல்பாட்டை ஸ்க்ரீன் ரீடர் பயனர்கள் புரிந்துகொள்ள உதவியாக இருக்கும். [மேலும் அறிக](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "`<input type=\"image\">` உறுப்புகளுக்கு `[alt]` உரை இல்லை"
+    "message": "`<input type=\"image\">` உறுப்புகளில் `[alt]` உரை இல்லை"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "`<input type=\"image\">` உறுப்புகளுக்கு `[alt]` உரை உள்ளது"
+    "message": "`<input type=\"image\">` உறுப்புகள் `[alt]` உரையைக் கொண்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "ஸ்க்ரீன் ரீடர்கள் போன்ற உதவிகரமான தொழில்நுட்பங்களால் சரியாக அறிவிக்கப்படும் வகையில் படிவக் கட்டுப்பாடுகள் இருப்பதை லேபிள்கள் உறுதிசெய்கின்றன. [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "ஸ்க்ரீன் ரீடர்கள் போன்ற உதவிகரமான தொழில்நுட்பங்களால் சரியாக அறிவிக்கப்படும் வகையில் படிவக் கட்டுப்பாடுகள் இருப்பதை லேபிள்கள் உறுதிசெய்கின்றன. [மேலும் அறிக](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "படிவ உறுப்புகளுக்கு, தொடர்புடைய லேபிள்கள் இல்லை"
@@ -201,16 +201,16 @@
     "message": "படிவ உறுப்புகளுக்கு, தொடர்புடைய லேபிள்கள் உள்ளன"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "தளவமைப்புக்காகப் பயன்படுத்தப்படும் டேபிளில் th அல்லது வசன உறுப்புகள் அல்லது சுருக்கவிவரப் பண்புக்கூறு போன்ற தரவு உறுப்புகளைச் சேர்க்கக் கூடாது, ஏனெனில் இது ஸ்க்ரீன் ரீடர் பயனர்களுக்குக் குழப்பத்தை ஏற்படுத்தும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "தளவமைப்புக்காகப் பயன்படுத்தப்படும் டேபிளில் th, வசன உறுப்புகள், சுருக்கவிவரப் பண்புக்கூறு போன்ற தரவு உறுப்புகளை சேர்க்கக் கூடாது, ஏனெனில் இது ஸ்க்ரீன் ரீடர் பயனர்களுக்குக் குழப்பத்தை ஏற்படுத்தும். [மேலும் அறிக](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "விளக்க `<table>` உறுப்புகள் `<th>`, `<caption>` அல்லது `[summary]` பண்புக்கூறைப் பயன்படுத்துவதைத் தவிர்க்கவில்லை."
+    "message": "`<th>`, `<caption>` அல்லது `[summary]` பண்புக்கூறைப் பயன்படுத்துவதை விளக்க `<table>` உறுப்புகள் தவிர்க்கவில்லை."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "விளக்க `<table>` உறுப்புகளில் `<th>`, `<caption>` அல்லது `[summary]` பண்புக்கூறின் உபயோகம் தவிர்க்கப்பட்டுள்ளது."
+    "message": "`<th>`, `<caption>` அல்லது `[summary]` பண்புக்கூறைப் பயன்படுத்துவதை விளக்க `<table>` உறுப்புகள் தவிர்க்கும்."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "தெளிவான, தனித்துவமான, மையப்படுத்தக்கூடிய இணைப்பு உரை (மற்றும் இணைப்புகளாகப் பயன்படுத்தப்படும் படங்களுக்கான மாற்று உரை) ஸ்க்ரீன் ரீடர் பயனர்களுக்கான வழிகாட்டும் அனுபவத்தை மேம்படுத்தும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "தெளிவான, தனித்துவமான, மையப்படுத்தக்கூடிய இணைப்பு உரை (மற்றும் இணைப்புகளாகப் பயன்படுத்தப்படும் படங்களுக்கான மாற்று உரை) ஸ்க்ரீன் ரீடர் பயனர்களுக்கான வழிகாட்டும் அனுபவத்தை மேம்படுத்தும். [மேலும் அறிக](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "இணைப்புகளுக்குத் தெளிவான பெயர் இல்லை"
@@ -219,103 +219,115 @@
     "message": "இணைப்புகளுக்குத் தெளிவான பெயர்கள் உள்ளன"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "பட்டியல்களை அறிவிப்பதற்கு ஸ்க்ரீன் ரீடர்களுக்கென ஒரு குறிப்பிட்ட வழிமுறை உள்ளது. சரியான பட்டியல் வடிவமைப்பை உறுதிசெய்தால், அது ஸ்க்ரீன் ரீடர் வெளியீட்டுக்கு உதவிசெய்யும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "பட்டியல்களை அறிவிப்பதற்கு ஸ்க்ரீன் ரீடர்களுக்கென ஒரு குறிப்பிட்ட வழிமுறை உள்ளது. சரியான பட்டியல் வடிவமைப்பை உறுதிசெய்தால் அது ஸ்க்ரீன் ரீடர் வெளியீட்டுக்கு உதவிசெய்யும். [மேலும் அறிக](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "பட்டியல்களில் `<li>` உறுப்புகள் மற்றும் ஸ்கிரிப்ட்டை ஆதரிக்கும் உறுப்புகள் (`<script>` மற்றும் `<template>`) மட்டும் இல்லை."
+    "message": "பட்டியல்களில் `<li>` உறுப்புகள், ஸ்கிரிப்ட்டை ஆதரிக்கும் உறுப்புகள்(`<script>`,`<template>`) மட்டுமல்லாமல் வேறு உறுப்புகளும் உள்ளன."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "பட்டியல்களில் `<li>` உறுப்புகள் மற்றும் ஸ்கிரிப்ட்டை ஆதரிக்கும் உறுப்புகள் (`<script>` and `<template>`) மட்டும் உள்ளன."
+    "message": "`<li>` உறுப்புகள், ஸ்கிரிப்ட்டை ஆதரிக்கும் உறுப்புகள் (`<script>`, `<template>`) ஆகியவை மட்டும் பட்டியல்களில் உள்ளன."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "பட்டியல் உறுப்புகளை (`<li>`) ஸ்க்ரீன் ரீடர்கள் சரியாகப் படிப்பதற்கு, அவை ஒரு முதல்நிலை `<ul>` அல்லது `<ol>`க்குள் இருக்க வேண்டும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "பட்டியல் உறுப்புகளை (`<li>`) ஸ்க்ரீன் ரீடர்கள் சரியாகப் படிப்பதற்கு அவை ஒரு முதல்நிலை `<ul>` அல்லது `<ol>`க்குள் இருக்க வேண்டும். [மேலும் அறிக](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "(`<li>`) பட்டியல் உறுப்புகள், `<ul>` அல்லது `<ol>` முதல்நிலை உறுப்புகளுக்குள் இல்லை."
+    "message": "பட்டியலிலுள்ளவை (`<li>`) `<ul>` என்பதிலோ `<ol>` முதல்நிலை உறுப்புகளிலோ இல்லை."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "பட்டியல் உறுப்புகள் (`<li>`), `<ul>` அல்லது `<ol>` முதல்நிலை உறுப்புகளுக்குள் இல்லை"
+    "message": "பட்டியலிலுள்ளவை (`<li>`), `<ul>` அல்லது `<ol>` முதல்நிலை உறுப்புகளுக்குள் இருக்கும்"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "பக்கம் தானாகப் புதுப்பிக்கும் எனப் பயனர்கள் எதிர்பார்க்க மாட்டார்கள். அவ்வாறு ஏற்பட்டால் பக்கம் மீண்டும் முதலில் இருந்தே காட்டப்படும். இது அவர்களுக்குக் குழப்பத்தை விளைவிக்கக்கூடும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "பக்கம் தானாகப் புதுப்பிக்கும் எனப் பயனர்கள் எதிர்பார்க்க மாட்டார்கள். அவ்வாறு ஏற்பட்டால் பக்கம் மீண்டும் முதலில் இருந்தே காட்டப்படும். இது அவர்களுக்குக் குழப்பத்தை விளைவிக்கக்கூடும். [மேலும் அறிக](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "`<meta http-equiv=\"refresh\">`ஐ ஆவணம் பயன்படுத்துகிறது"
+    "message": "ஆவணம் `<meta http-equiv=\"refresh\">`ஐப் பயன்படுத்துகிறது"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "`<meta http-equiv=\"refresh\">`ஐப் படிவம் பயன்படுத்தவில்லை"
+    "message": "`<meta http-equiv=\"refresh\">`ஐ ஆவணம் பயன்படுத்தவில்லை"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "அளவு மாற்றத்தை முடக்கினால், இணையப் பக்கத்தின் உள்ளடக்கத்தைச் சரியாகப் பார்ப்பதற்குத் திரை உருப்பெருக்கச் செயல்பாட்டைச் சார்ந்துள்ள பார்வைக் குறைபாடுள்ள பயனர்களுக்குச் சிக்கல் ஏற்படும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "அளவை மாற்றும் வசதியை முடக்கினால் இணையப் பக்கத்தில் உள்ளவற்றைத் தெளிவாகப் பார்க்க 'திரையைப் பெரிதாக்கும் செயல்பாட்டைப்' பயன்படுத்தும் பார்வைக் குறைபாடுள்ள பயனர்களுக்கு சிக்கல் ஏற்படும். [மேலும் அறிக](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "`<meta name=\"viewport\">` உறுப்பு அல்லது `[maximum-scale]` பண்புக்கூறில் பயன்படுத்தப்பட்டுள்ள `[user-scalable=\"no\"]` இன் மதிப்பு 5க்கும் குறைவாக உள்ளது."
+    "message": "`<meta name=\"viewport\">` உறுப்பில் `[user-scalable=\"no\"]` பயன்படுத்தப்பட்டுள்ளது அல்லது `[maximum-scale]` பண்புக்கூறின் மதிப்பு 5க்குக் கீழ் உள்ளது."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
     "message": "`<meta name=\"viewport\">` உறுப்பில் `[user-scalable=\"no\"]` பயன்படுத்தப்படவில்லை, `[maximum-scale]` பண்புக்கூறு 5க்குக் குறைவாக இல்லை."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "உரை அல்லாத உள்ளடக்கத்தை ஸ்க்ரீன் ரீடர்களால் மொழிபெயர்க்க முடியாது. `<object>` உறுப்புகளுக்கு மாற்று உரையைச் சேர்ப்பது பயனர்களுக்கு ஸ்க்ரீன் ரீடர்கள் சரியான அர்த்தத்தை வெளிப்படுத்த உதவும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "உரை அல்லாதவற்றை ஸ்க்ரீன் ரீடர்களால் மொழிபெயர்க்க முடியாது. `<object>` உறுப்புகளுக்கு மாற்று உரையை சேர்த்தால் அவற்றுக்கான அர்த்தத்தை ஸ்க்ரீன் ரீடர்கள் பயனர்களுக்குத் தெரிவிக்கும். [மேலும் அறிக](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "`<object>` உறுப்புகளுக்கு `[alt]` உரை இல்லை"
+    "message": "`<object>` உறுப்புகளில் `[alt]` உரை இல்லை"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "`<object>` உறுப்புகளில் `[alt]` உரை உள்ளது"
+    "message": "`<object>` உறுப்புகள் `[alt]` உரையைக் கொண்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "0க்கு அதிகமான மதிப்பு, வெளிப்படையான ஒரு வழிகாட்டும் ஆணையைக் குறிப்பிடுகிறது. முறைப்படி செல்லுபடியாகும் என்றாலும், தொழில்நுட்பங்களைச் சார்ந்திருக்கும் மாற்றுத்திறன் பயனர்களுக்கு இது பெரும்பாலும் குழப்பமான அனுபவத்தையே உருவாக்கும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "0க்கு அதிகமான மதிப்பானது வெளிப்படையான ஒரு வழிகாட்டும் ஆணையைக் குறிப்பிடுகிறது. முறைப்படி செல்லுபடியாகும் என்றாலும் தொழில்நுட்பங்களை சார்ந்திருக்கும் மாற்றுத்திறன் பயனர்களுக்கு இது பெரும்பாலும் குழப்பமான அனுபவத்தையே உருவாக்கும். [மேலும் அறிக](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "சில உறுப்புகளுக்கு `[tabindex]` மதிப்பு 0ஐ விட அதிகமாக உள்ளது"
+    "message": "சில உறுப்புகளின் `[tabindex]` மதிப்பு 0க்கு அதிகமாக இருக்கும்"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
     "message": "எந்த உறுப்புக்கும் `[tabindex]` மதிப்பு 0க்கு அதிகமாக இல்லை"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "டேபிள்களில் எளிதாகச் செல்வதற்கு ஸ்க்ரீன் ரீடர்களில் அம்சங்கள் உள்ளன. `[headers]` பண்புக்கூறைப் பயன்படுத்தும் `<td>` கலங்கள் அதே டேபிளில் உள்ள பிற கலங்களை மட்டும் குறிப்பிடுவதை உறுதிசெய்தால், அது ஸ்க்ரீன் ரீடர் பயனர்களின் அனுபவத்தை மேம்படுத்தக்கூடும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "டேபிள்களில் எளிதாக செல்வதற்கு ஸ்க்ரீன் ரீடர்களில் அம்சங்கள் உள்ளன. `[headers]` பண்புக்கூறைப் பயன்படுத்தும் `<td>` கலங்கள் அதே டேபிளில் உள்ள பிற கலங்களை மட்டும் குறிப்பிடுவதை உறுதிசெய்தால் அது ஸ்க்ரீன் ரீடர் பயனர்களின் அனுபவத்தை மேம்படுத்தக்கூடும். [மேலும் அறிக](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "`[headers]` பண்புக்கூறைப் பயன்படுத்தும் ஒரு `<table>` உறுப்பிலுள்ள கலங்கள் அதே டேபிளின் பிற கலங்களைக் குறிப்பிடும்."
+    "message": "`<table>` பண்புக்கூறைப் பயன்படுத்தும் ஒரு `[headers]` உறுப்பிலுள்ள கலங்கள் அதே டேபிளின் பிற கலங்களைக் குறிப்பிடும்."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "`[headers]` பண்புக்கூறைப் பயன்படுத்தும் `<table>` உறுப்பிலுள்ள கலங்கள், அதே டேபிளில் உள்ள பிற கலங்களை மட்டுமே குறிப்பிடுகின்றன."
+    "message": "`[headers]` பண்புக்கூறைப் பயன்படுத்தும் `<table>` உறுப்பிலுள்ள கலங்கள் அதே அட்டவணையின் பிற கலங்களைக் குறிப்பிடுகின்றன."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "டேபிள்களில் எளிதாகச் செல்வதற்கு ஸ்க்ரீன் ரீடர்களில் அம்சங்கள் உள்ளன. டேபிள் தலைப்புகள் எப்போதும் சில கலங்களின் தொகுப்பைக் குறிப்பிடுமாறு அமைப்பது ஸ்க்ரீன் ரீடர் பயனர்களின் அனுபவத்தை மேம்படுத்தக்கூடும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "டேபிள்களில் எளிதாக செல்வதற்கு ஸ்க்ரீன் ரீடர்களில் அம்சங்கள் உள்ளன. டேபிள் தலைப்புகள் எப்போதும் சில கலங்களின் தொகுப்பைக் குறிப்பிடுமாறு அமைப்பது ஸ்க்ரீன் ரீடர் பயனர்களின் அனுபவத்தை மேம்படுத்தக்கூடும். [மேலும் அறிக](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "`<th>` உறுப்புகள் மற்றும் `[role=\"columnheader\"/\"rowheader\"]` உள்ள உறுப்புகளில் அவை விவரிக்கும் தரவுக் கலங்கள் இல்லை."
+    "message": "`<th>` உறுப்புகளிலும் `[role=\"columnheader\"/\"rowheader\"]`ஐக் கொண்டுள்ள உறுப்புகளிலும் அவற்றைப் பற்றி விவரிக்கும் தரவுக் கலங்கள் இல்லை."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "`<th>` உறுப்புகள் மற்றும் `[role=\"columnheader\"/\"rowheader\"]` உள்ள உறுப்புகளில் அவை விவரிக்கும் தரவுக் கலங்கள் உள்ளன."
+    "message": "`<th>` உறுப்புகளிலும் `[role=\"columnheader\"/\"rowheader\"]`ஐக் கொண்டுள்ள உறுப்புகளிலும் அவற்றை விவரிக்கும் தரவுக் கலங்கள் உள்ளன."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "உறுப்புகளில் செல்லுபடியாகும் [BCP 47 language]ஐ (https://www.w3.org/International/questions/qa-choosing-language-tags#question) குறிப்பிட்டால், அது உரையை ஸ்க்ரீன் ரீடர் சரியாகப் படிப்பதற்கு உதவியாக இருக்கும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "உறுப்புகளில் செல்லுபடியாகும் [BCP 47 மொழியைக்](https://www.w3.org/International/questions/qa-choosing-language-tags#question) குறிப்பிட்டால், உரையை ஸ்க்ரீன் ரீடர் சரியாக உச்சரிக்கிறதா என்பதை உறுதிப்படுத்திக் கொள்ள அது உதவும். [மேலும் அறிக](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "`[lang]` பண்புக்கூறுகளுக்குச் செல்லுபடியாகும் மதிப்பு இல்லை"
+    "message": "`[lang]` பண்புக்கூறுகள் செல்லுபடியாகும் மதிப்பைக் கொண்டிருக்கவில்லை"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "`[lang]` பண்புக்கூறுகளுக்குச் செல்லுபடியாகும் மதிப்பு உள்ளது"
+    "message": "`[lang]` பண்புக்கூறுகள் செல்லுபடியாகும் மதிப்பைக் கொண்டுள்ளன"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "வீடியோவில் தலைப்பு குறிப்பிடப்பட்டிருந்தால், அதைக் குறித்த தகவல்களைக் காது கேளாத மற்றும் செவித்திறன் குறைபாடுள்ள பயனர்கள் அறிந்துகொள்ள எளிதாக இருக்கும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "வீடியோவில் தலைப்பு குறிப்பிடப்பட்டிருந்தால் காது கேளாதோர், செவித்திறன் குறைபாடுள்ளவர்கள் அதுகுறித்த தகவல்களை அறிந்துகொள்ள எளிதாக இருக்கும். [மேலும் அறிக](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "`<video>` உறுப்புகளில் `[kind=\"captions\"]` உள்ள `<track>` உறுப்பு இல்லை."
+    "message": "`[kind=\"captions\"]` உடன் `<track>` உறுப்பைக் கொண்டிருக்காத `<video>` உறுப்புகள்."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "`<video>` உறுப்புகளில் `[kind=\"captions\"]` உள்ள `<track>` உறுப்பு உள்ளது"
+    "message": "`[kind=\"captions\"]` உடன் `<track>` உறுப்பைக் கொண்டிருக்கும் `<video>` உறுப்புகள்"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "வீடியோக்களில் வசனங்களால் வெளிப்படுத்த முடியாத முக பாவனைகள், காட்சிகள் போன்றவற்றுக்கான தொடர்புடைய தகவல்களை ஆடியோ விளக்கங்கள் வழங்கும். [மேலும் அறிக](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "வீடியோக்களில் வசனங்களால் வெளிப்படுத்த முடியாத முக பாவனைகள், காட்சிகள் போன்றவற்றுக்கான தொடர்புடைய தகவல்களை ஆடியோ விளக்கங்கள் வழங்கும். [மேலும் அறிக](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "`<video>` உறுப்புகளில் `[kind=\"description\"]` உள்ள `<track>` உறுப்பு இல்லை."
+    "message": "`[kind=\"description\"]` உடன் `<track>` உறுப்பைக் கொண்டிருக்காத `<video>` உறுப்புகள்."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "`<video>` உறுப்புகள், `[kind=\"description\"]` உள்ள `<track>` உறுப்பைக் கொண்டுள்ளன"
+    "message": "`[kind=\"description\"]` உடன் `<track>` உறுப்பைக் கொண்டிருக்கும் `<video>` உறுப்புகள்"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "முகப்புத் திரையில் பயனர்கள் சேர்க்கும்போது iOSஸில் சிறப்பாகத் தோன்ற apple-touch-icon ஒன்றை வரையறுக்கவும். அது ஒளிபுகுத்தன்மையற்ற 192px (அல்லது 180px) அளவுள்ள கட்ட வடிவ PNGயைக் காட்ட வேண்டும். [மேலும் அறிக](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "செல்லுபடியாகும் `apple-touch-icon`ஐ வழங்காது"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` காலாவதியாகிவிட்டது; `apple-touch-icon` என்பதே விருப்பத் தேர்வாக உள்ளது."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "செல்லுபடியாகும் `apple-touch-icon`ஐ வழங்கும்"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome நீட்டிப்புகள் இந்தப் பக்கத்தின் ஏற்றுதல் செயல்திறனை எதிர்மறையாகப் பாதிக்கின்றன. மறைநிலையிலோ, நீட்டிப்புகள் இல்லாத ஒரு Chrome கணக்கிலிருந்தோ பக்கத்தைத் தணிக்கை செய்ய முயலவும்."
@@ -330,7 +342,7 @@
     "message": "மொத்த CPU நேரம்"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "JSஸைப் பாகுபடுத்துதல், தொகுத்தல் மற்றும் இயக்குவதில் செலவழிக்கும் நேரத்தைக் குறைக்க முயற்சி செய்யவும். இதற்கு, சிறிய அளவிலான JS ஆதாரங்களை வழங்குவது உதவக்கூடும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "JSஸைப் பாகுபடுத்துதல், தொகுத்தல் மற்றும் இயக்குவதில் செலவழிக்கும் நேரத்தைக் குறைக்கவும். இதற்கு சிறிய அளவிலான JS ஆதாரங்களை வழங்குவது உதவக்கூடும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "JavaScript செயல்பாட்டு நேரத்தைக் குறைக்கவும்"
@@ -339,13 +351,13 @@
     "message": "JavaScript செயல்பாட்டு நேரம்"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "அனிமேஷன் செய்யப்பட்ட உள்ளடக்கத்தை வழங்குவதற்குப் பெரிய அளவிலான GIFகள் பொருத்தமானவை அல்ல. நெட்வொர்க் பைட்களைச் சேமிப்பதற்கு, GIFக்குப் பதிலாக அனிமேஷன்களுக்கு MPEG4/WebM வீடியோக்களையும் நிலையான படங்களுக்கு PNG/WebP வடிவமைப்புகளையும் பயன்படுத்தலாம். [மேலும் அறிக](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "அனிமேஷன் செய்தவற்றைக் காட்டுவதற்கு பெரிய அளவிலான GIFகள் பொருத்தமானவை அல்ல. நெட்வொர்க் பைட்களை சேமிக்க GIFக்குப் பதிலாக அனிமேஷன்களுக்கு MPEG4/WebM வீடியோக்களையும் நிலையான படங்களுக்கு PNG/WebP வடிவமைப்புகளையும் பயன்படுத்தவும். [மேலும் அறிக](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "அனிமேஷன் செய்யப்பட்ட உள்ளடக்கங்களுக்கு வீடியோ வடிவமைப்புகளைப் பயன்படுத்தவும்"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "எதிர்வினையாற்றும் நேரத்தைக் குறைப்பதற்கு, முக்கியமான அனைத்து ஆதாரங்களும் ஏற்றப்பட்ட பின்னர், திரைக்கு வெளியிலுள்ள மற்றும் மறைக்கப்பட்ட படங்களை மெதுவாக ஏற்றுமாறு அமைக்கவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "எதிர்வினையாற்றும் நேரத்தைக் குறைக்க முக்கியமான அனைத்து ஆதாரங்களும் ஏற்றப்பட்ட பின்னர், திரைக்கு வெளியிலுள்ள மற்றும் மறைக்கப்பட்ட படங்களை மெதுவாக ஏற்றுமாறு அமைக்கவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "திரைக்கு வெளியிலுள்ள படங்களைத் தவிர்க்கவும்"
@@ -357,10 +369,10 @@
     "message": "ரென்டரிங்கைத் தடுக்கும் ஆதாரங்களை நீக்கவும்"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "அதிகளவிலான நெட்வொர்க் ஆதாரங்கள், பயனர்களுக்குப் பண இழப்பை ஏற்படுத்துவதோடு, பக்கங்கள் ஏற்றப்பட நீண்ட நேரமாவதற்கும் காரணமாகின்றன. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "அதிகளவிலான நெட்வொர்க் ஆதாரங்கள், பயனர்களுக்குப் பண இழப்பை ஏற்படுத்துவதோடு பக்கங்கள் ஏற்றப்பட நீண்ட நேரமாவதற்கும் காரணமாகின்றன. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "மொத்த அளவு {totalBytes, number, bytes} கி.பை."
+    "message": "மொத்த அளவு: {totalBytes, number, bytes} கி.பை."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "அபரிமிதமான நெட்வொர்க் ஆதாரங்களைத் தவிர்க்கவும்"
@@ -369,13 +381,13 @@
     "message": "அபரிமிதமான நெட்வொர்க் ஆதாரங்களைத் தவிர்க்கிறது"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "CSS கோப்புகளைச் சிறிதாக்கினால் நெட்வொர்க் ஆதாரங்களின் அளவுகள் குறையலாம். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "CSS கோப்புகளை சிறிதாக்கினால் நெட்வொர்க் ஆதாரங்களின் அளவுகள் குறையலாம். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "CSSஸைச் சிறிதாக்கவும்"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "JavaScript கோப்புகளைச் சிறிதாக்கினால், ஆதாரங்களின் அளவுகளும் ஸ்கிரிப்ட் பாகுபடுத்தப்படும் நேரமும் குறையலாம். [மேலும் அறிக](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "JavaScript கோப்புகளை சிறிதாக்கி ஆதாரங்களின் அளவுகளையும் ஸ்கிரிப்ட் பாகுபடுத்தப்படும் நேரத்தையும் குறைக்கலாம். [மேலும் அறிக](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "JavaScriptடைச் சிறிதாக்கவும்"
@@ -393,7 +405,7 @@
     "message": "பயன்படுத்தப்படாத JavaScriptடை அகற்றவும்"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "தற்காலிக நினைவகத்தின் ஆயுட்காலம் நீண்டதாக இருந்தால், அது மீண்டும் மீண்டும் திறக்கப்படும் உங்கள் இணையப் பக்கங்களை விரைவாக ஏற்றக்கூடும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "தற்காலிக நினைவகத்தின் ஆயுட்காலம் நீண்டதாக இருந்தால் அது மீண்டும் மீண்டும் திறக்கப்படும் உங்கள் இணையப் பக்கங்களை விரைவாக ஏற்றக்கூடும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{1 ஆதாரம் கண்டறியப்பட்டது}other{# ஆதாரங்கள் கண்டறியப்பட்டன}}"
@@ -405,13 +417,13 @@
     "message": "நிலையான உள்ளடக்கத்தில் திறனுள்ள தற்காலிக நினைவகக் கொள்கையைப் பயன்படுத்துகிறது"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "மேம்படுத்தப்பட்ட படங்கள் மேலும் விரைவாக ஏற்றப்படுவதோடு குறைவான மொபைல் டேட்டாவைப் பயன்படுத்தும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "மேம்படுத்தப்பட்ட படங்கள் குறைவான மொபைல் டேட்டாவைப் பயன்படுத்தி விரைவாக ஏற்றும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "படங்களைத் திறம்பட என்கோடிங் செய்யவும்"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "மொபைல் டேட்டாவைச் சேமிக்கவும், பக்கத்தை விரைவாக ஏற்றவும் படங்களைச் சரியான அளவில் வழங்கவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "மொபைல் டேட்டாவை சேமிக்கவும் பக்கத்தை விரைவாக ஏற்றவும் படங்களை சரியான அளவில் வழங்கவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "படங்களைச் சரியான அளவுக்கு மாற்றவும்"
@@ -423,19 +435,70 @@
     "message": "உரைச் சுருக்கத்தை இயக்கவும்"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "JPEG 2000, JPEG XR, WebP போன்ற பட வடிவமைப்புகள், PNG அல்லது JPEGயைக் காட்டிலும் சிறந்த அளவுச் சுருக்கத்தை வழங்குகின்றன, இதன் மூலம் பதிவிறக்கங்கள் வேகமாக நடைபெறும், அத்துடன் டேட்டா பயன்பாடும் குறையும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "JPEG 2000, JPEG XR, WebP போன்ற பட வடிவமைப்புகளானது PNG அல்லது JPEGயைக் காட்டிலும் சிறந்த அளவு சுருக்கத்தை வழங்குகின்றன, இதன் மூலம் பதிவிறக்கங்கள் வேகமாக நடைபெறுவதுடன் டேட்டா உபயோகமும் குறையும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "படங்களை நவீன வடிவமைப்புகளில் வழங்கவும்"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "கீழுள்ள 'முக்கியக் கோரிக்கை வரிசைகள்', எந்தெந்த ஆதாரங்கள் உயர் முன்னுரிமையுடன் ஏற்றப்பட்டன என்பதைக் காண்பிக்கின்றன. பக்கம் ஏற்றப்படுவதன் வேகத்தை அதிகரிக்க, வரிசைகளின் நீளத்தைக் குறைத்தல், ஆதாரங்களின் பதிவிறக்க அளவைக் குறைத்தல் அல்லது தேவையற்ற ஆதாரங்களைப் பதிவிறக்குவதைத் தவிர்த்தல் போன்றவற்றை முயற்சி செய்யவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "கீழே இருக்கும் 'முக்கியக் கோரிக்கை வரிசைகள்' எந்தெந்த ஆதாரங்கள் அதிக முன்னுரிமையுடன் ஏற்றப்பட்டன என்பதைக் காட்டுகின்றன. பக்கம் ஏற்றப்படுவதன் வேகத்தை அதிகரிக்க, வரிசைகளின் நீளத்தைக் குறைத்தல், ஆதாரங்களின் பதிவிறக்க அளவைக் குறைத்தல் அல்லது தேவையற்ற ஆதாரங்களைப் பதிவிறக்குவதைத் தவிர்த்தல் போன்றவற்றை முயற்சி செய்யவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 வரிசை கண்டறியப்பட்டது}other{# வரிசைகள் கண்டறியப்பட்டன}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "'முக்கியக் கோரிக்கைகளின் அடுக்கைக்' குறைக்கவும்"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "தடுத்தல் / எச்சரித்தல்"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "வரி"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "தடுக்கப்பட்ட APIகள் இறுதியில் உலாவியிலிருந்து அகற்றப்படும். [மேலும் அறிக](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 எச்சரிக்கை கண்டறியப்பட்டது}other{# எச்சரிக்கைகள் கண்டறியப்பட்டுள்ளன}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "தடுக்கப்பட்ட APIகளைப் பயன்படுத்துகிறது"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "தடுக்கப்பட்டுள்ள APIகளைத் தவிர்க்கும்"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "ஆப்ஸின் தற்காலிக சேமிப்பு தடுக்கப்பட்டுள்ளது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" கண்டறியப்பட்டது"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "ஆப்ஸின் தற்காலிக சேமிப்பைப் பயன்படுத்துகிறது"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "ஆப்ஸின் தற்காலிக சேமிப்பைத் தவிர்க்கும்"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "ஆவண வகையைக் குறிப்பிடுவதால் உலாவி குவர்க்ஸ் பயன்முறைக்கு மாறுவதைத் தடுக்கும். மேலும் தெரிந்துகொள்ள [MDN Web Docs பக்கத்திற்கு](https://developer.mozilla.org/en-US/docs/Glossary/Doctype) செல்லவும்"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "ஆவண வகையின் பெயர் சிற்றெழுத்துகளில் இருக்க வேண்டும் `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "ஆவணமானது ஏதேனுமொரு ஆவண வகையைக் கொண்டிருக்க வேண்டும்"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "எதிர்பார்க்கப்பட்ட பப்ளிக்ஐடி காலியாக உள்ளது"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "எதிர்பார்க்கப்பட்ட சிஸ்டம்ஐடி காலியாக உள்ளது"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "பக்கத்தில் HTML ஆவண வகை இல்லாததால் குவர்க்ஸ் பயன்முறையை இயக்குகிறது"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "இந்தப் பக்கமானது HTML ஆவண வகையில் உள்ளது"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "உறுப்பு"
@@ -447,7 +510,7 @@
     "message": "மதிப்பு"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "~1,500 DOM உறுப்புகளுக்குக் குறைவான உறுப்புகளைக் கொண்ட பக்கங்களை உலாவிப் பொறியாளர்கள் பரிந்துரைக்கின்றனர். 32 உறுப்புகளுக்குக் குறைவான கிளை அடுக்குகளும் 60க்குக் குறைவான துணைக்கிளை/கிளை உறுப்புகளும் இருப்பது உகந்தது. ஒரு பெரிய DOM, நினைவகப் பயன்பாட்டை அதிகரிக்கலாம், [ஸ்டைல் கணக்கீடுகளை] நீட்டிக்கலாம், மேலும் (https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) அதிகச் செலவு பிடிக்கும் [தளவமைப்பு மறுசீராக்கங்களை] ஏற்படுத்தலாம் (https://developers.google.com/speed/articles/reflow). [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "உலாவிப் பொறியாளர்கள் ~1,500 DOM உறுப்புகளுக்குக் குறைவாக இருக்கும் பக்கங்களையே பரிந்துரைக்கின்றனர். ட்ரீ டெப்த் 32 உறுப்புகளுக்குக் கீழ் இருப்பதும் உபநிலை/முதல்நிலை உறுப்புகள் 60க்குக் கீழ் இருப்பதும் மிக சரியான அளவுகளாகும். ஒரு பெரிய DOMமால் நினைவக உபயோகத்தை அதிகரிக்கவும், [ஸ்டைல் கணக்கீடுகளை](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) நீட்டிக்கவும், அதிக செலவு பிடிக்கும் [தளவமைப்பு மறுசீராக்கங்களை](https://developers.google.com/speed/articles/reflow) ஏற்படுத்தவும் முடியும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 உறுப்பு}other{# உறுப்புகள்}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "அபரிமிதமான DOM அளவைத் தவிர்க்கிறது"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "இலக்கு"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "ஏதேனும் புற இணைப்புகளின் செயல்திறனை அதிகரிக்கவும் அவற்றிலுள்ள பாதுகாப்புக் குறைபாடுகளைத் தடுக்கவும் `rel=\"noopener\"` அல்லது `rel=\"noreferrer\"`ஐ சேர்க்கவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "வேறு மூலங்களுக்கு செல்லும் இணைப்புகள் பாதுகாப்பற்றவை"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "வேறு மூலங்களுக்கு செல்லும் இணைப்புகள் பாதுகாப்பானவை"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "ஆங்கருக்கான இடத்தை நிர்ணயிக்க முடியவில்லை ({anchorHTML}). லிங்க்காகப் பயன்படாதபட்சத்தில் target=_blank என்பதை அகற்றவும்."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "சரியான காரணங்கள் இன்றி இருப்பிடத்தை அறிய கோரிக்கையிடும் தளங்களால் பயனர்கள் குழப்பமடையலாம் அல்லது சந்தேகப்படலாம். அதற்கு பதிலாக பயனர் செயல்பாட்டை முயலவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "பக்கம் ஏற்றப்படும்போது உங்கள் புவி இருப்பிடத்தைத் தெரிந்துகொள்வதற்கான அனுமதியைக் கோரும்"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "பக்கம் ஏற்றப்படும்போது உங்கள் புவி இருப்பிடத்தைத் தெரிந்துகொள்வதற்கான அனுமதியைக் கோராது"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "பதிப்பு"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "பக்கத்திலுள்ள அனைத்து ஃபிரெண்ட் எண்ட் JavaScript லைப்ரரிகளும் கண்டறியப்பட்டன."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "JavaScript லைப்ரரிகள் கண்டறியப்பட்டுள்ளன"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "வேகம் குறைந்த இணைய சேவை உள்ள பயனர்களுக்கு, வெளி ஸ்கிரிப்ட்களை `document.write()` வழியாக உட்செலுத்தும்போது பக்கத்தை ஏற்றுவதை அது பல வினாடிகள் தாமதிக்கும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "`document.write()`ஐப் பயன்படுத்துகிறது"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "`document.write()`ஐத் தவிர்க்கும்"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "அதிகபட்ச அபாயம்"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "லைப்ரரி பதிப்பு"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "பாதுகாப்புக் குறைபாடுகளின் எண்ணிக்கை"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "சில மூன்றாம் தரப்பு ஸ்கிரிப்ட்களில் ஹேக்கர்கள் எளிதாக அடையாளம் கண்டுகொண்டு பயன்படுத்திக் கொள்ளக்கூடிய தெரிந்த பாதுகாப்புக் குறைபாடுகள் இருக்கக்கூடும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 பாதுகாப்புக் குறைபாடு கண்டறியப்பட்டுள்ளது}other{# பாதுகாப்புக் குறைபாடுகள் கண்டறியப்பட்டுள்ளன}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "தெரிந்த பாதுகாப்புக் குறைபாடுகளுள்ள ஃபிரெண்ட் எண்டு JavaScript லைப்ரரிகள் இதில் அடங்கும்"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "அதிகம்"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "குறைவானது"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "நடுத்தரமானது"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "தெரிந்த பாதுகாப்புக் குறைபாடுகளுடைய ஃபிரெண்ட் எண்ட் JavaScript லைப்ரரிகளைத் தவிர்க்கிறது"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "சரியான காரணங்கள் இன்றி அறிவிப்புகளை அனுப்பக் கோரிக்கையிடும் தளங்களால் பயனர்கள் குழப்பமடையலாம் அல்லது சந்தேகப்படலாம். அதற்கு பதிலாக பயனர் சைகைகளை முயலவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "பக்கம் ஏற்றப்படும்போது அதுகுறித்த அறிவிப்பைத் தெரிந்துகொள்வதற்கான அனுமதியைக் கோரும்"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "பக்கம் ஏற்றப்படும்போது அதுகுறித்த அறிவிப்பைத் தெரிந்துகொள்வதற்கான அனுமதியைக் கோராது"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "தோல்வியுற்ற உறுப்புகள்"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "கடவுச்சொல்லை ஒட்டுவதைத் தடுப்பதால் நல்ல பாதுகாப்புக் கொள்கையின் மதிப்பு குறைகிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "கடவுச்சொல் புலங்களில் பயனர்கள் ஒட்டுவதைத் தடுக்கும்"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "கடவுச்சொல் புலங்களில் பயனர்கள் ஒட்டுவதை அனுமதிக்கும்"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "நெறிமுறை"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/1.1ஐ விட அதிகப் பலன்களை HTTP/2 வழங்குகிறது. அவற்றில் பைனரி ஹெட்டர்கள், மல்டிஃபிளெக்ஸிங் மற்றும் சர்வர் ஃபுஷ் போன்றவை அடங்கும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{HTTP/2 வழியாக 1 கோரிக்கை பதிலளிக்கப்படவில்லை}other{HTTP/2 வழியாக # கோரிக்கைகள் பதிலளிக்கப்படவில்லை}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "அதன் அனைத்து ஆதாரங்களுக்கும் HTTP/2வைப் பயன்படுத்தவில்லை"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "அதன் சொந்த ஆதாரங்களுக்கு HTTP/2வைப் பயன்படுத்துகிறது"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "உங்கள் பக்கத்தின் நகர்த்துதல் செயல்திறனை மேம்படுத்த டச் மற்றும் வீல் ஈவண்ட் லிசனர்களை `passive` என அமைக்கவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "நகர்த்துதல் செயல்திறனை மேம்படுத்துவதற்காக பேசிவ் லிசனர்களைப் பயன்படுத்தவில்லை"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "நகர்த்துதல் செயல்திறனை மேம்படுத்துவதற்காக பேசிவ் லிசனர்களைப் பயன்படுத்துகின்றன"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "விளக்கம்"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "கன்சோலில் பிழைகள் பதிவு செய்யப்படுவது சிக்கல்கள் தீர்க்கப்படவில்லை என்பதைக் குறிக்கிறது. நெட்வொர்க் கோரிக்கை தொடர்பான பிழைகளிலிருந்தும் வேறு உலாவி தொடர்பான சிக்கல்களிலிருந்தும் அவை வந்திருக்கலாம்."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "கன்சோலில் உலாவி தொடர்பான பிழைகள் பதிவு செய்யப்பட்டுள்ளன"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "கன்சோலில் உலாவியின் பிழைகள் எதுவும் பதிவு செய்யப்படவில்லை"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "இணைய எழுத்துருக்கள் ஏற்றப்படும்போது உரை எழுத்துகள் பயனருக்குத் தெரிவதை உறுதிசெய்வதற்கு, எழுத்துருக் காட்சியின் CSS அம்சத்தைச் சேர்க்கவும். [மேலும் அறிக](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "இணைய எழுத்துருக்கள் ஏற்றப்படும்போது உரை எழுத்துகள் பயனருக்குத் தெரிவதை உறுதிசெய்ய எழுத்துருக் காட்சியின் CSS அம்சத்தை சேர்க்கவும். [மேலும் அறிக](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "இணைய எழுத்துரு ஏற்றப்படும்போது உரை எழுத்துகள் தெரிவதை உறுதிசெய்யவும்"
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "இணைய எழுத்துருக்கள் ஏற்றப்படும்போது உரை எழுத்துகள் அனைத்தும் தெரிகின்றன"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "பின்வரும் URLளுக்கான எழுத்துருக் காட்சியின் மதிப்பை Lighthouseஸால் தானாக சரிபார்க்க முடியவில்லை: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "தோற்ற விகிதம் (அசல்)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "தோற்ற விகிதம் (காட்சிப்படுத்தப்பட்டது)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "படத்தின் காட்சிப் பரிமாணங்கள் இயல்பான தோற்ற விகிதத்துடன் பொருந்த வேண்டும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "தவறான தோற்ற விகிதமுள்ள படங்களைக் காட்டுகிறது"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "சரியான தோற்ற விகிதத்துடன் படங்களைக் காட்டுகிறது"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "பட அளவு குறித்த தகவல் செல்லாதது {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "பாதுகாப்பில்லாத URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "அனைத்துத் தளங்களும் HTTPSஸுடன் பாதுகாக்கப்பட வேண்டும், பாதுகாக்கப்பட வேண்டிய தனிப்பட்ட தரவைக் கொண்டிருக்காத தளங்களுக்கும் இது பொருந்தும். உங்கள் ஆப்ஸிற்கும் பயனர்களுக்கும் இடையில் நடக்கும் தகவல் பரிமாற்ற விவரங்களை அவர்களுக்குத் தெரியாமல் பார்ப்பவர்களையும் கேட்பவர்களையும் HTTPS தடுக்கிறது. அது HTTP/2 மற்றும் பல புதிய பிளாட்ஃபார்ம் APIகளில் முக்கியமாக இருக்க வேண்டியதாகும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{பாதுகாப்பு இல்லாத 1 கோரிக்கை கண்டறியப்பட்டுள்ளது}other{பாதுகாப்பு இல்லாத # கோரிக்கைகள் கண்டறியப்பட்டுள்ளன}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "HTTPSஸைப் பயன்படுத்தவில்லை"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "HTTPSஸைப் பயன்படுத்துகிறது"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "மொபைல் நெட்வொர்க்கில் பக்கம் வேகமாக ஏற்றப்பட்டால் அது மொபைல் பயனர்களுக்குச் சிறந்த அனுபவத்தை வழங்கும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "மொபைல் நெட்வொர்க்கில் பக்கம் வேகமாக ஏற்றப்பட்டால் அது மொபைல் பயனர்களுக்கு சிறந்த அனுபவத்தை வழங்கும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "{timeInMs, number, seconds} வினாடிகளில் பதிலளிக்கிறது"
+    "message": "பக்கம் பதிலளிக்க எடுத்துக்கொண்ட நேரம்: {timeInMs, number, seconds} வி."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "மாதிரி மொபைல் நெட்வொர்க்கில் {timeInMs, number, seconds} வினாடிகளில் பதிலளிக்கிறது"
@@ -504,46 +735,52 @@
     "message": "முக்கியத் தொடரிழையின் பணியைக் குறைக்கிறது"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "தோராய உள்ளீட்டுத் தாமதம் என்பது பக்கம் ஏற்றப்படும் பிஸியான 5 வினாடி காலஅளவின்போது பயனரின் உள்ளீட்டுக்குப் பதிலளிக்க உங்கள் ஆப்ஸ் எவ்வளவு நேரம் எடுத்துக் கொள்கிறது என்பதற்கான தோராய மதிப்பாகும், இது மில்லிவினாடிகளில் கணக்கிடப்படுகிறது. பதிலளிப்பதற்கு 50 மி.வி.க்கு அதிகமாகத் தாமதமானால், பயனர்கள் உங்கள் ஆப்ஸை “மெதுவானது” என்று கருதக்கூடும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "'தோராய உள்ளீட்டுத் தாமதம்' என்பது பக்கம் ஏற்றப்படும் பிஸியான 5 வினாடி காலஅளவின்போது பயனரின் உள்ளீட்டுக்கு பதிலளிக்க உங்கள் ஆப்ஸ் எவ்வளவு நேரம் எடுத்துக் கொள்கிறது என்பதற்கான தோராய மதிப்பாகும். பதிலளிக்க 50 மி.வி.க்கு மேல் தாமதமானால் உங்கள் ஆப்ஸ் மெதுவானது என்று பயனர்கள் கருதக்கூடும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "தோராயமான உள்ளீட்டுத் தாமதம்"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "'உள்ளடக்கத்துடன் முதல் தோற்றம்' என்பது, முதல் உரை அல்லது படம் தோன்றும் நேரத்தைக் குறிக்கிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "'உள்ளடக்கமுள்ள முதல் தோற்றம்' என்பது முதல் உரையையோ படம் தோன்றும் நேரத்தையோ குறிக்கிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "உள்ளடக்கமுள்ள முதல் தோற்றம்"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "'CPU செயல்படாநிலையின் தொடக்க நேரம்' என்பது, உள்ளீட்டை பக்கத்தின் முக்கியத் தொடரிழை கையாள்வதற்குத் தயாராக, செயல்படாநிலையில் இருக்கும் நேரத்தின் தொடக்கத்தைக் குறிக்கிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "'CPU செயல்படாநிலையின் தொடக்க நேரம்' என்பது உள்ளீட்டை பக்கத்தின் முக்கியத் தொடரிழை கையாள்வதற்குத் தயாராக, செயல்படாநிலையில் இருக்கும் நேரத்தின் தொடக்கத்தைக் குறிக்கிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "CPU செயல்படாநிலையின் தொடக்க நேரம்"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "'அர்த்தமுள்ள முதல் தோற்றம்' என்பது பக்கத்தின் முதன்மை உள்ளடக்கம் எப்போது தெரிகிறது என்பதை அளவிடுகிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "'பயனுள்ள முதல் தோற்றம்' என்பது பக்கத்தின் முதன்மை உள்ளடக்கம் எப்போது தெரிகிறது என்பதை அளவிடுகிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "அர்த்தமுள்ள முதல் தோற்றம்"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "எதிர்வினை நேரம் என்பது பக்கம் முழுமையாக எதிர்வினையாற்றும் வகையில் ஏற்றப்படுவதற்கான காலஅளவாகும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "எதிர்வினை நேரம் என்பது பக்கம் முழுமையாக எதிர்வினையாற்றும் வகையில் ஏற்றப்படுவதற்கான கால அளவாகும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "எதிர்வினை நேரம்"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "உங்கள் பயனர்கள் எதிர்கொள்ளக்கூடிய சாத்தியமான ’முதல் உள்ளீட்டுத் தாமதம்’ என்பது மில்லிவினாடிகளில் குறிப்பிடப்படும் மிக நீண்ட பணியின் காலஅளவாகும்."
+    "message": "உங்கள் பயனர்கள் எதிர்கொள்ளக்கூடிய அதிக சாத்தியமான ’முதல் உள்ளீட்டுத் தாமதம்’ என்பது மில்லி வினாடிகளில் குறிப்பிடப்படும் மிக நீண்ட பணியின் காலஅளவாகும். [மேலும் அறிக](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "அதிகபட்ச சாத்தியமான FID"
+    "message": "முதல் உள்ளீட்டிற்கு பதிலளிக்கக்கூடிய அதிகபட்ச நேரம்"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "பக்கத்திலுள்ள உள்ளடக்கங்கள் எவ்வளவு விரைவாகத் தெரிகின்றன என்பதை 'வேக அட்டவணை' காண்பிக்கிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "வேக அட்டவணை"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "பணியின் நீளம் 50மி.வி.களைத் தாண்டும்போது FCP மற்றும் எதிர்வினை நேரத்திற்கு இடையில் இருக்கும் மொத்தக் கால அளவுகளும் மில்லி வினாடிகளில் தெரிவிக்கப்படும்."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "தடுக்கப்படும் மொத்த நேரம்"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "நெட்வொர்க் ரவுண்ட் டிரிப் டைம்ஸ் (Round Trip Times - RTT) செயல்திறனில் பெரும் தாக்கத்தை ஏற்படுத்தும். அசல் சேவையகத்துடனான RTT அதிகமாக இருந்தால் பயனரின் அருகில் இருக்கும் சேவையகங்கள் இணையதளத்தின் செயல்திறனை மேம்படுத்தலாம் என்பதைக் குறிக்கும். [மேலும் அறிக](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -552,10 +789,22 @@
     "message": "நெட்வொர்க் ரவுண்ட் டிரிப் நேரங்கள்"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "சேவையகத் தாமதங்கள் இணையச் செயல்திறனைப் பாதிக்கக்கூடும். மூலச் சேவையகத்தின் தாமதம் அதிகமாக இருந்தால், சேவையகத்தின் வேலைப் பளு அதிகமாக உள்ளது அல்லது மோசமான பின்னணிச் செயல்திறன் உள்ளது என்று பொருள். [மேலும் அறிக](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "சேவையகத் தாமதங்கள் இணைய செயல்திறனைப் பாதிக்கக்கூடும். மூல சேவையகத்தில் தாமதம் அதிகமாக இருந்தால் சேவையகத்தின் வேலைப் பளு அதிகமாக உள்ளது அல்லது மோசமான பின்னணி செயல்திறன் உள்ளது என்று பொருள். [மேலும் அறிக](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "சேவையக பேக்எண்ட் தாமதங்கள்"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "பட்ஜெட்டைத் தாண்டிவிட்டது"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "நெட்வொர்க் கோரிக்கைகளின் அளவையும் எண்ணிக்கையையும் செயல்திறன் பட்ஜெட் அமைத்துள்ள இலக்கீடுகளுக்குள் வைத்திருக்கவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 கோரிக்கை}other{# கோரிக்கைகள்}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "செயல்திறன் பட்ஜெட்"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "'திசைதிருப்புதல்கள்' பக்கம் ஏற்றப்படுவதற்கு முன்பு கூடுதல் தாமதங்களை ஏற்படுத்தலாம். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
@@ -563,47 +812,53 @@
   "lighthouse-core/audits/redirects.js | title": {
     "message": "பல பக்கங்களுக்குத் திசைதிருப்புவதைத் தவிர்க்கவும்"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "பக்க ஆதாரங்களின் அளவையும் எண்ணிக்கைக்கான பட்ஜெட்களையும் அமைக்க budget.json கோப்பை சேர்க்கவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 கோரிக்கை}other{# கோரிக்கைகள்}} • {byteCount, number, bytes} கி.பை."
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "கோரிக்கை எண்ணிக்கைகளைக் குறைவாகவும் பரிமாற்ற அளவுகளை சிறியதாகவும் வைத்திருங்கள்"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "தேடல் முடிவுகளில் எந்த URLலைக் காண்பிக்க வேண்டும் என்பதை ’தீர்மானமான இணைப்புகள்’ பரிந்துரைக்கும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "முரண்பாடான பல URLகள் ({urlList})"
+    "message": "பல முரண்படும் URLகள் ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "வேறொரு டொமைனை ({url}) குறிப்பிடுகிறது"
+    "message": "வேறொரு டொமைனைக் காட்டுகிறது ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "தவறான URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "மற்றொரு `hreflang` இடத்தை ({url}) குறிப்பிடுகிறது"
+    "message": "வேறொரு `hreflang` URL முகவரியைக் காட்டுகிறது ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "சார்பு URL ({url})"
+    "message": "தொடர்புடைய URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "உள்ளடக்கத்திற்குப் பொருத்தமான பக்கத்திற்குப் பதிலாக டொமைனின் மூல URLலை (முகப்புப்பக்கம்) குறிப்பிடுகிறது"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "செல்லுபடியாகும் `rel=canonical` ஆவணத்தில் இல்லை"
+    "message": "ஆவணத்தில் செல்லுபடியாகும் `rel=canonical` இல்லை"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "செல்லுபடியாகும் `rel=canonical` ஆவணத்தில் உள்ளது"
+    "message": "ஆவணத்தில் செல்லுபடியாகும்`rel=canonical` உள்ளது"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "12pxக்குக் குறைவான எழுத்துரு அளவுகள் படிப்பதற்கு மிகச் சிறியவை, இதனால் மொபைல் பயனாளர்கள் உரையைப் படிக்க, ”அளவை மாற்ற பின்ச் செய்தல்” அம்சத்தைப் பயன்படுத்த வேண்டியிருக்கும். பக்கத்தின் 60% அதிகமான உரையை 12pxக்கு அதிகமான எழுத்துரு அளவுக்கு அமைக்கவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "12pxக்குக் குறைவான எழுத்துரு அளவுகள் படிப்பதற்கு மிக சிறியவை, இதனால் மொபைல் பயனாளர்கள் உரையைப் படிக்க, ”அளவை மாற்ற பின்ச் செய்தல்” அம்சத்தைப் பயன்படுத்த வேண்டியிருக்கும். எனவே பக்கத்தின் 60% அதிகமான உரைக்கு 12px அல்லது அதற்கு அதிகமான எழுத்துரு அளவை அமைக்க முயலவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} தெளிவான உரை"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "உரையின் {decimalProportion, number, extendedPercent} மிகச் சிறிதாக உள்ளது."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "மொபைல் திரைகளுக்கேற்ப காட்சிப் பகுதி மேலதிகத் தகவல் மேம்படுத்தப்படாததால் உரையைச் சரியாகப் படிக்க முடியவில்லை."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "உரையில் {decimalProportion, number, extendedPercent} மிகச் சிறிதாக உள்ளது ({decimalProportionVisited, number, extendedPercent} மாதிரியின் அடிப்படையில்)."
+    "message": "{decimalProportion, number, extendedPercent} உரை மிகவும் சிறியது ({decimalProportionVisited, number, extendedPercent} மாதிரியின் அடிப்படையில்)."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "ஆவணத்தில் தெளிவான எழுத்துரு அளவுகள் பயன்படுத்தப்படவில்லை"
@@ -612,13 +867,13 @@
     "message": "ஆவணத்தில் தெளிவான எழுத்துரு அளவுகள் பயன்படுத்தப்பட்டுள்ளன"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "hreflang இணைப்புகள், குறிப்பிட்ட ஒரு மொழி அல்லது மண்டலத்திற்கான தேடல் முடிவுகளில் ஒரு பக்கத்தின் எந்தப் பதிப்பைப் பட்டியலிட வேண்டும் என்பதைத் தேடல் இன்ஜின்களுக்கு சொல்கின்றன. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "hreflang இணைப்புகளானது குறிப்பிட்ட ஒரு மொழியிலோ பகுதிக்கான தேடல் முடிவுகளிலோ ஒரு பக்கத்தின் எந்தப் பதிப்பைப் பட்டியலிட வேண்டும் என்பதைத் தேடல் இன்ஜின்களுக்கு சொல்கின்றன. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "செல்லுபடியாகும் `hreflang` ஆவணத்தில் இல்லை"
+    "message": "ஆவணத்தில் செல்லுபடியாகும் `hreflang` இல்லை"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "செல்லுபடியாகும் `hreflang` ஆவணத்தில் உள்ளது"
+    "message": "ஆவணத்தில் செல்லுபடியாகும்`hreflang` உள்ளது"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "வெற்றியடையாத HTTP நிலைக் குறியீடுகள் உள்ள பக்கங்கள் சரியாக அட்டவணைப்படுத்தப்படாமல் போகலாம். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -630,7 +885,7 @@
     "message": "பக்கத்தில் வெற்றிகரமான HTTP நிலைக் குறியீடு உள்ளது"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "தேடல் இன்ஜின்களுக்கு உங்கள் பக்கங்களை உருட்டுவதற்கான அனுமதி இல்லையென்றால், அவற்றால் உங்கள் பக்கங்களைத் தேடல் முடிவுகளில் சேர்க்க முடியாது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "தேடல் இன்ஜின்களுக்கு உங்கள் பக்கங்களை உருட்டுவதற்கான அனுமதி இல்லையென்றால் அவற்றால் உங்கள் பக்கங்களைத் தேடல் முடிவுகளில் சேர்க்க முடியாது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "பக்கம் அட்டவணைப்படுத்தப்படுவதிலிருந்து தடுக்கப்பட்டுள்ளது"
@@ -639,7 +894,7 @@
     "message": "பக்கம் அட்டவணைப்படுத்தப்படுவதிலிருந்து தடுக்கப்படவில்லை"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "தேடல் இன்ஜின்கள் உங்கள் உள்ளடக்கத்தைச் சரியாகப் புரிந்துகொள்ள இணைப்புக்கான விரிவான உரை உதவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "தேடல் இன்ஜின்கள் உங்கள் உள்ளடக்கத்தைப் புரிந்துகொள்ள இணைப்புக்கான விளக்க உரை உதவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{1 இணைப்பு உள்ளது}other{# இணைப்புகள் உள்ளன}}"
@@ -651,13 +906,13 @@
     "message": "இணைப்புகளுக்கு விளக்க உரை உள்ளது"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "கட்டமைந்த தரவைச் சரிபார்க்க, [கட்டமைந்த தரவுச் சோதனைக் கருவி](https://search.google.com/structured-data/testing-tool/), [கட்டமைந்த தரவு லிண்டர்]](http://linter.structured-data.org/) ஆகியவற்றை இயக்கவும். [மேலும் அறிக](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "கட்டமைந்த தரவை சரிபார்க்க [கட்டமைந்த தரவு சோதனைக் கருவியையும்](https://search.google.com/structured-data/testing-tool/) [கட்டமைந்த தரவு லிண்டரையும்](http://linter.structured-data.org/) இயக்கவும். [மேலும் அறிக](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "கட்டமைந்த தரவு செல்லுபடியாகிறது"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "பக்கத்தின் உள்ளடக்கத்தைத் தெளிவாகச் சுருக்கி விளக்குவதற்கு, மீவிளக்கங்களைத் தேடல் முடிவுகளில் சேர்க்கலாம். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "பக்கத்தின் உள்ளடக்கத்தைத் தெளிவாக சுருக்கி விளக்குவதற்கு, மீவிளக்கங்களைத் தேடல் முடிவுகளில் சேர்க்கலாம். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "விளக்க உரை காலியாக உள்ளது."
@@ -681,7 +936,7 @@
     "message": "உங்கள் robots.txt கோப்பு தவறான வடிவமைப்பில் இருந்தால், உங்கள் இணையதளத்தை எப்படி உருட்ட அல்லது அட்டவணைப்படுத்த விரும்புகிறீர்கள் என்பதை crawler மென்பொருட்களால் புரிந்துகொள்ள முடியாமல் போகலாம்."
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueHttpBadCode": {
-    "message": "robots.txtக்கான கோரிக்கை இந்த HTTP நிலையைப் பதிலனுப்பியுள்ளது: {statusCode}"
+    "message": "robots.txtக்கான கோரிக்கைக்கு குறிப்பிட்ட HTTP நிலையை பதிலாக அனுப்பியுள்ளது: {statusCode}"
   },
   "lighthouse-core/audits/seo/robots-txt.js | displayValueValidationError": {
     "message": "{itemCount,plural, =1{1 பிழை உள்ளது}other{# பிழைகள் உள்ளன}}"
@@ -699,7 +954,7 @@
     "message": "பட்டன்கள், இணைப்புகள் போன்ற எதிர்வினையாற்றும் உறுப்புகள் போதுமான அளவு பெரிதாகவும் (48x48px) அவற்றைச் சுற்றி போதுமான இடத்துடனும் இருக்க வேண்டும், இதனால் அவற்றைப் பிற உறுப்புகளின் குறுக்கீடு இல்லாமல் எளிதாகத் தட்டலாம். [மேலும் அறிக](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
-    "message": "{decimalProportion, number, percent} பொருத்தமான அளவுள்ள தட்டுவதற்கான இலக்குகள்"
+    "message": "{decimalProportion, number, percent} தட்டுவதற்கான இலக்குகள் பொருத்தமான அளவில் இருக்கின்றன"
   },
   "lighthouse-core/audits/seo/tap-targets.js | explanationViewportMetaNotOptimized": {
     "message": "மொபைல் திரைகளுக்கேற்ப காட்சிப் பகுதி மேலதிகத் தகவல் மேம்படுத்தப்படாததால் தட்டுவதற்கான இலக்குகள் மிகச் சிறிதாக உள்ளன"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "குறுக்கிடும் இலக்கு"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "அளவு"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "தட்டுவதற்கான இலக்கு"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "தட்டுவதற்கான இலக்குகள் சரியாக அளவிடப்பட்டுள்ளன"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "முக்கியத் தொடரிழைக்கான நேரம்"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "மூன்றாம் தரப்பு"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "மூன்றாம் தரப்பு குறியீடானது ஏற்றுதல் செயல்திறனைக் குறிப்பிடத்தக்க வகையில் பாதிக்கக்கூடும். தேவையற்ற மூன்றாம் தரப்பு சேவை வழங்குநர்களின் எண்ணிக்கையைக் குறைத்துக் கொள்ளவும். மேலும் உங்கள் பக்கத்தின் முதன்மை விவரங்களை ஏற்றியபிறகு மூன்றாம் தரப்பு குறியீட்டை ஏற்ற முயலவும். [மேலும் அறிக](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 மூன்றாம் தரப்பு கண்டறியப்பட்டது}other{# மூன்றாம் தரப்புகள் கண்டறியப்பட்டுள்ளன}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "மூன்றாம் தரப்பு உபயோகம்"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "'முதல் பைட்டின் நேரம்' என்பது உங்கள் சேவையகம் ஒரு பதிலை அனுப்பும் நேரத்தைச் சுட்டிக்காட்டுகிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "'முதல் பைட்டின் நேரம்' என்பது உங்கள் சேவையகம் ஒரு பதிலை அனுப்பும் நேரத்தை சுட்டிக்காட்டுகிறது. [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "மூல ஆவணம் ஏற்றப்படுவதற்கு {timeInMs, number, milliseconds} மி.வி. ஆனது"
+    "message": "மூல ஆவணம் எடுத்துக் கொண்ட நேரம்: {timeInMs, number, milliseconds} மி.வி."
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "சேவையக எதிர்வினை நேரங்களைக் குறைக்கவும் (TTFB)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "கால அளவு"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "பெயர்"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "தொடக்க நேரம்"
   },
@@ -744,7 +1008,7 @@
     "message": "வகை"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "முக்கியப் பயனர் அனுபவங்களின்போது உங்கள் ஆப்ஸின் நிகழ்நேர செயல்திறனை அளவிடுவதற்கு, உங்கள் ஆப்ஸில் User Timing APIஐப் பயன்படுத்தலாம். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "முக்கியமான பயனர் அனுபவங்களின்போது உங்கள் ஆப்ஸின் நிகழ்நேர செயல்திறனை அளவிட உங்கள் ஆப்ஸில் User Timing APIயைப் பயன்படுத்தவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 பயனர் நேரம்}other{# பயனர் நேரங்கள்}}"
@@ -753,19 +1017,19 @@
     "message": "பயனர் நேரக் குறிப்புகளும் அளவீடுகளும்"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "\"{securityOrigin}\"க்கான <link> முன்னிணைப்பு கண்டறியப்பட்டது, ஆனால் அது உலாவியால் பயன்படுத்தப்படவில்லை. `crossorigin` பண்புக்கூறைச் சரியாகப் பயன்படுத்துகிறீர்களா என்பதைச் சரிபார்க்கவும்."
+    "message": "{securityOrigin}க்கான <link> முன்னிணைப்பு கண்டறியப்பட்டது, ஆனால் அது உலாவியால் பயன்படுத்தப்படவில்லை. `crossorigin` பண்புக்கூறை முறையாகப் பயன்படுத்துகிறீர்களா என்று சரிபார்க்கவும்."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "முக்கியமான மூன்றாம் தரப்பு டொமைன்களுடன் விரைவான இணைப்புகளை ஏற்படுத்த, ப்ரீகனெக்ட் அல்லது dns-ப்ரீஃபெட்ச் ஆதாரக் குறிப்புகளைச் சேர்க்கலாம். [மேலும் அறிக](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "முக்கியமான மூன்றாம் தரப்பு டொமைன்களுடன் விரைவான இணைப்புகளை ஏற்படுத்த, முன்பே இணைக்கப்பட்ட ஆதாரக் குறிப்புகளையோ அல்லது dns-prefetch ஆதாரக் குறிப்புகளையோ சேர்க்கவும். [மேலும் அறிக](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "தேவைப்படும் டொமைன் பெயர்களுக்கு முன்கூட்டியே இணைப்பு வழங்கவும்"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "\"{preloadURL}\"க்கான முன்ஏற்றப்பட்ட <link> இணைப்பு கண்டறியப்பட்டது, எனினும் உலாவி அதைப் பயன்படுத்தவில்லை. `crossorigin` பண்புக்கூறைச் சரியாகப் பயன்படுத்துகிறீர்களா என்பதைச் சரிபார்க்கவும்."
+    "message": "\"{preloadURL}\"க்கான <link> முன்னிணைப்பு கண்டறியப்பட்டது, ஆனால் உலாவியால் அது பயன்படுத்தப்படவில்லை. `crossorigin` பண்புக்கூறை முறையாகப் பயன்படுத்துகிறீர்களா என்று சரிபார்க்கவும்."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "பக்கம் ஏற்றப்படும்போது, தற்போது பின்னர் கோரப்படும் ஆதாரங்களை முன்னதாகப் பெறுவதற்கு முன்னுரிமைப்படுத்த, <link rel=preload>ஐப் பயன்படுத்தவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "பக்கம் ஏற்றப்படும்போது தற்சமயம் பின்னர் கோரிக்கையளிக்கப்படும் ஆதாரங்களை முன்னுரிமை அளிக்க `<link rel=preload>`ஐப் பயன்படுத்தவும். [மேலும் அறிக](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "முக்கியக் கோரிக்கைகளை முன்கூட்டியே ஏற்றவும்"
@@ -789,10 +1053,10 @@
     "message": "சிறந்த நடைமுறைகள்"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "இந்தச் சரிபார்ப்புகள் [உங்கள் இணைய ஆப்ஸின் அணுகல்தன்மையை மேம்படுத்துவதற்கான] வாய்ப்புகளைத் தனிப்படுத்துகின்றன(https://developers.google.com/web/fundamentals/accessibility). நேரடிச் சோதனையையும் ஊக்கப்படுத்துவதற்காக, அணுகல்தன்மைச் சிக்கல்களில் சிலவற்றை மட்டுமே தானாகக் கண்டறிய முடியும்."
+    "message": "இந்த சரிபார்ப்புகள் [உங்கள் இணைய ஆப்ஸின் அணுகல்தன்மையை மேம்படுத்துவதற்கான](https://developers.google.com/web/fundamentals/accessibility) வாய்ப்புகளைத் தனிப்படுத்திக் காட்டுகின்றன. அணுகல்தன்மை சிக்கல்களில் சிலவற்றை மட்டுமே தானாகக் கண்டறிய முடியும் என்பதால் நேரடி பரிசோதனையையும் செய்ய ஊக்குவிக்கிறோம்."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "தானியங்கி சோதனைக் கருவியால் சோதிக்க முடியாத பகுதிகளை இவை சோதிக்கும். [அணுகல்தன்மை மதிப்பாய்வை நடத்துதல்](https://developers.google.com/web/fundamentals/accessibility/how-to-review) குறித்து எங்கள் வழிகாட்டியில் மேலும் அறிக."
+    "message": "தானியங்கி சோதனைக் கருவியால் சோதிக்க முடியாத பகுதிகளை இவை சோதிக்கும். எங்கள் வழிகாட்டியில் [அணுகல்தன்மை மதிப்பாய்வை நடத்துவதைப்](https://developers.google.com/web/fundamentals/accessibility/how-to-review) பற்றி மேலும் தெரிந்துகொள்ளவும்."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "அணுகல்தன்மை"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "டேபிள்கள் & பட்டியல்கள்"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "சிறந்த நடைமுறைகள்"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "செயல்திறன் பட்ஜெட்கள் உங்கள் தளத்தின் செயல்திறனுக்கான தர நிலைகளை அமைக்கும்."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "பட்ஜெட்கள்"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "உங்கள் ஆப்ஸின் செயல்திறன் பற்றிய மேலும் சில தகவல்கள்."
+    "message": "உங்கள் ஆப்ஸின் செயல்திறன் பற்றிய மேலும் சில தகவல்கள். இந்த மதிப்புகளானது செயல்திறனின் ஸ்கோரை [நேரடியாகப் பாதிக்காது](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "பகுப்பாய்வு"
@@ -840,7 +1113,7 @@
     "message": "முதல் தோற்ற மேம்பாடுகள்"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "இந்த மேம்படுத்ததுதல்கள் உங்கள் பக்கத்தை வேகமாக ஏற்றலாம்."
+    "message": "இந்தப் பரிந்துரைகள் உங்கள் பக்கத்தை வேகமாக ஏற்ற உதவும். அவை செயல்திறன் ஸ்கோரை [நேரடியாகப் பாதிக்காது](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "பரிந்துரைகள்"
@@ -888,7 +1161,7 @@
     "message": "கிராலிங் & அட்டவணைப்படுத்துதல்"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "பக்கங்களின் உள்ளடக்கத்தைப் பயனர்கள் பின்ச் செய்தோ பெரிதாக்கியோ படிக்க வேண்டிய அவசியம் ஏற்படாதவாறு உங்கள் பக்கங்கள் மொபைலுக்கு ஏற்றவையாக இருக்க வேண்டும். [மேலும் அறிக](https://developers.google.com/search/mobile-sites/)."
+    "message": "பக்கங்களின் உள்ளடக்கத்தை பயனர்கள் பின்ச் செய்தோ பெரிதாக்கியோ படிக்க வேண்டிய அவசியம் ஏற்படாதவாறு உங்கள் பக்கங்கள் மொபைலுக்கு ஏற்றவையாக இருக்க வேண்டும். [மேலும் அறிக](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "மொபைலுக்கேற்றது"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "தற்காலிக நினைவக TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "இடம்"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "பெயர்"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "கோரிக்கைகள்"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "ஆதார வகை"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "அளவு (கி.பை.)"
+    "message": "அளவு"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "செலவிட்ட நேரம்"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "பரிமாற்ற அளவு"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "தோராயமான சேமிப்பு (கி.பை.)"
+    "message": "சேமிக்கப்படக்கூடியவை"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "தோராயமான சேமிப்புகள் (மி.வி.)"
+    "message": "சேமிக்கப்படக்கூடியவை"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "சேமிக்கக்கூடிய அளவு: {wastedBytes, number, bytes} கி.பை."
+    "message": "சேமிக்கக்கூடிய அளவு: {wastedBytes, number, bytes} கி.பை."
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "சேமிக்கக்கூடிய நேரம்: {wastedMs, number, milliseconds} மி.வி."
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "ஆவணம்"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "எழுத்துரு"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "படம்"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "மீடியா"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} மி.வி."
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "மற்றவை"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "ஸ்கிரிப்ட்"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} வி"
+    "message": "{timeInMs, number, seconds} வி."
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "ஸ்டைல்ஷீட்"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "மூன்றாம் தரப்பு"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "மொத்தம்"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "உங்கள் பக்கம் ஏற்றப்படுகையில் டிரேஸைப் பதிவுசெய்யும்போது ஏதோ தவறாகிவிட்டது. Lighthouseஸை மீண்டும் இயக்கவும். ({errorCode})"
@@ -930,13 +1245,19 @@
     "message": "முதல் பிழைதிருத்தும் நெறிமுறை இணைப்பிற்கான நேரமுடிவு காத்திருப்பு."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "பக்கம் ஏற்றப்பட்டபோது ஸ்க்ரீன்ஷாட்கள் எதையும் Chrome சேகரிக்கவில்லை. பக்கத்தில் உள்ளடக்கம் காண்பிக்கப்படுவதை உறுதிசெய்து, Lighthouseஸை மீண்டும் இயக்கவும். ({errorCode})"
+    "message": "பக்கம் ஏற்றப்பட்டபோது ஸ்க்ரீன்ஷாட்கள் எதையும் Chrome சேகரிக்கவில்லை. பக்கத்தில் ஏதேனும் உள்ளடக்கம் காண்பிக்கப்படுவதை உறுதிப்படுத்திக் கொண்டு Lighthouseஸை மீண்டும் இயக்கவும். ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "வழங்கப்பட்டுள்ள டொமைனை DNS சேவையகங்களால் அடையாளம் காண முடியவில்லை."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "தேவைப்படும் {artifactName} சேகரிப்பானில் பிழையொன்று ஏற்பட்டது: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Chrome அகப் பிழை நேர்ந்தது. Chromeமை மீண்டும் தொடங்கி, Lighthouseஸை மீண்டும் இயக்கவும்."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "தேவைப்படும் {artifactName} சேகரிப்பான் இயங்கவில்லை."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "நீங்கள் கோரிய பக்கத்தை Lighthouseஸால் முழுமையாக ஏற்ற முடியவில்லை. நீங்கள் சரியான URLலைச் சோதிப்பதையும் அனைத்துக் கோரிக்கைகளுக்கும் சேவையகம் சரியாகப் பதிலளிப்பதையும் உறுதிசெய்யவும்."
@@ -945,19 +1266,22 @@
     "message": "பக்கம் பதிலளிப்பதை நிறுத்தியதால் நீங்கள் கோரிய URLலை Lighthouseஸால் முழுமையாக ஏற்ற முடியவில்லை."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "நீங்கள் வழங்கியுள்ள URLகளுக்குச் செல்லுபடியாகும் பாதுகாப்பு அனுமதிச் சான்றுகள் இல்லை. {securityMessages}"
+    "message": "நீங்கள் வழங்கியுள்ள URLலில் செல்லுபடியாகும் பாதுகாப்பு சான்றிதழ்கள் இல்லை. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "பக்கத்தை ஏற்றுவதை இடைச்செருகல் திரையொன்றின் மூலம் Chrome தடுத்துவிட்டது. நீங்கள் சரியான URLலைப் பரிசோதிப்பதையும் அனைத்துக் கோரிக்கைகளுக்கும் சேவையகம் முறையாக பதிலளிப்பதையும் உறுதிசெய்து கொள்ளவும்."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "நீங்கள் கோரிய பக்கத்தை Lighthouseஸால் முழுமையாக ஏற்ற முடியவில்லை. நீங்கள் சரியான URLலைச் சோதிப்பதையும் அனைத்துக் கோரிக்கைகளுக்கும் சேவையகம் சரியாகப் பதிலளிப்பதையும் உறுதிசெய்யவும். (விவரங்கள்: {errorDetails})"
+    "message": "நீங்கள் கோரிய பக்கத்தை Lighthouseஸால் முழுமையாக ஏற்ற முடியவில்லை. நீங்கள் சரியான URLலைப் பரிசோதிப்பதையும் அனைத்துக் கோரிக்கைகளுக்கும் சேவையகம் முறையாக பதிலளிப்பதையும் உறுதிசெய்து கொள்ளவும். (விவரங்கள்: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "நீங்கள் கோரிய பக்கத்தை Lighthouseஸால் முழுமையாக ஏற்ற முடியவில்லை. நீங்கள் சரியான URLலைச் சோதிப்பதையும் அனைத்துக் கோரிக்கைகளுக்கும் சேவையகம் சரியாகப் பதிலளிப்பதையும் உறுதிசெய்யவும். (நிலைக் குறியீடு: {statusCode})"
+    "message": "நீங்கள் கோரிய பக்கத்தை Lighthouseஸால் முழுமையாக ஏற்ற முடியவில்லை. நீங்கள் சரியான URLலைப் பரிசோதிப்பதையும் அனைத்துக் கோரிக்கைகளுக்கும் சேவையகம் முறையாக பதிலளிப்பதையும் உறுதிசெய்து கொள்ளவும். (நிலைக் குறியீடு: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "உங்கள் பக்கம் ஏற்றப்படுவதற்கு நீண்ட நேரமானது. பக்கத்தின் ஏற்றுதல் நேரத்தைக் குறைக்க, அறிக்கையில் உள்ள வாய்ப்புகளைப் பின்பற்றி, Lighthouseஸை மீண்டும் இயக்கவும். ({errorCode})"
+    "message": "உங்கள் பக்கம் ஏற்றப்பட நீண்ட நேரம் எடுத்துக்கொண்டது. பக்கத்தின் ஏற்றுதல் நேரத்தைக் குறைக்க அறிக்கையிலுள்ள வாய்ப்புகளைப் பின்பற்றி Lighthouseஸை மீண்டும் இயக்கவும். ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "ஒதுக்கப்பட்ட நேரத்தை DevTools நெறிமுறைக்குக் காத்திருக்கும் நேரம் மீறிவிட்டது. (முறை: {protocolMethod})"
+    "message": "DevTools நெறிமுறைக்காகக் காத்திருக்கும் ஒதுக்கப்பட்ட நேரத்தை மீறிவிட்டது. (முறை:{protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "ஒதுக்கப்பட்ட நேரத்தை ஆதார உள்ளடக்கத்தைப் பெறுவதற்கான நேரம் மீறிவிட்டது"
@@ -984,7 +1308,7 @@
     "message": "ஆய்வகத் தரவு"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) எமுலேடட் மொபைல் நெட்வொர்க்கில் தற்போதைய பக்கத்திற்கான பகுப்பாய்வு செய்யப்பட்டது. மதிப்புகள் தோராயமானவை, மாறுபடக்கூடியவை."
+    "message": "எமுலேட்டட் மொபைல் நெட்வொர்க்கில் தற்போதைய பக்கத்திற்கான [Lighthouse](https://developers.google.com/web/tools/lighthouse/) பகுப்பாய்வு. மதிப்புகள் தோராயமானவை, மாறுபடக்கூடியவை."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "கைமுறையாகச் சரிபார்க்க வேண்டிய கூடுதல் விஷயங்கள்"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "துணுக்கை விரி"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "மூன்றாம் தரப்பு ஆதாரங்களைக் காட்டு"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Lighthouseஸின் இந்த இயக்கத்தைச் சில சிக்கல்கள் பாதிக்கின்றன:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "மதிப்புகள் தோராயமானவை மற்றும் மாறுபடக்கூடியவை."
+    "message": "மதிப்புகள் தோராயமானவை, மாறுபடக்கூடியவை. [இந்த அளவீடுகளின் அடிப்படையில் மட்டுமே](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) செயல்திறன் ஸ்கோர் கணக்கிடப்படும்."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "தணிக்கைகளில் தேர்ச்சிபெற்றவை, ஆனால் எச்சரிக்கைகள் உள்ளவை"
@@ -1023,10 +1350,10 @@
     "message": "உங்கள் GIFஃபை HTML5 வீடியோவாக உட்பொதிந்து கிடைக்கச் செய்யும் சேவையில் பதிவேற்ற முயலுங்கள்."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "[lazy-load WordPress செருகுநிரலை] நிறுவி (https://wordpress.org/plugins/search/lazy+load/) திரைக்கு வெளியிலுள்ள படங்களைத் தேவையான போது ஏற்றும் திறனைப் பெறலாம் அல்லது அந்தத் திறனுள்ள தீமிற்கு மாறலாம். [AMP செருகுநிரலையும்](https://wordpress.org/plugins/amp/) பயன்படுத்திப் பார்க்கவும்."
+    "message": "[lazy-load WordPress செருகுநிரலை](https://wordpress.org/plugins/search/lazy+load/) நிறுவி திரைக்கு வெளியிலுள்ள படங்களைத் தேவையான போது ஏற்றும் திறனைப் பெறலாம் அல்லது அந்தத் திறன் கொண்ட தீமிற்கு மாறலாம். [AMP செருகுநிரலையும்](https://wordpress.org/plugins/amp/) பயன்படுத்திப் பார்க்கவும்."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "[முக்கியமான சொத்துகளை முன்னிலைப்படுத்தவும்](https://wordpress.org/plugins/search/critical+css/) அல்லது [முக்கியத்துவம் குறைவான ஆதாரங்களைத் தவிர்க்கவும்](https://wordpress.org/plugins/search/defer+css+javascript/) உங்களுக்கு உதவக்கூடிய பல WordPress செருகுநிரல்கள் உள்ளன. இந்தச் செருகுநிரல்கள் வழங்கும் மேம்படுத்துதல்கள் உங்கள் தீமிலோ செருகுநிரலிலோ உள்ள அம்சத்தைப் பாதிக்கலாம். அதனால் நீங்கள் குறியீட்டில் சில மாற்றங்களைச் செய்ய வேண்டியிருக்கும்."
+    "message": "[முக்கியமான சொத்துகளை முன்னிலைப்படுத்தவோ](https://wordpress.org/plugins/search/critical+css/) [முக்கியத்துவம் குறைவான ஆதாரங்களைத் தவிர்க்கவோ](https://wordpress.org/plugins/search/defer+css+javascript/) உங்களுக்கு உதவக்கூடிய பல WordPress செருகுநிரல்கள் உள்ளன. இந்த செருகுநிரல்கள் வழங்கும் மேம்படுத்துதல்கள் உங்கள் தீமிலோ செருகுநிரலிலோ உள்ள அம்சத்தைப் பாதிக்கலாம். அதனால் நீங்கள் குறியீட்டில் சில மாற்றங்களை செய்ய வேண்டியிருக்கும்."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "தீம்கள், செருகுநிரல்கள், சேவையக விவரக்குறிப்புகள் அனைத்தும் சேவையகத்தின் வேகத்தை நிர்ணயிக்கும். மேலும் மேம்படுத்தப்பட்ட தீமைக் கண்டறிந்து, மேம்படுத்தும் செருகுநிரலைக் கவனமாகத் தேர்ந்தெடுத்து மற்றும்/அல்லது சேவையகத்தை மேம்படுத்தவும்."
@@ -1035,30 +1362,30 @@
     "message": "இடுகைப் பட்டியல்களில் முக்கியமான பகுதியை மட்டும் காட்டலாம் (உதாரணமாக மேலும் என்ற குறிச்சொல்லுடன்), பக்கத்தில் இடுகைகளின் எண்ணிக்கையைக் குறைக்கலாம், ஒரு பெரிய இடுகையைப் பல சின்ன பக்கங்களாகப் பிரிக்கலாம் அல்லது தேவையுள்ள போது மட்டும் கருத்துகளைச் செருகுநிரல்கள் மூலம் ஏற்றலாம்."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "பல [WordPress செருகுநிரல்கள்](https://wordpress.org/plugins/search/minify+javascript/) உங்கள் இணையதளத்தில் உள்ள ஸ்டைல்களைச் சிறிதாக்கியும், சுருக்கியும், ஒன்றிணைத்தும் அதை வேகப்படுத்த முடியும். முடிந்தால், ஸ்கிரிப்ட்களை முன்னதாகவே சிறிதாக்க பதிப்பு முறைமையைப் பயன்படுத்திப் பார்க்கலாம்."
+    "message": "பல [WordPress செருகுநிரல்கள்](https://wordpress.org/plugins/search/minify+css/) உங்கள் இணையதளத்தில் உள்ள ஸ்டைல்களை சிறிதாக்கியும், சுருக்கியும், ஒன்றிணைத்தும் அதை வேகப்படுத்த முடியும். முடிந்தால், ஸ்கிரிப்ட்களை முன்னதாகவே சிறிதாக்க பதிப்பு முறைமையைப் பயன்படுத்திப் பார்க்கலாம்."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "பல [WordPress செருகுநிரல்கள்](https://wordpress.org/plugins/search/minify+javascript/) உங்கள் இணையதளத்தில் உள்ள ஸ்கிரிப்ட்களைச் சிறிதாக்கியும், சுருக்கியும், ஒன்றிணைத்தும் அதை வேகப்படுத்த முடியும். முடிந்தால், ஸ்கிரிப்ட்களை முன்னதாகவே சிறிதாக்க பதிப்பு முறைமையைப் பயன்படுத்திப் பார்க்கலாம்."
+    "message": "பல [WordPress செருகுநிரல்கள்](https://wordpress.org/plugins/search/minify+javascript/) உங்கள் இணையதளத்திலுள்ள ஸ்கிரிப்ட்களை சிறிதாக்கியும், சுருக்கியும், ஒன்றிணைத்தும் அதை வேகப்படுத்த முடியும். முடிந்தால், ஸ்கிரிப்ட்களை முன்னதாகவே சிறிதாக்க பதிப்பு முறைமையைப் பயன்படுத்திப் பார்க்கலாம்."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "உங்கள் பக்கத்தில் [WordPress செருகுநிரல்கள்](https://wordpress.org/plugins/) ஏற்றும் பயன்படுத்தப்படாத CSSகளின் எண்ணிக்கையைக் குறைக்கவும் அல்லது மாற்றிப் பார்க்கவும். Chrome DevToolsஸில் [குறியீட்டுக் கவரேஜ்] (https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) என்பதை இயக்கி தேவையற்ற CSSஸைச் சேர்க்கும் செருகுநிரல்களைக் கண்டறியலாம். stylesheetடின் URLலில் இதற்குக் காரணமான தீம்/செருகுநிரலைக் கண்டறியலாம். அதிகமாகச் சிகப்பில் உள்ள குறியீட்டுக் கவரேஜைக் கொண்ட பட்டியலில் பல stylesheetகளைக் கொண்ட செருகுநிரல்களைக் கண்டறியவும். இணையப் பக்கத்தில் பயன்படுத்தும் பட்சத்தில் ஒரு செருகுநிரல் ஒரு stylesheetடை மட்டுமே வரிசையில் சேர்க்க வேண்டும்."
+    "message": "உங்கள் பக்கத்தில் [WordPress செருகுநிரல்கள்](https://wordpress.org/plugins/) ஏற்றும் பயன்படுத்தப்படாத CSSஸின் எண்ணிக்கையைக் குறைக்கவும் அல்லது மாற்றிப் பார்க்கவும். Chrome DevToolsஸில் [குறியீட்டுக் கவரேஜ் ](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) என்பதை இயக்கி தேவையற்ற CSSஸை சேர்க்கும் செருகுநிரல்களைக் கண்டறியவும். ஸ்டைல்ஷீட்டின் URLலில் இதற்குக் காரணமான தீம்/செருகுநிரலைக் கண்டறியலாம். அதிகளவு சிகப்பில் உள்ள குறியீட்டுக் கவரேஜைக் கொண்ட பட்டியலில் பல ஸ்டைல்ஷீட்களைக் கொண்ட செருகுநிரல்களைக் கண்டறியவும். இணையப் பக்கத்தில் பயன்படுத்தும் பட்சத்தில் ஒரு செருகுநிரல் ஒரு ஸ்டைல்ஷீட்டை மட்டுமே வரிசையில் சேர்க்க வேண்டும்."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "உங்கள் பக்கத்தில் [WordPress செருகுநிரல்கள்](https://wordpress.org/plugins/) ஏற்றும் பயன்படுத்தப்படாத JavaScriptகளின் எண்ணிக்கையைக் குறைக்கவும் அல்லது மாற்றிப் பார்க்கவும். Chrome DevToolsஸில் [குறியீட்டுக் கவரேஜ்](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) என்பதை இயக்கி தேவையற்ற JSகளைச் சேர்க்கும் செருகுநிரல்களைக் கண்டறியவும். ஸ்கிரிப்ட்டின் URLலில் இதற்குக் காரணமான தீம்/செருகுநிரலைக் கண்டறியலாம். அதிகமாகச் சிகப்பில் உள்ள குறியீட்டுக் கவரேஜைக் கொண்ட பட்டியலில் பல ஸ்கிரிப்ட்களைக் கொண்ட செருகுநிரல்களைக் கண்டறியவும். இணையப் பக்கத்தில் பயன்படுத்தும் பட்சத்தில் ஒரு செருகுநிரல் ஒரு ஸ்கிரிப்ட்டை மட்டுமே வரிசையில் சேர்க்க வேண்டும்."
+    "message": "உங்கள் பக்கத்தில் [WordPress செருகுநிரல்கள்](https://wordpress.org/plugins/) ஏற்றும் பயன்படுத்தப்படாத JavaScriptகளின் எண்ணிக்கையைக் குறைக்கவும் அல்லது மாற்றிப் பார்க்கவும். Chrome DevToolsஸில் [குறியீட்டுக் கவரேஜ் ](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) என்பதை இயக்கி தேவையற்ற JSகளைச் சேர்க்கும் செருகுநிரல்களைக் கண்டறியவும். ஸ்கிரிப்ட்டின் URLலில் இதற்குக் காரணமான தீம்/செருகுநிரலைக் கண்டறியலாம். அதிகளவு சிகப்பில் உள்ள குறியீட்டுக் கவரேஜைக் கொண்ட பட்டியலில் பல ஸ்கிரிப்ட்களைக் கொண்ட செருகுநிரல்களைக் கண்டறியவும். இணையப் பக்கத்தில் பயன்படுத்தும் பட்சத்தில் ஒரு செருகுநிரல் ஒரு ஸ்கிரிப்ட்டை மட்டுமே வரிசையில் சேர்க்க வேண்டும்."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "[WordPressஸில் உலாவியின் தற்காலிக சேமிப்பு] பற்றி அறிய: (https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "[WordPressஸில் உலாவியின் தற்காலிக சேமிப்பு](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching) பற்றித் தெரிந்துகொள்ளவும்."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "இதைப் பயன்படுத்தி உங்கள் படங்களின் தரத்தை இழக்காமல் சுருக்கலாம்: [படங்களை மேம்படுத்தும் WordPress செருகுநிரல்](https://wordpress.org/plugins/search/optimize+images/)"
+    "message": "[படங்களை மேம்படுத்தும் WordPress செருகுநிரலைப்](https://wordpress.org/plugins/search/optimize+images/) பயன்படுத்தி உங்கள் படங்களின் தரத்திற்குப் பாதிப்பு ஏற்படாமல் சுருக்கலாம்."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "[மீடியா லைப்ரரி](https://codex.wordpress.org/Media_Library_Screen) மூலம் படத்தை நேரடியாகப் பதிவேற்றி சரியான அளவில் கிடைக்கிறதா என்று உறுதிப்படுத்தலாம், பிறகு மீடியா லைப்ரரியிலிருந்தோ பட விட்ஜெட்டைப் பயன்படுத்தியோ மேம்படுத்தப்பட்ட அளவில் படங்கள் பயன்படுத்தப்படுகிறதா என்பதை உறுதி செய்யவும் (பதிலளிக்கும் அளவு வரம்புகள் உட்பட). பயன்படுத்துவதற்கு ஏதுவான அளவுகள் உள்ளபோது மட்டுமே 'முழு அளவு' படங்களைப் பயன்படுத்தவும். [மேலும் அறிக](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "[மீடியா லைப்ரரி](https://codex.wordpress.org/Media_Library_Screen) மூலம் படத்தை நேரடியாகப் பதிவேற்றி சரியான அளவில் கிடைக்கிறதா என்று உறுதிப்படுத்திக் கொள்ளலாம். பிறகு மீடியா லைப்ரரியிலிருந்தோ பட விட்ஜெட்டைப் பயன்படுத்தியோ மேம்படுத்தப்பட்ட அளவில் படங்கள் பயன்படுத்தப்படுகின்றனவா என்பதை உறுதி செய்யவும் (பதிலளிக்கும் அளவு வரம்புகள் உட்பட). பயன்படுத்த ஏதுவான அளவுகள் உள்ளபோது மட்டுமே `Full Size` படங்களைப் பயன்படுத்தவும். [மேலும் அறிக](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "இணையச் சேவையக உள்ளமைவில் உரை சுருக்குதலை இயக்கலாம்."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "நீங்கள் பதிவேற்றிய படங்களை மேம்படுத்தப்பட்ட வடிவத்திற்குத் தானாக மாற்ற ஒரு [செருகுநிரலையோ](https://wordpress.org/plugins/search/convert+webp/) சேவையையோ பயன்படுத்திப் பாருங்கள்."
+    "message": "நீங்கள் பதிவேற்றிய படங்களை மேம்படுத்தப்பட்ட வடிவமைப்புகளுக்குத் தானாக மாற்றும் ஒரு [செருகுநிரலையோ](https://wordpress.org/plugins/search/convert+webp/) சேவையையோ பயன்படுத்தவும்."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/te.json
+++ b/lighthouse-core/lib/i18n/locales/te.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "యాక్సెస్ కీలతో వినియోగదారులు పేజీలోని నిర్దిష్ట భాగంపై వేగంగా దృష్టి సారించగలరు. సక్రమమైన నావిగేషన్ కోసం, ప్రతి యాక్సెస్ కీ తప్పనిసరిగా విభిన్నంగా ఉండాలి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "యాక్సెస్ కీలతో వినియోగదారులు పేజీలోని నిర్దిష్ట భాగంపై వేగంగా దృష్టి సారించగలరు. సక్రమమైన నావిగేషన్ కోసం, ప్రతి యాక్సెస్ కీ తప్పనిసరిగా విభిన్నంగా ఉండాలి. [మరింత తెలుసుకోండి](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "`[accesskey]` విలువలు ప్రత్యేకమైనవి కావు"
+    "message": "'`[accesskey]`' విలువలు విశిష్ఠమైనవి కావు"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "`[accesskey]` విలువలు విశిష్ఠమైనవి"
+    "message": "`[accesskey]` విలువలు ప్రత్యేకమైనవి"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "ప్రతి ARIA `role` నిర్దిష్ట సబ్‌సెట్ `aria-*` లక్షణాలకు మద్దతు ఇస్తుంది. వీటిని తప్పుగా సరిపోల్చితే `aria-*` లక్షణాలు చెల్లనివిగా అయిపోతాయి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "ప్రతి ARIA `role`, `aria-*` లక్షణాల నిర్ధిష్ట సబ్‌సెట్‌కు మద్దతు ఇస్తుంది. వీటికి సరిపోలకపోతే `aria-*` లక్షణాలను చెల్లనివిగా చేస్తుంది. [మరింత తెలుసుకోండి](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "`[aria-*]` లక్షణాలు వాటి పాత్రలతో సరిపోలలేదు"
+    "message": "``[aria-*]`` లక్షణాలు వాటి పాత్రలతో సరిపోలలేదు"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "`[aria-*]` లక్షణాలు వాటి పాత్రలతో సరిపోలాలి"
+    "message": "'`[aria-*]`' లక్షణాలు వాటి పాత్రలతో సరిపోలాలి"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "కొన్ని ARIA పాత్రలు మూలకం స్థితిని స్క్రీన్ రీడర్‌లకు వివరించే ఆవశ్యక లక్షణాలను కలిగి ఉన్నాయి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "కొన్ని ARIA పాత్రలు మూలకం స్థితిని స్క్రీన్ రీడర్‌లకు వివరించే ఆవశ్యక లక్షణాలను కలిగి ఉన్నాయి. [మరింత తెలుసుకోండి](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "`[role]` అన్ని అవసరమైన `[aria-*]` మూలకాలు కలిగి లేదు"
+    "message": "'`[role]`'లలో అవసరమైన అన్ని '`[aria-*]`' లక్షణాలు లేవు"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "`[role]`లు అన్ని అవసరమైన `[aria-*]` లక్షణాలను కలిగి ఉన్నాయి"
+    "message": "'`[role]`'లకు అన్ని అవసరమైన అన్ని '`[aria-*]`' లక్షణాలు ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "కొన్ని ARIA మూలాధార పాత్రలు తప్పనిసరిగా నిర్దిష్ట ఉపాంశ పాత్రల కలయికతో వాటి ఉద్దేశిత యాక్సెసిబిలిటీ ఫంక్షన్‌లు సరిగ్గా అమలయ్యే విధంగా ఉండాలి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "కొన్ని ARIA మూలాధార పాత్రలు తప్పనిసరిగా నిర్దిష్ట ఉపాంశ పాత్రల కలయికతో వాటి ఉద్దేశిత యాక్సెసిబిలిటీ ఫంక్షన్‌లు సరిగ్గా అమలయ్యే విధంగా ఉండాలి. [మరింత తెలుసుకోండి](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "నిర్దిష్ట ఉపాంశ `[role]` అవసరమైన `[role]` మూలకాలు కనిపించడం లేదు."
+    "message": "నిర్దిష్ట ఉపాంశ '`[role]`'లు అవసరమైన '`[role]`' గల మూలకాలు ఉన్నాయి."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "నిర్దిష్ట ఉపాంశ `[role]`లు అవసరమైన `[role]` మూలకాలు ఉన్నాయి."
+    "message": "నిర్దిష్ట ఉపాంశ '`[role]`'లు అవసరమైన '`[role]`' గల మూలకాలు ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "కొన్ని ARIA ఉపాంశ పాత్రలు తప్పనిసరిగా నిర్దిష్ట మూలధార పాత్రల కలయికతో వాటి ఉద్దేశిత యాక్సెసిబిలిటీ ఫంక్షన్‌లు సరిగ్గా అమలయ్యే విధంగా ఉండాలి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "కొన్ని ARIA ఉపాంశ పాత్రలు తప్పనిసరిగా నిర్దిష్ట మూలధార పాత్రల కలయికతో వాటి ఉద్దేశిత యాక్సెసిబిలిటీ ఫంక్షన్‌లు సరిగ్గా అమలయ్యే విధంగా ఉండాలి. [మరింత తెలుసుకోండి](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "`[role]`లు వాటి అవసరమైన మూలాధార మూలకంతో లేవు"
+    "message": "``[role]``లు వాటి అవసరమైన మూలాధార మూలకంతో లేవు"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "`[role]` వాటి అవసరమైన మూలాధార మూలకంతో ఉన్నాయి"
+    "message": "``[role]``లు వాటికి అవసరమైన మూలాధార మూలకాలలో ఉన్నాయి."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA పాత్రలు వాటి ఉద్దేశిత యాక్సెసిబిలిటీ ఫంక్షన్‌లను అమలు చేయడానికి తప్పనిసరిగా వాటిలో చెల్లుబాటయ్యే విలువలు ఉండాలి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA పాత్రలు వాటి ఉద్దేశిత యాక్సెసిబిలిటీ ఫంక్షన్‌లను అమలు చేయడానికి తప్పనిసరిగా వాటిలో చెల్లుబాటయ్యే విలువలు ఉండాలి. [మరింత తెలుసుకోండి](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "`[role]` విలువలు చెల్లుబాటయ్యేవి కావు"
+    "message": "`[role]` విలువలు చెల్లుబాటు అయ్యేవి కావు"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
     "message": "`[role]` విలువలు చెల్లుబాటు అయ్యేవి"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "స్క్రీన్ రీడర్‌ల లాంటి సహాయక సాంకేతిక పరిజ్ఞానాలు చెల్లుబాటు కాని విలువల గల ARIA లక్షణాలను అర్థం చేసుకోలేవు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "స్క్రీన్ రీడర్‌ల లాంటి సహాయక సాంకేతిక పరిజ్ఞానాలు చెల్లుబాటు కాని విలువలు గల ARIA లక్షణాలను అర్థం చేసుకోలేవు. [మరింత తెలుసుకోండి](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "`[aria-*]` లక్షణాలలో చెల్లుబాటయ్యే విలువలు లేవు"
+    "message": "'`[aria-*]`' లక్షణాలలో చెల్లుబాటయ్యే విలువలు లేవు"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "`[aria-*]` లక్షణాలు చెల్లుబాటయ్యే విలువలను కలిగి ఉన్నాయి"
+    "message": "'`[aria-*]`' లక్షణాలు చెల్లుబాటయ్యే విలువలను కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "స్క్రీన్ రీడర్‌ల లాంటి సహాయక సాంకేతిక పరిజ్ఞానాలు చెల్లుబాటు కాని పేర్లు గల ARIA లక్షణాలను అర్థం చేసుకోలేవు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "స్క్రీన్ రీడర్‌ల లాంటి సహాయక సాంకేతిక పరిజ్ఞానాలు చెల్లుబాటు కాని పేర్లు గల ARIA లక్షణాలను అర్థం చేసుకోలేవు. [మరింత తెలుసుకోండి](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "`[aria-*]` లక్షణాలు చెల్లుబాటు అయ్యేవి కావు లేదా అక్షరదోషాలు ఉన్నాయి"
+    "message": "``[aria-*]`` లక్షణాలు చెల్లుబాటు అయ్యేవి కావు లేదా అక్షరదోషాలు ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "`[aria-*]` లక్షణాలు చెల్లుబాటు అయ్యేవి, అక్షరదోషాలేవీ లేవు"
+    "message": "``[aria-*]`` లక్షణాలు చెల్లుబాటు అయ్యేవి, అక్షరదోషాలేవీ లేవు"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "శీర్షికల సహాయంతో ఆడియో మూలకాలలో ఏమి ఉన్నది చెవిటి లేదా వినికిడి సమస్య ఉన్న వినియోగదారులు అర్థం చేసుకోగలరు, దీని ద్వారా ఎవరు మాట్లాడుతున్నారు, ఏమి చెబుతున్నారు లాంటి కీలకమైన సమాచారం, ఇతర సంభాషణేతర సమాచారం అందించబడుతుంది. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "శీర్షికల సహాయంతో ఆడియో మూలకాలలో ఏమి ఉన్నది చెవిటి లేదా వినికిడి సమస్య ఉన్న వినియోగదారులు అర్థం చేసుకోగలరు, దీని ద్వారా ఎవరు మాట్లాడుతున్నారు, ఏమి చెబుతున్నారు లాంటి కీలకమైన సమాచారం, ఇతర సంభాషణేతర సమాచారం అందించబడుతుంది. [మరింత తెలుసుకోండి](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "`<audio>` మూలకాలలో `[kind=\"captions\"]`తో `<track>` మూలకం లేదు."
+    "message": "'`<audio>`' మూలకాలలో '`[kind=\"captions\"]`'తో '`<track>`' మూలకం లేదు."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "`<audio>` మూలకాలలో `[kind=\"captions\"]`తో `<track>` మూలకం ఉంది"
+    "message": "'`<audio>`' మూలకాలు '`[kind=\"captions\"]`'తో '`<track>`' మూలకం కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "విఫలం అవుతున్న మూలకాలు"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "ఒక బటన్‌కు యాక్సెస్ చేయదగిన పేరు లేనప్పుడు, స్క్రీన్ రీడర్‌లు దీనిని \"బటన్\"గా ప్రకటిస్తాయి, తద్వారా స్క్రీన్ రీడర్‌లపై ఆధారపడే వినియోగదారులకు నిరుపయోగమైనవిగా చేస్తాయి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "ఒక బటన్‌కు యాక్సెస్ చేయదగిన పేరు లేనప్పుడు, స్క్రీన్ రీడర్‌లు దానిని \"బటన్\"గా ప్రకటిస్తాయి, తద్వారా స్క్రీన్ రీడర్‌లపై ఆధారపడే వినియోగదారులకు నిరుపయోగమైనవిగా చేస్తాయి. [మరింత తెలుసుకోండి](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "బటన్‌లకు యాక్సెస్‌కి తగిన పేరు లేదు"
@@ -93,7 +93,7 @@
     "message": "బటన్‌లు యాక్సెస్ చేయదగిన పేరును కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "పునరావృత కంటెంట్‌ను దాటవేయడానికి మార్గాలను జోడించడం వలన కీబోర్డ్ వినియోగదారులు పేజీలో మరింత సమర్థవంతంగా నావిగేట్ చేయగలరు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "పునరావృత కంటెంట్‌ను దాటవేయడానికి మార్గాలను జోడించడం వలన కీబోర్డ్ వినియోగదారులు పేజీలో మరింత సమర్థవంతంగా నావిగేట్ చేయగలరు. [మరింత తెలుసుకోండి](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "పేజీలో ముఖ్యశీర్షిక, దాటివేత లింక్ లేదా ల్యాండ్‌మార్క్ ప్రాంతం లేవు"
@@ -102,7 +102,7 @@
     "message": "పేజీలో ముఖ్య శీర్షిక, దాటివేత లింక్ లేదా ల్యాండ్‌మార్క్ ప్రాంతం ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "తక్కువ వర్ణభేద వచనం- చాలా మంది వినియోగదారులు చదవడానికి కష్టసాధ్యమైనది లేదా అసలు సాధ్యం కానిది. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "తక్కువ వర్ణభేద వచనం- చాలా మంది వినియోగదారులు చదవడానికి కష్టసాధ్యమైనది లేదా అసలు సాధ్యం కానిది. [మరింత తెలుసుకోండి](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "నేపథ్యం, ముందువైపు రంగులు తగినంత వర్ణభేద నిష్పత్తితో లేవు"
@@ -111,88 +111,88 @@
     "message": "నేపథ్యం మరియు ముందువైపు రంగులు తగినంత వర్ణభేద నిష్పత్తితో ఉంటున్నాయి"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "నిర్వచన జాబితాలను సరిగ్గా గుర్తు పట్టే విధంగా సెట్ చేయనప్పుడు, స్క్రీన్ రీడర్‌లు అయోమయానికి గురి చేసేలా లేదా అనిర్దిష్టమైన అవుట్‌పుట్‌ను అందించవచ్చు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "నిర్వచన జాబితాలను సరిగ్గా గుర్తు పట్టే విధంగా సెట్ చేయనప్పుడు, స్క్రీన్ రీడర్‌లు అయోమయానికి గురి చేసే లేదా అనిర్దిష్టమైన అవుట్‌పుట్‌ను అందించవచ్చు. [మరింత తెలుసుకోండి](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "`<dl>`లకు సంబంధించి కేవలం సక్రమంగా ఆర్డర్ చేసిన ఏకైక `<dt>` మరియు `<dd>` సమూహాలు, `<script>` లేదా `<template>` మూలకాలు లేవు."
+    "message": "'`<dl>`'లకు సంబంధించి కేవలం సక్రమంగా ఆర్డర్ చేసిన ఏకైక '`<dt>`', '`<dd>`' సమూహాలు, '`<script>`' లేదా '`<template>`' మూలకాలతో ఉండకూడదు."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "`<dl>`లకు సంబంధించి సక్రమంగా ఆర్డర్ చేసిన ఏకైక `<dt>` మరియు `<dd>` సమూహాలు, `<script>` లేదా `<template>` మూలకాలు మాత్రమే ఉన్నాయి."
+    "message": "'`<dl>`'లలో కేవలం సక్రమంగా ఆర్డర్ చేసిన '`<dt>`', '`<dd>`' సమూహాలు, '`<script>`' లేదా '`<template>`' మూలకాలు ఉన్నాయి."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "స్క్రీన్ రీడర్‌లు నిర్వచన జాబితా అంశాలను (`<dt>` మరియు `<dd>`) సక్రమంగా ప్రకటించడం కోసం వాటిని తప్పనిసరిగా మూలధార `<dl>` మూలకంలో సర్దుబాటు చేయాలి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "స్క్రీన్ రీడర్‌లు నిర్వచన జాబితా అంశాలను ('`<dt>`', '`<dd>`') సక్రమంగా ప్రకటించడం కోసం వాటిని తప్పనిసరిగా మూలాధార '`<dl>`' మూలకంలో సర్దుబాటు చేయాలి. [మరింత తెలుసుకోండి](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "నిర్వచన జాబిత అంశాలను `<dl>` మూలకాలలో సర్దుబాటు చేయలేదు"
+    "message": "నిర్వచన జాబితా అంశాలు '`<dl>`' మూలకాలలో సర్దుబాటు చేయబడలేదు"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "నిర్వచన జాబితా అంశాలు `<dl>` మూలకాలలో సర్దుబాటు చేయబడ్డాయి"
+    "message": "నిర్వచన జాబితా అంశాలు '`<dl>`' మూలకాలలో సర్దుబాటు చేయబడ్డాయి"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "శీర్షిక అన్నది స్క్రీన్ రీడర్ వినియోగదారులకు పేజీ గురించి అవగాహన కలుగజేస్తుంది, అలాగే శోధన ఇంజిన్ వినియోగదారులు ఒక పేజీ వారి శోధన సంబంధితమైనదో కాదో గుర్తించడానికి చాలా ఎక్కువగా దీనిపై ఆధారపడుతుంటారు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "శీర్షిక అన్నది స్క్రీన్ రీడర్ వినియోగదారులకు పేజీ గురించి అవగాహన కలుగజేస్తుంది, అలాగే శోధన ఇంజిన్ వినియోగదారులు ఒక పేజీ వారి శోధనకు సంబంధితమైనదో కాదో గుర్తించడానికి చాలా ఎక్కువగా దీనిపై ఆధారపడుతుంటారు. [మరింత తెలుసుకోండి](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "పత్రానికి `<title>` మూలకం లేదు"
+    "message": "పత్రంలో '`<title>`' మూలకం లేదు"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "పత్రానికి `<title>` మూలకం ఉంది"
+    "message": "పత్రంలో '`<title>`' మూలకం ఉంది"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "సహాయకర సాంకేతిక పరిజ్ఞానాల ద్వారా ఇతర సందర్భాలు విస్మరించబడకుండా నిరోధించడానికి id లక్షణం విలువ ప్రత్యేకంగా ఉండాలి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "సహాయకర సాంకేతిక పరిజ్ఞానాల ద్వారా ఇతర సందర్భాలు విస్మరించబడకుండా నిరోధించడానికి id లక్షణం విలువ ప్రత్యేకంగా ఉండాలి. [మరింత తెలుసుకోండి](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "పేజీలోని `[id]` లక్షణాలు విశిష్ఠమైనవి కావు"
+    "message": "పేజీలోని ``[id]`` లక్షణాలు విశిష్ఠమైనవి కావు"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "పేజీలోని `[id]` లక్షణాలు విశిష్ఠంగా ఉన్నాయి"
+    "message": "పేజీలోని ``[id]`` లక్షణాలు విశిష్ఠంగా ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "స్క్రీన్ రీడర్ వినియోగదారులు ఫ్రేమ్‌ల కంటెంట్‌లను వివరించడానికి ఫ్రేమ్ శీర్షికలపై ఆధారపడతారు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "స్క్రీన్ రీడర్ వినియోగదారులు ఫ్రేమ్‌ల కంటెంట్‌లను వివరించడానికి ఫ్రేమ్ శీర్షికలపై ఆధారపడతారు. [మరింత తెలుసుకోండి](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "`<frame>` లేదా `<iframe>` మూలకాలలో శీర్షిక లేదు"
+    "message": "'`<frame>`' లేదా '`<iframe>`' మూలకాలకు పేరు అందించలేదు"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "`<frame>` లేదా `<iframe>` మూలకాలు శీర్షికను కలిగి ఉన్నాయి"
+    "message": "'`<frame>`' లేదా '`<iframe>`' మూలకాలలో శీర్షికలు ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "ఒక పేజీ భాషా లక్షణాన్ని పేర్కొనకుంటే, స్క్రీన్ రీడర్‌ను సెట్ చేస్తున్నప్పుడు వినియోగదారు ఎంచుకున్న డిఫాల్ట్ భాషలో పేజీ ఉందని స్క్రీన్ రీడర్ భావిస్తుంది. ఒకవేళ పేజీ డిఫాల్ట్ భాషలో లేదని అనుకుంటే, స్క్రీన్ రీడర్ పేజీ వచనం సరిగ్గా ఉందని ప్రకటించకపోవచ్చు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "ఒక పేజీలో భాషా లక్షణాన్ని పేర్కొనకుంటే, స్క్రీన్ రీడర్‌ను సెట్ చేస్తున్నప్పుడు వినియోగదారు ఎంచుకున్న డిఫాల్ట్ భాషలో పేజీ ఉందని స్క్రీన్ రీడర్ భావిస్తుంది. ఒకవేళ ఆ పేజీ డిఫాల్ట్ భాషలో లేకపోతే, ఆ పేజీలోని వచనాన్ని స్క్రీన్ రీడర్ సరిగ్గా చదివి వినిపించలేకపోవచ్చు. [మరింత తెలుసుకోండి](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "`<html>` మూలకంలో `[lang]` లక్షణం లేదు"
+    "message": "'`<html>`' మూలకంలో '`[lang]`' మూలకం లేదు"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "`<html>` మూలకం `[lang]` లక్షణాన్ని కలిగి ఉంది"
+    "message": "'`<html>`' మూలకంలో `[lang]` లక్షణం ఉంది"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "చెల్లుబాటయ్యే [BCP 47 భాష](https://www.w3.org/International/questions/qa-choosing-language-tags#question)ను పేర్కొనడం అన్నది వచనాన్ని సక్రమంగా ప్రకటించడంలో స్క్రీన్ రీడర్‌లకు సహాయపడుతుంది. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "చెల్లుబాటయ్యే [BCP 47 భాష](https://www.w3.org/International/questions/qa-choosing-language-tags#question)ను పేర్కొనడం అనేది, వచనాన్ని సక్రమంగా ప్రకటించడంలో స్క్రీన్ రీడర్‌లకు సహాయపడుతుంది. [మరింత తెలుసుకోండి](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "`<html>` మూలకంలో దాని `[lang]` లక్షణానికి చెల్లుబాటయ్యే విలువ లేదు."
+    "message": "'`<html>`' మూలకంలో దాని '`[lang]`' లక్షణం కోసం చెల్లుబాటయ్యే విలువ లేదు."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "`<html>` మూలకం దాని `[lang]` లక్షణానికి చెల్లుబాటయ్యే విలువను కలిగి ఉంది"
+    "message": "'`<html>`' మూలకంలో దాని '`[lang]`' లక్షణానికి చెల్లుబాటయ్యే విలువ ఉంది"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "సమాచార మూలకాలు సంక్షిప్తమైన, వివరణాత్మక ప్రత్యామ్నాయ వచనాన్ని లక్ష్యంగా చేసుకోవాలి. అలంకార మూలకాలను ఖాళీ alt లక్షణంతో విస్మరించవచ్చు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "సమాచార మూలకాలు సంక్షిప్తమైన, వివరణాత్మక ప్రత్యామ్నాయ వచనాన్ని లక్ష్యంగా చేసుకోవాలి. అలంకార మూలకాలను ఖాళీ alt లక్షణంతో విస్మరించవచ్చు. [మరింత తెలుసుకోండి](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "చిత్రం మూలకాలలో `[alt]` లక్షణాలు లేవు"
+    "message": "చిత్రం మూలకాలలో '`[alt]`' లక్షణాలు ఏవీ లేవు"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "చిత్ర మూలకాలు `[alt]` లక్షణాలను కలిగి ఉన్నాయి"
+    "message": "చిత్ర మూలకాలు '`[alt]`' లక్షణాలను కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "ఒక చిత్రం `<input>` బటన్‌గా ఉపయోగిస్తున్నప్పుడు, ప్రత్యామ్నాయ వచనం అందించడమనేది బటన్ ప్రయోజనాన్ని అర్థం చేసుకోవడంలో స్క్రీన్ రీడర్ వినియోగదారులకు సహాయం చేస్తుంది. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "ఒక చిత్రం '`<input>`' బటన్‌గా ఉపయోగిస్తున్నప్పుడు, ప్రత్యామ్నాయ వచనం అందించడమనేది బటన్ ప్రయోజనాన్ని అర్థం చేసుకోవడంలో స్క్రీన్ రీడర్ వినియోగదారులకు సహాయం చేస్తుంది. [మరింత తెలుసుకోండి](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "`<input type=\"image\">` మూలకాలలో `[alt]` వచనం లేదు"
+    "message": "'`<input type=\"image\">`' మూలకాలలో '`[alt]`' వచనం లేదు"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "`<input type=\"image\">` మూలకాలు `[alt]` వచనాన్ని కలిగి ఉన్నాయి"
+    "message": "'`<input type=\"image\">`' మూలకాలు '`[alt]`' వచనాన్ని కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "స్క్రీన్ రీడర్‌ల లాంటి సహాయక సాంకేతిక పరిజ్ఞానాల ద్వారా ఫారమ్ నియంత్రణలు సక్రమంగా ప్రకటించబడుతున్నాయని లేబుల్‌లు నిర్ధారిస్తున్నాయి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "స్క్రీన్ రీడర్‌ల లాంటి సహాయక సాంకేతిక పరిజ్ఞానాల ద్వారా ఫారమ్ నియంత్రణలు సక్రమంగా ప్రకటించబడుతున్నాయని లేబుల్‌లు నిర్ధారిస్తున్నాయి. [మరింత తెలుసుకోండి](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "ఫారమ్ మూలకాలలో అనుబంధిత లేబుల్‌లు లేవు"
@@ -201,16 +201,16 @@
     "message": "ఫారమ్ మూలకాలు అనుబంధిత లేబుల్‌లను కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "లేఅవుట్ ప్రయోజనాల కోసం ఉపయోగించే పట్టికలో th లాంటి డేటా మూలకాలు లేదా శీర్షిక మూలకాలు లేదా సారంశ లక్షణం ఉండకూడదు, ఎందుకంటే ఇది స్క్రీన్ రీడర్ వినియోగదారులకు గందరగోళమైన అనుభవాన్ని అందించవచ్చు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "లేఅవుట్ ప్రయోజనాల కోసం ఉపయోగించే పట్టికలో th లాంటి డేటా మూలకాలు లేదా శీర్షిక మూలకాలు లేదా సారంశ లక్షణం ఉండకూడదు, ఎందుకంటే ఇది స్క్రీన్ రీడర్ వినియోగదారులకు గందరగోళమైన అనుభవాన్ని అందించవచ్చు. [మరింత తెలుసుకోండి](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "ప్రదర్శన సంబంధిత `<table>` మూలకాలు `<th>`, `<caption>` లేదా `[summary]` లక్షణాన్ని ఉపయోగించడం నివారించవు."
+    "message": "ప్రదర్శన సంబంధిత '`<table>`' మూలకాలలో '`<th>`', '`<caption>`' లేదా '`[summary]`' లక్షణాన్ని వినియోగించడం నివారించబడలేదు."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "ప్రదర్శన సంబంధిత `<table>` మూలకాలు `<th>`, `<caption>` లేదా `[summary]` లక్షణాన్ని ఉపయోగించడం నివారిస్తాయి."
+    "message": "ప్రదర్శన సంబంధిత '`<table>`' మూలకాలు '`<th>`', '`<caption>`' లేదా `[summary]` లక్షణాన్ని వినియోగించడం నివారిస్తున్నాయి."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "కనుగొనదగిన, విశిష్ఠమైన, దృష్టి కేంద్రీకరించగలిగిన లింక్ వచనం (అలాగే చిత్రాలను లింక్‌లుగా ఉపయోగించినప్పుడు వాటి ప్రత్యామ్నాయ వచనం) సహాయంతో స్క్రీన్ రీడర్ వినియోగదారులకు నావిగేషన్ అనుభవం మరింత మెరుగవుతుంది. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "కనుగొనదగిన, విశిష్ఠమైన, దృష్టి కేంద్రీకరించగలిగిన లింక్ వచనం (అలాగే చిత్రాలను లింక్‌లుగా ఉపయోగించినప్పుడు వాటి ప్రత్యామ్నాయ వచనం) సహాయంతో స్క్రీన్ రీడర్ వినియోగదారులకు నావిగేషన్ అనుభవం మరింత మెరుగవుతుంది. [మరింత తెలుసుకోండి](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "లింక్‌లలో కనుగొనదగిన పేరు లేదు"
@@ -219,103 +219,115 @@
     "message": "లింక్‌లలో కనుగొనదగిన పేరు ఉంది"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "స్క్రీన్ రీడర్‌లు నిర్దిష్ట రకమైన ప్రకటనల జాబితాలను కలిగి ఉన్నాయి. సక్రమమైన జాబితా నిర్మాణక్రమం నిర్ధారించుకోవడం స్క్రీన్ రీడర్ అవుట్‌పుట్‌కు ఉపకరిస్తుంది. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "స్క్రీన్ రీడర్‌లు, జాబితాలను ఒక నిర్దిష్ట రకమైన రీతిలో ప్రకటిస్తాయి. జాబితా నిర్మాణక్రమం సక్రమ రీతిలో ఉందని నిర్ధారించుకుంటే, అది స్క్రీన్ రీడర్ అవుట్‌పుట్‌కు ఉపకరిస్తుంది. [మరింత తెలుసుకోండి](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "జాబితాలు కేవలం `<li>` మూలకాలు, స్క్రిప్ట్ మద్దతు మూలకాలు (`<script>` మరియు `<template>`)తో ఉండకూడదు."
+    "message": "జాబితాలు కేవలం '`<li>`' మూలకాలు, స్క్రిప్ట్ మద్దతు మూలకాలు ('`<script>`', '`<template>`')తో ఉండకూడదు."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "జాబితాలు కేవలం `<li>` మూలకాలు, స్క్రిప్ట్ మద్దతు మూలకాలు (`<script>` మరియు `<template>`) మాత్రమే కలిగి ఉన్నాయి."
+    "message": "జాబితాలలో కేవలం '`<li>`' మూలకాలు, స్క్రిప్ట్ మద్దతు మూలకాలు (`<script>`, `<template>`) మాత్రమే ఉన్నాయి."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "స్క్రీన్ రీడర్‌ల కోసం జాబితా అంశాలను (`<li>`) మూలాధార అంశం `<ul>`లో ఉంచాలి లేదా `<ol>`ను సక్రమంగా ప్రకటించాలి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "జాబితా అంశాలను ('`<li>`') స్క్రీన్ రీడర్‌లు సక్రమంగా ప్రకటించాలంటే, వాటిని మూలాధార అంశం '`<ul>`' లేదా '`<ol>`'లో ఉంచాలి. [మరింత తెలుసుకోండి](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "జాబితా అంశాలు (`<li>`) `<ul>` లేదా `<ol>` మూలాధార మూలకాలలో లేవు."
+    "message": "జాబితా అంశాలు ('`<li>`') అన్నవి '`<ul>`' లేదా '`<ol>`' మూలాధార మూలకాలలో లేవు."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "జాబితా అంశాలు (`<li>`) `<ul>` లేదా `<ol>` మూలాధార మూలకాలలో ఉన్నాయి."
+    "message": "జాబితా అంశాలు ('`<li>`') అనేవి '`<ul>`' లేదా '`<ol>`' అనే మూలాధార మూలకాలలో భాగంగా ఉంటాయి"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "వినియోగదారులు పేజీ ఆటోమేటిక్‌గా రిఫ్రెష్ కావాలని కోరుకోరు. అలా చేయడం వలన దృష్టి కేంద్రీకరణ తిరిగి పేజీ పైభాగంలోకి వెళ్తుంది. ఇది విసుగు తెప్పించే లేదా అయోమయానికి గురి చేసే అనుభవం అందించవచ్చు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "వినియోగదారులు పేజీ ఆటోమేటిక్‌గా రిఫ్రెష్ కావాలని కోరుకోరు, అలా చేయడం వలన దృష్టి కేంద్రీకరణ తిరిగి పేజీ పైభాగంలోకి వెళ్తుంది. ఇది విసుగు తెప్పించే లేదా అయోమయానికి గురి చేసే అనుభవం అందించవచ్చు. [మరింత తెలుసుకోండి](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "పత్రం `<meta http-equiv=\"refresh\">` ఉపయోగిస్తుంది"
+    "message": "పత్రం '`<meta http-equiv=\"refresh\">`'ను వినియోగిస్తోంది"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "పత్రం `<meta http-equiv=\"refresh\">`ని ఉపయోగించడం లేదు"
+    "message": "పత్రంలో '`<meta http-equiv=\"refresh\">`'ను వినియోగించలేదు"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "జూమ్ చేయగల సామర్థ్యం నిలిపివేస్తే, స్క్రీన్ మ్యాగ్నిఫికేషన్‌పై ఆధారపడే తక్కువ కంటిచూపు ఉన్న వినియోగదారులు వెబ్ పేజీ కంటెంట్‌లను సరిగ్గా చూడలేరు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "జూమ్ చేయగల సామర్థ్యం నిలిపివేస్తే, స్క్రీన్ మ్యాగ్నిఫికేషన్‌పై ఆధారపడే తక్కువ కంటిచూపు ఉన్న వినియోగదారులు వెబ్ పేజీ కంటెంట్‌లను సరిగ్గా చూడలేరు. [మరింత తెలుసుకోండి](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "`[user-scalable=\"no\"]` అన్నది `<meta name=\"viewport\">` మూలకంలో ఉపయోగించబడింది, అలాగే `[maximum-scale]` లక్షణం 5 కంటే తక్కువ ఉంది."
+    "message": "'`[user-scalable=\"no\"]`' అన్నది '`<meta name=\"viewport\">`' మూలకంలో ఉపయోగించబడింది, అలాగే '`[maximum-scale]`' లక్షణం 5 కంటే తక్కువ ఉంది."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "`[user-scalable=\"no\"]` అన్నది `<meta name=\"viewport\">` మూలకంలో ఉపయోగించలేదు, అలాగే `[maximum-scale]` లక్షణం 5 కంటే తక్కువ లేదు."
+    "message": "'`[user-scalable=\"no\"]`' అన్నది '`<meta name=\"viewport\">`' మూలకంలో ఉపయోగించలేదు, అలాగే '`[maximum-scale]`' లక్షణం 5 కంటే తక్కువగా లేదు."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "స్క్రీన్ రీడర్‌లు వచనేతర కంటెంట్‌ను అనువదించలేవు. `<object>` మూలకాలకు alt వచనాన్ని జోడించడం వలన స్క్రీన్ రీడర్‌లు వాటి అర్థాన్ని వినియోగదారులకు సరిగ్గా అందించగలుగుతాయి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "స్క్రీన్ రీడర్‌లు వచనేతర కంటెంట్‌ను అనువదించలేవు. '`<object>`' మూలకాలకు ప్రత్యామ్నాయ వచనాన్ని జోడించడం వలన స్క్రీన్ రీడర్‌లు వాటి అర్థాన్ని వినియోగదారులకు సరిగ్గా అందించగలుగుతాయి. [మరింత తెలుసుకోండి](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "`<object>` మూలకాలలో `[alt]` వచనం లేదు"
+    "message": "'`<object>`' మూలకాలలో '`[alt]`' వచనం లేదు"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "`<object>` మూలకాలు `[alt]` వచనాన్ని కలిగి ఉన్నాయి"
+    "message": "'`<object>`' మూలకాలు '`[alt]`' వచనాన్ని కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "0 కంటే పెద్ద విలువ విశిష్ఠమైన నావిగేషన్ క్రమాన్ని సూచిస్తుంది. సాంకేతికంగా చెల్లుబాటు అయినప్పటికీ, సహాయక సాంకేతిక పరిజ్ఞానంపై ఆధారపడిన వినియోగదారులకు ఇది తరచూ విసుగు తెప్పించే అనుభవాలను సృష్టిస్తుంది. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "0 కంటే పెద్ద విలువ విశిష్ఠమైన నావిగేషన్ క్రమాన్ని సూచిస్తుంది. సాంకేతికంగా చెల్లుబాటు అయినప్పటికీ, సహాయక సాంకేతిక పరిజ్ఞానంపై ఆధారపడిన వినియోగదారులకు ఇది తరచూ విసుగు తెప్పించే అనుభవాలను సృష్టిస్తుంది. [మరింత తెలుసుకోండి](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "కొన్ని మూలకాలు 0 కంటే పెద్దవైన `[tabindex]` విలువను కలిగి ఉన్నాయి"
+    "message": "కొన్ని మూలకాలు 0 కంటే పెద్దవైన ``[tabindex]`` విలువను కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "ఏ మూలకానికి సున్నా కంటే పెద్ద `[tabindex]` విలువ లేదు"
+    "message": "ఏ మూలకానికీ సున్నా కంటే పెద్ద ``[tabindex]`` విలువ లేదు"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "పట్టికలను నావిగేట్ చేయడం సులభతరం చేసే ఫీచర్‌లను స్క్రీన్ రీడర్‌లు కలిగి ఉన్నాయి. `[headers]` లక్షణాన్ని ఉపయోగిస్తున్న `<td>` సెల్‌లు కేవలం అదే పట్టికలోని ఇతర సెల్‌లను సూచించడం స్క్రీన్ రీడర్ వినియోగదారుల అనుభవాన్ని మెరుగుపరచవచ్చు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "పట్టికలను నావిగేట్ చేయడం సులభతరం చేసే ఫీచర్‌లు స్క్రీన్ రీడర్‌లలో ఉంటాయి. '`[headers]`' లక్షణాన్ని ఉపయోగిస్తున్న '`<td>`' సెల్‌లు కేవలం అదే పట్టికలోని ఇతర సెల్‌లను సూచించడం స్క్రీన్ రీడర్ వినియోగదారుల అనుభవాన్ని మెరుగుపరచవచ్చు. [మరింత తెలుసుకోండి](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "`<table>` మూలకంలో '[headers]` లక్షణాన్ని ఉపయోగించే సెల్‌లు, అదే పట్టికలోని ఇతర సెల్‌లను సూచిస్తున్నాయి."
+    "message": "'`<table>`' మూలకంలో '`[headers]`' లక్షణాన్ని ఉపయోగించే సెల్‌లు కేవలం అదే పట్టికలోని ఇతర సెల్‌లను సూచిస్తాయి."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "`<table>` మూలకంలో '[headers]` లక్షణాన్ని ఉపయోగించే సెల్‌లు కేవలం అదే పట్టికలోని ఇతర సెల్‌లను సూచిస్తున్నాయి."
+    "message": "'`<table>`' మూలకంలో '`[headers]`' లక్షణాన్ని వినియోగించే సెల్‌లు కేవలం అదే పట్టికలోని ఇతర సెల్‌లకు మాత్రమే సూచించబడతాయి."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "పట్టికలను నావిగేట్ చేయడం సులభతరం చేసే ఫీచర్‌లను స్క్రీన్ రీడర్‌లు కలిగి ఉన్నాయి. పట్టిక ముఖ్య శీర్షికలు ఎల్లప్పుడూ కొన్ని సెల్‌ల సెట్‌ను సూచించేలా నిర్ధారించుకోవడం ద్వారా స్క్రీన్ రీడర్ వినియోగదారుల అనుభవాన్ని మెరుగుపరచవచ్చు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "పట్టికలను నావిగేట్ చేయడం సులభతరం చేసే ఫీచర్‌లు స్క్రీన్ రీడర్‌లలో ఉంటాయి. పట్టిక ముఖ్య శీర్షికలు ఎల్లప్పుడూ కొన్ని సెల్‌ల సెట్‌ను సూచించేలా నిర్ధారించుకోవడం ద్వారా స్క్రీన్ రీడర్ వినియోగదారుల అనుభవాన్ని మెరుగుపరచవచ్చు. [మరింత తెలుసుకోండి](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "`<th>` మూలకాలు, `[role=\"columnheader\"/\"rowheader\"]` కలిగి ఉన్న మూలకాలలో అవి వివరిస్తున్న డేటా సెల్‌లు లేవు."
+    "message": "'`<th>`' మూలకాలలో, అలాగే '`[role=\"columnheader\"/\"rowheader\"]`' కలిగి ఉండే మూలకాలలో అవి వివరిస్తున్న డేటా సెల్‌లు లేవు."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "`<th>` మూలకాలు, `[role=\"columnheader\"/\"rowheader\"]` కలిగి ఉన్న మూలకాలలో అవి వివరిస్తున్న సెల్‌లు ఉన్నాయి."
+    "message": "'`<th>`' మూలకాలు, '`[role=\"columnheader\"/\"rowheader\"]`' కలిగి ఉన్న మూలకాలలో అవి వివరిస్తున్న డేటా సెల్‌లు ఉన్నాయి."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "మూలకాలలో చెల్లుబాటయ్యే [BCP 47 భాష](https://www.w3.org/International/questions/qa-choosing-language-tags#question) పేర్కొనడమన్నది వచనం స్క్రీన్ రీడర్ ద్వారా సరిగ్గా ఉచ్చరించబడేలా నిర్ధారిస్తుంది. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "మూలకాలలో చెల్లుబాటయ్యే [BCP 47 భాష](https://www.w3.org/International/questions/qa-choosing-language-tags#question) పేర్కొనడం అన్నది, వచనాన్ని స్క్రీన్ రీడర్ సరిగ్గా ఉచ్చరించేలా నిర్ధారిస్తుంది. [మరింత తెలుసుకోండి](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "`[lang]` లక్షణాలలో చెల్లుబాటయ్యే విలువ లేదు"
+    "message": "``[lang]`` లక్షణాలలో చెల్లుబాటు అయ్యే విలువ లేదు"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "`[lang]` లక్షణాలు చెల్లుబాటయ్యే విలువను కలిగి ఉన్నాయి"
+    "message": "'`[lang]`' లక్షణాలు చెల్లుబాటయ్యే విలువను కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "వీడియో, శీర్షికను అందిస్తే, చెవిటి వారు లేదా వినికిడి సమస్య ఉన్న వినియోగదారులు వీడియోలోని సమాచారాన్ని సులభంగా యాక్సెస్ చేయగలుగుతారు. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "వీడియోకు శీర్షికను అందిస్తే, చెవిటి వారు లేదా వినికిడి సమస్య ఉన్న వినియోగదారులు వీడియోలోని సమాచారాన్ని సులభంగా యాక్సెస్ చేయగలుగుతారు. [మరింత తెలుసుకోండి](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "`<video>` మూలకాలలో `[kind=\"captions\"]`తో `<track>` మూలకం లేదు."
+    "message": "'`<video>`' మూలకాలలో '`[kind=\"captions\"]`'తో '`<track>`' మూలకం లేదు."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "`<video>` మూలకాలలో `[kind=\"captions\"]`తో `<track>` మూలకం ఉంది"
+    "message": "'`<video>`' మూలకాలు '`[kind=\"captions\"]`'తో '`<track>`' మూలకం కలిగి ఉన్నాయి"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "డైలాగులతో కాకుండా, ముఖంలోని హావభావాలు, దృశ్యాలతో నిండిన వీడియోలకు ఆడియో వివరణలు సంబంధిత సమాచారాన్ని అందిస్తాయి. [మరింత తెలుసుకోండి](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "డైలాగ్‌లతో కాకుండా, ముఖంలోని హావభావాలు, దృశ్యాలతో నిండిన వీడియోలకు ఆడియో వివరణలు సంబంధిత సమాచారాన్ని అందిస్తాయి. [మరింత తెలుసుకోండి](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "`<video>` మూలకాలలో `[kind=\"description\"]`తో `<track>` మూలకం లేదు."
+    "message": "'`<video>`' మూలకాలలో '`[kind=\"description\"]`'తో '`<track>`' మూలకం లేదు."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "`<video>` మూలకాలు `[kind=\"description\"]`తో `<track>` మూలకాన్ని కలిగి ఉన్నాయి"
+    "message": "'`<video>`' మూలకాలు '`[kind=\"description\"]`'తో '`<track>`' మూలకం కలిగి ఉన్నాయి"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "వినియోగదారులు హోమ్ స్క్రీన్‌కు జోడించినప్పుడు iOSలో ఉత్తమ ప్రదర్శన కోసం, 'apple-touch-icon'ను నిర్వచించండి. అది తప్పనిసరిగా పారదర్శకం కాని 192px (లేదా 180px) చతురస్రాకార PNGని సూచించాలి. [మరింత తెలుసుకోండి](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "చెల్లుబాటయ్యే '`apple-touch-icon`' లేదు"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "'`apple-touch-icon-precomposed`' గడువు ముగిసింది, `apple-touch-icon`ను ప్రాధాన్యంగా తీసుకోవాలి."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "చెల్లుబాటు అయ్యే '`apple-touch-icon`'ను అందిస్తుంది"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome ఎక్స్‌టెన్షన్‌లు ఈ పేజీ లోడ్ పనితీరును ప్రతికూలంగా ప్రభావితం చేసాయి. ఎక్స్టెన్షన్‌లు లేకుండా పేజీని అజ్ఞాత మోడ్‌లో లేదా ఎక్స్‌టెన్షన్‌లు లేని Chrome ప్రొఫైల్‌లో ఆడిట్ చేయడాన్ని ప్రయత్నించండి."
@@ -330,7 +342,7 @@
     "message": "మొత్తం CPU సమయం"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "అన్వయించడం, సంగ్రహణ చేయడం మరియు JSను అమలు చేయడానికి వెచ్చించే సమయాన్ని తగ్గించడాన్ని పరిగణించండి. చిన్న JS పేలోడ్‌లను అందించడం ఈ విషయంలో మీకు సహాయకరంగా అనిపించవచ్చు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "JSను అన్వయించడం, సంకలనం చేయడం, అమలు చేయడం కోసం వెచ్చించే సమయాన్ని తగ్గించడాన్ని పరిశీలించండి. చిన్న JS పేలోడ్‌లను అందించడం ఈ విషయంలో మీకు సహాయపడవచ్చు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "JavaScript అమలు సమయాన్ని తగ్గించండి"
@@ -339,28 +351,28 @@
     "message": "JavaScript అమలు సమయం"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "యానిమేట్ చేయబడిన కంటెంట్‌ను అందించడంలో పెద్ద GIFలు సమర్థవంతంగా పనిచేయవు. నెట్‌వర్క్ బైట్‌లను పొదుపు చేయడానికి GIFకి బదులుగా యానిమేషన్ కోసం MPEG4/WebM వీడియోలను, నిశ్చల చిత్రాల కోసం PNG/WebPను ఉపయోగించడాన్ని పరిగణించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "యానిమేట్ చేయబడిన కంటెంట్‌ను అందించడంలో పెద్ద GIFలు సమర్థవంతంగా పని చేయవు. నెట్‌వర్క్ బైట్‌లను పొదుపు చేయడానికి, యానిమేషన్‌ల కోసం MPEG4/WebM వీడియోలను, GIFకి బదులుగా నిశ్చల చిత్రాల కోసం PNG/WebPను ఉపయోగించడం పరిశీలించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "యానిమేటెడ్ కంటెంట్ కోసం వీడియో ఫార్మాట్‌లను ఉపయోగించండి"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "పేజీలో పూర్తి పరస్పర చర్యకు పట్టే సమయం తక్కువగా ఉన్నప్పుడు అన్ని క్లిష్టమైన వనరులు లోడ్ అవ్వడం పూర్తి చేసి, ఆ తర్వాతే ఆఫ్‌స్క్రీన్ మరియు దాగి ఉన్న చిత్రాలను నెమ్మదిగా లోడ్ చేయడాన్ని పరిగణించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "పేజీలో పూర్తి పరస్పర చర్యకు పట్టే సమయం తగ్గించడానికి అన్ని క్లిష్టమైన వనరులు లోడ్ అవ్వడం పూర్తయిన తర్వాతే ఆఫ్‌స్క్రీన్, దాగి ఉన్న చిత్రాలను నెమ్మదిగా లోడ్ చేయడాన్ని పరిశీలించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "ఆఫ్‌స్క్రీన్ చిత్రాలను వాయిదా వేయండి"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "వనరులు మీ పేజీ మొదటి పెయింట్‌ను బ్లాక్ చేస్తున్నాయి. క్లిష్టమైన JS/CSSలను ఇన్‌లైన్‌లో పంపించడం మరియు క్లిష్టం-కాని అన్ని JS/శైలులను తీసివేయడాన్ని పరిగణించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "వనరులు మీ పేజీలోని మొదటి పెయింట్‌ను బ్లాక్ చేస్తున్నాయి. ముఖ్యమైన JS/CSSలను ఇన్‌లైన్‌లో అందించడం, ముఖ్యం-కానటువంటి అన్ని JS/శైలులను తీసివేయడాన్ని పరిశీలించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "రెండర్-బ్లాకింగ్ వనరులను నివారించండి"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "పెద్ద నెట్‌వర్క్ పేలోడ్‌లకు వినియోగదారులు నిజమైన డబ్బును చెల్లించాలి మరియు అవి అధికంగా సుదీర్ఘ లోడ్ సమయాలతో ముడిపడి ఉంటాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "పెద్ద నెట్‌వర్క్ పేలోడ్‌లకు వినియోగదారులు నిజమైన డబ్బును చెల్లించాలి. అవి అధికంగా సుదీర్ఘ లోడ్ సమయాలతో ముడిపడి ఉంటాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "మొత్తం పరిమాణం {totalBytes, number, bytes} KBగా ఉండేది"
+    "message": "మొత్త పరిమాణం {totalBytes, number, bytes} KBగా ఉండేది"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "అతి పెద్ద నెట్‌వర్క్ పేలోడ్‌లను నివారించండి"
@@ -369,19 +381,19 @@
     "message": "అతి పెద్ద నెట్‌వర్క్ పేలోడ్‌లను నివారిస్తుంది"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "CSS ఫైల్‌లను చిన్నవిగా చేయడం నెట్‌వర్క్ పేలోడ్ పరిమాణాలను తగ్గించవచ్చు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "CSS ఫైల్‌లను చిన్నవిగా చేయడం వలన నెట్‌వర్క్ పేలోడ్ పరిమాణాలు తగ్గిపోగలవు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "CSSని చిన్నదిగా చేయండి"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "JavaScript ఫైల్‌లను చిన్నవిగా చేయడం పేలోడ్ పరిమాణాలని మరియు స్క్రిప్ట్‌ను అన్వయించడానికి పట్టే సమయాన్ని తగ్గించగలదు. [మరింత తెలుసుకోండి](https://developers.google.com/speed/docs/insights/MinifyResources)."
+    "message": "JavaScript ఫైల్‌లను చిన్నవిగా చేయడం పేలోడ్ పరిమాణాలను, స్క్రిప్ట్‌ను అన్వయించడానికి పట్టే సమయాన్ని తగ్గించగలదు. [మరింత తెలుసుకోండి](https://developers.google.com/speed/docs/insights/MinifyResources)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "JavaScriptను చిన్నదిగా చేయండి"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "నెట్‌వర్క్ కార్యకలాపంలో ఉపయోగించబడే అనవసరమైన బైట్‌లను తగ్గించడం కోసం, స్టైల్‌షీట్‌ల నుండి గడువు ముగిసిన నియమాలను తీసివేయండి మరియు మడత పైన ఉన్న కంటెంట్ కోసం ఉపయోగించని CSSను లోడ్ చేయకుండా ఆపివేయండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "నెట్‌వర్క్ కార్యకలాపంలో ఉపయోగించబడే అనవసరమైన బైట్‌లను తగ్గించడం కోసం, స్టైల్‌షీట్‌ల నుండి గడువు ముగిసిన నియమాలను తీసివేయండి. అలాగే, మడత పైన ఉన్న కంటెంట్ కోసం ఉపయోగించని CSSను లోడ్ చేయకుండా ఆపివేయండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "ఉపయోగించని CSS తీసివేయబడింది"
@@ -405,13 +417,13 @@
     "message": "నిశ్చలమైన ఆస్తులపై సమర్ధవంతమైన కాష్ విధానాన్ని ఉపయోగిస్తుంది"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "ఆప్టిమైజ్ చేయబడిన చిత్రాలు త్వరగా లోడ్ అవుతాయి మరియు తక్కువ సెల్యులార్ డేటాను ఉపయోగిస్తాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
+    "message": "ఆప్టిమైజ్ చేసిన చిత్రాలు త్వరగా లోడ్ అవుతాయి, తక్కువ సెల్యులార్ డేటాను ఉపయోగిస్తాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "చిత్రాలను సమర్థవంతంగా ఎన్‌కోడ్ చేయండి"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "సెల్యులార్ డేటాను పొదుపు చేయడానికి మరియు లోడ్ సమయాన్ని మెరుగుపరచడానికి తగిన-పరిమాణానికి మార్చబడిన చిత్రాలను అందించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "సెల్యులార్ డేటాను పొదుపు చేయడానికి, లోడ్ సమయాన్ని మెరుగుపరచడానికి తగిన-పరిమాణానికి మార్చబడిన చిత్రాలను అందించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "చిత్రాల పరిమాణాన్ని సరిగ్గా మార్చండి"
@@ -423,19 +435,70 @@
     "message": "వచనం కుదింపును ప్రారంభించండి"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "JPEG 2000, JPEG XR, మరియు WebP వంటి చిత్రం ఫార్మాట్‌లు తరచుగా PNG లేదా JPEG కంటే మెరుగైన కుదింపును అందిస్తాయి, దీనర్ధం వేగవంతమైన డౌన్‌లోడ్‌లు మరియు తక్కువ డేటా వినియోగం. [మరింత తెలుసుకోండి] (https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "JPEG 2000, JPEG XR, WebP లాంటి చిత్రం ఫార్మాట్‌లు తరచుగా PNG లేదా JPEG కంటే మెరుగైన కుదింపును అందిస్తాయి. దీని వలన, డౌన్‌లోడ్‌లు మరింత వేగంగా ఉంటాయి, తక్కువ డేటా వినియోగం అవుతుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "చిత్రాలను తర్వాతి-తరం ఫార్మాట్‌లలో అందించండి"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "కింది క్లిష్టమైన అభ్యర్ధన గొలుసులు ఏ వనరులు అధిక ప్రాధాన్యతతో లోడ్ అయ్యాయో చూపిస్తాయి. పేజీ లోడ్‌ను మెరుగుపరచడానికి గొలుసుల పొడవును తగ్గించడం, వనరుల డౌన్‌లోడ్ పరిమాణాన్ని తగ్గించడం, లేదా అనవసర వనరులను డౌన్‌లోడ్ చేయడాన్ని వాయిదా వేయడం పరిగణించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "కింద పేర్కొన్న ముఖ్యమైన అభ్యర్ధన గొలుసులు ఏ వనరులు అధిక ప్రాధాన్యతతో లోడ్ అయ్యాయో చూపిస్తాయి. పేజీ లోడ్‌ను మెరుగుపరచడానికి గొలుసుల పొడవును తగ్గించడం, వనరుల డౌన్‌లోడ్ పరిమాణాన్ని తగ్గించడం, లేదా అనవసర వనరులను డౌన్‌లోడ్ చేయడాన్ని వాయిదా వేయడం పరిశీలించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{1 గొలుసు కనుగొనబడింది}other{# గొలుసులు కనుగొనబడ్డాయి}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "క్లిష్టమైన అభ్యర్ధనల గాఢత్వమును తగ్గించండి"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "విస్మరణ / హెచ్చరిక"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "పంక్తి"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "విస్మరించబడిన APIలు క్రమంగా బ్రౌజర్ నుండి తీసివేయబడతాయి. [మరింత తెలుసుకోండి](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 హెచ్చరిక కనుగొనబడింది}other{# హెచ్చరికలు కనుగొనబడ్డాయి}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "విస్మరించబడిన APIలను వినియోగిస్తోంది"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "విస్మరించబడిన APIలను నివారిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "అప్లికేషన్ కాష్ విస్మరించబడింది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" కనుగొనబడింది"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "అప్లికేషన్ కాష్‌ను వినియోగిస్తున్నారు"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "అప్లికేషన్ కాష్‌ను నివారిస్తోంది"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "'doctype'ను పేర్కొనడం వలన క్విర్క్స్-మోడ్‌కు మారనివ్వకుండా బ్రౌజర్ నిరోధించబడుతుంది. [MDN వెబ్ డాక్స్ పేజీ](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)లో మరింత చదవండి"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "'Doctype' పేరు తప్పనిసరిగా లోయర్-కేస్ స్ట్రింగ్ రూపంలో ఉండాలి `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "పత్రంలో తప్పనిసరిగా doctype ఉండాలి"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "'publicId' ఒక ఖాళీ స్ట్రింగ్‌గా వదిలిపెట్టాలి"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "'systemId' ఒక ఖాళీ స్ట్రింగ్‌గా వదిలిపెట్టాలి"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "పేజీలో HTML doctype లేదు, కనుక క్విర్క్స్-మోడ్‌ను ట్రిగ్గర్ చేస్తోంది"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "పేజీలో 'HTML doctype' ఉంది"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "మూలకం"
@@ -447,7 +510,7 @@
     "message": "విలువ"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "బ్రౌజర్ ఇంజినీర్‌లు ~1,500 కంటే తక్కువ DOM మూలకాలు కలిగి ఉండే పేజీలను సిఫార్సు చేస్తారు. వృక్ష పటం భాగాలు < 32 మూలకాలు మరియు 60 కంటే తక్కువ ఉప మూలకాలు/మూలాధార మూలకాలు కలిగి ఉన్నవి అత్యుత్తమమైనవి. పెద్ద DOM మెమరీ వినియోగాన్ని పెంచవచ్చు, సుదీర్ఘ [శైలి గణనలు](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)కు దారి తీయవచ్చు, అలాగే ఖరీదైన [లేఅవుట్ రీఫ్లోలు](https://developers.google.com/speed/articles/reflow) ఉత్పాదించవచ్చు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "బ్రౌజర్ ఇంజినీర్‌లు ~1,500 కంటే తక్కువ DOM మూలకాలను కలిగి ఉండే పేజీలను సిఫార్సు చేస్తారు. అత్యుత్తమ ప్రమాణంలో ట్రీ డెప్త్ < 32 మూలకాలు, 60 కంటే తక్కువ ఉపాంశ/మూలాధార మూలకాలు ఉండాలి. పెద్ద DOM వలన మెమరీ వినియోగం పెరగవచ్చు. దీర్ఘమైన [స్టైల్ గణనలు](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) జరగవచ్చు, ఖరీదైన [లేఅవుట్ రీఫ్లోలు](https://developers.google.com/speed/articles/reflow) అందించవచ్చు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 మూలకం}other{# మూలకాలు}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "అధిక DOM పరిమాణాన్ని నివారిస్తుంది"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "లక్ష్యం"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "పనితీరును మెరుగుపరచడానికి, అలాగే భద్రతా ప్రమాదాలను నిరోధించడానికి ఏవైనా బయటి లింక్‌లకు '`rel=\"noopener\"`' లేదా '`rel=\"noreferrer\"`'లను జోడించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "క్రాస్-ఆరిజిన్ గమ్యస్థానాలకు తీసుకెళ్లే లింక్‌లు అసురక్షితమైనవి"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "క్రాస్-ఆరిజిన్ గమ్యస్థానాలకు తీసుకెళ్లే లింక్‌లు సురక్షితమైనవి"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "యాంకర్ ({anchorHTML}) కోసం గమ్యస్థానాన్ని కనుగొనడం సాధ్యపడలేదు. ఒకవేళ హైపర్‌లింక్ లాగా ఉపయోగించకుంటే, 'target=_blank'ను తీసివేయడం గురించి పరిశీలించండి."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "సందర్భం ఏమీ లేకుండా స్థానాన్ని అభ్యర్థించే సైట్‌లను వినియోగదారులు నమ్మరు లేదా గందరగోళానికి గురి అవుతారు. దానికి బదులుగా, వినియోగదారు చర్యతో అభ్యర్థనను ప్రయత్నించడం పరిశీలించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "పేజీ లోడ్ సమయంలో భౌగోళిక స్థానం అనుమతిని అభ్యర్థిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "పేజీ లోడ్ సమయంలో భౌగోళిక స్థానం అనుమతిని అభ్యర్థించడం నివారిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "వెర్షన్"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "పేజీలోని అన్ని ఫ్రంట్-ఎండ్ JavaScript లైబ్రరీలు గుర్తించబడ్డాయి."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "JavaScript లైబ్రరీలు గుర్తించబడ్డాయి"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "కనెక్షన్‌లు నెమ్మదిగా పని చేస్తున్న వినియోగదారుల కోసం, '`document.write()`' ద్వారా డైనమిక్‌గా ఇంజెక్ట్ చేయబడే బయటి స్క్రిప్ట్‌ల వలన పేజీ పదుల సెకన్ల పాటు ఆలస్యంగా లోడ్ కాగలదు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "'`document.write()`'ను వినియోగిస్తోంది"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "'`document.write()`'ను నివారిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "అత్యంత తీవ్రత"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "లైబ్రరీ వెర్షన్"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "భద్రతా ప్రమాదాల సంఖ్య"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "కొన్ని మూడవ పక్షం స్క్రిప్ట్‌లలో, దాడులకు పాల్పడేవారు సులభంగా గుర్తించగలిగే, సమాచారం దొంగిలించగలిగే తెలిసిన భద్రతా ప్రమాదాలు ఉండవచ్చు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 ప్రమాద కారకం గుర్తించబడింది}other{# ప్రమాద కారకాలు గుర్తించబడ్డాయి}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "తెలిసిన భద్రతా ప్రమాదాలను కలిగి ఉండే ఫ్రంట్-ఎండ్ JavaScript లైబ్రరీలను జోడిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "అధికం"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "తక్కువ"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "మధ్యస్థం"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "తెలిసిన భద్రతా ప్రమాదాలను కలిగి ఉండే ఫ్రంట్-ఎండ్ JavaScript లైబ్రరీలను నివారిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "సందర్భం ఏమీ లేకుండా నోటిఫికేషన్‌లను పంపడానికి అనుమతి కోరే సైట్‌లను వినియోగదారులు నమ్మరు లేదా గందరగోళానికి గురి అవుతారు. బదులుగా వినియోగదారు సంజ్ఞలకు అభ్యర్థనను ప్రయత్నించడం పరిశీలించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "పేజీ లోడ్ సమయంలో నోటిఫికేషన్ అనుమతిని అభ్యర్థిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "పేజీ లోడ్ సమయంలో నోటిఫికేషన్ అనుమతిని అభ్యర్థించడం నివారిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "విఫలం అవుతున్న మూలకాలు"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "పాస్‌వర్డ్‌లో అతికించే చర్యను నిరోధించడం వలన మంచి భద్రతా విధానానికి ఆటంకం ఏర్పడుతుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "పాస్‌వర్డ్ ఫీల్డ్‌లలో అతికించడం చేయలేకుండా వినియోగదారులను నిరోధిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "పాస్‌వర్డ్ ఫీల్డ్‌లలో అతికించడానికి వినియోగదారులను అనుమతిస్తుంది"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "ప్రోటోకాల్"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 ద్వారా HTTP/1.1 కంటే ఎక్కువ ప్రయోజనాలు, అలాగే బైనరీ హెడర్‌లు, మల్టీప్లెక్సింగ్, సర్వర్ పుష్ కూడా అందించబడతాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 అభ్యర్థన 'HTTP/2' ద్వారా అందించబడలేదు}other{# అభ్యర్థనలు 'HTTP/2' ద్వారా అందించబడలేదు}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "'HTTP/2' దాని వనరులు అన్నింటిలో వినియోగించబడలేదు"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "\"HTTP/2\" దాని స్వంత వనరులు అన్నింటిలో వినియోగించబడుతోంది"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "మీ పేజీ స్క్రోలింగ్ పనితీరును మెరుగుపరచడానికి మీ స్పర్శ, చక్రం కదలికలను గుర్తుపట్టే లిజనర్‌లను '`passive`'కు సెట్ చేయడం పరిశీలించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "స్క్రోలింగ్ పనితీరును మెరుగుపరచడానికి పాసివ్ లిజనర్‌లను వినియోగించడం లేదు"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "స్క్రోలింగ్ పనితీరును మెరుగుపరచడానికి పాసివ్ లిజనర్‌లను వినియోగిస్తుంది"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "వివరణ"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "కన్సోల్‌లో లాగ్ చేయబడిన ఎర్రర్‌లు పరిష్కారం కాని సమస్యలను సూచిస్తాయి. నెట్‌వర్క్ అభ్యర్థన వైఫల్యాలు, ఇతర బ్రౌజర్ ఇబ్బందుల వలన అవి ఏర్పడి ఉంటాయి."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "బ్రౌజర్ ఎర్రర్‌లు కన్సోల్‌లో లాగ్ చేయబడ్డాయి"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "కన్సోల్‌లో లాగ్ చేయబడిన బ్రౌజర్ ఎర్రర్‌లు ఏవీ లేవు"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "వెబ్ ఫాంట్‌లు లోడ్ అవుతున్నప్పుడు వచనం వినియోగదారుకు కనిపించేలా ఉందని నిర్ధారించుకోవడానికి ఫాంట్-ప్రదర్శన CSS ఫీచర్‌ను శక్తివంతం చేయండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "వెబ్ ఫాంట్ లోడ్‌ల సమయంలో వచనం మొత్తం కనిపిస్తూ ఉంటుంది"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "కింది URL కోసం ఫాంట్ ప్రదర్శన విలువను Lighthouse ఆటోమేటిక్‌గా తనిఖీ చేయలేకపోయింది: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "ఆకార నిష్పత్తి (ఉండాల్సినది)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "ఆకార నిష్పత్తి (ప్రదర్శించబడింది)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "చిత్ర ప్రదర్శన కొలతలు సహజ ఆకార నిష్పత్తికి సరిపోలే విధంగా ఉండాలి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "తప్పు ఆకార నిష్పత్తిని కలిగి ఉన్న చిత్రాలను ప్రదర్శిస్తుంది"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "సరైన ఆకార నిష్పత్తితో చిత్రాలను ప్రదర్శిస్తుంది"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "చెల్లుబాటు కాని చిత్ర పరిమాణ సమాచారం {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "అసురక్షితమైన URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "అన్ని సైట్‌లకు 'HTTPS' రక్షణను జోడించాలి. సున్నితమైన వ్యక్తిగత సమాచారం ఏదీ లేని వాటికి కూడా ఈ రక్షణను జోడించాలి. HTTPS రక్షణను జోడించడం వలన దాడులకు పాల్పడేవారు ఎవరూ కూడా మీ యాప్, మీ వినియోగదారుల మధ్య జరిగే కమ్యూనికేషన్‌లను ట్యాంపర్ చేయడం లేదా దొంగచాటుగా వినడం లాంటివి చేయకుండా అడ్డుకోబడతారు. అలాగే HTTP/2, ఇంకా అనేక కొత్త వెబ్ ప్లాట్‌ఫామ్ APIల కోసం దీనిని తప్పనిసరిగా వినియోగించాలి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 అసురక్షితమైన అభ్యర్థన కనుగొనబడింది}other{# అసురక్షితమైన అభ్యర్థనలు కనుగొనబడ్డాయి}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "'HTTPS'ను ఉపయోగించడం లేదు"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "HTTPSను ఉపయోగిస్తుంది"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "పేజీ కనుక సెల్యులార్ నెట్‌వర్క్‌లో వేగంగా లోడ్ అయితే మంచి మొబైల్ వినియోగదారు అనుభవాన్ని అందిస్తుందని అర్థం. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "పేజీ కనుక సెల్యులార్ నెట్‌వర్క్‌లో వేగంగా లోడ్ అయితే తప్పకుండా మంచి మొబైల్ వినియోగదారు అనుభవాన్ని అందిస్తుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "సహకారం స్థాయి {timeInMs, number, seconds} సె"
+    "message": "ప్రభావశీలత సమయం {timeInMs, number, seconds} సెకన్లు"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "సిములేటెడ్ మొబైల్ నెట్‌వర్క్‌లో సహకారం {timeInMs, number, seconds} సె"
+    "message": "సిములేటెడ్ మొబైల్ నెట్‌వర్క్‌లో ప్రభావశీలత సమయం {timeInMs, number, seconds} సెకన్లు"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "మొబైల్ నెట్‌వర్క్‌లలో పేజీ తగినంత వేగంగా లోడ్ కావడం లేదు"
@@ -504,25 +735,25 @@
     "message": "ప్రధాన థ్రెడ్ పనిని తగ్గిస్తుంది"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "పేజీ లోడ్‌కు అత్యంత రద్దీ అయిన 5 సెకన్ల విండో సమయంలో, వినియోగదారు ఇన్‌పుట్‌కు ప్రతిస్పందిచడానికి, మిల్లీ సెకన్లలో, మీ యాప్ తీసుకునే సమయం యొక్క అంచనాను 'అంచనా వేసిన ఇన్‌పుట్ ప్రతిస్పందన సమయం' అని అంటారు. మీ ప్రతిస్పందన సమయం 50 మిల్లీ సెక‌న్ల‌ కన్నా ఎక్కువ అయితే, మీ యాప్ వేగవంతంగా పని చేయట్లేదని వినియోగదారులు భావించవచ్చు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "పేజీ లోడ్‌కు అత్యంత రద్దీ అయిన 5 సెకన్ల విండో సమయంలో, వినియోగదారు ఇన్‌పుట్‌కు ప్రతిస్పందించడానికి, మిల్లీ సెకన్లలో, మీ యాప్ తీసుకునే సమయం యొక్క అంచనాను 'అంచనా వేసిన ఇన్‌పుట్ ప్రతిస్పందన సమయం' అని అంటారు. మీ ప్రతిస్పందన సమయం 50 మిల్లీ సెక‌న్ల‌ కన్నా ఎక్కువ అయితే, మీ యాప్ వేగవంతంగా పని చేయట్లేదని వినియోగదారులు భావించవచ్చు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "అంచనా వేయబడిన ఇన్‌పుట్ ప్రతిస్పందన సమయం"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "మొదటి కంటెంట్ సహిత పెయింట్ ఏదైనా వచనం లేదా చిత్రం మొదటిసారి పెయింట్ చేయబడిన సమయాన్ని గుర్తిస్తుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "మొదటి కంటెంట్ సహిత పెయింట్ ఏదైనా వచనం లేదా చిత్రం మొదటిసారి పెయింట్ చేయబడిన సమయాన్ని గుర్తిస్తుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "మొదటి కంటెంట్ సహిత పెయింట్"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "మొదటి CPU ఖాళీ సమయం మొదటి సారిగా పేజీ యొక్క ప్రధాన థ్రెడ్ ఇన్‌పుట్‌ను నిర్వహించడానికి సరిపోయినంత ఖాళీగా ఉన్న సమయాన్ని గుర్తిస్తుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "'మొదటి CPU ఖాళీ సమయం' కొలమానం, మొదటి సారి పేజీ యొక్క ప్రధాన థ్రెడ్ ఇన్‌పుట్‌ను నిర్వహించడానికి తీసుకున్న సమయాన్ని గుర్తిస్తుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "CPU మొదటి ఖాళీ సమయం"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "మొదటి అర్ధవంతమైన పెయింట్ ఒక పేజీ ప్రాథమిక కంటెంట్ ఎప్పుడు కనిపించింది అనేదానికి ఒక కొలమానం. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "ఒక పేజీ ప్రాథమిక కంటెంట్ ఎప్పుడు కనిపించింది అనేదానికి, మొదటి అర్ధవంతమైన పెయింట్ ఒక కొలమానం. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "మొదటి అర్థవంతమైన పెయింట్"
@@ -534,16 +765,22 @@
     "message": "పేజీలో పూర్తి పరస్పర చర్యకు పట్టే సమయం"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "మీ వినియోగదారులు ఎదుర్కోగల మొదటి ఇన్‌పుట్ ఆలస్యం అన్నది సుదీర్ఘ టాస్క్‌లో మిల్లీసెకన్ల వ్యవధిలో ఉంటుంది."
+    "message": "మీ వినియోగదారులు ఎదుర్కోగల గరిష్ఠ మొదటి ఇన్‌పుట్ ఆలస్యం అన్నది సుదీర్ఘ టాస్క్‌లో మిల్లీసెకన్ల వ్యవధిలో ఉంటుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "గరిష్ఠ అంచనా FID"
+    "message": "మొదటి ఇన్‌పుట్ ఆలస్య గరిష్ఠ వ్యవధి"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "వేగం సూచిక ఒక పేజీ కంటెంట్‌లు ఎంత వేగంగా ప్రత్యక్షంగా చూపించబడతాయో చూపిస్తుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "వేగం సూచిక అనేది, ఒక పేజీలోని కంటెంట్‌లు ఎంత వేగంగా ప్రత్యక్షంగా చూపించబడతాయో తెలియజేస్తుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "వేగం సూచిక"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "టాస్క్ వ్యవధి 50 మిల్లీసెకన్లు మించిపోయినప్పుడు FCP మరియు పేజీలో పూర్తి పరస్పర చర్యకు పట్టే సమయం మధ్య వేచి ఉండాల్సిన మొత్తం కాలవ్యవధి మిల్లీసెకన్లలో పేర్కొనబడుతుంది."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "మొత్తం బ్లాక్ చేయబడే సమయం"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "నెట్‌వర్క్ రౌండ్ ట్రిప్ సమయాలు (RTT) పనితీరుపై తీవ్రమైన ప్రభావం చూపుతాయి. మూలానికి RTT ఎక్కువగా ఉంటే, వినియోగదారుకు దగ్గరగా ఉన్న సర్వర్‌ల పనితీరు మెరుగ్గా ఉండవచ్చని సంకేతం. [మరింత తెలుసుకోండి](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,26 +794,47 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "సర్వర్ బ్యాక్ఎండ్ ప్రతిస్పందన సమయాలు"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "బడ్జెట్ దాటిపోయింది"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "నెట్‌వర్క్ అభ్యర్థనల సంఖ్య, పరిమాణాన్ని అందించబడిన పనితీరు బడ్జెట్ ప్రకారం నిర్దేశించిన లక్ష్యాల కంటే తక్కువకు ఉంచండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 అభ్యర్థన}other{# అభ్యర్థనలు}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "పనితీరు బడ్జెట్"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "మళ్లింపులు పేజీ లోడ్ అవ్వడానికి ముందు అదనపు ఆలస్యాలను కలగచేస్తాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "మళ్లింపులు పేజీ లోడ్ అవ్వడానికి ముందు అదనపు ఆలస్యాలను కలుగజేస్తాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "అనేక పేజీ మళ్లింపులను నివారించండి"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "పేజీ వనరుల సంఖ్య, పరిమాణం కోసం బడ్జెట్‌లను సెట్ చేయడానికి, 'budget.json' ఫైల్‌ను జోడించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 అభ్యర్థన}other{# అభ్యర్థనలు}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "అభ్యర్థనల సంఖ్యను తగ్గించుకోండి, బదిలీ పరిమాణాలు తక్కువగా ఉండేలా చూసుకోండి"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "శోధన ఫలితాలలో ఏ URLను చూపాలో నియమానుగుణమైన లింక్‌లు సూచిస్తాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "బహుళ వైరుధ్యం ఉన్న URLలు ({urlList})"
+    "message": "వైరుధ్యమైన అనేక URLలు ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "వేరే డొమైన్ ({url})ను సూచిస్తోంది"
+    "message": "వేరొక డొమైన్ ({url})కు సూచిస్తోంది"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "చెల్లని URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "మరో `hreflang` స్థానం ({url})ను సూచిస్తోంది"
+    "message": "మరొక '`hreflang`' స్థానం ({url})కు నిర్దేశిస్తోంది"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "సంబంధిత URL ({url})"
@@ -585,25 +843,22 @@
     "message": "అలాంటి కంటెంట్‌ను కలిగిన పేజీకి బదులుగా డొమైన్ యొక్క మూలాధార URL (హోమ్‌పేజీ)ని సూచిస్తుంది"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "పత్రంలో చెల్లుబాటు అయ్యే `rel=canonical` లేదు"
+    "message": "పత్రంలో చెల్లుబాటు అయ్యే '`rel=canonical`' లేదు"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "పత్రంలో చెల్లుబాటు అయ్యే `rel=canonical` ఉంది"
+    "message": "పత్రంలో చెల్లుబాటు అయ్యే '`rel=canonical`' ఉంది"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
-    "message": "12px కంటే తక్కువగా ఉన్న ఫాంట్ పరిమాణాలు చాలా చిన్నవిగా ఉంటాయి కనుక అవి సముచితంగా పరిగణించబడవు, వీటిని చదవడం కోసం మొబైల్ సందర్శకులు “జూమ్ చేయడానిక స్క్రీన్‌పై రెండు వేళ్లను ఉంచి ఆ వేళ్లను దగ్గరకు లేదా దూరానికి లాగాలి”. మీరు కలిగి ఉండాల్సింది >పేజీ వచనంలో 60% ≥12px. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
+    "message": "12px కంటే తక్కువగా ఉన్న ఫాంట్ పరిమాణాలు చాలా చిన్నవిగా ఉంటాయి, కనుక అవి సముచితంగా పరిగణించబడవు. వీటిని చదవడం కోసం మొబైల్ సందర్శకులు “జూమ్ చేయడానికి స్క్రీన్‌పై రెండు వేళ్లను ఉంచి ఆ వేళ్లను దగ్గరకు లేదా దూరానికి లాగాలి”. మీరు కలిగి ఉండాల్సింది >పేజీ వచనంలో 60% ≥12px. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} సముచిత వచనం"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} చాలా చిన్నదిగా ఉంది."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "మొబైల్ స్క్రీన్‌ల కోసం ఆప్టిమైజ్ చేసిన వీక్షణ పోర్ట్ మెటా ట్యాగ్ అందుబాటులో లేదు కనుక వచనం సముచితంగా లేదు."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} వచనం చాలా చిన్నదిగా ఉంది ({decimalProportionVisited, number, extendedPercent} నమూనా ఆధారంగా)."
+    "message": "'{decimalProportion, number, extendedPercent}' వచనం చాలా చిన్నదిగా ఉంది ('{decimalProportionVisited, number, extendedPercent}' నమూనా ఆధారంగా)."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "పత్రంలో సముచితమైన ఫాంట్ పరిమాణాలను ఉపయోగించలేదు"
@@ -612,13 +867,13 @@
     "message": "పత్రంలో ఫాంట్ పరిమాణాలు సముచితంగా ఉన్నాయి"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "నిర్దిష్ట భాష లేదా ప్రాంతం కోసం పేజీ యొక్క ఏ వెర్షన్‌ను శోధన ఇంజిన్‌లో శోధన ఫలితాలలో చూపాలన్నది hreflang లింక్‌లు తెలియజేస్తాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "'hreflang' లింక్‌లు అన్నవి నిర్దిష్ట భాష లేదా ప్రాంతం కోసం పేజీ యొక్క ఏ వెర్షన్‌ను శోధన ఫలితాలలో చూపాలన్నది శోధన ఇంజిన్‌లకు తెలియజేస్తాయి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "పత్రంలో చెల్లుబాటు అయ్యే `hreflang` లేదు"
+    "message": "పత్రంలో చెల్లుబాటు అయ్యే ``hreflang`` లేదు"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "పత్రంలో చెల్లుబాటు అయ్యే `hreflang` ఉంది"
+    "message": "పత్రంలో చెల్లుబాటు అయ్యే '`hreflang`' ఉంది"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "విజయవంతం కాని HTTP స్థితి కోడ్‌లను కలిగిన పేజీలు సరిగ్గా సూచిక చేయబడకపోవచ్చు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -651,7 +906,7 @@
     "message": "లింక్‌లలో వివరణాత్మక వచనం ఉంది"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "నిర్మాణాత్మకమైన డేటాను ప్రామాణీకరించడం కోసం [నిర్మాణాత్మక డేటా పరీక్ష సాధనం](https://search.google.com/structured-data/testing-tool/) మరియు [నిర్మాణాత్మక డేటా లింటర్](http://linter.structured-data.org/) అమలు చేయండి. [మరింత తెలుసుకోండి](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "నిర్మాణాత్మకమైన డేటాను ప్రామాణీకరించడం కోసం [నిర్మాణాత్మక డేటా పరీక్ష సాధనం](https://search.google.com/structured-data/testing-tool/), [నిర్మాణాత్మక డేటా లింటర్‌](http://linter.structured-data.org/)లను అమలు చేయండి. [మరింత తెలుసుకోండి](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "నిర్మాణాత్మక డేటా చెల్లుబాటు అవుతుంది"
@@ -669,7 +924,7 @@
     "message": "పత్రంలో మెటా వివరణ ఉంది"
   },
   "lighthouse-core/audits/seo/plugins.js | description": {
-    "message": "ప్లగ్ఇన్ కంటెంట్‌ను శోధన ఇంజిన్‌లు సూచిక చేయవు మరియు చాలా పరికరాలలో ప్లగ్ఇన్‌లు నియంత్రించబడతాయి లేదా వాటికి మద్దతు ఉండదు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
+    "message": "ప్లగ్ఇన్ కంటెంట్‌ను శోధన ఇంజిన్‌లు సూచిక చేయలేవు. అలాగే, చాలా పరికరాలలో ప్లగ్ఇన్‌లు నియంత్రించబడతాయి లేదా వాటికి మద్దతు ఉండదు. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/plugins)."
   },
   "lighthouse-core/audits/seo/plugins.js | failureTitle": {
     "message": "పత్రంలో ప్లగ్ఇన్‌లు ఉపయోగించబడుతున్నాయి"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "లక్ష్యం ఓవర్‌ల్యాప్ అవుతోంది"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "పరిమాణం"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "ట్యాప్ టార్గెట్"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "ట్యాప్‌టార్గెట్‌ల పరిమాణం సముచితంగా ఉంది"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "ప్రధాన థ్రెడ్ సమయం"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "మూడవ పక్షం"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "మూడవ పక్షం కోడ్ గణనీయ స్థాయిలో లోడ్ పనితీరుపై ప్రభావం చూపవచ్చు. అవసరం లేని మూడవ పక్ష ప్రదాతల సంఖ్యను పరిమితం చేసి, మీ పేజీ ప్రాథమికంగా లోడ్ కావడం పూర్తయిన తర్వాత మూడవ పక్ష కోడ్‌ను లోడ్ చేయడానికి ప్రయత్నించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 మూడవ పక్షం కనుగొనబడింది}other{# మూడవ పక్షాలు కనుగొనబడ్డాయి}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "మూడవ పక్షం వినియోగం"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "మొదటి బైట్ సమయం మీ సర్వర్ ప్రతిస్పందనను పంపించిన సమయాన్ని గుర్తిస్తుంది. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "రూట్ పత్రం {timeInMs, number, milliseconds} మి. సె తీసుకుంది"
+    "message": "రూట్ పత్రం {timeInMs, number, milliseconds} మి.సె తీసుకుంది"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "సర్వర్ ప్రతిస్పందన సమయాలను తగ్గించండి (TTFB)"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "వ్యవధి"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "పేరు"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "ప్రారంభ సమయం"
@@ -753,19 +1017,19 @@
     "message": "వినియోగదారు సమయం మార్కులు మరియు కొలమానాలు"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "\"{securityOrigin}\" కోసం ముందస్తు కనెక్షన్ <link> కనుగొనబడింది, కానీ బ్రౌజర్ ద్వారా ఉపయోగించబడలేదు. మీరు `crossorigin` లక్షణాన్ని సక్రమంగా ఉపయోగిస్తున్నారో లేదో తనిఖీ చేయండి."
+    "message": "\"{securityOrigin}\" కోసం ముందస్తు కనెక్షన్ <link> కనుగొనబడింది, కానీ బ్రౌజర్ ద్వారా ఉపయోగించబడలేదు. మీరు ``crossorigin`` లక్షణాన్ని సక్రమంగా ఉపయోగిస్తున్నారో లేదో తనిఖీ చేయండి."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "ముఖ్యమైన మూడవ-పక్ష మూలాలకు ముందస్తు కనెక్ష్‌లను స్థాపించడానికి ముందుగా కనెక్ట్ చేయి లేదా dns ప్రి-ఫెచింగ్ వనరు సూచనలను జోడించడాన్ని పరిగణించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "ముఖ్యమైన మూడవ పక్ష మూలాలకు ముందస్తు కనెక్షన్‌లను ఏర్పాటు చేయడానికి 'ముందుగా కనెక్ట్ చేయి' లేదా dns ప్రీ-ఫెచింగ్ వనరు సూచనలను జోడించడాన్ని పరిశీలించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "అవసరమైన మూలాలకు ముందుగా కనెక్ట్ చేయండి"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "\"{preloadURL}\" కోసం ముందే లోడ్ చేసిన ఒక <link> కనుగొనబడింది. కానీ దానిని బ్రౌజర్ ఉపయోగించలేదు. మీరు `crossorigin` లక్షణాన్ని సక్రమంగా ఉపయోగిస్తున్నారో లేదో తనిఖీ చేయండి."
+    "message": "'{preloadURL}' కోసం ముందే లోడ్ చేసిన ఒక <link> కనుగొనబడింది. కానీ దానిని బ్రౌజర్ ఉపయోగించలేదు. మీరు ``crossorigin`` లక్షణాన్ని సక్రమంగా ఉపయోగిస్తున్నారో లేదో తనిఖీ చేయండి."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "ప్రస్తుతం పేజీ లోడ్‌లో తర్వాత అభ్యర్ధించబడిన వనరులను పొందడాన్ని ప్రాధాన్యపరచడానికి <link rel=preload>ను ఉపయోగించడాన్ని పరిగణించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "ప్రస్తుతం పేజీ లోడ్‌లో తర్వాత అభ్యర్ధించబడిన వనరులను పొందడాన్ని ప్రాధాన్యపరచడానికి '`<link rel=preload>`'ను ఉపయోగించడం పరిశీలించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "కీలక అభ్యర్ధనలను ముందుగా లోడ్ చేయండి"
@@ -789,10 +1053,10 @@
     "message": "ఉత్తమ అభ్యాసాలు"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "[మీ వెబ్ యాప్ యొక్క యాక్సెసిబిలిటీని మెరుగుపరచగల] అవకాశాలను ఈ తనిఖీలు హైలైట్ చేస్తాయి (https://developers.google.com/web/fundamentals/accessibility). యాక్సెసిబిలిటీ సమస్యలలోని ఒక సబ్‌సెట్‌ను మాత్రమే ఆటోమేటిక్‌గా గుర్తించడం సాధ్యపడుతుంది, కనుక మాన్యువల్ పరీక్ష కూడా చేయాల్సిందిగా సిఫార్సు చేస్తున్నాము."
+    "message": "[మీ వెబ్ యాప్ యొక్క యాక్సెసిబిలిటీని మెరుగుపరచగల](https://developers.google.com/web/fundamentals/accessibility) అవకాశాలను ఈ తనిఖీలు హైలైట్ చేస్తాయి. యాక్సెసిబిలిటీ సమస్యలలోని ఒక సబ్‌సెట్‌ను మాత్రమే ఆటోమేటిక్‌గా గుర్తించడం సాధ్యపడుతుంది, కనుక మాన్యువల్ పరీక్ష కూడా చేయాల్సిందిగా సిఫార్సు చేస్తున్నాము."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "ఆటోమేటెడ్ పరీక్ష సాధనం కవర్ చేయని ప్రాంతాలను ఈ అంశాలు పేర్కొంటాయి. [యాక్సెసిబిలిటీ సమీక్షను నిర్వహించడం]లో ఉన్న మా గైడ్‌లో మరింత తెలుసుకోండి (https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
+    "message": "ఆటోమేటెడ్ పరీక్ష సాధనం కవర్ చేయని ప్రాంతాలను ఈ అంశాలు పేర్కొంటాయి. [యాక్సెసిబిలిటీ సమీక్షను నిర్వహించడం](https://developers.google.com/web/fundamentals/accessibility/how-to-review) గురించి మా గైడ్‌లో మరింత తెలుసుకోండి."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "యాక్సెసిబిలిటీ"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "పట్టికలు మరియు జాబితాలు"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "ఉత్తమ అభ్యాసాలు"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "పనితీరు బడ్జెట్‌లు అనేవి మీ సైట్ యొక్క పనితీరు ప్రమాణాలను నిర్దేశిస్తాయి."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "బడ్జెట్‌లు"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "మీ అప్లికేషన్ పనితీరు గురించి మరింత సమాచారం."
+    "message": "మీ అప్లికేషన్ పనితీరు గురించి మరింత సమాచారం. ఈ సంఖ్యలు పనితీరు స్కోర్‌ను [నేరుగా ప్రభావితం చేయవు](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "సమస్య విశ్లేషణ"
@@ -840,7 +1113,7 @@
     "message": "మొదటి పెయింట్ మెరుగుదలలు"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "ఈ ఆప్టిమైజేషన్‌లు మీ పేజీ లోడ్‌ అవ్వడాన్ని వేగవంతం చేయవచ్చు."
+    "message": "మీ పేజీని వేగంగా లోడ్ చేయడంలో ఈ సూచనలు సహాయపడగలవు. అవి పనితీరు స్కోర్‌పై [నేరుగా ప్రభావం](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) చూపవు."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "అవకాశాలు"
@@ -867,7 +1140,7 @@
     "message": "PWA ఆప్టిమైజ్ చేసినవి"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "శోధన ఇంజిన్ ఫలితాల ర్యాంకింగ్ కోసం మీ పేజీ ఆప్టిమైజ్ చేయబడినట్లు ఈ తనిఖీలు నిర్ధారిస్తాయి. మీ శోధన ర్యాంకింగ్‌పై ప్రభావం చూపగల ఈ అదనపు కారకాలను లైట్‌హౌస్ తనిఖీ చేయదు. [మరింత తెలుసుకోండి](https://support.google.com/webmasters/answer/35769)."
+    "message": "శోధన ఇంజిన్ ఫలితాల ర్యాంకింగ్ కోసం మీ పేజీ ఆప్టిమైజ్ చేయబడినట్లు ఈ తనిఖీలు నిర్ధారిస్తాయి. మీ శోధన ర్యాంకింగ్‌పై ప్రభావం చూపగల ఈ అదనపు అంశాలను Lighthouse తనిఖీ చేయదు. [మరింత తెలుసుకోండి](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "అదనపు SEO ఉత్తమ అభ్యాసాలను తనిఖీ చేయడం కోసం మీ సైట్‌లో అదనపు వాలిడేటర్‌లను అమలు చేయండి."
@@ -888,7 +1161,7 @@
     "message": "క్రాలింగ్ మరియు అనుక్రమణ"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "వినియోగదారులు కంటెంట్ పేజీలను స్క్రీన్‌పై రెండు వేళ్లను ఉంచి ఆ వేళ్లను దగ్గరకు లేదా దూరానికి లాగుతూ లేదా దగ్గరగా జూమ్ చేసి చదవవలసిన అవసరం లేకుండా, మీ పేజీలు మొబైల్ అనుకూలంగా ఉన్నాయని నిర్థారించుకోండి. [మరింత తెలుసుకోండి](https://developers.google.com/search/mobile-sites/)."
+    "message": "వినియోగదారులు కంటెంట్ పేజీలను చదవడం కోసం స్క్రీన్‌పై రెండు వేళ్లను ఉంచి దగ్గరకు లేదా దూరానికి లాగుతూ లేదా దగ్గరగా జూమ్ చేసి ఇబ్బందిపడేలా కాకుండా మీ పేజీలు మొబైల్ అనుకూలంగా ఉన్నాయని నిర్థారించుకోండి. [మరింత తెలుసుకోండి](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "మొబైల్-అనుకూలం"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "కాష్ TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "స్థానం"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "పేరు"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "అభ్యర్థనలు"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "వనరు రకం"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "పరిమాణం (KB)"
+    "message": "పరిమాణం"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "వెచ్చించిన సమయం"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "బదిలీ పరిమాణం"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "ఆదా చేయగల పరిమాణం (KB)"
+    "message": "ఆదా చేయగల పరిమాణం"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "ఆదా చేయగల వ్యవధి (మి. సె)"
+    "message": "ఆదా చేయగల వ్యవధి"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "ఆదా చేయగల పరిమాణం {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "ఆదా చేయగల వ్యవధి {wastedMs, number, milliseconds} మి. సెలు"
+    "message": "ఆదా చేయగల వ్యవధి {wastedMs, number, milliseconds} మి.సెలు"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "పత్రం"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "ఫాంట్"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "చిత్రం"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "మీడియా"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds} మి. సె"
+    "message": "{timeInMs, number, milliseconds} మి.సె"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "ఇతరం"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "స్క్రిప్ట్"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} సె"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "స్టైల్‌షీట్"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "మూడవ పక్షం"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "మొత్తం"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "మీ పేజీ లోడ్ చేసే సమయంలో స్థితిగతిని రికార్డ్ చేస్తున్నప్పుడు ఏదో తప్పు జరిగింది. దయచేసి Lighthouseని మళ్లీ అమలు చేయండి. ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS సర్వర్‌లు అందించిన డొమైన్‌ని పరిష్కరించలేవు."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "అవసరమైన '{artifactName}' గ్యాదరర్ ఒక ఎర్రర్‌ను ఎదుర్కొంది: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "అంతర్గత Chrome ఎర్రర్ ఏర్పడింది. దయచేసి Chromeని పునఃప్రారంభించి, Lighthouseని తిరిగి అమలు చేయడం ప్రయత్నించండి."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "అవసరమైన '{artifactName}' గ్యాదరర్ అమలు కాలేదు."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "మీరు అభ్యర్థించిన పేజీని Lighthouse విశ్వసనీయ రీతిలో పేజీని లోడ్ చేయలేకపోయింది. మీరు సరైన URLని పరీక్షిస్తున్నారని, సర్వర్ అన్ని అభ్యర్థనలకు సరిగ్గా ప్రతిస్పందిస్తుందని నిర్ధారించుకోండి."
@@ -945,16 +1266,19 @@
     "message": "పేజీ ప్రతిస్పందించడం ఆపివేసినందున, మీరు అభ్యర్థించిన URLని విశ్వసనీయ రీతిలో Lighthouse లోడ్ చేయలేకపోయింది."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "మీరు అందించిన URLకు చెల్లుబాటయ్యే భద్రతా ఆధారాలు లేవు. {securityMessages}"
+    "message": "మీరు అందించిన URLకు చెల్లుబాటయ్యే భద్రత సర్టిఫికెట్ లేదు. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "మధ్యలో వచ్చే సందేశ బ్యానర్‌తో పేజీ లోడ్ కావడాన్ని Chrome నిరోధించింది. మీరు సరైన URLను పరీక్షిస్తున్నారని, సర్వర్ అన్ని అభ్యర్థనలకు సరిగ్గా ప్రతిస్పందిస్తోందని నిర్ధారించుకోండి."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "మీరు అభ్యర్థించిన పేజీని Lighthouse విశ్వసనీయ రీతిలో పేజీని లోడ్ చేయలేకపోయింది. మీరు సరైన URLని పరీక్షిస్తున్నారని, సర్వర్ అన్ని అభ్యర్థనలకు సరిగ్గా ప్రతిస్పందిస్తుందని నిర్ధారించుకోండి. (వివరాలు: {errorDetails})"
+    "message": "మీరు అభ్యర్థించిన పేజీని Lighthouse విశ్వసనీయ రీతిలో లోడ్ చేయలేకపోయింది. మీరు సరైన URLను పరీక్షిస్తున్నారని, సర్వర్ అన్ని అభ్యర్థనలకు సరిగ్గా ప్రతిస్పందిస్తోందని నిర్ధారించుకోండి. (వివరాలు: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "మీరు అభ్యర్థించిన పేజీని Lighthouse విశ్వసనీయ రీతిలో పేజీని లోడ్ చేయలేకపోయింది. మీరు సరైన URLని పరీక్షిస్తున్నారని, సర్వర్ అన్ని అభ్యర్థనలకు సరిగ్గా ప్రతిస్పందిస్తుందని నిర్ధారించుకోండి. (స్థితి కోడ్: {statusCode})"
+    "message": "మీరు అభ్యర్థించిన పేజీని Lighthouse విశ్వసనీయ రీతిలో లోడ్ చేయలేకపోయింది. మీరు సరైన URLను పరీక్షిస్తున్నారని, సర్వర్ అన్ని అభ్యర్థనలకు సరిగ్గా ప్రతిస్పందిస్తోందని నిర్ధారించుకోండి. (స్థితి కోడ్: {statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "మీ పేజీ లోడ్ కావడానికి చాలా ఎక్కువ సమయం పట్టింది. మీ పేజీ లోడ్ సమయం తగ్గించడానికి దయచేసి నివేదికలో ఉన్న అవకాశాలను అనుసరించి, ఆపై Lighthouseని తిరిగి అమలు చేయడం ప్రయత్నించండి. ({errorCode})"
+    "message": "మీ పేజీ లోడ్ కావడానికి చాలా ఎక్కువ సమయం పట్టింది. మీ పేజీ లోడ్ సమయం తగ్గించడానికి దయచేసి నివేదికలో ఉన్న అవకాశాలను అనుసరించి, ఆపై Lighthouseను తిరిగి అమలు చేయడానికి ప్రయత్నించండి. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "DevTools ప్రోటోకాల్ ప్రతిస్పందన కోసం వేచి ఉండటం వలన కేటాయించిన సమయాన్ని దాటిపోయింది. (పద్ధతి: {protocolMethod})"
@@ -984,7 +1308,7 @@
     "message": "ల్యాబ్ డేటా"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "అనుసరించబడిన మొబైల్ నెట్‌వర్క్‌లో ప్రస్తుత పేజీకి సంబంధించిన [Lighthouse](https://developers.google.com/web/tools/lighthouse/) విశ్లేషణ. విలువలు అంచనా వేయబడ్డాయి మరియు మారవచ్చు."
+    "message": "అనుకరణ మొబైల్ నెట్‌వర్క్‌లో ప్రస్తుత పేజీకి సంబంధించిన [Lighthouse](https://developers.google.com/web/tools/lighthouse/) విశ్లేషణ. విలువలు కేవలం అంచనా మాత్రమే, ఇవి మారే అవకాశం ఉంది."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "మాన్యువల్‌గా తనిఖీ చేయవలసిన అదనపు అంశాలు"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "స్నిప్పెట్‌ను విస్తరించు"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "3వ పక్షం వనరులను చూపు"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Lighthouse యొక్క ఈ అమలును ప్రభావితం చేసిన సమస్యలు ఉన్నాయి:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "విలువలు అంచనా వేయబడ్డాయి మరియు మారవచ్చు."
+    "message": "విలువలు కేవలం అంచనా మాత్రమే, ఇవి మారే అవకాశం ఉంది. పనితీరు స్కోర్ [కేవలం ఈ కొలమానాల ఆధారంగా అందించబడుతుంది](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "ఆడిట్‌లు పాస్ అయ్యాయి కానీ హెచ్చరికలు ఉన్నాయి"
@@ -1023,10 +1350,10 @@
     "message": "మీ GIFను HTML5 వీడియోగా పొందుపరచగల సౌలభ్యం అందించే సేవకు అప్‌లోడ్ చేయడానికి ప్రయత్నించండి."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "ఏవైనా ఆఫ్‌స్క్రీన్ చిత్రాలు ఉంటే, వాటిని మినహాయించగల సామర్థ్యం కలిగి ఉండే లేదా ఆ కార్యశీలతను అందించే థీమ్‌కు మార్చగలిగే [లేజీ-లోడ్ WordPress ప్లగ్ఇన్](https://wordpress.org/plugins/search/lazy+load/)ను ఇన్‌స్టాల్ చేసుకోండి. అలాగే, [AMP ప్లగ్ఇన్](https://wordpress.org/plugins/amp/) ఉపయోగించడం కూడా పరిశీలించండి."
+    "message": "ఏవైనా ఆఫ్‌స్క్రీన్ చిత్రాలు ఉంటే, వాటిని మినహాయించగల సామర్థ్యం కలిగి ఉండే లేదా ఆ కార్యశీలతను అందించే థీమ్‌కు మార్చగలిగే [లేజీ-లోడ్ WordPress ప్లగ్ఇన్‌](https://wordpress.org/plugins/search/lazy+load/)ను ఇన్‌స్టాల్ చేసుకోండి. అలాగే, [AMP ప్లగ్ఇన్‌](https://wordpress.org/plugins/amp/)ను ఉపయోగించడం కూడా పరిశీలించండి."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "[కీలకమైన ఆస్తులను రేఖాక్రమంలో ఉంచడానికి](https://wordpress.org/plugins/search/critical+css/) లేదా [తక్కువ ప్రాముఖ్యత ఉన్న వనరులను మినహాయించడానికి](https://wordpress.org/plugins/search/defer+css+javascript/) మీకు సహాయపడగల అనేక WordPress ప్లగ్ఇన్‌లు ఉన్నాయి. ఈ ప్లగ్ఇన్‌ల ద్వారా అందించబడే ఆప్టిమైజేషన్‌లు మీ థీమ్ లేదా ప్లగ్ఇన్‌ల ఫీచర్‌లను విడగొట్టవచ్చని గుర్తుంచుకోండి, దీని వలన మీరు కోడ్‌కు మార్పులు చేయాల్సి రావచ్చు."
+    "message": "[కీలకమైన ఆస్తులను ఇన్‌లైన్‌లో ఉంచడానికి](https://wordpress.org/plugins/search/critical+css/) లేదా [తక్కువ ప్రాముఖ్యత ఉన్న వనరులను మినహాయించడానికి](https://wordpress.org/plugins/search/defer+css+javascript/) మీకు సహాయపడగల అనేక WordPress ప్లగ్ఇన్‌లు ఉన్నాయి. ఈ ప్లగ్ఇన్‌ల ద్వారా అందించబడే ఆప్టిమైజేషన్‌లు మీ థీమ్ లేదా ప్లగ్ఇన్‌ల ఫీచర్‌లను విడగొట్టవచ్చని గుర్తుంచుకోండి, దీని వలన మీరు కోడ్‌కు మార్పులు చేయాల్సి రావచ్చు."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "థీమ్‌లు, ప్లగ్ఇన్‌లు, సర్వర్ లక్షణాలన్నీ కూడా సర్వర్ ప్రతిస్పందన సమయాన్ని ప్రభావితం చేస్తాయి. మరింత ఆప్టిమైజ్ చేయబడిన థీమ్‌ను కనుగొనడానికి, చాలా జాగ్రత్తగా ఆప్టిమైజేషన్ ప్లగ్ఇన్‌ను ఎంచుకోవడానికి మరియు/లేదా మీ సర్వర్‌ను అప్‌గ్రేడ్ చేయడానికి ప్రయత్నించండి."
@@ -1035,25 +1362,25 @@
     "message": "ఇవ్వబడిన పేజీలో చూపబడే పోస్ట్‌ల సంఖ్యను తగ్గించడం, మీ పొడవైన పోస్ట్‌లను బహుళ పేజీలుగా విడగొట్టడం లేదా మందకొడి లోడింగ్ వ్యాఖ్యల కోసం ప్లగ్ఇన్‌ను ఉపయోగించడం ద్వారా (అంటే, మరిన్ని ట్యాగ్ ద్వారా) మీ పోస్ట్ జాబితాలలో సారాంశాలను చూపడానికి ప్రయత్నించండి."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "అనేక [WordPress ప్లగ్ఇన్‌లు](https://wordpress.org/plugins/search/minify+css/) మీ శైలులను క్రమపరచడం, చిన్నవిగా చేయడం, కుదించడం ద్వారా మీ సైట్‌ను మరింత వేగవంతం చేయవచ్చు. వీలైతే, ఈ కనిష్ఠీకరణను ముందుగానే నిర్వహించేలా కూడా మీరు ఒక బిల్డ్ ప్రాసెస్‌ను ఉపయోగించాలని కోరుకోవచ్చు."
+    "message": "అనేక '[WordPress ప్లగ్ఇన్‌లు](https://wordpress.org/plugins/search/minify+css/)' మీ శైలులను క్రమపరచడం, చిన్నవిగా చేయడం, కుదించడం ద్వారా మీ సైట్‌ను మరింత వేగవంతం చేయవచ్చు. వీలైతే, ఈ కనిష్ఠీకరణను ముందుగానే నిర్వహించేలా కూడా మీరు ఒక బిల్డ్ ప్రాసెస్‌ను ఉపయోగించవచ్చు."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "అనేక [WordPress ప్లగ్ఇన్‌లు](https://wordpress.org/plugins/search/minify+javascript/) మీ స్క్రిప్ట్‌లను క్రమపరచడం, చిన్నవిగా చేయడం, కుదించడం ద్వారా మీ సైట్‌ను మరింత వేగవంతం చేయవచ్చు. వీలైతే, ఈ కనిష్ఠీకరణను ముందుగానే నిర్వహించేలా కూడా మీరు ఒక బిల్డ్ ప్రాసెస్‌ను ఉపయోగించాలని కోరుకోవచ్చు."
+    "message": "అనేక [WordPress ప్లగ్ఇన్‌లు](https://wordpress.org/plugins/search/minify+javascript/) మీ స్క్రిప్ట్‌లను క్రమపరచడం, చిన్నవిగా చేయడం, కుదించడం ద్వారా మీ సైట్‌ను మరింత వేగవంతం చేయవచ్చు. వీలైతే, ఈ కనిష్ఠీకరణను ముందుగానే నిర్వహించేలా కూడా మీరు ఒక బిల్డ్ ప్రాసెస్‌ను ఉపయోగించడం పరిగణించవచ్చు."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "మీ పేజీలో ఉపయోగించని CSSను లోడ్ చేస్తున్న [WordPress ప్లగ్ఇన్‌లు] (https://wordpress.org/plugins/) సంఖ్యను తగ్గించడం లేదా మార్చడం పరిగణనలోకి తీసుకోండి. అదనపు CSSను జోడిస్తున్న ప్లగ్ఇన్‌లను గుర్తించడానికి, Chrome DevToolsలో [కోడ్ కవరేజీ](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) అమలు చేయడానికి ప్రయత్నించండి. అందుకు కారణమైన థీమ్/ప్లగ్ఇన్‌ను స్టైల్‌షీట్‌లోని URL నుండి మీరు గుర్తించవచ్చు. కోడ్ కవరేజ్‌లో ఎక్కువ ఎరుపు రంగు కలిగి ఉన్న జాబితాలో అనేక స్టైల్‌షీట్‌లను కలిగి ఉన్న ప్లగ్ఇన్‌లను వెతకండి. నిజంగా ప్లగ్ఇన్‌ను ఆ పేజీలో ఉపయోగించిప్పుడు మాత్రమే స్టైల్‌షీట్‌కు జత చేయాలి."
+    "message": "మీ పేజీలో ఉపయోగించని CSSను లోడ్ చేస్తున్న '[WordPress ప్లగ్ఇన్‌‌ల](https://wordpress.org/plugins/)' సంఖ్యను తగ్గించడం లేదా మార్చడాన్ని పరిశీలించండి. అదనపు CSSను జోడించే ప్లగ్ఇన్‌లను గుర్తించడానికి, Chrome DevToolsలో '[కోడ్ కవరేజీ](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)' అమలు చేయడానికి ప్రయత్నించండి. అందుకు కారణమైన థీమ్/ప్లగ్ఇన్‌ను స్టైల్‌షీట్‌లోని URL నుండి మీరు గుర్తించవచ్చు. కోడ్ కవరేజ్‌లో ఎక్కువ ఎరుపు రంగు కలిగి ఉన్న జాబితాలో అనేక స్టైల్‌షీట్‌లను కలిగి ఉన్న ప్లగ్ఇన్‌లను వెతకండి. నిజంగా ప్లగ్ఇన్‌ను ఆ పేజీలో ఉపయోగించినప్పుడు మాత్రమే స్టైల్‌షీట్‌కు జత చేయాలి."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "మీ పేజీలో ఉపయోగించని JavaScriptను లోడ్ చేస్తున్న [WordPress ప్లగ్ఇన్‌లు] (https://wordpress.org/plugins/) సంఖ్యను తగ్గించడం లేదా మార్చడాన్ని పరిశీలించండి. అదనపు JSను జోడించే ప్లగ్ఇన్‌లను గుర్తించడానికి, Chrome DevToolsలో [కోడ్ కవరేజీ] (https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) అమలు చేయడానికి ప్రయత్నించండి. అందుకు కారణమైన థీమ్/ప్లగ్ఇన్‌ను స్టైల్‌షీట్‌లోని URL నుండి మీరు గుర్తించవచ్చు. కోడ్ కవరేజ్‌లో ఎక్కువ ఎరుపు కలిగి ఉన్న జాబితాలో అనేక స్క్రిప్ట్‌లను కలిగి ఉన్న ప్లగ్ఇన్‌లను వెతకండి. నిజంగా ప్లగ్ఇన్‌ను ఆ పేజీలో ఉపయోగించిప్పుడు మాత్రమే స్టైల్‌షీట్‌కు జత చేయాలి."
+    "message": "మీ పేజీలో ఉపయోగించని JavaScriptను లోడ్ చేస్తున్న '[WordPress ప్లగ్ఇన్‌‌ల](https://wordpress.org/plugins/)' సంఖ్యను తగ్గించడం లేదా మార్చడాన్ని పరిశీలించండి. అదనపు JSను జోడించే ప్లగ్ఇన్‌లను గుర్తించడానికి, Chrome DevToolsలో '[కోడ్ కవరేజీ](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)' అమలు చేయడానికి ప్రయత్నించండి. అందుకు కారణమైన థీమ్/ప్లగ్ఇన్‌ను స్క్రిప్ట్ యొక్క URL నుండి మీరు గుర్తించవచ్చు. కోడ్ కవరేజ్‌లో ఎక్కువ ఎరుపు రంగు కలిగి ఉన్న జాబితాలో అనేక స్క్రిప్ట్‌లను కలిగి ఉన్న ప్లగ్ఇన్‌లను వెతకండి. నిజంగా ప్లగ్ఇన్‌ను ఆ పేజీలో ఉపయోగించినప్పుడు మాత్రమే స్క్రిప్ట్‌కు జత చేయాలి."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "[WordPressలో బ్రౌజర్ కాష్ విధానం](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching) గురించి చదవండి."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "నాణ్యత తగ్గకుండా మీ చిత్రాలను కుదించే [చిత్రం ఆప్టిమైజేషన్ WordPress ప్లగ్ఇన్](https://wordpress.org/plugins/search/optimize+images/)ను ఉపయోగించడం పరిశీలించండి."
+    "message": "నాణ్యత తగ్గకుండా మీ చిత్రాలను కుదించే [చిత్రం ఆప్టిమైజేషన్ WordPress ప్లగ్ఇన్‌](https://wordpress.org/plugins/search/optimize+images/)ను ఉపయోగించడం పరిశీలించండి."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "అవసరమైన చిత్ర పరిమాణాలు అందుబాటులో ఉన్నాయో లేదో నిర్ధారించుకోవడానికి చిత్రాలను నేరుగా [మీడియా లైబ్రరీ] (https://codex.wordpress.org/Media_Library_Screen) ద్వారా అప్‌లోడ్ చేయండి, ఆపై వాటిని మీడియా లైబ్రరీ నుండి చొప్పించండి లేదా అనుకూలమైన చిత్ర పరిమాణాలను ఉపయోగించారని నిర్ధారించుకోవడానికి (ప్రతిస్పందనాత్మక బ్రేక్ పాయింట్‌లు కలిగి ఉండే వాటికి కూడా) చిత్ర విడ్జెట్‌ను ఉపయోగించండి. కొలతలు వాటి వినియోగానికి తగినట్లుగా ఉంటే మినహా, `పూర్తి పరిమాణం` చిత్రాలను వినియోగించడం నివారించండి. [మరింత తెలుసుకోండి](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "అవసరమైన చిత్ర పరిమాణాలు అందుబాటులో ఉన్నాయో లేదో నిర్ధారించుకోవడానికి చిత్రాలను నేరుగా [మీడియా లైబ్రరీ](https://codex.wordpress.org/Media_Library_Screen) ద్వారా అప్‌లోడ్ చేయండి. ఆపై వాటిని మీడియా లైబ్రరీ నుండి చొప్పించండి లేదా అనుకూలమైన చిత్ర పరిమాణాలు ఉపయోగించబడ్డాయో లేదో నిర్ధారించుకోవడానికి (ప్రతిస్పందనాత్మక బ్రేక్ పాయింట్‌లు కలిగి ఉండే వాటికి కూడా) చిత్ర విడ్జెట్‌ను ఉపయోగించండి. కొలతలు వాటి వినియోగానికి తగినట్లుగా ఉంటే తప్పితే, '`Full Size`' చిత్రాలను వినియోగించడం నివారించండి. [మరింత తెలుసుకోండి](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "మీరు మీ వెబ్ సర్వర్ కన్ఫిగరేషన్‌లో వచన కుదింపును ప్రారంభించవచ్చు."

--- a/lighthouse-core/lib/i18n/locales/th.json
+++ b/lighthouse-core/lib/i18n/locales/th.json
@@ -1,6 +1,6 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "คีย์การเข้าถึงให้ผู้ใช้โฟกัสที่ส่วนหนึ่งของหน้าได้อย่างรวดเร็ว คีย์การเข้าถึงแต่ละรายการต้องไม่ซ้ำกันเพื่อให้ไปยังส่วนต่างๆ ได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)"
+    "message": "คีย์การเข้าถึงให้ผู้ใช้โฟกัสที่ส่วนหนึ่งของหน้าได้อย่างรวดเร็ว คีย์การเข้าถึงแต่ละรายการต้องไม่ซ้ำกันเพื่อให้ไปยังส่วนต่างๆ ได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://web.dev/accesskeys/)"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
     "message": "ค่า `[accesskey]` ซ้ำกัน"
@@ -9,7 +9,7 @@
     "message": "ค่า `[accesskey]` ไม่ซ้ำกัน"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "`role` ของ ARIA แต่ละรายการรองรับชุดย่อยของแอตทริบิวต์ `aria-*` ที่เจาะจง หากรายการเหล่านี้ไม่ตรงกันจะทำให้แอตทริบิวต์ `aria-*` ไม่ถูกต้อง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)"
+    "message": "`role` ของ ARIA แต่ละรายการรองรับชุดย่อยของแอตทริบิวต์ `aria-*` ที่เจาะจง หากรายการเหล่านี้ไม่ตรงกันจะทำให้แอตทริบิวต์ `aria-*` ไม่ถูกต้อง [ดูข้อมูลเพิ่มเติม](https://web.dev/aria-allowed-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
     "message": "แอตทริบิวต์ `[aria-*]` ไม่ตรงกับบทบาทของตน"
@@ -18,7 +18,7 @@
     "message": "แอตทริบิวต์ `[aria-*]` ตรงกับบทบาทของตน"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "บทบาท ARIA บางบทบาทกำหนดให้มีแอตทริบิวต์ที่อธิบายสถานะขององค์ประกอบให้โปรแกรมอ่านหน้าจอทราบ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)"
+    "message": "บทบาท ARIA บางบทบาทกำหนดให้มีแอตทริบิวต์ที่อธิบายสถานะขององค์ประกอบให้โปรแกรมอ่านหน้าจอทราบ [ดูข้อมูลเพิ่มเติม](https://web.dev/aria-required-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
     "message": "`[role]` ไม่มีแอตทริบิวต์ `[aria-*]` ทั้งหมดที่จำเป็น"
@@ -27,7 +27,7 @@
     "message": "`[role]` มีแอตทริบิวต์ `[aria-*]` ที่จำเป็นทั้งหมด"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "บทบาท ARIA ระดับบนสุดบางบทบาทต้องมีบทบาทย่อยที่เจาะจงเพื่อใช้ฟังก์ชันการช่วยเหลือพิเศษตามวัตถุประสงค์ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)"
+    "message": "บทบาท ARIA ระดับบนสุดบางบทบาทต้องมีบทบาทย่อยที่เจาะจงเพื่อใช้ฟังก์ชันการช่วยเหลือพิเศษตามวัตถุประสงค์ [ดูข้อมูลเพิ่มเติม](https://web.dev/aria-required-children/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
     "message": "ไม่มีองค์ประกอบที่มี `[role]` ซึ่งกำหนดให้มี `[role]` ย่อยที่เจาะจง"
@@ -36,7 +36,7 @@
     "message": "มีองค์ประกอบที่มี `[role]` ซึ่งกำหนดให้มี `[role]` ย่อยที่เจาะจง"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "บทบาท ARIA ย่อยบางบทบาทต้องอยู่ในบทบาทระดับบนสุดที่เจาะจงเพื่อให้ใช้ฟังก์ชันการช่วยเหลือพิเศษตามวัตถุประสงค์ได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)"
+    "message": "บทบาท ARIA ย่อยบางบทบาทต้องอยู่ในบทบาทระดับบนสุดที่เจาะจงเพื่อให้ใช้ฟังก์ชันการช่วยเหลือพิเศษตามวัตถุประสงค์ได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://web.dev/aria-required-parent/)"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
     "message": "`[role]` ไม่ได้อยู่ในองค์ประกอบระดับบนสุดที่กำหนด"
@@ -45,7 +45,7 @@
     "message": "`[role]` อยู่ในองค์ประกอบระดับบนสุดที่กำหนด"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "บทบาท ARIA ต้องมีค่าที่ถูกต้องเพื่อใช้ฟังก์ชันการช่วยเหลือพิเศษตามวัตถุประสงค์ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)"
+    "message": "บทบาท ARIA ต้องมีค่าที่ถูกต้องเพื่อใช้ฟังก์ชันการช่วยเหลือพิเศษตามวัตถุประสงค์ [ดูข้อมูลเพิ่มเติม](https://web.dev/aria-roles/)"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
     "message": "ค่า `[role]` ไม่ถูกต้อง"
@@ -54,7 +54,7 @@
     "message": "ค่า `[role]` ถูกต้อง"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "เทคโนโลยีอำนวยความสะดวก เช่น โปรแกรมอ่านหน้าจอ จะตีความแอตทริบิวต์ ARIA ที่มีค่าไม่ถูกต้องไม่ได้ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)"
+    "message": "เทคโนโลยีอำนวยความสะดวก เช่น โปรแกรมอ่านหน้าจอ จะตีความแอตทริบิวต์ ARIA ที่มีค่าไม่ถูกต้องไม่ได้ [ดูข้อมูลเพิ่มเติม](https://web.dev/aria-valid-attr-value/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
     "message": "แอตทริบิวต์ `[aria-*]` ไม่มีค่าที่ถูกต้อง"
@@ -63,7 +63,7 @@
     "message": "แอตทริบิวต์ `[aria-*]` มีค่าที่ถูกต้อง"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "เทคโนโลยีอำนวยความสะดวก เช่น โปรแกรมอ่านหน้าจอ จะตีความแอตทริบิวต์ ARIA ที่มีชื่อไม่ถูกต้องไม่ได้ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)"
+    "message": "เทคโนโลยีอำนวยความสะดวก เช่น โปรแกรมอ่านหน้าจอ จะตีความแอตทริบิวต์ ARIA ที่มีชื่อไม่ถูกต้องไม่ได้ [ดูข้อมูลเพิ่มเติม](https://web.dev/aria-valid-attr/)"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
     "message": "แอตทริบิวต์ `[aria-*]` ไม่ถูกต้องหรือสะกดผิด"
@@ -72,10 +72,10 @@
     "message": "แอตทริบิวต์ `[aria-*]` ถูกต้องและสะกดถูกต้อง"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "คำบรรยายวิดีโอช่วยให้คนหูหนวกหรือผู้ใช้ที่มีความบกพร่องทางการได้ยินเข้าใจองค์ประกอบเสียง โดยให้ข้อมูลสำคัญ เช่น ผู้ที่กำลังพูด สิ่งที่กำลังพูด และข้อมูลอื่นๆ ที่ไม่ใช่เสียงพูด [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)"
+    "message": "คำบรรยายวิดีโอช่วยให้คนหูหนวกหรือผู้ใช้ที่มีความบกพร่องทางการได้ยินเข้าใจองค์ประกอบเสียง โดยให้ข้อมูลสำคัญ เช่น ผู้ที่กำลังพูด สิ่งที่กำลังพูด และข้อมูลอื่นๆ ที่ไม่ใช่เสียงพูด [ดูข้อมูลเพิ่มเติม](https://web.dev/audio-caption/)"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "องค์ประกอบ `<audio>` ไม่มีองค์ประกอบ `<track>` ที่มี `[kind=\"captions\"]`"
+    "message": "องค์ประกอบ `<audio>` ไม่มีองค์ประกอบ `<track>` ที่มี`[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
     "message": "องค์ประกอบ `<audio>` มีองค์ประกอบ `<track>` ที่มี `[kind=\"captions\"]`"
@@ -84,7 +84,7 @@
     "message": "องค์ประกอบที่ไม่ผ่านการตรวจสอบ"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "เมื่อปุ่มไม่มีชื่อสำหรับการช่วยเหลือพิเศษ โปรแกรมอ่านหน้าจอจะอ่านปุ่มนั้นว่า \"ปุ่ม\" ซึ่งทำให้ผู้ที่ต้องใช้โปรแกรมอ่านหน้าจอใช้ปุ่มดังกล่าวไม่ได้ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)"
+    "message": "เมื่อปุ่มไม่มีชื่อสำหรับการช่วยเหลือพิเศษ โปรแกรมอ่านหน้าจอจะอ่านปุ่มนั้นว่า \"ปุ่ม\" ซึ่งทำให้ผู้ที่ต้องใช้โปรแกรมอ่านหน้าจอใช้ปุ่มดังกล่าวไม่ได้ [ดูข้อมูลเพิ่มเติม](https://web.dev/button-name/)"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "ปุ่มต่างๆ ไม่มีชื่อสำหรับการช่วยเหลือพิเศษ"
@@ -93,7 +93,7 @@
     "message": "ปุ่มต่างๆ มีชื่อสำหรับการช่วยเหลือพิเศษ"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "การเพิ่มวิธีข้ามผ่านเนื้อหาที่ซ้ำกันช่วยให้ผู้ใช้แป้นพิมพ์ไปยังส่วนต่างๆ ของหน้าได้อย่างมีประสิทธิภาพมากขึ้น [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)"
+    "message": "การเพิ่มวิธีข้ามผ่านเนื้อหาที่ซ้ำกันช่วยให้ผู้ใช้แป้นพิมพ์ไปยังส่วนต่างๆ ของหน้าได้อย่างมีประสิทธิภาพมากขึ้น [ดูข้อมูลเพิ่มเติม](https://web.dev/bypass/)"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "หน้าเว็บไม่มีส่วนหัว ลิงก์การข้าม หรือภูมิภาคของจุดสังเกต"
@@ -102,7 +102,7 @@
     "message": "หน้าเว็บมีส่วนหัว ลิงก์การข้าม หรือภูมิภาคของจุดสังเกต"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "ข้อความคอนทราสต์ต่ำมักทำให้ผู้ใช้จำนวนมากอ่านได้ยากหรืออ่านไม่ได้เลย [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)"
+    "message": "ข้อความคอนทราสต์ต่ำมักทำให้ผู้ใช้จำนวนมากอ่านได้ยากหรืออ่านไม่ได้เลย [ดูข้อมูลเพิ่มเติม](https://web.dev/color-contrast/)"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "สีพื้นหลังและสีพื้นหน้ามีอัตราส่วนคอนทราสต์ไม่เพียงพอ"
@@ -111,25 +111,25 @@
     "message": "สีพื้นหลังและสีพื้นหน้ามีอัตราส่วนคอนทราสต์ที่เพียงพอ"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "เมื่อมีการทำเครื่องหมายรายการคำจำกัดความอย่างไม่ถูกต้อง โปรแกรมอ่านหน้าจออาจสร้างเอาต์พุตที่ทำให้สับสนหรือไม่แม่นยำ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)"
+    "message": "เมื่อมีการทำเครื่องหมายรายการคำจำกัดความอย่างไม่ถูกต้อง โปรแกรมอ่านหน้าจออาจสร้างเอาต์พุตที่ทำให้สับสนหรือไม่แม่นยำ [ดูข้อมูลเพิ่มเติม](https://web.dev/definition-list/)"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "`<dl>` ไม่ได้มีเพียงกลุ่ม `<dt>` และ `<dd>`, `<script>` หรือองค์ประกอบ `<template>` ที่เรียงลำดับอย่างถูกต้อง"
+    "message": "`<dl>` ไม่ได้มีเพียงกลุ่ม `<dt>` และ `<dd>` หรือองค์ประกอบ `<script>` หรือ `<template>` ที่เรียงลำดับอย่างถูกต้อง"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "`<dl>` มีเพียงกลุ่ม `<dt>` และ `<dd>`, `<script>` หรือองค์ประกอบ `<template>` ที่เรียงลำดับอย่างถูกต้อง"
+    "message": "`<dl>` มีเพียงกลุ่ม `<dt>` และ `<dd>` องค์ประกอบ `<script>` หรือ `<template>` ที่เรียงลำดับอย่างถูกต้อง"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "รายการย่อยของคำจำกัดความ (`<dt>` และ `<dd>`) ต้องรวมอยู่ในองค์ประกอบ `<dl>` ระดับบนสุดเพื่อดูแลให้โปรแกรมอ่านหน้าจออ่านได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)"
+    "message": "รายการย่อยของคำจำกัดความ (`<dt>` และ `<dd>`) ต้องรวมอยู่ในองค์ประกอบ `<dl>` ระดับบนสุดเพื่อดูแลให้โปรแกรมอ่านหน้าจออ่านได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://web.dev/dlitem/)"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
     "message": "รายการย่อยของคำจำกัดความไม่ได้รวมอยู่ในองค์ประกอบ `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "รายการย่อยของคำจำกัดความจะรวมอยู่ในองค์ประกอบ `<dl>`"
+    "message": "รายการย่อยของคำจำกัดความรวมอยู่ในองค์ประกอบ `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "ชื่อช่วยให้ผู้ใช้โปรแกรมอ่านหน้าจอทราบถึงภาพรวมของหน้า และผู้ใช้เครื่องมือค้นหาจะดูความเกี่ยวข้องของหน้ากับการค้นหาของตนจากชื่อเป็นหลัก [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/title)"
+    "message": "ชื่อช่วยให้ผู้ใช้โปรแกรมอ่านหน้าจอทราบถึงภาพรวมของหน้า และผู้ใช้เครื่องมือค้นหาจะดูความเกี่ยวข้องของหน้ากับการค้นหาของตนจากชื่อเป็นหลัก [ดูข้อมูลเพิ่มเติม](https://web.dev/document-title/)"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "เอกสารไม่มีองค์ประกอบ `<title>`"
@@ -138,7 +138,7 @@
     "message": "เอกสารมีองค์ประกอบ `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "ค่าของแอตทริบิวต์รหัสต้องไม่ซ้ำกันเพื่อป้องกันไม่ให้เทคโนโลยีอำนวยความสะดวกมองข้ามอินสแตนซ์อื่นๆ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)"
+    "message": "ค่าของแอตทริบิวต์รหัสต้องไม่ซ้ำกันเพื่อป้องกันไม่ให้เทคโนโลยีอำนวยความสะดวกมองข้ามอินสแตนซ์อื่นๆ [ดูข้อมูลเพิ่มเติม](https://web.dev/duplicate-id/)"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
     "message": "แอตทริบิวต์ `[id]` ในหน้าเว็บซ้ำกัน"
@@ -147,7 +147,7 @@
     "message": "แอตทริบิวต์ `[id]` ในหน้าเว็บไม่ซ้ำกัน"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "ผู้ใช้โปรแกรมอ่านหน้าจอต้องใช้ชื่อเฟรมเพื่ออธิบายเนื้อหาของเฟรม [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)"
+    "message": "ผู้ใช้โปรแกรมอ่านหน้าจอต้องใช้ชื่อเฟรมเพื่ออธิบายเนื้อหาของเฟรม [ดูข้อมูลเพิ่มเติม](https://web.dev/frame-title/)"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "องค์ประกอบ `<frame>` หรือ `<iframe>` ไม่มีชื่อ"
@@ -156,7 +156,7 @@
     "message": "องค์ประกอบ `<frame>` หรือ `<iframe>` มีชื่อ"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "หากหน้าเว็บไม่ได้ระบุแอตทริบิวต์ lang โปรแกรมอ่านหน้าจอจะถือว่าหน้าดังกล่าวใช้ภาษาเริ่มต้นที่ผู้ใช้เลือกเมื่อตั้งค่าโปรแกรมอ่านหน้าจอ หากที่จริงแล้วหน้าดังกล่าวไม่ได้ใช้ภาษาเริ่มต้น โปรแกรมอ่านหน้าจออาจอ่านข้อความในหน้าได้ไม่ถูกต้อง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)"
+    "message": "หากหน้าเว็บไม่ได้ระบุแอตทริบิวต์ lang โปรแกรมอ่านหน้าจอจะถือว่าหน้าดังกล่าวใช้ภาษาเริ่มต้นที่ผู้ใช้เลือกเมื่อตั้งค่าโปรแกรมอ่านหน้าจอ หากที่จริงแล้วหน้าดังกล่าวไม่ได้ใช้ภาษาเริ่มต้น โปรแกรมอ่านหน้าจออาจอ่านข้อความในหน้าได้ไม่ถูกต้อง [ดูข้อมูลเพิ่มเติม](https://web.dev/html-has-lang/)"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
     "message": "องค์ประกอบ `<html>` ไม่มีแอตทริบิวต์ `[lang]`"
@@ -165,7 +165,7 @@
     "message": "องค์ประกอบ `<html>` มีแอตทริบิวต์ `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "การระบุ[ภาษา BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ที่ถูกต้องช่วยให้โปรแกรมอ่านหน้าจออ่านข้อความได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)"
+    "message": "การระบุ[ภาษา BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ที่ถูกต้องช่วยให้โปรแกรมอ่านหน้าจออ่านข้อความได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://web.dev/html-lang-valid/)"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
     "message": "องค์ประกอบ `<html>` ไม่มีค่าที่ถูกต้องสำหรับแอตทริบิวต์ `[lang]`"
@@ -174,7 +174,7 @@
     "message": "องค์ประกอบ `<html>` มีค่าที่ถูกต้องสำหรับแอตทริบิวต์ `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "องค์ประกอบเพื่อการให้ข้อมูลควรมีข้อความสำรองที่สั้นกระชับและสื่อความหมาย การใช้แอตทริบิวต์ Alt ที่ว่างเปล่าจะเป็นการเพิกเฉยต่อองค์ประกอบเพื่อการตกแต่ง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)"
+    "message": "องค์ประกอบเพื่อการให้ข้อมูลควรมีข้อความสำรองที่สั้นกระชับและสื่อความหมาย การใช้แอตทริบิวต์ Alt ที่ว่างเปล่าจะเป็นการเพิกเฉยต่อองค์ประกอบเพื่อการตกแต่ง [ดูข้อมูลเพิ่มเติม](https://web.dev/image-alt/)"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
     "message": "องค์ประกอบรูปภาพไม่มีแอตทริบิวต์ `[alt]`"
@@ -183,7 +183,7 @@
     "message": "องค์ประกอบรูปภาพมีแอตทริบิวต์ `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "เมื่อมีการใช้รูปภาพเป็นปุ่ม `<input>` การระบุข้อความสำรองจะช่วยให้ผู้ใช้โปรแกรมอ่านหน้าจอเข้าใจวัตถุประสงค์ของปุ่มได้ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)"
+    "message": "เมื่อมีการใช้รูปภาพเป็นปุ่ม `<input>` การระบุข้อความสำรองจะช่วยให้ผู้ใช้โปรแกรมอ่านหน้าจอเข้าใจวัตถุประสงค์ของปุ่มได้ [ดูข้อมูลเพิ่มเติม](https://web.dev/input-image-alt/)"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "องค์ประกอบ `<input type=\"image\">` ไม่มีข้อความ `[alt]`"
@@ -192,7 +192,7 @@
     "message": "องค์ประกอบ `<input type=\"image\">` มีข้อความ `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "ป้ายกำกับช่วยดูแลให้เทคโนโลยีอำนวยความสะดวกอย่างเช่น โปรแกรมอ่านหน้าจอ อ่านส่วนควบคุมฟอร์มได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)"
+    "message": "ป้ายกำกับช่วยดูแลให้เทคโนโลยีอำนวยความสะดวกอย่างเช่น โปรแกรมอ่านหน้าจอ อ่านส่วนควบคุมฟอร์มได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://web.dev/label/)"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "องค์ประกอบฟอร์มไม่มีป้ายกำกับที่เชื่อมโยง"
@@ -201,7 +201,7 @@
     "message": "องค์ประกอบฟอร์มมีป้ายกำกับที่เชื่อมโยงอยู่"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "ตารางที่ใช้สำหรับการออกแบบต้องไม่มีองค์ประกอบข้อมูล เช่น องค์ประกอบ th หรือคำอธิบายภาพ หรือแอตทริบิวต์สรุป เพราะอาจสร้างความสับสนระหว่างการใช้งานของผู้ใช้โปรแกรมอ่านหน้าจอ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)"
+    "message": "ตารางที่ใช้สำหรับการออกแบบต้องไม่มีองค์ประกอบข้อมูล เช่น องค์ประกอบ th หรือคำอธิบายภาพ หรือแอตทริบิวต์สรุป เพราะอาจสร้างความสับสนระหว่างการใช้งานของผู้ใช้โปรแกรมอ่านหน้าจอ [ดูข้อมูลเพิ่มเติม](https://web.dev/layout-table/)"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
     "message": "องค์ประกอบ `<table>` สำหรับการนำเสนอไม่หลีกเลี่ยงการใช้ `<th>`, `<caption>` หรือแอตทริบิวต์ `[summary]`"
@@ -210,7 +210,7 @@
     "message": "องค์ประกอบ `<table>` สำหรับการนำเสนอหลีกเลี่ยงการใช้ `<th>`, `<caption>` หรือแอตทริบิวต์ `[summary]`"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "ข้อความลิงก์ (และข้อความสำรองสำหรับรูปภาพเมื่อใช้เป็นลิงก์) ที่แยกแยะได้ ไม่ซ้ำกัน และโฟกัสได้ ช่วยปรับปรุงประสบการณ์การไปยังส่วนต่างๆ สำหรับผู้ใช้โปรแกรมอ่านหน้าจอ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)"
+    "message": "ข้อความลิงก์ (และข้อความสำรองสำหรับรูปภาพเมื่อใช้เป็นลิงก์) ที่แยกแยะได้ ไม่ซ้ำกัน และโฟกัสได้ ช่วยปรับปรุงประสบการณ์การไปยังส่วนต่างๆ สำหรับผู้ใช้โปรแกรมอ่านหน้าจอ [ดูข้อมูลเพิ่มเติม](https://web.dev/link-name/)"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "ลิงก์ไม่มีชื่อที่แยกแยะได้"
@@ -219,43 +219,43 @@
     "message": "ลิงก์มีชื่อที่แยกแยะได้"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "โปรแกรมอ่านหน้าจอมีวิธีเฉพาะในการอ่านรายการ การดูแลให้รายการมีโครงสร้างที่ถูกต้องช่วยโปรแกรมอ่านหน้าจอในการอ่านเนื้อหา [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)"
+    "message": "โปรแกรมอ่านหน้าจอมีวิธีเฉพาะในการอ่านรายการ การดูแลให้รายการมีโครงสร้างที่ถูกต้องช่วยโปรแกรมอ่านหน้าจอในการอ่านเนื้อหา [ดูข้อมูลเพิ่มเติม](https://web.dev/list/)"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "รายการไม่ได้มีเพียงองค์ประกอบ `<li>` และองค์ประกอบที่รองรับสคริปต์ (`<script>` และ `<template>`)"
+    "message": "รายการไม่ได้มีแต่องค์ประกอบ `<li>` และองค์ประกอบที่รองรับสคริปต์ (`<script>` และ`<template>`)"
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
     "message": "รายการมีเพียงองค์ประกอบ `<li>` และองค์ประกอบที่รองรับสคริปต์ (`<script>` และ `<template>`)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "โปรแกรมอ่านหน้าจอกำหนดให้รายการย่อย (`<li>`) อยู่ใน `<ul>` หรือ `<ol>` ระดับบนสุดเพื่อให้อ่านได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)"
+    "message": "โปรแกรมอ่านหน้าจอกำหนดให้รายการย่อย (`<li>`) อยู่ใน `<ul>` หรือ `<ol>` ระดับบนสุดเพื่อให้อ่านได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://web.dev/listitem/)"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
     "message": "รายการย่อย (`<li>`) ไม่ได้อยู่ภายในองค์ประกอบระดับบนสุด `<ul>` หรือ `<ol>`"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "รายการย่อย (`<li>`) อยู่ภายในองค์ประกอบระดับบนสุด `<ul>` หรือ `<ol>`"
+    "message": "รายการย่อย (`<li>`) อยู่ในองค์ประกอบระดับบนสุด `<ul>` หรือ `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "ผู้ใช้ไม่ได้คาดหวังให้หน้าเว็บรีเฟรชโดยอัตโนมัติ และการรีเฟรชหน้าเว็บจะย้ายโฟกัสกลับไปที่ด้านบนของหน้า ซึ่งอาจทำให้ผู้ใช้ได้รับประสบการณ์การใช้งานที่สับสนหรือน่าหงุดหงิด [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)"
+    "message": "ผู้ใช้ไม่ได้คาดหวังให้หน้าเว็บรีเฟรชโดยอัตโนมัติ และการรีเฟรชหน้าเว็บจะย้ายโฟกัสกลับไปที่ด้านบนของหน้า ซึ่งอาจทำให้ผู้ใช้ได้รับประสบการณ์การใช้งานที่สับสนหรือน่าหงุดหงิด [ดูข้อมูลเพิ่มเติม](https://web.dev/meta-refresh/)"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
     "message": "เอกสารใช้ `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "เอกสารไม่ได้ใช้ `<meta http-equiv=\"refresh\">`"
+    "message": "เอกสารนี้ไม่ได้ใช้ `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "การปิดใช้การซูมจะเป็นปัญหาสำหรับผู้ใช้ที่มีสายตาเลือนรางซึ่งต้องใช้การขยายหน้าจอเพื่อให้ดูเนื้อหาของหน้าเว็บได้อย่างชัดเจน [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)"
+    "message": "การปิดใช้การซูมจะเป็นปัญหาสำหรับผู้ใช้ที่มีสายตาเลือนรางซึ่งต้องใช้การขยายหน้าจอเพื่อให้ดูเนื้อหาของหน้าเว็บได้อย่างชัดเจน [ดูข้อมูลเพิ่มเติม](https://web.dev/meta-viewport/)"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "มีการใช้ `[user-scalable=\"no\"]` ในองค์ประกอบ `<meta name=\"viewport\">` หรือแอตทริบิวต์ `[maximum-scale]` น้อยกว่า 5"
+    "message": "มีการใช้ `[user-scalable=\"no\"]` ในองค์ประกอบ `<meta name=\"viewport\">`หรือแอตทริบิวต์ `[maximum-scale]` น้อยกว่า 5"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
     "message": "ไม่มีการใช้ `[user-scalable=\"no\"]` ในองค์ประกอบ `<meta name=\"viewport\">` และแอตทริบิวต์ `[maximum-scale]` ไม่น้อยกว่า 5"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "โปรแกรมอ่านหน้าจอแปลเนื้อหาที่ไม่ใช่ข้อความไม่ได้ การเพิ่มข้อความแสดงแทนลงในองค์ประกอบ `<object>` ช่วยโปรแกรมอ่านหน้าจอถ่ายทอดความหมายให้แก่ผู้ใช้ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)"
+    "message": "โปรแกรมอ่านหน้าจอแปลเนื้อหาที่ไม่ใช่ข้อความไม่ได้ การเพิ่มข้อความแสดงแทนลงในองค์ประกอบ `<object>` ช่วยโปรแกรมอ่านหน้าจอถ่ายทอดความหมายให้แก่ผู้ใช้ [ดูข้อมูลเพิ่มเติม](https://web.dev/object-alt/)"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "องค์ประกอบ `<object>` ไม่มีข้อความ `[alt]`"
@@ -264,7 +264,7 @@
     "message": "องค์ประกอบ `<object>` มีข้อความ `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "ค่าที่มากกว่า 0 หมายความว่ามีการจัดเรียงการนำทางที่ชัดเจน แม้ว่าการทำงานนี้จะไม่มีปัญหาในทางเทคนิค แต่มักก่อให้เกิดประสบการณ์การใช้งานที่น่าหงุดหงิดสำหรับผู้ใช้เทคโนโลยีอำนวยความสะดวก [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)"
+    "message": "ค่าที่มากกว่า 0 หมายความว่ามีการจัดเรียงการนำทางที่ชัดเจน แม้ว่าการทำงานนี้จะไม่มีปัญหาในทางเทคนิค แต่มักก่อให้เกิดประสบการณ์การใช้งานที่น่าหงุดหงิดสำหรับผู้ใช้เทคโนโลยีอำนวยความสะดวก [ดูข้อมูลเพิ่มเติม](https://web.dev/tabindex/)"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "องค์ประกอบบางอย่างมีค่า `[tabindex]` มากกว่า 0"
@@ -273,16 +273,16 @@
     "message": "ไม่มีองค์ประกอบที่มีค่า `[tabindex]` มากกว่า 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "โปรแกรมอ่านหน้าจอมีฟีเจอร์ที่ช่วยให้ไปยังส่วนต่างๆ ของตารางได้ง่ายขึ้น การดูแลให้เซลล์ `<td>` ที่ใช้แอตทริบิวต์ `[headers]` อ้างอิงถึงเซลล์อื่นๆ ในตารางเดียวกันเท่านั้นอาจช่วยปรับปรุงประสบการณ์สำหรับผู้ใช้โปรแกรมอ่านหน้าจอ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)"
+    "message": "โปรแกรมอ่านหน้าจอมีฟีเจอร์ที่ช่วยให้ไปยังส่วนต่างๆ ของตารางได้ง่ายขึ้น การดูแลให้เซลล์ `<td>` ที่ใช้แอตทริบิวต์ `[headers]` อ้างอิงถึงเซลล์อื่นๆ ในตารางเดียวกันเท่านั้นอาจช่วยปรับปรุงประสบการณ์สำหรับผู้ใช้โปรแกรมอ่านหน้าจอ [ดูข้อมูลเพิ่มเติม](https://web.dev/td-headers-attr/)"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "เซลล์ในองค์ประกอบ `<table>` ที่ใช้แอตทริบิวต์ `[headers]` จะอ้างอิงถึงเซลล์อื่นๆ ของตารางเดียวกันนั้น"
+    "message": "เซลล์ในองค์ประกอบ `<table>` ที่ใช้แอตทริบิวต์ `[headers]` อ้างอิงถึงเซลล์อื่นๆ ของตารางเดียวกันเท่านั้น"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
     "message": "เซลล์ในองค์ประกอบ `<table>` ที่ใช้แอตทริบิวต์ `[headers]` อ้างอิงถึงเซลล์อื่นๆ ของตารางเดียวกันเท่านั้น"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "โปรแกรมอ่านหน้าจอมีฟีเจอร์ที่ช่วยให้ไปยังส่วนต่างๆ ของตารางได้ง่ายขึ้น การดูแลให้ส่วนหัวของตารางอ้างอิงถึงชุดเซลล์บางชุดอยู่เสมออาจช่วยปรับปรุงประสบการณ์สำหรับผู้ใช้โปรแกรมอ่านหน้าจอ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)"
+    "message": "โปรแกรมอ่านหน้าจอมีฟีเจอร์ที่ช่วยให้ไปยังส่วนต่างๆ ของตารางได้ง่ายขึ้น การดูแลให้ส่วนหัวของตารางอ้างอิงถึงชุดเซลล์บางชุดอยู่เสมออาจช่วยปรับปรุงประสบการณ์สำหรับผู้ใช้โปรแกรมอ่านหน้าจอ [ดูข้อมูลเพิ่มเติม](https://web.dev/th-has-data-cells/)"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
     "message": "องค์ประกอบ `<th>` และองค์ประกอบที่มี `[role=\"columnheader\"/\"rowheader\"]` ไม่มีเซลล์ข้อมูลที่องค์ประกอบอธิบาย"
@@ -291,7 +291,7 @@
     "message": "องค์ประกอบ `<th>` และองค์ประกอบที่มี `[role=\"columnheader\"/\"rowheader\"]` มีเซลล์ข้อมูลที่องค์ประกอบอธิบาย"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "การระบุ[ภาษา BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ที่ถูกต้องในองค์ประกอบต่างๆ ช่วยดูแลให้โปรแกรมอ่านหน้าจอออกเสียงข้อความได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)"
+    "message": "การระบุ[ภาษา BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ที่ถูกต้องในองค์ประกอบต่างๆ ช่วยดูแลให้โปรแกรมอ่านหน้าจอออกเสียงข้อความได้อย่างถูกต้อง [ดูข้อมูลเพิ่มเติม](https://web.dev/valid-lang/)"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
     "message": "แอตทริบิวต์ `[lang]` ไม่มีค่าที่ถูกต้อง"
@@ -300,7 +300,7 @@
     "message": "แอตทริบิวต์ `[lang]` มีค่าที่ถูกต้อง"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "เมื่อวิดีโอมีคำอธิบายภาพ คนหูหนวกและผู้ใช้ที่มีความบกพร่องทางการได้ยินจะเข้าถึงข้อมูลของวิดีโอได้ง่ายขึ้น [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)"
+    "message": "เมื่อวิดีโอมีคำอธิบายภาพ คนหูหนวกและผู้ใช้ที่มีความบกพร่องทางการได้ยินจะเข้าถึงข้อมูลของวิดีโอได้ง่ายขึ้น [ดูข้อมูลเพิ่มเติม](https://web.dev/video-caption/)"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
     "message": "องค์ประกอบ `<video>` ไม่มีองค์ประกอบ `<track>` ที่มี `[kind=\"captions\"]`"
@@ -309,13 +309,25 @@
     "message": "องค์ประกอบ `<video>` มีองค์ประกอบ `<track>` ที่มี `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "คำอธิบายเสียงให้ข้อมูลเกี่ยวข้องสำหรับวิดีโอที่สื่อสารผ่านบทพูดไม่ได้ เช่น สีหน้าและฉากต่างๆ [ดูข้อมูลเพิ่มเติม](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)"
+    "message": "คำอธิบายเสียงให้ข้อมูลเกี่ยวข้องสำหรับวิดีโอที่สื่อสารผ่านบทพูดไม่ได้ เช่น สีหน้าและฉากต่างๆ [ดูข้อมูลเพิ่มเติม](https://web.dev/video-description/)"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
     "message": "องค์ประกอบ `<video>` ไม่มีองค์ประกอบ `<track>` ที่มี `[kind=\"description\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
     "message": "องค์ประกอบ `<video>` มีองค์ประกอบ `<track>` ที่มี `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "ให้ระบุ apple-touch-icon เพื่อให้เหมาะสำหรับการปรากฎใน iOS เมื่อผู้ใช้เพิ่มไปที่หน้าจอหลัก โดยต้องชี้ไปที่สี่เหลี่ยมจตุรัสแบบไม่โปร่งใสขนาด 192 พิกเซล (หรือ 180 พิกเซล) รูปแบบ PNG [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "ไม่ได้ให้ `apple-touch-icon` ที่ถูกต้อง"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` ไม่อัปเดต แนะนำให้ใช้ `apple-touch-icon` จะดีกว่า"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "มี `apple-touch-icon` ที่ถูกต้อง"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "ส่วนขยาย Chrome ส่งผลเสียต่อประสิทธิภาพในการโหลดของหน้านี้ ลองตรวจสอบหน้าในโหมดไม่ระบุตัวตนหรือจากโปรไฟล์ Chrome ที่ไม่มีส่วนขยาย"
@@ -345,13 +357,13 @@
     "message": "ใช้รูปแบบวิดีโอสำหรับเนื้อหาภาพเคลื่อนไหว"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "พิจารณาโหลดรูปภาพนอกหน้าจอและรูปภาพที่ซ่อนไว้เท่าที่จำเป็นหลังจากที่ทรัพยากรที่สำคัญทั้งหมดโหลดเสร็จแล้วเพื่อลดเวลาในการโต้ตอบ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
+    "message": "พิจารณาโหลดรูปภาพนอกหน้าจอและรูปภาพที่ซ่อนไว้แบบ Lazy Loading หลังจากที่ทรัพยากรที่สำคัญทั้งหมดโหลดเสร็จแล้วเพื่อลดเวลาในการโต้ตอบ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "เลื่อนเวลาโหลดรูปภาพนอกจอภาพ"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "ทรัพยากรบล็อกการแสดงผลครั้งแรกของหน้าเว็บอยู่ พิจารณาแสดง JS/CSS ที่สำคัญในหน้าและเลื่อนเวลาแสดง JS/สไตล์ที่ไม่สำคัญทั้งหมดออกไป [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
+    "message": "ทรัพยากรบล็อก First Paint ของหน้าเว็บอยู่ พิจารณาแสดง JS/CSS ที่สำคัญในหน้าและเลื่อนเวลาแสดง JS/สไตล์ที่ไม่สำคัญทั้งหมดออกไป [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "กำจัดทรัพยากรที่บล็อกการแสดงผล"
@@ -411,7 +423,7 @@
     "message": "เข้ารหัสรูปภาพอย่างมีประสิทธิภาพ"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "แสดงรูปภาพที่มีขนาดเหมาะสมเพื่อประหยัดอินเทอร์เน็ตมือถือและปรับปรุงเวลาในการโหลด [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
+    "message": "แสดงรูปภาพที่มีขนาดที่เหมาะสมเพื่อประหยัดอินเทอร์เน็ตมือถือและปรับปรุงเวลาในการโหลด [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "ปรับขนาดรูปภาพให้เหมาะสม"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "ลดความลึกของคำขอที่สำคัญ"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "การเลิกใช้งาน / คำเตือน"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "บรรทัด"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "API ที่เลิกใช้งานแล้วจะถูกนำออกจากเบราว์เซอร์ในท้ายที่สุด [ดูข้อมูลเพิ่มเติม](https://www.chromestatus.com/features#deprecated)"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{พบคำเตือน 1 รายการ}other{พบคำเตือน # รายการ}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "ใช้ API ที่เลิกใช้งานแล้ว"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "หลีกเลี่ยงการใช้ API ที่เลิกใช้งานแล้ว"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "แคชของแอปพลิเคชันเลิกใช้งานแล้ว [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/appcache)"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "พบ \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "ใช้แคชของแอปพลิเคชัน"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "หลีกเลี่ยงการใช้แคชของแอปพลิเคชัน"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "การระบุ DOCTYPE ช่วยป้องกันไม่ให้เบราว์เซอร์เปลี่ยนไปใช้โหมดที่ไม่มาตรฐาน อ่านเพิ่มเติมเกี่ยวกับ[หน้า MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "ชื่อ DOCTYPE ต้องเป็นสตริงตัวพิมพ์เล็ก `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "เอกสารต้องมี DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "สตริง publicId ควรจะว่าง"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "สตริง systemId ควรจะว่าง"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "หน้าไม่มี DOCTYPE HTML ดังนั้นจึงทริกเกอร์โหมดที่ไม่มาตรฐาน"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "หน้ามี DOCTYPE HTML"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "องค์ประกอบ"
   },
@@ -447,7 +510,7 @@
     "message": "ค่า"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "วิศวกรเบราว์เซอร์แนะนำให้ใช้หน้าเว็บที่มีองค์ประกอบ DOM น้อยกว่า 1,500 รายการโดยประมาณ ความลึกที่เหมาะที่สุดคือแบบต้นไม้ซึ่งมีองค์ประกอบน้อยกว่า 32 รายการและมีองค์ประกอบย่อย/หลักน้อยกว่า 60 รายการ DOM ขนาดใหญ่อาจใช้หน่วยความจำเพิ่มขึ้น ทำให้[การคำนวณสไตล์](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) ยาวนานขึ้น และสร้าง[การจัดเรียงการออกแบบใหม่](https://developers.google.com/speed/articles/reflow) ซึ่งมีค่าใช้จ่ายสูง [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
+    "message": "วิศวกรเบราว์เซอร์แนะนำให้ใช้หน้าเว็บที่มีองค์ประกอบ DOM น้อยกว่า 1,500 รายการโดยประมาณ ความลึกที่เหมาะที่สุดคือแบบต้นไม้ซึ่งมีองค์ประกอบน้อยกว่า 32 รายการและมีองค์ประกอบย่อย/หลักน้อยกว่า 60 รายการ รายการ DOM ขนาดใหญ่อาจใช้หน่วยความจำเพิ่มขึ้น ทำให้[การคำนวณสไตล์](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)ยาวนานขึ้น และสร้าง[การจัดเรียงการออกแบบใหม่](https://developers.google.com/speed/articles/reflow)ซึ่งมีค่าใช้จ่ายสูง [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/dom-size)"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 องค์ประกอบ}other{# องค์ประกอบ}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "หลีกเลี่ยง DOM ที่มีขนาดใหญ่เกินไป"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "เป้าหมาย"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "เพิ่ม `rel=\"noopener\"` หรือ `rel=\"noreferrer\"` ไปยังลิงก์ภายนอกใดๆ เพื่อปรับปรุงประสิทธิภาพและป้องกันช่องโหว่ด้านความปลอดภัย [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/noopener)"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "ลิงก์ไปปลายทางแบบ Cross-Origin ไม่ปลอดภัย"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "ลิงก์ไปปลายทางแบบ Cross-Origin ปลอดภัย"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "ระบุปลายทางสำหรับโฆษณาด้านล่างสุด ({anchorHTML}) ไม่ได้ หากไม่ได้ใช้เป็นไฮเปอร์ลิงก์ ลองเอา target=_blank ออก"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "ผู้ใช้ไม่เชื่อถือหรือเกิดความสับสนในเว็บไซต์ที่ขอข้อมูลตำแหน่งโดยไม่มีบริบทให้ พิจารณาผูกคำขอกับการกระทำของผู้ใช้แทน [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "ขอสิทธิ์เข้าถึงตำแหน่งทางภูมิศาสตร์ในการโหลดหน้าเว็บ"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "หลีกเลี่ยงการขอสิทธิ์เข้าถึงตำแหน่งทางภูมิศาสตร์ในการโหลดหน้าเว็บ"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "เวอร์ชัน"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "ไลบรารี JavaScript ส่วนหน้าทั้งหมดที่ตรวจพบในหน้า"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "ตรวจพบไลบรารี JavaScript"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "สำหรับผู้ใช้ที่การเชื่อมต่อช้า สคริปต์ภายนอกที่แทรกเข้ามาแบบไดนามิกผ่านทาง `document.write()` จะช่วยหน่วงการโหลดหน้าเว็บได้หลายสิบวินาที [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/document-write)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "ใช้ `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "หลีกเลี่ยงการใช้ `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "ความรุนแรงสูงสุด"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "เวอร์ชันของไลบรารี"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "จำนวนช่องโหว่"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "สคริปต์ของบุคคลที่สามบางรายการอาจมีช่องโหว่ด้านความปลอดภัยที่เป็นที่รู้จักซึ่งผู้โจมตีจะหาพบได้ง่ายและใช้ประโยชน์จากช่องโหว่นั้น [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{ตรวจพบช่องโหว่ 1 รายการ}other{ตรวจพบช่องโหว่ # รายการ}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "มีไลบรารี JavaScript ส่วนหน้าที่มีช่องโหว่ด้านความปลอดภัย"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "สูง"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "ต่ำ"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "ปานกลาง"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "หลีกเลี่ยงการใช้ไลบรารี JavaScript ส่วนหน้าที่มีช่องโหว่ด้านความปลอดภัย"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "ผู้ใช้ไม่เชื่อถือหรือเกิดความสับสนในเว็บไซต์ที่ขอส่งการแจ้งเตือนโดยไม่มีบริบทให้ พิจารณาผูกคำขอกับท่าทางสัมผัสของผู้ใช้แทน [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "ขอสิทธิ์การแจ้งเตือนในการโหลดหน้าเว็บ"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "หลีกเลี่ยงการขอสิทธิ์การแจ้งเตือนในการโหลดหน้าเว็บ"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "องค์ประกอบที่ไม่ผ่านการตรวจสอบ"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "การป้องกันการวางรหัสผ่านทำให้นโยบายความปลอดภัยที่ดีอ่อนแอลง [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "ป้องกันผู้ใช้ไม่ให้วางรหัสผ่านในช่อง"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "อนุญาตผู้ใช้ให้วางรหัสผ่านในช่องได้"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "โปรโตคอล"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 มีข้อดีที่มากกว่า HTTP/1.1 คือ ส่วนหัวแบบไบนารี การทำมัลติเพล็กซิง และการ Push ไปที่เซิร์ฟเวอร์ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/http2)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{คำขอ 1 รายการไม่ได้แสดงผ่าน HTTP/2}other{คำขอ # รายการไม่ได้แสดงผ่าน HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "ไม่ได้ใช้ HTTP/2 สำหรับทรัพยากรทั้งหมด"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "ใช้ HTTP/2 กับทรัพยากรของตนเอง"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "ลองระบุ Listener เหตุการณ์แบบแตะและลูกกลิ้งเป็น `passive` เพื่อปรับปรุงประสิทธิภาพการเลื่อนของหน้าเว็บ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "ไม่ได้ใช้ Listener แบบแพสซีฟเพื่อปรับปรุงประสิทธิภาพการเลื่อน"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "ใช้ Listener แบบแพสซีฟเพื่อปรับปรุงประสิทธิภาพการเลื่อน"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "รายละเอียด"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "ข้อผิดพลาดที่บันทึกลงในคอนโซลแสดงให้เห็นถึงปัญหาที่ไม่ได้รับการแก้ไข ข้อผิดพลาดอาจมาจากคำขอเครือข่ายที่ไม่สำเร็จ และปัญหาอื่นๆ เกี่ยวกับเบราว์เซอร์"
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "บันทึกข้อผิดพลาดเบราว์เซอร์ลงในคอนโซลแล้ว"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "ไม่มีข้อผิดพลาดเบราว์เซอร์บันทึกลงในคอนโซล"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "ใช้ประโยชน์จากฟีเจอร์ CSS สำหรับแสดงแบบอักษรเพื่อให้ผู้ใช้มองเห็นข้อความได้ในขณะที่กำลังโหลดเว็บฟอนต์ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/updates/2016/02/font-display)"
   },
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "ข้อความทั้งหมดจะยังมองเห็นได้ในระหว่างการโหลดเว็บฟอนต์"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse ตรวจสอบค่าการแสดงแบบอักษรสำหรับ URL ต่อไปนี้โดยอัตโนมัติไม่ได้: {fontURL}"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "สัดส่วนภาพ (ขนาดจริง)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "สัดส่วนภาพ (ที่แสดง)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "ขนาดแสดงรูปภาพควรจะมีสัดส่วนที่เป็นธรรมชาติ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "แสดงรูปภาพที่มีสัดส่วนไม่ถูกต้อง"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "แสดงรูปภาพที่มีสัดส่วนถูกต้อง"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "ข้อมูลขนาดรูปภาพไมู่กต้อง {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL ไม่ปลอดภัย"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "ทุกเว็บไซต์ควรป้องกันด้วยการใช้ HTTPS แม้ว่าจะเป็นเว็บไซต์ที่ไม่มีข้อมูลที่ละเอียดอ่อนก็ตาม HTTPS ป้องกันผู้บุกรุกไม่ให้แทรกแซงหรือแอบฟังการสื่อสารระหว่างแอปกับผู้ใช้ของคุณ และเป็นข้อกำหนดที่ต้องทำก่อนสำหรับ HTTP/2 รวมถึง API ของแพลตฟอร์มเว็บใหม่ๆ อีกมาก [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/https)"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{พบคำขอที่ไม่ปลอดภัย 1 รายการ}other{พบคำขอที่ไม่ปลอดภัย # รายการ}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "ไม่ได้ใช้ HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "ใช้ HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "การโหลดหน้าเว็บที่รวดเร็วผ่านเครือข่ายมือถือช่วยให้มั่นใจว่าผู้ใช้ได้รับประสบการณ์การใช้งานที่ดีในอุปกรณ์เคลื่อนที่ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "มีการโต้ตอบที่ {timeInMs, number, seconds} วินาที"
+    "message": "โต้ตอบที่ {timeInMs, number, seconds} วินาที"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "มีการโต้ตอบในเครือข่ายมือถือจำลองที่ {timeInMs, number, seconds} วินาที"
@@ -516,7 +747,7 @@
     "message": "การแสดงผลที่มีเนื้อหาเต็มครั้งแรก"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "CPU ไม่ได้ใช้งานครั้งแรกระบุครั้งแรกที่เธรดหลักของหน้าเว็บว่างพอที่จะจัดการกับอินพุต [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
+    "message": "First CPU Idle ระบุครั้งแรกที่เธรดหลักของหน้าเว็บว่างพอที่จะจัดการกับอินพุต [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "CPU ไม่ได้ใช้งานครั้งแรก"
@@ -534,16 +765,22 @@
     "message": "เวลาในการโต้ตอบ"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "หน่วงเวลาอินพุตแรกที่อาจเกิดขึ้นซึ่งผู้ใช้อาจเจอคือระยะเวลาของงานที่ยาวที่สุดเป็นมิลลิวินาที"
+    "message": "First Input Delay สูงสุดที่อาจเกิดขึ้นซึ่งผู้ใช้อาจเจอคือระยะเวลาของงานที่ยาวที่สุดเป็นมิลลิวินาที [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/updates/2018/05/first-input-delay)"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID สูงสุดที่อาจเกิดขึ้น"
+    "message": "First Input Delay สูงสุดที่อาจเกิดขึ้น"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "ดัชนีความเร็วแสดงให้เห็นความเร็วที่เนื้อหาของหน้าปรากฏจนดูสมบูรณ์ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "ดัชนีความเร็ว"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "ผลรวมช่วงเวลาทั้งหมดระหว่าง FCP และเวลาในการตอบสนอง เมื่อความยาวของงานเกิน 50ms หน่วยเป็นมิลลิวินาที"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "เวลาที่บล็อกทั้งหมด"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "ระยะเวลารับส่งข้อมูล (RTT) ของเครือข่ายมีผลกระทบอย่างมากต่อประสิทธิภาพ หากต้นทางมี RTT สูง แสดงว่าเซิร์ฟเวอร์ที่อยู่ใกล้กับผู้ใช้มากกว่าอาจช่วยปรับปรุงประสิทธิภาพได้ [ดูข้อมูลเพิ่มเติม](https://hpbn.co/primer-on-latency-and-bandwidth/)"
@@ -552,16 +789,37 @@
     "message": "ระยะเวลารับส่งข้อมูลของเครือข่าย"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "เวลาในการตอบสนองต่อเซิร์ฟเวอร์อาจส่งผลกระทบต่อประสิทธิภาพของเว็บ หากต้นทางใช้เวลาในการตอบสนองต่อเซิร์ฟเวอร์สูง แสดงว่ามีการใช้งานเซิร์ฟเวอร์มากเกินไปหรือประสิทธิภาพแบ็กเอนด์ของเซิร์ฟเวอร์ไม่ดี [ดูข้อมูลเพิ่มเติม](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
+    "message": "เวลาในการตอบสนองต่อเซิร์ฟเวอร์อาจส่งผลกระทบต่อประสิทธิภาพของเว็บ หากต้นทางใช้เวลาในการตอบสนองต่อเซิร์ฟเวอร์นาน แสดงว่ามีการใช้งานเซิร์ฟเวอร์มากเกินไปหรือประสิทธิภาพแบ็กเอนด์ของเซิร์ฟเวอร์ไม่ดี [ดูข้อมูลเพิ่มเติม](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "เวลาในการตอบสนองจากแบ็กเอนด์ของเซิร์ฟเวอร์"
+  },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "เกินงบประมาณ"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "ควบคุมให้จำนวนและขนาดของคำขอเครือข่ายอยู่ภายในเป้าหมายที่กำหนดตามงบประมาณประสิทธิภาพที่ให้มา [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 คำขอ}other{# คำขอ}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "งบประมาณประสิทธิภาพ"
   },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "การเปลี่ยนเส้นทางทำให้เกิดความล่าช้ามากขึ้นก่อนที่หน้าเว็บจะโหลดได้ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "หลีกเลี่ยงการเปลี่ยนเส้นทางหลายหน้า"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "หากต้องการตั้งงบประมาณสำหรับจำนวนและขนาดของทรัพยากรหน้า ให้เพิ่มไฟล์ budget.json [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/budgets)"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 คำขอ}other{# คำขอ}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "ควบคุมให้จำนวนคำขอมีไม่มากและการโอนมีขนาดเล็ก"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "ลิงก์ Canonical จะบอกถึง URL ที่จะแสดงในผลการค้นหา [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/canonical)"
@@ -576,7 +834,7 @@
     "message": "URL ไม่ถูกต้อง ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "ชี้ไปที่ตำแหน่ง `hreflang` อื่น ({url})"
+    "message": "ชี้ไปที่ `hreflang` ตำแหน่งอื่น ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "URL แบบสัมพัทธ์ ({url})"
@@ -595,9 +853,6 @@
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "ข้อความที่อ่านได้ชัดเจน {decimalProportion, number, extendedPercent}"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} ของข้อความมีขนาดเล็กเกินไป"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "ข้อความอ่านได้ไม่ชัดเจนเพราะไม่มีเมตาแท็กวิวพอร์ตที่เพิ่มประสิทธิภาพให้เหมาะกับหน้าจออุปกรณ์เคลื่อนที่"
@@ -651,7 +906,7 @@
     "message": "ลิงก์มีข้อความอธิบาย"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "เรียกใช้[เครื่องมือทดสอบข้อมูลที่มีโครงสร้าง](https://search.google.com/structured-data/testing-tool/) และ [Linter ข้อมูลที่มีโครงสร้าง](http://linter.structured-data.org/) เพื่อตรวจสอบความถูกต้องของข้อมูลที่มีโครงสร้าง [ดูข้อมูลเพิ่มเติม](https://developers.google.com/search/docs/guides/mark-up-content)"
+    "message": "เรียกใช้[เครื่องมือทดสอบข้อมูลที่มีโครงสร้าง](https://search.google.com/structured-data/testing-tool/)และ [Linter ข้อมูลที่มีโครงสร้าง](http://linter.structured-data.org/)เพื่อตรวจสอบความถูกต้องของข้อมูลที่มีโครงสร้าง [ดูข้อมูลเพิ่มเติม](https://developers.google.com/search/docs/guides/mark-up-content)"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "ข้อมูลที่มีโครงสร้างถูกต้อง"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "เป้าหมายซ้อนทับกัน"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "ขนาด"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "เป้าหมายการแตะ"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "เป้าหมายการแตะมีขนาดที่เหมาะสม"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "เวลาของเธรดหลัก"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "บุคคลที่สาม"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "โค้ดของบุคคลที่สามอาจส่งผลกระทบที่สำคัญต่อประสิทธิภาพการโหลด จำกัดจำนวนผู้ให้บริการบุคคลที่สามที่มากเกินไปและพยายามโหลดโค้ดของบุคคลที่สามหลังจากที่หน้าเว็บโหลดเบื้องต้นเสร็จเรียบร้อยแล้ว [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{พบบุคคลที่สาม 1 ราย}other{พบบุคคลที่สาม # ราย}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "การใช้งานของบุคคลที่สาม"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "เวลาที่ใช้ไบต์แรกระบุเวลาที่เซิร์ฟเวอร์ส่งการตอบกลับ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
+    "message": "Time To First Byte ระบุเวลาที่เซิร์ฟเวอร์ส่งการตอบกลับ [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "เอกสารรากใช้เวลา {timeInMs, number, milliseconds} มิลลิวินาที"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "ระยะเวลา"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "ชื่อ"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "เวลาเริ่มต้น"
@@ -765,7 +1029,7 @@
     "message": "พบ <link> ที่โหลดล่วงหน้าสำหรับ \"{preloadURL}\" แต่เบราว์เซอร์ไม่ได้นำไปใช้งาน โปรดตรวจสอบว่าคุณใช้แอตทริบิวต์ `crossorigin` อย่างถูกต้องแล้ว"
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "พิจารณาใช้ <link rel=preload> เพื่อจัดลำดับความสำคัญในการเรียกทรัพยากรที่มีการขอให้โหลดหน้าเว็บภายหลัง [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/preload)"
+    "message": "พิจารณาใช้ `<link rel=preload>` เพื่อจัดลำดับความสำคัญในการเรียกทรัพยากรที่มีการขอให้โหลดหน้าเว็บภายหลัง [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/tools/lighthouse/audits/preload)"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "โหลดคำขอสำคัญล่วงหน้า"
@@ -792,7 +1056,7 @@
     "message": "การตรวจสอบเหล่านี้ไฮไลต์โอกาสในการ[ปรับปรุงการช่วยเหลือพิเศษของเว็บแอป](https://developers.google.com/web/fundamentals/accessibility) โดยจะตรวจพบอัตโนมัติได้เฉพาะปัญหากลุ่มย่อยด้านการช่วยเหลือพิเศษ เราจึงขอแนะนำให้ตรวจสอบด้วยตนเองด้วย"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
-    "message": "รายการเหล่านี้จัดการพื้นที่ที่เครื่องมือทดสอบอัตโนมัติไม่ครอบคลุม ดูข้อมูลเพิ่มเติมในคำแนะนำของเราเกี่ยวกับ[การดำเนินการตรวจสอบการช่วยเหลือพิเศษ](https://developers.google.com/web/fundamentals/accessibility/how-to-review)"
+    "message": "รายการเหล่านี้จัดการพื้นที่ที่เครื่องมือทดสอบอัตโนมัติไม่ครอบคลุม ดูข้อมูลเพิ่มเติมในคำแนะนำเกี่ยวกับ[การดำเนินการตรวจสอบการช่วยเหลือพิเศษ](https://developers.google.com/web/fundamentals/accessibility/how-to-review)"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "การช่วยเหลือพิเศษ"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "ตารางและรายการ"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "แนวทางปฏิบัติที่ดีที่สุด"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "งบประมาณประสิทธิภาพจะใช้เป็นมาตรฐานสำหรับประสิทธิภาพของเว็บไซต์คุณ"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "งบประมาณ"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "ข้อมูลเพิ่มเติมเกี่ยวกับประสิทธิภาพของแอปพลิเคชัน"
+    "message": "ข้อมูลเพิ่มเติมเกี่ยวกับประสิทธิภาพของแอปพลิเคชัน ตัวเลขเหล่านี้ไม่[ส่งผลกระทบโดยตรง](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)ต่อคะแนนประสิทธิภาพ"
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "การวินิจฉัย"
@@ -840,7 +1113,7 @@
     "message": "การปรับปรุงการแสดงผลครั้งแรก"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "การเพิ่มประสิทธิภาพเหล่านี้เพิ่มความเร็วในการโหลดหน้าเว็บได้"
+    "message": "คำแนะนำเหล่านี้จะช่วยให้หน้าโหลดได้เร็วขึ้น โดยจะไม่[ส่งผลกระทบโดยตรง](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)ต่อคะแนนประสิทธิภาพ"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "โอกาส"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "แคช TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "ตำแหน่ง"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "ชื่อ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "คำขอ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "ประเภททรัพยากร"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "ขนาด (KB)"
+    "message": "ขนาด"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "เวลาที่ใช้"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "ขนาดการโอน"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "ไบต์ที่อาจประหยัดได้ (KB)"
+    "message": "เวลาที่อาจประหยัดได้"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "เวลาที่อาจประหยัดได้ (มิลลิวินาที)"
+    "message": "เวลาที่อาจประหยัดได้"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "อาจประหยัดได้ {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "อาจประหยัดเวลาได้ {wastedMs, number, milliseconds} มิลลิวินาที"
+    "message": "อาจประหยัดได้ {wastedMs, number, milliseconds} มิลลิวินาที"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "เอกสาร"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "แบบอักษร"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "รูปภาพ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "สื่อ"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} มิลลิวินาที"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "อื่นๆ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "สคริปต์"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} วินาที"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "สไตล์ชีต"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "บุคคลที่สาม"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "รวม"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "เกิดข้อผิดพลาดในการบันทึกการติดตามระหว่างการโหลดหน้าเว็บ โปรดเรียกใช้ Lighthouse อีกครั้ง ({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "เซิร์ฟเวอร์ DNS แก้ปัญหาโดเมนที่ระบุไม่ได้"
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "ตัวรวบรวม {artifactName} ที่จำเป็นพบข้อผิดพลาด: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "เกิดข้อผิดพลาดภายในของ Chrome โปรดรีสตาร์ท Chrome และลองเรียกใช้ Lighthouse อีกครั้ง"
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "ตัวรวบรวม {artifactName} ที่จำเป็นไม่ทำงาน"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse โหลดหน้าเว็บที่คุณขออย่างน่าเชื่อถือไม่ได้ ตรวจสอบว่าคุณกำลังทดสอบ URL ที่ถูกต้องและเซิร์ฟเวอร์ตอบสนองคำขอทั้งหมดอย่างถูกต้อง"
@@ -945,7 +1266,10 @@
     "message": "Lighthouse โหลด URL ที่คุณขออย่างน่าเชื่อถือไม่ได้เพราะหน้าเว็บไม่ตอบสนอง"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "URL ที่ระบุไม่มีข้อมูลเข้าสู่ระบบความปลอดภัยที่ถูกต้อง {securityMessages}"
+    "message": "URL ที่ระบุไม่มีใบรับรองความปลอดภัยที่ถูกต้อง {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome ป้องกันการโหลดหน้าเว็บด้วยโฆษณาคั่นระหว่างหน้า ตรวจสอบว่าคุณกำลังทดสอบ URL ที่ถูกต้องและเซิร์ฟเวอร์ตอบสนองคำขอทั้งหมดอย่างถูกต้อง"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse โหลดหน้าเว็บที่คุณขออย่างน่าเชื่อถือไม่ได้ ตรวจสอบว่าคุณกำลังทดสอบ URL ที่ถูกต้องและเซิร์ฟเวอร์ตอบสนองคำขอทั้งหมดอย่างถูกต้อง (รายละเอียด: {errorDetails})"
@@ -984,7 +1308,7 @@
     "message": "ข้อมูลในห้องทดลอง"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "การวิเคราะห์หน้าปัจจุบันโดย [Lighthouse](https://developers.google.com/web/tools/lighthouse/) ในเครือข่ายมือถือจำลอง ค่ามาจากการประมาณและอาจแตกต่างกันไป"
+    "message": "การวิเคราะห์หน้าปัจจุบันในเครือข่ายมือถือจำลองโดย [Lighthouse](https://developers.google.com/web/tools/lighthouse/) ค่ามาจากการประมาณและอาจแตกต่างกันไป"
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "รายการเพิ่มเติมที่ควรตรวจสอบด้วยตนเอง"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "ขยายตัวอย่างข้อมูล"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "แสดงทรัพยากรของบุคคลที่สาม"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "เกิดปัญหาที่มีผลต่อการทำงานนี้ของ Lighthouse"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "ค่ามาจากการประมาณและอาจแตกต่างกันไป"
+    "message": "ค่ามาจากการประมาณและอาจแตกต่างกันไป คะแนนประสิทธิภาพ[อิงจากเมตริกเหล่านี้เท่านั้น](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)"
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "ผ่านการตรวจสอบแต่มีคำเตือน"
@@ -1023,7 +1350,7 @@
     "message": "ลองอัปโหลด GIF ไปยังบริการซึ่งจะทำให้ใช้ GIF เพื่อฝังเป็นวิดีโอ HTML5 ได้"
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "ติดตั้ง[ปลั๊กอิน WordPress การโหลดแบบ Lazy Loading](https://wordpress.org/plugins/search/lazy+load/) ที่จะช่วยเลื่อนเวลาโหลดรูปภาพนอกหน้าจอ หรือเปลี่ยนไปใช้ธีมที่มีฟังก์ชันดังกล่าว นอกจากนี้แล้วให้ลองใช้[ปลั๊กอิน AMP](https://wordpress.org/plugins/amp/) ด้วย"
+    "message": "ติดตั้ง[ปลั๊กอินการโหลดแบบ Lazy Loading ของ WordPress](https://wordpress.org/plugins/search/lazy+load/) ที่จะช่วยเลื่อนเวลาโหลดรูปภาพนอกหน้าจอ หรือเปลี่ยนไปใช้ธีมที่มีฟังก์ชันดังกล่าว และอาจลองพิจารณาใช้[ปลั๊กอิน AMP](https://wordpress.org/plugins/amp/)"
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "มีปลั๊กอิน WordPress หลายรายการที่ช่วยคุณ[แทรกเนื้อหาที่สำคัญ](https://wordpress.org/plugins/search/critical+css/) หรือ[เลื่อนเวลาโหลดทรัพยากรที่สำคัญน้อยกว่า](https://wordpress.org/plugins/search/defer+css+javascript/) โปรดระวังว่าการเพิ่มประสิทธิภาพโดยปลั๊กอินเหล่านี้อาจทำให้ฟีเจอร์ของธีมหรือปลั๊กอินของคุณเสียหาย ซึ่งน่าจะทำให้คุณต้องแก้ไขโค้ด"
@@ -1038,27 +1365,27 @@
     "message": "มี[ปลั๊กอิน WordPress](https://wordpress.org/plugins/search/minify+css/) หลายอย่างที่ช่วยให้เว็บไซต์เร็วขึ้นได้ด้วยการลิงก์ ลดขนาด และบีบอัดสไตล์ นอกจากนี้คุณอาจใช้กระบวนการของเวอร์ชันเพื่อลดขนาดล่วงหน้าหากเป็นไปได้"
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "มี[ปลั๊กอิน WordPress]https://wordpress.org/plugins/search/minify+javascript/) หลายอย่างที่ช่วยให้เว็บไซต์เร็วขึ้นได้ด้วยการลิงก์ ลดขนาด และบีบอัดสคริปต์ นอกจากนี้คุณอาจใช้กระบวนการของเวอร์ชันเพื่อลดขนาดล่วงหน้าหากเป็นไปได้"
+    "message": "มี[ปลั๊กอิน WordPress](https://wordpress.org/plugins/search/minify+javascript/) หลายอย่างที่ช่วยให้เว็บไซต์เร็วขึ้นได้ด้วยการลิงก์ ลดขนาด และบีบอัดสคริปต์ นอกจากนี้คุณอาจใช้กระบวนการของเวอร์ชันเพื่อลดขนาดล่วงหน้าหากเป็นไปได้"
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "ลองลดหรือเปลี่ยนจำนวน[ปลั๊กอิน WordPress](https://wordpress.org/plugins/) ที่โหลด CSS ที่ไม่ได้ใช้ในหน้าเว็บของคุณ หากต้องการระบุปลั๊กอินที่เพิ่ม CSS โดยไม่จำเป็น ให้ลองเรียกใช้[การครอบคลุมโค้ด](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) ใน DevTools ของ Chrome คุณระบุธีม/ปลั๊กอินที่รับผิดชอบได้จาก URL ของสไตล์ชีต หาปลั๊กอินที่มีสไตล์ชีตจำนวนมากอยู่ในรายการซึ่งมีสีแดงอยู่จำนวนมากในการครอบคลุมโค้ด ปลั๊กอินควรเป็นเพียงตัวกำหนดลำดับของสไตล์ชีตเท่านั้นหากใช้ปลั๊กอินในหน้าจริงๆ"
+    "message": "ลองลดหรือเปลี่ยนจำนวน[ปลั๊กอิน WordPress](https://wordpress.org/plugins/) ที่โหลด CSS ที่ไม่ได้ใช้ในหน้าเว็บของคุณ หากต้องการระบุปลั๊กอินที่เพิ่ม CSS โดยไม่จำเป็น ให้ลองเรียกใช้[การครอบคลุมโค้ด](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)ใน DevTools ของ Chrome คุณระบุธีม/ปลั๊กอินที่รับผิดชอบได้จาก URL ของสไตล์ชีต หาปลั๊กอินที่มีสไตล์ชีตจำนวนมากอยู่ในรายการซึ่งมีสีแดงอยู่จำนวนมากในการครอบคลุมโค้ด ปลั๊กอินควรเป็นเพียงตัวกำหนดลำดับของสไตล์ชีตเท่านั้นหากใช้ปลั๊กอินในหน้าจริงๆ"
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "ลองลดหรือเปลี่ยนจำนวน[ปลั๊กอิน WordPress](https://wordpress.org/plugins/) ที่โหลด JavaScript ที่ไม่ได้ใช้ในหน้าเว็บของคุณ หากต้องการระบุปลั๊กอินที่เพิ่ม JS โดยไม่จำเป็น ให้ลองเรียกใช้[การครอบคลุมโค้ด](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)ใน DevTools ของ Chrome คุณระบุธีม/ปลั๊กอินที่รับผิดชอบได้จาก URL ของสคริปต์ หาปลั๊กอินที่มีสคริปต์จำนวนมากอยู่ในรายการซึ่งมีสีแดงอยู่จำนวนมากในการครอบคลุมโค้ด ปลั๊กอินควรเป็นเพียงตัวกำหนดลำดับของสคริปต์เท่านั้นหากใช้ปลั๊กอินในหน้าจริงๆ"
+    "message": "ลองลดหรือเปลี่ยนจำนวน[ปลั๊กอิน WordPress](https://wordpress.org/plugins/) ที่โหลด JavaScript ที่ไม่ได้ใช้ในหน้าเว็บของคุณ หากต้องการระบุปลั๊กอินที่เพิ่ม JS โดยไม่จำเป็น ให้ลองเรียกใช้ [การครอบคลุมโค้ด](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)ใน DevTools ของ Chrome คุณระบุธีม/ปลั๊กอินที่รับผิดชอบได้จาก URL ของสคริปต์ หาปลั๊กอินที่มีสคริปต์จำนวนมากอยู่ในรายการซึ่งมีสีแดงอยู่จำนวนมากในการครอบคลุมโค้ด ปลั๊กอินควรเป็นเพียงตัวกำหนดลำดับของสคริปต์เท่านั้นหากใช้ปลั๊กอินในหน้าจริงๆ"
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "อ่านเกี่ยวกับ[การแคชเบราว์เซอร์ใน WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)"
+    "message": "อ่านเกี่ยวกับ[การแคชของเบราว์เซอร์ใน WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)"
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "ลองใช้[ปลั๊กอิน WordPress การเพิ่มประสิทธิภาพรูปภาพ](https://wordpress.org/plugins/search/optimize+images/) ที่บีบอัดรูปภาพแต่ยังคงคุณภาพไว้ได้"
+    "message": "พิจารณาใช้[ปลั๊กอิน WordPress การเพิ่มประสิทธิภาพรูปภาพ](https://wordpress.org/plugins/search/optimize+images/)ที่บีบอัดรูปภาพแต่ยังคงคุณภาพไว้ได้"
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "อัปโหลดรูปภาพโดยตรงผ่าน[คลังสื่อ](https://codex.wordpress.org/Media_Library_Screen) เพื่อให้แน่ใจว่ามีขนาดรูปภาพที่จำเป็นพร้อมใช้งาน จากนั้นแทรกรูปภาพจากคลังสื่อหรือใช้วิดเจ็ตรูปภาพเพื่อให้มีการใช้ขนาดรูปภาพที่มีประสิทธิภาพสูงสุด (รวมถึงขนาดสำหรับเบรกพอยท์ที่ปรับเปลี่ยนตามอุปกรณ์) หลีกเลี่ยงการใช้รูปภาพ \"ขนาดเต็ม\" นอกเสียจากว่าขนาดจะเพียงพอต่อการใช้งาน [ดูข้อมูลเพิ่มเติม](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
+    "message": "อัปโหลดรูปภาพโดยตรงผ่าน[ไลบรารีสื่อ](https://codex.wordpress.org/Media_Library_Screen)เพื่อให้แน่ใจว่ามีขนาดรูปภาพที่จำเป็นพร้อมใช้งาน จากนั้นแทรกรูปภาพจากไลบรารีสื่อหรือใช้วิดเจ็ตรูปภาพเพื่อให้มีการใช้ขนาดรูปภาพที่มีประสิทธิภาพสูงสุด (รวมถึงขนาดสำหรับเบรกพอยท์ที่ปรับเปลี่ยนตามอุปกรณ์) หลีกเลี่ยงการใช้รูปภาพ`Full Size` นอกเสียจากว่าขนาดจะเพียงพอต่อการใช้งาน [ดูข้อมูลเพิ่มเติม](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "คุณเปิดใช้การบีบอัดข้อความในการกำหนดค่าเว็บเซิร์ฟเวอร์ได้"
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "ลองใช้[ปลั๊กอิน](https://wordpress.org/plugins/search/convert+webp/) หรือบริการที่จะแปลงรูปภาพที่อัปโหลดเป็นรูปแบบที่เหมาะสมที่สุดโดยอัตโนมัติ"
+    "message": "พิจารณาใช้[ปลั๊กอิน](https://wordpress.org/plugins/search/convert+webp/)หรือบริการที่จะแปลงรูปภาพที่อัปโหลดเป็นรูปแบบที่เหมาะสมที่สุดโดยอัตโนมัติ"
   }
 }

--- a/lighthouse-core/lib/i18n/locales/tr.json
+++ b/lighthouse-core/lib/i18n/locales/tr.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Erişim anahtarları, kullanıcıların sayfanın bir bölümüne hızlıca odaklanmalarını sağlar. Gezinmenin düzgün bir şekilde gerçekleştirilebilmesi için her bir erişim anahtarının benzersiz olması gerekir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Erişim anahtarları, kullanıcıların sayfanın bir bölümüne hızlıca odaklanmalarını sağlar. Gezinmenin düzgün bir şekilde gerçekleştirilebilmesi için her bir erişim anahtarının benzersiz olması gerekir [Daha fazla bilgi](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "\"[accesskey]\" değerleri benzersiz değil"
+    "message": "`[accesskey]` değerleri benzersiz değil"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "\"[accesskey]\" değerleri benzersiz"
+    "message": "`[accesskey]` değerleri benzersiz"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Her ARIA \"rolü\", belirli bir \"aria-*\" özellik alt kümesini destekler. Bunların uyuşmazlığı, \"aria-*\" özelliklerinin geçersiz kılınmasına neden olur. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Her ARIA `role`, belirli bir `aria-*` özellik alt kümesini destekler. Bunların eşleşmemesi `aria-*` özelliklerini geçersiz kılar. [Daha fazla bilgi](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "\"[aria-*]\" özellikleri, rolleriyle eşleşmiyor"
+    "message": "`[aria-*]` özellikleri, rolleriyle eşleşmiyor"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "\"[aria-*]\" özellikleri rolleriyle eşleşiyor"
+    "message": "`[aria-*]` özellikleri rolleriyle eşleşiyor"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Bazı ARIA rolleri, öğenin durumunu ekran okuyuculara açıklayan gerekli özelliklere sahiptir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Bazı ARIA rolleri, öğenin durumunu ekran okuyuculara açıklayan gerekli özelliklere sahiptir. [Daha fazla bilgi](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "\"[role]\" rolleri gereken tüm \"[aria-*]\" özelliklerine sahip değil"
+    "message": "`[role]` rolleri gereken tüm `[aria-*]` özelliklerine sahip değil"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "\"[role]\"ler gereken tüm \"[aria-*]\" özelliklerine sahip"
+    "message": "`[role]` öğelerinin rolleri, gereken tüm`[aria-*]` özelliklerine sahip"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Bazı ARIA üst rollerinin amaçlanan erişilebilirlik işlevlerini gerçekleştirebilmek için belirli alt rolleri içermesi gerekir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Bazı ARIA üst rollerinin amaçlanan erişilebilirlik işlevlerini gerçekleştirebilmek için belirli alt rolleri içermesi gerekir. [Daha fazla bilgi](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Belirli alt \"[role]\" rolleri gerektiren, \"[role]\" rolüne sahip öğeler eksik."
+    "message": "Belirli alt `[role]`rolleri gerektiren,`[role]` rolüne sahip öğeler eksik."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Belirli alt \"[role]\"leri gerektiren, \"[role]\"e sahip öğeler mevcut"
+    "message": "Belirli alt `[role]` rolleri gerektiren,`[role]` rolüne sahip öğeler mevcut"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Bazı ARIA alt rollerinin amaçlanan erişilebilirlik işlevlerini gerektiği gibi gerçekleştirebilmesi için belirli üst rollerin içinde bulunması gerekir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Bazı ARIA alt rollerinin amaçlanan erişilebilirlik işlevlerini gerektiği gibi gerçekleştirebilmesi için belirli üst rollerin içinde bulunması gerekir. [Daha fazla bilgi](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "\"[role]\" rolleri gerekli üst öğelerinin içinde bulunmuyor"
+    "message": "`[role]` rolleri gerekli üst öğelerinin içinde bulunmuyor"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "\"[role]\"ler gerekli üst öğelerinin içinde bulunuyor"
+    "message": "`[role]` öğeleri gerekli üst öğelerinin içinde bulunuyor"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA rollerinin amaçlanan erişilebilirlik işlevlerini gerçekleştirebilmesi için geçerli değerlere sahip olması gerekir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "ARIA rollerinin amaçlanan erişilebilirlik işlevlerini gerçekleştirebilmesi için geçerli değerlere sahip olması gerekir. [Daha fazla bilgi](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "\"[role]\" değerleri geçerli değil"
+    "message": "`[role]` değerleri geçerli değil"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "\"[role]\" değerleri geçerli"
+    "message": "`[role]` değerleri geçerli"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Ekran okuyucular gibi yardımcı teknolojiler geçersiz değerlere sahip ARIA özelliklerini yorumlayamaz. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Ekran okuyucular gibi yardımcı teknolojiler geçersiz değerlere sahip ARIA özelliklerini yorumlayamaz. [Daha fazla bilgi](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "\"[aria-*]\" özellikleri geçerli değerlere sahip değil"
+    "message": "`[aria-*]` özellikleri geçerli değerlere sahip değil"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "\"[aria-*]\" özelliklerinin geçerli değerleri var"
+    "message": "`[aria-*]` özelliklerinin geçerli değerleri var"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Ekran okuyucular gibi yardımcı teknolojiler geçersiz adlara sahip ARIA özelliklerini yorumlayamaz. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Ekran okuyucular gibi yardımcı teknolojiler geçersiz adlara sahip ARIA özelliklerini yorumlayamaz. [Daha fazla bilgi](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "\"[aria-*]\" özellikleri geçerli değil veya yanlış yazılmış"
+    "message": "`[aria-*]` özellikleri geçerli değil veya yanlış yazılmış"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "\"[aria-*]\" özellikleri geçerli ve yanlış yazılmamış"
+    "message": "`[aria-*]` özellikleri geçerli ve yanlış yazılmamış"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Altyazılar kimin konuştuğu, neler dediği gibi önemli bilgiler ve konuşma dışında başka bilgiler sağlayarak ses öğelerinin sağır veya işitme engelli kullanıcılar tarafından kullanılabilmesini sağlar. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Altyazılar kimin konuştuğu, neler dediği gibi önemli bilgiler ve konuşma dışında başka bilgiler sağlayarak ses öğelerinin işitme engelli veya işitme zorluğuna sahip kullanıcılar tarafından kullanılabilmesini sağlar. [Daha fazla bilgi](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "\"<audio>\" öğelerinde \"[kind=\"captions\"]\" içeren bir \"<track>\" öğesi bulunmuyor."
+    "message": "`<audio>` öğelerinde `[kind=\"captions\"]` içeren bir `<track>` öğesi bulunmuyor."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "\"<audio>\" öğelerinde \"[kind=\"captions\"]\" içeren bir \"<track>\" öğesi bulunuyor"
+    "message": "`<audio>` öğelerinde `[kind=\"captions\"]`içeren bir `<track>` öğesi bulunuyor"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Başarısız Öğeler"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Bir düğmenin erişilebilir adı olmadığında ekran okuyucular onu \"düğme\" olarak duyurur ve düğme, ekran okuyuculara bel bağlayan kullanıcılar için kullanılamaz hale gelir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Bir düğmenin erişilebilir özellikli bir adı yoksa ekran okuyucular bu düğmeyi yalnızca \"düğme\" olarak okuyacağı için bu, ekran okuyuculardan yararlanan kullanıcılar için yararlı olmaz. [Daha fazla bilgi](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Düğmelerin erişilebilir adları yok"
@@ -93,7 +93,7 @@
     "message": "Düğmeler erişilebilir bir ada sahip"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Tekrar eden içeriği atlamanın yollarını eklemek, klavye kullanıcılarının sayfada daha verimli bir şekilde gezinmesini sağlar. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Tekrar eden içeriği atlamanın yollarını eklemek, klavye kullanıcılarının sayfada daha verimli bir şekilde gezinmesini sağlar. [Daha fazla bilgi](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Bu sayfa bir başlık, atlama bağlantısı veya önemli nokta bölgesi içermiyor"
@@ -102,7 +102,7 @@
     "message": "Sayfa bir başlık, atlama bağlantısı veya önemli nokta bölgesi içeriyor"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Birçok kullanıcı, düşük kontrastlı metni okumakta zorlanır veya okuyamaz. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Birçok kullanıcı, düşük kontrastlı metni okumakta zorlanır veya okuyamaz. [Daha fazla bilgi](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Arka plan ve ön plan renkleri yeterli kontrast oranına sahip değil."
@@ -111,88 +111,88 @@
     "message": "Arka plan ve ön plan renkleri yeterli kontrast oranına sahip"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Tanım listeleri gerektiği gibi işaretlenmediğinde ekran okuyucular kafa karışıklığına yol açan veya yanlış çıkışlar sunabilir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Tanım listeleri gerektiği gibi işaretlenmediğinde ekran okuyucular kafa karışıklığına yol açan veya yanlış çıkışlar sunabilir. [Daha fazla bilgi](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "\"<dl>\"ler yalnızca gerektiği gibi sıralanmış \"<dt>\" ve \"<dd>\" gruplarını, \"<script>\" veya \"<template>\" öğelerini içermiyor."
+    "message": "`<dl>` öğeleri yalnızca gerektiği gibi sıralanmış `<dt>` ve `<dd>` gruplarını,`<script>` veya `<template>` öğelerini içermiyor."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "\"<dl>\"ler yalnızca gerektiği gibi sıralanmış \"<dt>\" ve \"<dd>\" gruplarını, \"<script>\" veya \"<template>\" öğelerini içeriyor."
+    "message": "`<dl>` öğeleri yalnızca gerektiği gibi sıralanmış `<dt>` ve `<dd>` gruplarını, `<script>` veya `<template>` öğelerini içeriyor."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Tanım listesi öğelerinin (\"<dt>\" ve \"<dd>\") ekran okuyucular tarafından düzgün bir şekilde duyurulabilmesi için üst \"<dl>\" öğesinin içine yerleştirilmesi gerekir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Tanım listesi öğelerinin (`<dt>` ve `<dd>`) ekran okuyucular tarafından düzgün bir şekilde duyurulabilmesi için üst `<dl>` öğesinin içine yerleştirilmesi gerekir. [Daha fazla bilgi](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Tanım listesi öğeleri \"<dl>\" öğeleri arasına yerleştirilmemiş"
+    "message": "Tanım listesi öğeleri `<dl>` öğeleri arasına yerleştirilmemiş"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Tanım listesi öğeleri \"<dl>\" öğeleri arasına yerleştirilmiş"
+    "message": "Tanım listesi öğeleri `<dl>` öğeleri arasına yerleştirilmiş"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Başlık, ekran okuyucu kullanıcılarına sayfayla ilgili genel bir fikir verir ve arama motoru kullanıcılarının bir sayfanın aramalarıyla ilgili olup olmadığını belirlemeleri açısından son derece önemlidir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Başlık, ekran okuyucu kullanıcılarına sayfayla ilgili genel bir fikir verir ve arama motoru kullanıcılarının bir sayfanın aramalarıyla ilgili olup olmadığını belirlemeleri açısından son derece önemlidir. [Daha fazla bilgi](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Dokümanın \"<title>\" öğesi yok"
+    "message": "Dokümanın `<title>` öğesi yok"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Dokümanın \"<title>\" öğesi var"
+    "message": "Doküman geçerli bir `<title>` öğesi içeriyor"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Kimlik özelliğinin değeri benzersiz olmalıdır. Bunun nedeni, yardımcı teknolojilerin farkına varmadan diğer örnekleri atlamasını önlemektir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Kimlik özelliğinin değeri benzersiz olmalıdır. Bunun nedeni, yardımcı teknolojilerin farkına varmadan diğer örnekleri atlamasını önlemektir. [Daha fazla bilgi](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Sayfadaki \"[id]\" özellikleri benzersiz değil"
+    "message": "Sayfadaki `[id]` özellikleri benzersiz değil"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Sayfadaki \"[id]\" özellikleri benzersiz"
+    "message": "Sayfadaki `[id]` özellikleri benzersiz"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Ekran okuyucu kullanıcıları, çerçevelerin içeriklerinin açıklanması için çerçeve başlıklarından yararlanır. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Ekran okuyucu kullanıcıları, çerçevelerin içeriklerinin açıklanması için çerçeve başlıklarından yararlanır. [Daha fazla bilgi](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "\"<frame>\" veya \"<iframe>\" öğelerinin başlığı yok"
+    "message": "`<frame>` veya `<iframe>` öğelerinin başlığı yok"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "\"<frame>\" veya \"<iframe>\" öğelerinin başlığı var"
+    "message": "`<frame>` veya `<iframe>` öğesi bir başlığa sahip"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Sayfa bir lang özelliği belirtmezse, ekran okuyucu, sayfanın kullanıcı ekran okuyucuyu kurarken seçtiği varsayılan dilde olduğunu varsayar. Sayfa aslında varsayılan dilde değilse, ekran okuyucu, sayfanın metnini doğru bir şekilde duyurmayabilir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Sayfa bir lang özelliği belirtmezse ekran okuyucu, sayfanın kullanıcı ekran okuyucuyu kurarken seçtiği varsayılan dilde olduğunu varsayar. Sayfa aslında varsayılan dilde değilse ekran okuyucu, sayfanın metnini doğru bir şekilde duyurmayabilir. [Daha fazla bilgi](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "\"<html>\" öğesinin \"[lang]\" özelliği yok"
+    "message": "`<html>` öğesinin `[lang]` özelliği yok"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "\"<html>\" öğesinin \"[lang]\" özelliği var"
+    "message": "`<html>` öğesi `[lang]` özelliği içeriyor"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Geçerli bir [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) belirtilmesi, ekran okuyucuların metni düzgün bir şekilde duyurmasına yardımcı olur. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Geçerli bir [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) belirtilmesi, ekran okuyucuların metni düzgün bir şekilde duyurmasına yardımcı olur. [Daha fazla bilgi](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "\"<html>\" öğesi, \"[lang]\" özelliği için geçerli değere sahip değil."
+    "message": "`<html>` öğesi, `[lang]` özelliği için geçerli bir değeri sahip değil."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "\"<html>\" öğesi, \"[lang]\" özelliği için geçerli bir değere sahip"
+    "message": "`<html>` öğesi, `[lang]` özelliği için geçerli bir değere sahip"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Bilgilendirme amaçlı öğelerin hedefi, kısa ve açıklayıcı alternatif metinler olmalıdır. Dekoratif öğeler boş bir alt özelliğiyle yoksayılabilir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Bilgilendirme amaçlı öğelerin hedefi, kısa ve açıklayıcı alternatif metinler olmalıdır. Dekoratif öğeler boş bir alt özelliğiyle yok sayılabilir. [Daha fazla bilgi](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Resim öğelerinin \"[alt]\" özellikleri yok"
+    "message": "Resim öğelerinin `[alt]` özellikleri yok"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Resim öğelerinin \"[alt]\" özellikleri var"
+    "message": "Resim öğelerinin `[alt]` özellikleri var"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Bir resim \"<input>\" düğmesi olarak kullanılırken alternatif metin sağlamak, ekran okuyucu kullanıcılarının düğmenin amacını anlamalarına yardımcı olabilir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Bir resim `<input>` düğmesi olarak kullanılırken alternatif metin sağlamak, ekran okuyucu kullanıcılarının düğmenin amacını anlamalarına yardımcı olabilir. [Daha fazla bilgi](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "\"<input type=\"image\">\" öğelerinin \"[alt]\" metni yok"
+    "message": "`<input type=\"image\">` öğelerinin `[alt]` metni yok"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "\"<input type=\"image\">\" öğelerinin \"[alt]\" metni var"
+    "message": "`<input type=\"image\">` öğelerinin `[alt]` metni var"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Etiketler, form kontrollerinin ekran okuyucular gibi yardımcı teknolojiler tarafından düzgün bir şekilde duyurulmasını sağlar. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Etiketler, form kontrollerinin ekran okuyucular gibi yardımcı teknolojiler tarafından düzgün bir şekilde duyurulmasını sağlar. [Daha fazla bilgi](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Form öğelerinin ilişkili etiketleri yok"
@@ -201,16 +201,16 @@
     "message": "Form öğelerinin ilişkili etiketleri var"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Düzen amaçlı kullanılan bir tablonun, veri öğeleri (ör. th veya başlık öğeleri ya da özet özelliği) içermemesi gerekir. Zira bu durum, ekran okuyucu kullanıcılarının kafa karıştırıcı bir deneyim yaşamalarına neden olabilir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Düzen amaçlı kullanılan bir tablonun, veri öğeleri (ör. th veya başlık öğeleri ya da özet özelliği) içermemesi gerekir. Zira bu durum, ekran okuyucu kullanıcılarının kafa karıştırıcı bir deneyim yaşamalarına neden olabilir. [Daha fazla bilgi](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Sunu amaçlı \"<table>\" öğeleri \"<th>\", \"<caption>\" veya \"[summary]\" özelliğini kullanmaktan kaçınmıyor."
+    "message": "Sunu amaçlı `<table>` öğeleri `<th>`, `<caption>` veya `[summary]` özelliğini kullanmaktan kaçınmıyor."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Sunum amaçlı \"<table>\" öğeleri \"<th>\", \"<caption>\" veya \"[summary]\" özelliğini kullanmaktan kaçınıyor."
+    "message": "Sunum amaçlı `<table>` öğeleri `<th>`, `<caption>` veya `[summary]` özelliğini kullanmaktan kaçınıyor."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Ayırt edilebilir, benzersiz ve odaklanılabilir bağlantı metni (ve bağlantı olarak kullanıldığında resimler için alternatif metin), ekran okuyucu kullanıcılarına daha iyi bir gezinme deneyimi sunar. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Ayırt edilebilir, benzersiz ve odaklanılabilir bağlantı metni (ve bağlantı olarak kullanıldığında resimler için alternatif metin), ekran okuyucu kullanıcılarına daha iyi bir gezinme deneyimi sunar. [Daha fazla bilgi](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Bağlantıların ayırt edilebilir adları yok"
@@ -219,103 +219,115 @@
     "message": "Bağlantıların ayırt edilebilir adları var"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Ekran okuyucular listeleri duyurmak için belirli bir yöntem kullanır. Liste yapısının gerektiği gibi olmasını sağlamak, ekran okuyucu çıkışının düzgün olmasına yardımcı olur. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Ekran okuyucular listeleri duyurmak için belirli bir yöntem kullanır. Liste yapısının gerektiği gibi olmasını sağlamak, ekran okuyucu çıkışının düzgün olmasına yardımcı olur. [Daha fazla bilgi](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Listeler yalnızca \"<li>\" öğelerini ve komut dosyası destekleyen öğeleri (\"<script>\" ve \"<template>\") içermiyor."
+    "message": "Listeler yalnızca `<li>` öğelerini ve komut dosyası destekleyen öğeleri (`<script>` ve `<template>`) içermiyor."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Listeler yalnızca \"<li>\" öğelerini ve komut dosyası destekleyen öğeleri (\"<script>\" ve \"<template>\") içeriyor."
+    "message": "Listeler yalnızca `<li>` öğelerini ve komut dosyası destekleyen öğeleri (`<script>` ve `<template>`) içeriyor."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Ekran okuyucuların liste öğelerini (\"<li>\") düzgün bir şekilde duyurabilmesi için liste öğelerinin, üst \"<ul>\" veya \"<ol>\" öğesinde yer alması gerekir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Ekran okuyucuların liste öğelerini (`<li>`) düzgün bir şekilde okuyabilmesi için liste öğelerinin, üst `<ul>` veya `<ol>` öğesinde yer alması gerekir. [Daha fazla bilgi](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Liste öğeleri (\"<li>\"), \"<ul>\" veya \"<ol>\" üst öğelerinde yer almıyor."
+    "message": "Liste öğeleri (`<li>`), `<ul>` veya `<ol>` üst öğelerinde yer almıyor."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Liste öğeleri (\"<li>\"), \"<ul>\" veya \"<ol>\" üst öğelerinde yer alıyor"
+    "message": "Liste öğeleri (`<li>`), `<ul>` veya `<ol>` üst öğelerinde yer alıyor"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Kullanıcılar bir sayfanın otomatik olarak yenileneceğini düşünmez ve bu işlem yeniden sayfanın üst tarafına odaklanılmasına neden olur. Bu durum, can sıkıcı veya kafa karışıklığına yol açan bir deneyime yol açabilir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Kullanıcılar bir sayfanın otomatik olarak yenileneceğini düşünmez ve bu işlem yeniden sayfanın üst tarafına odaklanılmasına neden olur. Bu durum, can sıkıcı veya kafa karışıklığına yol açan bir deneyime yol açabilir. [Daha fazla bilgi](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Doküman \"<meta http-equiv=\"refresh\">\" kullanıyor"
+    "message": "Doküman `<meta http-equiv=\"refresh\">` kullanıyor"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Doküman \"<meta http-equiv=\"refresh\">\" kullanmıyor"
+    "message": "Doküman `<meta http-equiv=\"refresh\">` öğesini kullanmıyor"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Yakınlaştırmanın devre dışı bırakılması, az gören ve bir web sayfasının içeriğini düzgün bir şekilde görebilmek için ekran büyütme özelliğinden yararlanan kullanıcılar için sorun teşkil eder. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Yakınlaştırmanın devre dışı bırakılması, az gören ve bir web sayfasının içeriğini düzgün bir şekilde görebilmek için ekran büyütme özelliğinden yararlanan kullanıcılar için sorun teşkil eder. [Daha fazla bilgi](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "\"[user-scalable=\"no\"]\", \"<meta name=\"viewport\">\" öğesinde kullanılmış veya \"[maximum-scale]\" özelliği 5'ten küçük."
+    "message": "`[user-scalable=\"no\"]`, `<meta name=\"viewport\">` öğesinde kullanılmış veya `[maximum-scale]` özelliği 5'ten küçük."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "\"[user-scalable=\"no\"]\", \"<meta name=\"viewport\">\" öğesinde kullanılmamış ve \"[maximum-scale]\" özelliği 5'ten küçük değil."
+    "message": "`[user-scalable=\"no\"]`, `<meta name=\"viewport\">` öğesinde kullanılmamış ve `[maximum-scale]` özelliği 5'ten küçük değil."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Ekran okuyucular metin dışı içeriği çeviremez. \"<object>\" öğelerine alternatif metin eklemek, ekran okuyucuların anlamı kullanıcılara iletmesine yardımcı olur. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Ekran okuyucular metin dışı içeriği çeviremez. `<object>` öğelerine alternatif metin eklemek, ekran okuyucuların ilgili öğenin ne anlama geldiğini kullanıcılara söylemesine yardımcı olur. [Daha fazla bilgi](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "\"<object>\" öğelerinin \"[alt]\" metni yok"
+    "message": "`<object>` öğelerinin `[alt]` metni yok"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "\"<object>\" öğelerinin \"[alt]\" metni var"
+    "message": "`<object>` öğelerinin `[alt]` metni var"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "0'dan büyük bir değer, açık bir gezinme sıralamasını belirtir. Bu durum teknik olarak geçerli olsa da yardımcı teknolojilerden yararlanan kullanıcıların genellikle sinir bozucu deneyimler yaşamalarına neden olur. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "0'dan büyük bir değer, açık bir gezinme sıralamasını belirtir. Bu durum teknik olarak geçerli olsa da yardımcı teknolojilerden yararlanan kullanıcıların genellikle sinir bozucu deneyimler yaşamalarına neden olur. [Daha fazla bilgi](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Bazı öğeler 0'dan büyük bir \"[tabindex]\" değeri içeriyor"
+    "message": "Bazı öğeler 0'dan büyük bir `[tabindex]` değeri içeriyor"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Hiçbir öğe 0'dan büyük \"[tabindex]\" değeri içermiyor"
+    "message": "Hiçbir öğe 0'dan büyük `[tabindex]` değeri içermiyor"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Ekran okuyucuların tablolarda daha kolay gezinmeyi sağlayan özellikleri vardır. \"[headers]\" özelliğini kullanan \"<td>\" hücrelerinin yalnızca aynı tablodaki diğer hücrelere atıfta bulunmasını sağlamak, ekran okuyucu kullanıcılarına daha iyi bir deneyim sunabilir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Ekran okuyucuların tablolarda daha kolay gezinmeyi sağlayan özellikleri vardır. `[headers]` özelliğini kullanan`<td>` hücrelerinin yalnızca aynı tablodaki diğer hücrelere atıfta bulunmasını sağlamak, ekran okuyucu kullanıcılarına daha iyi bir deneyim sunabilir. [Daha fazla bilgi](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "\"<table>\" öğesinde olup \"[headers]\" özelliğini kullanan hücreler, aynı tablodaki diğer hücrelere atıfta bulunuyor."
+    "message": "`<table>` öğesinde olup `[headers]` özelliğini kullanan hücreler, aynı tablodaki diğer hücrelere atıfta bulunuyor."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "\"<table>\" öğesinde olup \"[headers]\" özelliğini kullanan hücreler yalnızca aynı tablodaki diğer hücrelere atıfta bulunuyor."
+    "message": "`<table>` öğesinde olup `[headers]` özelliğini kullanan hücreler yalnızca aynı tablodaki diğer hücrelere atıfta bulunuyor."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Ekran okuyucuların tablolarda daha kolay gezinmeyi sağlayan özellikleri vardır. Tablo başlıklarının her zaman bazı hücre kümelerine atıfta bulunmasını sağlamak, ekran okuyucu kullanıcılarına daha iyi bir deneyim sunabilir. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Ekran okuyucuların tablolarda daha kolay gezinmeyi sağlayan özellikleri vardır. Tablo başlıklarının her zaman bazı hücre kümelerine atıfta bulunmasını sağlamak, ekran okuyucu kullanıcılarına daha iyi bir deneyim sunabilir. [Daha fazla bilgi](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "\"<th>\" öğelerinin ve \"[role=\"columnheader\"/\"rowheader\"]\" içeren öğelerin açıkladıkları veri hücreleri yok."
+    "message": "`<th>` öğelerinin ve `[role=\"columnheader\"/\"rowheader\"]` içeren öğelerin açıkladıkları veri hücreleri yok."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "\"<th>\" öğelerinin ve \"[role=\"columnheader\"/\"rowheader\"]\" içeren öğelerin açıkladıkları veri hücreleri var."
+    "message": "`<th>` öğelerinin ve`[role=\"columnheader\"/\"rowheader\"]` içeren öğelerin açıkladıkları veri hücreleri var."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Öğelerde geçerli bir [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) belirtilmesi, ekran okuyucunun metni doğru telaffuz etmesini sağlar. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Öğelerde geçerli bir [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) belirtilmesi, ekran okuyucunun metni doğru telaffuz etmesini sağlar. [Daha fazla bilgi](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "\"[lang]\" özellikleri geçerli bir değere sahip değil"
+    "message": "`[lang]` özellikleri geçerli bir değere sahip değil"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "\"[lang]\" özellikleri geçerli bir değere sahip"
+    "message": "`[lang]` özellikleri geçerli bir değere sahip"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Bir videoda altyazının yer alması sağır ve işitme engelli kullanıcıların videonun bilgilerine daha kolay erişmelerini sağlar. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Bir videoda altyazının yer alması işitme engelli ve işitme zorluğuna sahip kullanıcıların videonun bilgilerine daha kolay erişmelerini sağlar. [Daha fazla bilgi](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "\"<video>\" öğelerinde \"[kind=\"captions\"]\" içeren bir \"<track>\" öğesi bulunmuyor."
+    "message": "`<video>` öğelerinde `[kind=\"captions\"]` içeren bir `<track>` öğesi bulunmuyor."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "\"<video>\" öğelerinde \"[kind=\"captions\"]\" içeren bir \"<track>\" öğesi bulunuyor"
+    "message": "`<video>` öğelerinde `[kind=\"captions\"]`içeren bir `<track>` öğesi bulunuyor"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Sesli açıklamalar, videolarla ilgili olarak diyaloğun sağlayamayacağı bilgiler (ör. yüz ifadeleri ve sahneler) sağlar. [Daha fazla bilgi](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Sesli açıklamalar, videolarla ilgili olarak diyaloğun sağlayamayacağı bilgiler (ör. yüz ifadeleri ve sahneler) sağlar. [Daha fazla bilgi](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "\"<video>\" öğelerinde \"[kind=\"description\"]\" içeren bir \"<track>\" öğesi bulunmuyor."
+    "message": "`<video>` öğelerinde `[kind=\"description\"]` içeren bir `<track>` öğesi bulunmuyor."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "\"<video>\" öğelerinde \"[kind=\"description\"]\" içeren bir \"<track>\" öğesi bulunuyor"
+    "message": "`<video>` öğelerinde `[kind=\"description\"]`içeren bir `<track>` öğesi bulunuyor"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Kullanıcılar ana ekrana eklediklerinde iOS'ta ideal görünüm için bir apple-touch-icon tanımlayın. Tanım, saydam olmayan bir 192 piksel (veya 180 piksel) kare PNG'ye götürmelidir. [Daha fazla bilgi](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Geçerli bir `apple-touch-icon` öğesi içermiyor"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` güncel değil; `apple-touch-icon` tercih edilir."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Geçerli bir `apple-touch-icon` sunuyor"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome uzantıları bu sayfanın yükleme performansını olumsuz etkilemiştir. Sayfayı gizli modda veya uzantı içermeyen bir Chrome profilinden denetlemeyi deneyin."
@@ -330,7 +342,7 @@
     "message": "Toplam CPU Süresi"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "JS'yi ayrıştırma, derleme ve yürütme için harcanan zamanı azaltma seçeneğini değerlendirin. Daha küçük JS yüklerinin sağlanmasının bu konuda yardımcı olduğunu fark edebilirsiniz. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "JS'yi ayrıştırma, derleme ve yürütme için harcanan zamanı kısaltmayı düşünün. Daha küçük JS yüklerinin sağlanması bu konuda yardımcı olabilir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "JavaScript yürütme süresini azaltın"
@@ -345,22 +357,22 @@
     "message": "Animasyonlu içerik için video biçimleri kullanın"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Etkileşimli hale gelme süresini kısaltmak için ekran dışındaki ve gizli resimleri, tüm kritik kaynakların yüklenmesi bittikten sonra gecikmeli olarak yükleme seçeneğini değerlendirin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Etkileşim için hazır olma süresini kısaltmak için ekran dışı ve gizli resimleri, tüm kritik kaynakların yüklenmesi bittikten sonra gecikmeli olarak yükleme seçeneğini değerlendirin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Ekran dışındaki resimleri ertele"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Kaynaklar, sayfanızda ilk boyayı engelliyor. Kritik JS/CSS'yi satır içinde yayınlama ve kritik olmayan tüm JS/stilleri erteleme seçeneğini değerlendirin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Kaynaklar, sayfanızda ilk boyamayı engelliyor. Kritik JS/CSS'yi satır içinde yayınlama ve kritik olmayan tüm JS/stilleri erteleme seçeneğini değerlendirin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Oluşturmayı engelleyen kaynakları ortadan kaldırın"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Büyük ağ yüklerinin kullanıcılara maddi anlamda maliyeti vardır ve bu ağ yükleri, uzun yükleme süreleriyle yakından ilişkilidir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Büyük ağ yükleri kullanıcılar için parasal maliyet anlamına gelir ve yükleme sürelerinin uzamasında yüksek bir etkiye sahiptir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "Toplam boyut: {totalBytes, number, bytes} KB"
+    "message": "Toplam boyut {totalBytes, number, bytes} KB'tı"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Çok büyük ağ yüklerinden kaçının"
@@ -411,7 +423,7 @@
     "message": "Resimleri verimli bir şekilde kodlayın"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Hücresel veriden tasarruf etmek ve yükleme süresini iyileştirmek için uygun boyutlu resimler sunun. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Hücresel veriden tasarruf etmek ve yükleme süresini kısaltmak için uygun boyutlu resimler sunun. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Doğru boyuta sahip resimler"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Kritik İsteklerin Derinliğini En Aza İndirin"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Kullanımdan Kaldırma / Uyarı"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Satır"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Kullanımdan kaldırılan API'ler sonunda tarayıcıdan kaldırılacaktır. [Daha fazla bilgi](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 uyarı bulundu}other{# uyarı bulundu}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Kullanımdan kaldırılan API'leri kullanıyor"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Kullanımdan kaldırılan API'leri içermiyor"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Application Cache API'si kullanımdan kaldırılmıştır. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "\"{AppCacheManifest}\" bulundu"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Uygulama Önbelleği Kullanma"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Uygulama Önbelleği Kullanılmıyor"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Bir DOCTYPE belirlemek, tarayıcının Quirks moduna geçmesini önler. Daha fazla bilgiyi [MDN Web Dokümanları sayfasında](https://developer.mozilla.org/en-US/docs/Glossary/Doctype) bulabilirsiniz"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "DOCTYPE adı, küçük harf `html` dizesi olmalıdır"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Doküman bir DOCTYPE içermelidir"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Beklenen publicId boş bir dize olmalı"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Beklenen systemId boş bir dize olmalı"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Sayfada HTML DOCTYPE eksik, bu nedenle Quirks modunu tetikliyor"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Sayfa HTML DOCTYPE içeriyor"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Öğe"
   },
@@ -447,7 +510,7 @@
     "message": "Değer"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Tarayıcı mühendisleri, sayfaların yaklaşık olarak 1.500'den az DOM öğesi içermesini önerir. En iyisi, 32 öğeden ve 60 alt/üst öğeden az olan bir ağaç derinliğidir. Büyük bir DOM, bellek kullanımını artırarak daha uzun [stil hesaplamalarına](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) yol açabilir ve yüksek maliyetli [düzen yeniden düzenlemeleri](https://developers.google.com/speed/articles/reflow) oluşturabilir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Tarayıcı mühendisleri, sayfaların yaklaşık olarak 1.500'den az DOM öğesi içermesini önerir. En iyisi, 32 öğeden ve 60 alt/üst öğeden az olan bir ağaç derinliğidir. Büyük bir DOM, bellek kullanımını artırarak daha uzun [stil hesaplamalarına](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), yol açabilir ve yüksek maliyetli [düzen yeniden düzenlemeleri](https://developers.google.com/speed/articles/reflow). [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 öğe}other{# öğe}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Aşırı büyük bir DOM boyutunu önler"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Hedef"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Performansı artırmak ve güvenlik açıklarını önlemek için harici bağlantılara `rel=\"noopener\"` veya `rel=\"noreferrer\"` ekleyin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Çapraz kökenli hedeflere bağlantılar güvenli değildir"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Çapraz kökenli hedeflere bağlantılar güvenli"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Bağlantı için hedef belirlenemedi ({anchorHTML}). Köprü olarak kullanılmadıysa target=_blank öğesini kaldırmayı değerlendirin."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Kullanıcılar herhangi bir bağlam olmadan konum bilgilerini isteyen sitelere şüpheyle bakarlar veya bu istek karşısında şaşırırlar. Onun yerine isteği bir kullanıcı işlemine bağlamayı değerlendirin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Sayfa yüklemede coğrafi konum izni istiyor"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Sayfa yüklemede coğrafi konum izni istemiyor"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Sürüm"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Sayfadaki tüm JavaScript kitaplıkları kullanıcı arabirimleri algılandı."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "JavaScript kitaplıkları algılandı"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "`document.write()` aracılığıyla dinamik olarak enjekte edilen harici komut dosyaları, yavaş bağlantıdaki kullanıcılar için sayfa yüklemeyi onlarca saniye geciktirebilir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "`document.write()` öğesini kullanıyor"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "`document.write()` öğesinden kaçınıyor"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "En Yüksek Önem Derecesi"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Kitaplık Sürümü"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Güvenlik Açığı Sayısı"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Bazı üçüncü taraf komut dosyaları, saldırganlar tarafından kolayca belirlenen ve istismar edilen bilinen güvenlik açıkları içerebilir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 güvenlik açığı algılandı}other{# güvenlik açığı algılandı}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Bilinen güvenlik açıklarına sahip JavaScript kitaplıkları kullanıcı arabirimi içeriyor"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Yüksek"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Düşük"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Orta"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Bilinen güvenlik açıklarına sahip JavaScript kitaplıkları kullanıcı arabirimini önlüyor"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Kullanıcılar herhangi bir bağlam olmadan bildirim göndermek isteyen sitelere şüpheyle bakarlar veya bu istek karşısında şaşırırlar. Onun yerine isteği kullanıcı hareketlerine bağlamayı değerlendirin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Sayfa yüklemede bildirim izni istiyor"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Sayfa yüklemede bildirim izni istemiyor"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Başarısız Öğeler"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Şifre yapıştırmanın engellenmesi, iyi güvenlik politikasına zarar verir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Kullanıcıların şifre alanlarına yapıştırmalarını önler"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Kullanıcıların şifre alanlarına yapıştırmalarına izin verir"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Protokol"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2, HTTP/1.1'e kıyasla ikili başlıklar, çoğullama ve sunucu push mesajları dahil olmak üzere birçok avantaj sunar. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 istek HTTP/2 üzerinden sunulmuyor}other{# istek HTTP/2 üzerinden sunulmuyor}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Tüm kaynakları için HTTP/2 kullanmıyor"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Kendi kaynakları için HTTP/2 kullanıyor"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Sayfanızın kaydırma performansını artırmak için dokunma ve ve tekerlek etkinliği işleyicilerini `passive` olarak işaretlemeyi değerlendirin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Kaydırma performansını artırmak için pasif işleyicileri kullanmıyor"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Kaydırma performansını artırmak için pasif işleyicileri kullanıyor"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Açıklama"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Konsola kaydedilen hatalar çözülmemiş problemleri belirtir Bunlar, ağ istek hatalarından ve diğer tarayıcı sorunlarından gelebilir."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Tarayıcı hataları konsola kaydedildi"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Konsola tarayıcı hatası kaydedilmedi"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "Web yazı tipleri yüklenirken kullanıcının metni görebilmesini sağlamak için yazı tipi görüntüleme CSS özelliğinden yararlanın. [Daha fazla bilgi](https://developers.google.com/web/updates/2016/02/font-display)."
   },
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Web yazı tipi yüklenirken tüm metin görünür halde kalır"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse, şu URL için yazı tipi görüntüleme değerini otomatik olarak kontrol edemedi: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "En Boy Oranı (Gerçek)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "En Boy Oranı (Görüntülenen)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Resim görüntüleme boyutları doğal en boy oranıyla eşleşmeli. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Yanlış en boy oranına sahip resimler görüntülüyor"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Resimleri doğru en boy oranıyla görüntülüyor"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Geçersiz resim boyutlandırma bilgileri {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Güvenli olmayan URL"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Tüm siteler (hassas veriler işlemeyenler dahi) HTTPS ile korunmalıdır . HTTPS, izinsiz kişilerin uygulamanızla kullanıcılarınız arasındaki iletişime müdahale etmelerine veya pasif olarak dinlemelerini önler ayrıca HTTP/2 ve birçok yeni web platformu için ön koşuldur. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Güvenli olmayan 1 istek bulundu}other{Güvenli olmayan # istek bulundu}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "HTTPS kullanmıyor"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "HTTPS kullanıyor"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Sayfaların hücresel ağ üzerinden hızlı bir şekilde yüklenmesi, mobil cihaz kullanıcılarının iyi bir deneyim yaşamalarını sağlar. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Sayfanın etkileşime hazır hale gelmesi {timeInMs, number, seconds} saniye sürdü"
+    "message": "Etkileşimli hale gelme süresi: {timeInMs, number, seconds} sn."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Sayfanın simüle mobil ağda etkileşime hazır hale gelmesi {timeInMs, number, seconds} saniye sürdü"
+    "message": "Sayfanın simüle mobil ağda etkileşime hazır hale gelmesi {timeInMs, number, seconds} sn. sürdü"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Sayfalar mobil ağlarda yeterince hızlı yüklenmiyor"
@@ -504,7 +735,7 @@
     "message": "Ana iş parçacığının çalışmasını en aza indirir"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Tahmini Giriş Gecikmesi, sayfa yüklemesinin en yoğun olduğu 5 saniyelik zaman aralığında uygulamanızın kullanıcı girişine kaç milisaniye içinde yanıt vereceğine dair bir tahmindir. Gecikmeniz 50 ms'nin üzerinde olursa kullanıcılar uygulamanızın durakladığını düşünebilir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Tahmini Giriş Gecikmesi, sayfa yüklemesinin en yoğun olduğu 5 saniyelik zaman aralığında uygulamanızın kullanıcı girişine kaç milisaniye içinde yanıt vereceğine dair bir tahmindir. Gecikmeniz 50 ms.nin üzerinde olursa kullanıcılar uygulamanızın durakladığını düşünebilir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Tahmini Giriş Gecikmesi"
@@ -522,7 +753,7 @@
     "message": "İlk CPU Boşta"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "İlk Anlamlı Boya, bir sayfanın ana içeriğinin ne zaman görünür hale geldiğini ölçer. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "İlk Anlamlı Boyama, bir sayfanın ana içeriğinin ne zaman görünür hale geldiğini ölçer. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "İlk Anlamlı Boya"
@@ -534,16 +765,22 @@
     "message": "Etkileşim Süresi"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Kullanıcılarınızın karşılaşabileceği olası İlk Giriş Gecikmesi, en uzun görevin milisaniye cinsinden süresidir."
+    "message": "Kullanıcılarınızın karşılaşabileceği olası maksimum İlk Giriş Gecikmesi, en uzun görevin milisaniye cinsinden süresidir. [Daha fazla bilgi](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
     "message": "Maksimum Olası İlk Giriş Gecikmesi"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Hız İndeksi, bir sayfa içeriğinin görsel olarak ne kadar hızlı doldurulabildiğini gösterir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Hız Endeksi, bir sayfa içeriğinin görsel olarak ne kadar hızlı doldurulabildiğini gösterir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Hız İndeksi"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Görev süresi 50 ms.yi aştığında, FCP ile Etkileşime Hazır Olma Süresi arasındaki tüm dönemlerin milisaniye cinsinden toplamı."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Toplam Engellenme Süresi"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "Ağ gidiş dönüş sürelerinin (RTT) performans üzerinde büyük bir etkisi vardır. Kaynağa RTT'nin fazla olması, kullanıcıya daha yakın olan sunucuların performansı iyileştirebileceğinin göstergesidir. [Daha fazla bilgi](https://hpbn.co/primer-on-latency-and-bandwidth/)."
@@ -557,26 +794,47 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Sunucunun Arka Uç Gecikmeleri"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Bütçe Aşımı"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Ağ isteklerinin miktarını ve büyüklüğünü, performans bütçesi tarafından belirlenen hedeflerin altında tutun. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 istek}other{# istek}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Performans bütçesi"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "Yönlendirmeler, sayfanın yüklenmesinden önce ek gecikmelere neden olur. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Birden çok sayfa yönlendirmesini önleyin"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Sayfa kaynaklarının miktarı ve büyüklüğü için bütçeler belirlemek üzere bir budget.json dosyası ekleyin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 istek}other{# istek}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "İstek sayısını az ve aktarma boyutlarını küçük tutun"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Standart bağlantılar, arama sonuçlarında hangi URL'nin gösterileceğini belirtir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Birden fazla çakışan URL ({urlList}) var"
+    "message": "Birden fazla çakışan URL ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Farklı bir alan adına ({url}) yönlendiriyor"
+    "message": "Farklı bir alan adına yönlendiriyor ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Geçersiz URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Başka bir \"hreflang\" konumuna ({url}) yönlendiriyor"
+    "message": "Başka bir `hreflang` konumuna ({url}) yönlendiriyor"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Göreli URL ({url})"
@@ -585,19 +843,16 @@
     "message": "İçeriğe eşdeğer bir sayfanın yerine alan adının kök URL'sine (ana sayfa) yönlendiriyor"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Doküman geçerli bir \"rel=canonical\" değeri içermiyor"
+    "message": "Doküman geçerli bir `rel=canonical` değeri içermiyor"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Doküman geçerli bir \"rel=canonical\" değeri içeriyor"
+    "message": "Doküman geçerli bir `rel=canonical` öğesi içeriyor"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "12 pikselden küçük yazı tipi boyutları okunamayacak kadar küçüktür ve mobil cihaz kullanıcılarının içeriği okuyabilmek için parmaklarıyla sıkıştırma hareketi yaparak yakınlaştırmalarını gerektirir. Sayfanın %60'ından fazlasının en az 12 piksel boyutunda olmasını sağlamaya çalışın. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} kadar okunabilir metin"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "Metnin {decimalProportion, number, extendedPercent} kadarı çok küçük."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Mobil ekranlar için optimize edilmiş görüntü alanı meta etiketi olmadığından metin okunaklı değil."
@@ -615,10 +870,10 @@
     "message": "hreflang bağlantıları, arama motorlarına, belirli bir dildeki veya bölgedeki arama sonuçlarında bir sayfanın hangi sürümünün listeleneceğini bildirir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Doküman geçerli bir \"hreflang\" öğesi içermiyor"
+    "message": "Doküman geçerli bir `hreflang` öğesi içermiyor"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Doküman geçerli bir \"hreflang\" öğesi içeriyor"
+    "message": "Doküman geçerli bir `hreflang` öğesi içeriyor"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "Başarısız HTTP durum kodlarına sahip olan sayfalar düzgün bir şekilde dizine eklenmeyebilir. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
@@ -651,7 +906,7 @@
     "message": "Bağlantılar açıklayıcı metin içeriyor"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Yapılandırılmış verileri doğrulamak için [Yapılandırılmış Veri Test Aracı]'nı (https://search.google.com/structured-data/testing-tool/) ve [Structured Data Linter]'ı (http://linter.structured-data.org/) çalıştırın. [Daha fazla bilgi](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Yapılandırılmış verileri doğrulamak için [Yapılandırılmış Veri Test Aracı](https://search.google.com/structured-data/testing-tool/)'nı ve [Structured Data Linter](http://linter.structured-data.org/)'ı çalıştırın. [Daha fazla bilgi](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Yapılandırılmış veriler geçerli"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Çakışan Hedef"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Boyut"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Dokunma Hedefi"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Dokunma hedefleri uygun boyutta"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Ana İş Parçacığı Süresi"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Üçüncü Taraf"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Üçüncü taraf kodu, yükleme performansını önemli ölçüde etkileyebilir. Yedekli üçüncü taraf sağlayıcıların sayısını sınırlayın ve öncelikle sayfanızın yüklenmesi tamamlandıktan sonra üçüncü taraf kodunu yükleyin. [Daha fazla bilgi](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 Adet Üçüncü Taraf Bulundu}other{# Adet Üçüncü Taraf Bulundu}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Üçüncü Taraf Kullanımı"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "İlk Bayt Zamanı, sunucunuzun bir yanıt gönderme zamanını tanımlar. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "İlk Bayt Zamanı, sunucunuzun yanıt gönderme zamanını tanımlar. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "Root dokümanı {timeInMs, number, milliseconds} ms sürdü"
+    "message": "Root doküman {timeInMs, number, milliseconds} ms. sürdü"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "Sunucu yanıt sürelerini kısaltın (TTFB)"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Süre"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Ad"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Başlangıç Zamanı"
@@ -753,7 +1017,7 @@
     "message": "Kullanıcı Zamanlaması işaretleri ve ölçüleri"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "\"{securityOrigin}\" için bir önceden bağlanma <link> bulundu ancak tarayıcı tarafından kullanılmadı. \"crossorigin\" özelliğini gerektiği gibi kullandığınızdan emin olun."
+    "message": "\"{securityOrigin}\" için bir önceden bağlanma <link> öğesi bulundu ancak tarayıcı tarafından kullanılmadı. `crossorigin` özelliğini gerektiği gibi kullandığınızdan emin olun."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "Önemli üçüncü taraf kaynaklarına erken bağlantılar oluşturmak için önceden bağlanma veya DNS önceden getirme kaynak ipuçları ekleme seçeneğini değerlendirin. [Daha fazla bilgi](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
@@ -762,10 +1026,10 @@
     "message": "Gerekli kaynaklara önceden bağlan"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "\"{preloadURL}\" için bir önceden yükleme <link> bulundu ancak tarayıcı tarafından kullanılmadı. \"crossorigin\" özelliğini gerektiği gibi kullandığınızdan emin olun."
+    "message": "\"{preloadURL}\" için bir önceden yükleme <link> bulundu ancak tarayıcı tarafından kullanılmadı. `crossorigin` özelliğini gerektiği gibi kullandığınızdan emin olun."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Şu anda istenen kaynakları sayfa yüklemenin sonraki aşamalarında getirmeye öncelik tanımak için <link rel=preload> öğesini kullanma seçeneğini değerlendirin. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Mevcut durumda sayfa yüklemesinden sonra istenen kaynakları daha önce getirmek için `<link rel=preload>` kullanmayı düşünün. [Daha fazla bilgi](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Önemli istekleri önceden yükleyin"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tablolar ve listeler"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "En İyi Uygulamalar"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Performans bütçeleri, sitenizin performansı için standartları belirler."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Bütçeler"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Uygulamanızın performansı hakkında daha fazla bilgi."
+    "message": "Uygulamanızın performansı hakkında daha fazla bilgi. Bu sayılar Performan skoruna [doğrudan etki](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) etmezler."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Teşhis"
@@ -840,7 +1113,7 @@
     "message": "İlk Boya İyileştirmeleri"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Bu optimizasyonlar, sayfanızın yüklenmesini hızlandırabilir."
+    "message": "Bu öneriler, sayfanızın daha hızlı yüklenmesine yardımcı olabilir. Performan skoruna [doğrudan etki](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) etmezler."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Fırsatlar"
@@ -888,7 +1161,7 @@
     "message": "Tarama ve Dizine Ekleme"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Kullanıcıların sayfadaki içerikleri okumak üzere sıkıştırma hareketi yapmak veya yakınlaştırmak zorunda kalmamaları için sayfalarınızın mobil uyumlu olduğundan emin olun. [Daha fazla bilgi](https://developers.google.com/search/mobile-sites/)."
+    "message": "Kullanıcıların küçültme veya yakınlaştırma hareketi yapmadan sayfadaki içerikleri okuyabilmelerini sağlamak için sayfalarınızın mobil uyumlu olduğundan emin olun. [Daha fazla bilgi](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Mobil Uyumlu"
@@ -896,35 +1169,77 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL'yi Önbelleğe Alma"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Konum"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Ad"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "İstek Sayısı"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Kaynak Türü"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Boyut (KB)"
+    "message": "Boyut"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Harcanan Süre"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Aktarım Boyutu"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Potansiyel Tasarruflar (KB)"
+    "message": "Potansiyel Tasarruflar"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Potansiyel Tasarruf (ms)"
+    "message": "Potansiyel Tasarruflar"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "{wastedBytes, number, bytes} KB potansiyel tasarruf"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "{wastedMs, number, milliseconds} ms potansiyel tasarruf"
+    "message": "{wastedMs, number, milliseconds} ms. potansiyel tasarruf"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Doküman"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Yazı tipi"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Resim"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Medya"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds} ms"
+    "message": "{timeInMs, number, milliseconds} ms."
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Diğer"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Komut dosyası"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} sn."
   },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Stil Sayfası"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Üçüncü taraf"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Toplam"
+  },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Sayfa yüklemenizin üzerine iz kaydedilirken bir sorun oluştu. Lütfen Lighthouse'u tekrar çalıştırın. ({errorCode})"
+    "message": "Sayfa yüklemenizin izlemesi kaydedilirken bir sorun oluştu. Lütfen Lighthouse'u tekrar çalıştırın. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "İlk Hata Ayıklayıcı Protokolü bağlantısı beklenirken zaman aşımı oluştu."
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS sunucuları sağlanan alan adını çözümleyemedi."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Zorunlu {artifactName} toplayıcı bir hatayla karşılaştı: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Dahili bir Chrome hatası oluştu. Lütfen Chrome'u yeniden başlatıp Lighthouse'u tekrar çalıştırmayı deneyin."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Zorunlu {artifactName} toplayıcı çalışmadı."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse istediğiniz sayfayı güvenli bir şekilde yükleyemedi. Doğru URL'yi test ettiğinizden ve sunucunun tüm isteklere gerektiği gibi yanıt verdiğinden emin olun."
@@ -945,10 +1266,13 @@
     "message": "Sayfa yanıt vermeyi durdurduğu için Lighthouse istediğiniz URL'yi güvenli bir şekilde yükleyemedi."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Sağladığınız URL, geçerli güvenlik kimlik bilgilerine sahip değil. {securityMessages}"
+    "message": "Sağladığınız URL, geçerli güvenlik sertifikasına sahip değil. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome bir geçiş reklamıyla sayfa yüklemesini önledi. Doğru URL'yi test ettiğinizden ve sunucunun tüm isteklere gerektiği gibi yanıt verdiğinden emin olun."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Lighthouse, istediğiniz sayfayı güvenli bir şekilde yükleyemedi. Doğru URL'yi test ettiğinizden ve sunucunun tüm isteklere gerektiği gibi yanıt verdiğinden emin olun. (Ayrıntılar: {errorDetails})"
+    "message": "Lighthouse istediğiniz sayfayı güvenli bir şekilde yükleyemedi. Doğru URL'yi test ettiğinizden ve sunucunun tüm isteklere gerektiği gibi yanıt verdiğinden emin olun. (Ayrıntılar: {errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
     "message": "Lighthouse istediğiniz sayfayı güvenli bir şekilde yükleyemedi. Doğru URL'yi test ettiğinizden ve sunucunun tüm isteklere gerektiği gibi yanıt verdiğinden emin olun. (Durum kodu: {statusCode})"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Snippet'i genişlet"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "3. taraf kaynaklarını göster"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Şu Lighthouse çalışmasını etkileyen sorunlar vardı:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Değerler tahminidir ve değişiklik gösterebilir."
+    "message": "Değerler tahminidir ve değişiklik gösterebilir. Performans skoru [sadece bu metriklere dayanır](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Kontrollerden geçti, ancak uyarılar var"
@@ -1023,7 +1350,7 @@
     "message": "GIF dosyanızı, HTML5 videosu olarak katıştırmak için kullanılabilmesini sağlayacak bir hizmete yüklemeyi düşünün."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Ekran dışı görüntüleri erteleme veya bu işlevselliği sağlayan bir temaya geçiş yapma olanağı veren bir [WordPress geç yükleme (lazy-load) eklentisi](https://wordpress.org/plugins/search/lazy+load/) yükleyin. Ayrıca [AMP eklentisini](https://wordpress.org/plugins/amp/) kullanmayı da düşünün."
+    "message": "Ekran dışı görüntüleri erteleme veya bu işlevselliği sağlayan bir temaya geçiş yapma olanağı veren bir [WordPress geç yükleme (lazy-load) eklentisi](https://wordpress.org/plugins/search/lazy+load/) yükleyin. Ayrıca [AMP eklentisini](https://wordpress.org/plugins/amp/) kullanmayı da değerlendirin."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "[Kritik öğeleri satır içi yapmanıza](https://wordpress.org/plugins/search/critical+css/) veya [daha az önemli kaynakları ertelemenize](https://wordpress.org/plugins/search/defer+css+javascript/) yardımcı olabilecek çeşitli WordPress eklentileri vardır. Bu eklentilerin sağlayacağı optimizasyonların tema veya eklentilerinizin özelliklerini bozabileceğine dikkat edin. Bunu engellemek için muhtemelen kodda değişiklik yapmanız gerekecektir."
@@ -1035,30 +1362,30 @@
     "message": "Yayın listelerinizde alıntılar göstermeyi (ör. daha fazla etiket kullanarak), belirli bir sayfada gösterilen yayınların sayısını azaltmayı, uzun yayınlarınızı birden fazla sayfaya bölmeyi veya yorumların geç yüklenmesi için bir eklenti kullanmayı düşünün."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Çeşitli [WordPress eklentileri](https://wordpress.org/plugins/search/minify+css/) stillerinizi sıralayarak, küçülterek ve sıkıştırarak sitenizi hızlandırabilir. Ayrıca mümkünse bu sadeleştirmeyi yapmak için bir derleme işlemi kullanmak isteyebilirsiniz."
+    "message": "Çeşitli [WordPress eklentileri](https://wordpress.org/plugins/search/minify+css/) stillerinizi sıralayarak, küçülterek ve sıkıştırarak sitenizi hızlandırabilir. Ayrıca mümkünse bu küçültme yapmak için bir derleme işlemi kullanmak isteyebilirsiniz."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Çeşitli [WordPress eklentileri](https://wordpress.org/plugins/search/minify+javascript/), komut dosyalarınızı sıralayarak, küçülterek ve sıkıştırarak sitenizi hızlandırabilir. Ayrıca mümkünse bu sadeleştirmeyi yapmak için bir derleme işlemi kullanmak isteyebilirsiniz."
+    "message": "Çeşitli [WordPress eklentileri](https://wordpress.org/plugins/search/minify+javascript/) komut dosyalarınızı sıralayarak, küçülterek ve sıkıştırarak sitenizi hızlandırabilir. Ayrıca mümkünse bu sadeleştirmeyi yapmak için bir derleme işlemi kullanmak isteyebilirsiniz."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Sayfanızda kullanılmayan CSS'leri yükleyen [WordPress eklentilerinin](https://wordpress.org/plugins/) sayısını azaltmayı veya değiştirmeyi düşünün. Gereksiz CSS yükleyen eklentileri belirlemek için Chrome DevTools'da [kod kapsamını](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) çalıştırmayı düşünün. Sorumlu temayı/eklentiyi stil sayfasının URL'sinden belirleyebilirsiniz. Listede çok sayıda stil sayfasına sahip olan ve kod kapsamında çok sayıda kırmızı işaret taşıyan eklentileri arayın. Bir eklenti sadece sayfada gerçekten kullanılan bir stil sayfasını kuyruğa almalıdır."
+    "message": "Sayfanızda kullanılmayan CSS'ler yükleyen [WordPress eklentilerinin](https://wordpress.org/plugins/) sayısını azaltmayı veya değiştirmeyi düşünün. Gereksiz CSS ekleyen eklentileri belirlemek için Chrome Geliştirme Araçlarında [kod kapsamını](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) çalıştırmayı deneyin. Sorumlu temayı/eklentiyi stil sayfasının URL'sinden belirleyebilirsiniz. Listede çok sayıda stil sayfasına sahip olan ve kod kapsamında çok sayıda kırmızı işaret taşıyan eklentileri arayın. Bir eklenti sadece sayfada gerçekten kullanılan bir stil sayfasını kuyruğa almalıdır."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Sayfanızda kullanılmayan JavaScript'ler yükleyen [WordPress eklentilerinin](https://wordpress.org/plugins/) sayısını azaltmayı veya değiştirmeyi düşünün. Gereksiz JS ekleyen eklentileri belirlemek için Chrome DevTools'da [kod kapsamını](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) çalıştırmayı düşünün. Sorumlu temayı/eklentiyi komut dosyasının URL'sinden belirleyebilirsiniz. Listede çok sayıda komut dosyasına sahip olan ve kod kapsamında çok sayıda kırmızı işaret taşıyan eklentileri arayın. Bir eklenti sadece sayfada gerçekten kullanılan bir komut dosyasını kuyruğa almalıdır."
+    "message": "Sayfanızda kullanılmayan JavaScript'ler yükleyen [WordPress eklentilerinin](https://wordpress.org/plugins/) sayısını azaltmayı veya değiştirmeyi değerlendirin. Gereksiz JS ekleyen eklentileri belirlemek için Chrome Geliştirme Araçlarında [kod kapsamını](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) çalıştırmayı düşünün. Sorumlu temayı/eklentiyi komut dosyasının URL'sinden belirleyebilirsiniz. Listede çok sayıda komut dosyasına sahip olan ve kod kapsamında çok sayıda kırmızı işaret taşıyan eklentileri arayın. Bir eklenti sadece sayfada gerçekten kullanılan bir komut dosyasını kuyruğa almalıdır."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "[WordPress'te Tarayıcı Önbelleği] (https://codex.wordpress.org/WordPress_Optimization#Browser_Caching) ile ilgili bilgi edinin."
+    "message": "[WordPress'te Tarayıcı Önbelleği](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching) ile ilgili bilgi edinin."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Kaliteden ödün vermeden resimlerinizi sıkıştıran bir [resim optimizasyonu WordPress eklentisi] (https://wordpress.org/plugins/search/optimize+images/) kullanmayı düşünün."
+    "message": "Kaliteden ödün vermeden resimlerinizi sıkıştıran bir [resim optimizasyonu WordPress eklentisi](https://wordpress.org/plugins/search/optimize+images/) kullanmayı değerlendirin."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Gerekli resim boyutlarının kullanılabilmesi için resimleri doğrudan [medya kitaplığından](https://codex.wordpress.org/Media_Library_Screen) yükleyin, ardından ideal resim boyutlarının kullanıldığından (esnek ayrılma noktası için olanlar dahil) emin olmak için resimleri medya kitaplığından ekleyin veya resim widget'ını kullanın. Boyutları kullanım için yeterli değilse \"Tam Boy\" resimler kullanmaktan kaçının. [Daha Fazla Bilgi](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Gerekli resim boyutlarının kullanılabilmesi için resimleri doğrudan [medya kitaplığından](https://codex.wordpress.org/Media_Library_Screen) yükleyin, ardından ideal resim boyutlarının kullanıldığından (esnek ayrılma noktası için olanlar dahil) emin olmak için resimleri medya kitaplığından ekleyin veya resim widget'ını kullanın. Boyutları kullanım için yeterli değilse `Full Size` resimler kullanmaktan kaçının. [Daha fazla bilgi](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Web sunucunuzun yapılandırmasında metin sıkıştırmayı etkinleştirebilirsiniz."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Yüklediğiniz resimleri ideal biçimlere otomatik olarak dönüştürecek bir [eklenti](https://wordpress.org/plugins/search/convert+webp/) veya hizmet kullanmayı düşünün."
+    "message": "Yüklediğiniz resimleri ideal biçimlere otomatik olarak dönüştürecek bir [eklenti](https://wordpress.org/plugins/search/convert+webp/) veya hizmet kullanmayı değerlendirin."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/uk.json
+++ b/lighthouse-core/lib/i18n/locales/uk.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Завдяки ключам доступу користувачі можуть швидко виділити частину сторінки. Щоб забезпечити належну навігацію, кожний ключ доступу має бути унікальний. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Ключі доступу дають змогу швидко виділяти частину сторінки. Для належної навігації кожний ключ доступу має бути унікальним. [Докладніше](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Значення [accesskey] неунікальні"
+    "message": "Значення `[accesskey]` неунікальні"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Значення [accesskey] унікальні"
+    "message": "Значення `[accesskey]` унікальні"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Кожна роль ARIA підтримує конкретний набір атрибутів aria-*. Якщо вони не збігаються, атрибути aria-* стають недійсні. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Кожна `role` ARIA підтримує конкретний набір атрибутів `aria-*`. Якщо вони не збігаються, атрибути `aria-*` стають недійсними. [Докладніше](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Атрибути [aria-*] не відповідають своїм ролям"
+    "message": "Атрибути `[aria-*]` не відповідають своїм ролям"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Атрибути [aria-*] відповідають своїм ролям"
+    "message": "Атрибути `[aria-*]` відповідають своїм ролям"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Деякі ролі ARIA мають обов’язкові атрибути, що описують стан елемента для програм зчитування з екрана. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Деякі ролі ARIA мають обов'язкові атрибути, що описують стан елемента для програм зчитування з екрана. [Докладніше](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "Ролі [role] не мають усіх обов’язкових атрибутів [aria-*]"
+    "message": "Ролі `[role]` не мають усіх обов'язкових атрибутів `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "Ролі [role] мають усі обов’язкові атрибути [aria-*]"
+    "message": "Ролі `[role]` мають усі потрібні атрибути `[aria-*]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Щоб виконувати потрібні функції спеціальних можливостей, деякі батьківські ролі ARIA повинні містити відповідні дочірні ролі. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Щоб виконувати потрібні функції спеціальних можливостей, деякі батьківські ролі ARIA повинні містити відповідні дочірні ролі. [Докладніше](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Немає елементів із роллю [role], які вимагають наявності конкретної дочірньої ролі [role]."
+    "message": "Відсутні елементи з роллю `[role]`, які вимагають наявності конкретних дочірніх ролей `[role]`."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Присутні елементи з роллю [role], які вимагають наявності конкретних дочірніх ролей [role]"
+    "message": "Присутні елементи з роллю `[role]`, які вимагають наявності конкретних дочірніх ролей `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Щоб належно виконувати потрібні функції спеціальних можливостей, відповідні батьківські ролі повинні містити деякі дочірні ролі ARIA. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Щоб належно виконувати потрібні функції спеціальних можливостей, відповідні батьківські ролі повинні містити деякі дочірні ролі ARIA. [Докладніше](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "Ролі [role] не містяться в обов’язковому батьківському елементі"
+    "message": "Ролі `[role]` не містяться в обов'язковому батьківському елементі"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "Ролі [role] містяться у відповідному батьківському елементі"
+    "message": "Ролі `[role]` містяться у відповідному батьківському елементі"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Щоб належно виконувати функції спеціальних можливостей, ролі ARIA повинні мати дійсні значення. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Щоб належно виконувати функції спеціальних можливостей, ролі ARIA повинні мати дійсні значення. [Докладніше](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Значення [role] недійсні"
+    "message": "Значення `[role]` недійсні"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Значення [role] дійсні"
+    "message": "Значення `[role]` дійсні"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Допоміжні технології, як-от програми зчитування з екрана, не можуть тлумачити атрибути ARIA з недійсними значеннями. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Допоміжні технології, як-от програми зчитування з екрана, не можуть тлумачити атрибути ARIA з недійсними значеннями. [Докладніше](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Атрибути [aria-*] не мають дійсних значень"
+    "message": "Атрибути `[aria-*]` не мають дійсних значень"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "Атрибути [aria-*] мають дійсні значення"
+    "message": "Атрибути `[aria-*]` мають дійсні значення"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Допоміжні технології, як-от програми зчитування з екрана, не можуть тлумачити атрибути ARIA з недійсними назвами. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Допоміжні технології, як-от програми зчитування з екрана, не можуть тлумачити атрибути ARIA з недійсними назвами. [Докладніше](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Атрибути [aria-*] недійсні або написані неправильно"
+    "message": "Атрибути `[aria-*]` недійсні або написані неправильно"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Атрибути [aria-*] дійсні та написані правильно"
+    "message": "Атрибути `[aria-*]` дійсні та написані правильно"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Субтитри роблять звукові елементи ефективнішими для користувачів із глухотою та вадами слуху, зокрема надають важливу інформацію про те, хто та що говорить, а також інші не пов’язані з мовленням деталі. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Субтитри роблять звукові елементи ефективнішими для користувачів із вадами слуху, зокрема надають важливу інформацію про те, хто й що говорить, а також інші непов'язані з мовленням деталі. [Докладніше](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Елементи <audio> не містять елемента <track> з атрибутом [kind=\"captions\"]."
+    "message": "Елементи `<audio>` не містять елемент `<track>` з атрибутом `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Елементи <audio> містять елемент <track> з атрибутом [kind=\"captions\"]"
+    "message": "Елементи `<audio>` містять елемент `<track>` з атрибутом `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Елементи, що не пройшли перевірку"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Коли кнопка не має доступної для зчитування назви, програми зчитування з екрана озвучують її словом \"кнопка\", через що вона стає непридатною для користувачів таких програм. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Коли кнопка не має зрозумілої назви, програми зчитування з екрана озвучують її словом \"кнопка\", через що вона стає непридатною для користувачів. [Докладніше](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Кнопки не мають доступних для зчитування назв"
@@ -93,7 +93,7 @@
     "message": "Кнопки мають доступну для зчитування назву"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Якщо додати способи обходу вмісту, що повторюється, користувачам буде простіше переходити між елементами на сторінці за допомогою клавіатури. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Якщо додати способи обходу вмісту, що повторюється, користувачам буде простіше переходити між елементами на сторінці за допомогою клавіатури. [Докладніше](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Сторінка не містить заголовка, посилання для пропуску вмісту чи мітки області"
@@ -102,7 +102,7 @@
     "message": "Сторінка містить заголовок, посилання для пропуску вмісту чи мітку області"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Для багатьох користувачів складно або неможливо читати текст із низькою контрастністю. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Для багатьох користувачів складно або неможливо читати текст із низькою контрастністю. [Докладніше](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Між кольорами фону та переднього плану недостатній коефіцієнт контрастності."
@@ -111,88 +111,88 @@
     "message": "Між кольорами фону та переднього плану достатній коефіцієнт контрастності"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Коли списки визначень мають неправильну розмітку, вихідні дані програм зчитування з екрана можуть бути незрозумілі або неточні. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Коли списки визначень мають неправильну розмітку, програми зчитування з екрана можуть генерувати незрозумілі або неточні дані. [Докладніше](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "Списки визначення <dl> містять не лише належно впорядковані групи <dt> та <dd> чи елементи <script> або <template>."
+    "message": "Списки визначення `<dl>` містять не лише належно впорядковані групи `<dt>` і `<dd>` чи елементи `<script>` або `<template>`."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "Списки визначень <dl> містять лише належно впорядковані групи <dt> та <dd>, а також елементи <script> або <template>."
+    "message": "Списки визначення `<dl>` містять лише належно впорядковані групи `<dt>` та `<dd>` чи елементи `<script>` або `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Щоб програми зчитування з екрана правильно озвучували елементи списку визначень (<dt> і <dd>), елементи має бути згруповано в батьківському елементі <dl>. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Щоб програми зчитування з екрана правильно озвучували елементи списку визначень (`<dt>` і `<dd>`), елементи має бути згруповано в батьківському елементі `<dl>`. [Докладніше](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "Елементи списку визначень не згруповано в елементах <dl>"
+    "message": "Елементи списку визначень не згруповано в елементах `<dl>`"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Елементи списку визначень згруповано в елементах <dl>"
+    "message": "Елементи списку визначень згруповано в елементах `<dl>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Завдяки назві користувачі програми зчитування з екрана дізнаються загальну інформацію про сторінку, а користувачі пошукових систем визначають, чи сторінка відповідає їхньому запиту. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Завдяки назві користувачі програми зчитування з екрана дізнаються загальну інформацію про сторінку, а користувачі пошукових систем визначають, чи сторінка відповідає їхньому запиту. [Докладніше](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "Документ не має елемента <title>"
+    "message": "Документ не має елемента `<title>`"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "Документ має елемент <title>"
+    "message": "Документ містить елемент `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Значення атрибута ідентифікатора має бути унікальним, щоб допоміжні технології не пропускали інші копії. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Значення атрибута ідентифікатора має бути унікальним, щоб допоміжні технології не пропускали інші копії. [Докладніше](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Атрибути [id] на сторінці неунікальні"
+    "message": "Атрибути `[id]` на сторінці неунікальні"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Атрибути [id] на сторінці унікальні"
+    "message": "Атрибути `[id]` на сторінці унікальні"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Користувачі програм зчитування з екрана використовують назви фреймів, щоб дізнатися їх вміст. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Користувачі програм зчитування з екрана використовують назви фреймів, щоб дізнатися їх вміст. [Докладніше](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Елементи <frame> або <iframe> не мають назви"
+    "message": "Елементи `<frame>` або `<iframe>` не мають назви"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "Елементи <frame> або <iframe> мають назву"
+    "message": "Елементи `<frame>` або `<iframe>` мають назву"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Якщо для сторінки не вказано атрибут мови, програма зчитування з екрана припускає, що мовою сторінки є мова за умовчанням, яку користувач вибрав під час налаштування програми зчитування. Якщо насправді мова сторінки інша, програма зчитування з екрана може неправильно озвучувати текст на сторінці. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Якщо для сторінки не вказано атрибут мови, програма зчитування з екрана припускає, що мовою сторінки є мова за умовчанням, яку користувач вибрав під час налаштування програми зчитування. Якщо насправді мова сторінки інша, програма зчитування з екрана може неправильно озвучувати текст на сторінці. [Докладніше](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Елемент <html> не має атрибута [lang]"
+    "message": "Елемент `<html>` не має атрибута `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Елемент <html> має атрибут [lang]"
+    "message": "Елемент `<html>` містить атрибут `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Визначення дійсного тегу мови [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) допоможе програмам зчитування з екрана правильно озвучувати текст. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Якщо указати дійсний тег мови за [стандартом BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), це допоможе програмі зчитування з екрана правильно озвучувати текст. [Докладніше](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Елемент <html> не має дійсного значення для свого атрибута [lang]."
+    "message": "Елемент `<html>` не містить дійсного значення для атрибута `[lang]`."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Елемент <html> має дійсне значення для свого атрибута [lang]"
+    "message": "Елемент `<html>` має дійсне значення атрибута `[lang]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Інформативні елементи повинні містити короткий, описовий альтернативний текст. Декоративні елементи можуть ігноруватись і мати порожній атрибут alt. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Інформативні елементи повинні містити короткий, описовий альтернативний текст. Декоративні елементи можуть ігноруватись і мати порожній атрибут alt. [Докладніше](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Елементи зображення не мають атрибутів [alt]"
+    "message": "Елементи зображення не мають атрибутів `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "Елементи зображення мають атрибути [alt]"
+    "message": "Елементи зображення мають атрибути `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Коли зображення використовується як кнопка <input>, додавши альтернативний текст, ви допоможете користувачам програм зчитування з екрана зрозуміти призначення кнопки. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Коли зображення використовується як кнопка `<input>`, додавши альтернативний текст, ви допоможете користувачам програм зчитування з екрана зрозуміти призначення кнопки. [Докладніше](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "Елементи <input type=\"image\"> не мають тексту [alt]"
+    "message": "Елементи `<input type=\"image\">` не містять текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "Елементи <input type=\"image\"> мають текст [alt]"
+    "message": "Елементи `<input type=\"image\">` містять текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Завдяки міткам допоміжні технології, як-от програми зчитування з екрана, правильно озвучують елементи керування формою. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Завдяки міткам допоміжні технології, як-от програми зчитування з екрана, правильно озвучують елементи керування формою. [Докладніше](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Елементи форми не мають пов’язаних міток"
@@ -201,16 +201,16 @@
     "message": "Елементи форми мають пов’язані мітки"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Таблиця, яка використовується як макет, не повинна містити елементів даних, як-от елементів th або caption чи атрибут summary, оскільки це може спантеличити користувачів програм зчитування з екрана. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Таблиця, яка використовується як макет, не повинна містити елементів даних, як-от елементів th або caption чи атрибут summary, оскільки це може спантеличити користувачів програм зчитування з екрана. [Докладніше](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "Презентаційні елементи <table> використовують атрибути <th>, <caption> чи [summary]."
+    "message": "Презентаційні елементи `<table>` використовують атрибути `<th>`, `<caption>` або `[summary]`."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "Презентаційні елементи <table> не використовують атрибути <th>, <caption> або [summary]."
+    "message": "Презентаційні елементи `<table>` не використовують атрибути `<th>`, `<caption>` або `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Унікальний і доступний для виділення текст посилання (а також альтернативний текст для зображень, коли вони використовуються як посилання), який можна розпізнати, покращує навігацію для користувачів програм зчитування з екрана. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Унікальний і доступний для виділення текст посилання (а також альтернативний текст для зображень, коли вони використовуються як посилання), який можна розпізнати, покращує навігацію для користувачів програм зчитування з екрана. [Докладніше](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Посилання не мають назв, які можна розпізнати"
@@ -219,103 +219,115 @@
     "message": "Посилання мають назви, які можна розпізнати"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Програми зчитування з екрана озвучують списки в особливий спосіб. Правильна структура списків допомагає таким програмам зчитувати інформацію. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Програми зчитування з екрана озвучують списки в особливий спосіб. Правильна структура списків допомагає таким програмам правильно розпізнавати інформацію. [Докладніше](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Списки містять не лише елементи <li> й елементи для підтримки виконання сценарію (<script> і <template>)."
+    "message": "Списки не містять лише елементи `<li>` і елементи для підтримки виконання сценарію (`<script>` та `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Списки містять лише елементи <li> й елементи для підтримки виконання сценарію (<script> і <template>)."
+    "message": "Списки містять лише елементи `<li>` й елементи для підтримки виконання сценарію (`<script>` і `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Щоб програми зчитування з екрана правильно озвучували елементи списку (<li>), ці елементи повинні міститися в батьківських елементах <ul> або <ol>. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Щоб програми зчитування з екрана правильно озвучували елементи списку (`<li>`), ці елементи повинні міститися в батьківських елементах `<ul>` або `<ol>`. [Докладніше](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Елементів списку (<li>) немає в батьківських елементах <ul> або <ol>."
+    "message": "Елементів списку (`<li>`) немає в батьківських елементах `<ul>` або `<ol>`."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Елементи списку (<li>) містяться в батьківських елементах <ul> або <ol>"
+    "message": "Елементи списку (`<li>`) містяться в батьківських елементах `<ul>` або `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Користувачі не очікують, що сторінка оновлюватиметься автоматично. Таке оновлення перемістить фокус назад угору сторінки. Це може роздратувати або спантеличити користувачів. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Користувачі не очікують, що сторінка оновлюватиметься автоматично. Таке оновлення перемістить фокус назад угору сторінки. Це може роздратувати або спантеличити користувачів. [Докладніше](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "Документ використовує метатег <meta http-equiv=\"refresh\">"
+    "message": "Документ використовує `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Документ не використовує метатег <meta http-equiv=\"refresh\">"
+    "message": "Документ не використовує тег `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Вимкнення масштабування створює проблеми для користувачів із поганим зором, які збільшують екран, щоб краще бачити вміст веб-сторінки. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Якщо вимкнути масштабування, користувачі з поганим зором не зможуть збільшити екран, щоб краще бачити вміст веб-сторінки. [Докладніше](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "Параметр [user-scalable=\"no\"] використовується в елементі <meta name=\"viewport\"> або атрибут [maximum-scale] менший ніж 5."
+    "message": "Параметр `[user-scalable=\"no\"]` використовується в елементі `<meta name=\"viewport\">` або атрибут `[maximum-scale]` менший за 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "Параметр [user-scalable=\"no\"] не використовується в елементі <meta name=\"viewport\">, а атрибут [maximum-scale] перевищує 5."
+    "message": "Параметр `[user-scalable=\"no\"]` не використовується в елементі `<meta name=\"viewport\">`, а атрибут `[maximum-scale]` має значення не менше 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Програми зчитування з екрана перекладають лише текстовий вміст. Якщо додати текст заміщення до елементів <object>, це допоможе програмам зчитування з екрана передати їх значення користувачам. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Програми зчитування з екрана розпізнають лише текст. Якщо додати текст заміщення до елементів `<object>`, це допоможе таким програмам передати їх значення користувачам. [Докладніше](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "Елементи <object> не мають тексту [alt]"
+    "message": "Елементи `<object>` не містять текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "Елементи <object> мають текст [alt]"
+    "message": "Елементи `<object>` містять текст `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Значення, що перевищує 0, передбачає явне встановлення порядку навігації. Хоча технічно воно дійсне, це часто ускладнює взаємодію для користувачів, які застосовують допоміжні технології. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Значення, що перевищує 0, передбачає явне встановлення порядку навігації. Хоча технічно воно дійсне, це часто ускладнює взаємодію для користувачів, які застосовують допоміжні технології. [Докладніше](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "Деякі елементи мають значення [tabindex], що перевищує 0"
+    "message": "Деякі елементи мають значення `[tabindex]`, що перевищує 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Жоден елемент не має значення [tabindex], що перевищує 0"
+    "message": "Жоден елемент не має значення `[tabindex]`, що перевищує 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Програми зчитування з екрана мають функції, які полегшують навігацію в таблицях. Якщо клітинки <td>, які використовують атрибут [headers], стосуються лише інших клітинок у тій самій таблиці, це може покращити взаємодію для користувачів програм зчитування з екрана. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Програми зчитування з екрана мають функції, які полегшують навігацію в таблицях. Якщо клітинки `<td>`, які використовують атрибут `[headers]`, посилаються лише на інші клітинки в тій самій таблиці, це може покращити взаємодію для користувачів програми зчитування з екрана. [Докладніше](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Клітинки в елементі <table>, які використовують атрибут [headers], стосуються інших клітинок тієї ж таблиці."
+    "message": "Клітинки в елементі `<table>`, які використовують атрибут `[headers]`, посилаються на інші клітинки тієї ж таблиці."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Клітинки в елементі <table>, які використовують атрибут [headers], стосуються лише інших клітинок тієї ж таблиці."
+    "message": "Клітинки в елементі `<table>`, які використовують атрибут `[headers]`, посилаються лише на інші клітинки в тій самій таблиці."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Програми зчитування з екрана мають функції, які полегшують навігацію в таблицях. Якщо заголовки таблиці завжди стосуються певного набору клітинок, це може покращити взаємодію для користувачів програм зчитування з екрана. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Програми зчитування з екрана мають функції, які полегшують навігацію в таблицях. Якщо заголовки таблиці завжди посилаються на певні набори клітинок, це може покращити взаємодію для користувачів програм зчитування з екрана. [Докладніше](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Елементи <th> і елементи з роллю [role=\"columnheader\"/\"rowheader\"] не містять клітинок із даними, які описують."
+    "message": "Елементи `<th>` і елементи з роллю `[role=\"columnheader\"/\"rowheader\"]` не містять клітинок із даними, які описують."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Елементи <th> і елементи з роллю [role=\"columnheader\"/\"rowheader\"] містять клітинки з даними, які описують."
+    "message": "Елементи `<th>` і елементи з роллю `[role=\"columnheader\"/\"rowheader\"]` містять клітинки з даними, які описують."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Визначення дійсного тегу мови [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) для елементів допоможе програмі зчитування з екрана правильно озвучувати текст. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Якщо для елементів указати дійсний тег мови за [стандартом BCP 47](https://www.w3.org/International/questions/qa-choosing-language-tags#question), це допоможе програмі зчитування з екрана правильно озвучувати текст. [Докладніше](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "Атрибути [lang] не мають дійсного значення"
+    "message": "Атрибути `[lang]` не мають дійсного значення"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Атрибути [lang] мають дійсне значення"
+    "message": "Атрибути `[lang]` мають дійсне значення"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Коли відео має субтитри, користувачам із глухотою та вадами слуху простіше зрозуміти його. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Коли відео має субтитри, користувачам із вадами слуху простіше зрозуміти його. [Докладніше](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "Елементи <video> не містять елемента <track> з атрибутом [kind=\"captions\"]."
+    "message": "Елементи `<video>` не містять елемент `<track>` з атрибутом `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Елементи <video> містять елемент <track> з атрибутом [kind=\"captions\"]"
+    "message": "Елементи `<video>` містять елемент `<track>` з атрибутом `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Звукові описи надають важливу інформацію про відео (як-от міміка й оточення), яку не можуть забезпечити діалоги. [Докладніше](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Звукові описи надають важливу інформацію про відео (як-от міміка й оточення), яку не можуть забезпечити діалоги. [Докладніше](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "Елементи <video> не містять елемента <track> з атрибутом [kind=\"description\"]."
+    "message": "Елементи `<video>` не містять елемент `<track>` з атрибутом `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Елементи <video> містять елемент <track> з атрибутом [kind=\"description\"]"
+    "message": "Елементи `<video>` містять елемент `<track>` з атрибутом `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Налаштуйте параметр apple-touch-icon для ідеального вигляду на пристроях iOS, коли користувачі додають значок на головний екран. Він має вказувати на непрозоре квадратне зображення PNG розміром 192px (або 180px). [Докладніше](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Не містить дійсного значка `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "Атрибут `apple-touch-icon-precomposed` застарів. Радимо використовувати `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Містить дійсний значок `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Розширення Chrome негативно впливають на завантаження цієї сторінки. Спробуйте перевірити сторінку в режимі анонімного перегляду або в профілі Chrome без розширень."
@@ -330,7 +342,7 @@
     "message": "Загальний процесорний час"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Радимо зменшити час синтаксичного аналізу, компілювання й запуску сценаріїв JavaScript. Завантажувати менші обсяги даних JavaScript може бути корисно. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Зменште час виконання синтаксичного аналізу, компілювання й запуску сценаріїв JavaScript. Для цього корисно завантажувати менші обсяги даних JavaScript. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Зменште час виконання JavaScript"
@@ -339,28 +351,28 @@
     "message": "Час виконання JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Великі файли GIF неефективні для передавання анімованого вмісту. Щоб заощадити байти мережі, радимо замість формату GIF використовувати MPEG4 або WebM для анімацій і PNG чи WebP для статичних зображень. [Докладніше](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Великі файли GIF неефективні для передавання анімованого вмісту. Щоб заощадити мережевий трафік даних, радимо замість формату GIF використовувати MPEG4 або WebM для анімацій і PNG чи WebP для статичних зображень. [Докладніше](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Використовуйте формати відео для анімованого вмісту"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Щоб пришвидшити взаємодію, використовуйте закадрові й приховані зображення, коли завантажаться всі важливі ресурси. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Щоб зменшити час до повного завантаження, використовуйте закадрові й приховані зображення, коли завантажаться всі важливі ресурси. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Відкладіть закадрові зображення"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Ресурси блокують перше відображення сторінки. Вбудовуйте важливі файли JavaScript або CSS і відкладайте всі некритичні файли JavaScript чи стилі. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Ресурси блокують першу візуалізацію сторінки. Надсилайте спершу важливі фрагменти JavaScript або таблиці CSS і відкладайте всі некритичні елементи. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Вилучіть ресурси, які блокують відображення"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Великі обсяги мережевих даних дорогі для користувачів і довго завантажуються. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Великі обсяги мережевих даних використовують багато коштовного трафіку відвідувачів і довго завантажуються. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "Загальний розмір – {totalBytes, number, bytes} KБ"
+    "message": "Загальний розмір – {totalBytes, number, bytes} КБ"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "Уникайте великих обсягів даних у мережі"
@@ -381,7 +393,7 @@
     "message": "Зменште файл JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Видаліть із таблиць стилів правила, які не використовуєте, і відкладіть завантаження CSS, що не застосовується для вмісту у верхній частині сторінки, щоб зменшити кількість зайвих байтів під час активності в мережі. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Щоб зменшити трафік даних у мережі, видаліть непотрібні правила з таблиць стилів і відкладіть завантаження таблиць CSS, що не використовуються для вмісту у верхній частині сторінки. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Видаліть вміст CSS, який не використовується"
@@ -393,7 +405,7 @@
     "message": "Вилучіть файли JavaScript, які ви не використовуєте"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Збереження кешу за довгий час може пришвидшити завантаження сторінки під час повторних відвідувань. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Якщо зберігати кеш за тривалий період часу, сторінки можуть завантажуватися швидше під час повторних відвідувань. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Знайдено 1 ресурс}one{Знайдено # ресурс}few{Знайдено # ресурси}many{Знайдено # ресурсів}other{Знайдено # ресурсу}}"
@@ -417,13 +429,13 @@
     "message": "Правильно виберіть розмір зображень"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Текстові ресурси потрібно відображати зі стисненням (Gzip, Deflate чи Brotli), щоб мінімізувати загальну кількість байтів у мережі. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Текстові ресурси потрібно відображати зі стисненням (Gzip, Deflate чи Brotli), щоб мінімізувати загальний трафік мережі. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Увімкніть стиснення тексту"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Формати зображень JPEG 2000, JPEG XR і WebP часто краще стискаються, ніж PNG чи JPEG. Тому вони швидше завантажуються й використовують менше даних. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Формати зображень JPEG 2000, JPEG XR і WebP часто стискаються краще, ніж PNG чи JPEG. Тому вони швидше завантажуються й використовують менше даних. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Показуйте зображення в нових форматах"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Мінімізуйте глибину важливих запитів"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Припинення підтримки/застереження"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Рядок"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "API, які більше не підтримуються, будуть видалені з веб-переглядача. [Докладніше](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Знайдено 1 застереження}one{Знайдено # застереження}few{Знайдено # застереження}many{Знайдено # застережень}other{Знайдено # застереження}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Використовує непідтримувані API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Уникає інтерфейсів API, які більше не підтримуються"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Application Cache API більше не підтримується. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Знайдено кеш \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Використовує кеш додатка"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Уникає кешу додатка"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Якщо вказати елемент doctype, веб-переглядач не перейде в режим сумісності. Докладніше читайте [на сторінці веб-документації MDN](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Назва елемента doctype має починатися з малої літери й мати значення `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Документ має містити тег doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "Очікується, що поле publicId буде порожнім"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "Очікується, що поле systemId буде порожнім"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Для сторінки не вказано елемента HTML doctype, що активує режим сумісності"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Сторінка має елемент HTML doctype"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Елемент"
   },
@@ -447,7 +510,7 @@
     "message": "Значення"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Розробники веб-переглядачів радять розміщувати на сторінці до ~1500 елементів DOM. Зона найкращого сприйняття – глибина дерева < 32 елементів і до 60 дитячих чи батьківських елементів. Через великий файл DOM використовується більше пам’яті, довше [обчислюються стилі](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) і дорого коштує [перекомпонування макетів](https://developers.google.com/speed/articles/reflow). [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Розробники веб-переглядачів радять розміщувати на сторінці до ~1500 елементів DOM. Зона найкращого сприйняття – глибина дерева, що має менше 32 елементів і менше ніж 60 дочірніх чи батьківських елементів. Через великий файл DOM використовується більше пам'яті, [стилі обчислюються](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) довше, а [перекомпонування макетів](https://developers.google.com/speed/articles/reflow) коштує дорого. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 елемент}one{# елемент}few{# елементи}many{# елементів}other{# елемента}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Уникається надмірний розмір DOM"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Ціль"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Додайте `rel=\"noopener\"` або `rel=\"noreferrer\"` до зовнішніх посилань, щоб покращити ефективність і підвищити їх захищеність. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Міждоменні посилання на веб-сторінці ненадійні"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Міждоменні посилання на веб-сторінці надійні"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Не вдалося визначити сервіс для прив'язки ({anchorHTML}). Якщо гіперпосилання не використовується, видаліть цю частину: \"target=_blank\"."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Сайти, які надсилають запит на доступ до місцезнаходження без пояснення, викликають у користувачів недовіру або спантеличеність. Радимо пов'язувати запит із діями користувача. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Надсилає запит на доступ до геолокації під час завантаження сторінки"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Уникає надсилання запитів на доступ до геолокації під час завантаження сторінки"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Версія"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Усі бібліотеки JavaScript зовнішнього інтерфейсу виявлено на сторінці."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Виявлені бібліотеки JavaScript"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Зовнішні сценарії, динамічно вставлені методом `document.write()`, можуть затримувати завантаження сторінки на десятки секунд для користувачів із повільним з'єднанням. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Використовує `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Уникає `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Найвищий рівень серйозності"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Версія бібліотеки"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Кількість прогалин системи безпеки"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Деякі сторонні сценарії можуть містити відомі прогалини системи безпеки, які зловмисники можуть легко виявити та використати. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Виявлено 1 прогалину системи безпеки}one{Виявлено # прогалину системи безпеки}few{Виявлено # прогалини системи безпеки}many{Виявлено # прогалин системи безпеки}other{Виявлено # прогалини системи безпеки}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Включає бібліотеки JavaScript зовнішнього інтерфейсу з відомими прогалинами системи безпеки"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Високий"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Низький"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Середній"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Уникає бібліотек JavaScript зовнішнього інтерфейсу з відомими прогалинами в системі безпеки"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Сайти, які надсилають запит на показ сповіщень без пояснення, викликають у користувачів недовіру або спантеличеність. Радимо пов'язувати запит із жестами користувача. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Надсилає запит на показ сповіщень під час завантаження сторінки"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Уникає надсилання запитів на показ сповіщень під час завантаження сторінки"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Відхилені елементи"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Якщо заборонити вставляти пароль, це порушить правила щодо високого рівня безпеки. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Не дозволяє користувачам вставляти вміст у поля паролів"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Дає змогу користувачам вставляти вміст у поля паролів"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Протокол"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "Протокол HTTP/2 має низку переваг над HTTP/1.1, як-от двійкові заголовки, мультиплексування та технологія Server Push. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 запит не розміщено через протокол HTTP/2}one{# запит не розміщено через протокол HTTP/2}few{# запити не розміщено через протокол HTTP/2}many{# запитів не розміщено через протокол HTTP/2}other{# запиту не розміщено через протокол HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Не використовує протокол HTTP/2 для всіх ресурсів"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Використовує протокол HTTP/2 для власних ресурсів"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Щоб сторінка краще прокручувалася, позначте блоки прослуховування подій сенсорного екрана та коліщатка як `passive`. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Не використовує пасивні прослуховувачі, щоб покращити функцію прокручування"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Використовує пасивні прослуховувачі, щоб покращити прокручування сторінки"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Опис"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Помилки, записані в журнал консолі, указують на невирішені проблеми. Вони можуть бути викликані збоями запитів мережі або іншими проблемами веб-переглядача."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Помилки веб-переглядача записано в журнал консолі"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Помилки веб-переглядача не записано в журнал консолі"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Використовуйте функцію відображення шрифтів CSS, щоб текст було видно під час завантаження шрифтів. [Докладніше](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Використовуйте функцію відображення шрифтів CSS, щоб текст було видно під час завантаження веб-шрифтів. [Докладніше](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Переконайтеся, що текст залишається видимим під час завантаження веб-шрифту"
@@ -476,14 +671,50 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Увесь текст залишається видимим під час завантаження веб-шрифтів"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Інструменту Lighthouse не вдалось автоматично перевірити значення відображення шрифтів для цієї URL-адреси: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Формат (фактичний)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Формат (відображуваний)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Розміри показаного зображення мають відповідати реальному формату. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Показує зображення неправильного формату"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Показує зображення правильного формату"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Недійсна інформація про розмір зображення {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "Ненадійна URL-адреса"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Усі сайти мають бути захищені протоколом HTTPS, навіть якщо вони не обробляють конфіденційні дані. HTTPS не дозволяє зловмисникам втручатись в обмін даними між додатком і користувачами або пасивно прослуховувати супутні події. Це обов'язкова умова для протоколу HTTP/2 та багатьох нових API веб-платформ. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Знайдено 1 ненадійний запит}one{Знайдено # ненадійний запит}few{Знайдено # ненадійні запити}many{Знайдено # ненадійних запитів}other{Знайдено # ненадійного запиту}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Не використовує протокол HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Використовує протокол HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "Якщо сторінка швидко завантажується в мобільній мережі, це покращує враження користувачів мобільних пристроїв. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Завантажується за {timeInMs, number, seconds} с"
+    "message": "Стає інтерактивною через {timeInMs, number, seconds} с"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
-    "message": "Завантажується через змодельовану мобільну мережу за {timeInMs, number, seconds} с"
+    "message": "Стає інтерактивною в емульованій мобільній мережі через {timeInMs, number, seconds} с"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | failureTitle": {
     "message": "Швидкість завантаження сторінки через мобільну мережу недостатньо висока"
@@ -504,13 +735,13 @@
     "message": "Мінімізується робота основного потоку"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Приблизна затримка введення показує, скільки часу в мілісекундах додаток відповідає на ввід користувача під час п’ятисекундного періоду завантаження сторінки. Якщо затримка перевищує 50 мс, користувачі можуть вважати ваш додаток повільним. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Приблизна затримка введення показує, скільки часу в мілісекундах додаток відповідає на ввід користувача під час п'ятисекундного періоду завантаження сторінки. Якщо затримка перевищує 50 мс, користувачі можуть вважати ваш додаток повільним. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Приблизна затримка введення"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Час завантаження першого вмісту показує, коли з’являється текст чи зображення. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Перша візуалізація вмісту показує, коли з'являється текст чи зображення. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Перше відображення всього вмісту"
@@ -522,22 +753,22 @@
     "message": "Перший простій ЦП"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Перше значне відображення вказує, коли видно основний вміст сторінки. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Час початку візуалізації вказує, коли видно основний вміст сторінки. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Перше значне відображення"
   },
   "lighthouse-core/audits/metrics/interactive.js | description": {
-    "message": "Час до повного завантаження – це період часу, через який сторінка повністю завантажиться. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
+    "message": "Час до повного завантаження – це період часу, через який сторінка стане повністю інтерактивною. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Час до повної взаємодії"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Потенційна затримка першого введення – це тривалість найдовшого завдання в мілісекундах."
+    "message": "Максимальна потенційна затримка відповіді на першу дію – це тривалість найдовшого завдання в мілісекундах. [Докладніше](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "Макс. потенційна затримка першого введення"
+    "message": "Максимальна потенційна затримка відповіді на першу дію"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "Індекс швидкості показує, через скільки часу відображається вміст сторінки. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
@@ -545,8 +776,14 @@
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "Індекс швидкості"
   },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Загальна тривалість усіх періодів часу в мілісекундах між першою візуалізацією вмісту та часом до повного завантаження, коли час виконання завдання перевищує 50 мс."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Загальний час блокування"
+  },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Час затримки передачі сигналу мережі суттєво впливає на ефективність. Якщо показник часу затримки передачі сигналу на сервер високий, це означає, що сервери, розташовані ближче до користувача, можуть покращити ефективність. [Докладніше](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Час затримки передачі сигналу мережі (RTT) суттєво впливає на ефективність. Якщо показник RTT високий, це означає, що сервери, розташовані ближче до користувача, можуть покращити ефективність. [Докладніше](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Час затримки передачі сигналу мережі"
@@ -557,17 +794,38 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Затримка сервера"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Перевищення бюджету"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Стежте, щоб кількість і розмір мережевих запитів не перевищували цільових значень, указаних у бюджеті ефективності. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 запит}one{# запит}few{# запити}many{# запитів}other{# запиту}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Бюджет ефективності"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Переспрямування додають затримки під час завантаження сторінки. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Переспрямування викликають додаткові затримки під час завантаження сторінки. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Уникайте переспрямувань кількох сторінок"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Щоб установити бюджет відповідно до кількості та розміру ресурсів на сторінці, додайте файл budget.json. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 запит}one{# запит}few{# запити}many{# запитів}other{# запиту}} • {byteCount, number, bytes} КБ"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Не надсилайте багато запитів і передавайте вміст малого розміру"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Канонічні посилання вказують, які URL-адреси показувати в результатах пошуку. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "Кілька конфліктних URL-адрес ({urlList})"
+    "message": "Кілька URL-адрес конфліктують ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
     "message": "Указує на інший домен ({url})"
@@ -576,7 +834,7 @@
     "message": "Недійсна URL-адреса ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "Указує на інше розташування атрибута hreflang ({url})"
+    "message": "Указує на інше місце `hreflang` ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "Відносна URL-адреса ({url})"
@@ -585,19 +843,16 @@
     "message": "Указує на основну URL-адресу домену (домашню сторінку), а не на еквівалентну сторінку вмісту"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "Документ не має дійсного посилання \"rel=canonical\""
+    "message": "Документ не має дійсного посилання `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "Документ має дійсне посилання \"rel=canonical\""
+    "message": "Документ має дійсний атрибут `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Розміри шрифту до 12px замалі й нечитабельні. Щоб користувачі мобільних пристроїв змогли прочитати текст, їм потрібно буде збільшувати масштаб пальцями. Бажано, щоб понад 60% тексту на сторінці було написано щонайменше шрифтом 12px. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)."
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} читабельного тексту"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} тексту має замалий шрифт."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Текст нечитабельний, оскільки метатег області перегляду не оптимізовано для мобільних пристроїв."
@@ -615,13 +870,13 @@
     "message": "Посилання hreflang указують пошуковим системам версію сторінки, яку потрібно додати в результати пошуку для певної мови чи регіону. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "Документ не має дійсного атрибута hreflang"
+    "message": "Документ не має дійсного атрибута `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "Документ має дійсний атрибут hreflang"
+    "message": "Документ має дійсний атрибут `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Сторінки з недійсними кодами статусу HTTP може бути проіндексовано неправильно. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Сторінки з недійсними кодами статусу HTTP можуть неправильно індексуватися. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "Сторінка має недійсний код статусу HTTP"
@@ -696,7 +951,7 @@
     "message": "Файл robots.txt дійсний"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Інтерактивні елементи, як-от кнопки та посилання, мають бути достатньо великі (48 x 48 пікселів), а навколо них має бути достатньо місця, щоб їх можна було легко натиснути, не зачепивши інші елементи. [Докладніше](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Інтерактивні елементи, як-от кнопки та посилання, мають бути достатньо великі (48x48 пікселів), а навколо них має бути достатньо місця, щоб їх можна було легко натиснути, не зачепивши інші елементи. [Докладніше](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} елементів для натискання мають правильний розмір"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Елементи для натискання накладаються"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Розмір"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Елемент для натискання"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Елементи для натискання мають правильний розмір"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Час основного ланцюжка"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Сторонні розробники"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Сторонній код може значно погіршити швидкість завантаження. Не використовуйте зайвий раз елементи коду сторонніх розробників та налаштуйте сторінку так, щоб сторонній код завантажувався після її основної частини. [Докладніше](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Знайдено 1 сторонній код}one{Знайдено # сторонній код}few{Знайдено # сторонні коди}many{Знайдено # сторонніх кодів}other{Знайдено # стороннього коду}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Використання стороннього коду"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Час до першого байта визначає швидкість реакції сервера. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "Кореневий документ відповів через {timeInMs, number, milliseconds} мс"
+    "message": "Кореневий документ відповів через {timeInMs, number, milliseconds} мс"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "Зменште час відповіді сервера (TTFB)"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Тривалість"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Назва"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Час початку"
@@ -753,19 +1017,19 @@
     "message": "Показники й мітки часу користувача"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Для {securityOrigin} знайдено посилання для попереднього з’єднання <link>, але веб-переглядач його не використав. Переконайтеся, що ви правильно використовуєте атрибут crossorigin."
+    "message": "Для {securityOrigin} знайдено посилання для попереднього з'єднання <link>, але веб-переглядач його не використав. Переконайтеся, що ви правильно використовуєте атрибут `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Додайте в ресурси корективи для попереднього з’єднання чи виклику DNS, щоб заздалегідь установлювати з’єднання з важливими джерелами третіх сторін. [Докладніше](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Додайте в ресурси корективи для попереднього з'єднання чи виклику DNS, щоб заздалегідь встановлювати з'єднання з важливими джерелами третіх сторін. [Докладніше](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Попередньо під’єднуйтеся до потрібних джерел"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Для {preloadURL} знайдено посилання для попереднього завантаження <link>, але веб-переглядач його не використав. Переконайтеся, що ви правильно використовуєте атрибут crossorigin."
+    "message": "Для {preloadURL} знайдено посилання для попереднього завантаження <link>, але веб-переглядач його не використав. Переконайтеся, що ви правильно використовуєте атрибут `crossorigin`."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Використовуйте <link rel=preload>, щоб указати пріоритетність завантаження ресурсів, які наразі запитуються пізніше під час завантаження сторінки. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Використовуйте `<link rel=preload>`, щоб указати пріоритетність завантаження ресурсів, які наразі отримуються пізніше під час завантаження сторінки. [Докладніше](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Попередньо завантажуйте основні запити"
@@ -789,7 +1053,7 @@
     "message": "Практичні поради"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Ці перевірки визначають можливості для [покращення доступності веб-додатка](https://developers.google.com/web/fundamentals/accessibility). Радимо також проводити перевірки вручну, оскільки автоматично визначаються лише певні проблеми з доступністю."
+    "message": "Ці перевірки визначають можливості для [покращення доступності веб-додатка](https://developers.google.com/web/fundamentals/accessibility). Радимо також проводити перевірки вручну, оскільки не всі проблеми з доступністю визначаються автоматично."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "Ці елементи опрацьовують області, які не може охопити автоматизований інструмент перевірки. Докладніше читайте в нашому посібнику з [перевірки доступності](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Таблиці та списки"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Практичні поради"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Бюджети визначають стандарти ефективності вашого сайту."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Бюджети"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Докладніше про ефективність додатка."
+    "message": "Докладніше про ефективність додатка. Ці числа не [впливають безпосередньо](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) на значення ефективності."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Діагностика"
@@ -840,7 +1113,7 @@
     "message": "Покращення першого відображення"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Ці оптимізації можуть пришвидшити завантаження сторінки."
+    "message": "Ці пропозиції допоможуть завантажувати сторінку швидше. Вони не [впливають безпосередньо](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) на значення ефективності."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Можливості"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "TTL кешу"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Місцезнаходження"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Назва"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Запити"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Тип ресурсу"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Розмір (КБ)"
+    "message": "Розмір"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Витрачений час"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Розмір передавання"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL-адреса"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Потенційне заощадження (КБ)"
+    "message": "Потенційне заощадження"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Потенційне заощадження (мс)"
+    "message": "Потенційне заощадження"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "Потенційне заощадження – {wastedBytes, number, bytes} КБ"
@@ -917,14 +1205,41 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "Потенційне заощадження – {wastedMs, number, milliseconds} мс"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Документ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Шрифт"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Зображення"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Медіа"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} мс"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Інше"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Сценарій"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} c"
+    "message": "{timeInMs, number, seconds} с"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Таблиця стилів"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Сторонні"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Усього"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Під час запису трасування завантаження вашої сторінки сталася помилка. Запустіть інструмент Lighthouse ще раз. ({errorCode})"
+    "message": "Не вдалося записати результати трасування для завантаження вашої сторінки. Запустіть інструмент Lighthouse ще раз. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Час очікування початкового з’єднання з протоколом Debugger минув."
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS-серверам не вдалось обробити вказаний домен."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "У збирачі обов'язкових ресурсів {artifactName} сталася помилка: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Сталася внутрішня помилка Chrome. Перезапустіть Chrome і спробуйте знову запустити інструмент Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Збирач обов'язкових ресурсів {artifactName} не запущено."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Інструменту Lighthouse не вдалося безпечно завантажити сторінку, яку ви вказали. Переконайтеся, що ви тестуєте правильну URL-адресу, а сервер належним чином відповідає на всі запити."
@@ -945,7 +1266,10 @@
     "message": "Інструменту Lighthouse не вдалося безпечно завантажити URL-адресу, яку ви вказали, оскільки сторінка перестала відповідати."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "Указана вами URL-адреса не має дійсних облікових даних системи безпеки. {securityMessages}"
+    "message": "Указана вами URL-адреса не має дійсного сертифіката безпеки. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Веб-переглядач Chrome заблокував завантаження сторінки та відобразив проміжний екран. Переконайтеся, що ви тестуєте правильну URL-адресу, а сервер належним чином відповідає на всі запити."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Інструменту Lighthouse не вдалося безпечно завантажити сторінку, яку ви вказали. Переконайтеся, що ви тестуєте правильну URL-адресу, а сервер належним чином відповідає на всі запити. (Деталі: {errorDetails})"
@@ -957,7 +1281,7 @@
     "message": "Сторінка завантажувалася задовго. Дотримуйтеся рекомендацій у звіті, щоб зменшити час завантаження сторінки, а потім спробуйте перезапустити інструмент Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "Час очікування відповіді протоколу DevTools перевищив установлений період. (Спосіб: {protocolMethod})"
+    "message": "Час очікування відповіді протоколу DevTools перевищив установлений період. (Метод: {protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "Час отримання вмісту ресурсу перевищив установлений час"
@@ -984,7 +1308,7 @@
     "message": "Дані тестів"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "Аналіз [Lighthouse](https://developers.google.com/web/tools/lighthouse/) поточної сторінки в імітованій мобільній мережі. Значення приблизні й можуть відрізнятися."
+    "message": "Аналіз [Lighthouse](https://developers.google.com/web/tools/lighthouse/) поточної сторінки в емульованій мобільній мережі. Значення приблизні й можуть відрізнятися."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Додаткові елементи, які потрібно перевірити вручну"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Розгорнути фрагмент"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Показати сторонні ресурси"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Під час запуску Lighthouse виникли перелічені нижче проблеми."
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Значення приблизні й можуть відрізнятися."
+    "message": "Значення приблизні й можуть відрізнятися. Значення ефективності визначається [на основі цих показників](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Перевірки зі статусом \"Пройдено\", що містять застереження"
@@ -1023,10 +1350,10 @@
     "message": "Спробуйте завантажити файл GIF у сервіс, де його можна вставити як відео HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Установіть [плагін lazy-load від WordPress](https://wordpress.org/plugins/search/lazy+load/), який дає змогу відкласти завантаження невидимих зображень, або виберіть тему, що дозволяє це зробити. Також можете скористатися [плагіном AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Установіть [плагін lazy-load від WordPress](https://wordpress.org/plugins/search/lazy+load/), який дає змогу відкласти завантаження закадрових зображень, або виберіть тему, що дозволяє це зробити. Також можете скористатися [плагіном AMP](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "Існує багато плагінів WordPress, які можуть допомогти [вбудувати важливі об’єкти](https://wordpress.org/plugins/search/critical+css/) або [відкласти менш важливі ресурси](https://wordpress.org/plugins/search/defer+css+javascript/). Зауважте, що така оптимізація може порушити функції теми або плагінів, тож доведеться змінити код."
+    "message": "Існує багато плагінів WordPress, які можуть допомогти [вбудувати важливі об'єкти](https://wordpress.org/plugins/search/critical+css/) або [відкласти менш важливі ресурси](https://wordpress.org/plugins/search/defer+css+javascript/). Зауважте, що така оптимізація може порушити функції теми або плагінів, тож доведеться змінити код."
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "Теми, плагіни й характеристики сервера впливають на час відповіді. Спробуйте знайти більш оптимізовану тему, підібрати плагін для оптимізації та/або оновити сервер."
@@ -1035,30 +1362,30 @@
     "message": "Спробуйте показувати витяги в списках дописів (через тег \"більше\"), зменшити кількість показаних публікацій на сторінці, розділити довгі дописи на кілька сторінок або скористатися плагіном, щоб відкласти завантаження коментарів."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Багато [плагінів WordPress](https://wordpress.org/plugins/search/minify+css/) можуть пришвидшити ваш сайт: вони об’єднують, зменшують і стискають стилі. Також можна скористатися процесом складання, щоб завчасно зменшити розмір, якщо це можливо."
+    "message": "Багато [плагінів WordPress](https://wordpress.org/plugins/search/minify+css/) можуть пришвидшити ваш сайт: вони об'єднують, зменшують і стискають стилі. Також можна скористатися процесом складання, щоб завчасно зменшити розмір, якщо це можливо."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Багато [плагінів WordPress](https://wordpress.org/plugins/search/minify+javascript/) можуть пришвидшити ваш сайт: вони об’єднують, зменшують і стискають сценарії. Також можна скористатися процесом складання, щоб завчасно зменшити розмір, якщо це можливо."
+    "message": "Багато [плагінів WordPress](https://wordpress.org/plugins/search/minify+javascript/) можуть пришвидшити ваш сайт: вони об'єднують, зменшують і стискають сценарії. Також можна скористатися процесом складання, щоб завчасно зменшити розмір, якщо це можливо."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Спробуйте зменшити або змінити кількість [плагінів WordPress](https://wordpress.org/plugins/), що завантажують на сторінці CSS, які не використовуються. Щоб визначити, які плагіни додають зайві CSS, спробуйте запустити [покриття коду](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) у Chrome DevTools. Ви можете визначити тему чи плагін через URL-адресу таблиці стилів. Шукайте плагіни з багатьма таблицями стилів у списку з великою кількістю червоного тексту в покритті коду. Плагін має ставити таблицю стилів у чергу, лише коли вона дійсно використовується на сторінці."
+    "message": "Спробуйте зменшити кількість [плагінів WordPress](https://wordpress.org/plugins/), що завантажують на сторінці непотрібні таблиці стилів CSS. Щоб визначити плагіни, які додають зайві таблиці CSS, перевірте [покриття коду](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) в Chrome DevTools. Ви можете визначити тему чи плагін через URL-адресу таблиці стилів. У покритті коду знайдіть плагіни з багатьма таблицями стилів за великим обсягом червоного тексту. Плагін має ставити таблицю стилів у чергу, лише коли вона дійсно використовується на сторінці."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Спробуйте зменшити або змінити кількість [плагінів WordPress](https://wordpress.org/plugins/), що завантажують на сторінці сценарій Javascript, який не використовується. Щоб визначити плагіни, які додають зайвий сценарій Javascript, спробуйте запустити [покриття коду](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) у Chrome DevTools. Ви можете визначити тему чи плагін через URL-адресу сценарію. Шукайте плагіни з багатьма сценаріями в списку з великою кількістю червоного тексту в покритті коду. Плагін має ставити сценарій у чергу, лише коли він дійсно використовується на сторінці."
+    "message": "Спробуйте зменшити кількість [плагінів WordPress](https://wordpress.org/plugins/), що завантажують на сторінці непотрібні фрагменти JavaScript. Щоб визначити плагіни, які додають зайвий код JavaScript, перевірте [покриття коду](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) в Chrome DevTools. Ви можете визначити тему чи плагін через URL-адресу сценарію. У покритті коду знайдіть плагіни з багатьма сценаріями за великим обсягом червоного тексту. Плагін має ставити сценарій у чергу, лише коли він дійсно використовується на сторінці."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
-    "message": "Докладніше про [кешування веб-переглядача у WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
+    "message": "Дізнайтеся про [кешування веб-переглядача у WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
     "message": "Спробуйте [плагін WordPress для оптимізації зображень](https://wordpress.org/plugins/search/optimize+images/), який стискає зображення, але зберігає їх якість."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Завантажуйте зображення просто через [бібліотеку медіа-файлів](https://codex.wordpress.org/Media_Library_Screen), щоб переконатися, що вони мають потрібні розміри. А тоді вставляйте їх з оптимальними розмірами (зокрема для адаптивних точок переходу) у бібліотеці або віджеті для зображень. Використовуйте зображення в повному розмірі, лише коли вони поміщаються. [Докладніше](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Завантажуйте зображення через [бібліотеку медіафайлів](https://codex.wordpress.org/Media_Library_Screen), щоб переконатися, що вони доступні в потрібному розмірі. Потім вставляйте їх в оптимальному розмірі з бібліотеки або через віджет для зображень (зокрема для адаптивних точок переходу). Використовуйте зображення, що мають `Full Size`, лише якщо вони повністю поміщаються. [Докладніше](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Ви можете ввімкнути стиснення тексту в конфігурації веб-сервера."
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "Скористайтеся [плагіном](https://wordpress.org/plugins/search/convert+webp/) або сервісом, який конвертує завантажені зображення в оптимальні формати."
+    "message": "Скористайтеся [плагіном](https://wordpress.org/plugins/search/convert+webp/) або сервісом, який автоматично конвертує завантажені зображення в оптимальні формати."
   }
 }

--- a/lighthouse-core/lib/i18n/locales/vi.json
+++ b/lighthouse-core/lib/i18n/locales/vi.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "Các phím truy cập cho phép người dùng lấy nhanh tiêu điểm vào một phần của trang. Để điều hướng đúng cách, mỗi phím truy cập phải là duy nhất. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)."
+    "message": "Các phím truy cập cho phép người dùng chuyển nhanh đến một phần của trang. Để di chuyển đúng cách, mỗi phím truy cập phải là duy nhất. [Tìm hiểu thêm](https://web.dev/accesskeys/)."
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "Các giá trị `[accesskey]` không phải là duy nhất"
+    "message": "Các giá trị của `[accesskey]` không phải là duy nhất"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "Các giá trị `[accesskey]` là duy nhất"
+    "message": "Các giá trị của `[accesskey]` là duy nhất"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "Mỗi `role` của Ứng dụng Internet phong phú dễ dùng (ARIA) hỗ trợ một tập hợp con cụ thể các thuộc tính `aria-*`. Nếu không trùng khớp, các thuộc tính `aria-*` sẽ trở nên vô hiệu. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)."
+    "message": "Mỗi `role` của Ứng dụng Internet phong phú dễ dùng (ARIA) hỗ trợ một tập hợp con cụ thể các thuộc tính `aria-*`. Nếu không trùng khớp, các thuộc tính `aria-*` sẽ bị vô hiệu. [Tìm hiểu thêm](https://web.dev/aria-allowed-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "Các thuộc tính `[aria-*]` không khớp với vai trò của chúng"
+    "message": "Các thuộc tính `[aria-*]` không khớp với vai trò tương ứng"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "Các thuộc tính `[aria-*]` khớp với vai trò của chúng"
+    "message": "Các thuộc tính `[aria-*]` khớp với vai trò tương ứng"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "Một số vai trò ARIA có các thuộc tính bắt buộc mô tả trạng thái của phần tử cho trình đọc màn hình. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)."
+    "message": "Một số vai trò ARIA có các thuộc tính bắt buộc mô tả trạng thái của phần tử cho trình đọc màn hình. [Tìm hiểu thêm](https://web.dev/aria-required-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "`[role]` không có tất cả thuộc tính `[aria-*]` bắt buộc"
+    "message": "`[role]` không có tất cả các thuộc tính `[aria-*]` bắt buộc"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "`[role]` có tất cả thuộc tính `[aria-*]` bắt buộc"
+    "message": "`[role]` có tất cả các thuộc tính `[aria-*]` bắt buộc"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "Một số vai trò mẹ của Ứng dụng Internet phong phú dễ dùng (ARIA) phải chứa các vai trò con cụ thể để thực hiện những chức năng hỗ trợ tiếp cận chủ định của các vai trò mẹ này. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)."
+    "message": "Một số vai trò mẹ của Ứng dụng Internet phong phú dễ dùng (ARIA) phải chứa vai trò con cụ thể để thực hiện các chức năng hỗ trợ tiếp cận chủ định tương ứng. [Tìm hiểu thêm](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Thiếu các phần tử có vai trò `[role]` yêu cầu phải có vai trò `[role]` con cụ thể."
+    "message": "Thiếu các phần tử có `[role]` yêu cầu phải có vai trò con `[role]` cụ thể."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Các phần tử có vai trò `[role]` yêu cầu phải có vai trò con `[role]` cụ thể đang hiện diện"
+    "message": "Các phần tử có `[role]` yêu cầu phải có phần tử con `[role]` cụ thể đang hiện diện"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "Các vai trò mẹ cụ thể phải chứa một số vai trò con của Ứng dụng Internet phong phú dễ dùng (ARIA) để thực hiện chính xác các chức năng hỗ trợ tiếp cận chủ định của các vai trò mẹ này. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)."
+    "message": "Các vai trò mẹ cụ thể phải chứa một số vai trò con của Ứng dụng Internet phong phú dễ dùng (ARIA) để thực hiện đúng cách các chức năng hỗ trợ tiếp cận chủ định tương ứng. [Tìm hiểu thêm](https://web.dev/aria-required-parent/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "`[role]` không có trong phần tử mẹ bắt buộc của chúng"
+    "message": "`[role]` không có trong phần tử mẹ bắt buộc tương ứng"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "`[role]` có trong phần tử mẹ bắt buộc của chúng"
+    "message": "`[role]` có trong phần tử mẹ bắt buộc tương ứng"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "Các vai trò của Ứng dụng Internet phong phú dễ dùng (ARIA) phải có giá trị hợp lệ để thực hiện những chức năng hỗ trợ tiếp cận chủ định của mình. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)."
+    "message": "Các vai trò của Ứng dụng Internet phong phú dễ dùng (ARIA) phải có giá trị hợp lệ để thực hiện những chức năng hỗ trợ tiếp cận chủ định tương ứng. [Tìm hiểu thêm](https://web.dev/aria-roles/)."
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "Các giá trị `[role]` là không hợp lệ"
+    "message": "Các giá trị của `[role]` là không hợp lệ"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "Các giá trị `[role]` là hợp lệ"
+    "message": "Các giá trị của `[role]` là hợp lệ"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "Các công nghệ hỗ trợ, chẳng hạn như trình đọc màn hình, không thể diễn giải thuộc tính của Ứng dụng Internet phong phú dễ dùng (ARIA) có giá trị không hợp lệ. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)."
+    "message": "Các công nghệ hỗ trợ, chẳng hạn như trình đọc màn hình, không thể diễn giải thuộc tính của Ứng dụng Internet phong phú dễ dùng (ARIA) có giá trị không hợp lệ. [Tìm hiểu thêm](https://web.dev/aria-valid-attr-value/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "Các thuộc tính `[aria-*]` không có giá trị hợp lệ"
+    "message": "Giá trị của các thuộc tính `[aria-*]` là không hợp lệ"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
     "message": "Các thuộc tính `[aria-*]` có giá trị hợp lệ"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "Các công nghệ hỗ trợ, chẳng hạn như trình đọc màn hình, không thể diễn giải các thuộc tính của Ứng dụng Internet phong phú dễ dùng (ARIA) có tên không hợp lệ. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)."
+    "message": "Các công nghệ hỗ trợ, chẳng hạn như trình đọc màn hình, không thể diễn giải các thuộc tính của Ứng dụng Internet phong phú dễ dùng (ARIA) có tên không hợp lệ. [Tìm hiểu thêm](https://web.dev/aria-valid-attr/)."
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "Các thuộc tính `[aria-*]` là không hợp lệ hoặc viết sai chính tả"
+    "message": "Các thuộc tính `[aria-*]` là không hợp lệ hoặc bị sai chính tả"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "Các thuộc tính `[aria-*]` là hợp lệ và không sai chính tả"
+    "message": "Các thuộc tính `[aria-*]` là hợp lệ và không bị sai chính tả"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "Phụ đề giúp người điếc hoặc người dùng khiếm thính có thể sử dụng các phần tử âm thanh, cung cấp cho họ những thông tin quan trọng như ai đang nói chuyện, những người đó đang nói gì và các thông tin khác không phải lời nói. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)."
+    "message": "Phụ đề giúp người điếc hoặc người dùng khiếm thính có thể sử dụng các phần tử âm thanh, cung cấp cho họ những thông tin quan trọng như ai đang nói chuyện, những người đó đang nói gì và các thông tin khác không phải lời nói. [Tìm hiểu thêm](https://web.dev/audio-caption/)."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "Các phần tử `<audio>` thiếu một phần tử `<track>` có `[kind=\"captions\"]`."
+    "message": "Các phần tử `<audio>` bị thiếu phần tử `<track>` có `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "Các phần tử `<audio>` chứa một phần tử `<track>` có `[kind=\"captions\"]`"
+    "message": "Các phần tử `<audio>` chứa phần tử `<track>` có `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "Các phần tử không đạt"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "Khi một nút không có tên có thể tiếp cận, trình đọc màn hình sẽ thông báo đó là \"nút\", khiến người dùng trình đọc màn hình không sử dụng được nút này. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)."
+    "message": "Khi một nút không có tên có thể tiếp cận, trình đọc màn hình sẽ thông báo đó là \"nút\", khiến người dùng trình đọc màn hình không sử dụng được nút này. [Tìm hiểu thêm](https://web.dev/button-name/)."
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "Các nút không có tên có thể tiếp cận được"
@@ -93,7 +93,7 @@
     "message": "Các nút có tên tiếp cận được"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "Bằng việc thêm các cách bỏ qua nội dung lặp lại, người dùng bàn phím có thể khám phá trang một cách hiệu quả hơn. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)."
+    "message": "Bằng việc thêm các cách bỏ qua nội dung lặp lại, người dùng bàn phím có thể khám phá trang một cách hiệu quả hơn. [Tìm hiểu thêm](https://web.dev/bypass/)."
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "Trang này không chứa tiêu đề, đường dẫn liên kết bỏ qua hoặc vùng mốc"
@@ -102,7 +102,7 @@
     "message": "Trang này chứa tiêu đề, phần tử liên kết bỏ qua hoặc vùng mốc"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "Nhiều người dùng gặp khó khăn khi đọc hoặc không thể đọc được văn bản có độ tương phản thấp. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)."
+    "message": "Nhiều người dùng gặp khó khăn khi đọc hoặc không thể đọc được văn bản có độ tương phản thấp. [Tìm hiểu thêm](https://web.dev/color-contrast/)."
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "Màu nền trước và nền sau không có đủ tỷ lệ tương phản."
@@ -111,7 +111,7 @@
     "message": "Màu nền trước và nền sau có đủ tỷ lệ tương phản"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "Khi danh sách định nghĩa không được đánh dấu đúng cách, thì trình đọc màn hình có thể đọc thông tin không chính xác hoặc gây nhầm lẫn. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)."
+    "message": "Khi danh sách định nghĩa không được đánh dấu đúng cách, thì trình đọc màn hình có thể tạo ra thông báo gây nhầm lẫn hoặc không chính xác. [Tìm hiểu thêm](https://web.dev/definition-list/)."
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
     "message": "`<dl>` không chỉ chứa các nhóm `<dt>` và `<dd>` được sắp xếp đúng cách, các phần tử `<script>` hoặc `<template>`."
@@ -120,16 +120,16 @@
     "message": "`<dl>` chỉ chứa các nhóm `<dt>` và `<dd>` được sắp xếp đúng cách, các phần tử `<script>` hoặc `<template>`."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "Các mục trong danh sách định nghĩa (`<dt>` và `<dd>`) phải được đưa vào một phần tử `<dl>` mẹ để đảm bảo rằng trình đọc màn hình có thể thông báo chính xác các mục này. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)."
+    "message": "Các mục trong danh sách định nghĩa (`<dt>` và `<dd>`) phải được đưa vào một phần tử `<dl>` mẹ để đảm bảo rằng trình đọc màn hình có thể thông báo đúng cách các mục này. [Tìm hiểu thêm](https://web.dev/dlitem/)."
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
     "message": "Các phần tử `<dl>` không bao gồm những mục trong danh sách định nghĩa"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "Các phần tử `<dl>` bao gồm những mục trong danh sách định nghĩa"
+    "message": "Các phần tử `<dl>` chứa mục trong danh sách định nghĩa"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "Tiêu đề giúp người dùng trình đọc màn hình nắm được thông tin tổng quan về trang, và giúp người dùng công cụ tìm kiếm chủ yếu dựa vào tiêu đề này xác định xem một trang có liên quan đến nội dung tìm kiếm của họ hay không. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/title)."
+    "message": "Tiêu đề giúp người dùng trình đọc màn hình nắm được thông tin tổng quan về trang, và giúp người dùng công cụ tìm kiếm chủ yếu dựa vào tiêu đề này xác định xem một trang có liên quan đến nội dung tìm kiếm của họ hay không. [Tìm hiểu thêm](https://web.dev/document-title/)."
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "Tài liệu không có phần tử `<title>`"
@@ -138,52 +138,52 @@
     "message": "Tài liệu có phần tử `<title>`"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "Giá trị của thuộc tính id phải là duy nhất để ngăn chặn tình trạng công nghệ hỗ trợ bỏ qua các điểm dữ liệu khác. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)."
+    "message": "Giá trị của thuộc tính id phải là duy nhất, có như vậy công nghệ hỗ trợ mới không bỏ qua các điểm dữ liệu khác. [Tìm hiểu thêm](https://web.dev/duplicate-id/)."
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "Các thuộc tính `[id]` trên trang này không phải là duy nhất"
+    "message": "Các thuộc tính `[id]` trên trang không phải là duy nhất"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "Các thuộc tính `[id]` trên trang này là duy nhất"
+    "message": "Các thuộc tính `[id]` trên trang là duy nhất"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "Người dùng trình đọc màn hình dựa vào tiêu đề khung để mô tả nội dung của khung. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)."
+    "message": "Người dùng trình đọc màn hình dựa vào tiêu đề khung để mô tả nội dung của khung. [Tìm hiểu thêm](https://web.dev/frame-title/)."
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "Các phần tử `<frame>` hoặc `<iframe>` không có tiêu đề"
+    "message": "Phần tử `<frame>` hoặc `<iframe>` không có tiêu đề"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
     "message": "Các phần tử `<frame>` hoặc `<iframe>` có tiêu đề"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "Nếu trang không chỉ định một thuộc tính ngôn ngữ, thì trình đọc màn hình sẽ xem như trang đó đang hiển thị bằng ngôn ngữ mặc định mà người dùng đã chọn khi thiết lập trình đọc màn hình. Nếu trên thực tế, trang đó không hiển thị bằng ngôn ngữ mặc định, thì trình đọc màn hình có thể không thông báo văn bản trên trang một cách chính xác. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)."
+    "message": "Nếu một trang chưa chỉ định thuộc tính ngôn ngữ, thì trình đọc màn hình sẽ xem như trang đó đang hiển thị bằng ngôn ngữ mặc định mà người dùng chọn khi thiết lập trình đọc màn hình. Nếu trên thực tế, trang đó không hiển thị bằng ngôn ngữ mặc định, tức là trình đọc màn hình có thể thông báo sai về văn bản của trang đó. [Tìm hiểu thêm](https://web.dev/html-has-lang/)."
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "Phần tử `<html>` không có thuộc tính `[lang]`"
+    "message": "Phần tử `<html>` chưa có thuộc tính `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "Phần tử `<html>` có một thuộc tính `[lang]`"
+    "message": "Phần tử `<html>` có thuộc tính `[lang]`"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "Việc chỉ định một [BCP 47 language] hợp lệ (https://www.w3.org/International/questions/qa-choosing-language-tags#question) sẽ giúp trình đọc màn hình thông báo văn bản chính xác. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Việc chỉ định [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) hợp lệ sẽ giúp trình đọc màn hình thông báo văn bản đúng cách. [Tìm hiểu thêm](https://web.dev/html-lang-valid/)."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "Phần tử `<html>` không có giá trị hợp lệ cho thuộc tính `[lang]` của phần tử này."
+    "message": "Thuộc tính `[lang]` của phần tử `<html>` không có giá trị hợp lệ."
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "Phần tử `<html>` có một giá trị hợp lệ cho thuộc tính `[lang]` của phần tử này"
+    "message": "Thuộc tính `[lang]` của phần tử `<html>` có giá trị hợp lệ"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "Các phần tử thông tin nên là đoạn văn bản thay thế ngắn, có tính mô tả. Có thể bỏ qua phần tử trang trí bằng một thuộc tính alt trống. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)."
+    "message": "Các phần tử thông tin nên là đoạn văn bản thay thế ngắn, có tính mô tả. Có thể bỏ qua phần tử trang trí bằng một thuộc tính alt trống. [Tìm hiểu thêm](https://web.dev/image-alt/)."
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "Các phần tử hình ảnh không có thuộc tính `[alt]`"
+    "message": "Phần tử hình ảnh không có thuộc tính `[alt]`"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
     "message": "Các phần tử hình ảnh có thuộc tính `[alt]`"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "Khi một hình ảnh đang dùng làm nút `<input>`, thì việc cung cấp văn bản thay thế có thể giúp người dùng trình đọc màn hình hiểu rõ mục đích của nút đó. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)."
+    "message": "Khi dùng một hình ảnh làm nút `<input>`, thì việc cung cấp văn bản thay thế có thể giúp người dùng trình đọc màn hình hiểu rõ mục đích của nút đó. [Tìm hiểu thêm](https://web.dev/input-image-alt/)."
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "Các phần tử `<input type=\"image\">` không có văn bản `[alt]`"
@@ -192,7 +192,7 @@
     "message": "Các phần tử `<input type=\"image\">` có văn bản `[alt]`"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "Các nhãn đảm bảo rằng những công nghệ hỗ trợ, chẳng hạn như trình đọc màn hình, thông báo chính xác các phần tử điều kiển của biểu mẫu. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)."
+    "message": "Các nhãn đảm bảo rằng những công nghệ hỗ trợ, chẳng hạn như trình đọc màn hình, thông báo các biện pháp kiểm soát biểu mẫu đúng cách. [Tìm hiểu thêm](https://web.dev/label/)."
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "Các phần tử biểu mẫu không có nhãn liên kết"
@@ -201,7 +201,7 @@
     "message": "Các phần tử biểu mẫu có nhãn liên quan"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "Bảng đang dùng cho mục đích bố cục không nên bao gồm phần tử dữ liệu, chẳng hạn như phần tử th, phần tử phụ đề hoặc thuộc tính tóm tắt, vì điều này có thể tạo ra trải nghiệm gây bối rối cho người dùng trình đọc màn hình. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)."
+    "message": "Bảng đang dùng cho mục đích bố cục không nên bao gồm phần tử dữ liệu, chẳng hạn như th, phần tử chú thích hoặc thuộc tính tóm tắt, vì điều này có thể tạo ra trải nghiệm gây bối rối cho người dùng trình đọc màn hình. [Tìm hiểu thêm](https://web.dev/layout-table/)."
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
     "message": "Các phần tử `<table>` dạng trình bày không tránh sử dụng `<th>`, `<caption>` hoặc thuộc tính `[summary]`."
@@ -210,7 +210,7 @@
     "message": "Các phần tử `<table>` dạng trình bày tránh sử dụng `<th>`, `<caption>` hoặc thuộc tính `[summary]`."
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "Văn bản liên kết (và văn bản thay thế cho hình ảnh, khi dùng làm liên kết) có thể thấy rõ, duy nhất và có thể lấy tiêu điểm sẽ cải thiện trải nghiệm khám phá cho người dùng trình đọc màn hình. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)."
+    "message": "Văn bản liên kết (và văn bản thay thế cho hình ảnh, khi dùng làm đường dẫn liên kết) có thể thấy rõ, duy nhất và có thể lấy tiêu điểm sẽ cải thiện trải nghiệm khám phá cho người dùng trình đọc màn hình. [Tìm hiểu thêm](https://web.dev/link-name/)."
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "Các phần tử liên kết không có tên có thể nhận rõ"
@@ -219,43 +219,43 @@
     "message": "Các phần tử liên kết có tên có thể nhận rõ"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "Các trình đọc màn hình có cách riêng để thông báo danh sách. Việc đảm bảo cấu trúc danh sách chính xác hỗ trợ thông tin mà trình đọc màn hình thông báo. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)."
+    "message": "Các trình đọc màn hình có cách riêng để thông báo về danh sách. Khi danh sách có cấu trúc phù hợp, trình đọc màn hình sẽ thông báo về danh sách chính xác hơn. [Tìm hiểu thêm](https://web.dev/list/)."
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "Các danh sách không chỉ chứa các phần tử `<li>` và phần tử hỗ trợ tập lệnh (`<script>` và `<template>`)."
+    "message": "Danh sách không chỉ chứa các phần tử `<li>` và phần tử hỗ trợ tập lệnh (`<script>` và `<template>`)."
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "Các danh sách chỉ chứa phần tử `<li>` và các phần tử hỗ trợ tập lệnh (`<script>` và `<template>`)."
+    "message": "Danh sách chỉ chứa các phần tử `<li>` và phần tử hỗ trợ tập lệnh (`<script>` và `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Trình đọc màn hình yêu cầu các mục thuộc danh sách (`<li>`) phải có trong một `<ul>` hoặc `<ol>` mẹ để được thông báo chính xác. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)."
+    "message": "Trình đọc màn hình yêu cầu các mục danh sách (`<li>`) phải có trong một `<ul>` hoặc `<ol>` mẹ để được thông báo đúng cách. [Tìm hiểu thêm](https://web.dev/listitem/)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "Liệt kê các mục (`<li>`) không có trong các phần tử mẹ `<ul>` hoặc `<ol>`."
+    "message": "Các mục trong danh sách (`<li>`) không có trong phần tử `<ul>` hoặc `<ol>` mẹ."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "Các mục danh sách (`<li>`) có trong các phần tử mẹ `<ul>` hoặc `<ol>`"
+    "message": "Các mục trong danh sách (`<li>`) có trong phần tử mẹ `<ul>` hoặc `<ol>`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "Người dùng không muốn một trang tự động làm mới, và việc trang tự động làm mới sẽ chuyển tiêu điểm về đầu trang. Điều này có thể tạo ra trải nghiệm khó chịu hoặc gây nhầm lẫn cho người dùng. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)."
+    "message": "Người dùng không muốn trang tự động làm mới. Khi trang tự động làm mới, tiêu điểm sẽ quay về đầu trang. Người dùng có thể cảm thấy khó chịu hoặc bị nhầm lẫn nếu gặp trường hợp này. [Tìm hiểu thêm](https://web.dev/meta-refresh/)."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
     "message": "Tài liệu này sử dụng `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "Tài liệu này không sử dụng `<meta http-equiv=\"refresh\">`"
+    "message": "Tài liệu này không dùng `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "Việc tắt tính năng thu phóng sẽ ảnh hưởng đến những người dùng có thị lực kém và dựa vào tính năng phóng to màn hình để xem rõ nội dung của trang web. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)."
+    "message": "Việc tắt tính năng thu phóng sẽ gây trở ngại cho những người dùng có thị lực kém bị lệ thuộc vào chức năng phóng to màn hình để thấy rõ nội dung trang web. [Tìm hiểu thêm](https://web.dev/meta-viewport/)."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "`[user-scalable=\"no\"]` được sử dụng trong phần tử `<meta name=\"viewport\">` hoặc thuộc tính `[maximum-scale]` nhỏ hơn 5."
+    "message": "`[user-scalable=\"no\"]` được dùng trong phần tử `<meta name=\"viewport\">` hoặc thuộc tính `[maximum-scale]` nhỏ hơn 5."
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
     "message": "`[user-scalable=\"no\"]` không được sử dụng trong phần tử `<meta name=\"viewport\">` và thuộc tính `[maximum-scale]` không nhỏ hơn 5."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "Trình đọc màn hình không thể dịch nội dung không ở dạng văn bản. Việc thêm văn bản thay thế vào các phần tử `<object>` sẽ giúp trình đọc màn hình truyền đạt ý nghĩa cho người dùng. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)."
+    "message": "Trình đọc màn hình không thể dịch nội dung không ở dạng văn bản. Khi bạn thêm văn bản thay thế vào các phần tử `<object>`, trình đọc màn hình sẽ truyền đạt được ý nghĩa cho người dùng. [Tìm hiểu thêm](https://web.dev/object-alt/)."
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "Các phần tử `<object>` không có văn bản `[alt]`"
@@ -264,58 +264,70 @@
     "message": "Các phần tử `<object>` có văn bản `[alt]`"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "Giá trị lớn hơn 0 ngụ ý thứ tự điều hướng rõ ràng. Mặc dù hợp lệ về mặt kỹ thuật nhưng điều này thường tạo ra trải nghiệm khó chịu cho những người dùng dựa vào công nghệ hỗ trợ. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)."
+    "message": "Giá trị lớn hơn 0 ngụ ý thứ tự di chuyển rõ ràng. Mặc dù hợp lệ về mặt kỹ thuật nhưng điều này thường tạo ra trải nghiệm khó chịu cho những người dùng bị lệ thuộc vào công nghệ hỗ trợ. [Tìm hiểu thêm](https://web.dev/tabindex/)."
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "Một số phần tử có giá trị `[tabindex]` lớn hơn 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "Không có phần tử nào có giá trị `[tabindex]` lớn hơn 0"
+    "message": "Không phần tử nào có giá trị `[tabindex]` lớn hơn 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "Trình đọc màn hình có các tính năng giúp người dùng dễ dàng sử dụng bảng hơn. Việc đảm bảo các ô `<td>` sử dụng thuộc tính `[headers]` chỉ tham chiếu các ô khác trong cùng bảng có thể cải thiện trải nghiệm của người dùng trình đọc màn hình. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)."
+    "message": "Trình đọc màn hình có các tính năng giúp người dùng dễ sử dụng bảng hơn. Việc đảm bảo các ô `<td>` sử dụng thuộc tính `[headers]` chỉ tham chiếu các ô khác trong cùng bảng có thể cải thiện trải nghiệm của người dùng trình đọc màn hình. [Tìm hiểu thêm](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Các ô trong một phần tử `<table>` sử dụng thuộc tính `[headers]` tham chiếu các ô khác trong cùng bảng đó."
+    "message": "Các ô trong một phần tử `<table>` sử dụng thuộc tính `[headers]` tham chiếu các ô khác trong chính bảng đó."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Các ô trong phần tử `<table>` sử dụng thuộc tính `[headers]` chỉ tham chiếu các ô khác trong cùng bảng đó."
+    "message": "Các ô trong phần tử `<table>` dùng thuộc tính `[headers]` chỉ tham chiếu các ô khác trong chính bảng đó."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "Trình đọc màn hình có các tính năng giúp người dùng dễ dàng sử dụng bảng hơn. Việc đảm bảo tiêu đề bảng luôn tham chiếu đến một nhóm ô nào đó có thể cải thiện trải nghiệm của người dùng trình đọc màn hình. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)."
+    "message": "Trình đọc màn hình có các tính năng giúp người dùng dễ sử dụng bảng hơn. Việc đảm bảo tiêu đề bảng luôn tham chiếu đến một nhóm ô nào đó có thể cải thiện trải nghiệm của người dùng trình đọc màn hình. [Tìm hiểu thêm](https://web.dev/th-has-data-cells/)."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "Các phần tử `<th>` và các phần tử có `[role=\"columnheader\"/\"rowheader\"]` không có các ô dữ liệu mà chúng mô tả."
+    "message": "Các phần tử `<th>` và phần tử có `[role=\"columnheader\"/\"rowheader\"]` không chứa các ô dữ liệu mà các phần tử đó mô tả."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "Các phần tử `<th>` và các phần tử có `[role=\"columnheader\"/\"rowheader\"]` có các ô dữ liệu mà chúng mô tả."
+    "message": "Các phần tử `<th>` và phần tử có `[role=\"columnheader\"/\"rowheader\"]` chứa các ô dữ liệu mà các phần tử này mô tả."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "Việc chỉ định một [BCP 47 language] hợp lệ (https://www.w3.org/International/questions/qa-choosing-language-tags#question) cho các phần tử sẽ giúp đảm bảo rằng trình đọc màn hình phát âm văn bản chính xác. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)."
+    "message": "Việc chỉ định một [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) hợp lệ cho các phần tử sẽ giúp trình đọc màn hình phát âm văn bản chính xác. [Tìm hiểu thêm](https://web.dev/valid-lang/)."
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
     "message": "Các thuộc tính `[lang]` không có giá trị hợp lệ"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "Các thuộc tính `[lang]` có một giá trị hợp lệ"
+    "message": "Các thuộc tính `[lang]` có giá trị hợp lệ"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "Khi video có phụ đề, người điếc và người dùng khiếm thính có thể tiếp cận thông tin của video dễ dàng hơn. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)."
+    "message": "Video có phụ đề có thể giúp người dùng bị khiếm thính và nặng tai dễ dàng tiếp cận nội dung video hơn. [Tìm hiểu thêm](https://web.dev/video-caption/)."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
     "message": "Các phần tử `<video>` không chứa phần tử `<track>` có `[kind=\"captions\"]`."
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "Các phần tử `<video>` chứa một phần tử `<track>` có `[kind=\"captions\"]`"
+    "message": "Các phần tử `<video>` chứa phần tử `<track>` có `[kind=\"captions\"]`"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "Phần mô tả âm thanh cung cấp thông tin liên quan cho video mà phần hội thoại không thể làm được, chẳng hạn như cảnh và biểu cảm khuôn mặt. [Tìm hiểu thêm](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)."
+    "message": "Phần mô tả âm thanh cung cấp thông tin liên quan cho video mà phần hội thoại không thể làm được, chẳng hạn như cảnh và biểu cảm khuôn mặt. [Tìm hiểu thêm](https://web.dev/video-description/)."
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
     "message": "Các phần tử `<video>` không chứa phần tử `<track>` có `[kind=\"description\"]`."
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "Các phần tử `<video>` chứa một phần tử `<track>` có `[kind=\"description\"]`"
+    "message": "Các phần tử `<video>` chứa phần tử `<track>` có `[kind=\"description\"]`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "Hãy xác định apple-touch-icon để thuộc tính này hiển thị đúng cách trên iOS khi người dùng thêm vào màn hình chính. Thuộc tính này phải trỏ đến ảnh PNG vuông có kích thước 192px (hoặc 180px) ở dạng không trong suốt. [Tìm hiểu thêm](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "Chưa cung cấp `apple-touch-icon` hợp lệ"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` đã lỗi thời, nên dùng `apple-touch-icon`."
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "Hãy cung cấp `apple-touch-icon` hợp lệ"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Các tiện ích của Chrome ảnh hưởng tiêu cực đến hiệu suất tải của trang này. Hãy thử kiểm tra trang ở chế độ ẩn danh hoặc từ một hồ sơ trên Chrome không có tiện ích."
@@ -330,7 +342,7 @@
     "message": "Tổng thời gian của CPU"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "Hãy xem xét giảm thời gian dùng để phân tích cú pháp, biên soạn và thực thi JS. Bạn có thể giải quyết vấn đề này bằng cách phân phối các tải trọng JS nhỏ hơn. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
+    "message": "Hãy cân nhắc giảm thời gian dùng để phân tích cú pháp, biên soạn và thực thi JS. Bạn có thể giải quyết vấn đề này bằng cách phân phối các tải trọng JS nhỏ hơn. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/bootup)."
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "Giảm thời gian thực thi JavaScript"
@@ -339,25 +351,25 @@
     "message": "Thời gian thực thi JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "Các ảnh GIF lớn không hiệu quả trong việc phân phối nội dung động. Hãy xem xét sử dụng video MPEG4/WebM cho ảnh động và PNG/WebP cho ảnh tĩnh thay vì ảnh GIF để tiết kiệm dữ liệu mạng (số byte mạng). [Tìm hiểu thêm](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "Ảnh GIF lớn không có hiệu quả trong việc phân phối nội dung động. Hãy cân nhắc sử dụng video MPEG4/WebM cho ảnh động và PNG/WebP cho ảnh tĩnh thay vì ảnh GIF để tiết kiệm dữ liệu mạng. [Tìm hiểu thêm](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "Sử dụng các định dạng video cho nội dung động"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "Xem xét trì hoãn tải các hình ảnh ẩn và ngoài màn hình sau khi tất cả tài nguyên quan trọng tải xong để giảm thời gian tương tác. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
+    "message": "Hãy cân nhắc tải từng phần các hình ảnh ẩn và nằm ngoài màn hình sau khi tải xong tất cả tài nguyên quan trọng nhằm giảm thời gian tương tác. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)."
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "Trì hoãn tải các hình ảnh ngoài màn hình"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "Các tài nguyên đang chặn hình ảnh đầu tiên trang của bạn. Hãy xem xét phân phối nội dòng JS/CSS quan trọng và trì hoãn mọi JS/kiểu không quan trọng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+    "message": "Các tài nguyên đang chặn lần hiển thị đầu tiên của trang. Hãy cân nhắc phân phối nội dòng JS/Biểu định kiểu xếp chồng (CSS) quan trọng và trì hoãn mọi JS/kiểu không quan trọng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Loại bỏ các tài nguyên chặn hiển thị"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "Tải trọng mạng lớn gây tốn tiền cho người dùng và thường dẫn đến thời gian tải lâu. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
+    "message": "Tải trọng mạng lớn gây tốn kém cho người dùng và thường khiến thời gian tải lâu. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)."
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Tổng kích thước là {totalBytes, number, bytes} KB"
@@ -369,7 +381,7 @@
     "message": "Tránh tài nguyên lớn trên mạng"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "Việc giảm kích thước tệp CSS có thể giảm kích thước tài nguyên trên mạng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
+    "message": "Việc giảm kích thước tệp Biểu định kiểu xếp chồng (CSS) có thể giảm kích thước tải trọng mạng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/minify-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Rút gọn CSS"
@@ -381,7 +393,7 @@
     "message": "Rút gọn JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "Xóa các quy tắc vô hiệu khỏi biểu định kiểu và trì hoãn tải Biểu định kiểu xếp chồng (CSS) không dùng cho nội dung trong màn hình đầu tiên để giảm số byte không cần thiết mà hoạt động mạng sử dụng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
+    "message": "Hãy xóa các quy tắc vô hiệu khỏi biểu định kiểu và trì hoãn tải Biểu định kiểu xếp chồng (CSS) không dùng cho nội dung trong màn hình đầu tiên để giảm số byte không cần thiết mà hoạt động mạng sử dụng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/unused-css)."
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "Xóa biểu định kiểu xếp chồng (CSS) không dùng"
@@ -393,7 +405,7 @@
     "message": "Xóa JavaScript không dùng"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "Tuổi thọ lâu dài của bộ nhớ đệm có thể tăng tốc số lượt truy cập lặp lại vào trang của bạn. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
+    "message": "Bộ nhớ đệm có thời gian hữu dụng dài có thể giúp tăng tốc số lượt truy cập lặp lại vào trang của bạn. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{Đã tìm thấy 1 tài nguyên}other{Đã tìm thấy # tài nguyên}}"
@@ -411,31 +423,82 @@
     "message": "Mã hóa hình ảnh hiệu quả"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "Phân phối hình ảnh có kích thước phù hợp để tiết kiệm dữ liệu di động và cải thiện thời gian tải. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
+    "message": "Phân phát hình ảnh có kích thước phù hợp để tiết kiệm dữ liệu di động và cải thiện thời gian tải. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "Thay đổi kích thước hình ảnh cho phù hợp"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "Các tài nguyên dựa trên văn bản phải được phân phối ở định dạng nén (gzip, deflate hoặc brotli) để giảm thiểu tổng số byte mạng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
+    "message": "Phải phân phát các tài nguyên dựa trên văn bản ở định dạng nén (gzip, deflate hoặc brotli) để giảm thiểu tổng số byte mạng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/text-compression)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "Bật tính năng nén văn bản"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "Các định dạng hình ảnh như JPEG 2000, JPEG XR và WebP thường nén tốt hơn so với các định dạng PNG hoặc JPEG. Điều này có nghĩa là tốc độ tải xuống nhanh hơn và tiêu tốn ít dữ liệu hơn. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/webp)."
+    "message": "Các định dạng hình ảnh như JPEG 2000, JPEG XR và WebP thường nén tốt hơn PNG hoặc JPEG, tức là tải xuống nhanh hơn và tiêu tốn ít dữ liệu hơn. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/webp)."
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "Phân phối hình ảnh ở định dạng mới và hiệu quả hơn"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "Các chuỗi yêu cầu quan trọng dưới đây cho bạn biết những tài nguyên có mức độ ưu tiên cao sẽ được tải. Hãy cân nhắc giảm độ dài chuỗi, giảm kích thước tài nguyên tải xuống hoặc trì hoãn tải xuống các tài nguyên không cần thiết để cải thiện tốc độ tải trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+    "message": "Các Chuỗi yêu cầu quan trọng dưới đây cho bạn biết những tài nguyên có mức độ ưu tiên cao sẽ được tải. Hãy cân nhắc giảm độ dài chuỗi, giảm kích thước tài nguyên tải xuống hoặc trì hoãn tải xuống các tài nguyên không cần thiết để cải thiện tốc độ tải trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{Đã tìm thấy 1 chuỗi}other{Đã tìm thấy # chuỗi}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "Giảm thiểu độ sâu của các yêu cầu quan trọng"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "Không dùng nữa/Cảnh báo"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Dòng"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "Cuối cùng, các API không dùng nữa sẽ bị xóa khỏi trình duyệt. [Tìm hiểu thêm](https://www.chromestatus.com/features#deprecated)."
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{Tìm thấy 1 cảnh báo}other{Tìm thấy # cảnh báo}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "Sử dụng các API không dùng nữa"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "Tránh các API không dùng nữa"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "Bộ nhớ đệm của ứng dụng không còn dùng nữa. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "Tìm thấy \"{AppCacheManifest}\""
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "Dùng bộ nhớ đệm của ứng dụng"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "Tránh sử dụng bộ nhớ đệm của ứng dụng"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "Khi bạn chỉ định loại tài liệu, trình duyệt sẽ không chuyển sang chế độ tương thích ngược. Hãy đọc thêm trên [trang Tài liệu web MDN](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "Tên loại tài liệu phải là chuỗi `html` viết thường"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "Tài liệu phải chứa một loại tài liệu"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "publicId lẽ ra phải là một chuỗi trống"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "systemId lẽ ra phải là một chuỗi trống"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "Trang thiếu loại tài liệu HTML nên đã kích hoạt chế độ tương thích ngược"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "Trang có loại tài liệu HTML"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Phần tử"
@@ -447,7 +510,7 @@
     "message": "Giá trị"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "Các kỹ sư trình duyệt khuyên rằng các trang không nên chứa quá 1.500 phần tử DOM. Tốt nhất là có độ sâu của cây nhỏ hơn 32 phần tử và có ít hơn 60 phần tử con/phần tử mẹ. Một DOM lớn có thể làm tăng mức sử dụng bộ nhớ, khiến [các phép tính về kiểu](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) dài hơn, đồng thời tạo ra [các quy trình trình bày lại bố cục](https://developers.google.com/speed/articles/reflow) tốn kém. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
+    "message": "Các kỹ sư trình duyệt khuyến cáo rằng các trang không nên chứa quá 1.500 phần tử DOM. Tốt nhất là có độ sâu của cây nhỏ hơn 32 phần tử và có ít hơn 60 phần tử con/phần tử mẹ. Một DOM lớn có thể làm tăng mức sử dụng bộ nhớ, khiến [các phép tính về kiểu](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations) dài hơn, đồng thời tạo ra [các quy trình trình bày lại bố cục](https://developers.google.com/speed/articles/reflow) tốn kém. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/dom-size)."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 phần tử}other{# phần tử}}"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Tránh kích thước DOM quá lớn"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "Mục tiêu"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "Thêm `rel=\"noopener\"` hoặc `rel=\"noreferrer\"` vào mọi đường dẫn liên kết ngoài để cải thiện hiệu suất và ngăn chặn các lỗ hổng bảo mật. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "Các đường dẫn liên kết đến các trang đích trên nhiều nguồn gốc là không an toàn"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "Các đường dẫn liên kết đến các trang đích trên nhiều nguồn gốc là an toàn"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "Không thể xác định trang đích cho phần tử neo ({anchorHTML}). Nếu không dùng làm siêu liên kết, hãy cân nhắc xóa target=_blank."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "Các trang web yêu cầu vị trí của người dùng mà không cung cấp ngữ cảnh sẽ khiến người dùng không tin tưởng hoặc bối rối. Hãy cân nhắc liên kết yêu cầu với hành động của người dùng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "Yêu cầu quyền truy cập vị trí địa lý khi tải trang"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "Tránh yêu cầu quyền truy cập vị trí địa lý khi tải trang"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "Phiên bản"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "Phát hiện thấy tất cả thư viện giao diện người dùng JavaScript trên trang này."
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "Thư viện JavaScript phát hiện được"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "Đối với những người dùng có kết nối chậm, các tập lệnh bên ngoài tự động được đưa vào qua `document.write()` có thể làm trang tải chậm hàng chục giây. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "Sử dụng `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "Tránh `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "Mức độ nghiêm trọng cao nhất"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "Phiên bản thư viện"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "Số lượng lỗ hổng"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "Một số tập lệnh của bên thứ ba có thể chứa các lỗ hổng bảo mật đã biết mà kẻ tấn công dễ dàng xác định và khai thác. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)."
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{Phát hiện thấy 1 lỗ hổng}other{Phát hiện thấy # lỗ hổng}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "Bao gồm các thư viện giao diện người dùng JavaScript có những lỗ hổng bảo mật đã biết"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "Cao"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "Thấp"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "Trung bình"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "Tránh các thư viện giao diện người dùng JavaScript có lỗ hổng bảo mật đã biết"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "Các trang web gửi thông báo không có ngữ cảnh sẽ khiến người dùng không tin tưởng hoặc bối rối. Hãy cân nhắc liên kết yêu cầu với cử chỉ của người dùng. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "Yêu cầu quyền truy cập thông báo khi tải trang"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "Tránh yêu cầu quyền truy cập thông báo khi tải trang"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "Các phần tử không đạt"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "Việc ngăn dán mật khẩu sẽ làm giảm tác dụng của chính sách bảo mật hiệu quả. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)."
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "Ngăn người dùng dán vào các trường mật khẩu"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "Cho phép người dùng dán vào các trường mật khẩu"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "Giao thức"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 mang lại nhiều lợi ích hơn HTTP/1.1, trong đó có tiêu đề nhị phân, đa hợp và máy chủ tự quyết. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{Chưa phân phát 1 yêu cầu qua HTTP/2}other{Chưa phân phát # yêu cầu qua HTTP/2}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "Không sử dụng HTTP/2 cho tất cả các tài nguyên của trang web"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "Sử dụng HTTP/2 cho các tài nguyên của chính trang web"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "Hãy cân nhắc đánh dấu trình xử lý sự kiện chạm và di chuyển con lăn là `passive` để cải thiện hiệu suất cuộn trên trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "Không sử dụng trình nghe bị động để cải thiện hiệu suất cuộn"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "Sử dụng trình nghe bị động để cải thiện hiệu suất cuộn"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "Nội dung mô tả"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "Các lỗi được ghi vào bảng điều khiển là những sự cố chưa giải quyết. Những sự cố này có thể do lỗi yêu cầu mạng và các vấn đề khác của trình duyệt gây ra."
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "Đã ghi lỗi của trình duyệt vào bảng điều khiển"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "Chưa ghi lỗi nào của trình duyệt vào bảng điều khiển"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "Sử dụng tính năng CSS hiển thị phông chữ để đảm bảo văn bản hiển thị với người dùng khi phông chữ web đang tải. [Tìm hiểu thêm](https://developers.google.com/web/updates/2016/02/font-display)."
+    "message": "Sử dụng tính năng Biểu định kiểu xếp chồng (CSS) hiển thị phông chữ để đảm bảo văn bản hiển thị với người dùng khi phông chữ web đang tải. [Tìm hiểu thêm](https://developers.google.com/web/updates/2016/02/font-display)."
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "Đảm bảo văn bản vẫn hiển thị trong khi tải phông chữ web"
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "Tất cả văn bản vẫn hiển thị trong khi tải phông chữ web"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse không thể tự động kiểm tra giá trị hiển thị phông chữ cho URL sau: {fontURL}."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "Tỷ lệ khung hình (Thực tế)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "Tỷ lệ khung hình (Hiển thị)"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "Kích thước hiển thị của hình ảnh phải khớp với tỷ lệ khung hình tự nhiên. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)."
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "Hiển thị hình ảnh có tỷ lệ khung hình không chính xác"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "Hiển thị hình ảnh có tỷ lệ khung hình chính xác"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "Thông tin kích thước hình ảnh không hợp lệ {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "URL không an toàn"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "Bạn phải bảo vệ tất cả các trang web bằng HTTPS, kể cả những trang web không xử lý dữ liệu nhạy cảm. HTTPS ngăn kẻ xâm nhập can thiệp hoặc vô tình biết được nội dung trao đổi giữa ứng dụng và người dùng của bạn, đồng thời là điều kiện tiên quyết nếu bạn muốn dùng HTTP/2 và nhiều API nền tảng web mới. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/https)."
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{Tìm thấy 1 yêu cầu không an toàn}other{Tìm thấy # yêu cầu không an toàn}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "Không sử dụng HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "Sử dụng HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "Tốc độ tải trang nhanh trên mạng di động đảm bảo mang đến trải nghiệm tích cực cho người dùng thiết bị di động. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
+    "message": "Tốc độ tải trang nhanh trên mạng di động giúp mang đến trải nghiệm tích cực cho người dùng thiết bị di động. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "Tương tác ở giây thứ {timeInMs, number, seconds} s"
+    "message": "Tương tác ở giây thứ {timeInMs, number, seconds}"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "Tương tác trên mạng di động mô phỏng ở giây thứ {timeInMs, number, seconds}"
@@ -504,25 +735,25 @@
     "message": "Giảm thiểu công việc theo chuỗi chính"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "Thời gian chờ nhập thông tin theo ước tính là thời gian ước tính mà ứng dụng cần để phản hồi thông tin do người dùng nhập (tính bằng mili giây) trong khoảng thời gian 5 giây tải trang bận bịu nhất. Nếu thời gian chờ lâu hơn 50 mili giây, thì người dùng có thể cho rằng ứng dụng chạy chậm. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
+    "message": "Thời gian chờ nhập thông tin theo ước tính là thời gian ước tính mà ứng dụng cần để phản hồi thông tin do người dùng nhập (tính bằng mili giây) trong khoảng thời gian 5 giây tải nhiều trang nhất. Nếu người dùng phải chờ quá 50 mili giây, thì ứng dụng của bạn bị coi là chạy chậm. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "Thời gian chờ nhập thông tin theo ước tính"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "Chỉ số Hình ảnh có nội dung đầu tiên đánh dấu thời điểm hiển thị văn bản hoặc hình ảnh đầu tiên. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
+    "message": "Chỉ số Hiển thị nội dung đầu tiên đánh dấu thời điểm hiển thị văn bản hoặc hình ảnh đầu tiên. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)."
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "Hình ảnh có nội dung đầu tiên"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "Chỉ số CPU nhàn rỗi đầu tiên đánh dấu thời điểm đầu tiên chuỗi chính của trang đủ yên tĩnh để xử lý thông tin nhập vào. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
+    "message": "Chỉ số CPU nhàn rỗi đầu tiên đánh dấu thời điểm đầu tiên chuỗi chính của trang không phải xử lý quá nhiều thông tin nhập vào. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "CPU nhàn rỗi đầu tiên"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "Chỉ số Hình ảnh có ý nghĩa đầu tiên đo lường thời điểm nội dung chính của trang hiển thị. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
+    "message": "Chỉ số Hiển thị nội dung đầu tiên đo lường thời điểm hiển thị nội dung chính của trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "Hình ảnh có ý nghĩa đầu tiên"
@@ -534,34 +765,61 @@
     "message": "Thời điểm tương tác"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "Thời gian phản hồi lần tương tác đầu tiên mà người dùng có thể gặp phải là thời gian thực hiện nhiệm vụ lâu nhất (tính bằng mili giây)."
+    "message": "Thời gian phản hồi lần tương tác đầu tiên tối đa mà người dùng có thể gặp phải là thời gian thực hiện nhiệm vụ lâu nhất (tính bằng mili giây). [Tìm hiểu thêm](https://developers.google.com/web/updates/2018/05/first-input-delay)."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID tối đa có thể có"
+    "message": "Thời gian phản hồi lần tương tác đầu tiên tối đa có thể"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "Chỉ mục tốc độ cho biết nội dung của một trang hiển thị nhanh chóng đến mức nào. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
+    "message": "Chỉ số tốc độ cho biết nội dung của một trang hiển thị nhanh chóng đến mức nào. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
-    "message": "Chỉ mục tốc độ"
+    "message": "Chỉ số tốc độ"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "Tổng tất cả các khoảng thời gian giữa thời điểm Hiển thị nội dung đầu tiên (FCP) và Thời điểm tương tác khi thời gian nhiệm vụ vượt quá 50 mili giây được biểu thị bằng đơn vị mili giây."
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "Tổng thời gian chặn"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
-    "message": "Thời gian trọn vòng (RTT) của mạng có ảnh hưởng lớn đến hiệu suất. Nếu mất nhiều thời gian trọn vòng để đến một điểm xuất phát, thì tức là máy chủ càng gần người dùng thì hiệu quả càng cao. [Tìm hiểu thêm](https://hpbn.co/primer-on-latency-and-bandwidth/)."
+    "message": "Thời gian trọn vòng (RTT) của mạng có ảnh hưởng lớn đến hiệu suất. Nếu mất nhiều thời gian trọn vòng (RTT) để đến một nguồn gốc, tức là máy chủ càng gần người dùng thì hiệu quả càng cao. [Tìm hiểu thêm](https://hpbn.co/primer-on-latency-and-bandwidth/)."
   },
   "lighthouse-core/audits/network-rtt.js | title": {
     "message": "Thời gian trọn vòng của mạng"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "Thời gian chờ của máy chủ có thể ảnh hưởng đến hiệu suất của web. Nếu máy chủ tại điểm xuất phát mất nhiều thời gian chờ, thì tức là máy chủ bị quá tải hoặc có hiệu suất phụ trợ kém. [Tìm hiểu thêm](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
+    "message": "Thời gian chờ của máy chủ có thể ảnh hưởng đến hiệu suất của trang web. Nếu máy chủ của một nguồn gốc có thời gian chờ cao, tức là máy chủ bị quá tải hoặc có hiệu suất phụ trợ thấp. [Tìm hiểu thêm](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)."
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Thời gian dưới nền của máy chủ"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "Vượt ngân sách"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "Đảm bảo số lượng và quy mô của yêu cầu mạng thấp hơn mục tiêu đặt ra của ngân sách hiệu suất đã cung cấp. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 yêu cầu}other{# yêu cầu}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "Ngân sách hiệu suất"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "Các lần chuyển hướng sẽ làm tốc độ tải trang chậm hơn. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
+    "message": "Các lần chuyển hướng sẽ làm giảm tốc độ tải trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/redirects)."
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "Tránh chuyển hướng trang nhiều lần"
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "Để thiết lập ngân sách cho số lượng và quy mô của tài nguyên trang, hãy thêm tệp budget.json. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/budgets)."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 yêu cầu}other{# yêu cầu}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Giảm số lượng yêu cầu và chuyển những tài nguyên có kích thước nhỏ"
   },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Phần tử liên kết chính tắc đề xuất URL nào nên hiển thị trong kết quả tìm kiếm. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/canonical)."
@@ -573,7 +831,7 @@
     "message": "Trỏ đến một miền khác ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "URL không hợp lệ ({url})"
+    "message": "URL không hợp lệ ({url})."
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
     "message": "Trỏ đến một vị trí `hreflang` khác ({url})"
@@ -596,14 +854,11 @@
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} văn bản dễ đọc"
   },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} văn bản có kích thước chữ quá nhỏ."
-  },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "Văn bản không đọc được vì không có thẻ meta viewport nào được tối ưu hóa cho màn hình thiết bị di động."
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} văn bản có cỡ chữ quá nhỏ (dựa trên mẫu {decimalProportionVisited, number, extendedPercent})."
+    "message": "Văn bản có tỷ lệ {decimalProportion, number, extendedPercent} là quá nhỏ (căn cứ vào mẫu {decimalProportionVisited, number, extendedPercent})."
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Tài liệu không sử dụng cỡ chữ dễ đọc"
@@ -612,7 +867,7 @@
     "message": "Tài liệu sử dụng cỡ chữ dễ đọc"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "Các phần tử liên kết hreflang cho công cụ tìm kiếm biết nên liệt kê phiên bản nào của trang trong kết quả tìm kiếm cho một ngôn ngữ hoặc khu vực cụ thể. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
+    "message": "Các phần tử liên kết hreflang cho công cụ tìm kiếm biết nên liệt kê phiên bản trang nào trong kết quả tìm kiếm cho một ngôn ngữ hoặc khu vực cụ thể. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/hreflang)."
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
     "message": "Tài liệu không có `hreflang` hợp lệ"
@@ -621,7 +876,7 @@
     "message": "Tài liệu có `hreflang` hợp lệ"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
-    "message": "Các trang có mã trạng thái HTTP không thành công có thể không được lập chỉ mục chính xác. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
+    "message": "Các trang có mã trạng thái HTTP không thành công có thể được lập chỉ mục không chính xác. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
   },
   "lighthouse-core/audits/seo/http-status-code.js | failureTitle": {
     "message": "Trang có mã trạng thái HTTP không thành công"
@@ -630,7 +885,7 @@
     "message": "Trang có mã trạng thái HTTP thành công"
   },
   "lighthouse-core/audits/seo/is-crawlable.js | description": {
-    "message": "Các công cụ tìm kiếm không thể bao gồm trang của bạn trong kết quả tìm kiếm nếu bạn không cấp cho các công cụ này quyền thu thập thông tin của trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
+    "message": "Các công cụ tìm kiếm không thể đưa trang của bạn vào kết quả tìm kiếm nếu bạn không cấp cho các công cụ này quyền thu thập thông tin của trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/indexing)."
   },
   "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": {
     "message": "Trang bị chặn lập chỉ mục"
@@ -639,7 +894,7 @@
     "message": "Trang không bị chặn lập chỉ mục"
   },
   "lighthouse-core/audits/seo/link-text.js | description": {
-    "message": "Văn bản mô tả của phần tử liên kết giúp công cụ tìm kiếm hiểu được nội dung của bạn. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
+    "message": "Văn bản mô tả trên đường dẫn liên kết giúp công cụ tìm kiếm hiểu được nội dung của bạn. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)."
   },
   "lighthouse-core/audits/seo/link-text.js | displayValue": {
     "message": "{itemCount,plural, =1{Đã tìm thấy 1 liên kết}other{Đã tìm thấy # liên kết}}"
@@ -651,13 +906,13 @@
     "message": "Các phần tử liên kết có văn bản mô tả"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "Chạy [Công cụ kiểm tra dữ liệu có cấu trúc](https://search.google.com/structured-data/testing-tool/) và [Công cụ khử lỗi dành cho dữ liệu có cấu trúc](http://linter.structured-data.org/) để xác thực dữ liệu có cấu trúc. [Tìm hiểu thêm](https://developers.google.com/search/docs/guides/mark-up-content)."
+    "message": "Chạy [Công cụ kiểm tra dữ liệu có cấu trúc](https://search.google.com/structured-data/testing-tool/) và [Công cụ khử lỗi dữ liệu có cấu trúc](http://linter.structured-data.org/) để xác thực loại dữ liệu này. [Tìm hiểu thêm](https://developers.google.com/search/docs/guides/mark-up-content)."
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "Dữ liệu có cấu trúc là hợp lệ"
   },
   "lighthouse-core/audits/seo/meta-description.js | description": {
-    "message": "Bạn có thể bao gồm phần mô tả meta trong kết quả tìm kiếm để tóm tắt ngắn gọn nội dung trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/description)."
+    "message": "Bạn có thể thêm phần mô tả meta vào kết quả tìm kiếm để tóm tắt ngắn gọn nội dung trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/description)."
   },
   "lighthouse-core/audits/seo/meta-description.js | explanation": {
     "message": "Văn bản mô tả hiện đang trống."
@@ -696,7 +951,7 @@
     "message": "robots.txt hợp lệ"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "Các phần tử tương tác, chẳng hạn như nút hoặc phần tử liên kết, nên có kích thước đủ lớn (48 x 48 pixel) và khoảng cách xung quanh các phần tử này đủ để nhấn mà không chồng chéo lên các phần tử khác. [Tìm hiểu thêm](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
+    "message": "Các phần tử tương tác, chẳng hạn như nút và phần tử liên kết, nên có kích thước đủ lớn (48x48 pixel) và khoảng cách xung quanh các phần tử này đủ để nhấn mà không chồng chéo lên các phần tử khác. [Tìm hiểu thêm](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)."
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} mục tiêu nhấn có kích thước phù hợp"
@@ -710,17 +965,29 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "Mục tiêu chồng chéo"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "Kích thước"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "Mục tiêu nhấn"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Mục tiêu nhấn có kích thước phù hợp"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Thời gian thực thi trên chuỗi chính"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Bên thứ ba"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Mã của bên thứ ba có thể tác động đáng kể đến hiệu suất tải. Hãy hạn chế số nhà cung cấp bên thứ ba dư thừa và cố gắng tải mã của bên thứ ba sau khi trang của bạn hoàn thành phần lớn quá trình tải. [Tìm hiểu thêm](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{Tìm thấy 1 bên thứ ba}other{Tìm thấy # bên thứ ba}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Mức sử dụng dịch vụ bên thứ ba"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "Chỉ số Thời gian cho byte đầu tiên xác định thời gian máy chủ của bạn gửi một phản hồi. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
+    "message": "Chỉ số Thời gian cho byte đầu tiên xác định thời gian máy chủ của bạn gửi phản hồi. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/ttfb)."
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Tài liệu gốc mất {timeInMs, number, milliseconds} mili giây"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "Thời lượng"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "Tên"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "Thời gian bắt đầu"
   },
@@ -744,7 +1008,7 @@
     "message": "Loại"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "Cân nhắc trang bị API Thời gian người dùng cho ứng dụng để đo lường hiệu suất thực tế của ứng dụng trong trải nghiệm người dùng chính. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+    "message": "Hãy cân nhắc trang bị API Thời gian người dùng cho ứng dụng để đo lường hiệu suất thực tế của ứng dụng trong trải nghiệm người dùng chính. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 dấu thời gian người dùng}other{# dấu thời gian người dùng}}"
@@ -753,19 +1017,19 @@
     "message": "Các thời điểm cụ thể và khoảng thời gian được ghi lại bằng API Thời gian người dùng"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "Đã tìm thấy <link> kết nối trước cho \"{securityOrigin}\" nhưng trình duyệt không sử dụng phần tử liên kết này. Hãy kiểm tra để đảm bảo rằng bạn đang sử dụng thuộc tính `crossorigin` đúng cách."
+    "message": "Tìm thấy <link> kết nối trước cho \"{securityOrigin}\" nhưng trình duyệt không sử dụng phần tử liên kết này. Hãy kiểm tra để đảm bảo rằng bạn đang sử dụng thuộc tính `crossorigin` đúng cách."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "Xem xét thêm các gợi ý về tài nguyên kết nối trước hoặc tìm nạp DNS trước để thiết lập các kết nối sớm tới các miền quan trọng của bên thứ ba. [Tìm hiểu thêm](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
+    "message": "Hãy cân nhắc thêm các gợi ý về tài nguyên kết nối trước hoặc tìm nạp DNS trước để thiết lập các kết nối sớm tới những nguồn gốc quan trọng của bên thứ ba. [Tìm hiểu thêm](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)."
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "Kết nối trước với các tên miền bắt buộc"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "Đã tìm thấy <link> tải trước cho \"{preloadURL}\" nhưng trình duyệt không sử dụng phần tử liên kết này. Hãy kiểm tra để đảm bảo bạn đang sử dụng thuộc tính `crossorigin` đúng cách."
+    "message": "Tìm thấy <link> tải trước cho \"{preloadURL}\" nhưng trình duyệt không sử dụng phần tử liên kết này. Hãy kiểm tra để đảm bảo rằng bạn đang sử dụng thuộc tính `crossorigin` đúng cách."
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "Hãy xem xét sử dụng <link rel=preload> để ưu tiên tìm nạp tài nguyên đang được yêu cầu vào một thời điểm khác trong quá trình tải trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/preload)."
+    "message": "Hãy cân nhắc sử dụng `<link rel=preload>` để ưu tiên tìm nạp các tài nguyên đang được yêu cầu vào một thời điểm khác trong quá trình tải trang. [Tìm hiểu thêm](https://developers.google.com/web/tools/lighthouse/audits/preload)."
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "Tải trước các yêu cầu chính"
@@ -789,7 +1053,7 @@
     "message": "Các phương pháp hay nhất"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "Các hoạt động kiểm tra này nhấn mạnh cơ hội [cải thiện khả năng hỗ trợ tiếp cận của ứng dụng web](https://developers.google.com/web/fundamentals/accessibility). Các hoạt động này chỉ có thể tự động phát hiện một phần vấn đề liên quan đến khả năng hỗ trợ tiếp cận, do đó bạn nên kiểm tra cả theo cách thủ công."
+    "message": "Các hoạt động kiểm tra này giúp xác định cơ hội [cải thiện khả năng hỗ trợ tiếp cận của ứng dụng web](https://developers.google.com/web/fundamentals/accessibility). Các hoạt động này chỉ có thể tự động phát hiện một phần vấn đề liên quan đến khả năng hỗ trợ tiếp cận, do đó, bạn nên kiểm tra cả theo cách thủ công."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "Các mục này nằm trong vùng không thể sử dụng công cụ kiểm tra tự động. Tìm hiểu thêm trong hướng dẫn của chúng tôi về cách [đánh giá khả năng hỗ trợ tiếp cận](https://developers.google.com/web/fundamentals/accessibility/how-to-review)."
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Bảng và danh sách"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "Phương pháp hay nhất"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Phần Ngân sách hiệu suất đặt ra tiêu chuẩn về hiệu suất của trang web."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Ngân sách"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "Thông tin khác về hiệu suất ứng dụng của bạn."
+    "message": "Thông tin bổ sung về hiệu suất của ứng dụng. Những số liệu này không [trực tiếp ảnh hưởng](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) đến Điểm hiệu suất."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Chẩn đoán"
@@ -840,7 +1113,7 @@
     "message": "Các thao tác để cải thiện thời gian hiển thị hình ảnh đầu tiên"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "Những đề xuất tối ưu hóa này có thể tăng tốc độ tải trang của bạn."
+    "message": "Những đề xuất này có thể giúp trang của bạn tải nhanh hơn, chứ không [trực tiếp ảnh hưởng](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) đến Điểm hiệu suất."
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Cơ hội"
@@ -849,7 +1122,7 @@
     "message": "Các chỉ số"
   },
   "lighthouse-core/config/default-config.js | overallImprovementsGroupDescription": {
-    "message": "Cải thiện trải nghiệm tải tổng thể để trang phản hồi và sẵn sàng cho bạn sử dụng sớm nhất có thể. Các số liệu chính: Thời điểm tương tác, Chỉ mục tốc độ"
+    "message": "Cải thiện trải nghiệm tải tổng thể để trang phản hồi và sẵn sàng cho bạn sử dụng sớm nhất có thể. Các số liệu chính: Thời điểm tương tác, Chỉ số tốc độ"
   },
   "lighthouse-core/config/default-config.js | overallImprovementsGroupTitle": {
     "message": "Các thao tác để cải thiện hiệu suất tổng thể"
@@ -867,7 +1140,7 @@
     "message": "PWA đã tối ưu hóa"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "Các hoạt động kiểm tra này đảm bảo rằng trang của bạn được tối ưu hóa cho thứ hạng trong kết quả của công cụ tìm kiếm. Có những yếu tố bổ sung mà Lighthouse không kiểm tra và có thể ảnh hưởng đến thứ hạng của bạn trong kết quả tìm kiếm. [Tìm hiểu thêm](https://support.google.com/webmasters/answer/35769)."
+    "message": "Các hoạt động kiểm tra này đảm bảo rằng trang của bạn được tối ưu hóa cho thứ hạng trong kết quả của công cụ tìm kiếm. Những yếu tố bổ sung mà Lighthouse không kiểm tra có thể ảnh hưởng đến thứ hạng của bạn trong kết quả tìm kiếm. [Tìm hiểu thêm](https://support.google.com/webmasters/answer/35769)."
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "Chạy những trình xác thực bổ sung này trên trang web của bạn để xem thêm các phương pháp hay nhất dành cho quy trình Tối ưu hóa cho công cụ tìm kiếm (SEO)."
@@ -888,7 +1161,7 @@
     "message": "Thu thập thông tin và lập chỉ mục"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "Đảm bảo các trang của bạn thân thiện với thiết bị di động để người dùng có thể đọc các trang nội dung mà không cần phải thu phóng. [Tìm hiểu thêm](https://developers.google.com/search/mobile-sites/)."
+    "message": "Đảm bảo các trang của bạn thân thiện với thiết bị di động để người dùng có thể đọc các trang nội dung mà không cần phải chụm hoặc thu phóng. [Tìm hiểu thêm](https://developers.google.com/search/mobile-sites/)."
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "Thân thiện với thiết bị di động"
@@ -896,47 +1169,95 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Thời gian tồn tại (TTL) của bộ nhớ đệm"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "Vị trí"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "Tên"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "Số yêu cầu"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "Loại tài nguyên"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "Kích thước (KB)"
+    "message": "Kích thước"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "Thời gian sử dụng"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "Kích thước cần chuyển"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "URL"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "Số byte có thể tiết kiệm được (KB)"
+    "message": "Lượng dữ liệu có thể tiết kiệm được"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "Thời lượng có thể tiết kiệm được (mili giây)"
+    "message": "Thời gian có thể tiết kiệm được"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "Số byte có thể tiết kiệm được là {wastedBytes, number, bytes} KB"
+    "message": "Lượng dữ liệu có thể tiết kiệm được là {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "Thời lượng có thể tiết kiệm được là {wastedMs, number, milliseconds} mili giây"
+    "message": "Thời gian có thể tiết kiệm được là {wastedMs, number, milliseconds} mili giây"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "Tài liệu"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "Phông chữ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "Hình ảnh"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "Nội dung nghe nhìn"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} mili giây"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "Khác"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "Tập lệnh"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} giây"
   },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "Biểu định kiểu"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "Bên thứ ba"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "Tổng"
+  },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Đã xảy ra sự cố khi ghi lại dấu vết trong quá trình tải trang của bạn. Vui lòng chạy lại Lighthouse. ({errorCode})"
+    "message": "Đã xảy ra lỗi khi ghi dấu vết quá trình tải trang của bạn. Vui lòng chạy lại Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | criTimeout": {
     "message": "Đã hết thời gian chờ kết nối với Giao thức của trình gỡ lỗi ban đầu ban đầu."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome không thu thập bất kỳ ảnh chụp màn hình nào trong quá trình tải trang. Hãy đảm bảo có nội dung hiển thị trên trang rồi thử chạy lại Lighthouse. ({errorCode})"
+    "message": "Chrome không thu thập được bất kỳ ảnh chụp màn hình nào trong quá trình tải trang. Hãy đảm bảo trang có nội dung hiển thị, sau đó thử chạy lại Lighthouse. ({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "Máy chủ DNS không thể phân giải miền đã cung cấp."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Trình thu thập {artifactName} bắt buộc đã gặp lỗi: {errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Đã xảy ra lỗi Chrome nội bộ. Vui lòng khởi động lại Chrome và thử chạy lại Lighthouse."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Trình thu thập {artifactName} bắt buộc không chạy."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse không thể tải trang bạn đã yêu cầu một cách đáng tin cậy. Hãy đảm bảo bạn đang kiểm tra URL chính xác và máy chủ đang phản hồi tất cả các yêu cầu đúng cách."
@@ -945,7 +1266,10 @@
     "message": "Lighthouse không thể tải URL bạn yêu cầu một cách đáng tin cậy vì trang này đã ngừng phản hồi."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "URL bạn đã cung cấp không có thông tin xác thực bảo mật hợp lệ. {securityMessages}"
+    "message": "URL bạn cung cấp không có chứng chỉ bảo mật hợp lệ. {securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome đã ngăn tải trang có quảng cáo xen kẽ. Hãy đảm bảo bạn đang kiểm tra URL chính xác và máy chủ đang phản hồi tất cả các yêu cầu đúng cách."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse không thể tải trang bạn đã yêu cầu một cách đáng tin cậy. Hãy đảm bảo bạn đang kiểm tra URL chính xác và máy chủ đang phản hồi tất cả các yêu cầu đúng cách. (Chi tiết: {errorDetails})"
@@ -984,7 +1308,7 @@
     "message": "Dữ liệu của phòng thí nghiệm"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "Kết quả phân tích [Lighthouse](https://developers.google.com/web/tools/lighthouse/) cho trang hiện tại dựa trên một mạng di động mô phỏng. Các giá trị được ước tính và có thể thay đổi."
+    "message": "Kết quả phân tích [Lighthouse](https://developers.google.com/web/tools/lighthouse/) cho trang hiện tại dựa trên một mạng di động mô phỏng. Các giá trị chỉ là ước tính và có thể thay đổi."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Các mục bổ sung cần kiểm tra theo cách thủ công"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "Mở rộng đoạn mã"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "Hiển thị tài nguyên của bên thứ ba"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "Đã xảy ra sự cố ảnh hưởng đến lần chạy Lighthouse này:"
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "Các giá trị chỉ là ước tính và có thể thay đổi."
+    "message": "Các giá trị chỉ là ước tính và có thể thay đổi. Điểm hiệu suất [chỉ căn cứ vào các chỉ số này](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)."
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "Đã vượt qua bài kiểm tra nhưng có cảnh báo"
@@ -1023,7 +1350,7 @@
     "message": "Hãy cân nhắc tải tệp GIF lên một dịch vụ mà nhờ đó, tệp GIF có thể được nhúng ở dạng video HTML5."
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "Cài đặt một [plugin tải từng phần của WordPress](https://wordpress.org/plugins/search/lazy+load/) giúp trì hoãn mọi hình ảnh ngoài màn hình, hoặc chuyển sang một giao diện cung cấp chức năng đó. Ngoài ra, hãy cân nhắc sử dụng [plugin AMP](https://wordpress.org/plugins/amp/)."
+    "message": "Cài đặt một [plugin tải từng phần của WordPress](https://wordpress.org/plugins/search/lazy+load/) để trì hoãn mọi hình ảnh ngoài màn hình, hoặc chuyển sang một giao diện cung cấp chức năng đó. Ngoài ra, hãy cân nhắc sử dụng [plugin AMP (Accelerated Mobile Pages)](https://wordpress.org/plugins/amp/)."
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
     "message": "Có một số plugin của WordPress có thể giúp bạn [đưa phần tử quan trọng vào nội tuyến](https://wordpress.org/plugins/search/critical+css/) hoặc [trì hoãn tài nguyên ít quan trọng hơn](https://wordpress.org/plugins/search/defer+css+javascript/). Xin lưu ý rằng những phương thức tối ưu hóa mà các plugin này cung cấp có thể làm gián đoạn tính năng của giao diện hoặc plugin, do đó, có thể bạn cần thay đổi mã."
@@ -1035,25 +1362,25 @@
     "message": "Hãy cân nhắc hiển thị phần trích dẫn trong danh sách bài đăng (ví dụ như qua thẻ thêm), giảm số lượng bài đăng hiển thị trên một trang cụ thể, chia các bài đăng dài thành nhiều trang hoặc sử dụng một plugin để tải nhận xét theo từng phần."
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "Một số [plugin của WordPress](https://wordpress.org/plugins/search/minify+css/) có thể tăng tốc độ trang web của bạn bằng cách ghép, thu nhỏ và nén kiểu. Bạn cũng có thể dùng quy trình tạo để tiến hành thu nhỏ trước nếu có thể."
+    "message": "Một số [plugin của WordPress](https://wordpress.org/plugins/search/minify+css/) có thể làm tăng tốc độ của trang web bằng cách ghép, giảm kích thước và nén kiểu. Bạn cũng có thể dùng quy trình tạo để tiến hành thu nhỏ trước, nếu có thể."
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "Một số [plugin của WordPress](https://wordpress.org/plugins/search/minify+javascript/) có thể tăng tốc độ trang web của bạn bằng cách ghép, thu nhỏ và nén tập lệnh. Ngoài ra, bạn nên dùng quy trình tạo để tiến hành thu nhỏ trước nếu có thể."
+    "message": "Một số [plugin của WordPress](https://wordpress.org/plugins/search/minify+javascript/) có thể làm tăng tốc độ của trang web bằng cách ghép, giảm kích thước và nén tập lệnh. Ngoài ra, bạn nên dùng quy trình tạo để tiến hành thu nhỏ trước, nếu có thể."
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "Hãy cân nhắc giảm hoặc chuyển đổi số lượng [plugin của WordPress](https://wordpress.org/plugins/) tải CSS không sử dụng trong trang của bạn. Để xác định các plugin đang thêm CSS không liên quan, hãy thử chạy [phạm vi của mã](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) trong Chrome DevTools. Bạn có thể xác định giao diện/plugin gây ra tình trạng này từ URL của biểu định kiểu. Hãy chú ý đến những plugin có nhiều biểu định kiểu trong danh sách. Những plugin này có nhiều màu đỏ trong phạm vi của mã. Một plugin chỉ nên thêm một biểu định kiểu vào hàng đợi nếu biểu định kiểu đó thực sự được sử dụng trên trang."
+    "message": "Hãy cân nhắc giảm hoặc chuyển đổi số lượng [plugin của WordPress](https://wordpress.org/plugins/) tải Biểu định kiểu xếp chồng (CSS) không dùng đến trong trang của bạn. Để xác định các plugin đang thêm Biểu định kiểu xếp chồng (CSS) không liên quan, hãy thử chạy [phạm vi của mã](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) trong Chrome DevTools. Bạn có thể xác định giao diện/plugin gây ra tình trạng này từ URL của biểu định kiểu. Hãy chú ý đến những plugin có nhiều biểu định kiểu trong danh sách. Những plugin này có nhiều màu đỏ trong phạm vi của mã. Một plugin chỉ nên thêm một biểu định kiểu vào hàng đợi nếu biểu định kiểu đó thực sự được sử dụng trên trang."
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "Hãy cân nhắc giảm hoặc chuyển đối số lượng [plugin của WordPress](https://wordpress.org/plugins/) tải JavaScript không sử dụng trong trang của bạn. Để xác định các plugin đang thêm JavaScript (JS) không liên quan, hãy thử chạy [phạm vi của mã](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) trong Chrome DevTools. Bạn có thể xác định giao diện/plugin gây ra tình trạng này từ URL của tập lệnh. Hãy chú ý đến những plugin có nhiều tập lệnh trong danh sách. Những plugin này có nhiều màu đỏ trong phạm vi của mã. Một plugin chỉ nên thêm một tập lệnh vào hàng đợi nếu tập lệnh đó thực sự được sử dụng trên trang."
+    "message": "Hãy cân nhắc giảm hoặc chuyển đổi số lượng [plugin của WordPress](https://wordpress.org/plugins/) tải JavaScript không dùng đến trong trang của bạn. Để xác định các plugin đang thêm JS không liên quan, hãy thử chạy [phạm vi của mã](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) trong Chrome DevTools. Bạn có thể xác định giao diện/plugin gây ra tình trạng này từ URL của tập lệnh. Hãy chú ý đến những plugin có nhiều tập lệnh trong danh sách. Những plugin này có nhiều màu đỏ trong phạm vi của mã. Một plugin chỉ nên thêm một tập lệnh vào hàng đợi nếu tập lệnh đó thực sự được dùng trên trang."
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "Hãy đọc về [Bộ nhớ đệm của trình duyệt trong WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)."
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "Hãy cân nhắc sử dụng một [plugin tối ưu hóa hình ảnh của WordPress](https://wordpress.org/plugins/search/optimize+images/) có khả năng nén hình ảnh mà vẫn giữ được chất lượng."
+    "message": "Hãy cân nhắc sử dụng một [plugin tối ưu hóa hình ảnh của WordPress](https://wordpress.org/plugins/search/optimize+images/) có khả năng nén hình ảnh mà vẫn đảm bảo chất lượng."
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "Trực tiếp tải hình ảnh lên thông qua [thư viện nội dung đa phương tiện](https://codex.wordpress.org/Media_Library_Screen) để đảm bảo có các kích thước hình ảnh theo yêu cầu, sau đó chèn hình ảnh từ thư viện nội dung đa phương tiện hoặc sử dụng tiện ích hình ảnh để đảm bảo sử dụng kích thước hình ảnh tối ưu (bao gồm cả các kích thước dành cho điểm ngắt phản hồi). Tránh sử dụng hình ảnh có `Kích thước đầy đủ` trừ khi những hình ảnh đó có kích thước phù hợp để sử dụng. [Tìm hiểu thêm](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
+    "message": "Trực tiếp tải hình ảnh lên thông qua [thư viện nội dung đa phương tiện](https://codex.wordpress.org/Media_Library_Screen) để đảm bảo có các kích thước hình ảnh theo yêu cầu, sau đó chèn hình ảnh từ thư viện nội dung đa phương tiện hoặc sử dụng tiện ích hình ảnh để đảm bảo sử dụng kích thước hình ảnh tối ưu (bao gồm cả các kích thước dành cho điểm ngắt thích ứng). Tránh sử dụng hình ảnh có `Full Size` trừ khi những hình ảnh đó có kích thước phù hợp. [Tìm hiểu thêm](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)."
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "Bạn có thể bật tính năng nén văn bản trong cấu hình máy chủ web."

--- a/lighthouse-core/lib/i18n/locales/zh-HK.json
+++ b/lighthouse-core/lib/i18n/locales/zh-HK.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "快速鍵可讓使用者快速聚焦網頁的特定部分。如要讓使用者正確瀏覽，每個快速鍵一律不可重複。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)。"
+    "message": "快速鍵可讓使用者快速聚焦網頁的特定部分。如要讓使用者正確瀏覽，每個快速鍵一律不可重複。[瞭解詳情](https://web.dev/accesskeys/)。"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "[accesskey] 的值重複"
+    "message": "`[accesskey]` 的值重複"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "[accesskey] 的值沒有重複"
+    "message": "`[accesskey]` 值獨一無二"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "每個 ARIA「角色」都支援一部分特定的「aria-*`」屬性。如配對錯誤，「aria-*」屬性將失去效力。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)。"
+    "message": "每個 ARIA「`role`」都支援一部分特定的「`aria-*`」屬性。配對錯誤會導致「`aria-*`」屬性無效。[瞭解詳情](https://web.dev/aria-allowed-attr/)。"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "[aria-*] 屬性與其角色不符"
+    "message": "`[aria-*]` 屬性與其角色不符"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "[aria-*] 屬性與其角色相符"
+    "message": "`[aria-*]` 屬性與其角色相符"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "部分 ARIA 角色的必要屬性會向螢幕閱讀器使用者說明元素的狀態。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)。"
+    "message": "部分 ARIA 角色的必要屬性會向螢幕閱讀器使用者說明元素的狀態。[瞭解詳情](https://web.dev/aria-required-attr/)。"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "[role] 未具備所有必要的 [aria-*] 屬性"
+    "message": "`[role]` 未具備所有必要的 `[aria-*]` 屬性"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "[role] 具備所有必要的 [aria-*] 屬性"
+    "message": "`[role]` 具備所有必要的 `[aria-*]` 屬性"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "部分 ARIA 父角色必須包含特定的子角色，才能正確執行無障礙功能。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)。"
+    "message": "部分 ARIA 父角色必須包含特定的子角色，才能正確執行無障礙功能。[瞭解詳情](https://web.dev/aria-required-children/)。"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "設有 [role] 的元素缺少必需的特定子元素 [role]。"
+    "message": "設有 `[role]` 的元素缺少必需的特定子元素 `[role]`。"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "設有 [role] 的元素具有必備的特定子元素 [role]"
+    "message": "`[role]` 的元素具備必需的特定子元素 `[role]`。"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "部分 ARIA 子角色必須包括在特定的父角色中，才能正確執行無障礙功能。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)。"
+    "message": "部分 ARIA 子角色必須包括在特定的父角色中，才能正確執行無障礙功能。[瞭解詳情](https://web.dev/aria-required-parent/)。"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "[role] 未包含在必要的父元素中"
+    "message": "`[role]` 未包含在必要的父元素中"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "[role] 已包含在必要的父元素中"
+    "message": "`[role]` 已包含在必要的父元素中"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA 角色必須具備有效值，才能執行無障礙功能。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)。"
+    "message": "ARIA 角色必須具備有效的值，才能執行無障礙功能。[瞭解詳情](https://web.dev/aria-roles/)。"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "[role] 的值無效"
+    "message": "`[role]` 值無效"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "[role] 的值有效"
+    "message": "`[role]` 值有效"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "輔助技術 (如螢幕閱讀器) 無法解讀具有無效值的 ARIA 屬性。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)。"
+    "message": "輔助技術 (如螢幕閱讀器) 無法解讀具有無效值的 ARIA 屬性。[瞭解詳情](https://web.dev/aria-valid-attr-value/)。"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "[aria-*] 屬並無缺有效值"
+    "message": "`[aria-*]` 屬性並無有效的值"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "[aria-*] 屬性具備有效值"
+    "message": "`[aria-*]` 屬性具備有效的值"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "輔助技術 (例如螢幕閱讀器) 無法解讀名稱無效的 ARIA 屬性。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)。"
+    "message": "輔助技術 (例如螢幕閱讀器) 無法解讀名稱無效的 ARIA 屬性。[瞭解詳情](https://web.dev/aria-valid-attr/)。"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "[aria-*] 屬性無效或拼字錯誤"
+    "message": "`[aria-*]` 屬性無效或拼字錯誤"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "[aria-*] 屬性有效且無拼字錯誤"
+    "message": "`[aria-*]` 屬性有效且無拼字錯誤"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "字幕可提供說話者身分、說話內容等關鍵資訊以及其他非口語資訊，方便失聰或聽障使用者使用音訊元素。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)。"
+    "message": "字幕可提供說話者身分、說話內容等關鍵資訊以及其他非口語資訊，方便失聰或聽障使用者使用音訊元素。[瞭解詳情](https://web.dev/audio-caption/)。"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "<audio> 元素缺少帶有 [kind=\"captions\"] 的<track> 元素。"
+    "message": "`<audio>` 元素缺少帶有 `[kind=\"captions\"]` 的 `<track>` 元素。"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "<audio> 元素包含帶有 [kind=\"captions\"] 的 <track> 元素。"
+    "message": "`<audio>` 元素包含帶有 `[kind=\"captions\"]` 的`<track>` 元素"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "審核失敗的元素"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "如果按鈕沒有可存取的名稱，螢幕閱讀器只會讀出「按鈕」，導致依賴螢幕閱讀器的使用者並法使用該按鈕。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)。"
+    "message": "如果按鈕沒有可存取的名稱，螢幕閱讀器只會讀出「按鈕」，導致依賴螢幕閱讀器的使用者並法使用該按鈕。[瞭解詳情](https://web.dev/button-name/)。"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "按鈕沒有可存取的名稱"
@@ -93,7 +93,7 @@
     "message": "按鈕有可存取的名稱"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "為重複的內容新增略過選項，可提高鍵盤使用者的網頁瀏覽效率。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)。"
+    "message": "為重複的內容新增略過選項，可提高鍵盤使用者的網頁瀏覽效率。[瞭解詳情](https://web.dev/bypass/)。"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "網頁中沒有標題、略過連結或地標區域"
@@ -102,7 +102,7 @@
     "message": "網頁包含標題、略過連結或地標區域"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "大部分使用者難以閱讀或無法閱讀低對比度的文字。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)。"
+    "message": "大部分使用者難以閱讀或無法閱讀低對比度的文字。[瞭解詳情](https://web.dev/color-contrast/)。"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "背景和前景顏色沒有足夠的對比度。"
@@ -111,88 +111,88 @@
     "message": "背景和前景顏色有足夠的對比度"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "如果定義清單的標記不正確，螢幕閱讀器可能會輸出令人混淆或不正確的內容。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)。"
+    "message": "如果定義清單的標記不正確，螢幕閱讀器可能會輸出令人混淆或不正確的內容。[瞭解詳情](https://web.dev/definition-list/)。"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "<dl> 並非只包含排序正確的 <dt> 和 <dd> 群組、<script> 或 <template> 元素。"
+    "message": "`<dl>` 並非只包含排序正確的 `<dt>` 和 `<dd>` 群組、`<script>` 或 `<template>` 元素。"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "<dl> 只包含排序正確的 <dt> 和 <dd> 群組、<script> 或 <template> 元素。"
+    "message": "`<dl>` 只包含排序正確的 `<dt>` 和 `<dd>` 群組、`<script>` 或 `<template>` 元素。"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "定義清單項目 (<dt> 和 <dd>) 必須納入在父 <dl> 元素中，才能確保螢幕閱讀器正確朗讀這些項目。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)。"
+    "message": "定義清單項目 (`<dt>` 和 `<dd>`) 必須納入在父 `<dl>` 元素中，才能確保螢幕閱讀器正確朗讀這些項目。[瞭解詳情](https://web.dev/dlitem/)。"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "定義清單項目未納入在 <dl> 元素中"
+    "message": "定義清單項目未納入在 `<dl>` 元素中"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "定義清單項目已納入在 <dl> 元素中"
+    "message": "定義清單項目已納入在 `<dl>` 元素中"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "標題可讓螢幕閱讀器使用者概略瞭解網頁內容；搜尋引擎使用者經常需要使用此資料，判斷網頁內容是否與他們的搜尋查詢有關。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/title)。"
+    "message": "標題可讓螢幕閱讀器使用者概略瞭解網頁內容；搜尋引擎使用者經常需要使用此資料，判斷網頁內容是否與他們的搜尋查詢有關。[瞭解詳情](https://web.dev/document-title/)。"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "文件沒有 <title> 元素"
+    "message": "文件並無有效的 `<title>` 元素"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "文件具有 <title> 元素"
+    "message": "文件具備 `<title>` 元素"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "ID 屬性的值不可重複，以免輔助技術忽略其他例項。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)。"
+    "message": "ID 屬性的值不可重複，以免輔助技術忽略其他例項。[瞭解詳情](https://web.dev/duplicate-id/)。"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "網頁中的 [id] 屬性重複"
+    "message": "網頁中的 `[id]` 屬性重複"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "網頁中的 [id] 屬性沒有重複"
+    "message": "網頁中的 `[id]` 屬性沒有重複"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "螢幕閱讀器使用者依賴頁框標題來瞭解頁框內容。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)。"
+    "message": "螢幕閱讀器使用者依賴頁框標題來瞭解頁框內容。[瞭解詳情](https://web.dev/frame-title/)。"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "<frame> 或 <iframe> 元素沒有名稱"
+    "message": "`<frame>` 或 `<iframe>` 元素沒有標題"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "<frame> 或 <iframe> 元素具有名稱"
+    "message": "`<frame>` 或 `<iframe>` 元素包含名稱"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "如果網頁未指定 [lang] 屬性，螢幕閱讀器會假設網頁採用使用者設定螢幕閱讀器時選擇的預設語言。如果網頁實際並非採用預設語言，螢幕閱讀器可能無法正確朗讀文字。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)。"
+    "message": "如果網頁未指定 [lang] 屬性，螢幕閱讀器會假設網頁採用使用者設定螢幕閱讀器時選擇的預設語言。如果網頁實際並非採用預設語言，螢幕閱讀器可能無法正確朗讀文字。[瞭解詳情](https://web.dev/html-has-lang/)。"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "<html> 元素並無 [lang] 屬性"
+    "message": "`<html>` 元素並無 `[lang]` 屬性"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "<html> 元素具有 [lang] 屬性"
+    "message": "`<html>` 元素具備 `[lang]` 屬性"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "指定有效的 [BCP 47 語言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)，可協助螢幕閱讀器正確朗讀文字。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)。"
+    "message": "指定有效的 [BCP 47 語言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)可協助螢幕閱讀器正確朗讀文字。[瞭解詳情](https://web.dev/html-lang-valid/)。"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "<html> 元素的 [lang] 屬性並無有效值。"
+    "message": "`<html>` 元素的 `[lang]` 屬性並無有效的值。"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "<html> 元素的 [lang] 屬性具備有效值"
+    "message": "`<html>` 元素的 `[lang]` 屬性具備有效的值"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "資訊型元素應提供簡短貼切的替代文字。只要將 alt 屬性留空，系統便會忽略該裝飾元素。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)。"
+    "message": "資訊型元素應提供簡短貼切的替代文字。只要將 alt 屬性留空，系統便會忽略該裝飾元素。[瞭解詳情](https://web.dev/image-alt/)。"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "圖片元素並無 [alt] 屬性"
+    "message": "圖片元素並無 `[alt]` 屬性"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "圖片元素具有 [alt] 屬性"
+    "message": "圖片元素具有 `[alt]` 屬性"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "如果 <input> 按鈕是以圖片呈現，提供替代文字可協助螢幕閱讀器使用者瞭解該按鈕的用途。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)。"
+    "message": "如果 `<input>` 按鈕是以圖片呈現，提供替代文字可協助螢幕閱讀器使用者瞭解該按鈕的用途。[瞭解詳情](https://web.dev/input-image-alt/)。"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "<input type=\"image\"> 元素未設定 [alt] 文字"
+    "message": "`<input type=\"image\">` 元素未設定 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "<input type=\"image\"> 元素具有 [alt] 文字"
+    "message": "`<input type=\"image\">` 元素具有 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "標籤可以確保輔助技術 (例如螢幕閱讀器) 正確朗讀表格控制項。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)。"
+    "message": "標籤可以確保輔助技術 (例如螢幕閱讀器) 正確朗讀表格控制項。[瞭解詳情](https://web.dev/label/)。"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "表格元素沒有相關聯的標籤"
@@ -201,16 +201,16 @@
     "message": "表格元素具有相關聯的標籤"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "用於版面配置的表格不應包含資料元素 (例如 th、字幕元素或摘要屬性)，因為這些元素可能會對螢幕閱讀器使用者造成混淆。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)。"
+    "message": "用於版面配置的表格不應包含資料元素 (例如 th、字幕元素或摘要屬性)，因為這些元素可能會對螢幕閱讀器使用者造成混淆。[瞭解詳情](https://web.dev/layout-table/)。"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "展示性元素 <table> 使用了 <th>、<caption> 元素或 [summary] 屬性。"
+    "message": "展示性元素 `<table>` 使用了 `<th>`、`<caption>` 元素或 `[summary]` 屬性。"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "展示性元素 <table> 並未使用 <th>、<caption> 或 [summary] 屬性。"
+    "message": "展示性元素 `<table>` 並未使用`<th>`、`<caption>` `[summary]` 屬性。"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "使用可辨別、不重複且可聚焦的連結文字 (以及連結圖片的替代文字)，有助改善螢幕閱讀器使用者的瀏覽體驗。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)。"
+    "message": "使用可辨別、不重複且可聚焦的連結文字 (以及連結圖片的替代文字)，有助改善螢幕閱讀器使用者的瀏覽體驗。[瞭解詳情](https://web.dev/link-name/)。"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "連結並無可辨別的名稱"
@@ -219,103 +219,115 @@
     "message": "連結具有可辨別的名稱"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "螢幕閱讀器會以特定方式朗讀清單。確認清單採用正確的結構有助螢幕閱讀器順利輸出內容。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)。"
+    "message": "螢幕閱讀器會以特定方式朗讀清單。確認清單採用正確的結構有助螢幕閱讀器順利輸出內容。[瞭解詳情](https://web.dev/list/)。"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "清單中並非只包含 <li> 元素和指令碼支援元素 (<script> 和 <template>)。"
+    "message": "清單中並非只包含 `<li>` 元素和指令碼支援元素 (`<script>` 和 `<template>`)。"
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "清單只包含 <li> 元素和指令碼支援元素 (<script> 和 <template>)。"
+    "message": "清單只包含 `<li>` 元素和支援指令碼的元素 (`<script>` 和 `<template>`)。"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "清單項目 (<li>) 必須包含在父元素 <ul> 或 <ol> 中，螢幕閱讀器才能正確朗讀這些項目。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)。"
+    "message": "清單項目 `<li>` 必須包含在父元素 `<ul>` 或 `<ol>` 中，螢幕閱讀器才能正確朗讀這些項目。[瞭解詳情](https://web.dev/listitem/)。"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "清單項目 (<li>) 未包含在 <ul> 或 <ol> 父元素中。"
+    "message": "清單項目 (`<li>`) 未包含在 `<ul>` 或 `<ol>` 父元素中。"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "清單項目 (<li>) 已包含在 <ul> 或 <ol> 父元素中"
+    "message": "清單項目 (`<li>`) 已包含在 `<ul>` 或 `<ol>` 父元素中。"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "使用者不會預期系統自動重新整理網頁，且執行此操作會將焦點移回網頁頂端。這可能會對使用者造成困擾或混淆。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)。"
+    "message": "使用者不會預期系統自動重新整理網頁，且執行此操作會將焦點移回網頁頂端。這可能會對使用者造成困擾或混淆。[瞭解詳情](https://web.dev/meta-refresh/)。"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "文件採用 <meta http-equiv=\"refresh\">"
+    "message": "文件使用 `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "文件未使用 <meta http-equiv=\"refresh\">"
+    "message": "文件未使用 `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "停用縮放功能會對低視力人士造成困擾，他們需要透過螢幕放大功能才能清楚看見網頁內容。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)。"
+    "message": "停用縮放功能會對低視力人士造成困擾，他們需要透過螢幕放大功能才能清楚看見網頁內容。[瞭解詳情](https://web.dev/meta-viewport/)。"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "<meta name=\"viewport\"> 元素中使用了 [user-scalable=\"no\"]，或[maximum-scale] 屬性少於 5。"
+    "message": "`<meta name=\"viewport\">` 元素中使用了 `[user-scalable=\"no\"]`，或 `[maximum-scale]` 屬性少於 5。"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "<meta name=\"viewport\"> 元素中未使用 [user-scalable=\"no\"]，而且 [maximum-scale] 屬性不少於 5。"
+    "message": "`<meta name=\"viewport\">` 元素中未有使用 `[user-scalable=\"no\"]` 元素，而且 `[maximum-scale]` 屬性少於 5。"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "螢幕閱讀器無法翻譯非文字內容。為 <object> 元素新增替代文字，可協助螢幕閱讀器向使用者傳達其意義。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)。"
+    "message": "螢幕閱讀器無法翻譯非文字內容。為 `<object>` 元素新增替代文字，可協助螢幕閱讀器向使用者傳達其意義。[瞭解詳情](https://web.dev/object-alt/)。"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "<object> 元素沒有 [alt] 文字"
+    "message": "`<object>` 元素未設定 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "<object> 元素具有 [alt] 文字"
+    "message": "`<object>` 元素具有 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "如果值大於 0，表示採用的是明確的瀏覽排序。雖然此做法在技術上可行，但通常會對依賴輔助技術的使用者造成困擾。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)。"
+    "message": "如果值大於 0，表示採用的是明確的瀏覽排序。雖然此做法在技術上可行，但通常會對依賴輔助技術的使用者造成困擾。[瞭解詳情](https://web.dev/tabindex/)。"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "部分元素的 [tabindex] 值大於 0"
+    "message": "部分元素的 `[tabindex]` 值大於 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "所有元素的 [tabindex] 值皆未超過 0"
+    "message": "所有元素的 `[tabindex]` 值皆未超過 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "螢幕閱讀器的功能可讓使用者更輕鬆瀏覽表格。如能確保採用 [headers] 屬性的 <td> 儲存格只參照同一表格中的其他儲存格，或許能改善螢幕閱讀器的使用體驗。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)。"
+    "message": "螢幕閱讀器的功能可讓使用者更輕鬆瀏覽表格。如能確保採用 `[headers]` 屬性的 `<td>` 儲存格只參照同一表格中的其他儲存格，或許能改善螢幕閱讀器的使用體驗。[瞭解詳情](https://web.dev/td-headers-attr/)。"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "<table> 元素中採用 [headers] 屬性的儲存格，參照了同一表格中的其他儲存格。"
+    "message": "`<table>` 元素中採用 `[headers]` 屬性的儲存格，參照了同一表格中的其他儲存格。"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "<table> 元素中採用 [headers] 屬性的儲存格，只參照了同一表格中的其他儲存格。"
+    "message": "`[headers]` 元素中採用 `<table>` 屬性的儲存格，只參照了同一表格中的其他儲存格。"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "螢幕閱讀器的功能可讓使用者更輕鬆瀏覽表格。如能確保表格標題一律參照特定一組儲存格，或許能有助改善螢幕閱讀器使用者的體驗。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)。"
+    "message": "螢幕閱讀器的功能可讓使用者更輕鬆瀏覽表格。如能確保表格標題一律參照特定一組儲存格，或許能有助改善螢幕閱讀器使用者的體驗。[瞭解詳情](https://web.dev/th-has-data-cells/)。"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "<th> 元素和帶有 [role=\"columnheader\"/\"rowheader\"] 的元素並沒有其描述的資料儲存格。"
+    "message": "`<th>` 元素及帶有 `[role=\"columnheader\"/\"rowheader\"]` 的元素沒有所描述的資料儲存格。"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "<th> 元素和帶有 [role=\"columnheader\"/\"rowheader\"] 的元素並沒有其描述的資料儲存格。"
+    "message": "`<th>` 元素和帶有 `[role=\"columnheader\"/\"rowheader\"]` 的元素有其描述的資料儲存格。"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "為元素指定有效的 [BCP 47 語言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)，可協助確保螢幕閱讀器正確朗讀文字。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)。"
+    "message": "指定元素有效的[[BCP 47 語言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)] 可協助螢幕閱讀器正確朗讀文字。[瞭解詳情](https://web.dev/valid-lang/)。"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "[lang] 屬性並無有效值"
+    "message": "`[lang]` 屬性並無有效的值"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "[lang] 屬性具備有效值"
+    "message": "`[lang]` 屬性具備有效的值"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "如果在影片中提供字幕，將有助於失聰或聽障使用者取得影片資料。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)。"
+    "message": "如果在影片中提供字幕，將有助於失聰或聽障使用者取得影片資料。[瞭解詳情](https://web.dev/video-caption/)。"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "<video> 元素不含任何帶有 [kind=\"captions\"] 的 <track> 元素。"
+    "message": "`<video>` 元素不含任何帶有 `[kind=\"captions\"]``<track>` 的元素"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "<video> 元素包含帶有 [kind=\"captions\"] 的 <track> 元素"
+    "message": "`<video>` 元素包含帶有 `[kind=\"captions\"]` 的`<track>` 元素"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "音訊說明可為影片提供對話功能無法提供的相關資料，例如面部表情和場景。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)。"
+    "message": "音訊說明可為影片提供對話功能無法提供的相關資料，例如面部表情和場景。[瞭解詳情](https://web.dev/video-description/)。"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "<video> 元素不含任何帶有 [kind=\"description\"] 的 <track> 元素。"
+    "message": "`<video>` 元素不含任何帶有 `[kind=\"description\"]``<track>` 的元素"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "<video> 元素包含帶有 [kind=\"description\"] 的 <track> 元素"
+    "message": "`<video>` 元素包含帶有 `[kind=\"description\"]` 的`<track>` 元素"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "請定義 apple-touch-icon。這樣，當 iOS 使用者將此項目新增到主畫面時，系統才會顯示正確圖示。apple-touch-icon 必須指向大小為 192 像素 (或 180 像素) 的不透明正方形 PNG。[瞭解詳情](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)。"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "未提供有效的 `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` 版本過舊，建議使用 `apple-touch-icon`。"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "提供有效的 `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome 擴充程式會對此頁面的載入效能產生負面影響。建議透過無痕模式或使用未安裝擴充程式的 Chrome 設定檔來審核頁面。"
@@ -429,13 +441,64 @@
     "message": "提供 next-gen 格式的圖片"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "下方的「關鍵要求鏈」顯示以高優先次序發佈的資源。為了提高頁面載入速度，建議您縮短鏈長，縮減下載資源的大小，或延遲下載不必要資源。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)。"
+    "message": "下方的「關鍵要求鏈結」顯示以高優先次序發佈的資源。為了提高頁面載入速度，建議您縮短鏈結長度，縮減下載資源的大小，或延遲下載不必要資源。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)。"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{已找到 1 個鏈結}other{已找到 # 個鏈結}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "將重要要求深度降至最低"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "淘汰/警告"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "行數"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "系統最終會從瀏覽器中移除已淘汰的 API。[瞭解詳情](https://www.chromestatus.com/features#deprecated)。"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{發現 1 個警告}other{發現 # 個警告}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "使用已淘汰的 API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "避免使用已淘汰的 API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "應用程式快取已被淘汰。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/appcache)。"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "已找到「{AppCacheManifest}」"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "使用應用程式快取"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "避免使用應用程式快取"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "指定 DOCTYPE 能防止瀏覽器切換至怪異模式。詳情請參閱 [MDN 網絡文件頁面](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "DOCTYPE 名稱必須是小寫字串 `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "文件必須包含 doctype"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "publicId 必須為空白字串"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "systemId 必須為空白字串"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "網頁缺少 HTML DOCTYPE，因此觸發了怪異模式"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "網頁含有 HTML DOCTYPE"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "元素"
@@ -447,7 +510,7 @@
     "message": "值"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "瀏覽器工程師建議，頁面包含的 DOM 元素數量應少於 1,500 個左右。理想樹狀深度應包含少於 32 個元素，且少於 60 個子/父元素。大型 DOM 會增加記憶體用量、導致[樣式運算](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)所用時間延長並產生昂貴的[版面配置自動重排](https://developers.google.com/speed/articles/reflow)費用。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/dom-size)。"
+    "message": "瀏覽器工程師建議網頁包含的 DOM 元素數量應少於 1,500 個左右。理想的樹狀結構深度包含少於 32 個元素，且子/父元素少於 60 個。大型 DOM 會增加記憶體用量、延長[樣式運算](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)的時間，並產生高昂的[版面配置重排](https://developers.google.com/speed/articles/reflow)。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/dom-size)。"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 個元素}other{# 個元素}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "避免 DOM 過大"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "目標"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "將 `rel=\"noopener\"` 或 `rel=\"noreferrer\"` 新增至所有外部連結，可提升效能並防範安全漏洞。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/noopener)。"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "跨原始來源目的地的連結不安全"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "跨來源目的地的連結安全"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "無法判斷錨點的目的地 ({anchorHTML})。如果 target=_blank 不是用作連結，請考慮移除。"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "如果未提供其他資訊就要求存取使用者的位置資訊，會讓使用者感到困惑而不信任網站。建議您在使用者執行特定動作時，再提出這項要求。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)。"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "在載入網頁時要求存取使用者的地理位置"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "避免在載入網頁時要求存取使用者的地理位置"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "版本"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "在此網頁上偵測到的所有前端 JavaScript 程式庫。"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "偵測到的 JavaScript 媒體庫"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "對於連線速度較慢的使用者，透過 `document.write()` 動態插入的外部指令碼可能會導致網頁延遲載入數十秒。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/document-write)。"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "使用 `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "避免使用 `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "嚴重程度"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "程式庫版本"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "安全漏洞數量"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "部分第三方指令碼可能包含已知的安全漏洞，攻擊者將能輕易識別及利用這些漏洞。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)。"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{偵測到 1 個安全漏洞}other{偵測到 # 個安全漏洞}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "包括前端 JavaScript 程式庫具有已知安全漏洞"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "高"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "低"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "中"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "避免使用包含已知安全漏洞的前端 JavaScript 程式庫"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "如果未提供其他資訊就要求使用者允許網站顯示通知，會讓使用者感到困惑而不信任網站。建議您在使用者操作特定手勢時，再提出這項要求。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)。"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "在載入網頁時要求使用者允許網站顯示通知"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "避免在載入網頁時要求使用者允許網站顯示通知"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "審核失敗的元素"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "禁止貼上密碼會對安全政策造成不良影響。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)。"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "禁止使用者貼到密碼欄位"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "允許使用者貼到密碼欄位"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "通訊協定"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 具備很多 HTTP/1.1 沒有的優點，包括二進制標題、多工處理和伺服器推送。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/http2)。"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{有 1 個要求未透過 HTTP/2 傳送}other{有 # 個要求未透過 HTTP/2 傳送}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "網頁要求的部分資源未使用 HTTP/2"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "為本身的資源使用 HTTP/2"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "建議將輕觸動作和滑鼠滾輪活動監聽器標示為 `passive`，以提升網頁的捲動效能。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)。"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "未使用被動事件監聽器來提升捲動效能"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "使用被動活動監聽器來提升捲動效能"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "說明"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "如果管理中心有錯誤記錄，表示系統有問題尚待解決，例如網絡要求錯誤和其他瀏覽器問題。"
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "瀏覽器錯誤已記錄在控制台"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "系統未在管理中心記錄瀏覽器發生的錯誤"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "運用顯示字型的 CSS 功能，確保使用者可在網頁字型載入時看到文字。[瞭解詳情](https://developers.google.com/web/updates/2016/02/font-display)。"
   },
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "在網頁字型載入時，所有文字仍然顯示"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse 無法自動檢查以下網址顯示字型的值：{fontURL}。"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "實際的圖片長寬比"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "網頁上顯示的圖片長寬比"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "圖片顯示尺寸應符合正常顯示長寬比。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)。"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "顯示的圖片長寬比不正確"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "顯示的圖片長寬比正確"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "圖片大小資料無效 {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "不安全的網址"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "所有網站都應該使用 HTTPS 確保安全，即使網站不處理敏感資料亦然。HTTPS 能防範入侵者竄改或被動監聽應用程式與使用者之間的通訊，且 HTTP/2 和很多新的網絡平台 API 都要求使用 HTTPS。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/https)。"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{發現 1 個不安全的要求}other{發現 # 個不安全的要求}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "未使用 HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "使用 HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "如果網頁在流動網絡中能快速載入，可為流動裝置使用者提供良好的使用體驗。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)。"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "在 {timeInMs, number, seconds} 秒時開始互動"
+    "message": "在 {timeInMs, number, seconds} 秒開始互動"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "在 {timeInMs, number, seconds} 秒時於模擬流動網絡上開始互動"
@@ -534,16 +765,22 @@
     "message": "可互動所需時間"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "使用者可以體驗到的「首次輸入延遲時間」就是最長的工作持續時間 (以毫秒為單位)。"
+    "message": "使用者可以體驗到最長的「首次輸入延遲時間」就是最長的工作持續時間 (以毫秒為單位)。[瞭解詳情](https://developers.google.com/web/updates/2018/05/first-input-delay)。"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID 最大預計值"
+    "message": "首次輸入延遲時間最長預計值"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "「速度指數」會顯示頁面內容的展現速度。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/speed-index)。"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "速度指數"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "當工作長度超過 50 毫秒時，所有 FCP 和「可互動所需時間」之間的時長總和 (以毫秒為單位)。"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "總封鎖時間"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "網絡來回通訊時間 (RTT) 對效能有很大影響。如果系統傳送到某個來源的來回通訊時間很高，表示靠近使用者端的伺服器可改善效能。[瞭解詳情](https://hpbn.co/primer-on-latency-and-bandwidth/)。"
@@ -557,26 +794,47 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "伺服器後端延遲時間"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "超出預算"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "讓網絡要求的數量和大小低於使用者根據效能預算所設定的目標。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/budgets)。"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 個要求}other{# 個要求}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "效能預算"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "重新導向會導致頁面延遲載入。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/redirects)。"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "避免多次頁面重新導向"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "如要設定網頁資源的數量和大小的預算，請新增 budget.json 檔案。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/budgets)。"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 個要求}other{# 個要求}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "降低要求數量並減少傳輸大小"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "標準連結會建議要在搜尋結果中顯示哪個網址。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/canonical)。"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "多個衝突的網址 ({urlList})"
+    "message": "多個互相衝突的網址 ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "指向不同的網域 ({url})"
+    "message": "指向其他網域 ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "無效的網址 ({url})"
+    "message": "網址無效 ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "指向其他「hreflang」位置 ({url})"
+    "message": "指向其他 `hreflang` 位置 ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "相對網址 ({url})"
@@ -585,10 +843,10 @@
     "message": "指向目標為網域的根網址 (首頁)，而非相應的內容網頁"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "文件並無有效的「rel=canonical」"
+    "message": "文件並無有效的 `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "文件具備有效的「rel=canonical」"
+    "message": "文件具備有效的 `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "如果字型小於 12 像素，文字會太小而難以辨識，流動裝置訪客需要「兩指縮放」才能閱讀內容。網頁中應有超過 60% 採用 12 像素或以上大小的文字。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)。"
@@ -596,14 +854,11 @@
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} 的文字清晰可讀"
   },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} 的文字太小。"
-  },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "由於網頁沒有為流動裝置螢幕設定合適的檢視區中繼標記，因文字難以辨識。"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} 的文字太小 (以 {decimalProportionVisited, number, extendedPercent} 範例為準)。"
+    "message": "{decimalProportion, number, extendedPercent} 的文字過小 (以 {decimalProportionVisited, number, extendedPercent} 範例為準)。"
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "文件使用的字型大小難以辨識"
@@ -615,10 +870,10 @@
     "message": "hreflang 連結會通知搜尋引擎，應在特定語言或區域的搜尋結果中該顯示哪個版本的網頁。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/hreflang)。"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "文件並無有效的「hreflang」"
+    "message": "文件並無有效的 `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "文件具備有效的「hreflang」"
+    "message": "文件具備有效的 `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "如果網頁傳回失敗的 HTTP 狀態碼，可能無法正確加入索引。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)。"
@@ -651,7 +906,7 @@
     "message": "連結具有說明文字"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "執行[結構化資料測試工具](https://search.google.com/structured-data/testing-tool/) 和[結構化資料 Linter](http://linter.structured-data.org/) 來驗證結構化資料。[瞭解詳情](https://developers.google.com/search/docs/guides/mark-up-content)。"
+    "message": "執行[結構化資料測試工具](https://search.google.com/structured-data/testing-tool/)和[結構化資料 Linter](http://linter.structured-data.org/) 來驗證結構化資料。[瞭解詳情](https://developers.google.com/search/docs/guides/mark-up-content)。"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "結構化資料有效"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "重疊的目標"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "大小"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "輕按目標"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "輕按目標已設定成適當大小"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "在主要執行緒的執行時間"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "第三方"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "第三方程式碼可能會嚴重影響載入效能。請盡量減少不必要的第三方供應商，並在網頁的主要內容載入完成後，再載入第三方程式碼。[瞭解詳情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)。"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{發現 1 個第三方程式碼}other{發現 # 個第三方程式碼}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "第三方使用情況"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "「首個字節時間」會指出您的伺服器傳送回應的時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/ttfb)。"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "根文件用了 {timeInMs, number, milliseconds} 毫秒"
+    "message": "根文件回應時間為 {timeInMs, number, milliseconds} 毫秒"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "縮短伺服器回應時間 (TTFB)"
@@ -733,9 +1000,6 @@
   },
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "時間長度"
-  },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "名稱"
   },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "開始時間"
@@ -753,7 +1017,7 @@
     "message": "用戶使用時間標記和測量結果"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "「{securityOrigin}」有預先連線的 <link>，但瀏覽器沒有使用。請檢查您使用「crossorigin」屬性的方式是否正確。"
+    "message": "「{securityOrigin}」有預先連線的 <link>，但瀏覽器沒有使用。請檢查您使用 `crossorigin` 屬性的方式是否正確。"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
     "message": "建議新增預先連線或預先擷取 DNS 的資源提示，及早連線至重要的第三方來源。[瞭解詳情](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)。"
@@ -762,10 +1026,10 @@
     "message": "預先連接至必要來源"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "「{preloadURL}」有預先載入的 <link>，但瀏覽器沒有使用。請檢查您使用「crossorigin」屬性的方式是否正確。"
+    "message": "{preloadURL} 有預先載入的 <link>，但瀏覽器沒有使用。請檢查您使用 `crossorigin` 屬性的方式是否正確。"
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "建議使用 <link rel=preload> 來指定優先需要的網絡要求，並預先擷取資源。[瞭解詳情(https://developers.google.com/web/tools/lighthouse/audits/preload)。"
+    "message": "建議使用 `<link rel=preload>` 來指定優先需要的網絡要求，並預先擷取資源。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/preload)。"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "預先載入關鍵要求"
@@ -789,7 +1053,7 @@
     "message": "最佳做法"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "這些檢查會提供[網頁應用程式無障礙功能的改善建議] (https://developers.google.com/web/fundamentals/accessibility)。系統只能自動偵測一部分的無障礙功能問題，因此建議您另行手動測試。"
+    "message": "這些檢查會提供[網頁應用程式無障礙功能的改善建議](https://developers.google.com/web/fundamentals/accessibility)。系統只能自動偵測一部分的無障礙功能問題，因此建議您另行手動測試。"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "這些審核項目會檢查自動化測試工具未涵蓋的區域。詳情請參閱[無障礙功能審查的執行指南](https://developers.google.com/web/fundamentals/accessibility/how-to-review)。"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "表格和清單"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "最佳做法"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "您可根據效能預算設定網站效能的標準。"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "預算"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "進一步瞭解應用程式效能。"
+    "message": "進一步瞭解應用程式效能。這些數字不會[直接影響](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)「效能」分數。"
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "診斷"
@@ -840,7 +1113,7 @@
     "message": "首次繪製改進"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "這些優化建議可提高您的頁面載入速度。"
+    "message": "這些建議可加快網頁載入速度，但不會[直接影響](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)「效能」分數。"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "優化建議"
@@ -867,7 +1140,7 @@
     "message": "已優化 PWA"
   },
   "lighthouse-core/config/default-config.js | seoCategoryDescription": {
-    "message": "這些檢查可確保網頁採用已優化的搜尋引擎結果排名設定。有些其他因素不在 Lighthouse 檢查範圍內，仍可能會影響您的搜尋排名。[瞭解詳情](https://support.google.com/webmasters/answer/35769)。"
+    "message": "這些檢查可確保網頁採用已優化的搜尋引擎結果排名設定。部分其他因素不在 Lighthouse 檢查範圍內，仍可能會影響您的搜尋排名。[瞭解詳情](https://support.google.com/webmasters/answer/35769)。"
   },
   "lighthouse-core/config/default-config.js | seoCategoryManualDescription": {
     "message": "在您的網站上執行這些額外的驗證工具，以檢查其他 SEO 最佳做法。"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "快取 TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "位置"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "名稱"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "要求"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "資源類型"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "大小 (KB)"
+    "message": "大小"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "所用的時間"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "傳輸大小"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "網址"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "可節省的用量 (KB)"
+    "message": "可節省的數據用量"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "可節省的時間 (毫秒)"
+    "message": "可節省的數據用量"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "可節省 {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "可節省 {wastedMs, number, milliseconds} 毫秒"
+    "message": "可減少 {wastedMs, number, milliseconds} 毫秒"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "文件"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "字型"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "圖片"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "媒體"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} 毫秒"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "其他"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "指令碼"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} 秒"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "樣式表"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "第三方"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "總計"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "追蹤記錄網頁載入情況時發生錯誤。請重新執行 Lighthouse。({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS 伺服器無法解析您提供的網域。"
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "必要的 {artifactName} 收集程式發生錯誤：{errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Chrome 發生內部錯誤。請重新啟動 Chrome，並嘗試重新執行 Lighthouse。"
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "未執行必要的 {artifactName} 收集程式。"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse 無法穩定載入您要求的網頁。請確認您測試的網址是否正確，以及伺服器是否正確回應所有要求。"
@@ -946,6 +1267,9 @@
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
     "message": "您提供的網址並無有效的安全憑證。{securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome 使用插頁式畫面阻止系統載入網頁。請確認您測試的網址是否正確，以及伺服器是否正確回應所有要求。"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse 無法穩定載入您要求的網頁。請確認您測試的網址是否正確，以及伺服器是否正確回應所有要求。(詳情：{errorDetails})"
@@ -984,7 +1308,7 @@
     "message": "實驗室數據"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "透過 [Lighthouse](https://developers.google.com/web/tools/lighthouse/) 在模擬流動網絡上對目前網頁進行的分析。此為預計值，可能與實際值有所不同。"
+    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) 在模擬流動網絡上對目前網頁進行的分析。此為預計值，可能與實際值有所不同。"
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "其他手動檢查項目"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "展開片段"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "顯示第三方資源"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "導致這次 Lighthouse 無法順利執行的問題："
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "此為預計值，可能與實際值有所不同。"
+    "message": "此為預計值，可能與實際值有所不同。系統[只會根據這些數據](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)計算效能分數。"
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "經過審核，但附有警告訊息"
@@ -1026,7 +1353,7 @@
     "message": "安裝可延遲載入所有畫面外圖片的[延遲載入 WordPress 外掛程式](https://wordpress.org/plugins/search/lazy+load/)，或改用提供此功能的主題。您亦可考慮使用 [AMP 外掛程式](https://wordpress.org/plugins/amp/)。"
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "有些 WordPress 外掛程式可助您[內嵌重要資產](https://wordpress.org/plugins/search/critical+css/)或[延後載入較不重要的資源](https://wordpress.org/plugins/search/defer+css+javascript/)。請注意，這些外掛程式的優化設定可能影響主題或外掛程式的功能，因此您可能需要變更程式碼。"
+    "message": "部分 WordPress 外掛程式可助您[內嵌重要資產](https://wordpress.org/plugins/search/critical+css/)或[延後載入較不重要的資源](https://wordpress.org/plugins/search/defer+css+javascript/)。請注意，這些外掛程式的優化設定可能影響主題或外掛程式的功能，因此您可能需要變更程式碼。"
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "主題、外掛程式和伺服器規格均會影響伺服器回應時間。建議尋找更優化的主題、謹慎選擇優化外掛程式和/或升級伺服器。"
@@ -1035,16 +1362,16 @@
     "message": "建議在文章清單中顯示摘錄 (例如加入更多標籤)、減少特定頁面顯示的文章數量、將較長的文章分為多個頁面，或使用可延遲載入留言的外掛程式。"
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/search/minify+css/)可透過串連及壓縮樣式來提升網站速度。可以的話，您亦可建立流程來直接進行此壓縮操作。"
+    "message": "部分 [WordPress 外掛程式](https://wordpress.org/plugins/search/minify+css/) 可以透過串連、縮小及壓縮樣式來提升網站速度。可以的話，您亦可建立流程來直接進行此壓縮操作。"
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/search/minify+javascript/)可透過串連及壓縮指令碼來提升網站速度。可以的話，您亦可建立流程來直接進行此壓縮操作。"
+    "message": "部分 [WordPress 外掛程式](https://wordpress.org/plugins/search/minify+javascript/) 可透過串連、縮小及壓縮指令碼來提升網站速度。可以的話，您亦可建立流程來直接進行此壓縮操作。"
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/) 會在網頁中載入未使用的 CSS，建議你減少這類外掛程式的數量，或改用其他外掛程式。如要找出會新增多餘 CSS 的外掛程式，請嘗試在 Chrome DevTools 中執行[程式碼覆蓋率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)功能。您可透過樣式表網址找出有問題的主題/外掛程式。請留意清單中包含很多樣式表，且程式碼覆蓋率中有大量紅色標示的外掛程式。外掛程式應只將網頁上實際使用的樣式表加入清單。"
+    "message": "部分 [WordPress 外掛程式](https://wordpress.org/plugins/)會在網頁中載入未使用的 CSS，建議你減少這類外掛程式的數量，或改用其他外掛程式。如要找出會新增多餘 CSS 的外掛程式，請嘗試在 Chrome DevTools 中執[程式碼覆蓋率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)。您可透過樣式表網址找出有問題的主題/外掛程式。請留意清單中包含很多樣式表，且程式碼覆蓋率中有大量紅色標示的外掛程式。外掛程式應只將網頁上實際使用的樣式表加入清單。"
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/)會在網頁中載入未使用的 JavaScript，建議你減少這類外掛程式的數量，或改用其他外掛程式。如要找出會新增多餘 JS 的外掛程式，請嘗試在 Chrome DevTools 中執行[程式碼覆蓋率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)功能。您可透過指令碼網址找出有問題的主題/外掛程式。請留意清單中包含很多指令碼，且程式碼覆蓋率中有大量紅色標示的外掛程式。外掛程式應只將網頁上實際使用的指令碼加入清單。"
+    "message": "部分 [WordPress 外掛程式](https://wordpress.org/plugins/)會在網頁中載入未使用的 JavaScript，建議你減少這類外掛程式的數量，或改用其他外掛程式。如要找出會新增多餘 JS 的外掛程式，請嘗試在 Chrome DevTools 中執[程式碼覆蓋率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)。您可透過指令碼網址找出有問題的主題/外掛程式。請留意清單中包含很多指令碼，且程式碼覆蓋率中有大量紅色標示的外掛程式。外掛程式應只將網頁上實際使用的指令碼加入清單。"
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "瞭解 [WordPress 的瀏覽器快取功能](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)。"
@@ -1053,7 +1380,7 @@
     "message": "建議使用[圖片優化 WordPress 外掛程式](https://wordpress.org/plugins/search/optimize+images/)，在壓縮圖片時保持畫質。"
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "您可直接透過[媒體庫](https://codex.wordpress.org/Media_Library_Screen)上載圖片，確保可使用所需的圖片大小，然後從媒體庫插入圖片，或使用圖片小工具來確保您使用優化的圖片大小 (包括回應式中斷點適用的圖片大小)。除非可用空間足夠，否則請避免使用「原來大小」圖片。[瞭解詳情](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)。"
+    "message": "您可直接透過[媒體庫](https://codex.wordpress.org/Media_Library_Screen)上載圖片，確保可使用所需的圖片大小，然後從媒體庫插入圖片，或使用圖片小工具來確保您使用優化的圖片大小 (包括回應式中斷點適用的圖片大小)。除非可用空間足夠，否則請避免使用「`Full Size`」圖片。[瞭解詳情](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)。"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "您可在網絡伺服器設定中啟用文字壓縮功能。"

--- a/lighthouse-core/lib/i18n/locales/zh-TW.json
+++ b/lighthouse-core/lib/i18n/locales/zh-TW.json
@@ -1,90 +1,90 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "快速鍵可讓使用者快速聚焦網頁的特定部分。要讓使用者正確瀏覽，每個快速鍵一律不得重複。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)。"
+    "message": "快速鍵可讓使用者快速聚焦網頁的特定部分。要讓使用者正確瀏覽，每個快速鍵一律不得重複。[瞭解詳情](https://web.dev/accesskeys/)。"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "[accesskey] 的值重複"
+    "message": "`[accesskey]` 的值重複"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "[accesskey] 的值沒有重複"
+    "message": "`[accesskey]` 的值沒有重複"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "每個 ARIA「角色」都支援一部分特定的「aria-*」屬性。若配對錯誤，「aria-*」屬性將失去效力。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)。"
+    "message": "每個 ARIA `role`都支援一部分特定的 `aria-*` 屬性。若配對錯誤，`aria-*` 屬性將失去效力。[瞭解詳情](https://web.dev/aria-allowed-attr/)。"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
-    "message": "[aria-*] 屬性與其角色不符"
+    "message": "`[aria-*]` 屬性與其角色不符"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": {
-    "message": "[aria-*] 屬性與其角色相符"
+    "message": "`[aria-*]` 屬性與其角色相符"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "部分 ARIA 角色的必要屬性會向螢幕閱讀器使用者說明元素的狀態。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)。"
+    "message": "部分 ARIA 角色的必要屬性會向螢幕閱讀器的使用者說明元素狀態。[瞭解詳情](https://web.dev/aria-required-attr/)。"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "[role] 未具備所有必要的 [aria-*] 屬性"
+    "message": "`[role]` 未具備所有必要的 `[aria-*]` 屬性"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
-    "message": "[role] 具備所有必要的 [aria-*] 屬性"
+    "message": "`[role]` 具備所有必要的 `[aria-*]` 屬性"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "部分 ARIA 上層角色必須包含特定的下層角色，才能正確執行其無障礙功能。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)。"
+    "message": "部分 ARIA 父項角色必須包含特定的子項角色，才能正確執行無障礙功能。[瞭解詳情](https://web.dev/aria-required-children/)。"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "設有 [role] 的元素缺少必備的特定子元素 [role]。"
+    "message": "設有 `[role]` 的元素缺少必備的特定子項 `[role]`。"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "設有 [role] 的元素具有必備的特定子元素 [role]"
+    "message": "設有 `[role]` 的元素具有必備的特定子項 `[role]`"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "部分 ARIA 下層角色必須包含在特定的上層角色中，才能正確執行其無障礙功能。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)。"
+    "message": "部分 ARIA 子項角色必須包含在特定的父項角色中，才能正確執行其無障礙功能。[瞭解詳情](https://web.dev/aria-required-parent/)。"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
-    "message": "[role] 未包含在必要的上層元素中"
+    "message": "`[role]` 未包含在必要的父項元素中"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | title": {
-    "message": "[role] 包含在必要的上層元素中"
+    "message": "`[role]` 包含在必要的父項元素中"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA 角色必須具備有效的值，才能執行其無障礙功能。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)。"
+    "message": "ARIA 角色必須具備有效的值，才能執行其無障礙功能。[瞭解詳情](https://web.dev/aria-roles/)。"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
-    "message": "[role] 的值無效"
+    "message": "`[role]` 不具備有效的值"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | title": {
-    "message": "[role] 的值有效"
+    "message": "`[role]` 具備有效的值"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "輔助技術 (例如螢幕閱讀器) 無法解讀數值無效的 ARIA 屬性。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)。"
+    "message": "輔助技術 (例如螢幕閱讀器) 無法解讀數值無效的 ARIA 屬性。[瞭解詳情](https://web.dev/aria-valid-attr-value/)。"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
-    "message": "[aria-*] 屬性缺少有效的值"
+    "message": "`[aria-*]` 屬性缺少有效的值"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": {
-    "message": "[aria-*] 屬性具備有效的值"
+    "message": "`[aria-*]` 屬性具備有效的值"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "輔助技術 (例如螢幕閱讀器) 無法解讀名稱無效的 ARIA 屬性。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)。"
+    "message": "輔助技術 (例如螢幕閱讀器) 無法解讀包含無效名稱的 ARIA 屬性。[瞭解詳情](https://web.dev/aria-valid-attr/)。"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
-    "message": "[aria-*] 屬性無效或有錯字"
+    "message": "`[aria-*]` 屬性無效或有錯字"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": {
-    "message": "[aria-*] 屬性有效且無拼字錯誤"
+    "message": "`[aria-*]` 屬性有效且拼字正確"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "字幕可提供說話者身分、說話內容等關鍵資訊以及其他非口語資訊，讓失聰或聽障使用者也能運用音訊元素。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)。"
+    "message": "字幕可提供說話者身分、說話內容等關鍵資訊以及其他非口語資訊，方便失聰或聽障使用者使用音訊元素。[瞭解詳情](https://web.dev/audio-caption/)。"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "<audio> 元素缺少帶有 [kind=\"captions\"] 的<track> 元素。"
+    "message": "`<audio>` 元素缺少帶有 `[kind=\"captions\"]` 的 `<track>` 元素。"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "<audio> 元素包含帶有 [kind=\"captions\"] 的 <track> 元素。"
+    "message": "`<audio>` 元素包含帶有 `[kind=\"captions\"]` 的 `<track>` 元素"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
     "message": "未通過稽核的元素"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "如果沒有可解讀的按鈕名稱，螢幕閱讀器只會讀出「按鈕」，這樣仰賴螢幕閱讀器的使用者就無法知道這個按鈕的用途。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)。"
+    "message": "如果沒有可解讀的按鈕名稱，螢幕閱讀器只會讀出「按鈕」，這樣仰賴螢幕閱讀器的使用者就無法知道這個按鈕的用途。[瞭解詳情](https://web.dev/button-name/)。"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "按鈕沒有可存取的名稱"
@@ -93,7 +93,7 @@
     "message": "按鈕具有可解讀的名稱"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "針對重複的內容增設略過選項，可提高鍵盤使用者的網頁瀏覽效率。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)。"
+    "message": "針對重複的內容增設略過選項，可提高鍵盤使用者的網頁瀏覽效率。[瞭解詳情](https://web.dev/bypass/)。"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "這個網頁中沒有標題、略過連結或標記區域"
@@ -102,7 +102,7 @@
     "message": "這個網頁包含標題、略過連結或標記區域"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "低對比度的文字對許多使用者來說是難以閱讀或無法閱讀的。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)。"
+    "message": "低對比度的文字對許多讀者來說難以閱讀或無法閱讀。[瞭解詳情](https://web.dev/color-contrast/)。"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "背景和前景顏色沒有足夠的對比度。"
@@ -111,88 +111,88 @@
     "message": "背景和前景顏色具有足夠的對比度"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "如果定義清單的標記不正確，螢幕閱讀器可能會輸出令人混淆或不正確的內容。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)。"
+    "message": "如果定義清單的標記不正確，螢幕閱讀器可能會輸出令人混淆或不正確的內容。[瞭解詳情](https://web.dev/definition-list/)。"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
-    "message": "<dl> 所含項目不只有排序正確的 <dt> 和 <dd> 群組、<script> 或 <template> 元素。"
+    "message": "`<dl>` 所含項目不只有排序正確的 `<dt>` 和 `<dd>` 群組、`<script>` 或 `<template>` 元素。"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | title": {
-    "message": "<dl> 所含項目只有排序正確的 <dt> 和 <dd> 群組、<script> 或 <template> 元素。"
+    "message": "`<dl>` 所含項目只有排序正確的 `<dt>` 和 `<dd>` 群組、`<script>` 或 `<template>` 元素。"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "定義清單項目 (「<dt>」和「<dd>」) 必須納入在上層「<dl>」元素中，才能確保螢幕閱讀器正確朗讀這些項目。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)。"
+    "message": "定義清單項目 (`<dt>` 和 `<dd>`) 必須納入在父項 `<dl>` 元素中，才能確保螢幕閱讀器正確朗讀這些項目。[瞭解詳情](https://web.dev/dlitem/)。"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "定義清單項目未納入在 <dl> 元素中"
+    "message": "定義清單項目未納入在 `<dl>` 元素中"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
-    "message": "定義清單項目已納入在 <dl> 元素中"
+    "message": "定義清單項目已納入在 `<dl>` 元素中"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "標題可讓螢幕閱讀器使用者概略瞭解網頁內容；搜尋引擎使用者經常需要使用這項資訊，判斷網頁內容是否與他們的搜尋查詢有關。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/title)。"
+    "message": "標題可讓螢幕閱讀器使用者概略瞭解網頁內容；搜尋引擎使用者經常需要使用這項資訊，以判斷網頁內容是否與他們的搜尋項目有關。[瞭解詳情](https://web.dev/document-title/)。"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
-    "message": "文件缺少 <title> 元素"
+    "message": "文件缺少 `<title>` 元素"
   },
   "lighthouse-core/audits/accessibility/document-title.js | title": {
-    "message": "文件具有 <title> 元素"
+    "message": "文件具有 `<title>` 元素"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "ID 屬性的值不得重複，以免輔助技術忽略其他重複的值。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)。"
+    "message": "ID 屬性的值不得重複，以免輔助技術忽略其他重複的值。[瞭解詳情](https://web.dev/duplicate-id/)。"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
-    "message": "網頁中的 [id] 屬性重複"
+    "message": "網頁中的 `[id]` 屬性重複"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | title": {
-    "message": "網頁中的 [id] 屬性沒有重複"
+    "message": "網頁中的 `[id]` 屬性沒有重複"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "螢幕閱讀器使用者需使用頁框標題來說明頁框內容。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)。"
+    "message": "螢幕閱讀器需使用頁框標題才能說明頁框內容。[瞭解詳情](https://web.dev/frame-title/)。"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
-    "message": "<frame> 或 <iframe> 元素沒有名稱"
+    "message": "`<frame>` 或 `<iframe>` 元素缺少名稱"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "<frame> 或 <iframe> 元素具有名稱"
+    "message": "`<frame>` 或 `<iframe>` 元素包含名稱"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "如果網頁未指定 [lang] 屬性，螢幕閱讀器會假設網頁採用的是使用者在設定螢幕閱讀器時所選擇的預設語言。如果網頁實際採用的並不是預設語言，那麼螢幕閱讀器可能無法正確朗讀網頁文字。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)。"
+    "message": "如果網頁未指定 [lang] 屬性，螢幕閱讀器會假設網頁採用的是使用者在設定螢幕閱讀器時所選擇的預設語言。如果網頁實際採用的語言並非預設語言，那麼螢幕閱讀器可能無法正確朗讀網頁文字。[瞭解詳情](https://web.dev/html-has-lang/)。"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
-    "message": "<html> 元素缺少 [lang] 屬性"
+    "message": "`<html>` 元素缺少 `[lang]` 屬性"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "<html> 元素具有 [lang] 屬性"
+    "message": "`<html>` 元素具備 `[lang]` 屬性"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "指定有效的 [BCP 47 語言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)，可協助螢幕閱讀器正確朗讀文字。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)。"
+    "message": "指定有效的 [BCP 47 語言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)，可協助螢幕閱讀器正確朗讀文字。[瞭解詳情](https://web.dev/html-lang-valid/)。"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
-    "message": "<html> 元素的 [lang] 屬性缺少有效的值。"
+    "message": "`<html>` 元素的 `[lang]` 屬性缺少有效的值。"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | title": {
-    "message": "<html> 元素的 [lang] 屬性具備有效的值"
+    "message": "`<html>` 元素的 `[lang]` 屬性具備有效的值"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "說明元素應提供簡短貼切的替代文字。如果是裝飾元素，只要將 alt 屬性留空，系統即會忽略該元素。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)。"
+    "message": "說明元素應提供簡短貼切的替代文字。如果是裝飾元素，只要將 alt 屬性留空，系統即會忽略該元素。[瞭解詳情](https://web.dev/image-alt/)。"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
-    "message": "圖片元素缺少 [alt] 屬性"
+    "message": "圖片元素缺少 `[alt]` 屬性"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | title": {
-    "message": "圖片元素具有 [alt] 屬性"
+    "message": "圖片元素具有 `[alt]` 屬性"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "如果「<input>」按鈕是以圖片呈現，提供替代文字可協助螢幕閱讀器使用者瞭解該按鈕的用途。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)。"
+    "message": "如果 `<input>` 按鈕是以圖片呈現，提供替代文字可協助螢幕閱讀器使用者瞭解該按鈕的用途。[瞭解詳情](https://web.dev/input-image-alt/)。"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
-    "message": "<input type=\"image\"> 元素未設定 [alt] 文字"
+    "message": "`<input type=\"image\">` 元素未設定 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "<input type=\"image\"> 元素具有 [alt] 文字"
+    "message": "`<input type=\"image\">` 元素具有 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "標籤可確保輔助技術 (例如螢幕閱讀器) 正確朗讀表單控制項。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)。"
+    "message": "標籤可確保輔助技術 (例如螢幕閱讀器) 正確朗讀表單控制項。[瞭解詳情](https://web.dev/label/)。"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "表單元素沒有相關聯的標籤"
@@ -201,16 +201,16 @@
     "message": "表單元素具有相關聯的標籤"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "用於版面配置的表格不應包含資料元素 (例如 th、字幕元素或摘要屬性)，否則可能會對螢幕閱讀器使用者造成混淆。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)。"
+    "message": "用於版面配置的表格不應包含資料元素 (例如 th、字幕元素或摘要屬性)，否則可能會對螢幕閱讀器使用者造成混淆。[瞭解詳情](https://web.dev/layout-table/)。"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "表示性元素 <table> 未避免使用 <th>、<caption> 元素或 [summary] 屬性。"
+    "message": "表示性元素 `<table>` 未避免使用 `<th>`、`<caption>` 元素或 `[summary]` 屬性。"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
-    "message": "表示性元素 <table> 並未使用 <th>、<caption> 或 [summary] 屬性。"
+    "message": "表示性元素 `<table>` 並未使用 `<th>`、`<caption>` 或 `[summary]` 屬性。"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "使用可辨別、未重複且可聚焦的連結文字 (以及連結圖片的替代文字)，有助於改善螢幕閱讀器使用者的瀏覽體驗。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)。"
+    "message": "使用可辨別、未重複且可聚焦的連結文字 (以及連結圖片的替代文字)，有助於改善螢幕閱讀器使用者的瀏覽體驗。[瞭解詳情](https://web.dev/link-name/)。"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "連結缺少可辨別的名稱"
@@ -219,103 +219,115 @@
     "message": "連結具有可辨別的名稱"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "螢幕閱讀器會以特定方式朗讀清單。請務必採用正確的清單結構，這樣螢幕閱讀器才能順利讀出畫面內容。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)。"
+    "message": "螢幕閱讀器會以特定方式朗讀清單。請務必採用正確的清單結構，這樣螢幕閱讀器才能順利讀出畫面內容。[瞭解詳情](https://web.dev/list/)。"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
-    "message": "清單中並非只包含 <li> 元素和指令碼支援元素 (<script> 和 <template>)。"
+    "message": "清單中並非只包含 `<li>` 元素和指令碼支援元素 (`<script>` 和 `<template>`)。"
   },
   "lighthouse-core/audits/accessibility/list.js | title": {
-    "message": "清單只包含 <li> 元素和指令碼支援元素 (<script> 和 <template>)。"
+    "message": "清單只包含 `<li>` 元素和指令碼支援元素 (`<script>` 和 `<template>`)。"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "清單項目 (「<li>」) 必須包含在上層元素「<ul>」或「<ol>」中，螢幕閱讀器才能正確朗讀這些項目。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)。"
+    "message": "清單項目 (`<li>`) 必須包含在父項元素 `<ul>` 或 `<ol>` 中，螢幕閱讀器才能正確朗讀這些項目。[瞭解詳情](https://web.dev/listitem/)。"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "清單項目 (<li>) 未包含在 <ul> 或 <ol> 上層元素中。"
+    "message": "清單項目 (`<li>`) 未包含在 `<ul>` 或 `<ol>` 父項元素中。"
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "清單項目 (<li>) 已包含在 <ul> 或 <ol> 上層元素中"
+    "message": "清單項目 (`<li>`) 已包含在 `<ul>` 或 `<ol>` 父項元素中"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "使用者不會預期系統自動重新整理網頁，而且重新整理會讓網頁焦點移回頂端。這可能會對使用者造成困擾或混淆。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)。"
+    "message": "使用者不會預期系統自動重新整理網頁，而且這麼做會將焦點移回網頁頂端。這可能會對使用者造成困擾或混淆。[瞭解詳情](https://web.dev/meta-refresh/)。"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "這個文件採用了 <meta http-equiv=\"refresh\">"
+    "message": "這個文件使用 `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "這個文件未使用 <meta http-equiv=\"refresh\">"
+    "message": "這個文件未使用 `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "停用縮放功能會對低視能使用者造成困擾，他們需透過螢幕放大功能才能清楚看見網頁內容。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)。"
+    "message": "停用縮放功能會對低視能使用者造成困擾，他們需要使用螢幕放大功能才能清楚看見網頁內容。[瞭解詳情](https://web.dev/meta-viewport/)。"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
-    "message": "<meta name=\"viewport\"> 元素中使用了 [user-scalable=\"no\"]，或是[maximum-scale] 屬性小於 5。"
+    "message": "`<meta name=\"viewport\">` 元素中使用了 `[user-scalable=\"no\"]`，或是 `[maximum-scale]` 屬性小於 5。"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | title": {
-    "message": "<meta name=\"viewport\"> 元素中未使用 [user-scalable=\"no\"]，而且 [maximum-scale] 屬性大於或等於 5。"
+    "message": "`<meta name=\"viewport\">` 元素中未使用 `[user-scalable=\"no\"]`，而且 `[maximum-scale]` 屬性大於或等於 5。"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "螢幕閱讀器無法翻譯非文字內容。為「<object>」元素新增替代文字，可協助螢幕閱讀器向使用者傳達該元素的意義。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)。"
+    "message": "螢幕閱讀器無法解讀非文字內容。為 `<object>` 元素新增替代文字，可協助螢幕閱讀器向使用者傳達該元素的意義。[瞭解詳情](https://web.dev/object-alt/)。"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
-    "message": "<object> 元素未設定 [alt] 文字"
+    "message": "`<object>` 元素未設定 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "<object> 元素具有 [alt] 文字"
+    "message": "`<object>` 元素具有 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "如果值大於 0，表示採用的是明確的瀏覽排序。雖然這在技術上可行，但經常會對仰賴輔助技術的使用者造成困擾。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)。"
+    "message": "如果值大於 0，表示採用的是明確的瀏覽排序。雖然這在技術上可行，但經常會對仰賴輔助技術的使用者造成困擾。[瞭解詳情](https://web.dev/tabindex/)。"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
-    "message": "部分元素的 [tabindex] 值大於 0"
+    "message": "部分元素的 `[tabindex]` 值大於 0"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | title": {
-    "message": "所有元素的 [tabindex] 值皆未超過 0"
+    "message": "所有元素的 `[tabindex]` 值皆未超過 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "螢幕閱讀器的功能可讓使用者輕鬆瀏覽表格。如果能確保採用「[headers]」屬性的「<td>」儲存格只參照同一表格中的其他儲存格，或許能讓螢幕閱讀器的使用體驗更上一層樓。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)。"
+    "message": "螢幕閱讀器的功能可讓使用者輕鬆瀏覽表格。請確保使用 `[headers]` 屬性的 `<td>` 儲存格只參照同一表格中的其他儲存格，這樣可改善螢幕閱讀器的使用體驗。[瞭解詳情](https://web.dev/td-headers-attr/)。"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "<table> 元素中採用 [headers] 屬性的儲存格，參照了同一表格中的其他儲存格。"
+    "message": "`<table>` 元素中採用 `[headers]` 屬性的儲存格，參照了同一表格中的其他儲存格。"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "<table> 元素中採用 [headers] 屬性的儲存格，只參照了同一表格中的其他儲存格。"
+    "message": "在 `<table>` 元素中使用 `[headers]` 屬性的儲存格只參照同一表格中的其他儲存格。"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "螢幕閱讀器的功能可讓使用者輕鬆瀏覽表格。如果能確保表格標題一律參照特定一組儲存格，或許能讓螢幕閱讀器的使用體驗更上一層樓。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)。"
+    "message": "螢幕閱讀器的功能可讓使用者輕鬆瀏覽表格。如果能確保表格標題一律參照特定一組儲存格，或許能讓螢幕閱讀器的使用體驗更上一層樓。[瞭解詳情](https://web.dev/th-has-data-cells/)。"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
-    "message": "<th> 元素和帶有 [role=\"columnheader\"/\"rowheader\"] 的元素不具有其所描述的資料儲存格。"
+    "message": "`<th>` 元素和具有 `[role=\"columnheader\"/\"rowheader\"]` 的元素不包含所描述的資料儲存格。"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": {
-    "message": "<th> 元素和帶有 [role=\"columnheader\"/\"rowheader\"] 的元素具有其所描述的資料儲存格。"
+    "message": "`<th>` 元素和帶有 `[role=\"columnheader\"/\"rowheader\"]` 的元素具有其所描述的資料儲存格。"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "為元素指定有效的 [BCP 47 語言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)，可協助確保螢幕閱讀器正確朗讀文字。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)。"
+    "message": "為元素指定有效的 [BCP 47 語言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)，可協助確保螢幕閱讀器正確朗讀文字。[瞭解詳情](https://web.dev/valid-lang/)。"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
-    "message": "[lang] 屬性缺少有效的值"
+    "message": "`[lang]` 屬性缺少有效的值"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "[lang] 屬性具備有效的值"
+    "message": "`[lang]` 屬性具備有效的值"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "如果在影片中提供字幕，將有助於失聰或聽障使用者瞭解影片資訊。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)。"
+    "message": "如果在影片中提供字幕，將有助於失聰或聽障使用者瞭解影片資訊。[瞭解詳情](https://web.dev/video-caption/)。"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "<video> 元素不含任何帶有 [kind=\"captions\"] 的 <track> 元素。"
+    "message": "`<video>` 元素不含任何帶有 `[kind=\"captions\"]` 的 `<track>` 元素。"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "<video> 元素包含帶有 [kind=\"captions\"] 的 <track> 元素"
+    "message": "`<video>` 元素包含帶有 `[kind=\"captions\"]` 的 `<track>` 元素"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "音訊說明可為影片提供對話功能無法提供的相關資訊，例如面部表情和場景。[瞭解詳情](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)。"
+    "message": "音訊說明可為影片提供對話功能無法提供的相關資訊，例如面部表情和場景。[瞭解詳情](https://web.dev/video-description/)。"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "<video> 元素不含任何帶有 [kind=\"description\"] 的 <track> 元素。"
+    "message": "`<video>` 元素不含任何帶有 `[kind=\"description\"]` 的 `<track>` 元素。"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "<video> 元素包含帶有 [kind=\"description\"] 的 <track> 元素"
+    "message": "`<video>` 元素包含帶有 `[kind=\"description\"]` 的 `<track>` 元素"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "請定義 apple-touch-icon，這樣一來，當 iOS 使用者將這個項目新增到主螢幕時，系統才會顯示正確圖示。apple-touch-icon 必須指向大小為 192 像素 (或 180 像素) 的不透明正方形 PNG。[瞭解詳情](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)。"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "未提供有效的 `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` 版本過舊，建議使用 `apple-touch-icon`。"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "具備有效的 `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome 擴充功能對這個頁面的載入效能有負面影響。建議透過無痕模式或不含擴充功能的 Chrome 設定檔來稽核頁面。"
@@ -330,7 +342,7 @@
     "message": "CPU 總執行時間"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "建議減少剖析、編譯和執行 JS 所耗費的時間。提供較小的 JS 酬載可能會有幫助。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/bootup)"
+    "message": "建議你縮短剖析、編譯及執行 JavaScript 所耗費的時間。提供較小的 JavaScript 酬載可能會有幫助。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/bootup)。"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "減少 JavaScript 執行時間"
@@ -339,25 +351,25 @@
     "message": "JavaScript 執行時間"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "使用大型 GIF 檔案來呈現動畫內容會降低網路傳輸效率，建議改用 MPEG4/WebM 影片格式來呈現動畫效果，或是使用 PNG/WebP 格式來顯示靜態圖片，以減少網路傳輸的資料量。[瞭解詳情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "使用大型 GIF 檔案呈現動畫內容會降低網路傳輸效率。建議你改用 MPEG4/WebM 影片格式呈現動畫內容，或是使用 PNG/WebP 格式顯示靜態圖片，以減少網路傳輸的資料量。[瞭解詳情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "使用影片格式的動畫內容"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "建議延遲載入畫面外的項目並隱藏圖片，直到重要資源全部載入後再開始作業，以減少可互動時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)"
+    "message": "建議在所有重要資源載入完成之前，延遲載入畫面外圖片和隱藏項目，以縮短互動準備時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)。"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "延後載入畫面外圖片"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "資源過多會妨礙首次繪製頁面。建議內嵌重要的 JS/CSS，延遲所有不重要的 JS/樣式。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)"
+    "message": "網頁的資源過多，因此妨礙了首次顯示畫面的時間。建議你先載入重要的內嵌 JavaScript/CSS，並延後載入不重要的 JavaScript/樣式。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)。"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "排除禁止轉譯的資源"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": {
-    "message": "大量網路酬載會造成使用者的費用負擔，而且往往會導致載入耗時過長。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)"
+    "message": "大量的網路酬載會增加使用者的費用負擔，而且往往會延長網頁載入時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)。"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "總大小為 {totalBytes, number, bytes} KB"
@@ -369,19 +381,19 @@
     "message": "避免耗用大量網路資源"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": {
-    "message": "壓縮 CSS 檔案可以減少網路酬載大小。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/minify-css)"
+    "message": "壓縮 CSS 檔案能減少網路酬載大小。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/minify-css)。"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "壓縮 CSS"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": {
-    "message": "壓縮 JavaScript 檔案可以減少酬載大小和指令碼剖析時間。[瞭解詳情](https://developers.google.com/speed/docs/insights/MinifyResources)"
+    "message": "壓縮 JavaScript 檔案能減少酬載大小，並縮短剖析指令碼的時間。[瞭解詳情](https://developers.google.com/speed/docs/insights/MinifyResources)。"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": {
     "message": "壓縮 JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": {
-    "message": "移除樣式表中的無用規則，並延遲載入在不需捲動位置內容中未使用的 CSS，盡量避免網路活動消耗不必要的流量。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/unused-css)。"
+    "message": "移除樣式表中的無用規則，並延遲載入在不需捲動位置內容中未使用的 CSS，儘量避免網路活動消耗不必要的流量。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/unused-css)。"
   },
   "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": {
     "message": "移除未使用的 CSS"
@@ -393,7 +405,7 @@
     "message": "移除未使用的 JavaScript"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": {
-    "message": "快取效期越長，增加造訪您頁面的頻率就越高。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)"
+    "message": "延長快取生命週期可以加快使用者再次造訪網頁的速度。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/cache-policy)。"
   },
   "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | displayValue": {
     "message": "{itemCount,plural, =1{找到 1 項資源}other{找到 # 項資源}}"
@@ -405,37 +417,88 @@
     "message": "使用有效的快取政策處理靜態資產"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": {
-    "message": "最佳化圖片載入速度，減少行動數據用量。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)"
+    "message": "經過最佳化的圖片載入速度較快，且能節省使用者的行動數據用量。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)。"
   },
   "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": {
     "message": "圖片編碼有效率"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "提供適當大小的圖片有助於節省行動數據用量、縮短載入時間。[Learn more](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)"
+    "message": "使用大小合適的圖片有助於節省行動數據用量並縮短載入時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)。"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "使用合適的圖片大小"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": {
-    "message": "提供的文字資源應經過 (gzip、deflate 或 brotli) 壓縮，將網路傳輸的資料量降至最低。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/text-compression)"
+    "message": "提供的文字資源應經過 (gzip、deflate 或 brotli) 壓縮，將網路傳輸的資料量降至最低。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/text-compression)。"
   },
   "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": {
     "message": "啟用文字壓縮"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": {
-    "message": "JPEG 2000、JPEG XR 和 WebP 等圖片格式通常壓縮效率優於 PNG 或 JPEG，能夠更快下載完成及減少數據用量。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/webp)"
+    "message": "JPEG 2000、JPEG XR 和 WebP 等圖片格式的壓縮效果通常優於 PNG 或 JPEG，因此能提高下載速度並節省使用者的數據用量。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/webp)。"
   },
   "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": {
     "message": "提供 next-gen 格式的圖片"
   },
   "lighthouse-core/audits/critical-request-chains.js | description": {
-    "message": "下方的「關鍵要求鏈結」顯示的是以高優先順序載入的資源。為了提高頁面載入速度，建議你縮短鏈結長度，降低下載資源的大小，或是延後下載非必要資源。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)。"
+    "message": "下方的「關鍵要求鏈結」顯示優先載入的資源。建議你縮短鏈結長度、降低下載資源的大小，或是將非必要資源延後載入，以提高網頁載入速度。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)。"
   },
   "lighthouse-core/audits/critical-request-chains.js | displayValue": {
     "message": "{itemCount,plural, =1{找到 1 個鏈結}other{找到 # 個鏈結}}"
   },
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "將關鍵要求層級降至最低"
+  },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "淘汰/警告"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "行數"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "系統最終會從瀏覽器中移除已淘汰的 API。[瞭解詳情](https://www.chromestatus.com/features#deprecated)。"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{發現 1 則警告}other{發現 # 則警告}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "使用已淘汰的 API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "避免使用已淘汰的 API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "應用程式快取已遭到淘汰。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/appcache)。"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "已找到「{AppCacheManifest}」"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "使用應用程式快取"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "避免使用應用程式快取"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "指定 DOCTYPE 能防止瀏覽器切換至相容模式。詳情請參閱 [MDN 網路文件頁面](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "DOCTYPE 名稱必須是小寫字串 `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "文件必須包含 DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "publicId 須為空白字串"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "systemId 須為空白字串"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "網頁缺少 HTML DOCTYPE，因此觸發了相容模式"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "網頁含有 HTML DOCTYPE"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "元素"
@@ -467,8 +530,140 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "避免 DOM 過大"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "目標"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "將 `rel=\"noopener\"` 或 `rel=\"noreferrer\"` 新增至所有外部連結，可提升效能並防範安全漏洞。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/noopener)。"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "跨原始來源目的地的連結不安全"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "跨來源目的地的連結很安全"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "無法判定錨點的目的地 ({anchorHTML})。如果 target=_blank 不是做為超連結使用，請考慮移除它。"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "如果未提供其他資訊就要求存取使用者的位置資訊，會讓使用者感到困惑而不信任網站。建議你在使用者執行特定動作時，再提出這項要求。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)。"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "在載入網頁時要求存取使用者的位置資訊"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "避免在載入網頁時要求存取使用者的位置資訊"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "版本"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "在此網頁上偵測到的所有前端 JavaScript 程式庫。"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "偵測到 JavaScript 程式庫"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "對於連線速度較慢的使用者，透過 `document.write()` 動態置入的外部指令碼可能會導致網頁延遲數十秒載入。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/document-write)。"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "使用 `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "避免使用 `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "最高嚴重性"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "程式庫版本"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "安全漏洞數量"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "部分第三方指令碼可能包含已知的安全漏洞，攻擊者將能輕易識別及利用這些漏洞。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)。"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{偵測到 1 項安全漏洞}other{偵測到 # 項安全漏洞}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "包含的前端 JavaScript 程式庫具有已知安全漏洞"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "高"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "低"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "中"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "避免使用包含已知安全漏洞的前端 JavaScript 程式庫"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "如果未提供其他資訊就要求使用者允許網站顯示通知，會讓使用者感到困惑而不信任網站。建議你在使用者操作特定手勢時，再提出這項要求。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)。"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "在載入網頁時要求使用者允許網站顯示通知"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "避免在載入網頁時要求使用者允許網站顯示通知"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "未通過稽核的元素"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "禁止貼上密碼會對安全性政策造成不良影響[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)。"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "禁止使用者貼到密碼欄位"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "允許使用者貼到密碼欄位"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "通訊協定"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 具備許多 HTTP/1.1 沒有的優點，包括二進位標題、多工處理和伺服器推送。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/http2)。"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{有 1 項要求未透過 HTTP/2 傳送}other{有 # 項要求未透過 HTTP/2 傳送}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "網頁要求的部分資源未使用 HTTP/2"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "針對本身的資源使用 HTTP/2"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "建議將輕觸動作和滑鼠滾輪事件監聽器標示為 `passive`，以提升網頁的捲動效能。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)。"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "未使用被動事件監聽器來提升捲動效能"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "使用被動事件監聽器來提升捲動效能"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "說明"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "如果主控台有錯誤記錄，表示系統有問題尚待解決，例如網路要求錯誤和其他瀏覽器問題。"
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "主控台已記錄瀏覽器發生的錯誤"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "系統未在主控台中記錄瀏覽器發生的錯誤"
+  },
   "lighthouse-core/audits/font-display.js | description": {
-    "message": "運用顯示字型的 CSS 功能，確保使用者可以在載入網路字型時看到文字。[瞭解詳情](https://developers.google.com/web/updates/2016/02/font-display)"
+    "message": "運用顯示字型的 CSS 功能，確保使用者可以在網站字型載入期間看到文字。[瞭解詳情](https://developers.google.com/web/updates/2016/02/font-display)。"
   },
   "lighthouse-core/audits/font-display.js | failureTitle": {
     "message": "確認載入網站字型時文字不會消失"
@@ -476,8 +671,44 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "載入網站字型時沒有任何文字消失"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse 無法自動檢查以下網址顯示字型的值：{fontURL}"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "實際顯示比例"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "網頁上顯示的圖片比例"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "圖片顯示尺寸應符合正常顯示比例。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)。"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "圖片的顯示比例不正確"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "圖片的顯示比例正確"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "圖片大小資訊無效 ({url})"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "不安全的網址"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "所有網站都應該使用 HTTPS 確保安全，即使網站未處理機密資料也一樣。HTTPS 能防範入侵者竄改或被動監聽應用程式與使用者之間的通訊，且 HTTP/2 和許多新的網路平台 API 都要求使用 HTTPS。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/https)。"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{發現 1 個不安全的要求}other{發現 # 個不安全的要求}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "未使用 HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "使用 HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
-    "message": "如果網頁在行動數據網路中能快速載入，可為行動裝置使用者提供良好的使用體驗。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)。"
+    "message": "如果網頁能透過行動網路快速載入，就可確保行動裝置使用者獲得良好的使用體驗。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)。"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
     "message": "在 {timeInMs, number, seconds} 秒開始互動"
@@ -504,25 +735,25 @@
     "message": "將主要執行緒的工作降到最低"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | description": {
-    "message": "預估輸入延遲時間是在頁面載入作業最忙碌的 5 秒中，應用程式對於使用者輸入動作的預估回應時間 (以毫秒為單位)。如果延遲超過 50 毫秒，使用者可能會覺得應用程式的速度很慢。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)。"
+    "message": "預估輸入延遲時間是指在頁面載入作業最忙碌的 5 秒中，應用程式對於使用者輸入動作的預估回應時間 (以毫秒為單位)。如果延遲時間超過 50 毫秒，使用者可能會覺得應用程式的速度很慢。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)。"
   },
   "lighthouse-core/audits/metrics/estimated-input-latency.js | title": {
     "message": "預估輸入延遲"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
-    "message": "「首次顯示內容所需時間」會標記寫下第一個文字或繪製第一張圖片的時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)。"
+    "message": "首次顯示內容所需時間是指瀏覽器首次顯示文字或圖片的時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint)。"
   },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | title": {
     "message": "首次內容繪製"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | description": {
-    "message": "首次 CPU 閒置標記的是頁面的主要執行緒在第一次處理輸入作業前所需的閒置時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)"
+    "message": "首次 CPU 閒置時間是指網頁的主要執行緒已不再忙碌，且有能力處理輸入內容的最早時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)。"
   },
   "lighthouse-core/audits/metrics/first-cpu-idle.js | title": {
     "message": "首次 CPU 閒置"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": {
-    "message": "首次有效繪製可供衡量頁面主要內容顯示的時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)"
+    "message": "畫面首次有效顯示所需時間是指網頁顯示主要內容的時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)。"
   },
   "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": {
     "message": "首次有效繪製"
@@ -534,16 +765,22 @@
     "message": "可互動時間"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "使用者可能要等待的「首次輸入延遲時間」就是耗時最久的工作所需要的處理時間 (以毫秒為單位)。"
+    "message": "使用者可能要等待的最長「首次輸入延遲時間」就是耗時最久的工作所需要的處理時間 (以毫秒為單位)。[瞭解詳情](https://developers.google.com/web/updates/2018/05/first-input-delay)。"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "FID 最大預估值"
+    "message": "首次輸入延遲時間最長預估值"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
-    "message": "速度指數會顯示頁面內容填入的速度。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/speed-index)"
+    "message": "速度指數會顯示網頁可見內容的填入速度。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/speed-index)。"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "速度指數"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "當工作長度超過 50 毫秒時，從 FCP 到互動準備時間的時間範圍總計 (以毫秒為單位)。"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "封鎖時間總計"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "網路封包往返時間 (RTT) 對效能有很大的影響。如果將封包傳送到某個來源的 RTT 很高，表示靠近使用者端的伺服器在效能方面有改善空間。[瞭解詳情](https://hpbn.co/primer-on-latency-and-bandwidth/)。"
@@ -552,31 +789,52 @@
     "message": "網路封包往返時間"
   },
   "lighthouse-core/audits/network-server-latency.js | description": {
-    "message": "伺服器延遲時間可能會影響網頁效能。如果來源端的伺服器延遲時間很高，表示伺服器有超載情形或後端效能不佳。[瞭解詳情](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)。"
+    "message": "伺服器延遲時間可能會影響網站效能。如果原始伺服器的延遲時間很高，表示伺服器有超載情形或後端效能不佳。[瞭解詳情](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall)。"
   },
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "伺服器後端延遲時間"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "超過預算"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "讓網路要求的數量和大小低於使用者根據效能預算所設定的目標。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/budgets)。"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 個要求}other{# 個要求}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "效能預算"
+  },
   "lighthouse-core/audits/redirects.js | description": {
-    "message": "重新導向會導致頁面延遲載入。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/redirects)"
+    "message": "重新導向會導致頁面延遲載入。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/redirects)。"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "避免進行多次頁面重新導向"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "如要針對網頁資源的數量和大小設定預算，請新增 budget.json 檔案。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/budgets)。"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 個要求}other{# 個要求}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "降低要求數量並減少傳輸大小"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
-    "message": "標準連結會建議要在搜尋結果中顯示哪個網址。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/canonical)。"
+    "message": "標準連結可指出要在搜尋結果中顯示哪個網址。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/canonical)。"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "多個衝突的網址 ({urlList})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "指向不同的網域 ({url})"
+    "message": "指向其他網域 ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "無效的網址 ({url})"
+    "message": "網址無效 ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "指向其他「hreflang」位置 ({url})"
+    "message": "指向其他 `hreflang` 位置 ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "相對網址 ({url})"
@@ -585,10 +843,10 @@
     "message": "指向目標為網域的根網址 (首頁)，而不是相應的內容網頁"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "文件缺少有效的「rel=canonical」"
+    "message": "文件缺少有效的 `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
-    "message": "文件具備有效的「rel=canonical」"
+    "message": "文件具備有效的 `rel=canonical`"
   },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "如果字型小於 12 像素，文字會太小而難以辨識；行動裝置訪客必須「以雙指撥動縮放」才能閱讀內容。網頁中應有超過 60% 的文字採用 12 像素以上的大小。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)。"
@@ -596,14 +854,11 @@
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
     "message": "{decimalProportion, number, extendedPercent} 的文字清晰易讀"
   },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} 的文字太小。"
-  },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "文字難以辨識，這是因為網頁沒有針對行動裝置螢幕設定合適的可視區域中繼標記。"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationWithDisclaimer": {
-    "message": "{decimalProportion, number, extendedPercent} 的文字太小 (以 {decimalProportionVisited, number, extendedPercent} 範例為準)。"
+    "message": "{decimalProportion, number, extendedPercent} 的文字過小 (根據 {decimalProportionVisited, number, extendedPercent} 的取樣結果)。"
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "文件使用的字型大小難以辨識"
@@ -612,13 +867,13 @@
     "message": "文件使用的字型大小清晰易讀"
   },
   "lighthouse-core/audits/seo/hreflang.js | description": {
-    "message": "hreflang 連結會告訴搜尋引擎在特定語言或區域的搜尋結果中該顯示哪種版本的網頁。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/hreflang)。"
+    "message": "hreflang 連結會告訴搜尋引擎在特定語言或區域的搜尋結果中應顯示哪種版本的網頁。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/hreflang)。"
   },
   "lighthouse-core/audits/seo/hreflang.js | failureTitle": {
-    "message": "文件缺少有效的 hreflang"
+    "message": "文件缺少有效的 `hreflang`"
   },
   "lighthouse-core/audits/seo/hreflang.js | title": {
-    "message": "文件具備有效的「hreflang」"
+    "message": "文件具備有效的 `hreflang`"
   },
   "lighthouse-core/audits/seo/http-status-code.js | description": {
     "message": "如果網頁傳回失敗的 HTTP 狀態碼，可能無法正確編入索引。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)。"
@@ -651,7 +906,7 @@
     "message": "連結具有說明文字"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "執行[結構化資料測試工具](https://search.google.com/structured-data/testing-tool/) 和 [Structured Data Linter](http://linter.structured-data.org/) 來驗證結構化資料。[瞭解詳情](https://developers.google.com/search/docs/guides/mark-up-content)。"
+    "message": "執行[結構化資料測試工具](https://search.google.com/structured-data/testing-tool/)和 [Structured Data Linter](http://linter.structured-data.org/) 來驗證結構化資料。[瞭解詳情](https://developers.google.com/search/docs/guides/mark-up-content)。"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "結構化資料有效"
@@ -696,7 +951,7 @@
     "message": "robots.txt 有效"
   },
   "lighthouse-core/audits/seo/tap-targets.js | description": {
-    "message": "按鈕和連結等互動元素的大小應至少有 48x48 像素，且周圍應保留足夠空間，讓使用者輕鬆點選，同時避免與其他元素重疊的情況。[瞭解詳情](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)。"
+    "message": "按鈕和連結等互動元素的大小應至少有 48x48 像素，且周圍應保留足夠空間，讓使用者能輕鬆點選，同時避免與其他元素重疊的情況。[瞭解詳情](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)。"
   },
   "lighthouse-core/audits/seo/tap-targets.js | displayValue": {
     "message": "{decimalProportion, number, percent} 的輕觸目標大小適中"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "重疊的目標"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "大小"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "輕觸目標"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "輕觸目標已設定成適當大小"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "在主要執行緒的執行時間"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "第三方"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "第三方程式碼可能會嚴重影響載入效能。請儘量減少不必要的第三方供應商，並在網頁的主要內容載入完畢後，再載入第三方程式碼。[瞭解詳情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)。"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{發現 1 個第三方程式碼}other{發現 # 個第三方程式碼}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "第三方使用情形"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
-    "message": "第一個位元組時間會指出您的伺服器傳送回應的時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/ttfb)"
+    "message": "第一個位元組時間會指出你的伺服器傳送回應的時間。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/ttfb)。"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "根文件用時 {timeInMs, number, milliseconds} 毫秒"
+    "message": "根文件回應時間為 {timeInMs, number, milliseconds} 毫秒"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "減少伺服器回應時間 (TTFB)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "時間長度"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "名稱"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "開始時間"
   },
@@ -744,7 +1008,7 @@
     "message": "類型"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "建議你使用 User Timing API 檢測應用程式在關鍵使用者體驗期間的實際成效。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/user-timing)。"
+    "message": "建議你使用 User Timing API 評估應用程式在關鍵使用者體驗期間的實際效能。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/user-timing)。"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 個 User Timing 標記}other{# 個 User Timing 標記}}"
@@ -753,19 +1017,19 @@
     "message": "User Timing 標記和測量結果"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "「{securityOrigin}」有預先連線的 <link>，但未獲瀏覽器使用。請檢查你使用「crossorigin」屬性的方式是否正確。"
+    "message": "「{securityOrigin}」有預先連線的 <link>，但未獲瀏覽器使用。請檢查你使用 `crossorigin` 屬性的方式是否正確。"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "建議新增預先連線或預先擷取 DNS 的資源提示，及早連線至重要的第三方來源。[瞭解詳情](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)"
+    "message": "建議你新增預先連線或預先擷取 DNS 的資源提示，及早連線至重要的第三方來源。[瞭解詳情](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)。"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "預先連上必要來源"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "「{preloadURL}」有預先載入的 <link>，但未獲瀏覽器使用。請檢查你使用「crossorigin」屬性的方式是否正確。"
+    "message": "「{preloadURL}」有預先載入的 <link>，但未獲瀏覽器使用。請檢查你使用 `crossorigin` 屬性的方式是否正確。"
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "建議使用 <link rel=preload> 指定在頁面載入後立即需要的資源，以優先擷取這類資源。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/preload)"
+    "message": "建議使用 `<link rel=preload>` 優先擷取目前在網頁載入時較晚要求的資源。[瞭解詳情](https://developers.google.com/web/tools/lighthouse/audits/preload)。"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "預先載入重要要求"
@@ -789,7 +1053,7 @@
     "message": "最佳做法"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
-    "message": "這些檢查會提供[網頁應用程式無障礙功能的改善建議] (https://developers.google.com/web/fundamentals/accessibility)。系統只能自動偵測一部分的無障礙功能問題，因此建議你另外進行手動測試。"
+    "message": "這些檢查會清楚說明[網頁應用程式無障礙功能的改善建議](https://developers.google.com/web/fundamentals/accessibility)，但系統只能自動偵測一部分的無障礙功能問題，因此建議你另外進行手動測試。"
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "這些稽核項目會檢查自動化測試工具未涵蓋的區域。詳情請參閱[無障礙功能審查的執行指南](https://developers.google.com/web/fundamentals/accessibility/how-to-review)。"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "表格和清單"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "最佳做法"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "你可以根據效能預算設定網站效能的標準。"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "預算"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "關於您應用程式效能的更多資訊。"
+    "message": "進一步瞭解應用程式的效能。這些數字不會[直接影響](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)「效能」分數。"
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "診斷"
@@ -840,7 +1113,7 @@
     "message": "改進首次繪製程序"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "這些最佳化建議可以提高您的頁面載入速度。"
+    "message": "這些建議有助於提升網頁載入速度，但不會[直接影響](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)「效能」分數。"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "最佳化建議"
@@ -888,7 +1161,7 @@
     "message": "檢索及建立索引"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupDescription": {
-    "message": "請確認你的網頁適合透過行動裝置瀏覽，讓使用者不須撥動雙指或縮放螢幕即可閱讀網頁內容。[瞭解詳情](https://developers.google.com/search/mobile-sites/)。"
+    "message": "請確認你的網頁適合透過行動裝置瀏覽，使用者不須撥動雙指或縮放螢幕即可閱讀網頁內容。[瞭解詳情](https://developers.google.com/search/mobile-sites/)。"
   },
   "lighthouse-core/config/default-config.js | seoMobileGroupTitle": {
     "message": "適合透過行動裝置瀏覽"
@@ -896,20 +1169,35 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "快取 TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "位置"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "名稱"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "要求"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "資源類型"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "大小 (KB)"
+    "message": "大小"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "花費的時間"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "傳輸大小"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "網址"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "潛在減少量 (KB)"
+    "message": "可節省的數據用量"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "潛在減少量 (毫秒)"
+    "message": "可節省的時間"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
     "message": "可減少 {wastedBytes, number, bytes} KB"
@@ -917,11 +1205,38 @@
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
     "message": "可減少 {wastedMs, number, milliseconds} 毫秒"
   },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "文件"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "字型"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "圖片"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "媒體"
+  },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} 毫秒"
   },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "其他"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "指令碼"
+  },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
     "message": "{timeInMs, number, seconds} 秒"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "樣式表"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "第三方"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "總計"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "追蹤記錄網頁載入情形時發生錯誤。請重新執行 Lighthouse。({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS 伺服器無法解析你提供的網域。"
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "必要的 {artifactName} 收集程式發生錯誤：{errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "Chrome 發生內部錯誤。請重新啟動 Chrome，並嘗試重新執行 Lighthouse。"
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "未執行必要的 {artifactName} 收集程式。"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse 無法穩定載入你要求的網頁。請確認你測試的網址是否正確，以及伺服器是否正確回應所有要求。"
@@ -947,14 +1268,17 @@
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
     "message": "你所提供的網址缺少有效的安全性憑證。{securityMessages}"
   },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome 使用插頁式畫面阻止系統載入網頁。請確認你的測試網址是否正確，以及伺服器是否正確回應所有要求。"
+  },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
-    "message": "Lighthouse 無法穩定載入你要求的網頁。請確認你測試的網址是否正確，以及伺服器是否正確回應所有要求。(詳細資料：{errorDetails})"
+    "message": "Lighthouse 無法穩定載入你要求的網頁。請確認你的測試網址是否正確，以及伺服器是否正確回應所有要求。(詳細資訊：{errorDetails})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithStatusCode": {
-    "message": "Lighthouse 無法穩定載入你要求的網頁。請確認你測試的網址是否正確，以及伺服器是否正確回應所有要求。(狀態代碼：{statusCode})"
+    "message": "Lighthouse 無法穩定載入你要求的網頁。請確認你的測試網址是否正確，以及伺服器是否正確回應所有要求。(狀態碼：{statusCode})"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "網頁的載入時間過長。請依照報告中的建議縮短網頁的載入時間，並嘗試重新啟動 Lighthouse。({errorCode})"
+    "message": "網頁載入時間過長。請按照報告中的建議做法縮短網頁載入時間，然後嘗試重新執行 Lighthouse。({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
     "message": "等待 DevTools 通訊協定回應的時間超出系統分配上限。(方法：{protocolMethod})"
@@ -984,7 +1308,7 @@
     "message": "研究資料"
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "透過 [Lighthouse](https://developers.google.com/web/tools/lighthouse/) 在模擬行動網路上對目前網頁進行的分析。此為預估值，可能與實際情況有所出入。"
+    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) 在模擬行動網路上對目前網頁進行的分析。此為預估值，可能與實際情況有所不同。"
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "其他手動檢查項目"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "展開程式碼片段"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "顯示第三方資源"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "有問題導致 Lighthouse 無法順利執行這項作業："
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "此為預估值，可能與實際情況有所出入。"
+    "message": "此為預估值，可能與實際情況有所出入。系統[只會根據這些指標](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)計算效能分數。"
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "通過稽核，但附有警告訊息"
@@ -1035,25 +1362,25 @@
     "message": "建議你在文章清單中顯示摘錄 (例如加入更多標記)、減少特定頁面顯示的文章數量、將較長的文章分為多個頁面，或使用可延遲載入留言的外掛程式。"
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/search/minify+css/)可以透過串聯、縮小及壓縮樣式來提升網站速度。你也可以考慮透過建構流程直接執行這項壓縮作業 (如果可行的話)。"
+    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/search/minify+css/) 可以透過串連、縮小及壓縮樣式來提升網站速度。你也可以透過建構流程直接執行這項壓縮作業 (如果可行的話)。"
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "有一些 [WordPress 外掛程式](https://wordpress.org/plugins/search/minify+javascript/)可以透過串聯、縮小及壓縮指令碼來提升網站速度。你也可以考慮透過建構流程直接執行這項壓縮作業 (如果可行的話)。"
+    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/search/minify+javascript/) 可以透過串連、縮小及壓縮指令碼來提升網站速度。你也可以透過建構流程直接執行這項壓縮作業 (如果可行的話)。"
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/) 會在網頁中載入未使用的 CSS，建議你減少這類外掛程式的數量，或改用其他外掛程式。如要找出會新增多餘 CSS 的外掛程式，請嘗試在 Chrome DevTools 中執行[程式碼涵蓋率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)功能。你可以透過樣式表網址找出有問題的主題/外掛程式。請留意在清單中包含許多樣式表，且程式碼涵蓋率中有許多紅色標示的外掛程式。外掛程式只應將網頁上實際使用的樣式表加入清單。"
+    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/)會在網頁中載入未使用的 CSS，建議你減少這類外掛程式的數量，或改用其他外掛程式。如要找出會新增多餘 CSS 的外掛程式，請嘗試在 Chrome DevTools 中執行[程式碼涵蓋率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)功能。你可以透過樣式表網址找出有問題的主題/外掛程式。請留意在清單中包含許多樣式表，且程式碼涵蓋率中有許多紅色標示的外掛程式。外掛程式只應將網頁上實際使用的樣式表加入清單。"
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/)會在網頁中載入未使用的 JavaScript，建議你減少這類外掛程式的數量，或改用其他外掛程式。如要找出會新增多餘 JS 的外掛程式，請嘗試在 Chrome DevTools 中執行[程式碼涵蓋率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)功能。你可以透過指令碼網址找出有問題的主題/外掛程式。請留意在清單中包含許多指令碼，且程式碼涵蓋率中有許多紅色標示的外掛程式。外掛程式只應將網頁實際使用的指令碼加入清單。"
+    "message": "有些 [WordPress 外掛程式](https://wordpress.org/plugins/)會在網頁中載入未使用的 JavaScript，建議你減少這類外掛程式的數量，或改用其他外掛程式。如要找出會新增多餘 JavaScript 的外掛程式，請嘗試在 Chrome DevTools 中執行[程式碼涵蓋率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)功能。你可以透過指令碼網址找出有問題的主題/外掛程式。請留意在清單中包含許多指令碼，且程式碼涵蓋率中有許多紅色標示的外掛程式。外掛程式只應將網頁實際使用的指令碼加入佇列。"
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "瞭解 [WordPress 的瀏覽器快取功能](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)。"
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "建議你使用[圖片最佳化 WordPress 外掛程式](https://wordpress.org/plugins/search/optimize+images/)，壓縮圖片時不會影響到畫質。"
+    "message": "建議你使用壓縮圖片時不會影響到畫質的[圖片最佳化 WordPress 外掛程式](https://wordpress.org/plugins/search/optimize+images/)。"
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "你可以直接透過[媒體庫](https://codex.wordpress.org/Media_Library_Screen)上傳圖片，確保你可以使用所需的圖片大小，然後透過從媒體庫插入圖片，或使用圖片小工具來確保你使用的是最佳圖片大小 (包括回應式中斷點適用的圖片大小)。除非圖片尺寸符合使用目的，否則請避免使用「原尺寸」圖片。[瞭解詳情](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)。"
+    "message": "你可以直接透過[媒體庫](https://codex.wordpress.org/Media_Library_Screen)上傳圖片，確保你可以使用所需的圖片大小，然後透過從媒體庫插入圖片，或使用圖片小工具來確保你使用的是最佳圖片大小 (包括回應式中斷點適用的圖片大小)。除非圖片尺寸符合使用目的，否則請避免使用`Full Size`圖片。[瞭解詳情](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)。"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "你可以在網路伺服器設定中啟用文字壓縮功能。"

--- a/lighthouse-core/lib/i18n/locales/zh.json
+++ b/lighthouse-core/lib/i18n/locales/zh.json
@@ -1,15 +1,15 @@
 {
   "lighthouse-core/audits/accessibility/accesskeys.js | description": {
-    "message": "快捷键可让用户快速转到页面的某个部分。为确保正确进行导航，每个快捷键都必须是独一无二的。[了解详情](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse)。"
+    "message": "快捷键可让用户快速转到页面的某个部分。为确保正确进行导航，每个快捷键都必须是独一无二的。[了解详情](https://web.dev/accesskeys/)。"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
-    "message": "`[accesskey]` 值不是独一无二的"
+    "message": "`[accesskey]` 值不是不独一无二的"
   },
   "lighthouse-core/audits/accessibility/accesskeys.js | title": {
-    "message": "`[accesskey]` 值是独一无二的"
+    "message": "“`[accesskey]`”值是独一无二的"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
-    "message": "每个 ARIA `role` 都支持一部分特定的 `aria-*` 属性。如果这些项不匹配，就会致使 `aria-*` 属性无效。[了解详情](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse)。"
+    "message": "每个 ARIA“`role`”都支持一部分特定的“`aria-*`”属性。如果这些项不匹配，会导致“`aria-*`”属性无效。[了解详情](https://web.dev/aria-allowed-attr/)。"
   },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | failureTitle": {
     "message": "`[aria-*]` 属性与其角色不匹配"
@@ -18,16 +18,16 @@
     "message": "`[aria-*]` 属性与其角色匹配"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | description": {
-    "message": "一些 ARIA 角色有必需属性，这些属性向屏幕阅读器描述了相应元素的状态。[了解详情](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse)。"
+    "message": "一些 ARIA 角色有必需属性，这些属性向屏幕阅读器描述了相应元素的状态。[了解详情](https://web.dev/aria-required-attr/)。"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | failureTitle": {
-    "message": "`[role]` 仅具备部分必需的 `[aria-*]` 属性"
+    "message": "`[role]` 缺少部分必需的 `[aria-*]` 属性"
   },
   "lighthouse-core/audits/accessibility/aria-required-attr.js | title": {
     "message": "`[role]` 具备所有必需的 `[aria-*]` 属性"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | description": {
-    "message": "一些 ARIA 父角色必须包含特定子角色，才能执行它们的预期无障碍功能。[了解详情](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse)。"
+    "message": "一些 ARIA 父角色必须包含特定子角色，才能执行它们的预期无障碍功能。[了解详情](https://web.dev/aria-required-children/)。"
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
     "message": "角色为 `[role]` 且需要特定子级 `[role]` 的元素缺少所需子级。"
@@ -36,7 +36,7 @@
     "message": "角色为 `[role]` 且需要特定子级 `[role]` 的元素具备所需子级"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
-    "message": "一些 ARIA 子角色必须包含在特定的父角色中，才能正确执行它们的预期无障碍功能。[了解详情](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse)。"
+    "message": "一些 ARIA 子角色必须包含在特定的父角色中，才能正确执行它们的预期无障碍功能。[了解详情](https://web.dev/aria-required-parent/)。"
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | failureTitle": {
     "message": "`[role]` 未包含在其必需的父元素中"
@@ -45,7 +45,7 @@
     "message": "`[role]` 包含在其必需的父元素中"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | description": {
-    "message": "ARIA 角色必须具备有效值，才能执行它们的预期无障碍功能。[了解详情](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse)。"
+    "message": "ARIA 角色必须具备有效值，才能执行它们的预期无障碍功能。[了解详情](https://web.dev/aria-roles/)。"
   },
   "lighthouse-core/audits/accessibility/aria-roles.js | failureTitle": {
     "message": "`[role]` 值无效"
@@ -54,7 +54,7 @@
     "message": "`[role]` 值有效"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": {
-    "message": "辅助技术（如屏幕阅读器）无法解读值无效的 ARIA 属性。[了解详情](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse)。"
+    "message": "辅助技术（如屏幕阅读器）无法解读值无效的 ARIA 属性。[了解详情](https://web.dev/aria-valid-attr-value/)。"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | failureTitle": {
     "message": "`[aria-*]` 属性缺少有效值"
@@ -63,7 +63,7 @@
     "message": "`[aria-*]` 属性具备有效值"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": {
-    "message": "辅助技术（如屏幕阅读器）无法解读名称无效的 ARIA 属性。[了解详情](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse)。"
+    "message": "辅助技术（如屏幕阅读器）无法解读名称无效的 ARIA 属性。[了解详情](https://web.dev/aria-valid-attr/)。"
   },
   "lighthouse-core/audits/accessibility/aria-valid-attr.js | failureTitle": {
     "message": "`[aria-*]` 属性无效或拼写有误"
@@ -72,19 +72,19 @@
     "message": "`[aria-*]` 属性有效且拼写正确"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | description": {
-    "message": "字幕让失聪用户或听障用户能够使用音频元素，并可提供关键信息（例如谁在说话、他们在说什么以及其他非语音信息）。[了解详情](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse)。"
+    "message": "字幕让失聪用户或听障用户能够使用音频元素，并可提供关键信息（例如谁在说话、他们在说什么以及其他非语音信息）。[了解详情](https://web.dev/audio-caption/)。"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | failureTitle": {
-    "message": "`<audio>` 元素缺少 `[kind=\"captions\"]` 的 `<track>` 元素。"
+    "message": "`<audio>` 元素缺少含 `[kind=\"captions\"]` 的 `<track>` 元素。"
   },
   "lighthouse-core/audits/accessibility/audio-caption.js | title": {
-    "message": "`<audio>` 元素包含 `[kind=\"captions\"]` 的 `<track>` 元素"
+    "message": "`<audio>` 元素包含带 `[kind=\"captions\"]` 的 `<track>` 元素"
   },
   "lighthouse-core/audits/accessibility/axe-audit.js | failingElementsHeader": {
-    "message": "失败的元素"
+    "message": "未通过审核的元素"
   },
   "lighthouse-core/audits/accessibility/button-name.js | description": {
-    "message": "当某个按钮没有可供访问的名称时，屏幕阅读器会将它读为“按钮”，这会导致依赖屏幕阅读器的用户无法使用它。[了解详情](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse)。"
+    "message": "当某个按钮没有可供访问的名称时，屏幕阅读器会将它读为“按钮”，这会导致依赖屏幕阅读器的用户无法使用它。[了解详情](https://web.dev/button-name/)。"
   },
   "lighthouse-core/audits/accessibility/button-name.js | failureTitle": {
     "message": "按钮缺少可供访问的名称"
@@ -93,7 +93,7 @@
     "message": "按钮有可供访问的名称"
   },
   "lighthouse-core/audits/accessibility/bypass.js | description": {
-    "message": "添加用于绕过重复内容的方式有助于键盘用户更高效地浏览页面。[了解详情](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse)。"
+    "message": "添加用于绕过重复内容的方式有助于键盘用户更高效地浏览页面。[了解详情](https://web.dev/bypass/)。"
   },
   "lighthouse-core/audits/accessibility/bypass.js | failureTitle": {
     "message": "该页面不含任何标题、跳过链接或地标区域"
@@ -102,7 +102,7 @@
     "message": "该页面包含一个标题、跳过链接或地标区域"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | description": {
-    "message": "对于许多用户而言，对比度低的文字都是难以阅读或无法阅读的。[了解详情](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse)。"
+    "message": "对于许多用户而言，对比度低的文字都是难以阅读或无法阅读的。[了解详情](https://web.dev/color-contrast/)。"
   },
   "lighthouse-core/audits/accessibility/color-contrast.js | failureTitle": {
     "message": "背景色和前景色没有足够高的对比度。"
@@ -111,7 +111,7 @@
     "message": "背景色和前景色具有足够高的对比度"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | description": {
-    "message": "如果未正确标记定义列表，屏幕阅读器可能会读出令人困惑或不准确的内容。[了解详情](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse)。"
+    "message": "如果未正确标记定义列表，屏幕阅读器可能会读出令人困惑或不准确的内容。[了解详情](https://web.dev/definition-list/)。"
   },
   "lighthouse-core/audits/accessibility/definition-list.js | failureTitle": {
     "message": "`<dl>` 并非只包含经过适当排序的 `<dt>` 和 `<dd>` 组及 `<script>` 或 `<template>` 元素。"
@@ -120,16 +120,16 @@
     "message": "`<dl>` 只包含经过适当排序的 `<dt>` 和 `<dd>` 组及 `<script>` 或 `<template>` 元素。"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | description": {
-    "message": "定义列表项（`<dt>` 和 `<dd>`）必须封装在父 `<dl>` 元素中，以确保屏幕阅读器可以正确地读出它们。[了解详情](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse)。"
+    "message": "定义列表项 (`<dt>` 和 `<dd>`) 必须封装在父 `<dl>` 元素中，以确保屏幕阅读器可以正确地读出它们。[了解详情](https://web.dev/dlitem/)。"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | failureTitle": {
-    "message": "定义列表项未封装在 `<dl>` 元素中"
+    "message": "定义列表项已封装在 `<dl>` 元素中"
   },
   "lighthouse-core/audits/accessibility/dlitem.js | title": {
     "message": "定义列表项已封装在 `<dl>` 元素中"
   },
   "lighthouse-core/audits/accessibility/document-title.js | description": {
-    "message": "屏幕阅读器用户可借助标题来大致了解某个页面的内容，搜索引擎用户则非常依赖标题来确定某个页面是否与其搜索相关。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/title)。"
+    "message": "屏幕阅读器用户可借助标题来大致了解某个页面的内容，搜索引擎用户则非常依赖标题来确定某个页面是否与其搜索相关。[了解详情](https://web.dev/document-title/)。"
   },
   "lighthouse-core/audits/accessibility/document-title.js | failureTitle": {
     "message": "文档不含 `<title>` 元素"
@@ -138,7 +138,7 @@
     "message": "文档包含 `<title>` 元素"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | description": {
-    "message": "id 属性的值必须独一无二，以防其他实例被辅助技术忽略。[了解详情](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse)。"
+    "message": "id 属性的值必须独一无二，以防其他实例被辅助技术忽略。[了解详情](https://web.dev/duplicate-id/)。"
   },
   "lighthouse-core/audits/accessibility/duplicate-id.js | failureTitle": {
     "message": "页面上的 `[id]` 属性不是独一无二的"
@@ -147,25 +147,25 @@
     "message": "页面上的 `[id]` 属性是独一无二的"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | description": {
-    "message": "屏幕阅读器用户依靠框架标题来描述框架的内容。[了解详情](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse)。"
+    "message": "屏幕阅读器用户依靠框架标题来描述框架的内容。[了解详情](https://web.dev/frame-title/)。"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | failureTitle": {
     "message": "`<frame>` 或 `<iframe>` 元素缺少标题"
   },
   "lighthouse-core/audits/accessibility/frame-title.js | title": {
-    "message": "`<frame>` 或 `<iframe>` 元素具有标题"
+    "message": "`<frame>` 或 `<iframe>` 元素有标题"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | description": {
-    "message": "如果页面未指定 lang 属性，屏幕阅读器便会假定该页面采用的是用户在设置屏幕阅读器时选择的默认语言。如果该页面实际上并未采用默认语言，则屏幕阅读器可能无法正确读出该页面中的文字。[了解详情](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)。"
+    "message": "如果页面未指定 lang 属性，屏幕阅读器便会假定该页面采用的是用户在设置屏幕阅读器时选择的默认语言。如果该页面实际上并未采用默认语言，则屏幕阅读器可能无法正确读出该页面中的文字。[了解详情](https://web.dev/html-has-lang/)。"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | failureTitle": {
     "message": "`<html>` 元素缺少 `[lang]` 属性"
   },
   "lighthouse-core/audits/accessibility/html-has-lang.js | title": {
-    "message": "`<html>` 元素具备 `[lang]` 属性"
+    "message": "`<html>` 元素包含 `[lang]` 属性"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | description": {
-    "message": "指定有效的 [BCP 47 语言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)有助于屏幕阅读器正确读出文字。[了解详情](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)。"
+    "message": "指定有效的 [BCP 47 语言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)有助于屏幕阅读器正确读出文字。[了解详情](https://web.dev/html-lang-valid/)。"
   },
   "lighthouse-core/audits/accessibility/html-lang-valid.js | failureTitle": {
     "message": "`<html>` 元素的 `[lang]` 属性缺少有效值。"
@@ -174,7 +174,7 @@
     "message": "`<html>` 元素的 `[lang]` 属性具备有效值"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | description": {
-    "message": "说明性元素应力求使用简短的描述性替代文字。未指定 alt 属性的装饰性元素可被忽略。[了解详情](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse)。"
+    "message": "说明性元素应力求使用简短的描述性替代文字。未指定 alt 属性的装饰性元素可被忽略。[了解详情](https://web.dev/image-alt/)。"
   },
   "lighthouse-core/audits/accessibility/image-alt.js | failureTitle": {
     "message": "图片元素缺少 `[alt]` 属性"
@@ -183,16 +183,16 @@
     "message": "图片元素具备 `[alt]` 属性"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | description": {
-    "message": "将图片用作 `<input>` 按钮时，提供替代文字有助于屏幕阅读器用户了解该按钮的用途。[了解详情](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse)。"
+    "message": "将图片用作 `<input>` 按钮时，提供替代文字有助于屏幕阅读器用户了解该按钮的用途。[了解详情](https://web.dev/input-image-alt/)。"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | failureTitle": {
     "message": "`<input type=\"image\">` 元素缺少 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/input-image-alt.js | title": {
-    "message": "`<input type=\"image\">` 元素具备 `[alt]` 文字"
+    "message": "`<input type=\"image\">` 元素包含 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/label.js | description": {
-    "message": "标签可确保辅助技术（如屏幕阅读器）正确读出表单控件。[了解详情](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse)。"
+    "message": "标签可确保辅助技术（如屏幕阅读器）正确读出表单控件。[了解详情](https://web.dev/label/)。"
   },
   "lighthouse-core/audits/accessibility/label.js | failureTitle": {
     "message": "表单元素不具备关联的标签"
@@ -201,16 +201,16 @@
     "message": "表单元素具有关联的标签"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | description": {
-    "message": "用于实现布局用途的表格不应包含数据元素（例如 th 或 caption 元素或 summary 属性），因为这会令屏幕阅读器用户感到困惑。[了解详情](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse)。"
+    "message": "用于实现布局用途的表格不应包含数据元素（例如 th 或 caption 元素或 summary 属性），因为这会令屏幕阅读器用户感到困惑。[了解详情](https://web.dev/layout-table/)。"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | failureTitle": {
-    "message": "展示性 `<table>` 元素使用了 `<th>`、`<caption>` 或 `[summary]` 属性。"
+    "message": "展示性 `<table>` 元素未避免使用 `<th>`、`<caption>` 或 `[summary]` 属性。"
   },
   "lighthouse-core/audits/accessibility/layout-table.js | title": {
     "message": "展示性 `<table>` 元素未使用 `<th>`、`<caption>` 或 `[summary]` 属性。"
   },
   "lighthouse-core/audits/accessibility/link-name.js | description": {
-    "message": "请确保链接文字（以及用作链接的图片替代文字）可识别、独一无二且可成为焦点，这样做会提升屏幕阅读器用户的导航体验。[了解详情](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse)。"
+    "message": "请确保链接文字（以及用作链接的图片替代文字）可识别、独一无二且可成为焦点，这样做会提升屏幕阅读器用户的导航体验。[了解详情](https://web.dev/link-name/)。"
   },
   "lighthouse-core/audits/accessibility/link-name.js | failureTitle": {
     "message": "链接缺少可识别的名称"
@@ -219,7 +219,7 @@
     "message": "链接具备可识别的名称"
   },
   "lighthouse-core/audits/accessibility/list.js | description": {
-    "message": "屏幕阅读器会采用特定的方法来读出列表内容。确保列表结构正确有助于屏幕阅读器顺利读出相应内容。[了解详情](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse)。"
+    "message": "屏幕阅读器会采用特定的方法来读出列表内容。确保列表结构正确有助于屏幕阅读器顺利读出相应内容。[了解详情](https://web.dev/list/)。"
   },
   "lighthouse-core/audits/accessibility/list.js | failureTitle": {
     "message": "列表并非只包含 `<li>` 元素和脚本支持元素（`<script>` 和 `<template>`）。"
@@ -228,7 +228,7 @@
     "message": "列表只包含 `<li>` 元素和脚本支持元素（`<script>` 和 `<template>`）。"
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "屏幕阅读器要求列表项 (`<li>`) 必须包含在父 `<ul>` 或 `<ol>` 中，才能正确读出它们。[了解详情](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse)。"
+    "message": "屏幕阅读器要求列表项 (`<li>`) 必须包含在父 `<ul>` 或 `<ol>` 中，这样才能正确读出它们。[了解详情](https://web.dev/listitem/)。"
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
     "message": "列表项 (`<li>`) 未包含在 `<ul>` 或 `<ol>` 父元素中。"
@@ -237,16 +237,16 @@
     "message": "列表项 (`<li>`) 包含在 `<ul>` 或 `<ol>` 父元素中"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
-    "message": "用户并不希望网页自动刷新，因为自动刷新会不断地将焦点移回到页面顶部。这可能会给用户带来不快或困惑。[了解详情](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse)。"
+    "message": "用户并不希望网页自动刷新，因为自动刷新会不断地将焦点移回到页面顶部。这可能会让用户感到沮丧或困惑。[了解详情](https://web.dev/meta-refresh/)。"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | failureTitle": {
-    "message": "该文档使用了 `<meta http-equiv=\"refresh\">`"
+    "message": "文档使用了 `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | title": {
-    "message": "该文档未使用 `<meta http-equiv=\"refresh\">`"
+    "message": "文档未使用 `<meta http-equiv=\"refresh\">`"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | description": {
-    "message": "对于必须依靠放大屏幕才能清晰看到网页内容的弱视用户而言，停用缩放功能会给他们带来问题。[了解详情](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse)。"
+    "message": "对于必须依靠放大屏幕才能清晰看到网页内容的弱视用户而言，停用缩放功能会给他们带来问题。[了解详情](https://web.dev/meta-viewport/)。"
   },
   "lighthouse-core/audits/accessibility/meta-viewport.js | failureTitle": {
     "message": "`<meta name=\"viewport\">` 元素中使用了 `[user-scalable=\"no\"]`，或者 `[maximum-scale]` 属性小于 5。"
@@ -255,16 +255,16 @@
     "message": "`[user-scalable=\"no\"]` 未用在 `<meta name=\"viewport\">` 元素中，并且 `[maximum-scale]` 属性不小于 5。"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | description": {
-    "message": "屏幕阅读器无法转换非文字内容。向 `<object>` 元素添加替代文字可帮助屏幕阅读器将含义传达给用户。[了解详情](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse)。"
+    "message": "屏幕阅读器无法转换非文字内容。向 `<object>` 元素添加替代文字可帮助屏幕阅读器将含义传达给用户。[了解详情](https://web.dev/object-alt/)。"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | failureTitle": {
     "message": "`<object>` 元素缺少 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/object-alt.js | title": {
-    "message": "`<object>` 元素具备 `[alt]` 文字"
+    "message": "`<object>` 元素包含 `[alt]` 文字"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | description": {
-    "message": "值大于 0 意味着明确的导航顺序。尽管这在技术上有效，但往往会让依赖辅助技术的用户感到沮丧。[了解详情](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse)。"
+    "message": "值大于 0 意味着明确的导航顺序。尽管这在技术上可行，但往往会让依赖辅助技术的用户感到沮丧。[了解详情](https://web.dev/tabindex/)。"
   },
   "lighthouse-core/audits/accessibility/tabindex.js | failureTitle": {
     "message": "一些元素的 `[tabindex]` 值大于 0"
@@ -273,16 +273,16 @@
     "message": "所有元素的 `[tabindex]` 值都不大于 0"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | description": {
-    "message": "屏幕阅读器提供了更便于用户浏览表格内容的功能。请确保那些使用 `[headers]` 属性的 `<td>` 单元格仅引用同一个表格中的其他单元格，这样做可提升屏幕阅读器用户的体验。[了解详情](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse)。"
+    "message": "屏幕阅读器提供了更便于用户浏览表格内容的功能。请确保那些使用 `[headers]` 属性的 `<td>` 单元格仅引用同一个表格中的其他单元格，这样做可提升屏幕阅读器用户的体验。[了解详情](https://web.dev/td-headers-attr/)。"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "`<table>` 元素中使用 `[headers]` 属性的单元格会引用同一个表格中的其他单元格。"
+    "message": "`<table>` 元素中使用 `[headers]` 属性的单元格仅会引用同一个表格中的其他单元格。"
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
     "message": "`<table>` 元素中使用 `[headers]` 属性的单元格仅会引用同一个表格中的其他单元格。"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
-    "message": "屏幕阅读器提供了更便于用户浏览表格内容的功能。确保表格标头始终引用同一组单元格可以提升屏幕阅读器用户的体验。[了解详情](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse)。"
+    "message": "屏幕阅读器提供了更便于用户浏览表格内容的功能。确保表格标头始终引用同一组单元格可以提升屏幕阅读器用户的体验。[了解详情](https://web.dev/th-has-data-cells/)。"
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | failureTitle": {
     "message": "`<th>` 元素和 `[role=\"columnheader\"/\"rowheader\"]` 的元素缺少它们所描述的数据单元格。"
@@ -291,31 +291,43 @@
     "message": "`<th>` 元素和 `[role=\"columnheader\"/\"rowheader\"]` 的元素具备它们所描述的数据单元格。"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | description": {
-    "message": "为元素指定有效的 [BCP 47 语言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)有助于确保屏幕阅读器正确读出文字。[了解详情](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse)。"
+    "message": "为元素指定有效的 [BCP 47 语言](https://www.w3.org/International/questions/qa-choosing-language-tags#question)有助于确保屏幕阅读器正确读出文字。[了解详情](https://web.dev/valid-lang/)。"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | failureTitle": {
     "message": "`[lang]` 属性缺少有效值"
   },
   "lighthouse-core/audits/accessibility/valid-lang.js | title": {
-    "message": "`[lang]` 属性具备有效值"
+    "message": "`[lang]` 属性的值有效"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | description": {
-    "message": "如果视频提供了字幕，失聪用户和听障用户便能更轻松地获取此视频中的信息。[了解详情](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse)。"
+    "message": "如果视频提供了字幕，失聪用户和听障用户便能更轻松地获取此视频中的信息。[了解详情](https://web.dev/video-caption/)。"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | failureTitle": {
-    "message": "`<video>` 元素不含 `[kind=\"captions\"]` 的 `<track>` 元素。"
+    "message": "`<video>` 元素缺少含 `[kind=\"captions\"]` 的 `<track>` 元素。"
   },
   "lighthouse-core/audits/accessibility/video-caption.js | title": {
-    "message": "`<video>` 元素包含 `[kind=\"captions\"]` 的 `<track>` 元素"
+    "message": "`<video>` 元素包含带 `[kind=\"captions\"]` 的 `<track>` 元素"
   },
   "lighthouse-core/audits/accessibility/video-description.js | description": {
-    "message": "音频说明可提供对话框无法提供的视频相关信息（例如面部表情和场景）。[了解详情](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse)。"
+    "message": "音频说明可提供对话框无法提供的视频相关信息（例如面部表情和场景）。[了解详情](https://web.dev/video-description/)。"
   },
   "lighthouse-core/audits/accessibility/video-description.js | failureTitle": {
-    "message": "`<video>` 元素不含 `[kind=\"description\"]` 的 `<track>` 元素。"
+    "message": "`<video>` 元素缺少含 `[kind=\"description\"]` 的 `<track>` 元素。"
   },
   "lighthouse-core/audits/accessibility/video-description.js | title": {
-    "message": "`<video>` 元素包含 `[kind=\"description\"]` 的 `<track>` 元素"
+    "message": "`<video>` 元素包含带 `[kind=\"description\"]` 的 `<track>` 元素"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | description": {
+    "message": "请定义一个 apple-touch-icon，以在 iOS 用户添加到主屏幕时获得理想的外观。它必须指向一张不透明的 192px（或 180px）方形 PNG 图片。[了解详情](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/)。"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | failureTitle": {
+    "message": "未提供有效的 `apple-touch-icon`"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | precomposedWarning": {
+    "message": "`apple-touch-icon-precomposed` 不是最新版本，建议使用 `apple-touch-icon`。"
+  },
+  "lighthouse-core/audits/apple-touch-icon.js | title": {
+    "message": "提供了有效的 `apple-touch-icon`"
   },
   "lighthouse-core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome 扩展程序对此网页的加载性能产生了负面影响。请尝试在无痕模式下或使用未安装这些扩展程序的 Chrome 个人资料审核此网页。"
@@ -330,7 +342,7 @@
     "message": "总 CPU 时间"
   },
   "lighthouse-core/audits/bootup-time.js | description": {
-    "message": "考虑减少为解析、编译和执行 JS 而花费的时间。您可能会发现，提供较小的 JS 负载有助于实现此目标。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/bootup)。"
+    "message": "建议您减少为解析、编译和执行 JS 而花费的时间。您可能会发现，提供较小的 JS 负载有助于实现此目标。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/bootup)。"
   },
   "lighthouse-core/audits/bootup-time.js | failureTitle": {
     "message": "缩短 JavaScript 执行用时"
@@ -339,19 +351,19 @@
     "message": "JavaScript 执行用时"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": {
-    "message": "使用大型 GIF 提供动画内容会导致效率低下。不妨考虑改用 MPEG4/WebM 视频（来提供动画）和 PNG/WebP（来提供静态图片）以减少网络活动消耗的字节数。[了解详情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
+    "message": "使用大型 GIF 提供动画内容会导致效率低下。建议您改用 MPEG4/WebM 视频（来提供动画）和 PNG/WebP（来提供静态图片）以减少网络活动消耗的字节数。[了解详情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)"
   },
   "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": {
     "message": "使用视频格式提供动画内容"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": {
-    "message": "考虑在所有关键资源加载完毕后推迟加载屏幕外图片和处于隐藏状态的图片，从而缩短可交互前的耗时。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)。"
+    "message": "建议您在所有关键资源加载完毕后推迟加载屏幕外图片和处于隐藏状态的图片，从而缩短可交互前的耗时。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images)。"
   },
   "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": {
     "message": "推迟加载屏幕外图片"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
-    "message": "资源阻止了系统对您网页的首次绘制。请考虑以内嵌方式提供关键的 JS/CSS 并推迟提供所有非关键的 JS/样式。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)。"
+    "message": "资源阻止了系统对您网页的首次绘制。建议以内嵌方式提供关键的 JS/CSS，并推迟提供所有非关键的 JS/样式。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)。"
   },
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "移除阻塞渲染的资源"
@@ -360,7 +372,7 @@
     "message": "网络负载过大不仅会让用户付出真金白银，还极有可能会延长加载用时。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/network-payloads)。"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
-    "message": "总大小为 {totalBytes, number, bytes} KB"
+    "message": "总大小为 {totalBytes, number, bytes} KB"
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | failureTitle": {
     "message": "避免网络负载过大"
@@ -411,7 +423,7 @@
     "message": "对图片进行高效编码"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
-    "message": "提供适当大小的图片可节省移动数据网络流量并缩短加载用时。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)。"
+    "message": "提供大小合适的图片可节省移动数据网络流量并缩短加载用时。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/oversized-images)。"
   },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": {
     "message": "适当调整图片大小"
@@ -437,6 +449,57 @@
   "lighthouse-core/audits/critical-request-chains.js | title": {
     "message": "最大限度地缩短关键请求深度"
   },
+  "lighthouse-core/audits/deprecations.js | columnDeprecate": {
+    "message": "弃用/警告"
+  },
+  "lighthouse-core/audits/deprecations.js | columnLine": {
+    "message": "Line"
+  },
+  "lighthouse-core/audits/deprecations.js | description": {
+    "message": "已弃用的的 API 最终将从浏览器中移除。[了解详情](https://www.chromestatus.com/features#deprecated)。"
+  },
+  "lighthouse-core/audits/deprecations.js | displayValue": {
+    "message": "{itemCount,plural, =1{发现了 1 条警告}other{发现了 # 条警告}}"
+  },
+  "lighthouse-core/audits/deprecations.js | failureTitle": {
+    "message": "使用了已弃用的 API"
+  },
+  "lighthouse-core/audits/deprecations.js | title": {
+    "message": "请勿使用已弃用的 API"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": {
+    "message": "应用缓存已被弃用。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/appcache)。"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | displayValue": {
+    "message": "发现了“{AppCacheManifest}”"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | failureTitle": {
+    "message": "使用了应用缓存"
+  },
+  "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": {
+    "message": "请勿使用应用缓存"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | description": {
+    "message": "指定 DOCTYPE 会阻止浏览器切换到怪异模式。请访问 [MDN 网页文档页面](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)阅读更多信息"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
+    "message": "DOCTYPE 名称必须为小写字符串 `html`"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
+    "message": "文档必需包含 DOCTYPE"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationPublicId": {
+    "message": "publicId 应为空字符串"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | explanationSystemId": {
+    "message": "systemId 应为空字符串"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | failureTitle": {
+    "message": "页面缺少 HTML DOCTYPE，从而触发了怪异模式"
+  },
+  "lighthouse-core/audits/dobetterweb/doctype.js | title": {
+    "message": "页面包含 HTML DOCTYPE"
+  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "元素"
   },
@@ -447,7 +510,7 @@
     "message": "值"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
-    "message": "浏览器工程师建议，网页包含的 DOM 元素最好少于 1500 个左右。理想状况是，树深度少于 32 个元素，且少于 60 个子/父元素。大型 DOM 可能会增加内存使用量、导致[样式计算](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)用时延长并产生高昂的[布局重排](https://developers.google.com/speed/articles/reflow)费用。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/dom-size)。"
+    "message": "浏览器工程师建议，页面包含的 DOM 元素最好少于 1,500 个左右。理想状况是，树深度少于 32 个元素，且少于 60 个子/父元素。大型 DOM 可能会增加内存使用量、导致[样式计算](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations)用时延长，并产生高昂的[布局重排](https://developers.google.com/speed/articles/reflow)费用。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/dom-size)。"
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | displayValue": {
     "message": "{itemCount,plural, =1{1 个元素}other{# 个元素}}"
@@ -467,6 +530,138 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "避免 DOM 规模过大"
   },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnRel": {
+    "message": "Rel"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | columnTarget": {
+    "message": "目标"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": {
+    "message": "向任何外部链接添加 `rel=\"noopener\"` 或 `rel=\"noreferrer\"`，可提高性能并减少安全漏洞。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/noopener)。"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | failureTitle": {
+    "message": "指向跨域目的地的链接不安全"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": {
+    "message": "指向跨域目的地的链接安全"
+  },
+  "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | warning": {
+    "message": "无法确定锚点 ({anchorHTML}) 的目的地。如果不用作超链接，建议移除 target=_blank。"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": {
+    "message": "如果网站在缺少上下文的情况下请求位置，会导致用户不信任网站或感到困惑。建议将请求与用户操作进行绑定。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)。"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | failureTitle": {
+    "message": "在网页加载时请求地理定位权限"
+  },
+  "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": {
+    "message": "避免在网页加载时请求地理定位权限"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | columnVersion": {
+    "message": "版本"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | description": {
+    "message": "页面上检测到所有前端 JavaScript 库。"
+  },
+  "lighthouse-core/audits/dobetterweb/js-libraries.js | title": {
+    "message": "已检测到的 JavaScript 库"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | description": {
+    "message": "对于连接速度较慢的用户，通过 `document.write()` 动态注入的外部脚本可将网页加载延迟数十秒。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/document-write)。"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": {
+    "message": "使用了 `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-document-write.js | title": {
+    "message": "请勿使用 `document.write()`"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": {
+    "message": "最高严重程度"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVersion": {
+    "message": "库版本"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnVuln": {
+    "message": "漏洞数量"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": {
+    "message": "某些第三方脚本可能包含已知的安全漏洞，攻击者很容易识别和利用这些漏洞。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities)。"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | displayValue": {
+    "message": "{itemCount,plural, =1{检测到 1 个漏洞}other{检测到 # 个漏洞}}"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
+    "message": "包含有已知安全漏洞的前端 JavaScript 库"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
+    "message": "高"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
+    "message": "低"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
+    "message": "中"
+  },
+  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
+    "message": "避免使用含已知安全漏洞的前端 JavaScript 库"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": {
+    "message": "如果网站在缺少上下文的情况下请求发送通知，会导致用户不信任网站或感到困惑。建议将请求与用户手势进行绑定。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)。"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | failureTitle": {
+    "message": "在网页加载时请求通知权限"
+  },
+  "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": {
+    "message": "避免在网页加载时请求通知权限"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | columnFailingElem": {
+    "message": "失败的元素"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": {
+    "message": "阻止密码粘贴，会破坏良好的安全政策。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/password-pasting)。"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | failureTitle": {
+    "message": "不允许用户粘贴内容到密码字段"
+  },
+  "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": {
+    "message": "允许用户粘贴内容到密码字段"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | columnProtocol": {
+    "message": "协议"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | description": {
+    "message": "HTTP/2 提供了许多优于 HTTP/1.1的优点，包括二进制标头、多路复用和服务器推送等。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/http2)。"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | displayValue": {
+    "message": "{itemCount,plural, =1{1 条请求未通过 HTTP/2 传送}other{# 条请求未通过 HTTP/2 传送}}"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | failureTitle": {
+    "message": "没有对所有网页资源使用 HTTP/2"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-http2.js | title": {
+    "message": "对其自身资源使用了 HTTP/2"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": {
+    "message": "建议您将触摸和滚轮事件监听器标记为 `passive`，以提高页面的滚动性能。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)。"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | failureTitle": {
+    "message": "未使用被动式监听器来提高滚动性能"
+  },
+  "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": {
+    "message": "使用被动式监听器来提高滚动性能"
+  },
+  "lighthouse-core/audits/errors-in-console.js | columnDesc": {
+    "message": "说明"
+  },
+  "lighthouse-core/audits/errors-in-console.js | description": {
+    "message": "控制台中记录的错误表明有未解决的问题。导致这些错误的可能是网络请求失败和其他浏览器问题。"
+  },
+  "lighthouse-core/audits/errors-in-console.js | failureTitle": {
+    "message": "控制台日志中已记录浏览器错误"
+  },
+  "lighthouse-core/audits/errors-in-console.js | title": {
+    "message": "控制台日志中未记录浏览器错误"
+  },
   "lighthouse-core/audits/font-display.js | description": {
     "message": "利用 font-display 这项 CSS 功能，确保文本在网页字体加载期间始终对用户可见。[了解详情](https://developers.google.com/web/updates/2016/02/font-display)。"
   },
@@ -476,11 +671,47 @@
   "lighthouse-core/audits/font-display.js | title": {
     "message": "在网页字体加载期间，所有文本都保持可见状态"
   },
+  "lighthouse-core/audits/font-display.js | undeclaredFontURLWarning": {
+    "message": "Lighthouse 无法自动检查以下网址的字体显示值：{fontURL}。"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnActual": {
+    "message": "宽高比（实际）"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | columnDisplayed": {
+    "message": "宽高比（显示）"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | description": {
+    "message": "图像显示尺寸应与自然宽高比相匹配。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio)。"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | failureTitle": {
+    "message": "显示的图像宽高比不正确"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | title": {
+    "message": "显示的图像宽高比正确"
+  },
+  "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
+    "message": "无效的图片大小信息 {url}"
+  },
+  "lighthouse-core/audits/is-on-https.js | columnInsecureURL": {
+    "message": "不安全的网址"
+  },
+  "lighthouse-core/audits/is-on-https.js | description": {
+    "message": "应该使用 HTTPS 保护所有网站（包括不会处理敏感数据的网站）。HTTPS 可防止入侵程序篡改或被动地监听您的应用与用户之间的通信，它是HTTP/2 和许多新的网络平台 API 的先决条件。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/https)。"
+  },
+  "lighthouse-core/audits/is-on-https.js | displayValue": {
+    "message": "{itemCount,plural, =1{发现 1 条不安全的请求}other{发现 # 条不安全的请求}}"
+  },
+  "lighthouse-core/audits/is-on-https.js | failureTitle": {
+    "message": "未使用 HTTPS"
+  },
+  "lighthouse-core/audits/is-on-https.js | title": {
+    "message": "使用 HTTPS"
+  },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": {
     "message": "如果网页在移动网络中的加载速度较快，则可确保良好的移动用户体验。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)。"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueText": {
-    "message": "需要 {timeInMs, number, seconds} 秒才能支持交互"
+    "message": "页面交互需要 {timeInMs, number, seconds} 秒"
   },
   "lighthouse-core/audits/load-fast-enough-for-pwa.js | displayValueTextWithOverride": {
     "message": "在模拟移动网络上需要 {timeInMs, number, seconds} 秒才能支持交互"
@@ -534,16 +765,22 @@
     "message": "可交互前的耗时"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "您的用户可能会遇到的潜在首次输入延迟是用时最长的任务的耗时（以毫秒为单位）。"
+    "message": "您的用户可能会遇到的最高潜在首次输入延迟是用时最长的任务的耗时（以毫秒为单位）。[了解详情](https://developers.google.com/web/updates/2018/05/first-input-delay)。"
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {
-    "message": "最长的潜在 FID"
+    "message": "最长潜在首次输入延迟"
   },
   "lighthouse-core/audits/metrics/speed-index.js | description": {
     "message": "速度指数表明了网页内容的可见填充速度。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/speed-index)。"
   },
   "lighthouse-core/audits/metrics/speed-index.js | title": {
     "message": "速度指数"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | description": {
+    "message": "当任务长度超过 50 毫秒时，首次内容渲染 (FCP) 和可交互时间之间的所有时间段的总和，以毫秒表示。"
+  },
+  "lighthouse-core/audits/metrics/total-blocking-time.js | title": {
+    "message": "总阻塞时间"
   },
   "lighthouse-core/audits/network-rtt.js | description": {
     "message": "网络往返时间 (RTT) 对性能有很大的影响。如果与源服务器之间的 RTT 较长，则表明缩短服务器与用户之间的距离可能会提高性能。[了解详情](https://hpbn.co/primer-on-latency-and-bandwidth/)。"
@@ -557,26 +794,47 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "服务器后端延迟"
   },
+  "lighthouse-core/audits/performance-budget.js | columnOverBudget": {
+    "message": "超出预算"
+  },
+  "lighthouse-core/audits/performance-budget.js | description": {
+    "message": "请将网络请求的数量和数据大小保持在提供的性能预算所设定的目标之内。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/budgets)。"
+  },
+  "lighthouse-core/audits/performance-budget.js | requestCountOverBudget": {
+    "message": "{count,plural, =1{1 条请求}other{# 条请求}}"
+  },
+  "lighthouse-core/audits/performance-budget.js | title": {
+    "message": "性能预算"
+  },
   "lighthouse-core/audits/redirects.js | description": {
     "message": "重定向会在网页可加载前引入更多延迟。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/redirects)。"
   },
   "lighthouse-core/audits/redirects.js | title": {
     "message": "避免多次网页重定向"
   },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "若要设置页面资源数量和大小的预算，请添加 budget.json 文件。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/budgets)。"
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount,plural, =1{1 条请求}other{# 条请求}} • {byteCount, number, bytes} KB"
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "请保持较低的请求数量和较小的传输大小"
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "规范链接用于建议应在搜索结果中显示哪个网址。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/canonical)。"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
-    "message": "存在多个相互冲突的网址 ({urlList})"
+    "message": "存在多个相互冲突的网址（{urlList}）"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "指向了另一网域 ({url})"
+    "message": "指向不同的域名 ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
-    "message": "网址 ({url}) 无效"
+    "message": "网址无效 ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationPointsElsewhere": {
-    "message": "指向了另一个 `hreflang` 位置 ({url})"
+    "message": "指向了其他 `hreflang` 位置 ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
     "message": "相对网址 ({url})"
@@ -585,7 +843,7 @@
     "message": "指向了网域的根网址（首页），而非等效内容页面"
   },
   "lighthouse-core/audits/seo/canonical.js | failureTitle": {
-    "message": "文档的 `rel=canonical` 无效"
+    "message": "文档缺少有效的 `rel=canonical`"
   },
   "lighthouse-core/audits/seo/canonical.js | title": {
     "message": "文档的 `rel=canonical` 有效"
@@ -594,10 +852,7 @@
     "message": "12px 以下的字体过小，会导致用户无法辨认；此外，这样的字体需要移动设备访问者“张合双指进行缩放”才能阅读。请力求 60% 以上的页面文字不小于 12px。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/font-sizes)。"
   },
   "lighthouse-core/audits/seo/font-size.js | displayValue": {
-    "message": "{decimalProportion, number, extendedPercent} 的文字清晰可辨"
-  },
-  "lighthouse-core/audits/seo/font-size.js | explanation": {
-    "message": "{decimalProportion, number, extendedPercent} 的文字过小。"
+    "message": "{decimalProportion, number, extendedPercent} 清晰可辨的文字"
   },
   "lighthouse-core/audits/seo/font-size.js | explanationViewport": {
     "message": "无法辨认文字，因为缺少已针对移动设备屏幕进行优化的 viewport meta 标记。"
@@ -651,7 +906,7 @@
     "message": "链接有描述性文字"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | description": {
-    "message": "运行[结构化数据测试工具](https://search.google.com/structured-data/testing-tool/)和 [Structured Data Linter](http://linter.structured-data.org/) 可验证结构化数据。[了解详情](https://developers.google.com/search/docs/guides/mark-up-content)。"
+    "message": "运行[结构化数据测试工具](https://search.google.com/structured-data/testing-tool/) 和 [Structured Data Linter](http://linter.structured-data.org/) 可验证结构化数据。[了解详情](https://developers.google.com/search/docs/guides/mark-up-content)。"
   },
   "lighthouse-core/audits/seo/manual/structured-data.js | title": {
     "message": "结构化数据有效"
@@ -710,20 +965,32 @@
   "lighthouse-core/audits/seo/tap-targets.js | overlappingTargetHeader": {
     "message": "点按目标重叠"
   },
-  "lighthouse-core/audits/seo/tap-targets.js | sizeHeader": {
-    "message": "大小"
-  },
   "lighthouse-core/audits/seo/tap-targets.js | tapTargetHeader": {
     "message": "点按目标"
   },
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "点按目标的大小合适"
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "主线程时间"
+  },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "第三方"
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "第三方代码可能会显著影响加载性能。请限制冗余第三方提供商的数量，并尝试在页面完成主要加载后再加载第三方代码。[了解详情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)。"
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount,plural, =1{发现 1 个第三方}other{发现 # 个第三方}}"
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "第三方使用"
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "首字节显示前的耗时表明了服务器发出响应的时间。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/ttfb)。"
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
-    "message": "根文档花费了 {timeInMs, number, milliseconds} 毫秒"
+    "message": "根文档花费了 {timeInMs, number, milliseconds} 毫秒"
   },
   "lighthouse-core/audits/time-to-first-byte.js | failureTitle": {
     "message": "缩短服务器响应用时 (TTFB)"
@@ -734,9 +1001,6 @@
   "lighthouse-core/audits/user-timings.js | columnDuration": {
     "message": "时长"
   },
-  "lighthouse-core/audits/user-timings.js | columnName": {
-    "message": "名称"
-  },
   "lighthouse-core/audits/user-timings.js | columnStartTime": {
     "message": "开始时间"
   },
@@ -744,7 +1008,7 @@
     "message": "类型"
   },
   "lighthouse-core/audits/user-timings.js | description": {
-    "message": "考虑使用 User Timing API 检测您的应用，从而衡量应用在关键用户体验中的实际性能。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/user-timing)。"
+    "message": "建议使用 User Timing API 检测您的应用，从而衡量应用在关键用户体验中的实际性能。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/user-timing)。"
   },
   "lighthouse-core/audits/user-timings.js | displayValue": {
     "message": "{itemCount,plural, =1{1 项 User Timing 结果}other{# 项 User Timing 结果}}"
@@ -753,19 +1017,19 @@
     "message": "User Timing 标记和测量结果"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | crossoriginWarning": {
-    "message": "找到了“{securityOrigin}”的预连接 <link>，但浏览器未使用该连接。请检查并确保您正确地使用了 `crossorigin` 属性。"
+    "message": "发现了“{securityOrigin}”的预连接 <link>，但浏览器未使用该连接。请检查并确保您正确地使用了 `crossorigin` 属性。"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | description": {
-    "message": "考虑添加 preconnect 或 dns-prefetch 资源提示，以尽早与重要的第三方来源建立连接。[了解详情](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)。"
+    "message": "建议添加 preconnect 或 dns-prefetch 资源提示，以尽早与重要的第三方来源建立连接。[了解详情](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect)。"
   },
   "lighthouse-core/audits/uses-rel-preconnect.js | title": {
     "message": "预先连接到必要的来源"
   },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
-    "message": "找到了“{preloadURL}”的预加载 <link>，但浏览器未使用该链接。请检查并确保您正确地使用了 `crossorigin` 属性。"
+    "message": "发现了“{preloadURL}”的预加载 <link>，但浏览器未使用该链接。请检查并确保您正确地使用了 `crossorigin` 属性。"
   },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
-    "message": "考虑使用 <link rel=preload> 来优先提取当前在网页加载后期请求的资源。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/preload)。"
+    "message": "建议使用 `<link rel=preload>` 来优先提取当前在网页加载后期请求的资源。[了解详情](https://developers.google.com/web/tools/lighthouse/audits/preload)。"
   },
   "lighthouse-core/audits/uses-rel-preload.js | title": {
     "message": "预加载关键请求"
@@ -827,8 +1091,17 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "表格和列表"
   },
+  "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": {
+    "message": "最佳做法"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "性能预算为您的网站的性能设置了标准。"
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "预算"
+  },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
-    "message": "详细了解您的应用的性能。"
+    "message": "详细了解您的应用的性能。这些数字不会[直接影响](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)性能得分。"
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "诊断结果"
@@ -840,7 +1113,7 @@
     "message": "改进首次绘制"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
-    "message": "这些优化建议可以加快网页加载速度。"
+    "message": "这些建议可以帮助您提高网页加载速度。它们不会[直接影响](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)性能得分。"
   },
   "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "优化建议"
@@ -896,32 +1169,74 @@
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "缓存 TTL"
   },
+  "lighthouse-core/lib/i18n/i18n.js | columnLocation": {
+    "message": "位置"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnName": {
+    "message": "名称"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnRequests": {
+    "message": "请求"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnResourceType": {
+    "message": "资源类型"
+  },
   "lighthouse-core/lib/i18n/i18n.js | columnSize": {
-    "message": "大小 (KB)"
+    "message": "大小"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": {
     "message": "花费的时间"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | columnTransferSize": {
+    "message": "传输文件大小"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnURL": {
     "message": "网址"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedBytes": {
-    "message": "有望节省的流量 (KB)"
+    "message": "可能达到的节省程度"
   },
   "lighthouse-core/lib/i18n/i18n.js | columnWastedMs": {
-    "message": "有望节省的时间（毫秒）"
+    "message": "可能达到的节省程度"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueByteSavings": {
-    "message": "有望节省 {wastedBytes, number, bytes} KB"
+    "message": "有望节省 {wastedBytes, number, bytes} KB"
   },
   "lighthouse-core/lib/i18n/i18n.js | displayValueMsSavings": {
-    "message": "有望节省 {wastedMs, number, milliseconds} 毫秒"
+    "message": "有望节省 {wastedMs, number, milliseconds} 毫秒"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | documentResourceType": {
+    "message": "文档"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | fontResourceType": {
+    "message": "字体"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | imageResourceType": {
+    "message": "图片"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | mediaResourceType": {
+    "message": "媒体"
   },
   "lighthouse-core/lib/i18n/i18n.js | ms": {
-    "message": "{timeInMs, number, milliseconds} 毫秒"
+    "message": "{timeInMs, number, milliseconds} 毫秒"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
+    "message": "其他"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
+    "message": "脚本"
   },
   "lighthouse-core/lib/i18n/i18n.js | seconds": {
-    "message": "{timeInMs, number, seconds} 秒"
+    "message": "{timeInMs, number, seconds} 秒"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | stylesheetResourceType": {
+    "message": "样式表"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | thirdPartyResourceType": {
+    "message": "第三方"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | totalResourceType": {
+    "message": "总计"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
     "message": "在您加载的网页上录制跟踪记录时发生了错误。请重新运行 Lighthouse。({errorCode})"
@@ -935,8 +1250,14 @@
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
     "message": "DNS 服务器无法解析所提供的网域。"
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "必需的 {artifactName} 收集器出现错误：{errorMessage}"
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "发生了内部 Chrome 错误。请重新启动 Chrome，然后尝试重新运行 Lighthouse。"
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "必需的 {artifactName} 收集器未运行。"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse 无法可靠地加载您请求的页面。请确保您测试的网址正确无误并且服务器可正确响应所有请求。"
@@ -945,7 +1266,10 @@
     "message": "Lighthouse 无法可靠地加载您请求的网址，因为页面已停止响应。"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure": {
-    "message": "您提供的网址缺少有效的安全凭据。{securityMessages}"
+    "message": "您提供的网址缺少有效的安全证书。{securityMessages}"
+  },
+  "lighthouse-core/lib/lh-error.js | pageLoadFailedInterstitial": {
+    "message": "Chrome 阻止了带有插页式广告的网页加载。请确保您测试的网址正确无误并且服务器可正确响应所有请求。"
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": {
     "message": "Lighthouse 无法可靠地加载您请求的页面。请确保您测试的网址正确无误并且服务器可正确响应所有请求。（详细信息：{errorDetails}）"
@@ -957,7 +1281,7 @@
     "message": "您的网页加载时间过长。请按照报告中给出的提示缩短网页加载时间，然后尝试重新运行 Lighthouse。({errorCode})"
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {
-    "message": "等待 DevTools 协议响应的用时超出了分配的时间。（方法：{protocolMethod}）"
+    "message": "等待 DevTools 协议响应的用时超出了分配的时间。(方法：{protocolMethod})"
   },
   "lighthouse-core/lib/lh-error.js | requestContentTimeout": {
     "message": "提取资源内容的用时超出了分配的时间"
@@ -1007,11 +1331,14 @@
   "lighthouse-core/report/html/renderer/util.js | snippetExpandButtonLabel": {
     "message": "展开代码段"
   },
+  "lighthouse-core/report/html/renderer/util.js | thirdPartyResourcesLabel": {
+    "message": "显示第三方资源"
+  },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "此次 Lighthouse 运行并不顺利，原因如下："
   },
   "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "这些值都是估算值，且可能会因时而异。"
+    "message": "这些值都是估算值，且可能会因时而异。性能得分[仅基于这些指标](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted)。"
   },
   "lighthouse-core/report/html/renderer/util.js | warningAuditsGroupTitle": {
     "message": "已顺利通过审核，但有警告消息"
@@ -1023,10 +1350,10 @@
     "message": "建议您将 GIF 上传到可让其作为 HTML5 视频嵌入的服务。"
   },
   "stack-packs/packs/wordpress.js | offscreen_images": {
-    "message": "安装[延迟加载 WordPress 插件](https://cn.wordpress.org/plugins/search/lazy+load/)以便能够推迟加载所有的屏幕外图片，或者改用可提供该功能的主题背景。另外，建议您使用 [AMP 插件](https://cn.wordpress.org/plugins/amp/)。"
+    "message": "安装[延迟加载 WordPress 插件](https://wordpress.org/plugins/search/lazy+load/)以便能够推迟加载所有的屏幕外图片，或者改用可提供该功能的主题背景。另外，建议您使用 [AMP 插件](https://wordpress.org/plugins/amp/)。"
   },
   "stack-packs/packs/wordpress.js | render_blocking_resources": {
-    "message": "有很多 WordPress 插件可帮助您[内嵌重要资源](https://cn.wordpress.org/plugins/search/critical+css/)或[推迟加载不太重要的资源](https://cn.wordpress.org/plugins/search/defer+css+javascript/)。请注意，这些插件提供的优化可能会导致您的主题背景或插件的功能中断，因此您可能需要更改代码。"
+    "message": "有很多 WordPress 插件可帮助您[内嵌重要资源](https://wordpress.org/plugins/search/critical+css/)或[推迟加载不太重要的资源](https://wordpress.org/plugins/search/defer+css+javascript/)。请注意，这些插件提供的优化可能会导致您的主题背景或插件的功能中断，因此您可能需要更改代码。"
   },
   "stack-packs/packs/wordpress.js | time_to_first_byte": {
     "message": "主题背景、插件和服务器规范都会影响服务器响应用时。建议您查找更优化的主题背景、仔细选择所需的优化插件并/或升级您的服务器。"
@@ -1035,30 +1362,30 @@
     "message": "建议您在博文列表中显示摘录（例如，通过“更多”标签）、减少给定页面上显示的博文的数量、将您的长博文拆分成多个页面或者使用插件延迟加载评论。"
   },
   "stack-packs/packs/wordpress.js | unminified_css": {
-    "message": "很多 [WordPress 插件](https://cn.wordpress.org/plugins/search/minify+css/)都可通过连接、削减和压缩您的样式来加快您网站的加载速度。另外，您最好使用编译流程预先执行此缩减操作（如果可能的话）。"
+    "message": "很多 [WordPress 插件](https://wordpress.org/plugins/search/minify+css/)都可通过连接、削减和压缩您的样式来加快您网站的加载速度。另外，您最好使用编译流程预先执行此缩减操作（如果可能的话）。"
   },
   "stack-packs/packs/wordpress.js | unminified_javascript": {
-    "message": "很多 [WordPress 插件](https://cn.wordpress.org/plugins/search/minify+javascript/)都可通过连接、削减和压缩您的脚本来加快您网站的加载速度。另外，您最好使用编译流程预先执行此缩减操作（如果可能的话）。"
+    "message": "很多 [WordPress 插件](https://wordpress.org/plugins/search/minify+javascript/)都可通过连接、削减和压缩您的脚本来加快您网站的加载速度。另外，您最好使用编译流程预先执行此缩减操作（如果可能的话）。"
   },
   "stack-packs/packs/wordpress.js | unused_css_rules": {
-    "message": "建议您减少或改变会在您网页中加载未使用的 CSS 的 [WordPress 插件](https://cn.wordpress.org/plugins/)的数量。若想找出会添加无关 CSS 的插件，请尝试在 Chrome DevTools 中运行[代码覆盖率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)测试。您可根据样式表网址找出导致问题的主题背景/插件。请留意在列表中包含多个以大量红色显示代码覆盖率的样式表的插件。插件应该只将网页中确实用到的样式表加入队列。"
+    "message": "建议您减少或改变会在您网页中加载未使用的 CSS 的 [WordPress 插件](https://wordpress.org/plugins/)的数量。若想找出会添加无关 CSS 的插件，请尝试在 Chrome DevTools 中运行[代码覆盖率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)测试。您可根据样式表网址找出导致问题的主题背景/插件。请留意在列表中包含多个以大量红色显示代码覆盖率的样式表的插件。插件应该只将网页中确实用到的样式表加入队列。"
   },
   "stack-packs/packs/wordpress.js | unused_javascript": {
-    "message": "建议您减少或改变会在您网页中加载未使用的 JavaScript 的 [WordPress 插件](https://cn.wordpress.org/plugins/)的数量。若想找出会添加无关 JS 的插件，请尝试在 Chrome DevTools 中运行[代码覆盖率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)测试。您可根据脚本网址找出导致问题的主题背景/插件。请留意在列表中包含多个以大量红色显示代码覆盖率的脚本的插件。插件应只将网页中确实用到的脚本加入队列。"
+    "message": "建议您减少或改变会在您网页中加载未使用的 JavaScript 的 [WordPress 插件](https://wordpress.org/plugins/)的数量。若想找出会添加无关 JS 的插件，请尝试在 Chrome DevTools 中运行[代码覆盖率](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage)测试。您可根据脚本网址找出导致问题的主题背景/插件。请留意在列表中包含多个以大量红色显示代码覆盖率的脚本的插件。插件应只将网页中确实用到的脚本加入队列。"
   },
   "stack-packs/packs/wordpress.js | uses_long_cache_ttl": {
     "message": "了解 [WordPress 中的浏览器缓存](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching)。"
   },
   "stack-packs/packs/wordpress.js | uses_optimized_images": {
-    "message": "建议您使用[图片优化 WordPress 插件](https://cn.wordpress.org/plugins/search/optimize+images/)以便既能压缩图片大小又不影响图片质量。"
+    "message": "建议您使用[图片优化 WordPress 插件](https://wordpress.org/plugins/search/optimize+images/)，以在不影响图片质量的前提下压缩图片大小。"
   },
   "stack-packs/packs/wordpress.js | uses_responsive_images": {
-    "message": "直接通过[媒体库](https://codex.wordpress.org/Media_Library_Screen)上传图片，以确保能够按要求的尺寸提供图片，然后从媒体库插入图片，或使用图片微件来确保采用最佳的图片尺寸（包括适用于自适应断点的尺寸）。避免使用“完整尺寸”图片，除非有足够的可用空间。[了解详情](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)。"
+    "message": "直接通过[媒体库](https://codex.wordpress.org/Media_Library_Screen)上传图片，以确保能够按要求的尺寸提供图片，然后从媒体库插入图片，或使用图片微件来确保采用最佳的图片尺寸（包括适用于自适应断点的尺寸）。避免使用 `Full Size` 图片，除非有足够的可用空间。[了解详情](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size)。"
   },
   "stack-packs/packs/wordpress.js | uses_text_compression": {
     "message": "您可以在网络服务器配置中启用文本压缩。"
   },
   "stack-packs/packs/wordpress.js | uses_webp_images": {
-    "message": "建议您使用可自动将您上传的图片转换为最佳格式的[插件](https://cn.wordpress.org/plugins/search/convert+webp/)或服务。"
+    "message": "建议您使用可自动将您上传的图片转换为最佳格式的[插件](https://wordpress.org/plugins/search/convert+webp/)或服务。"
   }
 }

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     },
     {
       "path": "./dist/lightrider/lighthouse-lr-bundle.js",
-      "maxSize": "1.1 MB"
+      "maxSize": "1.3 MB"
     },
     {
       "path": "./dist/viewer/src/viewer.js",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Import new tc/ translations.  This is the first round trip with placeholders! :tada: This will fix all points in i18n guffaws, also check out `en-XA`, it works again! This also includes the first (#9084) web.dev links in a11y! And adds best-practices!

**Related Issues/PRs**
fixes: #9197 
helps: #9492