### PR TITLE
tests(smokehouse): make bytes gzip size checks less restrictive

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -195,13 +195,13 @@ const expectations = [
               },
               {
                 url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
-                transferSize: 1158,
-                resourceSize: 52997,
+                transferSize: '1100 +/- 100',
+                resourceSize: '53000 +/- 1000',
               },
               {
                 url: 'http://localhost:10200/byte-efficiency/script.js',
-                transferSize: 53203,
-                resourceSize: 52997,
+                transferSize: '53200 +/- 1000',
+                resourceSize: '53000 +/- 1000',
               },
               {
                 url: 'http://localhost:10200/favicon.ico',

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -561,7 +561,10 @@ describe('GatherRunner', function() {
     };
 
     const artifacts = await GatherRunner.run(config.passes, options);
-    expect(artifacts.LighthouseRunWarnings).toHaveLength(1);
+    expect(artifacts.LighthouseRunWarnings).toEqual([
+      'lighthouse-core/gather/gather-runner.js | warningRedirected # 1',
+      'lighthouse-core/lib/lh-error.js | badTraceRecording # 0',
+    ]);
     expect(artifacts.PageLoadError).toEqual(null);
     // @ts-ignore: Test-only gatherer.
     expect(artifacts.TestGatherer).toBeUndefined();

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -561,10 +561,7 @@ describe('GatherRunner', function() {
     };
 
     const artifacts = await GatherRunner.run(config.passes, options);
-    expect(artifacts.LighthouseRunWarnings).toEqual([
-      'lighthouse-core/gather/gather-runner.js | warningRedirected # 1',
-      'lighthouse-core/lib/lh-error.js | badTraceRecording # 0',
-    ]);
+    expect(artifacts.LighthouseRunWarnings).toHaveLength(1);
     expect(artifacts.PageLoadError).toEqual(null);
     // @ts-ignore: Test-only gatherer.
     expect(artifacts.TestGatherer).toBeUndefined();


### PR DESCRIPTION
This change makes sense in isolation, but in particular I'm doing this to avoid an unnecessary modification to this smoke test expectation for LR (transfer sizes are different b/c response headers). I changed resource size too just b/c there's no need to be so specific.