### PR TITLE
deps(angular): update patch version of angular fixture

### DIFF
--- a/lighthouse-core/test/lib/minification-estimator-test.js
+++ b/lighthouse-core/test/lib/minification-estimator-test.js
@@ -214,9 +214,9 @@ describe('minification estimator', () => {
     });
 
     it('should handle large, real javscript files', () => {
-      assert.equal(angularFullScript.length, 1364217);
+      assert.equal(angularFullScript.length, 1371888);
       // 1 - 334968 / 1364217 = estimated 75% smaller minified
-      assert.equal(computeJSTokenLength(angularFullScript), 334968);
+      assert.equal(computeJSTokenLength(angularFullScript), 337959);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,9 +871,9 @@ ajv@^5.2.3, ajv@^5.3.0:
     json-schema-traverse "^0.3.0"
 
 angular@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.4.tgz#c1bf4884c2d470c06907737a1bf0835a9f646f31"
-  integrity sha512-nYTWc9CpZjTY57l8EA1+DGpQNzI6HewQ34bfRYoGXBYysIoPYjfcgTGWC+Vl3AaeCnhAb3VTkysVESvCBpUIoA==
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.9.tgz#e52616e8701c17724c3c238cfe4f9446fd570bc4"
+  integrity sha512-5se7ZpcOtu0MBFlzGv5dsM1quQDoDeUTwZrWjGtTNA7O88cD8TEk5IEKCTDa3uECV9XnvKREVUr7du1ACiWGFQ==
 
 ansi-align@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
fixes a security vuln warning on the repo.
![image](https://user-images.githubusercontent.com/39191/70486932-6e904d00-1aa8-11ea-897c-9c67f52f64db.png)

angular is included only for this test.  landed in https://github.com/GoogleChrome/lighthouse/pull/6138