### PR TITLE
tests(fixtures): use relative path in 404 page

### DIFF
--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -64,7 +64,7 @@ function requestHandler(request, response) {
 
   function fsExistsCallback(fileExists) {
     if (!fileExists) {
-      return sendResponse(404, `404 - File not found. ${absoluteFilePath}`);
+      return sendResponse(404, `404 - File not found. ${filePath}`);
     }
     fs.readFile(absoluteFilePath, 'binary', readFileCallback);
   }


### PR DESCRIPTION
**Summary**
The releasing script puts Lighthouse in a new folder that is named longer (`lighthouse-pristine`) which causes the 404 page to deliver SLIGHTLY more bytes on error due to a longer pathname: 
![image](https://user-images.githubusercontent.com/6392995/64658571-cb6a6180-d3ec-11e9-95ed-81840f0e81e2.png)

Causing the perf smoketests to fail :frowning: 
