### PR TITLE
core(seo): support korean in link-text audit

### DIFF
--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -53,6 +53,16 @@ const BLOCKLIST = new Set([
   'mais informações',
   'mais',
   'veja mais',
+  // Korean
+  '여기',
+  '여기를 클릭',
+  '클릭',
+  '링크',
+  '자세히',
+  '자세히 보기',
+  '계속',
+  '이동',
+  '전체 보기',
 ]);
 const i18n = require('../../lib/i18n/i18n.js');
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
Add Korean translations for the [Links Do Not Have Descriptive Text](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text).
<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->
[translated words for non-korean speakers](https://translate.google.co.kr/?hl=ko#view=home&op=translate&sl=ko&tl=en&text=여기%0A여기를%20클릭%0A클릭%0A링크%0A자세히%0A자세히%20보기%0A계속%0A이동%0A전체%20보기)

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
#7547 #5322 #9446