### PR TITLE
docs(audits): distinguish document.write() audit from intervention

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -20,7 +20,7 @@
  *
  * *This Audit*
  * This audit reports on document.write() calls which the intervention didn't stop.
- * (They worked as intended). If that happens, the browser also emit a verbose-level violation
+ * (They worked as intended). If that happens, the browser emits a verbose-level violation
  * console message (hidden by default) that says:
  *     "Parser was blocked due to document.write(<script>)". src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/frame/performance_monitor.cc?l=294-300&rcl=40b90cafad9f219e0845879ed8648bdcc96116dc
  */

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -14,7 +14,7 @@
  *  - "some" == mostly third-party situations. src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/script/document_write_intervention.cc?l=109&rcl=61a806621861e9abc07b3a57a6f2edae188d1742
  * If this happens, there will be a error message in the console. src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/script/document_write_intervention.cc?l=51-61&rcl=61a806621861e9abc07b3a57a6f2edae188d1742
  *  - Lighthouse doesn't report here on that situation, though it'll show up in `errors-in-console`
- * The intercention may also not block the .write() (because the connection wasn't slow),
+ * The intervention may also not block the .write() (because the connection wasn't slow),
  * but it will emit a console warning.
  *  - Lighthouse doesn't highlight this here or in errors-in-console. (TODO: it probably should?).
  *

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -16,7 +16,8 @@
  *  - Lighthouse doesn't report here on that situation, though it'll show up in `errors-in-console`
  * The intervention may also not block the .write() (because the connection wasn't slow),
  * but it will emit a console warning.
- *  - Lighthouse doesn't highlight this here or in errors-in-console. (TODO: it probably should?).
+ *  - Lighthouse will also report that here, as the .write() call succeeded.
+ * Demo URL: https://output.jsbin.com/qopijux/quiet
  *
  * *This Audit*
  * This audit reports on document.write() calls which the intervention didn't stop.

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -12,7 +12,7 @@
  * The intervention appears to only be enabled when the user is on a slow connnection. https://chromestatus.com/features#document.write
  * When it's enabled, _some_ calls to document.write() will just not do anything. They're just no-ops.
  *  - "some" == mostly third-party situations. src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/script/document_write_intervention.cc?l=109&rcl=61a806621861e9abc07b3a57a6f2edae188d1742
- * If this happens, there will be a error message in the console. src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/script/document_write_intervention.cc?l=51-61&rcl=61a806621861e9abc07b3a57a6f2edae188d1742
+ * If this happens, there will be an error message in the console. src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/script/document_write_intervention.cc?l=51-61&rcl=61a806621861e9abc07b3a57a6f2edae188d1742
  *  - Lighthouse doesn't report here on that situation, though it'll show up in `errors-in-console`
  * The intervention may also not block the .write() (because the connection wasn't slow),
  * but it will emit a console warning.

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -10,7 +10,7 @@
  * *Intervention*
  * There is a Chrome intervention for the API: https://developers.google.com/web/updates/2016/08/removing-document-write
  * The intervention appears to only be enabled when the user is on a slow connnection. https://chromestatus.com/features#document.write
- * When it's enabled, _some_ calls to document.write() will just not do anything. they're just no-ops.
+ * When it's enabled, _some_ calls to document.write() will just not do anything. They're just no-ops.
  *  - "some" == mostly third-party situations. src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/script/document_write_intervention.cc?l=109&rcl=61a806621861e9abc07b3a57a6f2edae188d1742
  * If this happens, there will be a error message in the console. src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/script/document_write_intervention.cc?l=51-61&rcl=61a806621861e9abc07b3a57a6f2edae188d1742
  *  - Lighthouse doesn't report here on that situation, though it'll show up in `errors-in-console`

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -5,7 +5,24 @@
  */
 
 /**
- * @fileoverview Audit a page to see if it's using document.write()
+ * @fileoverview Audit a page to see if it's using document.write(). document.write() has terrible performance characteristics.
+ *
+ * *Intervention*
+ * There is a Chrome intervention for the API: https://developers.google.com/web/updates/2016/08/removing-document-write
+ * The intervention appears to only be enabled when the user is on a slow connnection. https://chromestatus.com/features#document.write
+ * When it's enabled, _some_ calls to document.write() will just not do anything. they're just no-ops.
+ *  - "some" == mostly third-party situations. src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/script/document_write_intervention.cc?l=109&rcl=61a806621861e9abc07b3a57a6f2edae188d1742
+ * If this happens, there will be a error message in the console. src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/script/document_write_intervention.cc?l=51-61&rcl=61a806621861e9abc07b3a57a6f2edae188d1742
+ *  - Lighthouse doesn't report here on that situation, though it'll show up in `errors-in-console`
+ * The intercention may also not block the .write() (because the connection wasn't slow),
+ * but it will emit a console warning.
+ *  - Lighthouse doesn't highlight this here or in errors-in-console. (TODO: it probably should?).
+ *
+ * *This Audit*
+ * This audit reports on document.write() calls which the intervention didn't stop.
+ * (They worked as intended). If that happens, the browser also emit a verbose-level violation
+ * console message (hidden by default) that says:
+ *     "Parser was blocked due to document.write(<script>)". src: https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/frame/performance_monitor.cc?l=294-300&rcl=40b90cafad9f219e0845879ed8648bdcc96116dc
  */
 
 'use strict';


### PR DESCRIPTION
this resulted from some back-n-forth with @mfriesenhahn 