### PR TITLE
cli: allow extraHeaders as object

### DIFF
--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -107,8 +107,8 @@ async function begin() {
         ' Please use "--emulated-form-factor=none" instead.');
   }
 
-  if (cliFlags.extraHeaders) {
-    // TODO: LH.Flags.extraHeaders is actually a string at this point, but needs to be
+  if (typeof cliFlags.extraHeaders === 'string') {
+    // TODO: LH.Flags.extraHeaders is sometimes actually a string at this point, but needs to be
     // copied over to LH.Settings.extraHeaders, which is LH.Crdp.Network.Headers. Force
     // the conversion here, but long term either the CLI flag or the setting should have
     // a different name.

--- a/lighthouse-cli/test/cli/cli-flags-test.js
+++ b/lighthouse-cli/test/cli/cli-flags-test.js
@@ -40,6 +40,7 @@ describe('CLI bin', function() {
       budgetsPath: 'path/to/my/budget-from-command-line.json',
       onlyCategories: ['performance', 'seo'],
       chromeFlags: '--window-size 800,600',
+      extraHeaders: {'X-Men': 'wolverine'},
       throttlingMethod: 'devtools',
       throttling: {
         requestLatencyMs: 700,

--- a/lighthouse-cli/test/fixtures/cli-flags-path.json
+++ b/lighthouse-cli/test/fixtures/cli-flags-path.json
@@ -2,6 +2,7 @@
   "budgetPath": "path/to/my/budget-from-config.json",
   "onlyCategories": ["performance", "seo"],
   "chromeFlags": "--window-size 800,600",
+  "extraHeaders": {"X-Men": "wolverine"},
   "throttling-method": "devtools",
   "throttling": {
     "requestLatencyMs": 700,


### PR DESCRIPTION
**Summary**
The wart that was our string/object coercing of `extraHeaders` had a bug :) this allows the object form to be passed in too

**Related Issues/PRs**
fixes https://github.com/GoogleChrome/lighthouse/issues/9961
