### PR TITLE
core(offscreen-images): pass images with 'loading' attribute

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -115,8 +115,7 @@ setTimeout(() => {
   <!-- PASS(optimized): image is vector -->
   <!-- PASS(webp): image is vector -->
   <!-- PASS(responsive): image is vector -->
-  <!-- PASS(offscreen): image is offscreen and loads before TTI, however its loading=lazy -->
-  <!-- TODO: why does this pass offscreen now with loading=lazy? threshold? -->
+  <!-- PASS(offscreen): image is offscreen and loads before TTI, but loads lazily -->
   <img style="width: 100px; height: 100px;" src="large.svg?loadinglazy-offscreen" loading="lazy">
 
   <!-- PASS(optimized): image is JPEG optimized -->

--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -116,7 +116,8 @@ setTimeout(() => {
   <!-- PASS(webp): image is vector -->
   <!-- PASS(responsive): image is vector -->
   <!-- FAIL(offscreen): image is offscreen -->
-  <img style="width: 100px; height: 100px;" src="large.svg">
+  <!-- TODO: why does this pass offscreen now with loading=lazy? threshold? -->
+  <img style="width: 100px; height: 100px;" src="large.svg" loading=lazy>
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image has insigificant WebP savings -->

--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -37,7 +37,7 @@ function longTask(length = 75) {
   while (Date.now() < start + length) ;
 }
 
-// Add a long task to delay FI
+// Add a long task to delay FI and TTI
 setTimeout(longTask, 4000);
 
 // Lazily load the image
@@ -115,8 +115,14 @@ setTimeout(() => {
   <!-- PASS(optimized): image is vector -->
   <!-- PASS(webp): image is vector -->
   <!-- PASS(responsive): image is vector -->
+  <!-- FAIL(offscreen): image is offscreen -->
+  <img style="width: 100px; height: 100px;" src="large.svg">
+
+  <!-- PASS(optimized): image is vector -->
+  <!-- PASS(webp): image is vector -->
+  <!-- PASS(responsive): image is vector -->
   <!-- PASS(offscreen): image is offscreen and loads before TTI, but loads lazily -->
-  <img style="width: 100px; height: 100px;" src="large.svg?loadinglazy-offscreen" loading="lazy">
+  <img style="width: 100px; height: 100px;" src="large.svg?nativeLazyLoad" loading="lazy">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image has insigificant WebP savings -->

--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -38,7 +38,7 @@ function longTask(length = 75) {
 }
 
 // Add a long task to delay FI
-setTimeout(longTask, 2000);
+setTimeout(longTask, 4000);
 
 // Lazily load the image
 setTimeout(() => {
@@ -115,9 +115,9 @@ setTimeout(() => {
   <!-- PASS(optimized): image is vector -->
   <!-- PASS(webp): image is vector -->
   <!-- PASS(responsive): image is vector -->
-  <!-- FAIL(offscreen): image is offscreen -->
+  <!-- PASS(offscreen): image is offscreen and loads before TTI, however its loading=lazy -->
   <!-- TODO: why does this pass offscreen now with loading=lazy? threshold? -->
-  <img style="width: 100px; height: 100px;" src="large.svg" loading=lazy>
+  <img style="width: 100px; height: 100px;" src="large.svg?loadinglazy-offscreen" loading="lazy">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image has insigificant WebP savings -->

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -74,8 +74,6 @@ const expectations = [
                 url: /lighthouse-480x320.webp$/,
               }, {
                 url: /lighthouse-480x320.webp\?invisible$/,
-              }, {
-                url: /large.svg$/,
               },
             ],
           },

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -74,6 +74,8 @@ const expectations = [
                 url: /lighthouse-480x320.webp$/,
               }, {
                 url: /lighthouse-480x320.webp\?invisible$/,
+              }, {
+                url: /large.svg$/,
               },
             ],
           },

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -118,6 +118,36 @@ const expectations = [
       },
     },
   },
+  {
+    lhr: {
+      requestedUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+      finalUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+      audits: {
+        'network-requests': {
+          details: {
+            items: [
+              {
+                url: 'http://localhost:10200/byte-efficiency/gzip.html',
+              },
+              {
+                url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
+                transferSize: 1158,
+                resourceSize: 52997,
+              },
+              {
+                url: 'http://localhost:10200/byte-efficiency/script.js',
+                transferSize: 53203,
+                resourceSize: 52997,
+              },
+              {
+                url: 'http://localhost:10200/favicon.ico',
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
 ];
 
 module.exports = expectations;

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -118,36 +118,6 @@ const expectations = [
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
-      finalUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
-      audits: {
-        'network-requests': {
-          details: {
-            items: [
-              {
-                url: 'http://localhost:10200/byte-efficiency/gzip.html',
-              },
-              {
-                url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
-                transferSize: 1158,
-                resourceSize: 52997,
-              },
-              {
-                url: 'http://localhost:10200/byte-efficiency/script.js',
-                transferSize: 53203,
-                resourceSize: 52997,
-              },
-              {
-                url: 'http://localhost:10200/favicon.ico',
-              },
-            ],
-          },
-        },
-      },
-    },
-  },
 ];
 
 module.exports = expectations;

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -123,6 +123,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
         startTimesByURL.set(networkNode.record.url, timing.startTime);
       }
     }
+    console.log({images});
 
     return images.filter(image => {
       // Filter out images that had little waste
@@ -142,6 +143,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
    */
   static filterObservedResults(images, interactiveTimestamp) {
     return images.filter(image => {
+      console.log(image.url, (image.wastedBytes < IGNORE_THRESHOLD_IN_BYTES), (image.wastedBytes < IGNORE_THRESHOLD_IN_BYTES), image.requestStartTime < interactiveTimestamp / 1e6 - IGNORE_THRESHOLD_IN_MS / 1000);
       if (image.wastedBytes < IGNORE_THRESHOLD_IN_BYTES) return false;
       if (image.wastedPercent < IGNORE_THRESHOLD_IN_PERCENT) return false;
       return image.requestStartTime < interactiveTimestamp / 1e6 - IGNORE_THRESHOLD_IN_MS / 1000;
@@ -170,6 +172,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
    * @return {Promise<ByteEfficiencyAudit.ByteEfficiencyProduct>}
    */
   static async audit_(artifacts, networkRecords, context) {
+    console.log('****SDLOFDJSFLDJS FL')
     const images = artifacts.ImageElements;
     const viewportDimensions = artifacts.ViewportDimensions;
     const trace = artifacts.traces[ByteEfficiencyAudit.DEFAULT_PASS];
@@ -209,6 +212,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
       // use interactive to generate items
       const lanternInteractive = /** @type {LH.Artifacts.LanternMetric} */ (interactive);
       // Filter out images that were loaded after all CPU activity
+      console.log(interactive.timing);
       items = context.settings.throttlingMethod === 'simulate' ?
         OffscreenImages.filterLanternResults(unfilteredResults, lanternInteractive) :
         // @ts-ignore - .timestamp will exist if throttlingMethod isn't lantern

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -76,10 +76,10 @@ class OffscreenImages extends ByteEfficiencyAudit {
    */
   static computeWaste(image, viewportDimensions, networkRecords) {
     const networkRecord = networkRecords.find(record => record.url === image.src);
-    if (!image.resourceSize || !networkRecord || image.loading === 'lazy' ||
-        image.loading === 'eager') {
-      return null;
-    }
+    // If we don't know how big it was, we can't really report savings, treat it as passed.
+    if (!image.resourceSize || !networkRecord) return null;
+    // If the image had its loading behavior explicitly controlled already, treat it as passed.
+    if (image.loading === 'lazy' || image.loading === 'eager') return null;
 
     const url = URL.elideDataURI(image.src);
     const totalPixels = image.displayedWidth * image.displayedHeight;

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -76,7 +76,8 @@ class OffscreenImages extends ByteEfficiencyAudit {
    */
   static computeWaste(image, viewportDimensions, networkRecords) {
     const networkRecord = networkRecords.find(record => record.url === image.src);
-    if (!image.resourceSize || !networkRecord || image.isLazyLoaded) {
+    if (!image.resourceSize || !networkRecord || image.loading === 'lazy' ||
+        image.loading === 'eager') {
       return null;
     }
 
@@ -123,7 +124,6 @@ class OffscreenImages extends ByteEfficiencyAudit {
         startTimesByURL.set(networkNode.record.url, timing.startTime);
       }
     }
-    console.log({images});
 
     return images.filter(image => {
       // Filter out images that had little waste
@@ -143,7 +143,6 @@ class OffscreenImages extends ByteEfficiencyAudit {
    */
   static filterObservedResults(images, interactiveTimestamp) {
     return images.filter(image => {
-      console.log(image.url, (image.wastedBytes < IGNORE_THRESHOLD_IN_BYTES), (image.wastedBytes < IGNORE_THRESHOLD_IN_BYTES), image.requestStartTime < interactiveTimestamp / 1e6 - IGNORE_THRESHOLD_IN_MS / 1000);
       if (image.wastedBytes < IGNORE_THRESHOLD_IN_BYTES) return false;
       if (image.wastedPercent < IGNORE_THRESHOLD_IN_PERCENT) return false;
       return image.requestStartTime < interactiveTimestamp / 1e6 - IGNORE_THRESHOLD_IN_MS / 1000;
@@ -172,7 +171,6 @@ class OffscreenImages extends ByteEfficiencyAudit {
    * @return {Promise<ByteEfficiencyAudit.ByteEfficiencyProduct>}
    */
   static async audit_(artifacts, networkRecords, context) {
-    console.log('****SDLOFDJSFLDJS FL')
     const images = artifacts.ImageElements;
     const viewportDimensions = artifacts.ViewportDimensions;
     const trace = artifacts.traces[ByteEfficiencyAudit.DEFAULT_PASS];
@@ -212,7 +210,6 @@ class OffscreenImages extends ByteEfficiencyAudit {
       // use interactive to generate items
       const lanternInteractive = /** @type {LH.Artifacts.LanternMetric} */ (interactive);
       // Filter out images that were loaded after all CPU activity
-      console.log(interactive.timing);
       items = context.settings.throttlingMethod === 'simulate' ?
         OffscreenImages.filterLanternResults(unfilteredResults, lanternInteractive) :
         // @ts-ignore - .timestamp will exist if throttlingMethod isn't lantern

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -76,7 +76,6 @@ class OffscreenImages extends ByteEfficiencyAudit {
    */
   static computeWaste(image, viewportDimensions, networkRecords) {
     const networkRecord = networkRecords.find(record => record.url === image.src);
-    // TODO: sanity-check
     if (!image.resourceSize || !networkRecord || image.isLazyLoaded) {
       return null;
     }

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -76,7 +76,8 @@ class OffscreenImages extends ByteEfficiencyAudit {
    */
   static computeWaste(image, viewportDimensions, networkRecords) {
     const networkRecord = networkRecords.find(record => record.url === image.src);
-    if (!image.resourceSize || !networkRecord) {
+    // TODO: sanity-check
+    if (!image.resourceSize || !networkRecord || image.isLazyLoaded) {
       return null;
     }
 

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -51,6 +51,7 @@ function getHTMLImages(allElements) {
       naturalWidth: element.naturalWidth,
       naturalHeight: element.naturalHeight,
       isCss: false,
+      // @ts-ignore: loading attribute not yet added to HTMLImageElement definition.
       loading: element.loading,
       resourceSize: 0, // this will get overwritten below
       isPicture: !!element.parentElement && element.parentElement.tagName === 'PICTURE',

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -51,7 +51,7 @@ function getHTMLImages(allElements) {
       naturalWidth: element.naturalWidth,
       naturalHeight: element.naturalHeight,
       isCss: false,
-      isLazyLoaded: element.loading === 'lazy',
+      loading: element.loading,
       resourceSize: 0, // this will get overwritten below
       isPicture: !!element.parentElement && element.parentElement.tagName === 'PICTURE',
       usesObjectFit: ['cover', 'contain', 'scale-down', 'none'].includes(
@@ -92,9 +92,6 @@ function getCSSImages(allElements) {
       naturalWidth: 0,
       naturalHeight: 0,
       isCss: true,
-      // CSS images do not have the loading attribute
-      // https://web.dev/native-lazy-loading/?utm_source=lighthouse&utm_medium=cli#load-in-distance-threshold
-      isLazyLoaded: false,
       isPicture: false,
       usesObjectFit: false,
       resourceSize: 0, // this will get overwritten below

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -51,7 +51,7 @@ function getHTMLImages(allElements) {
       naturalWidth: element.naturalWidth,
       naturalHeight: element.naturalHeight,
       isCss: false,
-      isLazyLoaded: false, // TODO: actually get the attribute
+      isLazyLoaded: element.loading === 'lazy',
       resourceSize: 0, // this will get overwritten below
       isPicture: !!element.parentElement && element.parentElement.tagName === 'PICTURE',
       usesObjectFit: ['cover', 'contain', 'scale-down', 'none'].includes(
@@ -92,7 +92,7 @@ function getCSSImages(allElements) {
       naturalWidth: 0,
       naturalHeight: 0,
       isCss: true,
-      // CSS images do not have the loading attribute yet?
+      // CSS images do not have the loading attribute
       // https://web.dev/native-lazy-loading/?utm_source=lighthouse&utm_medium=cli#load-in-distance-threshold
       isLazyLoaded: false,
       isPicture: false,

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -51,6 +51,7 @@ function getHTMLImages(allElements) {
       naturalWidth: element.naturalWidth,
       naturalHeight: element.naturalHeight,
       isCss: false,
+      isLazyLoaded: false, // TODO: actually get the attribute
       resourceSize: 0, // this will get overwritten below
       isPicture: !!element.parentElement && element.parentElement.tagName === 'PICTURE',
       usesObjectFit: ['cover', 'contain', 'scale-down', 'none'].includes(
@@ -91,6 +92,9 @@ function getCSSImages(allElements) {
       naturalWidth: 0,
       naturalHeight: 0,
       isCss: true,
+      // CSS images do not have the loading attribute yet?
+      // https://web.dev/native-lazy-loading/?utm_source=lighthouse&utm_medium=cli#load-in-distance-threshold
+      isLazyLoaded: false,
       isPicture: false,
       usesObjectFit: false,
       resourceSize: 0, // this will get overwritten below

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -33,7 +33,13 @@ function generateSize(width, height, prefix = 'displayed') {
   return size;
 }
 
-function generateImage(size, coords, networkRecord, src = 'https://google.com/logo.png', loading = null) {
+function generateImage({
+  size,
+  coords,
+  networkRecord,
+  loading,
+  src = 'https://google.com/logo.png',
+}) {
   Object.assign(networkRecord || {}, {url: src});
 
   const x = coords[0];
@@ -68,7 +74,7 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage(generateSize(100, 100), [0, 0]),
+        generateImage({size: generateSize(100, 100), coords: [0, 0]}),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -89,9 +95,19 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage(generateSize(200, 200), [0, 0], recordA),
-        generateImage(generateSize(100, 100), [0, 1080], recordB, urlB),
-        generateImage(generateSize(400, 400), [1720, 1080], recordC, urlC),
+        generateImage({size: generateSize(200, 200), coords: [0, 0], networkRecord: recordA}),
+        generateImage({
+          size: generateSize(100, 100),
+          coords: [0, 1080],
+          networkRecord: recordB,
+          src: urlB,
+        }),
+        generateImage({
+          size: generateSize(400, 400),
+          coords: [1720, 1080],
+          networkRecord: recordC,
+          src: urlC,
+        }),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -115,15 +131,39 @@ describe('OffscreenImages audit', () => {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
         // Offscreen to the right.
-        generateImage(generateSize(200, 200), [3000, 0], networkRecords[0]),
+        generateImage({
+          size: generateSize(200, 200),
+          coords: [3000, 0],
+          networkRecord: networkRecords[0],
+        }),
         // Offscreen to the bottom.
-        generateImage(generateSize(100, 100), [0, 2000], networkRecords[1], url('B')),
+        generateImage({
+          size: generateSize(100, 100),
+          coords: [0, 2000],
+          networkRecord: networkRecords[1],
+          src: url('B'),
+        }),
         // Offscreen to the top-left.
-        generateImage(generateSize(100, 100), [-2000, -1000], networkRecords[2], url('C')),
+        generateImage({
+          size: generateSize(100, 100),
+          coords: [-2000, -1000],
+          networkRecord: networkRecords[2],
+          src: url('C'),
+        }),
         // Offscreen to the bottom-right.
-        generateImage(generateSize(100, 100), [3000, 2000], networkRecords[3], url('D')),
+        generateImage({
+          size: generateSize(100, 100),
+          coords: [3000, 2000],
+          networkRecord: networkRecords[3],
+          src: url('D'),
+        }),
         // Half offscreen to the top, should not warn.
-        generateImage(generateSize(1000, 1000), [0, -500], networkRecords[4], url('E')),
+        generateImage({
+          size: generateSize(1000, 1000),
+          coords: [0, -500],
+          networkRecord: networkRecords[4],
+          src: url('E'),
+        }),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -144,9 +184,21 @@ describe('OffscreenImages audit', () => {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
         // Offscreen to the right, but lazy loaded.
-        generateImage(generateSize(200, 200), [3000, 0], networkRecords[0], url('A'), 'lazy'),
+        generateImage({
+          size: generateSize(200, 200),
+          coords: [3000, 0],
+          networkRecord: networkRecords[0],
+          loading: 'lazy',
+          src: url('A'),
+        }),
         // Offscreen to the bottom, but eager loaded.
-        generateImage(generateSize(100, 100), [0, 2000], networkRecords[1], url('B'), 'eager'),
+        generateImage({
+          size: generateSize(100, 100),
+          coords: [0, 2000],
+          networkRecord: networkRecords[1],
+          loading: 'eager',
+          src: url('B'),
+        }),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -163,7 +215,7 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage(generateSize(0, 0), [0, 0], networkRecord),
+        generateImage({size: generateSize(0, 0), coords: [0, 0], networkRecord}),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -187,10 +239,28 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage(generateSize(50, 50), [0, 0], networkRecords[0]),
-        generateImage(generateSize(1000, 1000), [1000, 1000], networkRecords[1]),
-        generateImage(generateSize(50, 50), [0, 1500], networkRecords[2], urlB),
-        generateImage(generateSize(400, 400), [0, 1500], networkRecords[3], urlB),
+        generateImage({
+          size: generateSize(50, 50),
+          coords: [0, 0],
+          networkRecord: networkRecords[0],
+        }),
+        generateImage({
+          size: generateSize(1000, 1000),
+          coords: [1000, 1000],
+          networkRecord: networkRecords[1],
+        }),
+        generateImage({
+          size: generateSize(50, 50),
+          coords: [0, 1500],
+          networkRecord: networkRecords[2],
+          src: urlB,
+        }),
+        generateImage({
+          size: generateSize(400, 400),
+          coords: [0, 1500],
+          networkRecord: networkRecords[3],
+          src: urlB,
+        }),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -208,7 +278,7 @@ describe('OffscreenImages audit', () => {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
         // Offscreen to the right.
-        generateImage(generateSize(200, 200), [3000, 0], networkRecord),
+        generateImage({size: generateSize(200, 200), coords: [3000, 0], networkRecord}),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -225,7 +295,7 @@ describe('OffscreenImages audit', () => {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
         // Offscreen to the right.
-        generateImage(generateSize(200, 200), [3000, 0], networkRecord),
+        generateImage({size: generateSize(200, 200), coords: [3000, 0], networkRecord}),
       ],
       traces: {defaultPass: createTestTrace({traceEnd: 2000})},
       devtoolsLogs: {},
@@ -242,7 +312,7 @@ describe('OffscreenImages audit', () => {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
         // Offscreen to the right.
-        generateImage(generateSize(100, 100), [0, 2000], networkRecord),
+        generateImage({size: generateSize(100, 100), coords: [0, 2000], networkRecord}),
       ],
       traces: {defaultPass: createTestTrace({traceEnd: 2000})},
       devtoolsLogs: {},
@@ -280,8 +350,18 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage(generateSize(0, 0), [0, 0], recordA, recordA.url),
-        generateImage(generateSize(200, 200), [3000, 0], recordB, recordB.url),
+        generateImage({
+          size: generateSize(0, 0),
+          coords: [0, 0],
+          networkRecord: recordA,
+          src: recordA.url,
+        }),
+        generateImage({
+          size: generateSize(200, 200),
+          coords: [3000, 0],
+          networkRecord: recordB,
+          src: recordB.url,
+        }),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {defaultPass: devtoolsLog},
@@ -324,8 +404,18 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage(generateSize(0, 0), [0, 0], recordA, recordA.url),
-        generateImage(generateSize(200, 200), [3000, 0], recordB, recordB.url),
+        generateImage({
+          size: generateSize(0, 0),
+          coords: [0, 0],
+          networkRecord: recordA,
+          src: recordA.url,
+        }),
+        generateImage({
+          size: generateSize(200, 200),
+          coords: [3000, 0],
+          networkRecord: recordB,
+          src: recordB.url,
+        }),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {defaultPass: devtoolsLog},
@@ -349,8 +439,18 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage(generateSize(0, 0), [0, 0], networkRecords[0], 'a'),
-        generateImage(generateSize(200, 200), [3000, 0], networkRecords[1], 'b'),
+        generateImage({
+          size: generateSize(0, 0),
+          coords: [0, 0],
+          networkRecord: networkRecords[0],
+          src: 'a',
+        }),
+        generateImage({
+          size: generateSize(200, 200),
+          coords: [3000, 0],
+          networkRecord: networkRecords[1],
+          src: 'b',
+        }),
       ],
       traces: {defaultPass: createTestTrace({traceEnd: 2000})},
       devtoolsLogs: {},

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -46,14 +46,13 @@ function generateImage(size, coords, networkRecord, src = 'https://google.com/lo
     right: x + size.displayedWidth,
   };
 
-  // TODO: there is probably a better way to do this
-  const props = {
-    isLazyLoaded: isLazyLoaded,
+  return {
+    src,
+    clientRect,
+    isLazyLoaded,
+    ...networkRecord,
+    ...size,
   };
-
-  const image = {src, clientRect, ...networkRecord};
-  Object.assign(image, size, props);
-  return image;
 }
 
 describe('OffscreenImages audit', () => {

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -21,7 +21,7 @@ function generateRecord({
   return {
     url,
     mimeType,
-    startTime, // DevTools timestamp which is in seconds
+    startTime, // DevTools timestamp which is in seconds.
     resourceSize: resourceSizeInKb * 1024,
   };
 }
@@ -114,15 +114,15 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        // offscreen to the right
+        // Offscreen to the right.
         generateImage(generateSize(200, 200), [3000, 0], networkRecords[0]),
-        // offscreen to the bottom
+        // Offscreen to the bottom.
         generateImage(generateSize(100, 100), [0, 2000], networkRecords[1], url('B')),
-        // offscreen to the top-left
+        // Offscreen to the top-left.
         generateImage(generateSize(100, 100), [-2000, -1000], networkRecords[2], url('C')),
-        // offscreen to the bottom-right
+        // Offscreen to the bottom-right.
         generateImage(generateSize(100, 100), [3000, 2000], networkRecords[3], url('D')),
-        // half offscreen to the top, should not warn
+        // Half offscreen to the top, should not warn.
         generateImage(generateSize(1000, 1000), [0, -500], networkRecords[4], url('E')),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
@@ -143,9 +143,9 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        // offscreen to the right, lazy loaded
+        // Offscreen to the right, but lazy loaded.
         generateImage(generateSize(200, 200), [3000, 0], networkRecords[0], url('A'), 'lazy'),
-        // offscreen to the bottom, eager loaded
+        // Offscreen to the bottom, but eager loaded.
         generateImage(generateSize(100, 100), [0, 2000], networkRecords[1], url('B'), 'eager'),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
@@ -207,7 +207,7 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        // offscreen to the right
+        // Offscreen to the right.
         generateImage(generateSize(200, 200), [3000, 0], networkRecord),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
@@ -224,7 +224,7 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        // offscreen to the right
+        // Offscreen to the right.
         generateImage(generateSize(200, 200), [3000, 0], networkRecord),
       ],
       traces: {defaultPass: createTestTrace({traceEnd: 2000})},
@@ -241,7 +241,7 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        // offscreen to the right
+        // Offscreen to the right.
         generateImage(generateSize(100, 100), [0, 2000], networkRecord),
       ],
       traces: {defaultPass: createTestTrace({traceEnd: 2000})},

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -35,15 +35,13 @@ function generateSize(width, height, prefix = 'displayed') {
 
 function generateImage({
   size,
-  coords,
+  x,
+  y,
   networkRecord,
   loading,
   src = 'https://google.com/logo.png',
 }) {
   Object.assign(networkRecord || {}, {url: src});
-
-  const x = coords[0];
-  const y = coords[1];
 
   const clientRect = {
     top: y,
@@ -74,7 +72,7 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage({size: generateSize(100, 100), coords: [0, 0]}),
+        generateImage({size: generateSize(100, 100), x: 0, y: 0}),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -95,16 +93,23 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage({size: generateSize(200, 200), coords: [0, 0], networkRecord: recordA}),
+        generateImage({
+          size: generateSize(200, 200),
+          x: 0,
+          y: 0,
+          networkRecord: recordA,
+        }),
         generateImage({
           size: generateSize(100, 100),
-          coords: [0, 1080],
+          x: 0,
+          y: 1080,
           networkRecord: recordB,
           src: urlB,
         }),
         generateImage({
           size: generateSize(400, 400),
-          coords: [1720, 1080],
+          x: 1720,
+          y: 1080,
           networkRecord: recordC,
           src: urlC,
         }),
@@ -133,34 +138,39 @@ describe('OffscreenImages audit', () => {
         // Offscreen to the right.
         generateImage({
           size: generateSize(200, 200),
-          coords: [3000, 0],
+          x: 3000,
+          y: 0,
           networkRecord: networkRecords[0],
         }),
         // Offscreen to the bottom.
         generateImage({
           size: generateSize(100, 100),
-          coords: [0, 2000],
+          x: 0,
+          y: 2000,
           networkRecord: networkRecords[1],
           src: url('B'),
         }),
         // Offscreen to the top-left.
         generateImage({
           size: generateSize(100, 100),
-          coords: [-2000, -1000],
+          x: -2000,
+          y: -1000,
           networkRecord: networkRecords[2],
           src: url('C'),
         }),
         // Offscreen to the bottom-right.
         generateImage({
           size: generateSize(100, 100),
-          coords: [3000, 2000],
+          x: 3000,
+          y: 2000,
           networkRecord: networkRecords[3],
           src: url('D'),
         }),
         // Half offscreen to the top, should not warn.
         generateImage({
           size: generateSize(1000, 1000),
-          coords: [0, -500],
+          x: 0,
+          y: -500,
           networkRecord: networkRecords[4],
           src: url('E'),
         }),
@@ -186,7 +196,8 @@ describe('OffscreenImages audit', () => {
         // Offscreen to the right, but lazy loaded.
         generateImage({
           size: generateSize(200, 200),
-          coords: [3000, 0],
+          x: 3000,
+          y: 0,
           networkRecord: networkRecords[0],
           loading: 'lazy',
           src: url('A'),
@@ -194,7 +205,8 @@ describe('OffscreenImages audit', () => {
         // Offscreen to the bottom, but eager loaded.
         generateImage({
           size: generateSize(100, 100),
-          coords: [0, 2000],
+          x: 0,
+          y: 2000,
           networkRecord: networkRecords[1],
           loading: 'eager',
           src: url('B'),
@@ -215,7 +227,7 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        generateImage({size: generateSize(0, 0), coords: [0, 0], networkRecord}),
+        generateImage({size: generateSize(0, 0), x: 0, y: 0, networkRecord}),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -241,23 +253,27 @@ describe('OffscreenImages audit', () => {
       ImageElements: [
         generateImage({
           size: generateSize(50, 50),
-          coords: [0, 0],
+          x: 0,
+          y: 0,
           networkRecord: networkRecords[0],
         }),
         generateImage({
           size: generateSize(1000, 1000),
-          coords: [1000, 1000],
+          x: 1000,
+          y: 1000,
           networkRecord: networkRecords[1],
         }),
         generateImage({
           size: generateSize(50, 50),
-          coords: [0, 1500],
+          x: 0,
+          y: 1500,
           networkRecord: networkRecords[2],
           src: urlB,
         }),
         generateImage({
           size: generateSize(400, 400),
-          coords: [0, 1500],
+          x: 0,
+          y: 1500,
           networkRecord: networkRecords[3],
           src: urlB,
         }),
@@ -278,7 +294,7 @@ describe('OffscreenImages audit', () => {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
         // Offscreen to the right.
-        generateImage({size: generateSize(200, 200), coords: [3000, 0], networkRecord}),
+        generateImage({size: generateSize(200, 200), x: 3000, y: 0, networkRecord}),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
@@ -295,7 +311,7 @@ describe('OffscreenImages audit', () => {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
         // Offscreen to the right.
-        generateImage({size: generateSize(200, 200), coords: [3000, 0], networkRecord}),
+        generateImage({size: generateSize(200, 200), x: 3000, y: 0, networkRecord}),
       ],
       traces: {defaultPass: createTestTrace({traceEnd: 2000})},
       devtoolsLogs: {},
@@ -312,7 +328,7 @@ describe('OffscreenImages audit', () => {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
         // Offscreen to the right.
-        generateImage({size: generateSize(100, 100), coords: [0, 2000], networkRecord}),
+        generateImage({size: generateSize(100, 100), x: 0, y: 2000, networkRecord}),
       ],
       traces: {defaultPass: createTestTrace({traceEnd: 2000})},
       devtoolsLogs: {},
@@ -352,13 +368,15 @@ describe('OffscreenImages audit', () => {
       ImageElements: [
         generateImage({
           size: generateSize(0, 0),
-          coords: [0, 0],
+          x: 0,
+          y: 0,
           networkRecord: recordA,
           src: recordA.url,
         }),
         generateImage({
           size: generateSize(200, 200),
-          coords: [3000, 0],
+          x: 3000,
+          y: 0,
           networkRecord: recordB,
           src: recordB.url,
         }),
@@ -406,13 +424,15 @@ describe('OffscreenImages audit', () => {
       ImageElements: [
         generateImage({
           size: generateSize(0, 0),
-          coords: [0, 0],
+          x: 0,
+          y: 0,
           networkRecord: recordA,
           src: recordA.url,
         }),
         generateImage({
           size: generateSize(200, 200),
-          coords: [3000, 0],
+          x: 3000,
+          y: 0,
           networkRecord: recordB,
           src: recordB.url,
         }),
@@ -441,13 +461,15 @@ describe('OffscreenImages audit', () => {
       ImageElements: [
         generateImage({
           size: generateSize(0, 0),
-          coords: [0, 0],
+          x: 0,
+          y: 0,
           networkRecord: networkRecords[0],
           src: 'a',
         }),
         generateImage({
           size: generateSize(200, 200),
-          coords: [3000, 0],
+          x: 3000,
+          y: 0,
           networkRecord: networkRecords[1],
           src: 'b',
         }),

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -33,7 +33,7 @@ function generateSize(width, height, prefix = 'displayed') {
   return size;
 }
 
-function generateImage(size, coords, networkRecord, src = 'https://google.com/logo.png', isLazyLoadedFlag = false) {
+function generateImage(size, coords, networkRecord, src = 'https://google.com/logo.png', isLazyLoaded = false) {
   Object.assign(networkRecord || {}, {url: src});
 
   const x = coords[0];
@@ -46,9 +46,9 @@ function generateImage(size, coords, networkRecord, src = 'https://google.com/lo
     right: x + size.displayedWidth,
   };
 
-  // TODO: pick better name for flag
+  // TODO: there is probably a better way to do this
   const props = {
-    isLazyLoaded: isLazyLoadedFlag,
+    isLazyLoaded: isLazyLoaded,
   };
 
   const image = {src, clientRect, ...networkRecord};
@@ -135,21 +135,21 @@ describe('OffscreenImages audit', () => {
   });
 
   it('passes images with the lazy load attribute', async () => {
+    const urlB = `https://google.com/logo2.png`;
     const topLevelTasks = [{ts: 1900, duration: 100}];
-    const networkRecord = generateRecord({resourceSizeInKb: 100});
+    const networkRecord = generateRecord({url: urlB, resourceSizeInKb: 100});
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        // offscreen with lazy loaded attribute
-        // TODO: figure out whether true is being set as URL
-        generateImage(generateSize(100, 100), [3000, 0], networkRecord, true),
+        // offscreen, but has the lazy loaded attribute set
+        generateImage(generateSize(100, 100), [3000, 0], networkRecord, urlB, true),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
     };
 
     return UnusedImages.audit_(artifacts, [networkRecord], context).then(auditResult => {
-      assert.equal(auditResult.items.length, 1);
+      assert.equal(auditResult.items.length, 0);
     });
   });
 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -365,6 +365,8 @@ declare global {
         resourceSize: number;
         /** The MIME type of the underlying image file. */
         mimeType?: string;
+        /** Flags whether the loading attribute was specified as lazy. */
+        isLazyLoaded: boolean;
       }
 
       export interface OptimizedImage {

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -365,8 +365,8 @@ declare global {
         resourceSize: number;
         /** The MIME type of the underlying image file. */
         mimeType?: string;
-        /** Flags whether the loading attribute was specified as lazy. */
-        isLazyLoaded: boolean;
+        /** The loading attribute of the image. */
+        loading?: string;
       }
 
       export interface OptimizedImage {


### PR DESCRIPTION
**Summary**
Native lazy-loading was recently introduced in Chrome 76. This PR excludes images with a specified 'loading' attribute ('lazy' and 'eager', 'auto' TBD) from the 'defer offscreen images' check. 

See https://web.dev/native-lazy-loading/ for more details about the loading attribute. 

**Related Issues/PRs**
fixes: #10053