### PR TITLE
docs: add protobuf install directions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -254,12 +254,12 @@ If changing audit output, you'll likely also need to have the protocol-buffer (l
 # open a shell within that folder
 
 cd python
-/usr/bin/python setup.py build
-/usr/bin/python setup.py test
+python setup.py build
+python setup.py test
 (cd .. && autogen.sh && configure && make)
 (cd .. && sudo make install)
-/usr/bin/python setup.py build --cpp_implementation
-/usr/bin/python setup.py install --cpp_implementation
+python setup.py build --cpp_implementation
+sudo python setup.py install --cpp_implementation
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -246,7 +246,7 @@ yarn build-all
 ```
 
 #### installing protobuf
-If changing audit output, you'll likely also need to have the protocol-buffer (likely v3.7.1) compiler installed. See the [official installation instructions](https://github.com/protocolbuffers/protobuf#protocol-compiler-installation) and perhaps consult your [favorite package manager](https://formulae.brew.sh/formula/protobuf) for your OS. These are the steps that have worked well for us:
+If changing audit output, you'll need to have the protocol-buffer/protobuf compiler installed. (v3.7.1 is known to be compatible). These are the steps that have worked well for us:
 
 ```sh
 # Download https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-python-3.7.1.zip
@@ -261,6 +261,8 @@ python setup.py test
 python setup.py build --cpp_implementation
 sudo python setup.py install --cpp_implementation
 ```
+
+Also, see the [official installation instructions](https://github.com/protocolbuffers/protobuf#protocol-compiler-installation). Note that using a package manager to install will result in the latest version which **isn't** compatible with our output.
 
 
 ### Run

--- a/readme.md
+++ b/readme.md
@@ -245,7 +245,23 @@ yarn
 yarn build-all
 ```
 
-If changing audit output, you'll likely also need to have the protocol-buffer compiler installed. See the [official installation instructions](https://github.com/protocolbuffers/protobuf#protocol-compiler-installation) or consult your [favorite package manager](https://formulae.brew.sh/formula/protobuf) for your OS.
+#### installing protobuf
+If changing audit output, you'll likely also need to have the protocol-buffer (likely v3.7.1) compiler installed. See the [official installation instructions](https://github.com/protocolbuffers/protobuf#protocol-compiler-installation) and perhaps consult your [favorite package manager](https://formulae.brew.sh/formula/protobuf) for your OS. These are the steps that have worked well for us:
+
+```sh
+# Download https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-python-3.7.1.zip
+# unzip it
+# open a shell within that folder
+
+cd python
+/usr/bin/python setup.py build
+/usr/bin/python setup.py test
+(cd .. && autogen.sh && configure && make)
+(cd .. && sudo make install)
+/usr/bin/python setup.py build --cpp_implementation
+/usr/bin/python setup.py install --cpp_implementation
+```
+
 
 ### Run
 

--- a/readme.md
+++ b/readme.md
@@ -249,7 +249,10 @@ yarn build-all
 If changing audit output, you'll need to have the protocol-buffer/protobuf compiler installed. (v3.7.1 is known to be compatible). These are the steps that have worked well for us:
 
 ```sh
-# Download https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-python-3.7.1.zip
+mkdir protobuf-install && cd protobuf-install
+curl -L -o protobuf-python-3.7.1.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-python-3.7.1.zip
+unzip protobuf-python-3.7.1.zip
+cd protobuf-3.7.1
 # unzip it
 # open a shell within that folder
 

--- a/readme.md
+++ b/readme.md
@@ -246,15 +246,17 @@ yarn build-all
 ```
 
 #### installing protobuf
-If changing audit output, you'll need to have the protocol-buffer/protobuf compiler installed. (v3.7.1 is known to be compatible). These are the steps that have worked well for us:
+If changing audit output, you'll need to have v3.7.1 of the protocol-buffer/protobuf compiler installed. (v3.7.1 is known to be compatible, and 3.11.x is known to be **not** compatible.). 
+
+Homebrew should be able to install it correctly: `brew install protobuf@3.7.1`
+
+But if you want to do it manually, these steps that have worked well for us:
 
 ```sh
 mkdir protobuf-install && cd protobuf-install
 curl -L -o protobuf-python-3.7.1.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-python-3.7.1.zip
 unzip protobuf-python-3.7.1.zip
 cd protobuf-3.7.1
-# unzip it
-# open a shell within that folder
 
 cd python
 python setup.py build
@@ -265,7 +267,7 @@ python setup.py build --cpp_implementation
 sudo python setup.py install --cpp_implementation
 ```
 
-Also, see the [official installation instructions](https://github.com/protocolbuffers/protobuf#protocol-compiler-installation). Note that using a package manager to install will result in the latest version which **isn't** compatible with our output.
+Also, see the [official installation instructions](https://github.com/protocolbuffers/protobuf#protocol-compiler-installation).
 
 
 ### Run


### PR DESCRIPTION
okay i think these are reproducible and good.

i'm not sure when they changed the format that results in [this empty object to null change](https://github.com/GoogleChrome/lighthouse/pull/10242/commits/4a32b15f6c6e8cc5e8ddc61c7f1f936717f0e37a), but it was between 3.7.1 and 3.11.2.


