### PR TITLE
cli: fix csv for --output

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -138,7 +138,7 @@ function getFlags(manualArgv) {
 
       .group(['output', 'output-path', 'view'], 'Output:')
       .describe({
-        'output': `Reporter for the results, supports multiple values`,
+        'output': `Reporter for the results, supports multiple values. choices: ${printer.getValidOutputOptions().map(s => `"${s}"`).join(', ')}`,
         'output-path': `The file path to output the results. Use 'stdout' to write to stdout.
   If using JSON output, default is stdout.
   If using HTML or CSV output, default is a file in the working directory with a name based on the test URL and date.
@@ -153,7 +153,6 @@ function getFlags(manualArgv) {
         'list-trace-categories', 'view', 'verbose', 'quiet', 'help', 'print-config',
         'chrome-ignore-default-flags',
       ])
-      .choices('output', printer.getValidOutputOptions())
       .choices('emulated-form-factor', ['mobile', 'desktop', 'none'])
       .choices('throttling-method', ['devtools', 'provided', 'simulate'])
       .choices('preset', ['perf', 'mixed-content'])

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -92,7 +92,7 @@ describe('CLI run', function() {
 describe('flag coercing', () => {
   it('should force to array', () => {
     assert.deepStrictEqual(
-      getFlags('https://www.example.com --only-audits foo chrome://version').onlyAudits, ['foo']);
+      getFlags('https://www.example.com --only-audits foo').onlyAudits, ['foo']);
   });
 
   it('should allow csv', () => {

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -91,10 +91,15 @@ describe('CLI run', function() {
 
 describe('flag coercing', () => {
   it('should force to array', () => {
-    assert.deepStrictEqual(getFlags(`--only-audits foo chrome://version`).onlyAudits, ['foo']);
+    assert.deepStrictEqual(
+      getFlags('https://www.example.com --only-audits foo chrome://version').onlyAudits, ['foo']);
+  });
+
+  it('should allow csv', () => {
+    assert.deepStrictEqual(
+      getFlags('https://www.example.com --output html,json').output, ['html', 'json']);
   });
 });
-
 
 describe('saveResults', () => {
   it('will quit early if we\'re in gather mode', async () => {


### PR DESCRIPTION
`--output json,html` was meant to work, but `yargs.choices` was preventing that.

![image](https://user-images.githubusercontent.com/4071474/71936448-473ba700-315e-11ea-9246-551bbcfe835a.png)
