### PR TITLE
misc: support unset variables in lhci dogfood script

### DIFF
--- a/lighthouse-core/scripts/dogfood-lhci.sh
+++ b/lighthouse-core/scripts/dogfood-lhci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euox pipefail
+set -eox pipefail
 
 # This script requires LHCI_CANARY_SERVER_URL and LHCI_CANARY_SERVER_TOKEN variables to be set.
 


### PR DESCRIPTION
**Summary**
We can't fail on unrecognized variables and check for them at the same time :)
