### PR TITLE
deps: bump chrome-launcher to 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
   },
   "dependencies": {
     "axe-core": "3.3.0",
-    "chrome-launcher": "^0.11.2",
+    "chrome-launcher": "^0.12.0",
     "configstore": "^3.1.1",
     "cssstyle": "1.2.1",
     "details-element-polyfill": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1728,10 +1728,10 @@ chownr@^1.0.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
-chrome-launcher@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.11.2.tgz#c9a248dbccd3a08565553acf61adff879bcc982c"
-  integrity sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==
+chrome-launcher@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.12.0.tgz#08db81ef0f7b283c331df2c350e780c38bd0ce3a"
+  integrity sha512-rBUP4tvWToiileDi3UR0SbWKoUoDCYTRmVND2sdoBL1xANBgVz8V9h1yQluj3MEQaBJg0fRw7hW82uOPrJus7A==
   dependencies:
     "@types/node" "*"
     is-wsl "^2.1.0"


### PR DESCRIPTION
changes:

* `66a5e226` flags: add new --disable flags to reduce noise and disable backgrounding ([#170](https://github.com/GoogleChrome/chrome-launcher/pull/170))
  - --disable-component-extensions-with-background-pages
  - --disable-backgrounding-occluded-windows
  - --disable-renderer-backgrounding
  - --disable-background-timer-throttling
* `c4890ee3` feat: expose public interface for locating Chrome installations ([#177](https://github.com/GoogleChrome/chrome-launcher/pull/177))
  - `Launcher.getInstallations()` returns an array of paths to available Chrome binaries
* `a5ccaa4e` deps: update assorted dependencies ([#175](https://github.com/GoogleChrome/chrome-launcher/pull/175))
* `e67a10df` --disable-translation is now --disable-features=TranslateUI ([#167](https://github.com/GoogleChrome/chrome-launcher/pull/167))


----------

The first commit should improve testing reliability (in the CLI case).

- Described mostly here: https://blog.bigbinary.com/2018/08/15/debugging-failing-tests-in-background-tab-in-puppeteer.html
- Brings us more inline with pptr: https://github.com/GoogleChrome/puppeteer/blame/master/lib/Launcher.js
- test page for occlusion and timer drift: https://output.jsbin.com/goduxox/1/quiet

with these new flags:

- timers are no longer throttled when occluded or in a background tab
- the page visibility api/events are unaffected (still works the same)
- renderer continues to paint  when the window is occluded (on mac it normally doesn't)
- however renderer continues to not paint when the tab is backgrounded.