### PR TITLE
core: delete full config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,7 +197,7 @@ The groups property controls how to visually group audits within a category. For
 
 The stock Lighthouse configurations can be extended if you only need to make small tweaks, such as adding an audit or skipping an audit, but wish to still run most of what Lighthouse offers. When adding the `extends: 'lighthouse:default'` property to your config, the default passes, audits, groups, and categories will be automatically included, allowing you modify settings or add additional audits to a pass.
 
-Please note that you can only extend from `lighthouse:default` or `lighthouse:full` using the `extends` property. Other internal configs found in the [lighthouse-core/config](https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/config) directory can be used by importing the config object from file reference, or by using the [`--preset`](https://github.com/GoogleChrome/lighthouse#cli-options) CLI flag.
+Please note that you can only extend from `lighthouse:default` using the `extends` property. Other internal configs found in the [lighthouse-core/config](https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/config) directory can be used by importing the config object from file reference, or by using the [`--preset`](https://github.com/GoogleChrome/lighthouse#cli-options) CLI flag.
 
 See [more examples below](#more-examples) to view different types of extensions in action.
 
@@ -208,7 +208,6 @@ See [more examples below](#more-examples) to view different types of extensions 
 The best examples are the ones Lighthouse uses itself! There are several reference configuration files that are maintained as part of Lighthouse.
 
 * [lighthouse-core/config/default-config.js](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/default-config.js)
-* [lighthouse-core/config/full-config.js](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/full-config.js)
 * [lighthouse-core/config/lr-desktop-config.js](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/lr-desktop-config.js)
 * [lighthouse-core/config/lr-mobile-config.js](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/lr-mobile-config.js)
 * [lighthouse-core/config/perf-config.js](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/perf-config.js)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -100,7 +100,7 @@ In order to extend the Lighthouse configuration programmatically, you need to pa
 }
 ```
 
-You can extend base configuration from either [lighthouse:default](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/default-config.js) or [lighthouse:full](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/full-config.js). Alternatively, you can build up your own configuration from scratch to have complete control.
+You can extend base configuration from [lighthouse:default](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/default-config.js), or you can build up your own configuration from scratch to have complete control.
 
 For more information on the types of config you can provide, see [Lighthouse Configuration](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md).
 

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -155,7 +155,7 @@ function getFlags(manualArgv) {
       .choices('output', printer.getValidOutputOptions())
       .choices('emulated-form-factor', ['mobile', 'desktop', 'none'])
       .choices('throttling-method', ['devtools', 'provided', 'simulate'])
-      .choices('preset', ['full', 'perf', 'mixed-content'])
+      .choices('preset', ['perf', 'mixed-content'])
       // force as an array
       // note MUST use camelcase versions or only the kebab-case version will be forced
       .array('blockedUrlPatterns')

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -84,8 +84,8 @@ describe('CLI bin', function() {
     });
 
     it('should load the config from the preset', async () => {
-      cliFlags = {...cliFlags, preset: 'full'};
-      const actualConfig = require('../../../lighthouse-core/config/full-config.js');
+      cliFlags = {...cliFlags, preset: 'mixed-content'};
+      const actualConfig = require('../../../lighthouse-core/config/mixed-content-config.js');
       await bin.begin();
 
       expect(getRunLighthouseArgs()[2]).toEqual(actualConfig);

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/byte-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/byte-config.js
@@ -10,7 +10,7 @@
  * Config file for running byte efficiency smokehouse audits.
  */
 const config = {
-  extends: 'lighthouse:full',
+  extends: 'lighthouse:default',
   settings: {
     onlyAudits: [
       'accesskeys', // run axe on the page since we've had problems with interactions

--- a/lighthouse-cli/test/smokehouse/test-definitions/lantern/lantern-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/lantern/lantern-config.js
@@ -9,7 +9,7 @@
  * Config file for running byte efficiency smokehouse audits.
  */
 module.exports = {
-  extends: 'lighthouse:full',
+  extends: 'lighthouse:default',
   settings: {
     onlyCategories: ['performance'],
     precomputedLanternData: {

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -7,7 +7,6 @@
 
 const defaultConfigPath = './default-config.js';
 const defaultConfig = require('./default-config.js');
-const fullConfig = require('./full-config.js');
 const constants = require('./constants.js');
 const i18n = require('./../lib/i18n/i18n.js');
 
@@ -314,12 +313,8 @@ class Config {
     // We don't want to mutate the original config object
     configJSON = deepCloneConfigJson(configJSON);
 
-    // Extend the default or full config if specified
-    if (configJSON.extends === 'lighthouse:full') {
-      const explodedFullConfig = Config.extendConfigJSON(deepCloneConfigJson(defaultConfig),
-          deepCloneConfigJson(fullConfig));
-      configJSON = Config.extendConfigJSON(explodedFullConfig, configJSON);
-    } else if (configJSON.extends) {
+    // Extend the default config if specified
+    if (configJSON.extends) {
       configJSON = Config.extendConfigJSON(deepCloneConfigJson(defaultConfig), configJSON);
     }
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -556,7 +556,7 @@ describe('Config', () => {
     assert.deepStrictEqual(config.settings.output, ['html']);
   });
 
-  it('extends the full config', () => {
+  it('extends the config', () => {
     class CustomAudit extends Audit {
       static get meta() {
         return {
@@ -574,7 +574,7 @@ describe('Config', () => {
     }
 
     const config = new Config({
-      extends: 'lighthouse:full',
+      extends: 'lighthouse:default',
       audits: [
         CustomAudit,
       ],
@@ -628,7 +628,7 @@ describe('Config', () => {
   it('merges settings with correct priority', () => {
     const config = new Config(
       {
-        extends: 'lighthouse:full',
+        extends: 'lighthouse:default',
         settings: {
           disableStorageReset: true,
           emulatedFormFactor: 'mobile',

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -556,6 +556,12 @@ describe('Config', () => {
     assert.deepStrictEqual(config.settings.output, ['html']);
   });
 
+  it('does not throw on "lighthouse:full"', () => {
+    const config = new Config({extends: 'lighthouse:full'}, {output: ['html', 'json']});
+    assert.deepStrictEqual(config.settings.throttlingMethod, 'simulate');
+    assert.deepStrictEqual(config.settings.output, ['html', 'json']);
+  });
+
   it('extends the config', () => {
     class CustomAudit extends Audit {
       static get meta() {

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -14,7 +14,7 @@ declare global {
        * The pre-normalization Lighthouse Config format.
        */
       export interface Json {
-        extends?: 'lighthouse:default' | 'lighthouse:full' | string | boolean;
+        extends?: 'lighthouse:default' | string | boolean;
         settings?: SharedFlagsSettings;
         passes?: PassJson[] | null;
         audits?: Config.AuditJson[] | null;


### PR DESCRIPTION
**Summary**
per request in https://github.com/GoogleChrome/lighthouse/pull/9854#discussion_r342924896 this deletes the full config now that js coverage is part of default. we haven't had anything else to add to the full config in its 2 year existence, so seems pretty safe to remove

