### PR TITLE
i18n: remove translated messages when ICU arguments change

### DIFF
--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -145,7 +145,7 @@ function lookupLocale(locale) {
 function _preformatValues(icuMessage, messageFormatter, values = {}) {
   const clonedValues = JSON.parse(JSON.stringify(values));
 
-  const elements = _collectAllCustomElementsFromICU(messageFormatter.getAst().elements);
+  const elements = collectAllCustomElementsFromICU(messageFormatter.getAst().elements);
 
   return _processParsedElements(icuMessage, Array.from(elements.values()), clonedValues);
 }
@@ -165,10 +165,10 @@ function _preformatValues(icuMessage, messageFormatter, values = {}) {
  *  thus they are stored via a Map keyed on the "id" which is the ICU varName.
  *
  * @param {Array<MessageElement>} icuElements
- * @param {Map<string, ArgumentElement>} seenElementsById
+ * @param {Map<string, ArgumentElement>} [seenElementsById]
  * @return {Map<string, ArgumentElement>}
  */
-function _collectAllCustomElementsFromICU(icuElements, seenElementsById = new Map()) {
+function collectAllCustomElementsFromICU(icuElements, seenElementsById = new Map()) {
   for (const el of icuElements) {
     // We are only interested in elements that need ICU formatting (argumentElements)
     if (el.type !== 'argumentElement') continue;
@@ -180,7 +180,7 @@ function _collectAllCustomElementsFromICU(icuElements, seenElementsById = new Ma
     // Look at all options of the plural (=1{} =other{}...)
     for (const option of el.format.options) {
       // Run collections on each option's elements
-      _collectAllCustomElementsFromICU(option.value.elements, seenElementsById);
+      collectAllCustomElementsFromICU(option.value.elements, seenElementsById);
     }
   }
 
@@ -473,4 +473,5 @@ module.exports = {
   getFormattedFromIdAndValues,
   replaceIcuMessageInstanceIds,
   isIcuMessage,
+  collectAllCustomElementsFromICU,
 };

--- a/lighthouse-core/lib/i18n/locales/ar-XB.json
+++ b/lighthouse-core/lib/i18n/locales/ar-XB.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "‏‮Tap‬‏ ‏‮targets‬‏ ‏‮are‬‏ ‏‮sized‬‏ ‏‮appropriately‬‏"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "‏‮Main‬‏ ‏‮Thread‬‏ ‏‮Time‬‏"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "‏‮Third‬‏-‏‮Party‬‏"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "‏‮Third‬‏-‏‮party‬‏ ‏‮code‬‏ ‏‮can‬‏ ‏‮significantly‬‏ ‏‮impact‬‏ ‏‮load‬‏ ‏‮performance‬‏. ‏‮Limit‬‏ ‏‮the‬‏ ‏‮number‬‏ ‏‮of‬‏ ‏‮redundant‬‏ ‏‮third‬‏-‏‮party‬‏ ‏‮providers‬‏ ‏‮and‬‏ ‏‮try‬‏ ‏‮to‬‏ ‏‮load‬‏ ‏‮third‬‏-‏‮party‬‏ ‏‮code‬‏ ‏‮after‬‏ ‏‮your‬‏ ‏‮page‬‏ ‏‮has‬‏ ‏‮primarily‬‏ ‏‮finished‬‏ ‏‮loading‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 ‏‮Third‬‏-‏‮Party‬‏ ‏‮Found‬‏}zero{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}two{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}few{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}many{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}other{# ‏‮Third‬‏-‏‮Parties‬‏ ‏‮Found‬‏}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "‏‮Third‬‏-‏‮Party‬‏ ‏‮Usage‬‏"

--- a/lighthouse-core/lib/i18n/locales/ar.json
+++ b/lighthouse-core/lib/i18n/locales/ar.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "يتم تحديد حجم أهداف النقر بشكل مناسب"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "وقت سلسلة المحادثات الأساسية"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "الجهة الخارجية"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "يمكن أن يؤثر رمز الجهة الخارجية بشكل كبير في أداء التحميل. يمكنك تحديد عدد مقدِّمي الخدمة للجهات الخارجية المتكرّرين ومحاولة تحميل رمز الجهة الخارجية بعد انتهاء تحميل صفحتك بشكل أساسي. [مزيد من المعلومات](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{تم العثور على جهة خارجية واحدة}zero{تم العثور على # جهة خارجية}two{تم العثور على جهتين خارجيتين (#)}few{تم العثور على # جهات خارجية}many{تم العثور على # جهة خارجية}other{تم العثور على # جهة خارجية}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "استخدام الجهات الخارجية"

--- a/lighthouse-core/lib/i18n/locales/bg.json
+++ b/lighthouse-core/lib/i18n/locales/bg.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Целевите зони за докосване са оразмерени правилно"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Време на основната нишка"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Трета страна"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Кодът от трети страни може сериозно да повлияе върху скоростта на зареждане. Ограничете броя на излишните доставчици трети страни и опитайте да зареждате кода от трети страни, след като основното зареждане на страницата ви е приключило. [Научете повече](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Открит е 1 фрагмент с код от трета страна}other{Открити са # фрагмента с код от трета страна}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Използване на код от трети страни"

--- a/lighthouse-core/lib/i18n/locales/ca.json
+++ b/lighthouse-core/lib/i18n/locales/ca.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "La mida dels elements tàctils és correcta"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Durada del fil principal"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Tercers"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "El codi de tercers pot afectar significativament el rendiment de la càrrega. Limita el nombre de proveïdors externs redundants i prova de carregar codi de tercers quan la càrrega principal de la pàgina ha finalitzat. [Obtén més informació](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{S'ha trobat 1 tercer}other{S'han trobat # tercers}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Ús de tercers"

--- a/lighthouse-core/lib/i18n/locales/cs.json
+++ b/lighthouse-core/lib/i18n/locales/cs.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Dotykové prvky jsou dostatečně velké"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Doba hlavního podprocesu"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Třetí strana"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Kód třetích stran může mít významný dopad na rychlost načítání. Omezte počet redundantních externích poskytovatelů a snažte se kód třetích stran načítat až poté, co se dokončí načtení vaší stránky. [Další informace](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Byla nalezena 1 třetí strana}few{Byly nalezeny # třetí strany}many{Bylo nalezeno # třetí strany}other{Bylo nalezeno # třetích stran}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Použití zdrojů od třetích stran"

--- a/lighthouse-core/lib/i18n/locales/da.json
+++ b/lighthouse-core/lib/i18n/locales/da.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Trykbare elementer har en passende størrelse"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Tid for primær tråd"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Tredjepart"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Kode fra tredjeparter kan have en væsentlig indvirkning på indlæsningen. Begræns antallet af overflødige tredjepartsudbydere, og prøv at indlæse kode fra tredjeparter, når indlæsningen af siden næsten er færdig. [Få flere oplysninger](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 tredjepart blev fundet}one{# tredjepart blev fundet}other{# tredjeparter blev fundet}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Tredjepartsbrug"

--- a/lighthouse-core/lib/i18n/locales/de.json
+++ b/lighthouse-core/lib/i18n/locales/de.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Größe von Tippzielen ist richtig eingestellt"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Dauer des Hauptthreads"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Drittanbieter"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Code von Drittanbietern kann die Ladegeschwindigkeit erheblich beeinträchtigen. Beschränken Sie die Zahl redundanter Drittanbieter und versuchen Sie, solchen Code erst nachträglich zu laden. [Weitere Informationen.](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 Drittanbieter gefunden}other{# Drittanbieter gefunden}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Nutzung von Drittanbieter-Code"

--- a/lighthouse-core/lib/i18n/locales/el.json
+++ b/lighthouse-core/lib/i18n/locales/el.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Τα στοιχεία που επιλέγονται με πάτημα έχουν το κατάλληλο μέγεθος"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Χρόνος κύριου νήματος"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Τρίτο μέρος"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Ο κώδικας τρίτων παρόχων μπορεί να επηρεάσει σημαντικά την απόδοση φόρτωσης. Περιορίστε τον αριθμό των περιττών τρίτων παρόχων και προσπαθήστε η φόρτωση του κώδικα τρίτων παρόχων να γίνεται αφού πρώτα έχει ολοκληρωθεί η φόρτωση της σελίδας σας. [Μάθετε περισσότερα](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Βρέθηκε 1 τρίτο μέρος}other{Βρέθηκαν # τρίτα μέρη}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Χρήση κώδικα τρίτου"

--- a/lighthouse-core/lib/i18n/locales/en-GB.json
+++ b/lighthouse-core/lib/i18n/locales/en-GB.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Tap targets are sized appropriately"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Main thread time"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Third-party"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and try to load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 third-party found}other{# third-parties found}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Third-party usage"

--- a/lighthouse-core/lib/i18n/locales/en-XA.json
+++ b/lighthouse-core/lib/i18n/locales/en-XA.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "[Ţåþ ţåŕĝéţš åŕé šîžéð åþþŕöþŕîåţéļý one two three four five six seven eight]"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "[Måîñ Ţĥŕéåð Ţîmé one two]"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "[Ţĥîŕð-Þåŕţý one two]"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "[Ţĥîŕð-þåŕţý çöðé çåñ šîĝñîƒîçåñţļý îmþåçţ ļöåð þéŕƒöŕmåñçé. Ļîmîţ ţĥé ñûmбéŕ öƒ ŕéðûñðåñţ ţĥîŕð-þåŕţý þŕövîðéŕš åñð ţŕý ţö ļöåð ţĥîŕð-þåŕţý çöðé åƒţéŕ ýöûŕ þåĝé ĥåš þŕîmåŕîļý ƒîñîšĥéð ļöåðîñĝ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight]"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{[1 Ţĥîŕð-Þåŕţý Föûñð one two three]}other{[# Ţĥîŕð-Þåŕţîéš Föûñð one two three]}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "[Ţĥîŕð-Þåŕţý Ûšåĝé one two three]"

--- a/lighthouse-core/lib/i18n/locales/es-419.json
+++ b/lighthouse-core/lib/i18n/locales/es-419.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "El tamaño de los elementos táctiles es el adecuado"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Tiempo del subproceso principal"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Terceros"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "El código de terceros puede reducir en gran medida el rendimiento de carga. Limita la cantidad de proveedores externos redundantes y prueba cargar el código de terceros después de que haya finalizado la carga principal de tu página. [Obtén más información](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Se encontró 1 código de terceros}other{Se encontraron # códigos de terceros}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Uso por parte de terceros"

--- a/lighthouse-core/lib/i18n/locales/es.json
+++ b/lighthouse-core/lib/i18n/locales/es.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "El tamaño de los elementos táctiles es el adecuado"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Tiempo del hilo principal"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Proveedor externo"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "El código externo puede afectar mucho a la velocidad de carga. Limita el número de proveedores externos redundantes e intenta cargar el código externo cuando se haya completado la carga principal de tu página. [Más información](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Se ha encontrado 1 entidad de terceros}other{Se han encontrado # entidades de terceros}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Uso de código externo"

--- a/lighthouse-core/lib/i18n/locales/fi.json
+++ b/lighthouse-core/lib/i18n/locales/fi.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Napautuskohteet ovat sopivan kokoisia"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Pääsäikeen aika"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Kolmas osapuoli"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Kolmannen osapuolen koodi voi vaikuttaa lataustehokkuuteen merkittävästi. Rajoita tarpeettomien kolmannen osapuolen palveluntarjoajien määrää ja yritä ladata kolmannen osapuolen koodi sen jälkeen, kun sivun ensisijainen lataus on valmis. [Lue lisää](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 kolmas osapuoli löytyi}other{# kolmatta osapuolta löytyi}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Kolmannen osapuolen käyttö"

--- a/lighthouse-core/lib/i18n/locales/fil.json
+++ b/lighthouse-core/lib/i18n/locales/fil.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Angkop ang laki ng mga target ng pag-tap"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Oras sa Main Thread"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Third-Party"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Puwedeng lubos na makaapekto ang code ng third party sa performance ng pag-load. Limitahan ang bilang ng paulit-ulit na mga third-party na provider at subukang i-load ang code ng third party pagkatapos ng pangunahing pag-load ng iyong page. [Matuto pa](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 Third Party ang Nakita}one{# Third Party ang Nakita}other{# na Third Party ang Nakita}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Paggamit ng Third Party"

--- a/lighthouse-core/lib/i18n/locales/fr.json
+++ b/lighthouse-core/lib/i18n/locales/fr.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Les éléments tactiles sont dimensionnés correctement"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Temps d'exécution sur le thread principal"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Tiers"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Le code tiers peut affecter considérablement les performances de chargement des pages. Limitez le nombre de fournisseurs tiers redondants, et essayez de charger du code tiers une fois le chargement de votre page terminé. [En savoir plus](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 entité tierce trouvée}one{# entité tierce trouvée}other{# entités tierces trouvées}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Utilisation tierce"

--- a/lighthouse-core/lib/i18n/locales/he.json
+++ b/lighthouse-core/lib/i18n/locales/he.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "הרכיבים להקשה הוגדרו בגודל המתאים"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "משך הזמן של התהליכון הראשי"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "צד שלישי"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "קוד של צד שלישי עשוי להשפיע בצורה משמעותית על ביצועי הטעינה. מומלץ להגביל את הכמות של ספקי צד שלישי שאינם הכרחיים ולהשתדל לטעון קודים של צד שלישי רק אחרי שמסתיימת הטעינה של הדף. [מידע נוסף](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{נמצא צד שלישי אחד}two{נמצאו # צדדים שלישיים}many{נמצאו # צדדים שלישיים}other{נמצאו # צדדים שלישיים}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "שימוש של צד שלישי"

--- a/lighthouse-core/lib/i18n/locales/hi.json
+++ b/lighthouse-core/lib/i18n/locales/hi.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "टैप की जाने वाली जगहें सही आकार में हैं"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "मुख्य थ्रेड में लगने वाला समय"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "तीसरा पक्ष"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "तीसरे पक्ष के कोड आपके पेज की लोड परफ़ॉर्मेंस पर गहरा असर कर सकते हैं. ऐसी तीसरे-पक्ष की सेवा देने वाली कंपनियों का इस्तेमाल ज़्यादा न करें जिनके कोड अब आपके काम के नहीं हैं. साथ ही, तीसरे पक्ष का कोड तब लोड करें जब आपके पेज पर मुख्य लोडिंग का काम पूरा हो गया हो. [ज़्यादा जानें](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 तीसरा पक्ष मिला}one{# तीसरे पक्ष मिले}other{# तीसरे पक्ष मिले}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "इसका इस्तेमाल तीसरा पक्ष करता है"

--- a/lighthouse-core/lib/i18n/locales/hr.json
+++ b/lighthouse-core/lib/i18n/locales/hr.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Ciljevi dodira odgovarajuće su veličine"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Vrijeme glavne niti"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Treća strana"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Kôd treće strane može znatno utjecati na uspješnost učitavanja. Ograničite broj suvišnih pružatelja treće strane i pokušajte učitati kôd treće strane nakon primarnog zavšetka učitavanja vaše stranice. [Saznajte više](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Pronađena je jedna treća strana}one{Broj pronađenih trećih strana: #}few{Broj pronađenih trećih strana: #}other{Broj pronađenih trećih strana: #}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Upotreba trećih strana"

--- a/lighthouse-core/lib/i18n/locales/hu.json
+++ b/lighthouse-core/lib/i18n/locales/hu.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "A koppintási célok mérete megfelelő"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Főszálon töltött idő"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Harmadik fél"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "A harmadik felektől származó kódok jelentős hatással lehetnek a betöltés teljesítményére. Minél kevesebb harmadik féltől származó kódot használjon, és lehetőleg azután töltse be őket, hogy az oldal nagyrészt már betöltődött. [További információ](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 harmadik fél}other{# harmadik fél}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Harmadik féltől származó kód"

--- a/lighthouse-core/lib/i18n/locales/id.json
+++ b/lighthouse-core/lib/i18n/locales/id.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Target ketuk memiliki ukuran yang tepat"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Waktu Thread Utama"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Pihak Ketiga"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Kode pihak ketiga dapat memberikan dampak signifikan terhadap performa muatan. Batasi jumlah penyedia pihak ketiga yang berlebihan dan coba muat kode pihak ketiga terutama setelah halaman selesai memuat. [Pelajari lebih lanjut](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 Pihak Ketiga Ditemukan}other{# Pihak Ketiga Ditemukan}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Penggunaan oleh Pihak Ketiga"

--- a/lighthouse-core/lib/i18n/locales/it.json
+++ b/lighthouse-core/lib/i18n/locales/it.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "I target dei tocchi sono dimensionati in modo appropriato"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Tempo thread principale"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Terza parte"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Il codice di terze parti può incidere notevolmente sulle prestazioni del caricamento. Limita il numero di provider di terze parti superflui e prova a caricare il codice di terze parti al termine del caricamento della pagina. [Ulteriori informazioni](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 terza parte trovata}other{# terze parti trovate}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Uso di terze parti"

--- a/lighthouse-core/lib/i18n/locales/ja.json
+++ b/lighthouse-core/lib/i18n/locales/ja.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "タップ ターゲットのサイズは適切に設定されています"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "メインスレッド時間"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "第三者"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "第三者コードによって、読み込み速度が著しく低下する可能性があります。重複する第三者プロバイダの数を制限したうえで、ページのメインの部分を読み込み終えた後に第三者コードを読み込んでみてください。[詳細](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 件の第三者が見つかりました}other{# 件の第三者が見つかりました}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "第三者の利用"

--- a/lighthouse-core/lib/i18n/locales/ko.json
+++ b/lighthouse-core/lib/i18n/locales/ko.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "탭 타겟의 크기가 적절함"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "기본 스레드 시간"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "타사"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "타사 코드는 로드 성능에 크게 영향을 미칠 수 있습니다. 페이지에서 먼저 로딩을 끝낸 후 중복되는 타사 공급업체의 수를 제한하고 타사 코드를 로드해 보세요. [자세히 알아보기](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{타사 항목 1개 검색됨}other{타사 항목 #개 검색됨}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "타사 사용"

--- a/lighthouse-core/lib/i18n/locales/lt.json
+++ b/lighthouse-core/lib/i18n/locales/lt.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Liečiami objektai tinkamo dydžio"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Pagrindinės grupės laikas"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Trečioji šalis"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Trečiosios šalies kodas gali smarkiai paveikti įkėlimo našumą. Apribokite trečiosios šalies teikėjų skaičių ir pabandykite įkelti trečiosios šalies kodą, kai puslapis bus įkeltas. [Sužinokite daugiau](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Rasta 1 trečioji šalis}one{Rasta # trečioji šalis}few{Rastos # trečiosios šalys}many{Rasta # trečiosios šalies}other{Rasta # trečiųjų šalių}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Trečiosios šalies naudojimas"

--- a/lighthouse-core/lib/i18n/locales/lv.json
+++ b/lighthouse-core/lib/i18n/locales/lv.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Pieskārienu mērķi ir pietiekami liela izmēra"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Galvenā pavediena laiks"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Trešā puse"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Trešās puses kods var ievērojami ietekmēt ielādes veiktspēju. Ierobežojiet lieko trešo pušu pakalpojumu sniedzēju skaitu un mēģiniet ielādēt trešās puses kodu pēc tam, kad jūsu lapa būs ielādēta. [Uzziniet vairāk](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Atrasta 1 trešā puse}zero{Atrastas # trešās puses}one{Atrasta # trešā puse}other{Atrastas # trešās puses}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Trešo pušu lietojums"

--- a/lighthouse-core/lib/i18n/locales/nl.json
+++ b/lighthouse-core/lib/i18n/locales/nl.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Tikdoelen hebben het juiste formaat"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Tijd van primaire thread"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Derden"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Code van derden kan van grote invloed zijn op de laadprestaties. Beperkt het aantal overbodige externe providers en probeer code van derden te laden nadat je pagina primair is geladen. [Meer informatie](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 derde gevonden}other{# derden gevonden}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Gebruik door derden"

--- a/lighthouse-core/lib/i18n/locales/no.json
+++ b/lighthouse-core/lib/i18n/locales/no.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Trykkbare elementer er store nok"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Tid i hovedtråden"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Tredjepart"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Tredjepartskode kan ha betydelig innvirkning på hvor lang tid det tar å laste inn siden. Begrens antallet overflødige tredjepartsleverandører, og prøv å laste inn tredjepartskode etter at siden for det meste er ferdig innlastet. [Finn ut mer](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 tredjepart er funnet}other{# tredjeparter er funnet}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Tredjepartsbruk"

--- a/lighthouse-core/lib/i18n/locales/pl.json
+++ b/lighthouse-core/lib/i18n/locales/pl.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Elementy dotykowe mają odpowiednią wielkość"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Czas w wątku głównym"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Dostawca zewnętrzny"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Kod spoza witryny może znacznie spowalniać wczytywanie stron. Ogranicz liczbę zewnętrznych dostawców kodu i spróbuj wczytywać kod spoza witryny dopiero po zakończeniu wczytywania podstawowej strony. [Więcej informacji](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Znaleziono 1 zasób kodu spoza witryny}few{Znaleziono # zasoby kodu spoza witryny}many{Znaleziono # zasobów kodu spoza witryny}other{Znaleziono # zasobu kodu spoza witryny}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Używanie kodu spoza witryny"

--- a/lighthouse-core/lib/i18n/locales/pt-PT.json
+++ b/lighthouse-core/lib/i18n/locales/pt-PT.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Os alvos táteis estão dimensionados corretamente"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Tempo do thread principal"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Terceiros"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "O código de terceiros pode afetar significativamente o desempenho de carregamento. Limite o número de fornecedores terceiros redundantes e tente carregar o código de terceiros após a conclusão do carregamento da sua página. [Saiba mais](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 terceiro encontrado}other{# terceiros encontrados}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Utilização de terceiros"

--- a/lighthouse-core/lib/i18n/locales/pt.json
+++ b/lighthouse-core/lib/i18n/locales/pt.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "As áreas de toque estão dimensionadas corretamente"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Tempo na linha de execução principal"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Terceiros"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Código de terceiros pode afetar significativamente o desempenho de carregamento. Limite o número de provedores terceiros redundantes e carregue o código de terceiros depois que a página tiver sido carregada. [Saiba mais](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 terceiro encontrado}one{# terceiro encontrado}other{# terceiros encontrados}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Uso de terceiros"

--- a/lighthouse-core/lib/i18n/locales/ro.json
+++ b/lighthouse-core/lib/i18n/locales/ro.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Direcționările atingerilor sunt dimensionate corect"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Durata pentru firul principal"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Terță parte"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Codul terță parte poate influența semnificativ performanța de încărcare. Limitează numărul de furnizori terță parte redundanți și încearcă să încarce cod terță parte după ce pagina a terminat încărcarea de bază. [Află mai multe](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{S-a găsit o terță parte}few{S-au găsit # terțe părți}other{S-au găsit # de terțe părți}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Utilizarea terță parte"

--- a/lighthouse-core/lib/i18n/locales/ru.json
+++ b/lighthouse-core/lib/i18n/locales/ru.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Размер интерактивных элементов оптимален"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Время выполнения в основном потоке"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Сторонний поставщик"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Сторонний код может сильно замедлить загрузку страниц сайта. Рекомендуем использовать только самые необходимые сторонние ресурсы и сделать так, чтобы они загружались в последнюю очередь. [Подробнее…](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Обнаружен 1 сторонний фрагмент кода}one{Обнаружен # сторонний фрагмент кода}few{Обнаружено # сторонних фрагмента кода}many{Обнаружено # сторонних фрагментов кода}other{Обнаружено # стороннего фрагмента кода}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Сторонний код"

--- a/lighthouse-core/lib/i18n/locales/sk.json
+++ b/lighthouse-core/lib/i18n/locales/sk.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Cieľové oblasti klepnutia majú vhodnú veľkosť"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Čas hlavného vlákna"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Tretia strana"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Kód tretích strán môže výrazne ovplyvniť výkonnosť načítavania. Obmedzte počet nadbytočných poskytovateľov tretích strán a skúste načítavať kód tretích strán po dokončení načítavania stránky. [Ďalšie informácie](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Bola zistená 1 tretia strana}few{Boli zistené # tretie strany}many{# Third-Parties Found}other{Bolo zistených # tretích strán}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Využívanie tretích strán"

--- a/lighthouse-core/lib/i18n/locales/sl.json
+++ b/lighthouse-core/lib/i18n/locales/sl.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Cilji za dotikanje so ustrezne velikosti"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Čas glavne niti"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Drugi ponudniki"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Koda drugega ponudnika lahko znatno vpliva na učinkovitost nalaganja. Omejite število odvečnih drugih ponudnikov in poskusite naložiti kodo drugega ponudnika, ko je stran prvenstveno končala nalaganje. [Več o tem](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Najden je bil 1 drug ponudnik}one{Najden je bil # drug ponudnik}two{Najdena sta bila # druga ponudnika}few{Najdeni so bili # drugi ponudniki}other{Najdenih je bilo # drugih ponudnikov}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Uporaba drugih ponudnikov"

--- a/lighthouse-core/lib/i18n/locales/sr-Latn.json
+++ b/lighthouse-core/lib/i18n/locales/sr-Latn.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Ciljevi dodirivanja imaju odgovarajuću veličinu"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Vreme glavne niti"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Nezavisni dobavljač"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Kôd nezavisnog dobavljača može značajno da utiče na učinak učitavanja. Ograničite broj suvišnih nezavisnih dobavljača usluge i probajte da učitate kôd nezavisnog dobavljača kada stranica primarno završi sa učitavanjem. [Saznajte više](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Pronađen je 1 nezavisni}one{Pronađen je # nezavisni}few{Pronađena su # nezavisna}other{Pronađeno je # nezavisnih}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Nezavisna upotreba"

--- a/lighthouse-core/lib/i18n/locales/sr.json
+++ b/lighthouse-core/lib/i18n/locales/sr.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Циљеви додиривања имају одговарајућу величину"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Време главне нити"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Независни добављач"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Кôд независног добављача може значајно да утиче на учинак учитавања. Ограничите број сувишних независних добављача услуге и пробајте да учитате кôд независног добављача када страница примарно заврши са учитавањем. [Сазнајте више](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Пронађен је 1 независни}one{Пронађен је # независни}few{Пронађена су # независна}other{Пронађено је # независних}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Независна употреба"

--- a/lighthouse-core/lib/i18n/locales/sv.json
+++ b/lighthouse-core/lib/i18n/locales/sv.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Tryckmål har lämplig storlek"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Tid för huvudtråd"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Tredje part"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Kod från tredje part kan påverka inläsningsprestandan betydligt. Begränsa antalet överflödiga tredjepartsleverantörer och testa att låta tredjepartskod läsas in efter att sidans huvudinnehåll har lästs in helt. [Läs mer](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 tredje part hittades}other{# tredje parter hittades}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Tredjepartsanvändning"

--- a/lighthouse-core/lib/i18n/locales/ta.json
+++ b/lighthouse-core/lib/i18n/locales/ta.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "தட்டுவதற்கான இலக்குகள் சரியாக அளவிடப்பட்டுள்ளன"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "முக்கியத் தொடரிழைக்கான நேரம்"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "மூன்றாம் தரப்பு"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "மூன்றாம் தரப்பு குறியீடானது ஏற்றுதல் செயல்திறனைக் குறிப்பிடத்தக்க வகையில் பாதிக்கக்கூடும். தேவையற்ற மூன்றாம் தரப்பு சேவை வழங்குநர்களின் எண்ணிக்கையைக் குறைத்துக் கொள்ளவும். மேலும் உங்கள் பக்கத்தின் முதன்மை விவரங்களை ஏற்றியபிறகு மூன்றாம் தரப்பு குறியீட்டை ஏற்ற முயலவும். [மேலும் அறிக](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 மூன்றாம் தரப்பு கண்டறியப்பட்டது}other{# மூன்றாம் தரப்புகள் கண்டறியப்பட்டுள்ளன}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "மூன்றாம் தரப்பு உபயோகம்"

--- a/lighthouse-core/lib/i18n/locales/te.json
+++ b/lighthouse-core/lib/i18n/locales/te.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "ట్యాప్‌టార్గెట్‌ల పరిమాణం సముచితంగా ఉంది"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "ప్రధాన థ్రెడ్ సమయం"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "మూడవ పక్షం"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "మూడవ పక్షం కోడ్ గణనీయ స్థాయిలో లోడ్ పనితీరుపై ప్రభావం చూపవచ్చు. అవసరం లేని మూడవ పక్ష ప్రదాతల సంఖ్యను పరిమితం చేసి, మీ పేజీ ప్రాథమికంగా లోడ్ కావడం పూర్తయిన తర్వాత మూడవ పక్ష కోడ్‌ను లోడ్ చేయడానికి ప్రయత్నించండి. [మరింత తెలుసుకోండి](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 మూడవ పక్షం కనుగొనబడింది}other{# మూడవ పక్షాలు కనుగొనబడ్డాయి}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "మూడవ పక్షం వినియోగం"

--- a/lighthouse-core/lib/i18n/locales/th.json
+++ b/lighthouse-core/lib/i18n/locales/th.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "เป้าหมายการแตะมีขนาดที่เหมาะสม"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "เวลาของเธรดหลัก"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "บุคคลที่สาม"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "โค้ดของบุคคลที่สามอาจส่งผลกระทบที่สำคัญต่อประสิทธิภาพการโหลด จำกัดจำนวนผู้ให้บริการบุคคลที่สามที่มากเกินไปและพยายามโหลดโค้ดของบุคคลที่สามหลังจากที่หน้าเว็บโหลดเบื้องต้นเสร็จเรียบร้อยแล้ว [ดูข้อมูลเพิ่มเติม](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{พบบุคคลที่สาม 1 ราย}other{พบบุคคลที่สาม # ราย}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "การใช้งานของบุคคลที่สาม"

--- a/lighthouse-core/lib/i18n/locales/tr.json
+++ b/lighthouse-core/lib/i18n/locales/tr.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Dokunma hedefleri uygun boyutta"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Ana İş Parçacığı Süresi"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Üçüncü Taraf"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Üçüncü taraf kodu, yükleme performansını önemli ölçüde etkileyebilir. Yedekli üçüncü taraf sağlayıcıların sayısını sınırlayın ve öncelikle sayfanızın yüklenmesi tamamlandıktan sonra üçüncü taraf kodunu yükleyin. [Daha fazla bilgi](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{1 Adet Üçüncü Taraf Bulundu}other{# Adet Üçüncü Taraf Bulundu}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Üçüncü Taraf Kullanımı"

--- a/lighthouse-core/lib/i18n/locales/uk.json
+++ b/lighthouse-core/lib/i18n/locales/uk.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Елементи для натискання мають правильний розмір"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Час основного ланцюжка"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Сторонні розробники"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Сторонній код може значно погіршити швидкість завантаження. Не використовуйте зайвий раз елементи коду сторонніх розробників та налаштуйте сторінку так, щоб сторонній код завантажувався після її основної частини. [Докладніше](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Знайдено 1 сторонній код}one{Знайдено # сторонній код}few{Знайдено # сторонні коди}many{Знайдено # сторонніх кодів}other{Знайдено # стороннього коду}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Використання стороннього коду"

--- a/lighthouse-core/lib/i18n/locales/vi.json
+++ b/lighthouse-core/lib/i18n/locales/vi.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "Mục tiêu nhấn có kích thước phù hợp"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "Thời gian thực thi trên chuỗi chính"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "Bên thứ ba"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "Mã của bên thứ ba có thể tác động đáng kể đến hiệu suất tải. Hãy hạn chế số nhà cung cấp bên thứ ba dư thừa và cố gắng tải mã của bên thứ ba sau khi trang của bạn hoàn thành phần lớn quá trình tải. [Tìm hiểu thêm](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)."
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{Tìm thấy 1 bên thứ ba}other{Tìm thấy # bên thứ ba}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "Mức sử dụng dịch vụ bên thứ ba"

--- a/lighthouse-core/lib/i18n/locales/zh-HK.json
+++ b/lighthouse-core/lib/i18n/locales/zh-HK.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "輕按目標已設定成適當大小"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "在主要執行緒的執行時間"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "第三方"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "第三方程式碼可能會嚴重影響載入效能。請盡量減少不必要的第三方供應商，並在網頁的主要內容載入完成後，再載入第三方程式碼。[瞭解詳情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)。"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{發現 1 個第三方程式碼}other{發現 # 個第三方程式碼}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "第三方使用情況"

--- a/lighthouse-core/lib/i18n/locales/zh-TW.json
+++ b/lighthouse-core/lib/i18n/locales/zh-TW.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "輕觸目標已設定成適當大小"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "在主要執行緒的執行時間"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "第三方"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "第三方程式碼可能會嚴重影響載入效能。請儘量減少不必要的第三方供應商，並在網頁的主要內容載入完畢後，再載入第三方程式碼。[瞭解詳情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)。"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{發現 1 個第三方程式碼}other{發現 # 個第三方程式碼}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "第三方使用情形"

--- a/lighthouse-core/lib/i18n/locales/zh.json
+++ b/lighthouse-core/lib/i18n/locales/zh.json
@@ -971,17 +971,11 @@
   "lighthouse-core/audits/seo/tap-targets.js | title": {
     "message": "点按目标的大小合适"
   },
-  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
-    "message": "主线程时间"
-  },
   "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
     "message": "第三方"
   },
   "lighthouse-core/audits/third-party-summary.js | description": {
     "message": "第三方代码可能会显著影响加载性能。请限制冗余第三方提供商的数量，并尝试在页面完成主要加载后再加载第三方代码。[了解详情](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/)。"
-  },
-  "lighthouse-core/audits/third-party-summary.js | displayValue": {
-    "message": "{itemCount,plural, =1{发现 1 个第三方}other{发现 # 个第三方}}"
   },
   "lighthouse-core/audits/third-party-summary.js | title": {
     "message": "第三方使用"

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -13,8 +13,9 @@ const glob = require('glob');
 const path = require('path');
 const assert = require('assert');
 const tsc = require('typescript');
-const collectAndBakeCtcStrings = require('./bake-ctc-to-lhl.js');
 const Util = require('../../report/html/renderer/util.js');
+const {collectAndBakeCtcStrings} = require('./bake-ctc-to-lhl.js');
+const {cullObsoleteLhlMessages} = require('./cull-obsolete-lhl-messages.js');
 
 const LH_ROOT = path.join(__dirname, '../../../');
 const UISTRINGS_REGEX = /UIStrings = .*?\};\n/s;
@@ -576,11 +577,15 @@ if (require.main === module) {
   console.log('Written to disk!', 'en-XL.ctc.json');
 
   // Bake the ctc en-US and en-XL files into en-US and en-XL LHL format
-  const lhl = collectAndBakeCtcStrings.collectAndBakeCtcStrings(path.join(LH_ROOT, 'lighthouse-core/lib/i18n/locales/'),
-  path.join(LH_ROOT, 'lighthouse-core/lib/i18n/locales/'));
+  const lhl = collectAndBakeCtcStrings(path.join(LH_ROOT, 'lighthouse-core/lib/i18n/locales/'),
+      path.join(LH_ROOT, 'lighthouse-core/lib/i18n/locales/'));
   lhl.forEach(function(locale) {
     console.log(`Baked ${locale} into LHL format.`);
   });
+
+  // Remove any obsolete strings in existing LHL files.
+  console.log('Checking for out-of-date LHL messages...');
+  cullObsoleteLhlMessages();
 }
 
 module.exports = {

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -15,7 +15,7 @@ const assert = require('assert');
 const tsc = require('typescript');
 const Util = require('../../report/html/renderer/util.js');
 const {collectAndBakeCtcStrings} = require('./bake-ctc-to-lhl.js');
-const {cullObsoleteLhlMessages} = require('./cull-obsolete-lhl-messages.js');
+const {pruneObsoleteLhlMessages} = require('./prune-obsolete-lhl-messages.js');
 
 const LH_ROOT = path.join(__dirname, '../../../');
 const UISTRINGS_REGEX = /UIStrings = .*?\};\n/s;
@@ -585,7 +585,7 @@ if (require.main === module) {
 
   // Remove any obsolete strings in existing LHL files.
   console.log('Checking for out-of-date LHL messages...');
-  cullObsoleteLhlMessages();
+  pruneObsoleteLhlMessages();
 }
 
 module.exports = {

--- a/lighthouse-core/scripts/i18n/cull-obsolete-lhl-messages.js
+++ b/lighthouse-core/scripts/i18n/cull-obsolete-lhl-messages.js
@@ -1,0 +1,152 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+const MessageParser = require('intl-messageformat-parser').default;
+
+const {collectAllCustomElementsFromICU} = require('../../lib/i18n/i18n.js');
+
+/** @typedef {Record<string, {message: string}>} LhlMessages */
+
+/**
+ * Returns whether the string `lhlMessage` has ICU arguments matching the
+ * already extracted `goldenArgumentIds`. Assumes `goldenArgumentIds` is sorted.
+ * @param {Array<string>} goldenArgumentIds
+ * @param {string} lhlMessage
+ * @return {boolean}
+ */
+function equalArguments(goldenArgumentIds, lhlMessage) {
+  const parsedMessage = MessageParser.parse(lhlMessage);
+  const lhlArgumentElements = collectAllCustomElementsFromICU(parsedMessage.elements);
+  const lhlArgumentIds = [...lhlArgumentElements.keys()];
+
+  if (goldenArgumentIds.length !== lhlArgumentIds.length) return false;
+
+  lhlArgumentIds.sort();
+  for (let i = 0; i < goldenArgumentIds.length; i++) {
+    if (goldenArgumentIds[i] !== lhlArgumentIds[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Logs a message as removed if it hasn't been logged before.
+ * @param {Set<string>} alreadyLoggedCulls
+ * @param {string} messageId
+ * @param {string} reason
+ */
+function logRemoval(alreadyLoggedCulls, messageId, reason) {
+  if (alreadyLoggedCulls.has(messageId)) return;
+
+  // eslint-disable-next-line no-console
+  console.log(`Removing message\n\t'${messageId}'\nfrom translations: ${reason}.`);
+  alreadyLoggedCulls.add(messageId);
+}
+
+/**
+ * Returns a copy of `localeLhl` with only messages matching those from the golden locale.
+ * `goldenLocaleArgumentIds` values are assumed to be sorted.
+ * @param {Record<string, Array<string>>} goldenLocaleArgumentIds
+ * @param {LhlMessages} localeLhl
+ * @param {Set<string>} alreadyLoggedCulls Set of culls that have been logged and shouldn't be logged again.
+ * @return {LhlMessages}
+ */
+function cullLocale(goldenLocaleArgumentIds, localeLhl, alreadyLoggedCulls) {
+  /** @type {LhlMessages} */
+  const remainingMessages = {};
+
+  for (const [messageId, {message}] of Object.entries(localeLhl)) {
+    const goldenArgumentIds = goldenLocaleArgumentIds[messageId];
+    if (!goldenArgumentIds) {
+      logRemoval(alreadyLoggedCulls, messageId, 'it is no longer found in Lighthouse');
+      continue;
+    }
+
+    if (!equalArguments(goldenArgumentIds, message)) {
+      logRemoval(alreadyLoggedCulls, messageId,
+          'its ICU arguments don\'t match the current version of the message');
+      continue;
+    }
+
+    remainingMessages[messageId] = {message};
+  }
+
+  return remainingMessages;
+}
+
+/**
+ * Returns a copy of `goldenLhl` with the messages replaced with a sorted list of
+ * argument ids found in each message.
+ * @param {LhlMessages} goldenLhl
+ * @return {Record<string, Array<string>>}
+ */
+function getGoldenLocaleArgumentIds(goldenLhl) {
+  /** @type {Record<string, Array<string>>} */
+  const goldenLocaleArgumentIds = {};
+
+  for (const [messageId, {message}] of Object.entries(goldenLhl)) {
+    const parsedMessage = MessageParser.parse(message);
+    const goldenArgumentElements = collectAllCustomElementsFromICU(parsedMessage.elements);
+    const goldenArgumentIds = [...goldenArgumentElements.keys()].sort();
+
+    goldenLocaleArgumentIds[messageId] = goldenArgumentIds;
+  }
+
+  return goldenLocaleArgumentIds;
+}
+
+/**
+ * For every locale LHL file, remove any messages that don't have a matching
+ * message in `en-US.json`. There is a matching golden message if:
+ * - there is a golden message with the same message id and
+ * - that message has the same ICU arguments (by count and argument ids).
+ *
+ * If a new `en-US.json` message is sufficiently different so that existing
+ * translations should no longer be used, it's up to the author to remove them
+ * (e.g. by picking a new message id).
+ */
+function cullObsoleteLhlMessages() {
+  const goldenLhl = require('../../lib/i18n/locales/en-US.json');
+  const goldenLocaleArgumentIds = getGoldenLocaleArgumentIds(goldenLhl);
+
+  // Find all locale files, ignoring self-generated en-US, en-XL, and ctc files.
+  const ignore = [
+    '**/.ctc.json',
+    '**/en-US.json',
+    '**/en-XL.json',
+  ];
+  const globPattern = 'lighthouse-core/lib/i18n/locales/**/+([-a-zA-Z0-9]).json';
+  const lhRoot = `${__dirname}/../../../`;
+  const localePaths = glob.sync(globPattern, {
+    ignore,
+    cwd: lhRoot,
+  });
+
+  /** @type {Set<string>} */
+  const alreadyLoggedCulls = new Set();
+  for (const localePath of localePaths) {
+    const absoluteLocalePath = path.join(lhRoot, localePath);
+    const localeLhl = require(absoluteLocalePath);
+    const culledLocale = cullLocale(goldenLocaleArgumentIds, localeLhl, alreadyLoggedCulls);
+
+    const stringified = JSON.stringify(culledLocale, null, 2) + '\n';
+    fs.writeFileSync(absoluteLocalePath, stringified);
+  }
+}
+
+module.exports = {
+  cullObsoleteLhlMessages,
+
+  // Exported for testing.
+  getGoldenLocaleArgumentIds,
+  cullLocale,
+};

--- a/lighthouse-core/test/scripts/i18n/cull-obsolete-lhl-messages-test.js
+++ b/lighthouse-core/test/scripts/i18n/cull-obsolete-lhl-messages-test.js
@@ -1,0 +1,129 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const cullObsoleteLhlMessages = require('../../../scripts/i18n/cull-obsolete-lhl-messages.js');
+
+/**
+ * Cull `localeLhl` based on `goldenLhl`.
+ * @param {Record<string, {message: string}>} goldenLhl
+ * @param {Record<string, {message: string}>} localeLhl
+ */
+function cullLocale(goldenLhl, localeLhl) {
+  // Suppress logging by adding all message ids to the already-logged set.
+  const loggedCulls = new Set(Object.keys(localeLhl));
+
+  const goldenLocaleArgumentIds = cullObsoleteLhlMessages.getGoldenLocaleArgumentIds(goldenLhl);
+  return cullObsoleteLhlMessages.cullLocale(goldenLocaleArgumentIds, localeLhl, loggedCulls);
+}
+
+describe('Cull obsolete translations', () => {
+  const goldenLhl = {
+    plainString: {
+      message: 'Plain string',
+    },
+    displayValue: {
+      message: 'Total size was {totalBytes, number, bytes} KB',
+    },
+    nestedInPlural: {
+      // Ensure nested arguments are parsed and handled.
+      // eslint-disable-next-line max-len
+      message: '{requestCount, plural, =1 {1 request • {byteCount, number, bytes} KB} other {# requests • {byteCount, number, bytes} KB}}',
+    },
+  };
+
+  it('removes nothing if the messages are exactly the same', () => {
+    const culledLocale = cullLocale(goldenLhl, goldenLhl);
+    expect(culledLocale).toEqual(goldenLhl);
+  });
+
+  it('removes nothing if the text differs but the message and argument ids are the same', () => {
+    const localeLhl = {
+      plainString: {
+        message: 'Some other string',
+      },
+      displayValue: {
+        message: 'So we have...{totalBytes, number, bytes} sure, KB, why not',
+      },
+      nestedInPlural: {
+        // eslint-disable-next-line max-len
+        message: '{requestCount, plural, =1 {1 llama • {byteCount, number, bytes} KB} other {# llamas • {byteCount, number, bytes} KB}}',
+      },
+    };
+
+    const culledLocale = cullLocale(goldenLhl, localeLhl);
+    expect(culledLocale).toEqual(localeLhl);
+  });
+
+  it('removes messages not in the golden LHL', () => {
+    const localeLhl = {
+      ...goldenLhl,
+      obsoleteValue: {
+        message: 'string with one {argument}',
+      },
+    };
+
+    const culledLocale = cullLocale(goldenLhl, localeLhl);
+    expect(culledLocale).toEqual(goldenLhl);
+  });
+
+  it('removes messages with different arguments than found in the golden LHL', () => {
+    const localeLhl = {
+      plainString: {
+        message: 'Plain string',
+      },
+      displayValue: {
+        message: 'Total size was {differentArgument, number, bytes} KB',
+      },
+    };
+
+    const culledLocale = cullLocale(goldenLhl, localeLhl);
+    expect(culledLocale).toEqual({
+      plainString: {
+        message: 'Plain string',
+      },
+    });
+  });
+
+  it('removes messages with different number of arguments than found in the golden LHL', () => {
+    const localeLhl = {
+      plainString: {
+        message: 'Plain string',
+      },
+      displayValue: {
+        message: 'Total size was {totalBytes, number, bytes} KB, {salutation}!',
+      },
+    };
+
+    const culledLocale = cullLocale(goldenLhl, localeLhl);
+    expect(culledLocale).toEqual({
+      plainString: {
+        message: 'Plain string',
+      },
+    });
+  });
+
+  it('removes messages when a nested argument differs from the golden LHL', () => {
+    const localeLhl = {
+      plainString: {
+        message: 'Plain string',
+      },
+      nestedInPlural: {
+        // eslint-disable-next-line max-len
+        message: '{requestCount, plural, =1 {1 request • {timeInMs, number, seconds} s} other {# requests • {timeInMs, number, seconds} s}}',
+      },
+    };
+
+    const culledLocale = cullLocale(goldenLhl, localeLhl);
+    expect(culledLocale).toEqual({
+      plainString: {
+        message: 'Plain string',
+      },
+    });
+  });
+});

--- a/lighthouse-core/test/scripts/i18n/prune-obsolete-lhl-messages-test.js
+++ b/lighthouse-core/test/scripts/i18n/prune-obsolete-lhl-messages-test.js
@@ -7,22 +7,22 @@
 
 /* eslint-env jest */
 
-const cullObsoleteLhlMessages = require('../../../scripts/i18n/cull-obsolete-lhl-messages.js');
+const pruneObsoleteLhlMessages = require('../../../scripts/i18n/prune-obsolete-lhl-messages.js');
 
 /**
- * Cull `localeLhl` based on `goldenLhl`.
+ * Prune `localeLhl` based on `goldenLhl`.
  * @param {Record<string, {message: string}>} goldenLhl
  * @param {Record<string, {message: string}>} localeLhl
  */
-function cullLocale(goldenLhl, localeLhl) {
+function pruneLocale(goldenLhl, localeLhl) {
   // Suppress logging by adding all message ids to the already-logged set.
-  const loggedCulls = new Set(Object.keys(localeLhl));
+  const loggedPrunes = new Set(Object.keys(localeLhl));
 
-  const goldenLocaleArgumentIds = cullObsoleteLhlMessages.getGoldenLocaleArgumentIds(goldenLhl);
-  return cullObsoleteLhlMessages.cullLocale(goldenLocaleArgumentIds, localeLhl, loggedCulls);
+  const goldenLocaleArgumentIds = pruneObsoleteLhlMessages.getGoldenLocaleArgumentIds(goldenLhl);
+  return pruneObsoleteLhlMessages.pruneLocale(goldenLocaleArgumentIds, localeLhl, loggedPrunes);
 }
 
-describe('Cull obsolete translations', () => {
+describe('Prune obsolete translations', () => {
   const goldenLhl = {
     plainString: {
       message: 'Plain string',
@@ -38,8 +38,11 @@ describe('Cull obsolete translations', () => {
   };
 
   it('removes nothing if the messages are exactly the same', () => {
-    const culledLocale = cullLocale(goldenLhl, goldenLhl);
-    expect(culledLocale).toEqual(goldenLhl);
+    // Clone to make sure we aren't getting tricked by references and the object isn't structurally.
+    const localeLhl = JSON.parse(JSON.stringify(goldenLhl));
+
+    const prunedLocale = pruneLocale(goldenLhl, localeLhl);
+    expect(prunedLocale).toEqual(goldenLhl);
   });
 
   it('removes nothing if the text differs but the message and argument ids are the same', () => {
@@ -56,8 +59,8 @@ describe('Cull obsolete translations', () => {
       },
     };
 
-    const culledLocale = cullLocale(goldenLhl, localeLhl);
-    expect(culledLocale).toEqual(localeLhl);
+    const prunedLocale = pruneLocale(goldenLhl, localeLhl);
+    expect(prunedLocale).toEqual(localeLhl);
   });
 
   it('removes messages not in the golden LHL', () => {
@@ -68,8 +71,8 @@ describe('Cull obsolete translations', () => {
       },
     };
 
-    const culledLocale = cullLocale(goldenLhl, localeLhl);
-    expect(culledLocale).toEqual(goldenLhl);
+    const prunedLocale = pruneLocale(goldenLhl, localeLhl);
+    expect(prunedLocale).toEqual(goldenLhl);
   });
 
   it('removes messages with different arguments than found in the golden LHL', () => {
@@ -82,8 +85,8 @@ describe('Cull obsolete translations', () => {
       },
     };
 
-    const culledLocale = cullLocale(goldenLhl, localeLhl);
-    expect(culledLocale).toEqual({
+    const prunedLocale = pruneLocale(goldenLhl, localeLhl);
+    expect(prunedLocale).toEqual({
       plainString: {
         message: 'Plain string',
       },
@@ -100,8 +103,8 @@ describe('Cull obsolete translations', () => {
       },
     };
 
-    const culledLocale = cullLocale(goldenLhl, localeLhl);
-    expect(culledLocale).toEqual({
+    const prunedLocale = pruneLocale(goldenLhl, localeLhl);
+    expect(prunedLocale).toEqual({
       plainString: {
         message: 'Plain string',
       },
@@ -119,8 +122,8 @@ describe('Cull obsolete translations', () => {
       },
     };
 
-    const culledLocale = cullLocale(goldenLhl, localeLhl);
-    expect(culledLocale).toEqual({
+    const prunedLocale = pruneLocale(goldenLhl, localeLhl);
+    expect(prunedLocale).toEqual({
       plainString: {
         message: 'Plain string',
       },

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "gh-pages": "^2.0.1",
     "glob": "^7.1.3",
     "idb-keyval": "2.2.0",
+    "intl-messageformat-parser": "^1.8.1",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^24.3.0",
     "jsdom": "^12.2.0",


### PR DESCRIPTION
this came up in the course of writing #9580. If you don't care about an explanation of the status quo, skip to "This PR takes approach 3." :)

when we change a UIString in Lighthouse today:
- the usual case is we assume existing translations for that message (if any) are better than defaulting back to the english message while waiting for the new translations to come down the pipe, or
- the string changes so much that it makes sense to change the UIString key for the message, which means there is *only* the english message for all locales until new translations come through

An example is the recent move to web.dev for the doc links (or grammar changes or rewordings like for themed omnibox). It's very helpful to have the old translations still in place, even if they have a link to slightly older docs in them for a while.

Generally this has seemed to work ok (though we could probably be more cognizant when making these changes), but it does run into a problem when ICU arguments change, since the values passed into `str_()` won't work for both english and older versions of the message for other locales.

This is what is failing in #9580, where deleting an accidentally-included argument causes the `swap-locales` test to fail as it tries to use the updated argument on an older string in `es` that needs the old argument. But even if we don't include the error check from #9580, any non-en-US locale will fail if the old argument values aren't provided.

There are a few possible solutions:
1) always include the union of needed argument values, as is accidentally being done for `third-party-summary.js | displayValue` right now
2) let a test like the one in `swap-locale` just fail in that instance, forcing the author to manually make corrections
3) treat any updated message with different ICU arguments as sufficiently different that it's not worth keeping the old translations around any more and delete them.

after talking through these scenarios with @exterkamp, we decided 1 and 2 aren't really tenable as we approach all strings being translated and so any user-visible text change possibly becomes significant, and not all locales for a message land at the same time.

This PR takes approach 3. As noted in the jsdocs:

> For every locale LHL file, remove any messages that don't have a matching
> message in `en-US.json`. There is a matching golden message if:
>  - there is a golden message with the same message id and
>  - that message has the same ICU arguments (by count and argument ids).
> 
> If a new `en-US.json` message is sufficiently different so that existing
> translations should no longer be used, it's up to the author to remove them
> (e.g. by picking a new message id).

During `collect-strings`/`update:sample-json`, after `en-US.json` is updated, this new script runs through the non-`en-US` LHL files and deletes any messages that don't fit the above criteria.