### PR TITLE
core(image-elements): cache naturalSize results

### DIFF
--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -135,6 +135,7 @@ class ImageElements extends Gatherer {
     /** @type {Map<string, {naturalWidth: number, naturalHeight: number}>} */
     this._naturalSizeCache = new Map();
   }
+  
   /**
    * @param {Driver} driver
    * @param {LH.Artifacts.ImageElement} element

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -135,7 +135,7 @@ class ImageElements extends Gatherer {
     /** @type {Map<string, {naturalWidth: number, naturalHeight: number}>} */
     this._naturalSizeCache = new Map();
   }
-  
+
   /**
    * @param {Driver} driver
    * @param {LH.Artifacts.ImageElement} element

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -130,6 +130,11 @@ function determineNaturalSize(url) {
 }
 
 class ImageElements extends Gatherer {
+  constructor() {
+    super();
+    /** @type {Map<string, {naturalWidth: number, naturalHeight: number}>} */
+    this._naturalSizeCache = new Map();
+  }
   /**
    * @param {Driver} driver
    * @param {LH.Artifacts.ImageElement} element
@@ -137,11 +142,16 @@ class ImageElements extends Gatherer {
    */
   async fetchElementWithSizeInformation(driver, element) {
     const url = JSON.stringify(element.src);
+    if (this._naturalSizeCache.has(url)) {
+      return Object.assign(element, this._naturalSizeCache.get(url));
+    }
+
     try {
       // We don't want this to take forever, 250ms should be enough for images that are cached
       driver.setNextProtocolTimeout(250);
       /** @type {{naturalWidth: number, naturalHeight: number}} */
       const size = await driver.evaluateAsync(`(${determineNaturalSize.toString()})(${url})`);
+      this._naturalSizeCache.set(url, size);
       return Object.assign(element, size);
     } catch (_) {
       // determineNaturalSize fails on invalid images, which we treat as non-visible


### PR DESCRIPTION
This url is quite slow to run: https://www.selfridges.com/US/en/cat/womens/newin/

On the CLI, the ImageElements gatherer can take 25-30 seconds to run.

Turns out that gatherer finds ~2000 images, however 99% of them are country flag DOM elements with a css background using the exact same sprite image. 


----------


While we have added [that smart only-do-the-50-most-important-network-images check](https://github.com/GoogleChrome/lighthouse/pull/7274)... we don't handle the case of multiple background images pointing to the same asset that's within the top 50.

But now we do. :)