### PR TITLE
core(network-recorder): manually trigger loadingFinished for Fetch re…

### DIFF
--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -242,6 +242,14 @@ class NetworkRecorder extends EventEmitter {
     const request = this._findRealRequestAndSetSource(data.requestId, event.source);
     if (!request) return;
     request.onResponseReceived(data);
+
+    /**
+     * due to a bug in Chromium we have to manually trigger the onLoadingFinished event
+     * see also: https://bugs.chromium.org/p/chromium/issues/detail?id=1016754
+     */
+    if (request.type === 'Fetch') {
+      this.loadingFinished(event);
+    }
   }
 
   /**


### PR DESCRIPTION
…quests

<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
This patch is a bugfix. It becomes apparent if you audit a page that runs at least 3 fetch requests. While the audit is still being captured properly it will take up to 45s (until timeout) for it to finish.

<!-- Describe the need for this change -->
There seems to be a bug in Chromium where the `ResourceFinish` event is not being triggered for Fetch requests. I've logged the bug here: https://bugs.chromium.org/p/chromium/issues/detail?id=1016754. Until this is fixed, I'ld suggest to trigger the event manually. I am aware that the finish event and resource received event aren't happening at the same time I doubt that it will impact the audit results though.

<!-- Link any documentation or information that would help understand this change -->
See more in the bug report above.

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
n/a
