### PR TITLE
core(network-recorder): remove quic-request-finished workaround

### DIFF
--- a/lighthouse-core/test/lib/network-recorder-test.js
+++ b/lighthouse-core/test/lib/network-recorder-test.js
@@ -299,5 +299,21 @@ describe('network recorder', function() {
       const periods = NetworkRecorder.findNetworkQuietPeriods(records, 0);
       assert.deepStrictEqual(periods, []);
     });
+
+    it('should handle QUIC requests', () => {
+      const quicRequest = {
+        finished: false,
+        responseHeaders: [{name: 'ALT-SVC', value: 'hq=":49288";quic="1,1abadaba,51303334,0"'}],
+        timing: {receiveHeadersEnd: 1.28},
+      };
+
+      const records = [
+        record({startTime: 0, endTime: 1}),
+        record({startTime: 0, endTime: 2, ...quicRequest}),
+      ];
+
+      const periods = NetworkRecorder.findNetworkQuietPeriods(records, 0);
+      assert.deepStrictEqual(periods, []);
+    });
   });
 });

--- a/lighthouse-core/test/lib/network-recorder-test.js
+++ b/lighthouse-core/test/lib/network-recorder-test.js
@@ -299,23 +299,5 @@ describe('network recorder', function() {
       const periods = NetworkRecorder.findNetworkQuietPeriods(records, 0);
       assert.deepStrictEqual(periods, []);
     });
-
-    it('should handle QUIC requests', () => {
-      const quicRequest = {
-        finished: false,
-        responseHeaders: [{name: 'ALT-SVC', value: 'hq=":49288";quic="1,1abadaba,51303334,0"'}],
-        timing: {receiveHeadersEnd: 1.28},
-      };
-
-      const records = [
-        record({startTime: 0, endTime: 1}),
-        record({startTime: 0, endTime: 2, ...quicRequest}),
-      ];
-
-      const periods = NetworkRecorder.findNetworkQuietPeriods(records, 0);
-      assert.deepStrictEqual(periods, [
-        {start: 2000, end: Infinity},
-      ]);
-    });
   });
 });


### PR DESCRIPTION
#5256 added a workaround for #5254, where many QUIC requests never got a final `LoadingFinished` or `LoadingFailed` event, so we were treating them as forever open, we never reached network quiet, and so we always hit the LH load timeout. The workaround was to check if the request was over QUIC and if there was end timing information, calling that "finished".

We broke this workaround *I think* when we finally dropped our direct dependence on devtools-frontend and [wrote our own `NetworkRequest`](https://github.com/GoogleChrome/lighthouse/pull/5451). 

[`NetworkRequest._recomputeTimesWithResourceTiming`](https://github.com/GoogleChrome/lighthouse/blob/6ff02e42f7083b25c1a4b9869478419864c12c5b/lighthouse-core/lib/network-request.js#L324-L334) takes in some preliminary timing information that may or may not be updated later, but any QUIC requests always appear finished after this happens, whether or not they end up updated later.

This causes `networkidle` and `network-2-idle` to sometimes fire too early, which means we may be cutting off some runs before TTI would actually be possible. I'm not sure how bad the impact is in practice, however, as
- the requests are often finished soon after anyways
- the `Network` protocol events LH receives are often delayed well after they actually occurred
- it's rare that we're in e.g. `network-3-idle` where one of the requests is QUIC and appears finished and we're not almost `network-2-idle` anyways

Originally I was going to try to update the QUIC heuristic, but after doing a bunch of tests, I don't think the original behavior is an issue anymore. All but a tiny handful of QUIC requests I've observed have a `Network.loadingFinished` event, and every time I've encountered a case of one without a finish event (developers.google.com sometimes hits this), extending `networkQuietThresholdMs` was enough to make the problem go away, so I think they're just legitimately slow loads.

So this PR just removes the workaround :)