### PR TITLE
misc(build): minify report javascript for lightrider report generator

### DIFF
--- a/build/build-lightrider-bundles.js
+++ b/build/build-lightrider-bundles.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const makeDir = require('make-dir');
 const bundleBuilder = require('./build-bundle.js');
+const {minifyFileTransform} = require('./build-utils.js');
 
 const distDir = path.join(__dirname, '..', 'dist', 'lightrider');
 const sourceDir = __dirname + '/../clients/lightrider';
@@ -37,7 +38,11 @@ function buildEntryPoint() {
 function buildReportGenerator() {
   browserify(generatorFilename, {standalone: 'ReportGenerator'})
     // Transform the fs.readFile etc into inline strings.
-    .transform('@wardpeet/brfs', {global: true, parserOpts: {ecmaVersion: 10}})
+    .transform('@wardpeet/brfs', {
+      readFileSyncTransform: minifyFileTransform,
+      global: true,
+      parserOpts: {ecmaVersion: 10},
+    })
     .bundle((err, src) => {
       if (err) throw err;
       fs.writeFileSync(bundleOutFile, src.toString());

--- a/build/build-utils.js
+++ b/build/build-utils.js
@@ -1,0 +1,37 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const stream = require('stream');
+const terser = require('terser');
+
+/**
+ * Minifies file which are read by fs.readFileSync (brfs)
+ *
+ * @param {string} file
+ */
+function minifyFileTransform(file) {
+  return new stream.Transform({
+    transform(chunk, enc, next) {
+      if (file.endsWith('.js')) {
+        const result = terser.minify(chunk.toString());
+        if (result.error) {
+          throw result.error;
+        }
+
+        this.push(result.code);
+      } else {
+        this.push(chunk);
+      }
+
+      next();
+    },
+  });
+}
+
+module.exports = {
+  minifyFileTransform,
+};

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -10,7 +10,6 @@ const path = require('path');
 const {promisify} = require('util');
 const readFileAsync = promisify(fs.readFile);
 const writeFileAsync = promisify(fs.writeFile);
-const stream = require('stream');
 
 const browserify = require('browserify');
 const cpy = require('cpy');
@@ -97,30 +96,6 @@ async function html() {
   htmlSrc = htmlSrc.replace(/%%LIGHTHOUSE_TEMPLATES%%/, htmlReportAssets.REPORT_TEMPLATES);
 
   await safeWriteFileAsync(`${distDir}/index.html`, htmlSrc);
-}
-
-/**
- * Minifies file which are read by fs.readFileSync (brfs)
- *
- * @param {string} file
- */
-function minifyReadFileContent(file) {
-  return new stream.Transform({
-    transform(chunk, enc, next) {
-      if (file.endsWith('.js')) {
-        const result = terser.minify(chunk.toString());
-        if (result.error) {
-          throw result.error;
-        }
-
-        this.push(result.code);
-      } else {
-        this.push(chunk);
-      }
-
-      next();
-    },
-  });
 }
 
 /**

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -19,6 +19,7 @@ const lighthousePackage = require('../package.json');
 const makeDir = require('make-dir');
 const rimraf = require('rimraf');
 const terser = require('terser');
+const {minifyFileTransform} = require('./build-utils.js');
 
 const htmlReportAssets = require('../lighthouse-core/report/html/html-report-assets.js');
 const sourceDir = `${__dirname}/../lighthouse-viewer`;
@@ -99,30 +100,6 @@ async function html() {
 }
 
 /**
- * Minifies file which are read by fs.readFileSync (brfs)
- *
- * @param {string} file
- */
-function minifyReadFileContent(file) {
-  return new stream.Transform({
-    transform(chunk, enc, next) {
-      if (file.endsWith('.js')) {
-        const result = terser.minify(chunk.toString());
-        if (result.error) {
-          throw result.error;
-        }
-
-        this.push(result.code);
-      } else {
-        this.push(chunk);
-      }
-
-      next();
-    },
-  });
-}
-
-/**
  * Combine multiple JS files into single viewer.js file.
  * @return {Promise<void>}
  */
@@ -131,7 +108,7 @@ async function compileJs() {
   const generatorFilename = `${sourceDir}/../lighthouse-core/report/report-generator.js`;
   const generatorBrowserify = browserify(generatorFilename, {standalone: 'ReportGenerator'})
     .transform('@wardpeet/brfs', {
-      readFileSyncTransform: minifyReadFileContent,
+      readFileSyncTransform: minifyFileTransform,
     });
 
   /** @type {Promise<string>} */

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -99,6 +99,30 @@ async function html() {
 }
 
 /**
+ * Minifies file which are read by fs.readFileSync (brfs)
+ *
+ * @param {string} file
+ */
+function minifyReadFileContent(file) {
+  return new stream.Transform({
+    transform(chunk, enc, next) {
+      if (file.endsWith('.js')) {
+        const result = terser.minify(chunk.toString());
+        if (result.error) {
+          throw result.error;
+        }
+
+        this.push(result.code);
+      } else {
+        this.push(chunk);
+      }
+
+      next();
+    },
+  });
+}
+
+/**
  * Combine multiple JS files into single viewer.js file.
  * @return {Promise<void>}
  */

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@types/update-notifier": "^1.0.2",
     "@types/ws": "^4.0.1",
     "@types/yargs": "^8.0.2",
-    "@wardpeet/brfs": "2.1.0-0",
+    "@wardpeet/brfs": "^2.1.0-0",
     "angular": "^1.7.4",
     "archiver": "^3.0.0",
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -187,11 +187,15 @@
     },
     {
       "path": "./dist/viewer/src/viewer.js",
-      "maxSize": "76 kB"
+      "maxSize": "65 kB"
     },
     {
       "path": "./dist/lighthouse-dt-bundle.js",
       "maxSize": "400 kB"
+    },
+    {
+      "path": "./dist/lightrider/report-generator-bundle.js",
+      "maxSize": "50 kB"
     }
   ],
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@types/update-notifier": "^1.0.2",
     "@types/ws": "^4.0.1",
     "@types/yargs": "^8.0.2",
-    "@wardpeet/brfs": "^2.1.0-0",
+    "@wardpeet/brfs": "2.1.0-0",
     "angular": "^1.7.4",
     "archiver": "^3.0.0",
     "babel-core": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,7 +727,7 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-8.0.2.tgz#0f9c7b236e2d78cd8f4b6502de15d0728aa29385"
   integrity sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==
 
-"@wardpeet/brfs@2.1.0-0":
+"@wardpeet/brfs@^2.1.0-0":
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/@wardpeet/brfs/-/brfs-2.1.0-0.tgz#04e77dc088ca5bbc5b07051860faa45569e799f3"
   integrity sha512-ra9bDHPwsI+HBKQJk9CLMYaFDHLA7QGEH0teWlIcZ6/CHtFvjRb2YjwLBXc8jgtw+3LvCEuqme/BQaDfo74fUA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,7 +727,7 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-8.0.2.tgz#0f9c7b236e2d78cd8f4b6502de15d0728aa29385"
   integrity sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==
 
-"@wardpeet/brfs@^2.1.0-0":
+"@wardpeet/brfs@2.1.0-0":
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/@wardpeet/brfs/-/brfs-2.1.0-0.tgz#04e77dc088ca5bbc5b07051860faa45569e799f3"
   integrity sha512-ra9bDHPwsI+HBKQJk9CLMYaFDHLA7QGEH0teWlIcZ6/CHtFvjRb2YjwLBXc8jgtw+3LvCEuqme/BQaDfo74fUA==


### PR DESCRIPTION
cont. #9596 (I meant to just update that PR, but apparently I don't know how to push to a PR branch ...)

I updated @wardpeet's work with master, and also minified the assets for the LR report generator. I verified the report still works with a terser pass (if we rely on function or class names, we'd have to pass special flags, but it seems we don't for the report).

Can confirm this saves a lot of bytes.

![image](https://user-images.githubusercontent.com/4071474/66630404-12e53880-ebb9-11e9-89bb-fc67dc93ecf7.png)

`dist/lightrider/report-generator-bundle.js` 247 KB -> 152 KB (38%)
`dist/viewer/src/viewer.js` 309 KB -> 213 KB (31%) (done in #9596)
