### PR TITLE
clients(lr): only wait 25sec for fully loaded

### DIFF
--- a/lighthouse-core/config/lr-desktop-config.js
+++ b/lighthouse-core/config/lr-desktop-config.js
@@ -10,7 +10,7 @@ const config = {
   extends: 'lighthouse:default',
   settings: {
     maxWaitForFcp: 15 * 1000,
-    maxWaitForLoad: 35 * 1000,
+    maxWaitForLoad: 25 * 1000,
     emulatedFormFactor: 'desktop',
     throttling: {
       // Using a "broadband" connection type

--- a/lighthouse-core/config/lr-mobile-config.js
+++ b/lighthouse-core/config/lr-mobile-config.js
@@ -10,7 +10,7 @@ const config = {
   extends: 'lighthouse:default',
   settings: {
     maxWaitForFcp: 15 * 1000,
-    maxWaitForLoad: 35 * 1000,
+    maxWaitForLoad: 25 * 1000,
     // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
     skipAudits: ['uses-http2'],
   },


### PR DESCRIPTION
We currently allow 35 sec for fully loaded before we hit our timeout and give up. But in these cases, the page is quite complicated and often the rest of our gatherers/audits dont finish. (We hit the global 60s timeout and LH never completes). 

35s is overgenerous. 
If a site's main thread is busy enough at 25s then it rarely quiets by 35s.

So let's lower it.

This also means our timeout error rate will drop a lot and we'll at least be able to tell pages like https://www.selfridges.com/US/en/cat/womens/newin/ that their main thread is a sad story. (rather than tell them nothing)



