### PR TITLE
tests(report-ui-features): fix tools button suite to pass isolated run

### DIFF
--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -88,6 +88,7 @@ describe('ReportUIFeatures', () => {
 
     dom = new DOM(document.window.document);
     sampleResults = Util.prepareReportResult(sampleResultsOrig);
+    render(sampleResults);
   });
 
   afterAll(() => {
@@ -275,8 +276,6 @@ describe('ReportUIFeatures', () => {
     let dropDown;
 
     beforeEach(() => {
-      // render is a prerequisite for initFeatures
-      render(sampleResults);
       window = dom.document().defaultView;
       const features = new ReportUIFeatures(dom);
       features.initFeatures(sampleResults);

--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -275,6 +275,8 @@ describe('ReportUIFeatures', () => {
     let dropDown;
 
     beforeEach(() => {
+      // render is a prerequisite for initFeatures
+      render(sampleResults);
       window = dom.document().defaultView;
       const features = new ReportUIFeatures(dom);
       features.initFeatures(sampleResults);


### PR DESCRIPTION
**Summary**
Problem: the tools button test suite fails when run in isolation, for example:

```bash
$ npx jest lighthouse-core/test/report/html/renderer/report-ui-features-test.js -t="tools button"
...
Test Suites: 1 failed, 1 total
Tests:       15 failed, 15 total
```

Root cause: The tools button test suite setup calls ReportUiFeatures.initFeatures
which has an implicit prerequisite on ReportRenderer.renderReport.

The prerequisite was coincidentally being met when other test suites in
the file invoked the render test helper function.

Solution: Invoke the render test helper function in the tools button suite setup.

<!-- Thank you for submitting a pull request! -->


<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
#9433
