### PR TITLE
tests(lantern): attempt to download test set a few times

### DIFF
--- a/lighthouse-core/scripts/test-lantern.sh
+++ b/lighthouse-core/scripts/test-lantern.sh
@@ -21,8 +21,12 @@ if ! echo $CHANGED_FILES | grep -E 'dependency-graph|metrics|lantern' > /dev/nul
   exit 0
 fi
 
-printf "Lantern files affected!\n\nDownloading test set...\n"
-"$LH_ROOT/lighthouse-core/scripts/lantern/download-traces.sh"
+# Google Drive will sometimes respond with a bad result, so we repeat until it works.
+for i in {1..5}; do
+  printf "Lantern files affected!\n\nDownloading test set...\n"
+  "$LH_ROOT/lighthouse-core/scripts/lantern/download-traces.sh" && break || sleep 15;
+  echo "failed to download"
+done
 
 printf "\n\nRunning lantern on all sites...\n"
 "$LH_ROOT/lighthouse-core/scripts/lantern/run-on-all-assets.js"


### PR DESCRIPTION
noticed in CI that `yarn test-lantern` can fail while downloading the data.

Can repro locally if you attempt to download enough times.

![image](https://user-images.githubusercontent.com/4071474/66012174-fa6b7480-e47a-11e9-85da-1b93d5455eb9.png)

it's not a zip. It's sometimes an html file:

![image](https://user-images.githubusercontent.com/4071474/66012185-05bea000-e47b-11e9-88ba-f3b182ae78bc.png)

So just repeat a few times (5? sure.) until it works, so CI is happy.