### PR TITLE
core(renderer): improve the unknown timezone checks in util.js

### DIFF
--- a/lighthouse-core/report/html/renderer/i18n.js
+++ b/lighthouse-core/report/html/renderer/i18n.js
@@ -89,6 +89,7 @@ class I18n {
       formatter = new Intl.DateTimeFormat(this._numberDateLocale, options);
     } catch (err) {
       options.timeZone = 'UTC';
+      formatter = new Intl.DateTimeFormat(this._numberDateLocale, options);
     }
 
     return formatter.format(new Date(date));

--- a/lighthouse-core/report/html/renderer/i18n.js
+++ b/lighthouse-core/report/html/renderer/i18n.js
@@ -74,7 +74,7 @@ class I18n {
    * @param {string} date
    * @return {string}
    */
-   formatDateTime(date) {
+  formatDateTime(date) {
     /** @type {Intl.DateTimeFormatOptions} */
     const options = {
       month: 'short', day: 'numeric', year: 'numeric',

--- a/lighthouse-core/report/html/renderer/i18n.js
+++ b/lighthouse-core/report/html/renderer/i18n.js
@@ -74,23 +74,26 @@ class I18n {
    * @param {string} date
    * @return {string}
    */
-  formatDateTime(date) {
+   formatDateTime(date) {
     /** @type {Intl.DateTimeFormatOptions} */
     const options = {
       month: 'short', day: 'numeric', year: 'numeric',
       hour: 'numeric', minute: 'numeric', timeZoneName: 'short',
     };
-    let formatter = new Intl.DateTimeFormat(this._numberDateLocale, options);
 
     // Force UTC if runtime timezone could not be detected.
     // See https://github.com/GoogleChrome/lighthouse/issues/1056
-    const tz = formatter.resolvedOptions().timeZone;
-    if (!tz || tz.toLowerCase() === 'etc/unknown') {
+    // and https://github.com/GoogleChrome/lighthouse/pull/9822
+    try {
+      (new Date()).toLocaleTimeString();
+    } catch (err) {
       options.timeZone = 'UTC';
-      formatter = new Intl.DateTimeFormat(this._numberDateLocale, options);
     }
+
+    const formatter = new Intl.DateTimeFormat(this._numberDateLocale, options);
     return formatter.format(new Date(date));
   }
+
   /**
    * Converts a time in milliseconds into a duration string, i.e. `1d 2h 13m 52s`
    * @param {number} timeInMilliseconds

--- a/lighthouse-core/report/html/renderer/i18n.js
+++ b/lighthouse-core/report/html/renderer/i18n.js
@@ -84,13 +84,13 @@ class I18n {
     // Force UTC if runtime timezone could not be detected.
     // See https://github.com/GoogleChrome/lighthouse/issues/1056
     // and https://github.com/GoogleChrome/lighthouse/pull/9822
+    let formatter;
     try {
-      (new Date()).toLocaleTimeString();
+      formatter = new Intl.DateTimeFormat(this._numberDateLocale, options);
     } catch (err) {
       options.timeZone = 'UTC';
     }
 
-    const formatter = new Intl.DateTimeFormat(this._numberDateLocale, options);
     return formatter.format(new Date(date));
   }
 

--- a/lighthouse-core/test/report/html/renderer/i18n-test.js
+++ b/lighthouse-core/test/report/html/renderer/i18n-test.js
@@ -77,4 +77,14 @@ describe('util helpers', () => {
     assert.strictEqual(i18n.formatMilliseconds(number), `12.350${NBSP}ms`);
     assert.strictEqual(i18n.formatSeconds(number), `12,3${NBSP}s`);
   });
+
+  it('should not crash on unknown locales', () => {
+    const i18n = new I18n('unknown-mystery-locale', {...Util.UIStrings});
+    const timestamp = i18n.formatDateTime('2017-04-28T23:07:51.189Z');
+    assert.ok(
+      timestamp.includes('Apr 27, 2017') ||
+      timestamp.includes('Apr 28, 2017') ||
+      timestamp.includes('Apr 29, 2017')
+    );
+  });
 });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

This PR is a triple-down fix for https://github.com/GoogleChrome/lighthouse/issues/1056, which was partly fixed in https://github.com/GoogleChrome/lighthouse/commit/2f9ad6ffa8348f699933b211d7eb255a1b698f4a and https://github.com/GoogleChrome/lighthouse/pull/1086.

<!-- Describe the need for this change -->

Turns out that `Intl.DateTimeFormat` itself too throws if the timeZone is invalid.


The issue itself was fixed in newer Chromium versions, as it affects eg. Node 10 but not Node 12
<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/pull/1086
https://github.com/GoogleChrome/lighthouse/commit/2f9ad6ffa8348f699933b211d7eb255a1b6
https://github.com/GoogleChrome/lighthouse/issues/1056
