### PR TITLE
misc(travis): fix travis hang by disabling yarn GPG verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
     - node_js: "10"
     - node_js: "12"
       if: head_branch IS blank AND branch = master
+env:
+  - YARN_GPG=no
 cache:
   yarn: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: node_js
 branches:
   only:
   - master
-# Disable yarn installation GPG checks during PR builds
+# Temporarily disable yarn installation GPG checks. #10075
+# TODO: Remove after https://github.com/yarnpkg/website/pull/1030 lands
 env:
   global:
     - YARN_GPG=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ language: node_js
 branches:
   only:
   - master
+# Disable yarn installation GPG checks during PR builds
+env:
+  global:
+    - YARN_GPG=no
 matrix:
   include:
-    # Disable yarn installation GPG checks during PR builds
     - node_js: "10"
-      if: head_branch IS NOT blank
-      env:
-      - YARN_GPG=no
-    - node_js: "10"
-      if: head_branch IS blank
     - node_js: "12"
       if: head_branch IS blank AND branch = master
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ branches:
   - master
 matrix:
   include:
+    # Disable yarn installation GPG checks during PR builds
     - node_js: "10"
+      if: head_branch IS NOT blank
+      env:
+      - YARN_GPG=no
+    - node_js: "10"
+      if: head_branch IS blank
     - node_js: "12"
       if: head_branch IS blank AND branch = master
-env:
-  - YARN_GPG=no
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
**Summary**
Travis [pull requests](https://travis-ci.org/GoogleChrome/lighthouse/pull_requests) are running into 10 minute activity timeouts relatively frequently at the moment.  At the time of writing, only 1 in the last 25 pull request builds succeeded.

Based on some [web references](https://travis-ci.community/t/build-doesnt-finish-after-completing-tests/288/24), it looks like this _might_ be due to the fact that the [yarn install.sh script](https://github.com/yarnpkg/website/blob/ad15aa4735bb4cfb79221bf583aeae22c7e30ce4/install.sh#L49-L79) used by Travis may spin off a GPG agent during install verification, and this can prevent clean termination of build steps.

This changes attempts to disable the GPG verification check for PR builds  **only**, via the Travis CI [head_branch](https://github.com/travis-ci/travis-conditions/blame/f5a211ad5f81cb9594ada687a7f404ae4ed993b2/README.md#L109) conditional.

I'm not yet certain this is the build failure cause -- disabling GPG verification seems ungreat, and every indication is that this was only a problem on the **windows** platform, so this is an experimental change.