### PR TITLE
test(build): attempt bundle test three times in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - yarn test-clients
   - yarn test-viewer
   - yarn test-lantern
-  - yarn test-bundle
+  - yarn test-bundle || yarn test-bundle || yarn test-bundle
   - yarn i18n:checks
   - yarn dogfood-lhci
 before_cache:


### PR DESCRIPTION
We retry cli smoke tests in CI, but didn't do the same for the new bundle smoke tests. Quick and dirty way is to just retry a few times in the CI invocation. better solution may come later (internal to firehouse) but should wait for w/e refactors that may come its way soon.