### PR TITLE
core: add ids to gatherers

### DIFF
--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -68,6 +68,16 @@ function runA11yChecks() {
 
 class Accessibility extends Gatherer {
   /**
+   * @return {LH.Gatherer.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'Accessibility',
+      description: 'Using axe to collect accessibility data',
+    };
+  }
+
+  /**
    * @param {LH.Gatherer.PassContext} passContext
    * @return {Promise<LH.Artifacts.Accessibility>}
    */

--- a/lighthouse-core/gather/gatherers/gatherer.js
+++ b/lighthouse-core/gather/gatherers/gatherer.js
@@ -19,11 +19,29 @@
  */
 class Gatherer {
   /**
+   * @return {LH.Gatherer.Meta}
+   */
+  static get meta() {
+    // throw new Error('Gatherer meta information must be overridden.');
+    return {
+      // @ts-ignore
+      id: undefined,
+      // @ts-ignore
+      description: undefined,
+    };
+  }
+
+  /**
    * @return {keyof LH.GathererArtifacts}
    */
   get name() {
     // @ts-ignore - assume that class name has been added to LH.GathererArtifacts.
-    return this.constructor.name;
+    return this.constructor.meta.id || this.constructor.name;
+  }
+
+  get description() {
+    // @ts-ignore
+    return this.constructor.meta.description || this.name;
   }
 
   /* eslint-disable no-unused-vars */

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -11,6 +11,12 @@ import Driver = require('../lighthouse-core/gather/driver');
 
 declare global {
   module LH.Gatherer {
+    export interface Meta {
+      /** The string identifier of the gatherer, LooksLikeThis. */
+      id: keyof GathererArtifacts;
+      description: string;
+    }
+
     export interface PassContext {
       /** The url of the currently loaded page. If the main document redirects, this will be updated to keep track. */
       url: string;


### PR DESCRIPTION
closes #2087

I suppose `description` would only be used when we print the status.

![image](https://user-images.githubusercontent.com/4071474/71931373-764c1b80-3152-11ea-8293-8af97e820f91.png)

Do we especially want that, or do we just want an `id` instead of using the classname?