### PR TITLE
a11y: rewrite td-headers-attr titles

### DIFF
--- a/lighthouse-core/audits/accessibility/td-headers-attr.js
+++ b/lighthouse-core/audits/accessibility/td-headers-attr.js
@@ -20,7 +20,7 @@ const UIStrings = {
       'to table cells within the same table.',
   /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to header cells within the same table. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'Cells in a `<table>` element that use the `[headers]` attribute refer ' +
-      'to element `id`s not found within the same table.',
+      'to an element `id` not found within the same table.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Screen readers have features to make navigating tables easier. Ensuring ' +
       '`<td>` cells using the `[headers]` attribute only refer to other cells in the same ' +

--- a/lighthouse-core/audits/accessibility/td-headers-attr.js
+++ b/lighthouse-core/audits/accessibility/td-headers-attr.js
@@ -20,7 +20,7 @@ const UIStrings = {
       'to headers of that same table.',
   /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to header cells within the same table. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'Cells in a `<table>` element that use the `[headers]` ' +
-      'attribute refers to other cells of that same table, or elements outside the table.',
+      'attribute do not refer to headers of the same table.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Screen readers have features to make navigating tables easier. Ensuring ' +
       '`<td>` cells using the `[headers]` attribute only refer to other cells in the same ' +

--- a/lighthouse-core/audits/accessibility/td-headers-attr.js
+++ b/lighthouse-core/audits/accessibility/td-headers-attr.js
@@ -16,11 +16,11 @@ const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
   /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to header cells within the same table. This title is descriptive of the successful state and is shown to users when no user action is required. */
-  title: 'Cells in a `<table>` element that use the `[headers]` attribute only refer ' +
-      'to headers of that same table.',
+  title: 'Cells in a `<table>` element that use the `[headers]` attribute refer ' +
+      'to table cells within the same table.',
   /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to header cells within the same table. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
-  failureTitle: 'Cells in a `<table>` element that use the `[headers]` ' +
-      'attribute do not refer to headers of the same table.',
+  failureTitle: 'Cells in a `<table>` element that use the `[headers]` attribute refer ' +
+      'to element `id`s not found within the same table.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Screen readers have features to make navigating tables easier. Ensuring ' +
       '`<td>` cells using the `[headers]` attribute only refer to other cells in the same ' +

--- a/lighthouse-core/audits/accessibility/td-headers-attr.js
+++ b/lighthouse-core/audits/accessibility/td-headers-attr.js
@@ -15,12 +15,12 @@ const AxeAudit = require('./axe-audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
-  /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to cells within the same table. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to header cells within the same table. This title is descriptive of the successful state and is shown to users when no user action is required. */
   title: 'Cells in a `<table>` element that use the `[headers]` attribute only refer ' +
-      'to other cells of that same table.',
-  /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to cells within the same table. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+      'to other headers of that same table.',
+  /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to header cells within the same table. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'Cells in a `<table>` element that use the `[headers]` ' +
-      'attribute refers to other cells of that same table.',
+      'attribute refers to other cells of that same table, or cells outside the table.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Screen readers have features to make navigating tables easier. Ensuring ' +
       '`<td>` cells using the `[headers]` attribute only refer to other cells in the same ' +

--- a/lighthouse-core/audits/accessibility/td-headers-attr.js
+++ b/lighthouse-core/audits/accessibility/td-headers-attr.js
@@ -17,10 +17,10 @@ const i18n = require('../../lib/i18n/i18n.js');
 const UIStrings = {
   /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to header cells within the same table. This title is descriptive of the successful state and is shown to users when no user action is required. */
   title: 'Cells in a `<table>` element that use the `[headers]` attribute only refer ' +
-      'to other headers of that same table.',
+      'to headers of that same table.',
   /** Title of an accesibility audit that evaluates if all table cell elements in a table that use the headers HTML attribute use it correctly to refer to header cells within the same table. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'Cells in a `<table>` element that use the `[headers]` ' +
-      'attribute refers to other cells of that same table, or cells outside the table.',
+      'attribute refers to other cells of that same table, or elements outside the table.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Screen readers have features to make navigating tables easier. Ensuring ' +
       '`<td>` cells using the `[headers]` attribute only refer to other cells in the same ' +

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -276,10 +276,10 @@
     "message": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Cells in a `<table>` element that use the `[headers]` attribute do not refer to headers of the same table."
+    "message": "Cells in a `<table>` element that use the `[headers]` attribute refer to element `id`s not found within the same table."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Cells in a `<table>` element that use the `[headers]` attribute only refer to headers of that same table."
+    "message": "Cells in a `<table>` element that use the `[headers]` attribute refer to table cells within the same table."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
     "message": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://web.dev/th-has-data-cells/)."

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -276,7 +276,7 @@
     "message": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Cells in a `<table>` element that use the `[headers]` attribute refers to other cells of that same table, or elements outside the table."
+    "message": "Cells in a `<table>` element that use the `[headers]` attribute do not refer to headers of the same table."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
     "message": "Cells in a `<table>` element that use the `[headers]` attribute only refer to headers of that same table."

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -276,7 +276,7 @@
     "message": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Cells in a `<table>` element that use the `[headers]` attribute refer to element `id`s not found within the same table."
+    "message": "Cells in a `<table>` element that use the `[headers]` attribute refer to an element `id` not found within the same table."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
     "message": "Cells in a `<table>` element that use the `[headers]` attribute refer to table cells within the same table."

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -276,10 +276,10 @@
     "message": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Cells in a `<table>` element that use the `[headers]` attribute refers to other cells of that same table, or cells outside the table."
+    "message": "Cells in a `<table>` element that use the `[headers]` attribute refers to other cells of that same table, or elements outside the table."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other headers of that same table."
+    "message": "Cells in a `<table>` element that use the `[headers]` attribute only refer to headers of that same table."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
     "message": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://web.dev/th-has-data-cells/)."

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -276,10 +276,10 @@
     "message": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Cells in a `<table>` element that use the `[headers]` attribute refers to other cells of that same table."
+    "message": "Cells in a `<table>` element that use the `[headers]` attribute refers to other cells of that same table, or cells outside the table."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other cells of that same table."
+    "message": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other headers of that same table."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
     "message": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://web.dev/th-has-data-cells/)."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -276,7 +276,7 @@
     "message": "Ŝćr̂éêń r̂éâd́êŕŝ h́âv́ê f́êát̂úr̂éŝ t́ô ḿâḱê ńâv́îǵât́îńĝ t́âb́l̂éŝ éâśîér̂. Én̂śûŕîńĝ `<td>` ćêĺl̂ś ûśîńĝ t́ĥé `[headers]` ât́t̂ŕîb́ût́ê ón̂ĺŷ ŕêf́êŕ t̂ó ôt́ĥér̂ ćêĺl̂ś îń t̂h́ê śâḿê t́âb́l̂é m̂áŷ ím̂ṕr̂óv̂é t̂h́ê éx̂ṕêŕîén̂ćê f́ôŕ ŝćr̂éêń r̂éâd́êŕ ûśêŕŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ś t̂ó ôt́ĥér̂ ćêĺl̂ś ôf́ t̂h́ât́ ŝám̂é t̂áb̂ĺê, ór̂ él̂ém̂én̂t́ŝ óût́ŝíd̂é t̂h́ê t́âb́l̂é."
+    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é d̂ó n̂ót̂ ŕêf́êŕ t̂ó ĥéâd́êŕŝ óf̂ t́ĥé ŝám̂é t̂áb̂ĺê."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
     "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é ôńl̂ý r̂éf̂ér̂ t́ô h́êád̂ér̂ś ôf́ t̂h́ât́ ŝám̂é t̂áb̂ĺê."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -276,7 +276,7 @@
     "message": "Ŝćr̂éêń r̂éâd́êŕŝ h́âv́ê f́êát̂úr̂éŝ t́ô ḿâḱê ńâv́îǵât́îńĝ t́âb́l̂éŝ éâśîér̂. Én̂śûŕîńĝ `<td>` ćêĺl̂ś ûśîńĝ t́ĥé `[headers]` ât́t̂ŕîb́ût́ê ón̂ĺŷ ŕêf́êŕ t̂ó ôt́ĥér̂ ćêĺl̂ś îń t̂h́ê śâḿê t́âb́l̂é m̂áŷ ím̂ṕr̂óv̂é t̂h́ê éx̂ṕêŕîén̂ćê f́ôŕ ŝćr̂éêń r̂éâd́êŕ ûśêŕŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ t́ô él̂ém̂én̂t́ `id`ŝ ńôt́ f̂óûńd̂ ẃît́ĥín̂ t́ĥé ŝám̂é t̂áb̂ĺê."
+    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ t́ô án̂ él̂ém̂én̂t́ `id` n̂ót̂ f́ôún̂d́ ŵít̂h́îń t̂h́ê śâḿê t́âb́l̂é."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
     "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ t́ô t́âb́l̂é ĉél̂ĺŝ ẃît́ĥín̂ t́ĥé ŝám̂é t̂áb̂ĺê."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -276,10 +276,10 @@
     "message": "Ŝćr̂éêń r̂éâd́êŕŝ h́âv́ê f́êát̂úr̂éŝ t́ô ḿâḱê ńâv́îǵât́îńĝ t́âb́l̂éŝ éâśîér̂. Én̂śûŕîńĝ `<td>` ćêĺl̂ś ûśîńĝ t́ĥé `[headers]` ât́t̂ŕîb́ût́ê ón̂ĺŷ ŕêf́êŕ t̂ó ôt́ĥér̂ ćêĺl̂ś îń t̂h́ê śâḿê t́âb́l̂é m̂áŷ ím̂ṕr̂óv̂é t̂h́ê éx̂ṕêŕîén̂ćê f́ôŕ ŝćr̂éêń r̂éâd́êŕ ûśêŕŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é d̂ó n̂ót̂ ŕêf́êŕ t̂ó ĥéâd́êŕŝ óf̂ t́ĥé ŝám̂é t̂áb̂ĺê."
+    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ t́ô él̂ém̂én̂t́ `id`ŝ ńôt́ f̂óûńd̂ ẃît́ĥín̂ t́ĥé ŝám̂é t̂áb̂ĺê."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é ôńl̂ý r̂éf̂ér̂ t́ô h́êád̂ér̂ś ôf́ t̂h́ât́ ŝám̂é t̂áb̂ĺê."
+    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ t́ô t́âb́l̂é ĉél̂ĺŝ ẃît́ĥín̂ t́ĥé ŝám̂é t̂áb̂ĺê."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
     "message": "Ŝćr̂éêń r̂éâd́êŕŝ h́âv́ê f́êát̂úr̂éŝ t́ô ḿâḱê ńâv́îǵât́îńĝ t́âb́l̂éŝ éâśîér̂. Én̂śûŕîńĝ t́âb́l̂é ĥéâd́êŕŝ ál̂ẃâýŝ ŕêf́êŕ t̂ó ŝóm̂é ŝét̂ óf̂ ćêĺl̂ś m̂áŷ ím̂ṕr̂óv̂é t̂h́ê éx̂ṕêŕîén̂ćê f́ôŕ ŝćr̂éêń r̂éâd́êŕ ûśêŕŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/th-has-data-cells/)."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -276,10 +276,10 @@
     "message": "Ŝćr̂éêń r̂éâd́êŕŝ h́âv́ê f́êát̂úr̂éŝ t́ô ḿâḱê ńâv́îǵât́îńĝ t́âb́l̂éŝ éâśîér̂. Én̂śûŕîńĝ `<td>` ćêĺl̂ś ûśîńĝ t́ĥé `[headers]` ât́t̂ŕîb́ût́ê ón̂ĺŷ ŕêf́êŕ t̂ó ôt́ĥér̂ ćêĺl̂ś îń t̂h́ê śâḿê t́âb́l̂é m̂áŷ ím̂ṕr̂óv̂é t̂h́ê éx̂ṕêŕîén̂ćê f́ôŕ ŝćr̂éêń r̂éâd́êŕ ûśêŕŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ś t̂ó ôt́ĥér̂ ćêĺl̂ś ôf́ t̂h́ât́ ŝám̂é t̂áb̂ĺê."
+    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ś t̂ó ôt́ĥér̂ ćêĺl̂ś ôf́ t̂h́ât́ ŝám̂é t̂áb̂ĺê, ór̂ ćêĺl̂ś ôút̂śîd́ê t́ĥé t̂áb̂ĺê."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é ôńl̂ý r̂éf̂ér̂ t́ô ót̂h́êŕ ĉél̂ĺŝ óf̂ t́ĥát̂ śâḿê t́âb́l̂é."
+    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é ôńl̂ý r̂éf̂ér̂ t́ô ót̂h́êŕ ĥéâd́êŕŝ óf̂ t́ĥát̂ śâḿê t́âb́l̂é."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
     "message": "Ŝćr̂éêń r̂éâd́êŕŝ h́âv́ê f́êát̂úr̂éŝ t́ô ḿâḱê ńâv́îǵât́îńĝ t́âb́l̂éŝ éâśîér̂. Én̂śûŕîńĝ t́âb́l̂é ĥéâd́êŕŝ ál̂ẃâýŝ ŕêf́êŕ t̂ó ŝóm̂é ŝét̂ óf̂ ćêĺl̂ś m̂áŷ ím̂ṕr̂óv̂é t̂h́ê éx̂ṕêŕîén̂ćê f́ôŕ ŝćr̂éêń r̂éâd́êŕ ûśêŕŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/th-has-data-cells/)."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -276,10 +276,10 @@
     "message": "Ŝćr̂éêń r̂éâd́êŕŝ h́âv́ê f́êát̂úr̂éŝ t́ô ḿâḱê ńâv́îǵât́îńĝ t́âb́l̂éŝ éâśîér̂. Én̂śûŕîńĝ `<td>` ćêĺl̂ś ûśîńĝ t́ĥé `[headers]` ât́t̂ŕîb́ût́ê ón̂ĺŷ ŕêf́êŕ t̂ó ôt́ĥér̂ ćêĺl̂ś îń t̂h́ê śâḿê t́âb́l̂é m̂áŷ ím̂ṕr̂óv̂é t̂h́ê éx̂ṕêŕîén̂ćê f́ôŕ ŝćr̂éêń r̂éâd́êŕ ûśêŕŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/td-headers-attr/)."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | failureTitle": {
-    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ś t̂ó ôt́ĥér̂ ćêĺl̂ś ôf́ t̂h́ât́ ŝám̂é t̂áb̂ĺê, ór̂ ćêĺl̂ś ôút̂śîd́ê t́ĥé t̂áb̂ĺê."
+    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é r̂éf̂ér̂ś t̂ó ôt́ĥér̂ ćêĺl̂ś ôf́ t̂h́ât́ ŝám̂é t̂áb̂ĺê, ór̂ él̂ém̂én̂t́ŝ óût́ŝíd̂é t̂h́ê t́âb́l̂é."
   },
   "lighthouse-core/audits/accessibility/td-headers-attr.js | title": {
-    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é ôńl̂ý r̂éf̂ér̂ t́ô ót̂h́êŕ ĥéâd́êŕŝ óf̂ t́ĥát̂ śâḿê t́âb́l̂é."
+    "message": "Ĉél̂ĺŝ ín̂ á `<table>` êĺêḿêńt̂ t́ĥát̂ úŝé t̂h́ê `[headers]` át̂t́r̂íb̂út̂é ôńl̂ý r̂éf̂ér̂ t́ô h́êád̂ér̂ś ôf́ t̂h́ât́ ŝám̂é t̂áb̂ĺê."
   },
   "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": {
     "message": "Ŝćr̂éêń r̂éâd́êŕŝ h́âv́ê f́êát̂úr̂éŝ t́ô ḿâḱê ńâv́îǵât́îńĝ t́âb́l̂éŝ éâśîér̂. Én̂śûŕîńĝ t́âb́l̂é ĥéâd́êŕŝ ál̂ẃâýŝ ŕêf́êŕ t̂ó ŝóm̂é ŝét̂ óf̂ ćêĺl̂ś m̂áŷ ím̂ṕr̂óv̂é t̂h́ê éx̂ṕêŕîén̂ćê f́ôŕ ŝćr̂éêń r̂éâd́êŕ ûśêŕŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/th-has-data-cells/)."

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2059,7 +2059,7 @@
     },
     "td-headers-attr": {
       "id": "td-headers-attr",
-      "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to headers of that same table.",
+      "title": "Cells in a `<table>` element that use the `[headers]` attribute refer to table cells within the same table.",
       "description": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/).",
       "score": null,
       "scoreDisplayMode": "notApplicable"

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2059,7 +2059,7 @@
     },
     "td-headers-attr": {
       "id": "td-headers-attr",
-      "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other cells of that same table.",
+      "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other headers of that same table.",
       "description": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/).",
       "score": null,
       "scoreDisplayMode": "notApplicable"

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2059,7 +2059,7 @@
     },
     "td-headers-attr": {
       "id": "td-headers-attr",
-      "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other headers of that same table.",
+      "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to headers of that same table.",
       "description": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/).",
       "score": null,
       "scoreDisplayMode": "notApplicable"

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -2529,7 +2529,7 @@
             "id": "td-headers-attr",
             "score": null,
             "scoreDisplayMode": "notApplicable",
-            "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to headers of that same table."
+            "title": "Cells in a `<table>` element that use the `[headers]` attribute refer to table cells within the same table."
         },
         "th-has-data-cells": {
             "description": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://web.dev/th-has-data-cells/).",

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -2529,7 +2529,7 @@
             "id": "td-headers-attr",
             "score": null,
             "scoreDisplayMode": "notApplicable",
-            "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other headers of that same table."
+            "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to headers of that same table."
         },
         "th-has-data-cells": {
             "description": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://web.dev/th-has-data-cells/).",

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -2529,7 +2529,7 @@
             "id": "td-headers-attr",
             "score": null,
             "scoreDisplayMode": "notApplicable",
-            "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other cells of that same table."
+            "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other headers of that same table."
         },
         "th-has-data-cells": {
             "description": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://web.dev/th-has-data-cells/).",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Translators were confused by these titles, and looking into it, they don't seem to make sense.  This should be more accurate to the audit itself.

[Deque Link](https://dequeuniversity.com/rules/axe/3.2/td-headers-attr)

