### PR TITLE
i18n: rewrite aria-required-children titles

### DIFF
--- a/lighthouse-core/audits/accessibility/aria-required-children.js
+++ b/lighthouse-core/audits/accessibility/aria-required-children.js
@@ -16,11 +16,11 @@ const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
   /** Title of an accesibility audit that evaluates if the elements with an aria-role that require child elements have the required children. This title is descriptive of the successful state and is shown to users when no user action is required. */
-  title: 'Elements with an ARIA `[role]` that require children to contain specific ' +
-  '`[roles]`s have all required children.',
+  title: 'Elements with an ARIA `[role]` that require children to contain a specific ' +
+  '`[role]` have all required children.',
   /** Title of an accesibility audit that evaluates if the elements with an aria-role that require child elements have the required children. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
-  failureTitle: 'Elements with an ARIA `[role]` that require children to contain specific ' +
-  '`[roles]`s are missing some or all of those required children.',
+  failureTitle: 'Elements with an ARIA `[role]` that require children to contain a specific ' +
+  '`[role]` are missing some or all of those required children.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Some ARIA parent roles must contain specific child roles to perform ' +
       'their intended accessibility functions. ' +

--- a/lighthouse-core/audits/accessibility/aria-required-children.js
+++ b/lighthouse-core/audits/accessibility/aria-required-children.js
@@ -16,10 +16,11 @@ const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
   /** Title of an accesibility audit that evaluates if the elements with an aria-role that require child elements have the required children. This title is descriptive of the successful state and is shown to users when no user action is required. */
-  title: 'Elements with `[role]` that require specific children `[role]`s, are present',
+  title: 'Elements with an ARIA `[role]` that require children to contain specific ' +
+  '`[roles]`s have all required children.',
   /** Title of an accesibility audit that evaluates if the elements with an aria-role that require child elements have the required children. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
-  failureTitle: 'Elements with `[role]` that require specific children `[role]`s, ' +
-      'are missing.',
+  failureTitle: 'Elements with an ARIA `[role]` that require children to contain specific ' +
+  '`[roles]`s are missing some or all of those required children.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Some ARIA parent roles must contain specific child roles to perform ' +
       'their intended accessibility functions. ' +

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -30,10 +30,10 @@
     "message": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Elements with an ARIA `[role]` that require children to contain specific `[roles]`s are missing some or all of those required children."
+    "message": "Elements with an ARIA `[role]` that require children to contain a specific `[role]` are missing some or all of those required children."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Elements with an ARIA `[role]` that require children to contain specific `[roles]`s have all required children."
+    "message": "Elements with an ARIA `[role]` that require children to contain a specific `[role]` have all required children."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
     "message": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-parent/)."

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -30,10 +30,10 @@
     "message": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Elements with `[role]` that require specific children `[role]`s, are missing."
+    "message": "Elements with an ARIA `[role]` that require children to contain specific `[roles]`s are missing some or all of those required children."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Elements with `[role]` that require specific children `[role]`s, are present"
+    "message": "Elements with an ARIA `[role]` that require children to contain specific `[roles]`s have all required children."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
     "message": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-parent/)."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -30,10 +30,10 @@
     "message": "Ŝóm̂é ÂŔÎÁ p̂ár̂én̂t́ r̂ól̂éŝ ḿûśt̂ ćôńt̂áîń ŝṕêćîf́îć ĉh́îĺd̂ ŕôĺêś t̂ó p̂ér̂f́ôŕm̂ t́ĥéîŕ îńt̂én̂d́êd́ âćĉéŝśîb́îĺît́ŷ f́ûńĉt́îón̂ś. [L̂éâŕn̂ ḿôŕê](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Êĺêḿêńt̂ś ŵít̂h́ âń ÂŔÎÁ `[role]` t̂h́ât́ r̂éq̂úîŕê ćĥíl̂d́r̂én̂ t́ô ćôńt̂áîń ŝṕêćîf́îć `[roles]`ŝ ár̂é m̂íŝśîńĝ śôḿê ór̂ ál̂ĺ ôf́ t̂h́ôśê ŕêq́ûír̂éd̂ ćĥíl̂d́r̂én̂."
+    "message": "Êĺêḿêńt̂ś ŵít̂h́ âń ÂŔÎÁ `[role]` t̂h́ât́ r̂éq̂úîŕê ćĥíl̂d́r̂én̂ t́ô ćôńt̂áîń â śp̂éĉíf̂íĉ `[role]` ár̂é m̂íŝśîńĝ śôḿê ór̂ ál̂ĺ ôf́ t̂h́ôśê ŕêq́ûír̂éd̂ ćĥíl̂d́r̂én̂."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Êĺêḿêńt̂ś ŵít̂h́ âń ÂŔÎÁ `[role]` t̂h́ât́ r̂éq̂úîŕê ćĥíl̂d́r̂én̂ t́ô ćôńt̂áîń ŝṕêćîf́îć `[roles]`ŝ h́âv́ê ál̂ĺ r̂éq̂úîŕêd́ ĉh́îĺd̂ŕêń."
+    "message": "Êĺêḿêńt̂ś ŵít̂h́ âń ÂŔÎÁ `[role]` t̂h́ât́ r̂éq̂úîŕê ćĥíl̂d́r̂én̂ t́ô ćôńt̂áîń â śp̂éĉíf̂íĉ `[role]` h́âv́ê ál̂ĺ r̂éq̂úîŕêd́ ĉh́îĺd̂ŕêń."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
     "message": "Ŝóm̂é ÂŔÎÁ ĉh́îĺd̂ ŕôĺêś m̂úŝt́ b̂é ĉón̂t́âín̂éd̂ b́ŷ śp̂éĉíf̂íĉ ṕâŕêńt̂ ŕôĺêś t̂ó p̂ŕôṕêŕl̂ý p̂ér̂f́ôŕm̂ t́ĥéîŕ îńt̂én̂d́êd́ âćĉéŝśîb́îĺît́ŷ f́ûńĉt́îón̂ś. [L̂éâŕn̂ ḿôŕê](https://web.dev/aria-required-parent/)."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -30,10 +30,10 @@
     "message": "Ŝóm̂é ÂŔÎÁ p̂ár̂én̂t́ r̂ól̂éŝ ḿûśt̂ ćôńt̂áîń ŝṕêćîf́îć ĉh́îĺd̂ ŕôĺêś t̂ó p̂ér̂f́ôŕm̂ t́ĥéîŕ îńt̂én̂d́êd́ âćĉéŝśîb́îĺît́ŷ f́ûńĉt́îón̂ś. [L̂éâŕn̂ ḿôŕê](https://web.dev/aria-required-children/)."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | failureTitle": {
-    "message": "Êĺêḿêńt̂ś ŵít̂h́ `[role]` t̂h́ât́ r̂éq̂úîŕê śp̂éĉíf̂íĉ ćĥíl̂d́r̂én̂ `[role]`ś, âŕê ḿîśŝín̂ǵ."
+    "message": "Êĺêḿêńt̂ś ŵít̂h́ âń ÂŔÎÁ `[role]` t̂h́ât́ r̂éq̂úîŕê ćĥíl̂d́r̂én̂ t́ô ćôńt̂áîń ŝṕêćîf́îć `[roles]`ŝ ár̂é m̂íŝśîńĝ śôḿê ór̂ ál̂ĺ ôf́ t̂h́ôśê ŕêq́ûír̂éd̂ ćĥíl̂d́r̂én̂."
   },
   "lighthouse-core/audits/accessibility/aria-required-children.js | title": {
-    "message": "Êĺêḿêńt̂ś ŵít̂h́ `[role]` t̂h́ât́ r̂éq̂úîŕê śp̂éĉíf̂íĉ ćĥíl̂d́r̂én̂ `[role]`ś, âŕê ṕr̂éŝén̂t́"
+    "message": "Êĺêḿêńt̂ś ŵít̂h́ âń ÂŔÎÁ `[role]` t̂h́ât́ r̂éq̂úîŕê ćĥíl̂d́r̂én̂ t́ô ćôńt̂áîń ŝṕêćîf́îć `[roles]`ŝ h́âv́ê ál̂ĺ r̂éq̂úîŕêd́ ĉh́îĺd̂ŕêń."
   },
   "lighthouse-core/audits/accessibility/aria-required-parent.js | description": {
     "message": "Ŝóm̂é ÂŔÎÁ ĉh́îĺd̂ ŕôĺêś m̂úŝt́ b̂é ĉón̂t́âín̂éd̂ b́ŷ śp̂éĉíf̂íĉ ṕâŕêńt̂ ŕôĺêś t̂ó p̂ŕôṕêŕl̂ý p̂ér̂f́ôŕm̂ t́ĥéîŕ îńt̂én̂d́êd́ âćĉéŝśîb́îĺît́ŷ f́ûńĉt́îón̂ś. [L̂éâŕn̂ ḿôŕê](https://web.dev/aria-required-parent/)."

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1569,7 +1569,7 @@
     },
     "aria-required-children": {
       "id": "aria-required-children",
-      "title": "Elements with an ARIA `[role]` that require children to contain specific `[roles]`s have all required children.",
+      "title": "Elements with an ARIA `[role]` that require children to contain a specific `[role]` have all required children.",
       "description": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-children/).",
       "score": null,
       "scoreDisplayMode": "notApplicable"

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1569,7 +1569,7 @@
     },
     "aria-required-children": {
       "id": "aria-required-children",
-      "title": "Elements with `[role]` that require specific children `[role]`s, are present",
+      "title": "Elements with an ARIA `[role]` that require children to contain specific `[roles]`s have all required children.",
       "description": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-children/).",
       "score": null,
       "scoreDisplayMode": "notApplicable"

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -42,7 +42,7 @@
             "id": "aria-required-children",
             "score": null,
             "scoreDisplayMode": "notApplicable",
-            "title": "Elements with an ARIA `[role]` that require children to contain specific `[roles]`s have all required children."
+            "title": "Elements with an ARIA `[role]` that require children to contain a specific `[role]` have all required children."
         },
         "aria-required-parent": {
             "description": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-parent/).",

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -42,7 +42,7 @@
             "id": "aria-required-children",
             "score": null,
             "scoreDisplayMode": "notApplicable",
-            "title": "Elements with `[role]` that require specific children `[role]`s, are present"
+            "title": "Elements with an ARIA `[role]` that require children to contain specific `[roles]`s have all required children."
         },
         "aria-required-parent": {
             "description": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-parent/).",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
More feedback from translators.  Rewriting aria-required-children titles, I found this title super confusing without some more explanation of it.  The translators got really confused since it becomes more like "Elements with MARKDOWN that require specific children MARKDOWNs, are present"

Hopefully this is more clear.

[web.dev link](https://web.dev/aria-required-children/)
[aria list, which requires children listitem (good example)](https://www.w3.org/TR/wai-aria-1.1/#list)
