### PR TITLE
docs: devtools throttling deprecation notice

### DIFF
--- a/docs/devtools-throttling-deprecation.md
+++ b/docs/devtools-throttling-deprecation.md
@@ -1,0 +1,9 @@
+# DevTools Throttling Deprecation Notice
+
+Starting with Chrome 80, Lighthouse within Chrome DevTools is deprecating the throttling configuration. To wit:
+
+1. `Simulated Throttling` will become the only option
+1. For awhile, you may also use `Applied Throttling` by unchecking the `Simulated Throttling` checkbox
+1. `No Throttling` is removed
+
+We are keeping `Applied Throttling` for now because the `View Trace` button in the report does not show a sensible trace for `Simulated Throttling`. We plan to improve the story around viewing the simulated trace in the future. At that point the `Applied Throttling` option will be removed too.

--- a/docs/devtools-throttling-deprecation.md
+++ b/docs/devtools-throttling-deprecation.md
@@ -1,9 +1,0 @@
-# DevTools Throttling Deprecation Notice
-
-Starting with Chrome 80, Lighthouse within Chrome DevTools is deprecating the throttling configuration. To wit:
-
-1. `Simulated Throttling` will become the only option
-1. For awhile, you may also use `Applied Throttling` by unchecking the `Simulated Throttling` checkbox
-1. `No Throttling` is removed
-
-We are keeping `Applied Throttling` for now because the `View Trace` button in the report does not show a sensible trace for `Simulated Throttling`. We plan to improve the story around viewing the simulated trace in the future. At that point the `Applied Throttling` option will be removed too.

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -20,18 +20,17 @@ Within web performance testing, there are four typical styles of throttling:
 
 Lighthouse, by default, uses simulated throttling as it provides both quick evaluation and minimized variance. However, some may want to experiment with more accurate throttling... [Learn more about these throttling types and how they behave in in different scenarios](https://www.debugbear.com/blog/network-throttling-methods).
 
-## Audits Panel Throttling Settings
+## DevTools' Audits Panel Throttling
 
 In Chrome 79 and earlier, you could choose between [the throttling types](#types-of-throttling) of Simulated, Applied, and none.
 
-Starting with Chrome 80, the Audits panel is simplifying the throttling configuration. To wit:
+Starting with Chrome 80, the Audits panel is simplifying the throttling configuration:
 
 1. _Simulated throttling_ remains the default setting. This matches the setup of PageSpeed Insights and the Lighthouse CLI default, so this provides cross-tool consistency.
 1. _No throttling_ is removed as it leads to innacurate scoring and misleading metric results.
 1. Within the Audits panel settings, you can uncheck the _Simulated throttling_ checkbox to use _Applied throttling_. For the moment, we are keeping this _Applied throttling_ option available for users of the [`View Trace` button](https://developers.google.com/web/updates/2018/04/devtools#traces). Under applied throttling, the trace matches the metrics values, whereas under Simulated things do not currently match up.
 
 We plan to improve the experience of viewing a trace under simulated throttling. At that point, the _Applied throttling_ option will be removed from the Audits panel. Of course, CLI users can still control the exact [configuration](../#cli-options) of throttling.
-
 
 ## How do I get packet-level throttling?
 

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -30,7 +30,7 @@ Starting with Chrome 80, the Audits panel is simplifying the throttling configur
 1. _No throttling_ is removed as it leads to innacurate scoring and misleading metric results.
 1. Within the Audits panel settings, you can uncheck the _Simulated throttling_ checkbox to use _Applied throttling_. For the moment, we are keeping this _Applied throttling_ option available for users of the [`View Trace` button](https://developers.google.com/web/updates/2018/04/devtools#traces). Under applied throttling, the trace matches the metrics values, whereas under Simulated things do not currently match up.
 
-We plan to improve the experience of viewing a trace under simulated throttling. At that point, the _Applied throttling_ option will be removed from the Audits panel. Of course, CLI users can still control the exact [configuration](../#cli-options) of throttling.
+We plan to improve the experience of viewing a trace under simulated throttling. At that point, the _Applied throttling_ option will be removed and _Simulated throttling_ will be the only option within the DevTools Audits panel. Of course, CLI users can still control the exact [configuration](../#cli-options) of throttling.
 
 ## How do I get packet-level throttling?
 

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -22,6 +22,17 @@ Lighthouse, by default, uses simulated throttling as it provides both quick eval
 
 [Learn more about these throttling types and how they behave in in different scenarios](https://www.debugbear.com/blog/network-throttling-methods).
 
+# DevTools Throttling Deprecation Notice
+
+Starting with Chrome 80, Lighthouse within Chrome DevTools is deprecating the throttling configuration. To wit:
+
+1. `Simulated Throttling` will become the only option
+1. For awhile, you may also use `Applied Throttling` by unchecking the `Simulated Throttling` checkbox
+1. `No Throttling` is removed
+
+We are keeping `Applied Throttling` for now because the `View Trace` button in the report does not show a sensible trace for `Simulated Throttling`. We plan to improve the story around viewing the simulated trace in the future. At that point the `Applied Throttling` option will be removed too.
+
+
 ## How do I get packet-level throttling?
 
 This Performance Calendar article, [Testing with Realistic Networking Conditions](https://calendar.perfplanet.com/2016/testing-with-realistic-networking-conditions/), has a good explanation of packet-level traffic shaping (which applies across TCP/UDP/ICMP) and recommendations.

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -15,7 +15,7 @@ Within web performance testing, there are four typical styles of throttling:
 
 1. **_Simulated throttling_**, which Lighthouse uses by **default**, uses a simulation of a page load, based on the data observed in the initial unthrottled load. This approach which makes it both very fast and deterministic. However, due to the imperfect nature of predicting alternate execution paths, there is inherent inaccuracy that is summarized in this doc: [Lighthouse Metric Variability and Accuracy](https://docs.google.com/document/d/1BqtL-nG53rxWOI5RO0pItSRPowZVnYJ_gBEQCJ5EeUE/edit). The TLDR: while it's roughly as accurate or better than DevTools throttling for most sites, it suffers from edge cases and a deep investigation to performance should use _Packet-level_ throttling tools.
 1. **_Request-level throttling_** , also referred to as **_Applied throttling_** in the Audits panel or _`devtools` throttling_ in Lighthouse configuration, is how throttling is implemented with Chrome DevTools. In real mobile connectivity, latency affects things at the packet level rather than the request level. As a result, this throttling isn't highly accurate. It also has a few more downsides that are summarized in [Network Throttling & Chrome - status](https://docs.google.com/document/d/1TwWLaLAfnBfbk5_ZzpGXegPapCIfyzT4MWuZgspKUAQ/edit). The TLDR: while it's a [decent approximation](https://docs.google.com/document/d/10lfVdS1iDWCRKQXPfbxEn4Or99D64mvNlugP1AQuFlE/edit), it's not a sufficient model of a slow connection. The [multipliers used in Lighthouse](https://github.com/GoogleChrome/lighthouse/blob/3be483287a530fb560c843b7299ef9cfe91ce1cc/lighthouse-core/lib/emulation.js#L33-L39) attempt to correct for the differences.
-1. **_Proxy-level_** tools do not affect UDP data, so they're decent, but not ideal.
+1. **_Proxy-level_** throttling tools do not affect UDP data, so they're decent, but not ideal.
 1. **_Packet-level_** throttling tools are able to make the most accurate network simulation. While this approach can model real network conditions most effectively, it also can introduce [more variance](https://docs.google.com/document/d/1BqtL-nG53rxWOI5RO0pItSRPowZVnYJ_gBEQCJ5EeUE/edit) than request-level or simulated throttling. [WebPageTest uses](https://github.com/WPO-Foundation/wptagent/blob/master/docs/remote_trafficshaping.md) packet-level throttling.
 
 Lighthouse, by default, uses simulated throttling as it provides both quick evaluation and minimized variance. However, some may want to experiment with more accurate throttling... [Learn more about these throttling types and how they behave in in different scenarios](https://www.debugbear.com/blog/network-throttling-methods).
@@ -26,11 +26,9 @@ In Chrome 79 and earlier, you could choose between [the throttling types](#types
 
 Starting with Chrome 80, the Audits panel is simplifying the throttling configuration. To wit:
 
-1. _Simulated throttling_ becomes the default setting. This matches the setup of PageSpeed Insights and the Lighthouse CLI default, so you should see more consistent results.
+1. _Simulated throttling_ remains the default setting. This matches the setup of PageSpeed Insights and the Lighthouse CLI default, so this provides cross-tool consistency.
 1. _No throttling_ is removed as it leads to innacurate scoring and misleading metric results.
-1. Within the Audits panel settings, you can uncheck the _Simulated throttling_ checkbox to use _Applied throttling_.
-
-For the moment, we are keeping _Applied throttling_ option available for users of the [`View Trace` button](https://developers.google.com/web/updates/2018/04/devtools#traces). Under applied throttling, the trace matches the metrics values, whereas under Simulated things do not currently match up.
+1. Within the Audits panel settings, you can uncheck the _Simulated throttling_ checkbox to use _Applied throttling_. For the moment, we are keeping this _Applied throttling_ option available for users of the [`View Trace` button](https://developers.google.com/web/updates/2018/04/devtools#traces). Under applied throttling, the trace matches the metrics values, whereas under Simulated things do not currently match up.
 
 We plan to improve the experience of viewing a trace under simulated throttling. At that point, the _Applied throttling_ option will be removed from the Audits panel. Of course, CLI users can still control the exact [configuration](../#cli-options) of throttling.
 

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -14,23 +14,25 @@ These exact figures are used as [Lighthouse's throttling default](https://github
 Within web performance testing, there are four typical styles of throttling:
 
 1. **_Simulated throttling_**, which Lighthouse uses by **default**, uses a simulation of a page load, based on the data observed in the initial unthrottled load. This approach which makes it both very fast and deterministic. However, due to the imperfect nature of predicting alternate execution paths, there is inherent inaccuracy that is summarized in this doc: [Lighthouse Metric Variability and Accuracy](https://docs.google.com/document/d/1BqtL-nG53rxWOI5RO0pItSRPowZVnYJ_gBEQCJ5EeUE/edit). The TLDR: while it's roughly as accurate or better than DevTools throttling for most sites, it suffers from edge cases and a deep investigation to performance should use _Packet-level_ throttling tools.
-1. **_Request-level_** throttling, also referred to as _DevTools throttling_ or in the Audits Panel as _Applied throttling_, is how throttling is implemented with Chrome DevTools. In real mobile connectivity, latency affects things at the packet level rather than the request level. As a result, this throttling isn't highly accurate. It also has a few more downsides that are summarized in [Network Throttling & Chrome - status](https://docs.google.com/document/d/1TwWLaLAfnBfbk5_ZzpGXegPapCIfyzT4MWuZgspKUAQ/edit). The TLDR: while it's a [decent approximation](https://docs.google.com/document/d/10lfVdS1iDWCRKQXPfbxEn4Or99D64mvNlugP1AQuFlE/edit), it's not a sufficient model of a slow connection. The [multipliers used in Lighthouse](https://github.com/GoogleChrome/lighthouse/blob/3be483287a530fb560c843b7299ef9cfe91ce1cc/lighthouse-core/lib/emulation.js#L33-L39) attempt to correct for the differences.
-1. **_Proxy-level_** throttling tools do not affect UDP data, so they're decent, but not ideal.
+1. **_Request-level throttling_** , also referred to as **_Applied throttling_** in the Audits panel or _`devtools` throttling_ in Lighthouse configuration, is how throttling is implemented with Chrome DevTools. In real mobile connectivity, latency affects things at the packet level rather than the request level. As a result, this throttling isn't highly accurate. It also has a few more downsides that are summarized in [Network Throttling & Chrome - status](https://docs.google.com/document/d/1TwWLaLAfnBfbk5_ZzpGXegPapCIfyzT4MWuZgspKUAQ/edit). The TLDR: while it's a [decent approximation](https://docs.google.com/document/d/10lfVdS1iDWCRKQXPfbxEn4Or99D64mvNlugP1AQuFlE/edit), it's not a sufficient model of a slow connection. The [multipliers used in Lighthouse](https://github.com/GoogleChrome/lighthouse/blob/3be483287a530fb560c843b7299ef9cfe91ce1cc/lighthouse-core/lib/emulation.js#L33-L39) attempt to correct for the differences.
+1. **_Proxy-level_** tools do not affect UDP data, so they're decent, but not ideal.
 1. **_Packet-level_** throttling tools are able to make the most accurate network simulation. While this approach can model real network conditions most effectively, it also can introduce [more variance](https://docs.google.com/document/d/1BqtL-nG53rxWOI5RO0pItSRPowZVnYJ_gBEQCJ5EeUE/edit) than request-level or simulated throttling. [WebPageTest uses](https://github.com/WPO-Foundation/wptagent/blob/master/docs/remote_trafficshaping.md) packet-level throttling.
 
-Lighthouse, by default, uses simulated throttling as it provides both quick evaluation and minimized variance. However, some may want to experiment with more accurate throttling...
+Lighthouse, by default, uses simulated throttling as it provides both quick evaluation and minimized variance. However, some may want to experiment with more accurate throttling... [Learn more about these throttling types and how they behave in in different scenarios](https://www.debugbear.com/blog/network-throttling-methods).
 
-[Learn more about these throttling types and how they behave in in different scenarios](https://www.debugbear.com/blog/network-throttling-methods).
+## Audits Panel Throttling Settings
 
-# DevTools Throttling Deprecation Notice
+In Chrome 79 and earlier, you could choose between [the throttling types](#types-of-throttling) of Simulated, Applied, and none.
 
-Starting with Chrome 80, Lighthouse within Chrome DevTools is deprecating the throttling configuration. To wit:
+Starting with Chrome 80, the Audits panel is simplifying the throttling configuration. To wit:
 
-1. `Simulated Throttling` will become the only option
-1. For awhile, you may also use `Applied Throttling` by unchecking the `Simulated Throttling` checkbox
-1. `No Throttling` is removed
+1. _Simulated throttling_ becomes the default setting. This matches the setup of PageSpeed Insights and the Lighthouse CLI default, so you should see more consistent results.
+1. _No throttling_ is removed as it leads to innacurate scoring and misleading metric results.
+1. Within the Audits panel settings, you can uncheck the _Simulated throttling_ checkbox to use _Applied throttling_.
 
-We are keeping `Applied Throttling` for now because the `View Trace` button in the report does not show a sensible trace for `Simulated Throttling`. We plan to improve the story around viewing the simulated trace in the future. At that point the `Applied Throttling` option will be removed too.
+For the moment, we are keeping _Applied throttling_ option available for users of the [`View Trace` button](https://developers.google.com/web/updates/2018/04/devtools#traces). Under applied throttling, the trace matches the metrics values, whereas under Simulated things do not currently match up.
+
+We plan to improve the experience of viewing a trace under simulated throttling. At that point, the _Applied throttling_ option will be removed from the Audits panel. Of course, CLI users can still control the exact [configuration](../#cli-options) of throttling.
 
 
 ## How do I get packet-level throttling?


### PR DESCRIPTION
This doc will added via a link next to the throttling option in DevTools.

CL: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/1885347