### PR TITLE
tests: migrate travis to xenial for modern Chrome support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - node_js: "10"
     - node_js: "12"
       if: head_branch IS blank AND branch = master
-dist: trusty
+dist: xenial
 cache:
   yarn: true
   directories:
@@ -17,9 +17,6 @@ cache:
     - /home/travis/.rvm/gems/
 install:
   # Ensure we have the latest Chrome stable.
-  - sudo apt-get update
-  - sudo apt-get install dpkg
-  - sudo apt-get install --only-upgrade google-chrome-stable
   - google-chrome-stable --version
   # if our e2e tests fail in the future it might be that we are not compatible
   # with the latest puppeteer api so we probably need to run on chromimum

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,8 @@ install:
   - export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
   - yarn --frozen-lockfile
 before_script:
-  - export DISPLAY=:99.0
   # see comment above about puppeteer
   - export CHROME_PATH="$(which google-chrome-stable)"
-  - sh -e /etc/init.d/xvfb start
   # Print out the Chrome version so we know what we're working with
   - google-chrome-stable --version
   - yarn build-all
@@ -50,3 +48,5 @@ after_success:
   - yarn codecov
 addons:
   chrome: stable
+services:
+  - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
     - node_js: "10"
     - node_js: "12"
       if: head_branch IS blank AND branch = master
-dist: xenial
 cache:
   yarn: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ cache:
     - lantern-data
     - /home/travis/.rvm/gems/
 install:
+  # Ensure we have the latest Chrome stable.
+  - sudo apt-get update
+  - sudo apt-get install dpkg
+  - sudo apt-get install --only-upgrade google-chrome-stable
+  - google-chrome-stable --version
   # if our e2e tests fail in the future it might be that we are not compatible
   # with the latest puppeteer api so we probably need to run on chromimum
   # @see https://github.com/GoogleChrome/lighthouse/pull/4640/files#r171425004


### PR DESCRIPTION
**Summary**
traced the master failures of installing latest chrome stable to this bug https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627

just need to update dpkg before install chrome

