### PR TITLE
core(plugins): allow relative paths for local plugins

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -130,7 +130,7 @@ function getFlags(manualArgv) {
         'only-audits': 'Only run the specified audits',
         'only-categories': 'Only run the specified categories. Available categories: accessibility, best-practices, performance, pwa, seo',
         'skip-audits': 'Run everything except these audits',
-        'plugins': 'Run the specified plugins',
+        'plugins': 'Run the specified plugins. If plugin starts with a ".", it is loaded relative to the current directory. Otherwise, it is loaded like a node module.',
         'print-config': 'Print the normalized config for the given config and options, then exit.',
       })
       // set aliases

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -449,11 +449,11 @@ class Config {
    */
   static loadPluginJson(configJSON, pluginIdentifier, resolveLocations) {
     const {pluginName, relative} = Config.determinePluginName(pluginIdentifier);
-    const pluginPath = resolveModule(pluginIdentifier, resolveLocations, 'plugin');
 
     // We only care to assert that published plugins follow a naming convention.
     if (!relative) assertValidPluginName(configJSON, pluginName);
 
+    const pluginPath = resolveModule(pluginIdentifier, resolveLocations, 'plugin');
     const rawPluginJson = require(pluginPath);
     const pluginJson = ConfigPlugin.parsePlugin(rawPluginJson, pluginName);
 

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -424,22 +424,20 @@ class Config {
 
   /**
    * @param {string} pluginIdentifier
-   * @param {ResolveLocation[]} resolveLocations
    */
-  static determinePluginNameAndPath(pluginIdentifier, resolveLocations) {
+  static determinePluginName(pluginIdentifier) {
     const isRelativePath = pluginIdentifier.startsWith('.'); // TODO: also support absolute path?
+
     if (isRelativePath) {
       const absolutePath = path.resolve(pluginIdentifier);
       return {
         pluginName: path.basename(absolutePath),
-        pluginPath: resolveModule(pluginIdentifier, resolveLocations, 'plugin'),
         relative: true,
       };
     }
 
     return {
       pluginName: pluginIdentifier,
-      pluginPath: resolveModule(pluginIdentifier, resolveLocations, 'plugin'),
       relative: false,
     };
   }
@@ -450,7 +448,8 @@ class Config {
    * @param {ResolveLocation[]} resolveLocations
    */
   static loadPluginJson(configJSON, pluginIdentifier, resolveLocations) {
-    const {pluginName, pluginPath, relative} = Config.determinePluginNameAndPath(pluginIdentifier, resolveLocations);
+    const {pluginName, relative} = Config.determinePluginName(pluginIdentifier);
+    const pluginPath = resolveModule(pluginIdentifier, resolveLocations, 'plugin');
 
     // We only care to assert that published plugins follow a naming convention.
     if (!relative) assertValidPluginName(configJSON, pluginName);

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -756,6 +756,12 @@ describe('Config', () => {
     // Include a configPath flag so that config.js looks for the plugins in the fixtures dir.
     const configFixturePath = __dirname + '/../fixtures/config-plugins/';
 
+    function makeRelativePluginPath(pluginName) {
+      const absolutePath = path.resolve(configFixturePath, pluginName);
+      const relativePath = './' + path.relative('.', absolutePath);
+      return relativePath;
+    }
+
     it('should append audits', () => {
       const configJson = {
         audits: ['installable-manifest', 'metrics'],
@@ -856,12 +862,6 @@ describe('Config', () => {
     });
 
     it('should load plugins from the config and from passed-in flags (relative paths)', () => {
-      function makeRelativePluginPath(pluginName) {
-        const absolutePath = path.resolve(configFixturePath, pluginName);
-        const relativePath = './' + path.relative('.', absolutePath);
-        return relativePath;
-      }
-
       const baseConfigJson = {
         audits: ['installable-manifest'],
         categories: {
@@ -920,6 +920,14 @@ describe('Config', () => {
       };
       assert.throws(() => new Config(configJson, {configPath: configFixturePath}),
         /^Error: plugin name 'just-let-me-be-a-plugin' does not start with 'lighthouse-plugin-'/);
+    });
+
+    it('should not throw if the plugin name does not begin with "lighthouse-plugin-" (rel.)', () => {
+      const configJson = {
+        extends: 'lighthouse:default',
+        plugins: [makeRelativePluginPath('just-let-me-be-a-plugin')],
+      };
+      assert.doesNotThrow(() => new Config(configJson, {configPath: configFixturePath}));
     });
 
     it('should throw if the plugin name would shadow a category id', () => {

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -1129,7 +1129,7 @@ describe('Config', () => {
       assert.equal(typeof gatherer.instance.beforePass, 'function');
     });
 
-    it.only('loads a gatherer relative to a config path', () => {
+    it('loads a gatherer relative to a config path', () => {
       const config = new Config({
         passes: [{gatherers: ['../fixtures/valid-custom-gatherer']}],
       }, {configPath: __filename});

--- a/lighthouse-core/test/fixtures/config-plugins/just-let-me-be-a-plugin/package.json
+++ b/lighthouse-core/test/fixtures/config-plugins/just-let-me-be-a-plugin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "just-let-me-be-a-plugin",
+  "private": true,
+  "main": "./plugin-just-let-me-be-a-plugin.js"
+}

--- a/lighthouse-core/test/fixtures/config-plugins/just-let-me-be-a-plugin/plugin-just-let-me-be-a-plugin.js
+++ b/lighthouse-core/test/fixtures/config-plugins/just-let-me-be-a-plugin/plugin-just-let-me-be-a-plugin.js
@@ -1,0 +1,25 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/** @type {LH.Config.Plugin} */
+module.exports = {
+  groups: {
+    'new-group': {
+      title: 'New Group',
+    },
+  },
+  audits: [
+    {path: 'redirects'},
+    {path: 'user-timings'},
+  ],
+  category: {
+    title: 'Simple',
+    auditRefs: [
+      {id: 'redirects', weight: 1, group: 'new-group'},
+    ],
+  },
+};


### PR DESCRIPTION
Local plugin development is super easy now. Check it:

```
yarn lighthouse https://www.example.com/ --plugins=. 
```
