### PR TITLE
core(i18n): throw on excess placeholder replacement values

### DIFF
--- a/lighthouse-core/audits/third-party-summary.js
+++ b/lighthouse-core/audits/third-party-summary.js
@@ -165,7 +165,6 @@ class ThirdPartySummary extends Audit {
     return {
       score: Number(summary.wastedMs <= PASS_THRESHOLD_IN_MS),
       displayValue: str_(UIStrings.displayValue, {
-        itemCount: results.length,
         timeInMs: summary.wastedMs,
       }),
       details: Audit.makeTableDetails(headings, results, summary),

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -227,6 +227,17 @@ function _processParsedElements(icuMessage, argumentElements, values = {}) {
     }
   }
 
+  // Throw an error if a value is provided but has no placeholder in the message.
+  for (const valueId of Object.keys(values)) {
+    // errorCode is a special case always allowed to help ease of LHError use.
+    if (valueId === 'errorCode') continue;
+
+    if (!argumentElements.find(el => el.id === valueId)) {
+      throw new Error(`Provided value "${valueId}" does not match any placeholder in ` +
+        `ICU message "${icuMessage}"`);
+    }
+  }
+
   return values;
 }
 

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -100,7 +100,8 @@ class LighthouseError extends Error {
     super(errorDefinition.code);
     this.name = 'LHError';
     this.code = errorDefinition.code;
-    // Insert the i18n reference with errorCode and all additional ICU replacement properties.
+    // Add additional properties to be ICU replacements in the error string.
+    // `code` is always added as `errorCode` so callers don't need to specify the code multiple times.
     this.friendlyMessage = str_(errorDefinition.message, {errorCode: this.code, ...properties});
     this.lhrRuntimeError = !!errorDefinition.lhrRuntimeError;
     if (properties) Object.assign(this, properties);

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -5605,7 +5605,6 @@
       "lighthouse-core/audits/third-party-summary.js | displayValue": [
         {
           "values": {
-            "itemCount": 1,
             "timeInMs": 22.918000000000006
           },
           "path": "audits[third-party-summary].displayValue"


### PR DESCRIPTION
we have a check that all arguments in an ICU message have values passed into our i18n functions; this PR adds a check that all the values passed in have a place to be used in the ICU message. This is useful when strings change since we have no type checking that our localized strings match the values being passed in for replacement.

I was originally going to include this in #9570, but ran into a ton of errors in our unit tests. Turns out this is just because `LHError` always includes `errorCode` in the replacement values so you don't have to write `'NO_FCP'` three times just to get a `NO_FCP` error. I added a comment to remind the next person about `errorCode`.

This condition currently only happens in one place (the change in #9486 removing `itemCount`), but removing `itemCount` reveals a flaw in our system: if the ICU arguments in a string aren't provided in `values`, we throw an error (and if we don't throw one, `intl-messageformat` does). This is an issue when the other locale files have strings with different ICU arguments than the en-US one does (as is currently case for `third-party-summary.js | displayValue`).

This is a pretty fundamental issue so going to fix that before landing this :)