### PR TITLE
tests: avoid redirect in failureMode warn test

### DIFF
--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -535,7 +535,7 @@ describe('GatherRunner', function() {
 
     const gotoUrlForAboutBlank = jest.fn().mockResolvedValue(null);
     const gotoUrlForRealUrl = jest.fn()
-      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(requestedUrl)
       .mockRejectedValueOnce(navigationError);
     const driver = Object.assign({}, fakeDriver, {
       online: true,


### PR DESCRIPTION
**Summary**
Master was accidentally broken by some fast merging conflicts that were git-detectable conflicts.
