### PR TITLE
clients(devtools): split up runLighthouseInWorker and expose to worker

### DIFF
--- a/clients/devtools-entry.js
+++ b/clients/devtools-entry.js
@@ -29,18 +29,24 @@ function getDefaultConfigForCategories(categoryIDs) {
 
 /**
  * @param {RawProtocol.Port} port
+ * @returns {RawProtocol}
+ */
+function setUpWorkerConnection(port) {
+  return new RawProtocol(port);
+}
+
+/**
  * @param {string} url
  * @param {LH.Flags} flags Lighthouse flags.
  * @param {Array<string>} categoryIDs Name values of categories to include.
+ * @param {RawProtocol} connection
  * @return {Promise<LH.RunnerResult|void>}
  */
-function runLighthouseInWorker(port, url, flags, categoryIDs) {
+function runLighthouse(url, flags, categoryIDs, connection) {
   // Default to 'info' logging level.
   flags.logLevel = flags.logLevel || 'info';
   flags.channel = 'devtools';
   const config = getDefaultConfigForCategories(categoryIDs);
-  const connection = new RawProtocol(port);
-
   return lighthouse(url, flags, config, connection);
 }
 
@@ -52,7 +58,8 @@ function listenForStatus(listenCallback) {
 if (typeof module !== 'undefined' && module.exports) {
   // export for require()ing (via browserify).
   module.exports = {
-    runLighthouseInWorker,
+    setUpWorkerConnection,
+    runLighthouse,
     listenForStatus,
     registerLocaleData,
     lookupLocale,
@@ -63,7 +70,9 @@ if (typeof module !== 'undefined' && module.exports) {
 // @ts-ignore
 if (typeof self !== 'undefined') {
   // @ts-ignore
-  self.runLighthouseInWorker = runLighthouseInWorker;
+  self.setUpWorkerConnection = setUpWorkerConnection;
+  // @ts-ignore
+  self.runLighthouse = runLighthouse;
   // @ts-ignore
   self.listenForStatus = listenForStatus;
   // @ts-ignore


### PR DESCRIPTION
To support LH localization in DevTools, this PR splits `runLighthouseInWorker` into two functions and expose them to the audits worker. The first function is `setUpWorkerConnection` which sets up and returns the connection that allows the worker to make an xhr request to the LH locale file. The second function is `runLighthouse`, which processes the configs to run lighthouse and returns the report.