### PR TITLE
docs(related-projects): add the is-website-vulnerable CLI tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -301,6 +301,8 @@ This section details services that have integrated Lighthouse data. If you're wo
 
 * **[Web Page Test](https://www.webpagetest.org)** — An [open source](https://github.com/WPO-Foundation/webpagetest) tool for measuring and analyzing the performance of web pages on real devices. Users can choose to produce a Lighthouse report alongside the analysis of WebPageTest results.
 
+* **[is-website-vulnerable](https://github.com/lirantal/is-website-vulnerable)** - An [open source](https://github.com/lirantal/is-website-vulnerable) Node.js CLI tool that helps with finding publicly known security vulnerabilities in a website's frontend JavaScript libraries.
+
 ## Plugins
 
 * **[lighthouse-plugin-field-performance](https://github.com/treosh/lighthouse-plugin-field-performance)** - a plugin that adds real-user performance metrics for the URL using the data from [Chrome UX Report](https://developers.google.com/web/tools/chrome-user-experience-report/).

--- a/readme.md
+++ b/readme.md
@@ -301,7 +301,7 @@ This section details services that have integrated Lighthouse data. If you're wo
 
 * **[Web Page Test](https://www.webpagetest.org)** — An [open source](https://github.com/WPO-Foundation/webpagetest) tool for measuring and analyzing the performance of web pages on real devices. Users can choose to produce a Lighthouse report alongside the analysis of WebPageTest results.
 
-* **[is-website-vulnerable](https://github.com/lirantal/is-website-vulnerable)** - An [open source](https://github.com/lirantal/is-website-vulnerable) Node.js CLI tool that helps with finding publicly known security vulnerabilities in a website's frontend JavaScript libraries.
+* **[is-website-vulnerable](https://github.com/lirantal/is-website-vulnerable)** - An open source Node.js CLI tool that finds publicly known security vulnerabilities in a website's frontend JavaScript libraries.
 
 ## Plugins
 


### PR DESCRIPTION
**Summary**
I'd like to update the README documentation to list another CLI tool that has been built with Lighthouse to detect JS libs and their vulnerabilities:

![image](https://user-images.githubusercontent.com/316371/66515127-26c06a00-eae7-11e9-8f22-d3c94b2c0c1f.png)
