### PR TITLE
core(driver): fix error handling for Runtime.evaluate

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -528,8 +528,12 @@ class Driver {
     this.setNextProtocolTimeout(timeout);
     const response = await this.sendCommand('Runtime.evaluate', evaluationParams);
     if (response.exceptionDetails) {
-      // An error occurred before we could even create a Promise, should be *very* rare
-      return Promise.reject(new Error(`Evaluation exception: ${response.exceptionDetails.text}`));
+      // An error occurred before we could even create a Promise, should be *very* rare.
+      // Also occurs when the expression is not valid JavaScript.
+      const errorMessage = response.exceptionDetails.exception ?
+        response.exceptionDetails.exception.description :
+        response.exceptionDetails.text;
+      return Promise.reject(new Error(`Evaluation exception: ${errorMessage}`));
     }
     // Protocol should always return a 'result' object, but it is sometimes undefined.  See #6026.
     if (response.result === undefined) {


### PR DESCRIPTION
extracted from #9605 / #9650

repro by messing up the expression:

![image](https://user-images.githubusercontent.com/4071474/66691971-14f9d680-ec4f-11e9-8107-dba45fc211c9.png)

before:

![image](https://user-images.githubusercontent.com/4071474/66691963-09a6ab00-ec4f-11e9-81e4-b21a9239b12b.png)

after:

![image](https://user-images.githubusercontent.com/4071474/66691985-29d66a00-ec4f-11e9-8ec6-ff83906866f7.png)
