### PR TITLE
docs: update plugin list to include all examples

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -352,4 +352,7 @@ Most artifacts will try to represent as truthfully as possible what was observed
 
 - [Field Performance](https://github.com/treosh/lighthouse-plugin-field-performance) - A plugin to gather and display Chrome UX Report field data
 - [Publisher Ads Audits](https://github.com/googleads/pub-ads-lighthouse-plugin) - a well-written, but complex, plugin
+- [Green Web Foundation](https://github.com/thegreenwebfoundation/lighthouse-plugin-greenhouse) - A plugin to see which domains run on renewable power. 
+- [requests-content-md5](https://www.npmjs.com/package/lighthouse-plugin-md5) - A plugin to help you generate network requests content md5 and set in resource-content-md5 audit.
+- [Cinememe Plugin](https://github.com/exterkamp/lighthouse-plugin-cinememe) - Lighthouse plugin to find dank cinememes in a page.
 - [Lighthouse Plugin Recipe](./recipes/lighthouse-plugin-example)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -350,10 +350,11 @@ Most artifacts will try to represent as truthfully as possible what was observed
 
 ## Examples
 
-- [Lighthouse Plugin Recipe](./recipes/lighthouse-plugin-example)
-- [Cinememe Plugin](https://github.com/exterkamp/lighthouse-plugin-cinememe) - Lighthouse plugin to find dank cinememes in a page.
+- [Cinememe Plugin](https://github.com/exterkamp/lighthouse-plugin-cinememe) - Find and reward dank cinememes (5MB+ animated GIFs ;)
 - [YouTube Embed](https://github.com/connorjclark/lighthouse-plugin-yt) - Identifies YouTube embeds
+- [Lighthouse Plugin Recipe](./recipes/lighthouse-plugin-example)
 - [Field Performance](https://github.com/treosh/lighthouse-plugin-field-performance) - A plugin to gather and display Chrome UX Report field data
+- [AMP Plugin](https://github.com/ampproject/amp-toolbox/tree/master/packages/lighthouse-plugin-amp) - Runs pages through the AMP validator.
 - [Publisher Ads Audits](https://github.com/googleads/pub-ads-lighthouse-plugin) - a well-written, but complex, plugin
 - [Green Web Foundation](https://github.com/thegreenwebfoundation/lighthouse-plugin-greenhouse) - A plugin to see which domains run on renewable power. 
 - [requests-content-md5](https://www.npmjs.com/package/lighthouse-plugin-md5) - Generates MD5 hashes from the content of network requests..

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -350,9 +350,11 @@ Most artifacts will try to represent as truthfully as possible what was observed
 
 ## Examples
 
+- [Lighthouse Plugin Recipe](./recipes/lighthouse-plugin-example)
+- [Cinememe Plugin](https://github.com/exterkamp/lighthouse-plugin-cinememe) - Lighthouse plugin to find dank cinememes in a page.
+- [YouTube Embed](https://github.com/connorjclark/lighthouse-plugin-yt) - Identifies YouTube embeds
 - [Field Performance](https://github.com/treosh/lighthouse-plugin-field-performance) - A plugin to gather and display Chrome UX Report field data
 - [Publisher Ads Audits](https://github.com/googleads/pub-ads-lighthouse-plugin) - a well-written, but complex, plugin
 - [Green Web Foundation](https://github.com/thegreenwebfoundation/lighthouse-plugin-greenhouse) - A plugin to see which domains run on renewable power. 
-- [requests-content-md5](https://www.npmjs.com/package/lighthouse-plugin-md5) - A plugin to help you generate network requests content md5 and set in resource-content-md5 audit.
-- [Cinememe Plugin](https://github.com/exterkamp/lighthouse-plugin-cinememe) - Lighthouse plugin to find dank cinememes in a page.
-- [Lighthouse Plugin Recipe](./recipes/lighthouse-plugin-example)
+- [requests-content-md5](https://www.npmjs.com/package/lighthouse-plugin-md5) - Generates MD5 hashes from the content of network requests..
+


### PR DESCRIPTION
In advance of community plugins beta launch, this change ensures that all examples are featured in our documentation and we are up to date. This will be referenced by at least one FAQ about existing plugins. This just makes the list comprehensive.
