### PR TITLE
report: adjust score's arc length accounting for rounded linecap

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -335,13 +335,20 @@ class CategoryRenderer {
     // Cast `null` to 0
     const numericScore = Number(category.score);
     const gauge = this.dom.find('.lh-gauge', tmpl);
-    // 352 is ~= 2 * Math.PI * gauge radius (56)
-    // https://codepen.io/xgad/post/svg-radial-progress-meters
-    // score of 50: `stroke-dasharray: 176 352`;
     /** @type {?SVGCircleElement} */
     const gaugeArc = gauge.querySelector('.lh-gauge-arc');
+
     if (gaugeArc) {
-      gaugeArc.style.strokeDasharray = `${numericScore * 352} 352`;
+      const circumferencePx = 2 * Math.PI * Number(gaugeArc.getAttribute('r'));
+      // The rounded linecap of the stroke extends the arc past its start & end.
+      // First, we tweak the -90deg rotation to adjust
+      const strokeWidthPx = Number(gaugeArc.getAttribute('stroke-width'));
+      const rotationalAdjustmentPercent = 0.5 * strokeWidthPx / circumferencePx;
+      gaugeArc.style.transform = `rotate(${-90 + rotationalAdjustmentPercent * 360}deg)`;
+      // Then, we terminate the line a little early as well.
+      const arcLengthPx = numericScore * circumferencePx - strokeWidthPx;
+      // Credit to xgad for the technique: https://codepen.io/xgad/post/svg-radial-progress-meters
+      gaugeArc.style.strokeDasharray = `${Math.max(arcLengthPx, 0)} ${circumferencePx}`;
     }
 
     const scoreOutOf100 = Math.round(numericScore * 100);

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -353,7 +353,8 @@ class CategoryRenderer {
   }
 
   /**
-   *
+   * Define the score arc of the gauge
+   * Credit to xgad for the original technique: https://codepen.io/xgad/post/svg-radial-progress-meters
    * @param {SVGCircleElement} elem
    * @param {number} percent
    */
@@ -364,14 +365,13 @@ class CategoryRenderer {
     const strokeWidthPx = Number(elem.getAttribute('stroke-width'));
     const rotationalAdjustmentPercent = 0.25 * strokeWidthPx / circumferencePx;
     elem.style.transform = `rotate(${-90 + rotationalAdjustmentPercent * 360}deg)`;
+
     // Then, we terminate the line a little early as well.
     let arcLengthPx = percent * circumferencePx - strokeWidthPx / 2;
-
     // Special cases. No dot for 0, and full ring if 100
     if (percent === 0) elem.style.opacity = '0';
     if (percent === 1) arcLengthPx += strokeWidthPx / 2;
 
-    // Credit to xgad for the technique: https://codepen.io/xgad/post/svg-radial-progress-meters
     elem.style.strokeDasharray = `${Math.max(arcLengthPx, 0)} ${circumferencePx}`;
   }
 

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -355,24 +355,24 @@ class CategoryRenderer {
   /**
    * Define the score arc of the gauge
    * Credit to xgad for the original technique: https://codepen.io/xgad/post/svg-radial-progress-meters
-   * @param {SVGCircleElement} elem
+   * @param {SVGCircleElement} arcElem
    * @param {number} percent
    */
-  _setGaugeArc(elem, percent) {
-    const circumferencePx = 2 * Math.PI * Number(elem.getAttribute('r'));
+  _setGaugeArc(arcElem, percent) {
+    const circumferencePx = 2 * Math.PI * Number(arcElem.getAttribute('r'));
     // The rounded linecap of the stroke extends the arc past its start and end.
     // First, we tweak the -90deg rotation to adjust
-    const strokeWidthPx = Number(elem.getAttribute('stroke-width'));
+    const strokeWidthPx = Number(arcElem.getAttribute('stroke-width'));
     const rotationalAdjustmentPercent = 0.25 * strokeWidthPx / circumferencePx;
-    elem.style.transform = `rotate(${-90 + rotationalAdjustmentPercent * 360}deg)`;
+    arcElem.style.transform = `rotate(${-90 + rotationalAdjustmentPercent * 360}deg)`;
 
     // Then, we terminate the line a little early as well.
     let arcLengthPx = percent * circumferencePx - strokeWidthPx / 2;
     // Special cases. No dot for 0, and full ring if 100
-    if (percent === 0) elem.style.opacity = '0';
+    if (percent === 0) arcElem.style.opacity = '0';
     if (percent === 1) arcLengthPx = circumferencePx;
 
-    elem.style.strokeDasharray = `${Math.max(arcLengthPx, 0)} ${circumferencePx}`;
+    arcElem.style.strokeDasharray = `${Math.max(arcLengthPx, 0)} ${circumferencePx}`;
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -362,10 +362,15 @@ class CategoryRenderer {
     // The rounded linecap of the stroke extends the arc past its start & end.
     // First, we tweak the -90deg rotation to adjust
     const strokeWidthPx = Number(elem.getAttribute('stroke-width'));
-    const rotationalAdjustmentPercent = 0.5 * strokeWidthPx / circumferencePx;
+    const rotationalAdjustmentPercent = 0.5 * 0.5 * strokeWidthPx / circumferencePx;
     elem.style.transform = `rotate(${-90 + rotationalAdjustmentPercent * 360}deg)`;
     // Then, we terminate the line a little early as well.
-    const arcLengthPx = percent * circumferencePx - strokeWidthPx;
+    let arcLengthPx = percent * circumferencePx - strokeWidthPx / 4;
+
+    // Special cases. No dot for 0, and full ring if 100
+    if (percent === 0) elem.style.opacity = '0';
+    if (percent === 1) arcLengthPx += strokeWidthPx / 2;
+
     // Credit to xgad for the technique: https://codepen.io/xgad/post/svg-radial-progress-meters
     elem.style.strokeDasharray = `${Math.max(arcLengthPx, 0)} ${circumferencePx}`;
   }

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -361,7 +361,7 @@ class CategoryRenderer {
   _setGaugeArc(arcElem, percent) {
     const circumferencePx = 2 * Math.PI * Number(arcElem.getAttribute('r'));
     // The rounded linecap of the stroke extends the arc past its start and end.
-    // First, we tweak the -90deg rotation to adjust
+    // First, we tweak the -90deg rotation to start exactly at the top of the circle.
     const strokeWidthPx = Number(arcElem.getAttribute('stroke-width'));
     const rotationalAdjustmentPercent = 0.25 * strokeWidthPx / circumferencePx;
     arcElem.style.transform = `rotate(${-90 + rotationalAdjustmentPercent * 360}deg)`;

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -338,18 +338,7 @@ class CategoryRenderer {
     /** @type {?SVGCircleElement} */
     const gaugeArc = gauge.querySelector('.lh-gauge-arc');
 
-    if (gaugeArc) {
-      const circumferencePx = 2 * Math.PI * Number(gaugeArc.getAttribute('r'));
-      // The rounded linecap of the stroke extends the arc past its start & end.
-      // First, we tweak the -90deg rotation to adjust
-      const strokeWidthPx = Number(gaugeArc.getAttribute('stroke-width'));
-      const rotationalAdjustmentPercent = 0.5 * strokeWidthPx / circumferencePx;
-      gaugeArc.style.transform = `rotate(${-90 + rotationalAdjustmentPercent * 360}deg)`;
-      // Then, we terminate the line a little early as well.
-      const arcLengthPx = numericScore * circumferencePx - strokeWidthPx;
-      // Credit to xgad for the technique: https://codepen.io/xgad/post/svg-radial-progress-meters
-      gaugeArc.style.strokeDasharray = `${Math.max(arcLengthPx, 0)} ${circumferencePx}`;
-    }
+    if (gaugeArc) this._setGaugeArc(gaugeArc, numericScore);
 
     const scoreOutOf100 = Math.round(numericScore * 100);
     const percentageEl = this.dom.find('.lh-gauge__percentage', tmpl);
@@ -361,6 +350,24 @@ class CategoryRenderer {
 
     this.dom.find('.lh-gauge__label', tmpl).textContent = category.title;
     return tmpl;
+  }
+
+  /**
+   *
+   * @param {SVGCircleElement} elem
+   * @param {number} percent
+   */
+  _setGaugeArc(elem, percent) {
+    const circumferencePx = 2 * Math.PI * Number(elem.getAttribute('r'));
+    // The rounded linecap of the stroke extends the arc past its start & end.
+    // First, we tweak the -90deg rotation to adjust
+    const strokeWidthPx = Number(elem.getAttribute('stroke-width'));
+    const rotationalAdjustmentPercent = 0.5 * strokeWidthPx / circumferencePx;
+    elem.style.transform = `rotate(${-90 + rotationalAdjustmentPercent * 360}deg)`;
+    // Then, we terminate the line a little early as well.
+    const arcLengthPx = percent * circumferencePx - strokeWidthPx;
+    // Credit to xgad for the technique: https://codepen.io/xgad/post/svg-radial-progress-meters
+    elem.style.strokeDasharray = `${Math.max(arcLengthPx, 0)} ${circumferencePx}`;
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -370,7 +370,7 @@ class CategoryRenderer {
     let arcLengthPx = percent * circumferencePx - strokeWidthPx / 2;
     // Special cases. No dot for 0, and full ring if 100
     if (percent === 0) elem.style.opacity = '0';
-    if (percent === 1) arcLengthPx += strokeWidthPx / 2;
+    if (percent === 1) arcLengthPx = circumferencePx;
 
     elem.style.strokeDasharray = `${Math.max(arcLengthPx, 0)} ${circumferencePx}`;
   }

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -360,7 +360,7 @@ class CategoryRenderer {
    */
   _setGaugeArc(elem, percent) {
     const circumferencePx = 2 * Math.PI * Number(elem.getAttribute('r'));
-    // The rounded linecap of the stroke extends the arc past its start & end.
+    // The rounded linecap of the stroke extends the arc past its start and end.
     // First, we tweak the -90deg rotation to adjust
     const strokeWidthPx = Number(elem.getAttribute('stroke-width'));
     const rotationalAdjustmentPercent = 0.25 * strokeWidthPx / circumferencePx;

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -362,10 +362,10 @@ class CategoryRenderer {
     // The rounded linecap of the stroke extends the arc past its start & end.
     // First, we tweak the -90deg rotation to adjust
     const strokeWidthPx = Number(elem.getAttribute('stroke-width'));
-    const rotationalAdjustmentPercent = 0.5 * 0.5 * strokeWidthPx / circumferencePx;
+    const rotationalAdjustmentPercent = 0.25 * strokeWidthPx / circumferencePx;
     elem.style.transform = `rotate(${-90 + rotationalAdjustmentPercent * 360}deg)`;
     // Then, we terminate the line a little early as well.
-    let arcLengthPx = percent * circumferencePx - strokeWidthPx / 4;
+    let arcLengthPx = percent * circumferencePx - strokeWidthPx / 2;
 
     // Special cases. No dot for 0, and full ring if 100
     if (percent === 0) elem.style.opacity = '0';

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1064,13 +1064,12 @@
 .lh-gauge-base {
     opacity: 0.1;
     stroke: var(--circle-background);
-    stroke-width: var(--circle-border-width);
 }
 
 .lh-gauge-arc {
     fill: none;
     stroke: var(--circle-color);
-    stroke-width: var(--circle-border-width);
+    transform-origin: 50% 50%;
     animation: load-gauge var(--transition-length) ease forwards;
     animation-delay: 250ms;
 }
@@ -1134,7 +1133,6 @@
   text-decoration: none;
   padding: var(--score-container-padding);
 
-  --circle-border-width: 8;
   --transition-length: 1s;
 
   /* Contain the layout style paint & layers during animation*/

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -565,8 +565,8 @@ limitations under the License.
     <!-- Wrapper exists for the ::before plugin icon. Cannot create pseudo-elements on svgs. -->
     <div class="lh-gauge__svg-wrapper">
       <svg viewBox="0 0 120 120" class="lh-gauge">
-        <circle class="lh-gauge-base" r="56" cx="60" cy="60"></circle>
-        <circle class="lh-gauge-arc" transform="rotate(-90 60 60)" r="56" cx="60" cy="60"></circle>
+        <circle class="lh-gauge-base" r="56" cx="60" cy="60" stroke-width="8"></circle>
+        <circle class="lh-gauge-arc"  r="56" cx="60" cy="60" stroke-width="8"></circle>
       </svg>
     </div>
     <div class="lh-gauge__percentage"></div>


### PR DESCRIPTION


I noticed that with the rounded [linecap](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap), the arc visually extends farther than it really should.

![image](https://user-images.githubusercontent.com/39191/68079505-fc8d5f80-fda7-11e9-8a1d-d05a18f46ee3.png)

So here's the proper adjustment. After this change, the arc shortens up a little bit on both ends.

partial fix of #9803

----------------


**UPDATE.** I tweaked the math.. the arcs now go halfway between the two cases above.
![image](https://user-images.githubusercontent.com/39191/68153687-d1ffeb80-fefa-11e9-8a40-c74ff60a4ef2.png)



GIF of before and after (updated):
![Kapture 2019-11-04 at 11 59 19](https://user-images.githubusercontent.com/39191/68153568-9107d700-fefa-11e9-8723-6eda1562e120.gif)

