### PR TITLE
core(audits): Add more keywords to blocklist

### DIFF
--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -13,11 +13,16 @@ const BLOCKLIST = new Set([
   'click this',
   'go',
   'here',
-  'this',
-  'start',
-  'right here',
-  'more',
+  'information',
   'learn more',
+  'more',
+  'more info',
+  'more information',
+  'right here',
+  'read more',
+  'see more',
+  'start',
+  'this',
   // Japanese
   'ここをクリック',
   'こちらをクリック',
@@ -63,6 +68,13 @@ const BLOCKLIST = new Set([
   '계속',
   '이동',
   '전체 보기',
+  // Swedish
+  'här',
+  'klicka här',
+  'läs mer',
+  'mer',
+  'mer info',
+  'mer information'
 ]);
 const i18n = require('../../lib/i18n/i18n.js');
 

--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -74,7 +74,7 @@ const BLOCKLIST = new Set([
   'läs mer',
   'mer',
   'mer info',
-  'mer information'
+  'mer information',
 ]);
 const i18n = require('../../lib/i18n/i18n.js');
 


### PR DESCRIPTION
Adding the English keywords:

- `information`
- `more info`
- `more information`
- `read more`
- `see more`

And common Swedish terms used as link text (Google Translate links provided if you wish to confirm the meaning of the words):

- [`här`](https://translate.google.com/#view=home&op=translate&sl=sv&tl=en&text=h%C3%A4r)
-  [`klicka här`](https://translate.google.com/#view=home&op=translate&sl=sv&tl=en&text=klicka%20h%C3%A4r)
-  [`läs mer`](https://translate.google.com/#view=home&op=translate&sl=sv&tl=en&text=l%C3%A4s%20mer)
-  [`mer`](https://translate.google.com/#view=home&op=translate&sl=sv&tl=en&text=mer)
-  [`mer info`](https://translate.google.com/#view=home&op=translate&sl=sv&tl=en&text=mer%20info)
-  [`mer information`](https://translate.google.com/#view=home&op=translate&sl=sv&tl=en&text=mer%20information)
