### PR TITLE
core(lightwallet): refactor budget matching logic

### DIFF
--- a/lighthouse-core/audits/performance-budget.js
+++ b/lighthouse-core/audits/performance-budget.js
@@ -124,13 +124,7 @@ class ResourceBudget extends Audit {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const summary = await ResourceSummary.request({devtoolsLog, URL: artifacts.URL}, context);
     const mainResource = await MainResource.request({URL: artifacts.URL, devtoolsLog}, context);
-    // Clones budget so that the user-supplied version is not mutated.
-    /** @type {Array<LH.Budget>} */
-    const budgets = Array.from(context.settings.budgets || []);
-    // Applies the LAST matching budget
-    const budget = budgets ? budgets.reverse().find((b) => {
-      return Budget.urlMatchesPattern(mainResource.url, b.path);
-    }) : undefined;
+    const budget = Budget.matchingBudget(context.settings.budgets, mainResource.url);
 
     if (!budget) {
       return {

--- a/lighthouse-core/audits/performance-budget.js
+++ b/lighthouse-core/audits/performance-budget.js
@@ -124,7 +124,7 @@ class ResourceBudget extends Audit {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const summary = await ResourceSummary.request({devtoolsLog, URL: artifacts.URL}, context);
     const mainResource = await MainResource.request({URL: artifacts.URL, devtoolsLog}, context);
-    const budget = Budget.matchingBudget(context.settings.budgets, mainResource.url);
+    const budget = Budget.getMatchingBudget(context.settings.budgets, mainResource.url);
 
     if (!budget) {
       return {

--- a/lighthouse-core/config/budget.js
+++ b/lighthouse-core/config/budget.js
@@ -133,6 +133,25 @@ class Budget {
   }
 
   /**
+   * Returns the budget that applies to a given URL.
+   * If multiple budgets match based on thier 'path' property,
+   * then the last-listed of those budgets is returned.
+   * @param {Array<LH.Budget>|null} budgets
+   * @param {string} url
+   * @return {LH.Budget | undefined} budget
+   */
+  static matchingBudget(budgets, url) {
+    // Clones budget so that the user-supplied version is not mutated.
+    /** @type {Array<LH.Budget>} */
+    const clonedBudgets = JSON.parse(JSON.stringify(budgets || []));
+
+    // Applies the LAST matching budget
+    return clonedBudgets ? clonedBudgets.reverse().find((b) => {
+      return Budget.urlMatchesPattern(url, b.path);
+    }) : undefined;
+  }
+
+  /**
    * Determines whether a URL matches against a robots.txt-style "path".
    * Pattern should use the robots.txt format. E.g. "/*-article.html" or "/". Reference:
    * https://developers.google.com/search/reference/robots_txt#url-matching-based-on-path-values

--- a/lighthouse-core/config/budget.js
+++ b/lighthouse-core/config/budget.js
@@ -146,9 +146,9 @@ class Budget {
     const clonedBudgets = JSON.parse(JSON.stringify(budgets || []));
 
     // Applies the LAST matching budget
-    return clonedBudgets ? clonedBudgets.reverse().find((b) => {
+    return clonedBudgets.reverse().find((b) => {
       return Budget.urlMatchesPattern(url, b.path);
-    }) : undefined;
+    });
   }
 
   /**

--- a/lighthouse-core/config/budget.js
+++ b/lighthouse-core/config/budget.js
@@ -140,11 +140,10 @@ class Budget {
    * @param {string} url
    * @return {LH.Budget | undefined} budget
    */
-  static matchingBudget(budgets, url) {
+  static getMatchingBudget(budgets, url) {
     // Clones budget so that the user-supplied version is not mutated.
     /** @type {Array<LH.Budget>} */
     const clonedBudgets = JSON.parse(JSON.stringify(budgets || []));
-
     // Applies the LAST matching budget
     return clonedBudgets.reverse().find((b) => {
       return Budget.urlMatchesPattern(url, b.path);

--- a/lighthouse-core/config/budget.js
+++ b/lighthouse-core/config/budget.js
@@ -141,13 +141,15 @@ class Budget {
    * @return {LH.Budget | undefined} budget
    */
   static getMatchingBudget(budgets, url) {
-    // Clones budget so that the user-supplied version is not mutated.
-    /** @type {Array<LH.Budget>} */
-    const clonedBudgets = JSON.parse(JSON.stringify(budgets || []));
-    // Applies the LAST matching budget
-    return clonedBudgets.reverse().find((b) => {
-      return Budget.urlMatchesPattern(url, b.path);
-    });
+    if (budgets === null) return;
+
+    // Applies the LAST matching budget.
+    for (let i = budgets.length - 1; i >= 0; i--) {
+      const budget = budgets[i];
+      if (this.urlMatchesPattern(url, budget.path)) {
+        return budget;
+      }
+    }
   }
 
   /**

--- a/lighthouse-core/test/audits/performance-budget-test.js
+++ b/lighthouse-core/test/audits/performance-budget-test.js
@@ -167,18 +167,6 @@ describe('Performance: Resource budgets audit', () => {
       });
     });
 
-    describe('without a budget.json', () => {
-      beforeEach(() => {
-        context.settings.budgets = null;
-      });
-
-      it('returns "audit does not apply"', async () => {
-        const result = await ResourceBudgetAudit.audit(artifacts, context);
-        expect(result.details).toBeUndefined();
-        expect(result.notApplicable).toBe(true);
-      });
-    });
-
     describe('without a matching budget', () => {
       it('returns "audit does not apply"', async () => {
         context.settings.budgets = [{
@@ -191,6 +179,18 @@ describe('Performance: Resource budgets audit', () => {
           ],
         },
         ];
+        const result = await ResourceBudgetAudit.audit(artifacts, context);
+        expect(result.details).toBeUndefined();
+        expect(result.notApplicable).toBe(true);
+      });
+    });
+
+    describe('without a budget.json', () => {
+      beforeEach(() => {
+        context.settings.budgets = null;
+      });
+
+      it('returns "audit does not apply"', async () => {
         const result = await ResourceBudgetAudit.audit(artifacts, context);
         expect(result.details).toBeUndefined();
         expect(result.notApplicable).toBe(true);

--- a/lighthouse-core/test/audits/performance-budget-test.js
+++ b/lighthouse-core/test/audits/performance-budget-test.js
@@ -131,33 +131,70 @@ describe('Performance: Resource budgets audit', () => {
     });
   });
 
-  describe('without a budget.json', () => {
-    beforeEach(() => {
-      context.settings.budgets = null;
+  describe('budget selection', () => {
+    describe('with a matching budget', () => {
+      it('applies the correct budget', async () => {
+        context.settings.budgets = [{
+          path: '/',
+          resourceSizes: [
+            {
+              resourceType: 'script',
+              budget: 0,
+            },
+          ],
+        },
+        {
+          path: '/file.html',
+          resourceSizes: [
+            {
+              resourceType: 'image',
+              budget: 0,
+            },
+          ],
+        },
+        {
+          path: '/not-a-match',
+          resourceSizes: [
+            {
+              resourceType: 'document',
+              budget: 0,
+            },
+          ],
+        },
+        ];
+        const result = await ResourceBudgetAudit.audit(artifacts, context);
+        expect(result.details.items[0].resourceType).toBe('image');
+      });
     });
 
-    it('audit does not apply', async () => {
-      const result = await ResourceBudgetAudit.audit(artifacts, context);
-      expect(result.details).toBeUndefined();
-      expect(result.notApplicable).toBe(true);
-    });
-  });
+    describe('without a budget.json', () => {
+      beforeEach(() => {
+        context.settings.budgets = null;
+      });
 
-  describe('with no matching budget', () => {
-    it('returns "audit does not apply"', async () => {
-      context.settings.budgets = [{
-        path: '/not-a-match',
-        resourceSizes: [
-          {
-            resourceType: 'script',
-            budget: 0,
-          },
-        ],
-      },
-      ];
-      const result = await ResourceBudgetAudit.audit(artifacts, context);
-      expect(result.details).toBeUndefined();
-      expect(result.notApplicable).toBe(true);
+      it('returns "audit does not apply"', async () => {
+        const result = await ResourceBudgetAudit.audit(artifacts, context);
+        expect(result.details).toBeUndefined();
+        expect(result.notApplicable).toBe(true);
+      });
+    });
+
+    describe('without a matching budget', () => {
+      it('returns "audit does not apply"', async () => {
+        context.settings.budgets = [{
+          path: '/not-a-match',
+          resourceSizes: [
+            {
+              resourceType: 'script',
+              budget: 0,
+            },
+          ],
+        },
+        ];
+        const result = await ResourceBudgetAudit.audit(artifacts, context);
+        expect(result.details).toBeUndefined();
+        expect(result.notApplicable).toBe(true);
+      });
     });
   });
 });

--- a/lighthouse-core/test/config/budget-test.js
+++ b/lighthouse-core/test/config/budget-test.js
@@ -243,6 +243,11 @@ describe('Budget', () => {
       budgets[0].path = '/updated';
       expect(budget.path).toEqual('/');
     });
+
+    it('returns "undefined" when there is no budget config', () => {
+      const budget = Budget.matchingBudget(null, 'https://example.com');
+      expect(budget).toEqual(undefined);
+    });
   });
 
   describe('path validation', () => {

--- a/lighthouse-core/test/config/budget-test.js
+++ b/lighthouse-core/test/config/budget-test.js
@@ -227,25 +227,25 @@ describe('Budget', () => {
     },
     ];
     it('returns the last matching budget', () => {
-      const budget = Budget.matchingBudget(budgets, 'http://example.com/file.html');
+      const budget = Budget.getMatchingBudget(budgets, 'http://example.com/file.html');
       expect(budget).toEqual(budgets[1]);
     });
 
     it('does not mutate the budget config', async () => {
       const configBefore = JSON.parse(JSON.stringify(budgets));
-      Budget.matchingBudget(configBefore, 'https://example.com');
+      Budget.getMatchingBudget(configBefore, 'https://example.com');
       const configAfter = JSON.parse(JSON.stringify(budgets));
       expect(configBefore).toEqual(configAfter);
     });
 
     it('returns a copy of the matching budget', () => {
-      const budget = Budget.matchingBudget(budgets, 'https://example.com');
+      const budget = Budget.getMatchingBudget(budgets, 'https://example.com');
       budgets[0].path = '/updated';
       expect(budget.path).toEqual('/');
     });
 
     it('returns "undefined" when there is no budget config', () => {
-      const budget = Budget.matchingBudget(null, 'https://example.com');
+      const budget = Budget.getMatchingBudget(null, 'https://example.com');
       expect(budget).toEqual(undefined);
     });
   });

--- a/lighthouse-core/test/config/budget-test.js
+++ b/lighthouse-core/test/config/budget-test.js
@@ -238,12 +238,6 @@ describe('Budget', () => {
       expect(configBefore).toEqual(configAfter);
     });
 
-    it('returns a copy of the matching budget', () => {
-      const budget = Budget.getMatchingBudget(budgets, 'https://example.com');
-      budgets[0].path = '/updated';
-      expect(budget.path).toEqual('/');
-    });
-
     it('returns "undefined" when there is no budget config', () => {
       const budget = Budget.getMatchingBudget(null, 'https://example.com');
       expect(budget).toEqual(undefined);

--- a/lighthouse-core/test/config/budget-test.js
+++ b/lighthouse-core/test/config/budget-test.js
@@ -197,6 +197,54 @@ describe('Budget', () => {
     });
   });
 
+  describe('budget matching', () => {
+    const budgets = [{
+      path: '/',
+      resourceSizes: [
+        {
+          resourceType: 'script',
+          budget: 0,
+        },
+      ],
+    },
+    {
+      path: '/file.html',
+      resourceSizes: [
+        {
+          resourceType: 'image',
+          budget: 0,
+        },
+      ],
+    },
+    {
+      path: '/not-a-match',
+      resourceSizes: [
+        {
+          resourceType: 'document',
+          budget: 0,
+        },
+      ],
+    },
+    ];
+    it('returns the last matching budget', () => {
+      const budget = Budget.matchingBudget(budgets, 'http://example.com/file.html');
+      expect(budget).toEqual(budgets[1]);
+    });
+
+    it('does not mutate the budget config', async () => {
+      const configBefore = JSON.parse(JSON.stringify(budgets));
+      Budget.matchingBudget(configBefore, 'https://example.com');
+      const configAfter = JSON.parse(JSON.stringify(budgets));
+      expect(configBefore).toEqual(configAfter);
+    });
+
+    it('returns a copy of the matching budget', () => {
+      const budget = Budget.matchingBudget(budgets, 'https://example.com');
+      budgets[0].path = '/updated';
+      expect(budget.path).toEqual('/');
+    });
+  });
+
   describe('path validation', () => {
     it('recognizes valid budgets', () => {
       let budgets = [{path: '/'}];


### PR DESCRIPTION
**Summary**
- Moves the logic for determining the matching budget to `budget.js`. In a subsequent PR, the `'performance-budget'` audit will be split into `'resource-budget'` and `'timing-budget`', so this refactor allows the logic to be re-used across both audits.
- Minor fix: Use deep copy instead of shallow copy when finding matching budget.