### PR TITLE
report: don't use unnessary monospace

### DIFF
--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -67,7 +67,7 @@ class Deprecations extends Audit {
 
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [
-      {key: 'value', itemType: 'code', text: str_(UIStrings.columnDeprecate)},
+      {key: 'value', itemType: 'text', text: str_(UIStrings.columnDeprecate)},
       {key: 'url', itemType: 'url', text: str_(i18n.UIStrings.columnURL)},
       {key: 'lineNumber', itemType: 'text', text: str_(UIStrings.columnLine)},
     ];

--- a/lighthouse-core/audits/errors-in-console.js
+++ b/lighthouse-core/audits/errors-in-console.js
@@ -78,7 +78,7 @@ class ErrorLogs extends Audit {
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [
       {key: 'url', itemType: 'url', text: str_(i18n.UIStrings.columnURL)},
-      {key: 'description', itemType: 'text', text: str_(UIStrings.columnDesc)},
+      {key: 'description', itemType: 'code', text: str_(UIStrings.columnDesc)},
     ];
 
     const details = Audit.makeTableDetails(headings, tableRows);

--- a/lighthouse-core/audits/errors-in-console.js
+++ b/lighthouse-core/audits/errors-in-console.js
@@ -78,7 +78,7 @@ class ErrorLogs extends Audit {
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [
       {key: 'url', itemType: 'url', text: str_(i18n.UIStrings.columnURL)},
-      {key: 'description', itemType: 'code', text: str_(UIStrings.columnDesc)},
+      {key: 'description', itemType: 'text', text: str_(UIStrings.columnDesc)},
     ];
 
     const details = Audit.makeTableDetails(headings, tableRows);

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -596,7 +596,7 @@
         "headings": [
           {
             "key": "value",
-            "itemType": "code",
+            "itemType": "text",
             "text": "Deprecation / Warning"
           },
           {

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -403,7 +403,7 @@
             "details": {
                 "headings": [
                     {
-                        "itemType": "code",
+                        "itemType": "text",
                         "key": "value",
                         "text": "Deprecation / Warning"
                     },


### PR DESCRIPTION
we shouldn't render sentences or paragraphs in monospace. not very readable.



before
![image](https://user-images.githubusercontent.com/39191/63970148-4b411500-ca58-11e9-8e1b-10a346a01efa.png)

after
![image](https://user-images.githubusercontent.com/39191/63970142-454b3400-ca58-11e9-8c7a-29839e023d6f.png)

