### PR TITLE
core: fix icu error thrown while throwing protocol error

### DIFF
--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -120,10 +120,7 @@ class LighthouseError extends Error {
     // if we find one, use the friendly LighthouseError definition
     const matchedErrorDefinition = protocolErrors.find(e => e.pattern.test(protocolError.message));
     if (matchedErrorDefinition) {
-      return new LighthouseError(matchedErrorDefinition, {
-        protocolMethod: method,
-        protocolError: protocolError.message,
-      });
+      return new LighthouseError(matchedErrorDefinition);
     }
 
     // otherwise fallback to building a generic Error


### PR DESCRIPTION
fixes #9882

We could probably revisit how these protocol errors are generated because this function predates all of the i18n work and most of LHError handling, but this is the easy fix for now.

All of [the LHErrors that have patterns to match](https://github.com/GoogleChrome/lighthouse/blob/91531d689f4a5f15fb310aaf8e22b4822ce1edf5/lighthouse-core/lib/lh-error.js#L314-L332) use the [same message](https://github.com/GoogleChrome/lighthouse/blob/91531d689f4a5f15fb310aaf8e22b4822ce1edf5/lighthouse-core/lib/lh-error.js#L46-L47), which doesn't have any replacements, so these arguments can safely be removed.