### PR TITLE
i18n: fix import scripts

### DIFF
--- a/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
+++ b/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
@@ -75,11 +75,12 @@ function bakePlaceholders(messages) {
 
     if (placeholders) {
       for (const [placeholder, {content}] of Object.entries(placeholders)) {
-        const escapedPlaceholder = '$' + placeholder + '$';
-        if (!message.includes(escapedPlaceholder)) {
+        if (!message.includes('$' + placeholder + '$')) {
           throw Error(`Provided placeholder "${placeholder}" not found in message "${message}".`);
         }
-        message = message.replace(escapedPlaceholder, content);
+        // Need a global replace due to plural ICU copying ICU vars multiple times.
+        const regex = new RegExp(`\\$${placeholder}\\$`, 'g');
+        message = message.replace(regex, content);
       }
     }
 

--- a/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
+++ b/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
@@ -78,8 +78,9 @@ function bakePlaceholders(messages) {
         if (!message.includes('$' + placeholder + '$')) {
           throw Error(`Provided placeholder "${placeholder}" not found in message "${message}".`);
         }
-        // Need a global replace due to plural ICU copying ICU vars multiple times.
-        const regex = new RegExp(`\\$${placeholder}\\$`, 'g');
+        // Need a global replace due to plural ICU copying placeholders
+        // (and therefore ICU vars) multiple times.
+        const regex = new RegExp('\\$' + placeholder + '\\$', 'g');
         message = message.replace(regex, content);
       }
     }

--- a/lighthouse-core/scripts/i18n/prune-obsolete-lhl-messages.js
+++ b/lighthouse-core/scripts/i18n/prune-obsolete-lhl-messages.js
@@ -135,7 +135,7 @@ function pruneObsoleteLhlMessages() {
   const alreadyLoggedPrunes = new Set();
   for (const localePath of localePaths) {
     const absoluteLocalePath = path.join(lhRoot, localePath);
-    const localeLhl = require(absoluteLocalePath);
+    const localeLhl = JSON.parse(fs.readFileSync(absoluteLocalePath, 'utf-8'));
     const prunedLocale = pruneLocale(goldenLocaleArgumentIds, localeLhl, alreadyLoggedPrunes);
 
     const stringified = JSON.stringify(prunedLocale, null, 2) + '\n';

--- a/lighthouse-core/scripts/i18n/prune-obsolete-lhl-messages.js
+++ b/lighthouse-core/scripts/i18n/prune-obsolete-lhl-messages.js
@@ -135,6 +135,7 @@ function pruneObsoleteLhlMessages() {
   const alreadyLoggedPrunes = new Set();
   for (const localePath of localePaths) {
     const absoluteLocalePath = path.join(lhRoot, localePath);
+    // readFileSync so that the file is pulled again once updated by a collect-strings run
     const localeLhl = JSON.parse(fs.readFileSync(absoluteLocalePath, 'utf-8'));
     const prunedLocale = pruneLocale(goldenLocaleArgumentIds, localeLhl, alreadyLoggedPrunes);
 

--- a/lighthouse-core/test/scripts/i18n/bake-ctc-to-lhl-test.js
+++ b/lighthouse-core/test/scripts/i18n/bake-ctc-to-lhl-test.js
@@ -43,6 +43,25 @@ describe('Baking Placeholders', () => {
     });
   });
 
+  it('bakes a placeholder into the output string multiple times', () => {
+    const strings = {
+      hello: {
+        message: '$MARKDOWN_SNIPPET_0$ - $MARKDOWN_SNIPPET_0$',
+        placeholders: {
+          MARKDOWN_SNIPPET_0: {
+            content: '`World`',
+          },
+        },
+      },
+    };
+    const res = bakery.bakePlaceholders(strings);
+    expect(res).toStrictEqual({
+      hello: {
+        message: '`World` - `World`',
+      },
+    });
+  });
+
   it('throws when a placeholder cannot be found', () => {
     const strings = {
       hello: {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
This fixes 2 issues:
1. tc/ adds more plural paths for other languages (1, # -expand to-> 1, #, zero, few, two, etc.) and when it does this it copies the placeholders, so multiple placeholders are copied. This change performs a global replace for ICU values to replace all instances of a placeholder.
2. The pruning script used `require` which does not reload a file if it is modified in the same process, which is what happens when you `collect-strings`.  So we need to reload it to pick up changes in the lhl from an import. (thanks @patrickhulce)
