### PR TITLE
tests(report-ui-features): add empty list and single item test cases

### DIFF
--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -353,6 +353,22 @@ describe('ReportUIFeatures', () => {
         createDiv = () => dom.document().createElement('div');
       });
 
+      it('should return undefined when nodes is empty', () => {
+        const nodes = [];
+
+        const nextNode = dropDown._getNextSelectableNode(nodes);
+
+        assert.strictEqual(nextNode, undefined);
+      });
+
+      it('should return only node', () => {
+        const nodes = [createDiv()];
+
+        const nextNode = dropDown._getNextSelectableNode(nodes);
+
+        assert.strictEqual(nextNode, nodes[0]);
+      });
+
       it('should return first node when start is undefined', () => {
         const nodes = [createDiv(), createDiv()];
 

--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -361,12 +361,12 @@ describe('ReportUIFeatures', () => {
         assert.strictEqual(nextNode, undefined);
       });
 
-      it('should return only node', () => {
-        const nodes = [createDiv()];
+      it('should return the only node when start is defined', () => {
+        const node = createDiv();
 
-        const nextNode = dropDown._getNextSelectableNode(nodes);
+        const nextNode = dropDown._getNextSelectableNode([node], node);
 
-        assert.strictEqual(nextNode, nodes[0]);
+        assert.strictEqual(nextNode, node);
       });
 
       it('should return first node when start is undefined', () => {


### PR DESCRIPTION
**Summary**
Add two test cases to the _getNextSelectableNode suite missed in my original PR
- empty list
- list of 1

**Related Issues/PRs**
#9433
