### PR TITLE
core(artifacts): add property attribute to MetaElements

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -11,7 +11,6 @@
 <title>DoBetterWeb Mega Tester... Of Death</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="description" content="Smoke test description">
 <meta property="og:description" content="Open Graph smoke test description">
 
 <template id="links-blocking-first-paint-tmpl">

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -11,6 +11,8 @@
 <title>DoBetterWeb Mega Tester... Of Death</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="description" content="Smoke test description">
+<meta property="og:description" content="Open Graph smoke test description">
 
 <template id="links-blocking-first-paint-tmpl">
   <link rel="stylesheet" href="./dbw_tester.css?scriptActivated&delay=200"> <!-- PASS: initiator is script -->

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -136,11 +136,6 @@ const expectations = [
           property: '',
         },
         {
-          name: 'description',
-          content: 'Smoke test description',
-          property: '',
-        },
-        {
           name: '',
           content: 'Open Graph smoke test description',
           property: 'og:description',

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -128,12 +128,10 @@ const expectations = [
         {
           name: '',
           content: '',
-          property: '',
         },
         {
           name: 'viewport',
           content: 'width=device-width, initial-scale=1, minimum-scale=1',
-          property: '',
         },
         {
           name: '',

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -124,6 +124,28 @@ const expectations = [
           source: 'head',
         },
       ],
+      MetaElements: [
+        {
+          name: '',
+          content: '',
+          property: '',
+        },
+        {
+          name: 'viewport',
+          content: 'width=device-width, initial-scale=1, minimum-scale=1',
+          property: '',
+        },
+        {
+          name: 'description',
+          content: 'Smoke test description',
+          property: '',
+        },
+        {
+          name: '',
+          content: 'Open Graph smoke test description',
+          property: 'og:description',
+        },
+      ],
       TagsBlockingFirstPaint: [
         {
           tag: {

--- a/lighthouse-core/gather/gatherers/meta-elements.js
+++ b/lighthouse-core/gather/gatherers/meta-elements.js
@@ -25,6 +25,7 @@ class MetaElements extends Gatherer {
         return {
           name: meta.name.toLowerCase(),
           content: meta.content,
+          property: meta.attributes.property ? meta.attributes.property.value : '',
         };
       });
     })()`, {useIsolation: true});

--- a/lighthouse-core/gather/gatherers/meta-elements.js
+++ b/lighthouse-core/gather/gatherers/meta-elements.js
@@ -25,7 +25,7 @@ class MetaElements extends Gatherer {
         return {
           name: meta.name.toLowerCase(),
           content: meta.content,
-          property: meta.attributes.property ? meta.attributes.property.value : '',
+          property: meta.attributes.property ? meta.attributes.property.value : undefined,
         };
       });
     })()`, {useIsolation: true});

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -472,6 +472,16 @@
       "name": "viewport",
       "content": "width=device-width, initial-scale=1, minimum-scale=1",
       "property": ""
+    },
+    {
+      "name": "description",
+      "content": "Smoke test description",
+      "property": ""
+    },
+    {
+      "name": "",
+      "content": "Open Graph smoke test description",
+      "property": "og:description"
     }
   ],
   "RuntimeExceptions": [

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -465,13 +465,11 @@
   "MetaElements": [
     {
       "name": "",
-      "content": "",
-      "property": ""
+      "content": ""
     },
     {
       "name": "viewport",
-      "content": "width=device-width, initial-scale=1, minimum-scale=1",
-      "property": ""
+      "content": "width=device-width, initial-scale=1, minimum-scale=1"
     },
     {
       "name": "",

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -465,11 +465,13 @@
   "MetaElements": [
     {
       "name": "",
-      "content": ""
+      "content": "",
+      "property": ""
     },
     {
       "name": "viewport",
-      "content": "width=device-width, initial-scale=1, minimum-scale=1"
+      "content": "width=device-width, initial-scale=1, minimum-scale=1",
+      "property": ""
     }
   ],
   "RuntimeExceptions": [

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -474,11 +474,6 @@
       "property": ""
     },
     {
-      "name": "description",
-      "content": "Smoke test description",
-      "property": ""
-    },
-    {
       "name": "",
       "content": "Open Graph smoke test description",
       "property": "og:description"

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -72,7 +72,7 @@ declare global {
       /** All the link elements on the page or equivalently declared in `Link` headers. @see https://html.spec.whatwg.org/multipage/links.html */
       LinkElements: Artifacts.LinkElement[];
       /** The values of the <meta> elements in the head. */
-      MetaElements: Array<{name: string, content?: string}>;
+      MetaElements: Array<{name: string, content?: string, property?: string}>;
       /** Set of exceptions thrown during page load. */
       RuntimeExceptions: Crdp.Runtime.ExceptionThrownEvent[];
       /** Information on all script elements in the page. Also contains the content of all requested scripts and the networkRecord requestId that contained their content. Note, HTML documents will have one entry per script tag, all with the same requestId. */


### PR DESCRIPTION
**Summary**
The MetaElements artifacts contains now also de meta element attribute `property`. Now only the `name` attribute was present. The `property` attribute is often use by Open Graph meta tags. More information about `property`: https://stackoverflow.com/questions/22350105/whats-the-difference-between-meta-name-and-meta-property 

**Related Issues/PRs**
Fixes #9964 
