### PR TITLE
misc: add note about LCP required chrome version

### DIFF
--- a/lighthouse-core/computed/metrics/largest-contentful-paint.js
+++ b/lighthouse-core/computed/metrics/largest-contentful-paint.js
@@ -9,6 +9,13 @@ const makeComputedArtifact = require('../computed-artifact.js');
 const ComputedMetric = require('./metric.js');
 const LHError = require('../../lib/lh-error.js');
 
+/**
+ * @fileoverview Computed Largest Contentful Paint (LCP), the paint time of the largest in-viewport contentful element
+ * COMPAT: LCP's trace event was first introduced in m78. We can't surface an FCP for older Chrome versions
+ * @see https://github.com/WICG/largest-contentful-paint
+ * @see https://wicg.github.io/largest-contentful-paint/
+ * @see https://web.dev/largest-contentful-paint
+ */
 class LargestContentfulPaint extends ComputedMetric {
   /**
    * @param {LH.Artifacts.MetricComputationData} data

--- a/lighthouse-core/computed/metrics/largest-contentful-paint.js
+++ b/lighthouse-core/computed/metrics/largest-contentful-paint.js
@@ -11,7 +11,7 @@ const LHError = require('../../lib/lh-error.js');
 
 /**
  * @fileoverview Computed Largest Contentful Paint (LCP), the paint time of the largest in-viewport contentful element
- * COMPAT: LCP's trace event was first introduced in m78. We can't surface an FCP for older Chrome versions
+ * COMPAT: LCP's trace event was first introduced in m78. We can't surface an LCP for older Chrome versions
  * @see https://github.com/WICG/largest-contentful-paint
  * @see https://wicg.github.io/largest-contentful-paint/
  * @see https://web.dev/largest-contentful-paint

--- a/lighthouse-core/lib/tracehouse/trace-processor.js
+++ b/lighthouse-core/lib/tracehouse/trace-processor.js
@@ -524,6 +524,7 @@ class TraceProcessor {
       firstMeaningfulPaint = lastCandidate;
     }
 
+    // LCP's trace event was first introduced in m78. We can't surface an FCP for older Chrome versions
     // LCP comes from the latest `largestContentfulPaint::Candidate`, but it can be invalidated
     // by a `largestContentfulPaint::Invalidate` event. In the case that the last candidate is
     // invalidated, the value will be undefined.

--- a/lighthouse-core/lib/tracehouse/trace-processor.js
+++ b/lighthouse-core/lib/tracehouse/trace-processor.js
@@ -524,7 +524,7 @@ class TraceProcessor {
       firstMeaningfulPaint = lastCandidate;
     }
 
-    // LCP's trace event was first introduced in m78. We can't surface an FCP for older Chrome versions
+    // LCP's trace event was first introduced in m78. We can't surface an LCP for older Chrome versions
     // LCP comes from the latest `largestContentfulPaint::Candidate`, but it can be invalidated
     // by a `largestContentfulPaint::Invalidate` event. In the case that the last candidate is
     // invalidated, the value will be undefined.


### PR DESCRIPTION
i confirmed lcp was added in 78
(the [commit](https://chromium.googlesource.com/chromium/src/+/e7a0a11a0e6fbc429fe1daa82ed93724b3a5fd13) landed as r687032, which i dropped into the _Find Releases_ tool at https://omahaproxy.appspot.com/)

Just documenting that since it comes up a lot.