### PR TITLE
deps: update axe-core to 3.4.1

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
@@ -221,8 +221,8 @@ const expectations = [
                   'type': 'node',
                   'selector': '#color-contrast',
                   'snippet': '<div id="color-contrast" style="background-color: red; color: pink;">\n          Hello\n      </div>',
-                  // Default font size is different depending on the platform (e.g. 28.5 on travis, 30.0 on Mac), so use \d\d\.\d.
-                  'explanation': /^Fix any of the following:\n {2}Element has insufficient color contrast of 2\.59 \(foreground color: #ffc0cb, background color: #ff0000, font size: \d\d\.\dpt, font weight: normal\). Expected contrast ratio of 3:1$/,
+                  // Default font size is different depending on the platform (e.g. 28.5 on travis, 30.0 on Mac), and the px-converted units may have variable precision, so use \d+.\d+.
+                  'explanation': /^Fix any of the following:\n {2}Element has insufficient color contrast of 2\.59 \(foreground color: #ffc0cb, background color: #ff0000, font size: \d+.\d+pt \(\d+.\d+px\), font weight: normal\). Expected contrast ratio of 3:1$/,
                   'nodeLabel': 'Hello',
                 },
               },
@@ -475,7 +475,7 @@ const expectations = [
                   'type': 'node',
                   'selector': '#listitem',
                   'snippet': '<li id="listitem"></li>',
-                  'explanation': 'Fix any of the following:\n  List item does not have a <ul>, <ol> or role="list" parent element',
+                  'explanation': 'Fix any of the following:\n  List item does not have a <ul>, <ol> parent element',
                   'nodeLabel': 'li',
                 },
               },

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     },
     {
       "path": "./dist/lighthouse-dt-bundle.js",
-      "maxSize": "415 kB"
+      "maxSize": "440 kB"
     },
     {
       "path": "./dist/lightrider/report-generator-bundle.js",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "typescript": "3.5.3"
   },
   "dependencies": {
-    "axe-core": "3.3.0",
+    "axe-core": "3.4.1",
     "chrome-launcher": "^0.12.0",
     "configstore": "^3.1.1",
     "cssstyle": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,10 +1157,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.0.tgz#3b32d7e54390d89ff4891b20394d33ad7a192776"
-  integrity sha512-54XaTd2VB7A6iBnXMUG2LnBOI7aRbnrVxC5Tz+rVUwYl9MX/cIJc/Ll32YUoFIE/e9UKWMZoQenQu9dFrQyZCg==
+axe-core@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.4.1.tgz#e42623918bb85b5ef674633852cb9029db0309c5"
+  integrity sha512-+EhIdwR0hF6aeMx46gFDUy6qyCfsL0DmBrV3Z+LxYbsOd8e1zBaPHa3f9Rbjsz2dEwSBkLw6TwML/CAIIAqRpw==
 
 axios@0.19.0:
   version "0.19.0"


### PR DESCRIPTION
**Summary**
Updates `axe-core==3.4.1` following its release on 2019-12-18 ([release tag](https://github.com/dequelabs/axe-core/releases/tag/v3.4.1)).