### PR TITLE
core: rename Element to LHElement

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -7,7 +7,7 @@
 
 const NetworkRecorder = require('../lib/network-recorder.js');
 const emulation = require('../lib/emulation.js');
-const Element = require('../lib/element.js');
+const LHElement = require('../lib/lh-element.js');
 const LHError = require('../lib/lh-error.js');
 const NetworkRequest = require('../lib/network-request.js');
 const EventEmitter = require('events').EventEmitter;
@@ -1224,7 +1224,7 @@ class Driver {
 
   /**
    * @param {string} selector Selector to find in the DOM
-   * @return {Promise<Element|null>} The found element, or null, resolved in a promise
+   * @return {Promise<LHElement|null>} The found element, or null, resolved in a promise
    */
   async querySelector(selector) {
     const documentResponse = await this.sendCommand('DOM.getDocument');
@@ -1238,12 +1238,12 @@ class Driver {
     if (targetNode.nodeId === 0) {
       return null;
     }
-    return new Element(targetNode, this);
+    return new LHElement(targetNode, this);
   }
 
   /**
    * @param {string} selector Selector to find in the DOM
-   * @return {Promise<Array<Element>>} The found elements, or [], resolved in a promise
+   * @return {Promise<Array<LHElement>>} The found elements, or [], resolved in a promise
    */
   async querySelectorAll(selector) {
     const documentResponse = await this.sendCommand('DOM.getDocument');
@@ -1254,11 +1254,11 @@ class Driver {
       selector,
     });
 
-    /** @type {Array<Element>} */
+    /** @type {Array<LHElement>} */
     const elementList = [];
     targetNodeList.nodeIds.forEach(nodeId => {
       if (nodeId !== 0) {
-        elementList.push(new Element({nodeId}, this));
+        elementList.push(new LHElement({nodeId}, this));
       }
     });
     return elementList;
@@ -1274,7 +1274,7 @@ class Driver {
     return this.getNodesInDocument(pierce)
       .then(nodes => nodes
         .filter(node => node.nodeType === 1)
-        .map(node => new Element({nodeId: node.nodeId}, this))
+        .map(node => new LHElement({nodeId: node.nodeId}, this))
       );
   }
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1268,7 +1268,7 @@ class Driver {
    * Returns the flattened list of all DOM elements within the document.
    * @param {boolean=} pierce Whether to pierce through shadow trees and iframes.
    *     True by default.
-   * @return {Promise<Array<Element>>} The found elements, or [], resolved in a promise
+   * @return {Promise<Array<LHElement>>} The found elements, or [], resolved in a promise
    */
   getElementsInDocument(pierce = true) {
     return this.getNodesInDocument(pierce)

--- a/lighthouse-core/lib/lh-element.js
+++ b/lighthouse-core/lib/lh-element.js
@@ -7,7 +7,7 @@
 
 const Driver = require('../gather/driver.js'); // eslint-disable-line no-unused-vars
 
-class Element {
+class LHElement {
   /**
    * @param {{nodeId: number}} element
    * @param {Driver} driver
@@ -68,4 +68,4 @@ class Element {
   }
 }
 
-module.exports = Element;
+module.exports = LHElement;

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -7,7 +7,7 @@
 
 const Driver = require('../../gather/driver.js');
 const Connection = require('../../gather/connections/connection.js');
-const Element = require('../../lib/element.js');
+const LHElement = require('../../lib/lh-element.js');
 const EventEmitter = require('events').EventEmitter;
 const {protocolGetVersionResponse} = require('./fake-driver.js');
 const {createMockSendCommandFn, createMockOnceFn} = require('./mock-commands.js');
@@ -108,7 +108,7 @@ describe('.querySelector(All)', () => {
       .mockResponse('DOM.querySelector', {nodeId: 231});
 
     const result = await driver.querySelector('meta head');
-    expect(result).toBeInstanceOf(Element);
+    expect(result).toBeInstanceOf(LHElement);
   });
 
   it('returns [] when DOM.querySelectorAll finds no node', async () => {
@@ -127,7 +127,7 @@ describe('.querySelector(All)', () => {
 
     const result = await driver.querySelectorAll('#no.matches');
     expect(result).toHaveLength(1);
-    expect(result[0]).toBeInstanceOf(Element);
+    expect(result[0]).toBeInstanceOf(LHElement);
   });
 });
 

--- a/lighthouse-core/test/lib/lh-element-test.js
+++ b/lighthouse-core/test/lib/lh-element-test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Element = require('../../lib/element.js');
+const LHElement = require('../../lib/lh-element.js');
 const assert = require('assert');
 
 class DriverStub {
@@ -28,7 +28,7 @@ class DriverStub {
 }
 
 /* global describe, it, beforeEach */
-describe('Element', () => {
+describe('LHElement', () => {
   let stubbedDriver;
   let stubbedElement;
 
@@ -39,38 +39,38 @@ describe('Element', () => {
 
   it('throws when no driver or element is passed', () => {
     assert.throws(() => {
-      const _ = new Element();
+      const _ = new LHElement();
     });
   });
 
   it('throws when no driver is passed', () => {
     assert.throws(() => {
-      const _ = new Element(stubbedElement, undefined);
+      const _ = new LHElement(stubbedElement, undefined);
     });
   });
 
   it('throws when no element is passed', () => {
     assert.throws(() => {
-      const _ = new Element(undefined, stubbedDriver);
+      const _ = new LHElement(undefined, stubbedDriver);
     });
   });
 
   it('returns null from getAttribute when no attribute found', () => {
-    const element = new Element(stubbedElement, stubbedDriver);
+    const element = new LHElement(stubbedElement, stubbedDriver);
     return element.getAttribute('notanattribute').then(value => {
       assert.equal(value, null);
     });
   });
 
   it('returns attribute value from getAttribute', () => {
-    const element = new Element(stubbedElement, stubbedDriver);
+    const element = new LHElement(stubbedElement, stubbedDriver);
     return element.getAttribute('rel').then(value => {
       assert.equal(value, 'manifest');
     });
   });
 
   it('returns property value from getProperty', () => {
-    const element = new Element(stubbedElement, stubbedDriver);
+    const element = new LHElement(stubbedElement, stubbedDriver);
     return element.getProperty('test').then(value => {
       assert.equal(value, '123');
     });


### PR DESCRIPTION
While checking out the ts 3.7 beta, this typing mistake became apparent. We use the global `Element` type declaration (dom lib) where we really want our `lib/element.js`. Renaming to `LHElement` is a simple solution to this name clash.

![image](https://user-images.githubusercontent.com/4071474/66693428-8476c280-ec5d-11e9-93d3-cc3ffba92ac8.png)

the error was uncovered likely thanks to changes required for this bugfix: https://devblogs.microsoft.com/typescript/announcing-typescript-3-7-beta/ "Local and Imported Type Declarations Now Conflict"