### PR TITLE
core(tracehouse): allow child to start <1ms before parent

### DIFF
--- a/lighthouse-core/lib/tracehouse/main-thread-tasks.js
+++ b/lighthouse-core/lib/tracehouse/main-thread-tasks.js
@@ -281,7 +281,8 @@ class MainThreadTasks {
             // We'll reassign it to be the parent of `actualParentTask` in a bit.
             const grandparentTask = currentTask.parent;
             if (grandparentTask) {
-              if (grandparentTask.children[grandparentTask.children.length - 1] !== actualChildTask) {
+              const lastGrandparentChildIndex = grandparentTask.children.length - 1;
+              if (grandparentTask.children[lastGrandparentChildIndex] !== actualChildTask) {
                 // The child we need to swap should always be the most recently added child.
                 // But if not then there's a serious bug in this code, so double-check.
                 throw new Error('Fatal trace logic error - impossible children');

--- a/lighthouse-core/lib/tracehouse/main-thread-tasks.js
+++ b/lighthouse-core/lib/tracehouse/main-thread-tasks.js
@@ -266,8 +266,11 @@ class MainThreadTasks {
             nextTask.startTime - currentTask.startTime < 1000 &&
             !currentTask.children.length
           ) {
-            // The parent started less than 1ms before the child, we'll let it slide by swapping the two,
-            // and increasing the duration of the parent. Below is an artistic rendition of this situation.
+            // The true parent started less than 1ms before the true child, so we're looking at the relationship backwards.
+            // We'll let it slide and fix the situation by swapping the two tasks into their correct positions
+            // and increasing the duration of the parent.
+
+            // Below is an artistic rendition of the heirarchy we are trying to create.
             //   ████████████currentTask.parent██████████████████
             //       █████████nextTask██████████████
             //      ███████currentTask███████

--- a/lighthouse-core/lib/tracehouse/main-thread-tasks.js
+++ b/lighthouse-core/lib/tracehouse/main-thread-tasks.js
@@ -268,25 +268,25 @@ class MainThreadTasks {
           ) {
             // The parent started less than 1ms before the child, we'll let it slide by swapping the two,
             // and increasing the duration of the parent.
-            const actualParentTask = nextTask;
-            const actualChildTask = currentTask;
-            const actualGrandparentTask = currentTask.parent;
-            if (actualGrandparentTask) {
-              if (actualGrandparentTask.children[actualGrandparentTask.children.length - 1] !== actualChildTask) {
+            const parentTask = nextTask;
+            const childTask = currentTask;
+            const grandparentTask = currentTask.parent;
+            if (grandparentTask) {
+              if (grandparentTask.children[grandparentTask.children.length - 1] !== childTask) {
                 // The child we need to swap should always be the most recently added child.
                 // But if not then there's a serious bug in this code, so double-check.
                 throw new Error('Fatal trace logic error - impossible children');
               }
 
-              actualGrandparentTask.children.pop();
-              actualGrandparentTask.children.push(actualParentTask);
+              grandparentTask.children.pop();
+              grandparentTask.children.push(parentTask);
             }
 
-            actualParentTask.parent = actualGrandparentTask;
-            actualParentTask.startTime = actualChildTask.startTime;
-            actualParentTask.duration = actualParentTask.endTime - actualParentTask.startTime;
-            currentTask = actualParentTask;
-            nextTask = actualChildTask;
+            parentTask.parent = grandparentTask;
+            parentTask.startTime = childTask.startTime;
+            parentTask.duration = parentTask.endTime - parentTask.startTime;
+            currentTask = parentTask;
+            nextTask = childTask;
           } else {
             // None of our workarounds matched. It's time to throw an error.
             // When we fall into this error, it's usually because of one of two reasons.
@@ -376,7 +376,7 @@ class MainThreadTasks {
     // Phase 5 - Sort once more in case the order changed after wiring up relationships.
     return sortedTasks.sort(
       (taskA, taskB) => taskA.startTime - taskB.startTime || taskB.duration - taskA.duration
-    );;
+    );
   }
 
   /**

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -433,15 +433,15 @@ describe('Main Thread Tasks', () => {
   it('should handle nested tasks of the same name', () => {
     /*
     An artistic rendering of the below trace:
-      ████████████████TaskA██████████████████
-          ███████████TaskA████████████
+      ████████████████SameName██████████████████
+          ███████████SameName████████████
     */
     const traceEvents = [
       ...boilerplateTrace,
-      {ph: 'B', name: 'TaskA', pid, tid, ts: baseTs, args},
-      {ph: 'B', name: 'TaskA', pid, tid, ts: baseTs + 25e3, args},
-      {ph: 'E', name: 'TaskA', pid, tid, ts: baseTs + 75e3, args},
-      {ph: 'E', name: 'TaskA', pid, tid, ts: baseTs + 100e3, args},
+      {ph: 'B', name: 'SameName', pid, tid, ts: baseTs, args},
+      {ph: 'B', name: 'SameName', pid, tid, ts: baseTs + 25e3, args},
+      {ph: 'E', name: 'SameName', pid, tid, ts: baseTs + 75e3, args},
+      {ph: 'E', name: 'SameName', pid, tid, ts: baseTs + 100e3, args},
     ];
 
     traceEvents.forEach(evt => Object.assign(evt, {cat: 'devtools.timeline'}));
@@ -453,7 +453,7 @@ describe('Main Thread Tasks', () => {
         attributableURLs: [],
 
         children: [tasks[1]],
-        event: traceEvents.find(event => event.name === 'TaskA' && event.ts === baseTs),
+        event: traceEvents.find(event => event.name === 'SameName' && event.ts === baseTs),
         startTime: 0,
         endTime: 100,
         duration: 100,

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -459,6 +459,7 @@ describe('Main Thread Tasks', () => {
         duration: 100,
         selfTime: 50,
         group: taskGroups.other,
+        unbounded: false,
       },
       {
         parent: tasks[0],
@@ -471,6 +472,7 @@ describe('Main Thread Tasks', () => {
         duration: 50,
         selfTime: 50,
         group: taskGroups.other,
+        unbounded: false,
       },
     ]);
   });
@@ -586,7 +588,6 @@ describe('Main Thread Tasks', () => {
       {ph: 'E', name: 'TaskC', pid, tid, ts: baseTs + 60e3, args},
       {ph: 'E', name: 'TaskB', pid, tid, ts: baseTs + 90e3, args},
       {ph: 'E', name: 'TaskA', pid, tid, ts: baseTs + 100e3, args},
-      {ph: 'I', name: 'MarkerToPushOutTraceEnd', pid, tid, ts: baseTs + 110e3, args},
     ];
 
     traceEvents.forEach(evt => Object.assign(evt, {cat: 'devtools.timeline'}));
@@ -605,6 +606,7 @@ describe('Main Thread Tasks', () => {
         duration: 100,
         selfTime: 35,
         group: taskGroups.other,
+        unbounded: false,
       },
       {
         parent: taskA,
@@ -617,6 +619,7 @@ describe('Main Thread Tasks', () => {
         duration: 65,
         selfTime: 30,
         group: taskGroups.other,
+        unbounded: false,
       },
       {
         parent: taskB,
@@ -629,6 +632,7 @@ describe('Main Thread Tasks', () => {
         duration: 35,
         selfTime: 35,
         group: taskGroups.other,
+        unbounded: false,
       },
     ]);
   });

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -430,6 +430,51 @@ describe('Main Thread Tasks', () => {
     ]);
   });
 
+  it('should handle nested tasks of the same name', () => {
+    /*
+    An artistic rendering of the below trace:
+      ████████████████TaskA██████████████████
+          ███████████TaskA████████████
+    */
+    const traceEvents = [
+      ...boilerplateTrace,
+      {ph: 'B', name: 'TaskA', pid, tid, ts: baseTs, args},
+      {ph: 'B', name: 'TaskA', pid, tid, ts: baseTs + 25e3, args},
+      {ph: 'E', name: 'TaskA', pid, tid, ts: baseTs + 75e3, args},
+      {ph: 'E', name: 'TaskA', pid, tid, ts: baseTs + 100e3, args},
+    ];
+
+    traceEvents.forEach(evt => Object.assign(evt, {cat: 'devtools.timeline'}));
+
+    const tasks = run({traceEvents});
+    expect(tasks).toEqual([
+      {
+        parent: undefined,
+        attributableURLs: [],
+
+        children: [tasks[1]],
+        event: traceEvents.find(event => event.name === 'TaskA' && event.ts === baseTs),
+        startTime: 0,
+        endTime: 100,
+        duration: 100,
+        selfTime: 50,
+        group: taskGroups.other,
+      },
+      {
+        parent: tasks[0],
+        attributableURLs: [],
+
+        children: [],
+        event: traceEvents.find(event => event.ts === baseTs + 25e3),
+        startTime: 25,
+        endTime: 75,
+        duration: 50,
+        selfTime: 50,
+        group: taskGroups.other,
+      },
+    ]);
+  });
+
   it('should handle child events that extend <1ms beyond parent event', () => {
     /*
     An artistic rendering of the below trace:
@@ -526,6 +571,68 @@ describe('Main Thread Tasks', () => {
     ]);
   });
 
+  it('should handle child events that start <1ms before parent event', () => {
+    /*
+    An artistic rendering of the below trace:
+    ████████████████TaskA██████████████████
+            █████████TaskB██████████████
+           ████████TaskC█████████
+    */
+    const traceEvents = [
+      ...boilerplateTrace,
+      {ph: 'B', name: 'TaskA', pid, tid, ts: baseTs, args},
+      {ph: 'B', name: 'TaskB', pid, tid, ts: baseTs + 25e3 + 50, args}, // this is invalid, but happens in practice
+      {ph: 'B', name: 'TaskC', pid, tid, ts: baseTs + 25e3, args},
+      {ph: 'E', name: 'TaskC', pid, tid, ts: baseTs + 60e3, args},
+      {ph: 'E', name: 'TaskB', pid, tid, ts: baseTs + 90e3, args},
+      {ph: 'E', name: 'TaskA', pid, tid, ts: baseTs + 100e3, args},
+      {ph: 'I', name: 'MarkerToPushOutTraceEnd', pid, tid, ts: baseTs + 110e3, args},
+    ];
+
+    traceEvents.forEach(evt => Object.assign(evt, {cat: 'devtools.timeline'}));
+
+    const tasks = run({traceEvents});
+    const [taskA, taskB, taskC] = tasks;
+    expect(tasks).toEqual([
+      {
+        parent: undefined,
+        attributableURLs: [],
+
+        children: [taskB],
+        event: traceEvents.find(event => event.name === 'TaskA'),
+        startTime: 0,
+        endTime: 100,
+        duration: 100,
+        selfTime: 35,
+        group: taskGroups.other,
+      },
+      {
+        parent: taskA,
+        attributableURLs: [],
+
+        children: [taskC],
+        event: traceEvents.find(event => event.name === 'TaskB' && event.ph === 'B'),
+        startTime: 25,
+        endTime: 90,
+        duration: 65,
+        selfTime: 30,
+        group: taskGroups.other,
+      },
+      {
+        parent: taskB,
+        attributableURLs: [],
+
+        children: [],
+        event: traceEvents.find(event => event.name === 'TaskC' && event.ph === 'B'),
+        startTime: 25,
+        endTime: 60,
+        duration: 35,
+        selfTime: 35,
+        group: taskGroups.other,
+      },
+    ]);
+  });
+
   // Invalid sets of events.
   // All of these should have `traceEnd` pushed out to avoid falling into one of our mitigation scenarios.
   const invalidEventSets = [
@@ -558,6 +665,15 @@ describe('Main Thread Tasks', () => {
       // TaskB is missing a B event after an X
       {ph: 'X', name: 'TaskA', pid, tid, ts: baseTs, dur: 100e3, args},
       {ph: 'E', name: 'TaskB', pid, tid, ts: baseTs + 10e3, args},
+    ],
+    [
+      // TaskA is starting .5ms too late, but TaskB already has a child
+      {ph: 'B', name: 'TaskA', pid, tid, ts: baseTs + 500, args},
+      {ph: 'B', name: 'TaskB', pid, tid, ts: baseTs, args},
+      {ph: 'X', name: 'TaskC', pid, tid, ts: baseTs + 50, dur: 100, args},
+      {ph: 'E', name: 'TaskB', pid, tid, ts: baseTs + 100e3, args},
+      {ph: 'E', name: 'TaskA', pid, tid, ts: baseTs + 115e3, args},
+      {ph: 'I', name: 'MarkerToPushOutTraceEnd', pid, tid, ts: baseTs + 200e3, args},
     ],
   ];
 


### PR DESCRIPTION
**Summary**
Addresses one of the 3 remaining cases for `Fatal trace logic error - child cannot end after parent` error.

**Related Issues/PRs**
#7764, depends on #9785 
