### PR TITLE
docs(i18n): add 'meaning' to i18n README

### DIFF
--- a/lighthouse-core/lib/i18n/README.md
+++ b/lighthouse-core/lib/i18n/README.md
@@ -1,6 +1,6 @@
 # Terminology
 
-* **CTC format**: The [Chrome extension & Chrome app i18n format](https://developer.chrome.com/extensions/i18n-messages). JSON with their specified model for declaring placeholders, examples, etc. Used as an interchange data format. With some minor changes.
+* **CTC format**: The [Chrome extension & Chrome app i18n format](https://developer.chrome.com/extensions/i18n-messages) with some minor changes. JSON with their specified model for declaring placeholders, examples, etc. Used as an interchange data format.
 * **LHL syntax** (Lighthouse Localizable syntax): The ICU-friendly string syntax that is used to author `UIStrings` and is seen in the locale files in `i18n/locales/*.json`. Lighthouse has a custom syntax these strings combines many ICU message features along with some markdown.
 * **ICU**: ICU (International Components for Unicode) is a localization project and standard defined by the Unicode consortium. In general, we refer to "ICU" as the [ICU message formatting](http://userguide.icu-project.org/formatparse/messages) syntax.
 
@@ -195,14 +195,12 @@ CTC is a name that is distinct and identifies this as the Chrome translation for
 
 ### Parts of a CTC message
 
-(From the Chrome Docs)
-
 ```json
 {
   "name": {
     "message": "Message text, with optional placeholders.",
     "description": "Translator-aimed description of the message.",
-    "meaning": "Description given when a message is duplicated, in order to give context to the message.",
+    "meaning": "Description given when a message is duplicated, in order to give context to the message. Lighthouse uses a copy of the description for this.",
     "placeholders": {
       "placeholder_name": {
         "content": "A string to be placed within the message.",

--- a/lighthouse-core/lib/i18n/README.md
+++ b/lighthouse-core/lib/i18n/README.md
@@ -1,6 +1,6 @@
 # Terminology
 
-* **CTC format**: The [Chrome extension & Chrome app i18n format](https://developer.chrome.com/extensions/i18n-messages). JSON with their specified model for declaring placeholders, examples, etc. Used as an interchange data format.
+* **CTC format**: The [Chrome extension & Chrome app i18n format](https://developer.chrome.com/extensions/i18n-messages). JSON with their specified model for declaring placeholders, examples, etc. Used as an interchange data format. With some minor changes.
 * **LHL syntax** (Lighthouse Localizable syntax): The ICU-friendly string syntax that is used to author `UIStrings` and is seen in the locale files in `i18n/locales/*.json`. Lighthouse has a custom syntax these strings combines many ICU message features along with some markdown.
 * **ICU**: ICU (International Components for Unicode) is a localization project and standard defined by the Unicode consortium. In general, we refer to "ICU" as the [ICU message formatting](http://userguide.icu-project.org/formatparse/messages) syntax.
 
@@ -202,6 +202,7 @@ CTC is a name that is distinct and identifies this as the Chrome translation for
   "name": {
     "message": "Message text, with optional placeholders.",
     "description": "Translator-aimed description of the message.",
+    "meaning": "Description given when a message is duplicated, in order to give context to the message.",
     "placeholders": {
       "placeholder_name": {
         "content": "A string to be placed within the message.",


### PR DESCRIPTION
**Summary**
I noticed, upon reviewing the l10n plan for DevTools, that we never mention our divergence from `message.json` format (read: "meanings").
