### PR TITLE
core(network-recorder): optimize network idle detection

### DIFF
--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -72,11 +72,9 @@ class NetworkRecorder extends EventEmitter {
 
     for (let i = 0; i < this._records.length; i++) {
       const record = this._records[i];
-      if (!NetworkRecorder.isNetworkRecordFinished(record)) {
-        if (IGNORED_NETWORK_SCHEMES.includes(record.parsedURL.scheme)) continue;
-
-        inflightRequests++;
-      }
+      if (NetworkRecorder.isNetworkRecordFinished(record)) continue;
+      if (IGNORED_NETWORK_SCHEMES.includes(record.parsedURL.scheme)) continue;
+      inflightRequests++;
     }
 
     return inflightRequests <= allowedRequests;

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -54,24 +54,37 @@ class NetworkRecorder extends EventEmitter {
   }
 
   isIdle() {
-    return !!this._getActiveIdlePeriod(0);
+    return this._isActiveIdlePeriod(0);
   }
 
   is2Idle() {
-    return !!this._getActiveIdlePeriod(2);
+    return this._isActiveIdlePeriod(2);
   }
 
   /**
+   * Returns whether the number of currently inflight requests is less than or
+   * equal to the number of allowed concurrent requests.
    * @param {number} allowedRequests
+   * @return {boolean}
    */
-  _getActiveIdlePeriod(allowedRequests) {
-    const quietPeriods = NetworkRecorder.findNetworkQuietPeriods(this._records, allowedRequests);
-    return quietPeriods.find(period => !Number.isFinite(period.end));
+  _isActiveIdlePeriod(allowedRequests) {
+    let inflightRequests = 0;
+
+    for (let i = 0; i < this._records.length; i++) {
+      const record = this._records[i];
+      if (!NetworkRecorder.isNetworkRecordFinished(record)) {
+        if (IGNORED_NETWORK_SCHEMES.includes(record.parsedURL.scheme)) continue;
+
+        inflightRequests++;
+      }
+    }
+
+    return inflightRequests <= allowedRequests;
   }
 
   _emitNetworkStatus() {
-    const zeroQuiet = this._getActiveIdlePeriod(0);
-    const twoQuiet = this._getActiveIdlePeriod(2);
+    const zeroQuiet = this.isIdle();
+    const twoQuiet = this.is2Idle();
 
     if (twoQuiet && zeroQuiet) {
       log.verbose('NetworkRecorder', 'network fully-quiet');


### PR DESCRIPTION
The `NetworkRecorder.recordsFromLogs` performance described [here](https://github.com/GoogleChrome/lighthouse/pull/9491#discussion_r321531671) was pretty bad, the vast majority of time spent in `findNetworkQuietPeriods`. Something like 1380ms spent on this is especially bad because it happens three times in a typical LH run: once [right before `GatherRunner.afterPass` ](https://github.com/GoogleChrome/lighthouse/blob/52cb0c904648be2f3395f2791b13844d7fac4d58/lighthouse-core/gather/gather-runner.js#L300), once in a computed artifact for the first audit that requests networkRecords for the defaultPass, and once spread over the run of `pass()` where `NetworkRecorder` is essentially running `recordsFromLogs` as protocol events come in. That 3x becomes 6x if e.g. there's a valid offline site served by a SW.

The biggest issue was constructing a full set of quiet periods for the entire set of network records when really for `networkIdle` and `network-2-idle` we only care if there's *currently* a quiet period. That's equivalent to [this check](https://github.com/GoogleChrome/lighthouse/blob/52cb0c904648be2f3395f2791b13844d7fac4d58/lighthouse-core/lib/network-recorder.js#L162-L165) passing so it adds a final period ending at `Infinity`.

This PR adds a new internal method `_isActiveIdlePeriod` that does essentially that (also catching the ignored network schemes check). Behavior is maintained exactly as before.

In testing I've found a 75-90% drop in execution time, the more requests on a page makes for a bigger performance win (so maybe taking 3 seconds off that LH run on @paulirish's machine). We could probably knock off another 25% in a few ways, but they should wait for follow ups as they're more invasive and need to be considered more carefully than this equivalent transformation.