### PR TITLE
report: add channel to version string

### DIFF
--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -120,7 +120,9 @@ class ReportRenderer {
       env.appendChild(item);
     });
 
-    this._dom.find('.lh-footer__version', footer).textContent = report.lighthouseVersion;
+    this._dom.find('.lh-footer__version', footer).textContent = report.configSettings.channel ?
+      `${report.lighthouseVersion}-${report.configSettings.channel}` :
+      report.lighthouseVersion;
     return footer;
   }
 


### PR DESCRIPTION
The different execution environments are tantamount to entirely different code bases (different entry points, different constraints, etc.). So it makes sense to me that the version string in the report should contain the `channel` property.

Thoughts?

![image](https://user-images.githubusercontent.com/4071474/66966242-5f090080-f031-11e9-8662-22f6b27122f5.png)

And maybe we should set channel for the CLI? 