### PR TITLE
chore(lighthouse-viewer): replace deprecated uglify-es with terser

### DIFF
--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -142,11 +142,11 @@ async function compileJs() {
     output: {preamble: license}, // Insert license at top.
   };
   const uglified = Terser.minify(contents, options);
-  if (uglified.error) {
+  if (uglified.error || !uglified.code) {
     throw uglified.error;
   }
 
-  await safeWriteFileAsync(`${distDir}/src/viewer.js`, /** @type {string} */ (uglified.code));
+  await safeWriteFileAsync(`${distDir}/src/viewer.js`, uglified.code);
 }
 
 /**

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -18,7 +18,7 @@ const glob = promisify(require('glob'));
 const lighthousePackage = require('../package.json');
 const makeDir = require('make-dir');
 const rimraf = require('rimraf');
-const uglifyEs = require('uglify-es'); // Use uglify-es to get ES6 support.
+const Terser = require('terser');
 
 const htmlReportAssets = require('../lighthouse-core/report/html/html-report-assets.js');
 const sourceDir = `${__dirname}/../lighthouse-viewer`;
@@ -140,12 +140,12 @@ async function compileJs() {
   const options = {
     output: {preamble: license}, // Insert license at top.
   };
-  const uglified = uglifyEs.minify(contents, options);
+  const uglified = Terser.minify(contents, options);
   if (uglified.error) {
     throw uglified.error;
   }
 
-  await safeWriteFileAsync(`${distDir}/src/viewer.js`, uglified.code);
+  await safeWriteFileAsync(`${distDir}/src/viewer.js`, /** @type {string} */ (uglified.code));
 }
 
 /**

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -131,6 +131,7 @@ async function compileJs() {
   const viewJsFiles = await loadFiles(`${sourceDir}/app/src/*.js`);
 
   const contents = [
+    `"use strict";`,
     generatorJs,
     rendererJs,
     idbKeyvalJs,

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -18,7 +18,7 @@ const glob = promisify(require('glob'));
 const lighthousePackage = require('../package.json');
 const makeDir = require('make-dir');
 const rimraf = require('rimraf');
-const Terser = require('terser');
+const terser = require('terser');
 
 const htmlReportAssets = require('../lighthouse-core/report/html/html-report-assets.js');
 const sourceDir = `${__dirname}/../lighthouse-viewer`;
@@ -141,7 +141,7 @@ async function compileJs() {
   const options = {
     output: {preamble: license}, // Insert license at top.
   };
-  const uglified = Terser.minify(contents, options);
+  const uglified = terser.minify(contents, options);
   if (uglified.error || !uglified.code) {
     throw uglified.error;
   }

--- a/lighthouse-viewer/README.md
+++ b/lighthouse-viewer/README.md
@@ -9,7 +9,7 @@ Run the following in the root folder of a Lighthouse checkout:
 * `yarn`
 * `yarn build-viewer`
 
-This compiles and minifies `app/src/main.js` using terser. Results are written to `dist/viewer/`.
+This compiles and minifies `app/src/main.js`. Results are written to `dist/viewer/`.
 
 ## Deploy
 

--- a/lighthouse-viewer/README.md
+++ b/lighthouse-viewer/README.md
@@ -9,7 +9,7 @@ Run the following in the root folder of a Lighthouse checkout:
 * `yarn`
 * `yarn build-viewer`
 
-This compiles and minifies `app/src/main.js` using uglify-es. Results are written to `dist/viewer/`.
+This compiles and minifies `app/src/main.js` using terser. Results are written to `dist/viewer/`.
 
 ## Deploy
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "@types/resize-observer-browser": "^0.1.1",
     "@types/rimraf": "^2.0.2",
     "@types/semver": "^5.5.0",
-    "@types/uglify-es": "^3.0.0",
     "@types/update-notifier": "^1.0.2",
     "@types/ws": "^4.0.1",
     "@types/yargs": "^8.0.2",
@@ -126,8 +125,8 @@
     "prettier": "^1.14.3",
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "^1.19.0",
+    "terser": "^4.2.0",
     "typescript": "3.5.3",
-    "uglify-es": "3.0.15",
     "zone.js": "^0.7.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6889,15 +6889,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
-  integrity sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map-support@~0.5.12:
+source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
   integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,20 +704,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/uglify-es@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uglify-es/-/uglify-es-3.0.0.tgz#2c5e70b43c0e86643ac1c223f61df15fa0b87bc2"
-  integrity sha512-Oc/c7pGIQL0MVhC6g+VftWiDQethKsT4c3fQKYm6nOprkvkx9s1MLrnJprDTKlZL3ZJulMpCF9Qn7s6u3uCNxQ==
-  dependencies:
-    "@types/uglify-js" "*"
-
-"@types/uglify-js@*":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"
-  integrity sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
-  dependencies:
-    source-map "^0.6.1"
-
 "@types/update-notifier@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/update-notifier/-/update-notifier-1.0.2.tgz#7a9269a38545bfd90155aac1350669a19f8ecb4a"
@@ -1921,13 +1907,6 @@ commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
-
-commander@~2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
-  dependencies:
-    graceful-readlink ">= 1.0.0"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -3580,11 +3559,6 @@ graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 "growl@~> 1.10.0":
   version "1.10.5"
@@ -6923,12 +6897,20 @@ source-map-support@^0.5.6:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map-support@~0.5.12:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1, source-map@~0.5.3:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -7341,6 +7323,15 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
+terser@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.2.0.tgz#4b1b5f4424b426a7a47e80d6aae45e0d7979aef0"
+  integrity sha512-6lPt7lZdZ/13icQJp8XasFOwZjFJkxFFIb/N1fhYEQNoNI3Ilo3KABZ9OocZvZoB39r6SiIk/0+v/bt8nZoSeA==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
 test-exclude@^5.0.0, test-exclude@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.1.0.tgz#6ba6b25179d2d38724824661323b73e03c0c1de1"
@@ -7562,14 +7553,6 @@ typescript@3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
-
-uglify-es@3.0.15:
-  version "3.0.15"
-  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.0.15.tgz#4a23d0e9cb5f25f7bb3f1f0bbe0bb364e600d047"
-  integrity sha1-SiPQ6ctfJfe7Px8LvguzZOYA0Ec=
-  dependencies:
-    commander "~2.9.0"
-    source-map "~0.5.1"
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
**Summary**
I'm replacing uglify-es with terser to minify our viewer.js. Terser has been the successor to uglify-es as it's not actively maintained anymore.

**Related Issues/PRs**
Fixes #9558