### PR TITLE
docs(plugins): update recipe example's lighthouse peer dependency version

### DIFF
--- a/docs/recipes/lighthouse-plugin-example/package.json
+++ b/docs/recipes/lighthouse-plugin-example/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "main": "./plugin.js",
   "peerDependencies": {
-    "lighthouse": "^4.2.0"
+    "lighthouse": ">=5.2.0"
   }
 }

--- a/docs/recipes/lighthouse-plugin-example/package.json
+++ b/docs/recipes/lighthouse-plugin-example/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "main": "./plugin.js",
   "peerDependencies": {
-    "lighthouse": ">=5.2.0"
+    "lighthouse": "^5.0.0"
   }
 }

--- a/docs/recipes/lighthouse-plugin-example/readme.md
+++ b/docs/recipes/lighthouse-plugin-example/readme.md
@@ -9,7 +9,7 @@
 
 1. Install `lighthouse` v5 or later.
 2. Install the plugin as a (peer) dependency, parallel to `lighthouse`.
-3. Run `npx lighthouse lighthouse https://example.com --plugins=lighthouse-plugin-example --view`
+3. Run `npx -p lighthouse lighthouse https://example.com --plugins=lighthouse-plugin-example --view`
 
 The input to `--plugins` will be loaded from `node_modules/`.
 

--- a/docs/recipes/lighthouse-plugin-example/readme.md
+++ b/docs/recipes/lighthouse-plugin-example/readme.md
@@ -7,8 +7,8 @@
  
 ## To run
 
-- Install as a (peer) dependency, parallel to `lighthouse`.
-- `npx lighthouse https://example.com --plugins=lighthouse-plugin-example --view`
+1. Install the plugin as a (peer) dependency, parallel to `lighthouse`.
+2. Verify that the lighthouse version installed supports plugins >= 5.20 and run the following command `npx lighthouse https://example.com --plugins=lighthouse-plugin-example --view`
 
 The input to `--plugins` will be loaded from `node_modules/`.
 

--- a/docs/recipes/lighthouse-plugin-example/readme.md
+++ b/docs/recipes/lighthouse-plugin-example/readme.md
@@ -7,7 +7,6 @@
  
 ## To run
 
-1. Install the plugin as a (peer) dependency, parallel to `lighthouse`.
 1. Install `lighthouse` v5 or later.
 2. Install the plugin as a (peer) dependency, parallel to `lighthouse`.
 3. Run `npx lighthouse lighthouse https://example.com --plugins=lighthouse-plugin-example --view`

--- a/docs/recipes/lighthouse-plugin-example/readme.md
+++ b/docs/recipes/lighthouse-plugin-example/readme.md
@@ -8,7 +8,9 @@
 ## To run
 
 1. Install the plugin as a (peer) dependency, parallel to `lighthouse`.
-2. Verify that the lighthouse version installed supports plugins >= 5.20 and run the following command `npx lighthouse https://example.com --plugins=lighthouse-plugin-example --view`
+1. Install `lighthouse` v5 or later.
+2. Install the plugin as a (peer) dependency, parallel to `lighthouse`.
+3. Run `npx lighthouse https://example.com --plugins=lighthouse-plugin-example --view`
 
 The input to `--plugins` will be loaded from `node_modules/`.
 

--- a/docs/recipes/lighthouse-plugin-example/readme.md
+++ b/docs/recipes/lighthouse-plugin-example/readme.md
@@ -10,7 +10,7 @@
 1. Install the plugin as a (peer) dependency, parallel to `lighthouse`.
 1. Install `lighthouse` v5 or later.
 2. Install the plugin as a (peer) dependency, parallel to `lighthouse`.
-3. Run `npx lighthouse https://example.com --plugins=lighthouse-plugin-example --view`
+3. Run `npx lighthouse lighthouse https://example.com --plugins=lighthouse-plugin-example --view`
 
 The input to `--plugins` will be loaded from `node_modules/`.
 


### PR DESCRIPTION
**Summary**
- Update plugin recipe lighthouse peer dependency to a version that supports plugins. 
- Update lighthouse plugin recipe run command.
**Related Issues/PRs**
https://github.com/zkat/npx/issues/215 captures the issue with the npx command
