### PR TITLE
report: fix ghost menu in print

### DIFF
--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -360,6 +360,10 @@ limitations under the License.
         position: static;
         margin-left: 0;
       }
+
+      .lh-tools__dropdown {
+        display: none;
+      }
     }
   </style>
 


### PR DESCRIPTION
**Summary**
***Problem***
Print displays the tools drop down menu, rendering behind the category
headings.

*****Screenshot of menu rendered in report print preview*****
![image](https://user-images.githubusercontent.com/309310/72197318-c76b4200-33d4-11ea-80ad-9a3982c3dfa4.png)

***Root cause***
The drop down menu is made hidden by the CSS `visibility: hidden` and
toggled to `visibility: visible` when displayed to users and the print
media does not support this property (citation needed).

***Solution***
Use `display: none` for the `print` media query to hide it (print media
does not support drop drop interactions).

*****Screenshot of menu hidden in report print preview*****
![image](https://user-images.githubusercontent.com/309310/72197300-8d9a3b80-33d4-11ea-8861-543aa3a61f88.png)
