### PR TITLE
report: close drop down menu when focus is lost

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -752,7 +752,7 @@ class DropDown {
    * @param {Event} e
    */
   onMenuFocusOut(e) {
-    // The focusout event is not supported in our current version of typescript (3.5.3)
+    // TODO: The focusout event is not supported in our current version of typescript (3.5.3)
     // https://github.com/microsoft/TypeScript/issues/30716
     const focusEvent = /** @type {FocusEvent} */ (e);
     const focusedEl = /** @type {?HTMLElement} */ (focusEvent.relatedTarget);

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -620,6 +620,7 @@ class DropDown {
     this.onDocumentKeyDown = this.onDocumentKeyDown.bind(this);
     this.onToggleClick = this.onToggleClick.bind(this);
     this.onToggleKeydown = this.onToggleKeydown.bind(this);
+    this.onMenuFocusOut = this.onMenuFocusOut.bind(this);
     this.onMenuKeydown = this.onMenuKeydown.bind(this);
 
     this._getNextMenuItem = this._getNextMenuItem.bind(this);
@@ -647,6 +648,7 @@ class DropDown {
       // Refocus on the tools button if the drop down last had focus
       this._toggleEl.focus();
     }
+    this._menuEl.removeEventListener('focusout', this.onMenuFocusOut);
     this._dom.document().removeEventListener('keydown', this.onDocumentKeyDown);
   }
 
@@ -666,6 +668,7 @@ class DropDown {
 
     this._toggleEl.classList.add('active');
     this._toggleEl.setAttribute('aria-expanded', 'true');
+    this._menuEl.addEventListener('focusout', this.onMenuFocusOut);
     this._dom.document().addEventListener('keydown', this.onDocumentKeyDown);
   }
 
@@ -740,6 +743,21 @@ class DropDown {
    */
   onDocumentKeyDown(e) {
     if (e.keyCode === 27) { // ESC
+      this.close();
+    }
+  }
+
+  /**
+   * Focus out handler for the drop down menu.
+   * @param {Event} e
+   */
+  onMenuFocusOut(e) {
+    // The focusout event is not supported in our current version of typescript (3.5.3)
+    // https://github.com/microsoft/TypeScript/issues/30716
+    const focusEvent = /** @type {FocusEvent} */ (e);
+    const focusedEl = /** @type {?HTMLElement} */ (focusEvent.relatedTarget);
+
+    if (!this._menuEl.contains(focusedEl)) {
       this.close();
     }
   }

--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -397,10 +397,12 @@ describe('ReportUIFeatures', () => {
     });
 
     describe('onMenuFocusOut', () => {
-      it('should toggle active class when focus relatedTarget is null', () => {
+      beforeEach(() => {
         dropDown._toggleEl.click();
         assert.ok(dropDown._toggleEl.classList.contains('active'));
+      });
 
+      it('should toggle active class when focus relatedTarget is null', () => {
         const event = new window.FocusEvent('focusout', {relatedTarget: null});
         dropDown.onMenuFocusOut(event);
 
@@ -408,9 +410,6 @@ describe('ReportUIFeatures', () => {
       });
 
       it('should toggle active class when focus relatedTarget is document.body', () => {
-        dropDown._toggleEl.click();
-        assert.ok(dropDown._toggleEl.classList.contains('active'));
-
         const relatedTarget = dom.document().body;
         const event = new window.FocusEvent('focusout', {relatedTarget});
         dropDown.onMenuFocusOut(event);
@@ -419,9 +418,6 @@ describe('ReportUIFeatures', () => {
       });
 
       it('should toggle active class when focus relatedTarget is _toggleEl', () => {
-        dropDown._toggleEl.click();
-        assert.ok(dropDown._toggleEl.classList.contains('active'));
-
         const relatedTarget = dropDown._toggleEl;
         const event = new window.FocusEvent('focusout', {relatedTarget});
         dropDown.onMenuFocusOut(event);
@@ -430,9 +426,6 @@ describe('ReportUIFeatures', () => {
       });
 
       it('should not toggle active class when focus relatedTarget is a menu item', () => {
-        dropDown._toggleEl.click();
-        assert.ok(dropDown._toggleEl.classList.contains('active'));
-
         const relatedTarget = dropDown._getNextMenuItem();
         const event = new window.FocusEvent('focusout', {relatedTarget});
         dropDown.onMenuFocusOut(event);

--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -395,5 +395,50 @@ describe('ReportUIFeatures', () => {
         assert.strictEqual(nextNode, nodes[2]);
       });
     });
+
+    describe('onMenuFocusOut', () => {
+      it('should toggle active class when focus relatedTarget is null', () => {
+        dropDown._toggleEl.click();
+        assert.ok(dropDown._toggleEl.classList.contains('active'));
+
+        const event = new window.FocusEvent('focusout', {relatedTarget: null});
+        dropDown.onMenuFocusOut(event);
+
+        assert.ok(!dropDown._toggleEl.classList.contains('active'));
+      });
+
+      it('should toggle active class when focus relatedTarget is document.body', () => {
+        dropDown._toggleEl.click();
+        assert.ok(dropDown._toggleEl.classList.contains('active'));
+
+        const relatedTarget = dom.document().body;
+        const event = new window.FocusEvent('focusout', {relatedTarget});
+        dropDown.onMenuFocusOut(event);
+
+        assert.ok(!dropDown._toggleEl.classList.contains('active'));
+      });
+
+      it('should toggle active class when focus relatedTarget is _toggleEl', () => {
+        dropDown._toggleEl.click();
+        assert.ok(dropDown._toggleEl.classList.contains('active'));
+
+        const relatedTarget = dropDown._toggleEl;
+        const event = new window.FocusEvent('focusout', {relatedTarget});
+        dropDown.onMenuFocusOut(event);
+
+        assert.ok(!dropDown._toggleEl.classList.contains('active'));
+      });
+
+      it('should not toggle active class when focus relatedTarget is a menu item', () => {
+        dropDown._toggleEl.click();
+        assert.ok(dropDown._toggleEl.classList.contains('active'));
+
+        const relatedTarget = dropDown._getNextMenuItem();
+        const event = new window.FocusEvent('focusout', {relatedTarget});
+        dropDown.onMenuFocusOut(event);
+
+        assert.ok(dropDown._toggleEl.classList.contains('active'));
+      });
+    });
   });
 });


### PR DESCRIPTION
**Summary**
#### Problem
The report drop down menu does not close when the escape key
is pressed in the devtools.

***Gif of bug: menu does not close when escape key is pressed and console opens***
![devtools-menu-console-esc-bug](https://user-images.githubusercontent.com/309310/72118994-cd472180-3307-11ea-91e0-767d543d8c70.gif)

This creates a challenge for customer relying on the keyboard that wish
to dismiss the drop down.

This also does not align with the experience of the WAI ARIA practice
navigation menu button example [1].

#### Root cause
The escape key event is captured and not propagated by the
devtools to toggle the console drawer.

#### Solution
Close the menu when focus moves out of the menu.

This better aligns the menu with the Navigation menu button example for
which its interaction design is based on [1].

**Code Change**
* Add a menu focus out handler to close the drop down menu
* Unfortunately JSDOM does not support focusout events so JSDOM integration tests
  are not possible [2], instead I have added unit test for the onMenuFocusOut handler.
* A TypeScript upgrade is needed to better support the focusout event [3].

***Gif of bug fixed: menu does close when escape key is pressed and console opens***
![devtools-menu-console-esc-bug-fixed](https://user-images.githubusercontent.com/309310/72119010-d89a4d00-3307-11ea-9c8a-e758c06790e7.gif)

***Gif of menu escape key closing the menu***
![devtools-menu-console-esc-bug-fixed-demo-esc](https://user-images.githubusercontent.com/309310/72119043-efd93a80-3307-11ea-88df-de63ceea3402.gif)

***Gif of menu tabbing closing the menu***
![devtools-menu-console-esc-bug-fixed-demo-tabbing](https://user-images.githubusercontent.com/309310/72119079-0a131880-3308-11ea-81ee-f6665e125dbe.gif)

**Related Issues/PRs**
#9433

[1]: https://www.w3.org/TR/2019/NOTE-wai-aria-practices-1.1-20190207/examples/menu-button/menu-button-links.html
[2]: https://github.com/jsdom/jsdom/issues/2708
[3]: https://github.com/microsoft/TypeScript/issues/30716