### PR TITLE
report(details-renderer): support sub-rows within a table

### DIFF
--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -314,16 +314,16 @@ class DetailsRenderer {
    * @return {LH.Audit.Details.OpportunityColumnHeading}
    */
   _getCanonicalizedHeading(heading) {
-    let multi;
-    if (heading.multi) {
+    let subRows;
+    if (heading.subRows) {
       // @ts-ignore: It's ok that there is no text.
-      multi = this._getCanonicalizedHeading(heading.multi);
+      subRows = this._getCanonicalizedHeading(heading.subRows);
     }
 
     return {
       key: heading.key,
       valueType: heading.itemType,
-      multi,
+      subRows,
       label: heading.text,
       displayUnit: heading.displayUnit,
       granularity: heading.granularity,
@@ -335,17 +335,17 @@ class DetailsRenderer {
    * @param {LH.Audit.Details.OpportunityColumnHeading} heading
    * @return {Element?}
    */
-  _renderMultiValue(row, heading) {
+  _renderSubRows(row, heading) {
     const values = row[heading.key];
     if (!Array.isArray(values)) return null;
-    const valueElement = this._dom.createElement('div', 'lh-multi-values');
+    const subRowsElement = this._dom.createElement('div', 'lh-sub-rows');
     for (const childValue of values) {
-      const childValueElement = this._renderTableValue(childValue, heading);
-      if (!childValueElement) continue;
-      childValueElement.classList.add('lh-multi-value-entry');
-      valueElement.appendChild(childValueElement);
+      const subRowElement = this._renderTableValue(childValue, heading);
+      if (!subRowElement) continue;
+      subRowElement.classList.add('lh-sub-row');
+      subRowsElement.appendChild(subRowElement);
     }
-    return valueElement;
+    return subRowsElement;
   }
 
   /**
@@ -380,16 +380,16 @@ class DetailsRenderer {
           value !== undefined && !Array.isArray(value) && this._renderTableValue(value, heading);
         if (valueElement) valueFragment.appendChild(valueElement);
 
-        if (heading.multi) {
-          const multiHeading = {
-            key: heading.multi.key,
-            valueType: heading.multi.valueType || heading.valueType,
-            granularity: heading.multi.granularity || heading.granularity,
-            displayUnit: heading.multi.displayUnit || heading.displayUnit,
+        if (heading.subRows) {
+          const subRowsHeading = {
+            key: heading.subRows.key,
+            valueType: heading.subRows.valueType || heading.valueType,
+            granularity: heading.subRows.granularity || heading.granularity,
+            displayUnit: heading.subRows.displayUnit || heading.displayUnit,
             label: '',
           };
-          const multiElement = this._renderMultiValue(row, multiHeading);
-          if (multiElement) valueFragment.appendChild(multiElement);
+          const subRowsElement = this._renderSubRows(row, subRowsHeading);
+          if (subRowsElement) valueFragment.appendChild(subRowsElement);
         }
 
         if (valueFragment.childElementCount) {

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -331,13 +331,11 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {LH.Audit.Details.TableItem} row
+   * @param {LH.Audit.Details.Value[]} values
    * @param {LH.Audit.Details.OpportunityColumnHeading} heading
    * @return {Element?}
    */
-  _renderSubRows(row, heading) {
-    const values = row[heading.key];
-    if (!Array.isArray(values)) return null;
+  _renderSubRows(values, heading) {
     const subRowsElement = this._dom.createElement('div', 'lh-sub-rows');
     for (const childValue of values) {
       const subRowElement = this._renderTableValue(childValue, heading);
@@ -388,7 +386,9 @@ class DetailsRenderer {
             displayUnit: heading.subRows.displayUnit || heading.displayUnit,
             label: '',
           };
-          const subRowsElement = this._renderSubRows(row, subRowsHeading);
+          const values = row[subRowsHeading.key];
+          if (!Array.isArray(values)) continue;
+          const subRowsElement = this._renderSubRows(values, subRowsHeading);
           if (subRowsElement) valueFragment.appendChild(subRowsElement);
         }
 

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -337,7 +337,7 @@ class DetailsRenderer {
     for (const childValue of values) {
       const childValueElement = this._renderTableValue(childValue, heading);
       if (!childValueElement) continue;
-      childValueElement.classList.add('lh-multi-value-entry'); // TODO style with borders
+      childValueElement.classList.add('lh-multi-value-entry');
       valueElement.appendChild(childValueElement);
     }
     return valueElement;

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -304,11 +304,21 @@ class DetailsRenderer {
     }
 
     return tableLike.headings.map(heading => {
+      let multi;
+      if (heading.multi) {
+        multi = {
+          key: heading.multi.key,
+          valueType: heading.multi.itemType,
+          displayUnit: heading.displayUnit,
+          granularity: heading.granularity,
+        };
+      }
+
       return {
         key: heading.key,
         label: heading.text,
         valueType: heading.itemType,
-        multi: heading.multi,
+        multi,
         displayUnit: heading.displayUnit,
         granularity: heading.granularity,
       };
@@ -373,8 +383,11 @@ class DetailsRenderer {
 
         if (heading.multi) {
           const multiHeading = {
-            ...heading,
-            ...heading.multi,
+            key: heading.multi.key,
+            valueType: heading.multi.valueType || heading.valueType,
+            granularity: heading.multi.granularity || heading.granularity,
+            displayUnit: heading.multi.displayUnit || heading.displayUnit,
+            label: '',
           };
           const multiElement = this._renderMultiValue(row, multiHeading);
           if (multiElement) valueFragment.appendChild(multiElement);

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -370,16 +370,10 @@ class DetailsRenderer {
       for (const heading of headings) {
         const valueFragment = this._dom.createFragment();
 
-        if (heading.key === '_') {
-          const emptyElement = this._dom.createElement('div');
-          emptyElement.innerHTML = '&nbsp;';
-          valueFragment.appendChild(emptyElement);
-        } else {
-          const value = row[heading.key];
-          const valueElement =
-            value !== undefined && !Array.isArray(value) && this._renderTableValue(value, heading);
-          if (valueElement) valueFragment.appendChild(valueElement);
-        }
+        const value = row[heading.key];
+        const valueElement =
+          value !== undefined && !Array.isArray(value) && this._renderTableValue(value, heading);
+        if (valueElement) valueFragment.appendChild(valueElement);
 
         if (heading.multi) {
           const multiHeading = {

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -208,17 +208,12 @@ class DetailsRenderer {
    * Render a details item value for embedding in a table. Renders the value
    * based on the heading's valueType, unless the value itself has a `type`
    * property to override it.
-   * @param {LH.Audit.Details.TableItem[string] | LH.Audit.Details.OpportunityItem[string]} value
+   * @param {LH.Audit.Details.Value} value
    * @param {LH.Audit.Details.OpportunityColumnHeading} heading
    * @return {Element|null}
    */
   _renderTableValue(value, heading) {
     if (typeof value === 'undefined' || value === null) {
-      return null;
-    }
-
-    if (typeof value === 'object' && value.type === 'multi') {
-      console.warn('Invalid multi value given to _renderTableValue');
       return null;
     }
 
@@ -313,6 +308,7 @@ class DetailsRenderer {
         key: heading.key,
         label: heading.text,
         valueType: heading.itemType,
+        multi: heading.multi,
         displayUnit: heading.displayUnit,
         granularity: heading.granularity,
       };
@@ -320,12 +316,12 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {LH.Audit.Details.OpportunityItemMulti} multi
+   * @param {LH.Audit.Details.TableItem} row
    * @param {LH.Audit.Details.OpportunityColumnHeading} heading
    * @return {Element?}
    */
-  _renderMultiValue(multi, heading) {
-    const values = multi[heading.key];
+  _renderMultiValue(row, heading) {
+    const values = row[heading.key];
     if (!Array.isArray(values)) return null;
     const valueElement = this._dom.createElement('div', 'lh-multi-values');
     for (const childValue of values) {
@@ -370,20 +366,18 @@ class DetailsRenderer {
           valueFragment.appendChild(emptyElement);
         } else {
           const value = row[heading.key];
-          const valueElement = value !== undefined && this._renderTableValue(value, heading);
+          const valueElement =
+            value !== undefined && !Array.isArray(value) && this._renderTableValue(value, heading);
           if (valueElement) valueFragment.appendChild(valueElement);
         }
 
-        if (heading.multi && row.multi) {
-          // Make typescript happy.
-          if (typeof row.multi === 'object' && row.multi.type === 'multi') {
-            const multiHeading = {
-              ...heading,
-              ...heading.multi,
-            };
-            const multiElement = this._renderMultiValue(row.multi, multiHeading);
-            if (multiElement) valueFragment.appendChild(multiElement);
-          }
+        if (heading.multi) {
+          const multiHeading = {
+            ...heading,
+            ...heading.multi,
+          };
+          const multiElement = this._renderMultiValue(row, multiHeading);
+          if (multiElement) valueFragment.appendChild(multiElement);
         }
 
         if (valueFragment.childElementCount) {

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -296,33 +296,38 @@ class DetailsRenderer {
    * OpportunityColumnHeading type until we have all details use the same
    * heading format.
    * @param {LH.Audit.Details.Table|LH.Audit.Details.Opportunity} tableLike
-   * @return {Array<LH.Audit.Details.OpportunityColumnHeading>} header
+   * @return {Array<LH.Audit.Details.OpportunityColumnHeading>}
    */
-  _getCanonicalizedTableHeadings(tableLike) {
+  _getCanonicalizedHeadingsFromTable(tableLike) {
     if (tableLike.type === 'opportunity') {
       return tableLike.headings;
     }
 
-    return tableLike.headings.map(heading => {
-      let multi;
-      if (heading.multi) {
-        multi = {
-          key: heading.multi.key,
-          valueType: heading.multi.itemType,
-          displayUnit: heading.displayUnit,
-          granularity: heading.granularity,
-        };
-      }
+    return tableLike.headings.map(heading => this._getCanonicalizedHeading(heading));
+  }
 
-      return {
-        key: heading.key,
-        label: heading.text,
-        valueType: heading.itemType,
-        multi,
-        displayUnit: heading.displayUnit,
-        granularity: heading.granularity,
-      };
-    });
+  /**
+   * Get the headings of a table-like details object, converted into the
+   * OpportunityColumnHeading type until we have all details use the same
+   * heading format.
+   * @param {LH.Audit.Details.TableColumnHeading} heading
+   * @return {LH.Audit.Details.OpportunityColumnHeading}
+   */
+  _getCanonicalizedHeading(heading) {
+    let multi;
+    if (heading.multi) {
+      // @ts-ignore: It's ok that there is no text.
+      multi = this._getCanonicalizedHeading(heading.multi);
+    }
+
+    return {
+      key: heading.key,
+      valueType: heading.itemType,
+      multi,
+      label: heading.text,
+      displayUnit: heading.displayUnit,
+      granularity: heading.granularity,
+    };
   }
 
   /**
@@ -354,7 +359,7 @@ class DetailsRenderer {
     const theadElem = this._dom.createChildOf(tableElem, 'thead');
     const theadTrElem = this._dom.createChildOf(theadElem, 'tr');
 
-    const headings = this._getCanonicalizedTableHeadings(details);
+    const headings = this._getCanonicalizedHeadingsFromTable(details);
 
     for (const heading of headings) {
       const valueType = heading.valueType || 'text';

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -333,7 +333,7 @@ class DetailsRenderer {
   /**
    * @param {LH.Audit.Details.Value[]} values
    * @param {LH.Audit.Details.OpportunityColumnHeading} heading
-   * @return {Element?}
+   * @return {Element}
    */
   _renderSubRows(values, heading) {
     const subRowsElement = this._dom.createElement('div', 'lh-sub-rows');
@@ -389,7 +389,7 @@ class DetailsRenderer {
           const values = row[subRowsHeading.key];
           if (!Array.isArray(values)) continue;
           const subRowsElement = this._renderSubRows(values, subRowsHeading);
-          if (subRowsElement) valueFragment.appendChild(subRowsElement);
+          valueFragment.appendChild(subRowsElement);
         }
 
         if (valueFragment.childElementCount) {

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -167,6 +167,7 @@
     /* Pallete */
     --color-gray-200: var(--color-gray-800);
     --color-gray-400: var(--color-gray-600);
+    --color-gray-700: var(--color-gray-400);
     --color-gray-50: #757575;
     --color-gray-600: var(--color-gray-500);
     --color-green-700: var(--color-green);
@@ -310,6 +311,10 @@
 
 .lh-root [hidden] {
   display: none !important;
+}
+
+.lh-root pre {
+  margin: 0;
 }
 
 .lh-root details > summary {
@@ -1403,6 +1408,23 @@
 
 .lh-text__url > a:hover {
   text-decoration: underline dotted #999;
+}
+
+.lh-external-viz {
+  fill: var(--color-gray-700);
+}
+.lh-external-viz:hover {
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+/* .lh-multi-value-entry:nth-child(2n) {
+  background: var(--color-gray-200);
+} */
+
+.lh-multi-values:not(:first-child) .lh-multi-value-entry {
+  margin-left: 20px;
+  color: var(--color-gray-700);
 }
 
 /* Chevron

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -313,10 +313,6 @@
   display: none !important;
 }
 
-.lh-root pre {
-  margin: 0;
-}
-
 .lh-root details > summary {
   cursor: pointer;
 }
@@ -1409,18 +1405,6 @@
 .lh-text__url > a:hover {
   text-decoration: underline dotted #999;
 }
-
-.lh-external-viz {
-  fill: var(--color-gray-700);
-}
-.lh-external-viz:hover {
-  cursor: pointer;
-  opacity: 0.7;
-}
-
-/* .lh-multi-value-entry:nth-child(2n) {
-  background: var(--color-gray-200);
-} */
 
 .lh-multi-values:not(:first-child) .lh-multi-value-entry {
   margin-left: 20px;

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1406,7 +1406,7 @@
   text-decoration: underline dotted #999;
 }
 
-.lh-multi-values:not(:first-child) .lh-multi-value-entry {
+.lh-sub-rows:not(:first-child) .lh-sub-row {
   margin-left: 20px;
   color: var(--color-gray-700);
 }

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -570,11 +570,11 @@ describe('DetailsRenderer', () => {
       assert.equal(urlEl.textContent, 'https://example.com');
     });
 
-    describe('multiple values', () => {
+    describe('subRows', () => {
       it('renders', () => {
         const details = {
           type: 'table',
-          headings: [{key: 'url', itemType: 'url', multi: {key: 'sources', itemType: 'code'}}],
+          headings: [{key: 'url', itemType: 'url', subRows: {key: 'sources', itemType: 'code'}}],
           items: [
             {url: 'https://www.example.com', sources: ['a', 'b', 'c']},
           ],
@@ -590,11 +590,11 @@ describe('DetailsRenderer', () => {
         assert.equal(codeEl.textContent, 'https://www.example.com');
 
         // Second element lists the multiple values.
-        const multiValuesEl = columnElement.children[1];
-        assert.equal(multiValuesEl.localName, 'div');
-        assert.ok(multiValuesEl.classList.contains('lh-multi-values'));
+        const subRowsEl = columnElement.children[1];
+        assert.equal(subRowsEl.localName, 'div');
+        assert.ok(subRowsEl.classList.contains('lh-sub-rows'));
 
-        const multiValueEls = multiValuesEl.querySelectorAll('.lh-multi-value-entry');
+        const multiValueEls = subRowsEl.querySelectorAll('.lh-sub-row');
         assert.equal(multiValueEls[0].textContent, 'a');
         assert.ok(multiValueEls[0].classList.contains('lh-code'));
         assert.equal(multiValueEls[1].textContent, 'b');
@@ -606,7 +606,7 @@ describe('DetailsRenderer', () => {
       it('renders, uses heading properties as fallback', () => {
         const details = {
           type: 'table',
-          headings: [{key: 'url', itemType: 'url', multi: {key: 'sources'}}],
+          headings: [{key: 'url', itemType: 'url', subRows: {key: 'sources'}}],
           items: [
             {
               url: 'https://www.example.com',
@@ -629,11 +629,11 @@ describe('DetailsRenderer', () => {
         assert.equal(codeEl.textContent, 'https://www.example.com');
 
         // Second element lists the multiple values.
-        const multiValuesEl = columnElement.children[1];
-        assert.equal(multiValuesEl.localName, 'div');
-        assert.ok(multiValuesEl.classList.contains('lh-multi-values'));
+        const subRowsEl = columnElement.children[1];
+        assert.equal(subRowsEl.localName, 'div');
+        assert.ok(subRowsEl.classList.contains('lh-sub-rows'));
 
-        const multiValueEls = multiValuesEl.querySelectorAll('.lh-multi-value-entry');
+        const multiValueEls = subRowsEl.querySelectorAll('.lh-sub-row');
         assert.equal(multiValueEls[0].textContent, 'https://www.a.com');
         assert.ok(multiValueEls[0].classList.contains('lh-text__url'));
         assert.equal(multiValueEls[1].textContent, 'https://www.b.com');

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -548,7 +548,7 @@ describe('DetailsRenderer', () => {
         // itemType is overriden by code object
         headings: [{key: 'content', itemType: 'url', text: 'Heading'}],
         items: [
-          {content: {type: 'code', value: 'code object'}},
+          {content: {type: 'code', value: 'https://codeobject.com'}},
           {content: 'https://example.com'},
         ],
       };
@@ -560,7 +560,7 @@ describe('DetailsRenderer', () => {
       const codeEl = itemElements[0].firstChild;
       assert.equal(codeEl.localName, 'pre');
       assert.ok(codeEl.classList.contains('lh-code'));
-      assert.equal(codeEl.textContent, 'code object');
+      assert.equal(codeEl.textContent, 'https://codeobject.com');
 
       // Second item uses the heading's specified type for the column.
       const urlEl = itemElements[1].firstChild;
@@ -570,32 +570,76 @@ describe('DetailsRenderer', () => {
       assert.equal(urlEl.textContent, 'https://example.com');
     });
 
-    describe('multi', () => {
-      it('renders multiple', () => {
+    describe('multiple values', () => {
+      it('renders', () => {
         const details = {
           type: 'table',
-          headings: [{key: 'url', itemType: 'url', multi: {key: 'source', itemType: 'code'}}],
+          headings: [{key: 'url', itemType: 'url', multi: {key: 'sources', itemType: 'code'}}],
           items: [
-            {url: 'https://www.example.com', multi: {type: 'multi', source: ['a', 'b']}},
+            {url: 'https://www.example.com', sources: ['a', 'b', 'c']},
           ],
         };
 
         const el = renderer.render(details);
-        console.log(el.innerHTML);
-        const itemElements = el.querySelectorAll('td.lh-table-column--url');
+        const columnElement = el.querySelector('td.lh-table-column--url');
 
-        // First item's value uses its own type.
-        const codeEl = itemElements[0].firstChild;
-        assert.equal(codeEl.localName, 'pre');
-        assert.ok(codeEl.classList.contains('lh-code'));
-        assert.equal(codeEl.textContent, 'code object');
+        // First element is the url.
+        const codeEl = columnElement.firstChild;
+        assert.equal(codeEl.localName, 'div');
+        assert.ok(codeEl.classList.contains('lh-text__url'));
+        assert.equal(codeEl.textContent, 'https://www.example.com');
 
-        // Second item uses the heading's specified type for the column.
-        const urlEl = itemElements[1].firstChild;
-        assert.equal(urlEl.localName, 'div');
-        assert.ok(urlEl.classList.contains('lh-text__url'));
-        assert.equal(urlEl.title, 'https://example.com');
-        assert.equal(urlEl.textContent, 'https://example.com');
+        // Second element lists the multiple values.
+        const multiValuesEl = columnElement.children[1];
+        assert.equal(multiValuesEl.localName, 'div');
+        assert.ok(multiValuesEl.classList.contains('lh-multi-values'));
+
+        const multiValueEls = multiValuesEl.querySelectorAll('.lh-multi-value-entry');
+        assert.equal(multiValueEls[0].textContent, 'a');
+        assert.ok(multiValueEls[0].classList.contains('lh-code'));
+        assert.equal(multiValueEls[1].textContent, 'b');
+        assert.ok(multiValueEls[1].classList.contains('lh-code'));
+        assert.equal(multiValueEls[2].textContent, 'c');
+        assert.ok(multiValueEls[2].classList.contains('lh-code'));
+      });
+
+      it('renders, uses heading properties as fallback', () => {
+        const details = {
+          type: 'table',
+          headings: [{key: 'url', itemType: 'url', multi: {key: 'sources'}}],
+          items: [
+            {
+              url: 'https://www.example.com',
+              sources: [
+                'https://www.a.com',
+                {type: 'code', value: 'https://www.b.com'},
+                'https://www.c.com',
+              ],
+            },
+          ],
+        };
+
+        const el = renderer.render(details);
+        const columnElement = el.querySelector('td.lh-table-column--url');
+
+        // First element is the url.
+        const codeEl = columnElement.firstChild;
+        assert.equal(codeEl.localName, 'div');
+        assert.ok(codeEl.classList.contains('lh-text__url'));
+        assert.equal(codeEl.textContent, 'https://www.example.com');
+
+        // Second element lists the multiple values.
+        const multiValuesEl = columnElement.children[1];
+        assert.equal(multiValuesEl.localName, 'div');
+        assert.ok(multiValuesEl.classList.contains('lh-multi-values'));
+
+        const multiValueEls = multiValuesEl.querySelectorAll('.lh-multi-value-entry');
+        assert.equal(multiValueEls[0].textContent, 'https://www.a.com');
+        assert.ok(multiValueEls[0].classList.contains('lh-text__url'));
+        assert.equal(multiValueEls[1].textContent, 'https://www.b.com');
+        assert.ok(multiValueEls[1].classList.contains('lh-code'));
+        assert.equal(multiValueEls[2].textContent, 'https://www.c.com');
+        assert.ok(multiValueEls[2].classList.contains('lh-text__url'));
       });
     });
   });

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -569,5 +569,34 @@ describe('DetailsRenderer', () => {
       assert.equal(urlEl.title, 'https://example.com');
       assert.equal(urlEl.textContent, 'https://example.com');
     });
+
+    describe('multi', () => {
+      it('renders multiple', () => {
+        const details = {
+          type: 'table',
+          headings: [{key: 'url', itemType: 'url', multi: {key: 'source', itemType: 'code'}}],
+          items: [
+            {url: 'https://www.example.com', multi: {type: 'multi', source: ['a', 'b']}},
+          ],
+        };
+
+        const el = renderer.render(details);
+        console.log(el.innerHTML);
+        const itemElements = el.querySelectorAll('td.lh-table-column--url');
+
+        // First item's value uses its own type.
+        const codeEl = itemElements[0].firstChild;
+        assert.equal(codeEl.localName, 'pre');
+        assert.ok(codeEl.classList.contains('lh-code'));
+        assert.equal(codeEl.textContent, 'code object');
+
+        // Second item uses the heading's specified type for the column.
+        const urlEl = itemElements[1].firstChild;
+        assert.equal(urlEl.localName, 'div');
+        assert.ok(urlEl.classList.contains('lh-text__url'));
+        assert.equal(urlEl.title, 'https://example.com');
+        assert.equal(urlEl.textContent, 'https://example.com');
+      });
+    });
   });
 });

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -99,10 +99,10 @@ declare global {
          */
         itemType: ItemValueTypes;
         /**
-         * Optional header defining an inner table of values that correspond to this column.
+         * Optional - defines an inner table of values that correspond to this column.
          * Key is required - if other properties are not provided, the value for the heading is used.
-        */
-        multi?: {key: string, itemType?: ItemValueTypes, displayUnit?: string, granularity?: number};
+         */
+        subRows?: {key: string, itemType?: ItemValueTypes, displayUnit?: string, granularity?: number};
 
         displayUnit?: string;
         granularity?: number;
@@ -125,10 +125,10 @@ declare global {
          */
         valueType: ItemValueTypes;
         /**
-         * Optional header defining an inner table of values that correspond to this column.
+         * Optional - defines an inner table of values that correspond to this column.
          * Key is required - if other properties are not provided, the value for the heading is used.
-        */
-        multi?: {key: string, valueType?: ItemValueTypes, displayUnit?: string, granularity?: number};
+         */
+        subRows?: {key: string, valueType?: ItemValueTypes, displayUnit?: string, granularity?: number};
 
         // NOTE: not used by opportunity details, but used in the renderer until table/opportunity unification.
         displayUnit?: string;

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -194,7 +194,7 @@ declare global {
 
       /**
        * A value used within a details object, intended to be displayed as a
-       * linkified URL, regardless of the controlling heading's valueTypeMultiValue | .
+       * linkified URL, regardless of the controlling heading's valueType.
        */
       export interface UrlValue {
         type: 'url';

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -83,6 +83,7 @@ declare global {
 
       /** Possible types of values found within table items. */
       type ItemValueTypes = 'bytes' | 'code' | 'link' | 'ms' | 'multi' | 'node' | 'source-location' | 'numeric' | 'text' | 'thumbnail' | 'timespanMs' | 'url';
+      type Value = string | number | boolean | DebugData | NodeValue | SourceLocationValue | LinkValue | UrlValue | CodeValue;
 
       // TODO(bckenny): unify Table/Opportunity headings and items on next breaking change.
 
@@ -97,6 +98,11 @@ declare global {
          * could also be objects with their own type to override this field.
          */
         itemType: ItemValueTypes;
+        /**
+         * Optional header defining an inner table of values that correspond to this column.
+         * Key is required - if other properties are not provided, the value for the heading is used.
+        */
+        multi?: {key: string, itemType?: ItemValueTypes, displayUnit?: string, granularity?: number};
 
         displayUnit?: string;
         granularity?: number;
@@ -104,7 +110,7 @@ declare global {
 
       export type TableItem = {
         debugData?: DebugData;
-        [p: string]: undefined | string | number | boolean | undefined | DebugData | NodeValue | SourceLocationValue | LinkValue | UrlValue | CodeValue;
+        [p: string]: undefined | Value | Value[];
       }
 
       export interface OpportunityColumnHeading {
@@ -118,8 +124,11 @@ declare global {
          * could also be objects with their own type to override this field.
          */
         valueType: ItemValueTypes;
-        /** ... */
-        multi?: Omit<Partial<OpportunityColumnHeading>, 'label'|'multi'>;
+        /**
+         * Optional header defining an inner table of values that correspond to this column.
+         * Key is required - if other properties are not provided, the value for the heading is used.
+        */
+        multi?: {key: string, valueType?: ItemValueTypes, displayUnit?: string, granularity?: number};
 
         // NOTE: not used by opportunity details, but used in the renderer until table/opportunity unification.
         displayUnit?: string;
@@ -132,13 +141,7 @@ declare global {
         totalBytes?: number;
         wastedMs?: number;
         debugData?: DebugData;
-        [p: string]: number | boolean | string | undefined | DebugData | OpportunityItemMulti;
-        multi?: OpportunityItemMulti;
-      }
-
-      export interface OpportunityItemMulti {
-        type: 'multi',
-        [p: string]: number[] | boolean[] | string | string[] | undefined | DebugData[];
+        [p: string]: undefined | Value | Value[];
       }
 
       /**

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -82,7 +82,7 @@ declare global {
       }
 
       /** Possible types of values found within table items. */
-      type ItemValueTypes = 'bytes' | 'code' | 'link' | 'ms' | 'node' | 'source-location' | 'numeric' | 'text' | 'thumbnail' | 'timespanMs' | 'url';
+      type ItemValueTypes = 'bytes' | 'code' | 'link' | 'ms' | 'multi' | 'node' | 'source-location' | 'numeric' | 'text' | 'thumbnail' | 'timespanMs' | 'url';
 
       // TODO(bckenny): unify Table/Opportunity headings and items on next breaking change.
 
@@ -118,6 +118,8 @@ declare global {
          * could also be objects with their own type to override this field.
          */
         valueType: ItemValueTypes;
+        /** ... */
+        multi?: Omit<Partial<OpportunityColumnHeading>, 'label'|'multi'>;
 
         // NOTE: not used by opportunity details, but used in the renderer until table/opportunity unification.
         displayUnit?: string;
@@ -130,7 +132,13 @@ declare global {
         totalBytes?: number;
         wastedMs?: number;
         debugData?: DebugData;
-        [p: string]: number | boolean | string | undefined | DebugData;
+        [p: string]: number | boolean | string | undefined | DebugData | OpportunityItemMulti;
+        multi?: OpportunityItemMulti;
+      }
+
+      export interface OpportunityItemMulti {
+        type: 'multi',
+        [p: string]: number[] | boolean[] | string | string[] | undefined | DebugData[];
       }
 
       /**
@@ -183,7 +191,7 @@ declare global {
 
       /**
        * A value used within a details object, intended to be displayed as a
-       * linkified URL, regardless of the controlling heading's valueType.
+       * linkified URL, regardless of the controlling heading's valueTypeMultiValue | .
        */
       export interface UrlValue {
         type: 'url';

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -64,7 +64,6 @@ declare global {
       wastedBytes: number;
       totalBytes: number;
       wastedPercent?: number;
-      multi?: Audit.Details.OpportunityItemMulti;
     }
 
     /** Type returned by Audit.audit(). Only score is required.  */

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -64,6 +64,7 @@ declare global {
       wastedBytes: number;
       totalBytes: number;
       wastedPercent?: number;
+      multi?: Audit.Details.OpportunityItemMulti;
     }
 
     /** Type returned by Audit.audit(). Only score is required.  */


### PR DESCRIPTION
If a header defines a `mutli: { key: string}` property, the renderer will render each value in `item[key]` within the same column of that row. All other properties (besides label - it doesn't apply) can be set for this "multi header" - anything not set defaults to the outer `heading`.

Note: Originally there was a toplevel `multi: {}` object, which contained all the keys that could be arrays. Turns out that allowing any property of a audit product item to be an array does not complicate the renderer as much as I thought it would, so I removed it.

## Examples

With this PR, nothing yet uses this feature. To see it in use, see the `bundle-analysis` branch (#10064)

![image](https://user-images.githubusercontent.com/4071474/70479404-1ea68b80-1a92-11ea-980c-25ffff6025cf.png)

```
return {
      items,
      headings: [
        {key: 'url', valueType: 'url', multi: {key: 'sources', valueType: 'code'}, label: str_(i18n.UIStrings.columnURL)},
        {key: 'totalBytes', valueType: 'bytes', multi: {key: 'sourceBytes'}, label: str_(i18n.UIStrings.columnSize)},
        {key: 'wastedBytes', valueType: 'bytes', multi: {key: 'sourceWastedBytes'}, label: str_(i18n.UIStrings.columnWastedBytes)},
      ],
    };
```

__

![image](https://user-images.githubusercontent.com/4071474/70479459-3e3db400-1a92-11ea-9647-4aee13466d02.png)


```
    /** @type {LH.Audit.Details.OpportunityColumnHeading[]} */
    const headings = [
      {key: 'source', valueType: 'code', multi: {key: 'urls', valueType: 'url'}, label: str_(i18n.UIStrings.columnName)}, // TODO: or 'Source'?
      {key: '_', valueType: 'bytes', multi: {key: 'sourceBytes'}, granularity: 0.05, label: str_(i18n.UIStrings.columnSize)},
      {key: 'wastedBytes', valueType: 'bytes', granularity: 0.05, label: str_(i18n.UIStrings.columnWastedBytes)},
    ];

    return {
      items,
      headings,
      wastedBytesByUrl,
    };
```