### PR TITLE
tests(build): disable yarn directory cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
     - node_js: "12"
       if: head_branch IS blank AND branch = master
 cache:
-  yarn: true
   directories:
     - node_modules
     - lantern-data


### PR DESCRIPTION
**Summary**
This change disables caching of Yarn's filesystem-based content in Travis CI builds.  This has been causing frequent build timeouts recently and this makes it harder to filter true test/build failures from noise.

Removal of the `cache.yarn: true` value should not affect Travis' installation of the `yarn` package before builds commence.  Travis should still [detect](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#using-yarn) the requirement to install `yarn` thanks to the existence of `package.json` and `yarn.lock` in the repository root directory.

**Related Issues/PRs**
Additional background is available in https://github.com/GoogleChrome/lighthouse/pull/10072

cc @patrickhulce 
