### PR TITLE
bundling pubads for devtools

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -100,8 +100,9 @@ async function browserifyFile(entryPath, distPath) {
 
   // HACK: manually include the lighthouse-plugin-publisher-ads audits.
   if (isDevtools(entryPath)) {
+    bundle.require('lighthouse-plugin-publisher-ads');
     pubAdsAudits.forEach(pubAdAudit => {
-      bundle = bundle.require(pubAdAudit, {expose: '../../node_modules/' + pubAdAudit});
+      bundle = bundle.require(pubAdAudit);
     });
   }
 

--- a/clients/devtools-entry.js
+++ b/clients/devtools-entry.js
@@ -40,6 +40,7 @@ function runLighthouseInWorker(port, url, flags, categoryIDs) {
   // Default to 'info' logging level.
   flags.logLevel = flags.logLevel || 'info';
   flags.channel = 'devtools';
+  global.devtools = true;
   const config = getDefaultConfigForCategories(categoryIDs);
   const connection = new RawProtocol(port);
 

--- a/lighthouse-core/config/config-helpers.js
+++ b/lighthouse-core/config/config-helpers.js
@@ -138,10 +138,14 @@ function requireAudits(audits, configDir) {
       const coreAudit = coreList.find(a => a === auditPathJs);
       let requirePath = `../audits/${audit.path}`;
       if (!coreAudit) {
-        // Otherwise, attempt to find it elsewhere. This throws if not found.
-        const absolutePath = resolveModule(audit.path, configDir, 'audit');
-        // Use a relative path so bundler can easily expose it.
-        requirePath = path.relative(__dirname, absolutePath);
+        if (global.devtools) {
+          requirePath = audit.path;
+        } else {
+          // Otherwise, attempt to find it elsewhere. This throws if not found.
+          const absolutePath = resolveModule(audit.path, configDir, 'audit');
+          // Use a relative path so bundler can easily expose it.
+          requirePath = path.relative(__dirname, absolutePath);
+        }
       }
       implementation = /** @type {typeof Audit} */ (require(requirePath));
     }

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -431,7 +431,9 @@ class Config {
     for (const pluginName of pluginNames) {
       assertValidPluginName(configJSON, pluginName);
 
-      const pluginPath = resolveModule(pluginName, configDir, 'plugin');
+      const pluginPath = global.devtools ? 
+        pluginName :
+        resolveModule(pluginName, configDir, 'plugin');
       const rawPluginJson = require(pluginPath);
       const pluginJson = ConfigPlugin.parsePlugin(rawPluginJson, pluginName);
 


### PR DESCRIPTION
Rolling this patch (combined with #9377) is confirmed to work in DevTools.

Basically, just expose plugin modules by their regular, normalized paths (sans any relative path components or `node_modules`). Then directly `require` plugins if we are in devtools (skip the custom resolving we do).

@brendankenny to figure out if this is the best approach :)