### PR TITLE
test(smokehouse): fix tmp dir usage

### DIFF
--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -9,6 +9,7 @@
 /* eslint-disable no-console */
 
 const fs = require('fs');
+const mkdirp = require('mkdirp');
 const spawnSync = require('child_process').spawnSync;
 const yargs = require('yargs');
 const log = require('lighthouse-logger');
@@ -124,7 +125,10 @@ if (!smokeTest) {
   throw new Error(`could not find smoke ${smokeId}`);
 }
 
-const configPath = `./.tmp/smoke-config-${smokeTest.id}.json`;
+const lhRootDir = `${__dirname}/../../..`;
+const tmpDir = `${lhRootDir}/.tmp`;
+mkdirp.sync(tmpDir);
+const configPath = `${tmpDir}/smoke-config-${smokeTest.id}.json`;
 fs.writeFileSync(configPath, JSON.stringify(smokeTest.config));
 
 // Loop sequentially over expectations, comparing against Lighthouse run, and


### PR DESCRIPTION
If you don't run LH in the root directory, this breaks.

Also, the `test.sh` release script doesn't have a `.tmp` folder, so this breaks there too.

I plan on following up later with a centralized place to make temporary files (we do this in a few different places).