### PR TITLE
misc: trim missed yarn.lock cruft

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3968,7 +3968,7 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
-is-buffer@^1.0.2, is-buffer@^1.1.0, is-buffer@^1.1.5:
+is-buffer@^1.1.0, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -5311,11 +5311,6 @@ miller-rabin@^4.0.0:
   dependencies:
     bn.js "^4.0.0"
     brorand "^1.0.1"
-
-mime-db@~1.24.0:
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.24.0.tgz#e2d13f939f0016c6e4e9ad25a8652f126c467f0c"
-  integrity sha1-4tE/k58AFsbk6a0lqGUvEmxGfww=
 
 mime-db@~1.37.0:
   version "1.37.0"


### PR DESCRIPTION
after syncing to #9600, when I run `yarn` locally I get these changes to the `yarn.lock` file. Maybe an artifact of the yarn-deduplicate tool?

The changes seem fine (they don't appear to be depended on by anything), but if others aren't seeing this in their local install I can dig in more to see why these came up.