### PR TITLE
build: use npm pack'd lighthouse in doc integrations

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,6 @@ test_script:
   # run smoke tests serially, trying up to three times to prevent flakes.
   # FIXME: Exclude Appveyor from running `lantern` smoketest until we fix the flake.
   - yarn smoke -j=1 --retries=2 a11y errors oopif pwa pwa2 pwa3 dbw redirects seo offline byte perf metrics
-  - yarn test-docs
 
 cache:
   #- chrome-win32 -> appveyor.yml,package.json

--- a/.npmignore
+++ b/.npmignore
@@ -24,9 +24,11 @@ lighthouse-logger/
 # keep smokehouse tests, etc
 !lighthouse-cli/test
 
-node_modules
 results/
 lantern-data/
+
+# ignore all folders named as such
+node_modules
 latest-run
 
 # generated files

--- a/.npmignore
+++ b/.npmignore
@@ -24,10 +24,10 @@ lighthouse-logger/
 # keep smokehouse tests, etc
 !lighthouse-cli/test
 
-node_modules/
+node_modules
 results/
 lantern-data/
-latest-run/
+latest-run
 
 # generated files
 **/pages/scripts/lighthouse-report.js
@@ -50,3 +50,4 @@ results.html
 .eslintignore
 .eslintrc.js
 .travis.yml
+*.tgz

--- a/build/build-pack.sh
+++ b/build/build-pack.sh
@@ -7,4 +7,4 @@ cd tmp_dir
 npm pack "$lh_dir"
 mv *.tgz "$lh_dir/dist/lighthouse.tgz"
 
-rm -rf $tmp_dir
+rmdir $tmp_dir

--- a/build/build-pack.sh
+++ b/build/build-pack.sh
@@ -5,8 +5,8 @@ DIRNAME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 tmp_dir=$(mktemp -d -t lh-XXXXXXXXXX)
 lh_dir="$DIRNAME/.."
 
-cd tmp_dir
+cd "$tmp_dir"
 npm pack "$lh_dir"
 mv *.tgz "$lh_dir/dist/lighthouse.tgz"
 
-rmdir $tmp_dir
+rmdir "$tmp_dir"

--- a/build/build-pack.sh
+++ b/build/build-pack.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+DIRNAME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 tmp_dir=$(mktemp -d -t lh-XXXXXXXXXX)
-lh_dir=$(pwd)
+lh_dir=$(DIRNAME)
 
 cd tmp_dir
 npm pack "$lh_dir"

--- a/build/build-pack.sh
+++ b/build/build-pack.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+tmp_dir=$(mktemp -d -t lh-XXXXXXXXXX)
+lh_dir=$(pwd)
+
+cd tmp_dir
+npm pack "$lh_dir"
+mv *.tgz "$lh_dir/dist/lighthouse.tgz"
+
+rm -rf $tmp_dir

--- a/build/build-pack.sh
+++ b/build/build-pack.sh
@@ -3,7 +3,7 @@
 DIRNAME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 tmp_dir=$(mktemp -d -t lh-XXXXXXXXXX)
-lh_dir=$(DIRNAME)
+lh_dir="$DIRNAME/.."
 
 cd tmp_dir
 npm pack "$lh_dir"

--- a/build/build-pack.sh
+++ b/build/build-pack.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 DIRNAME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LH_ROOT="$DIRNAME/.."
 
 tmp_dir=$(mktemp -d -t lh-XXXXXXXXXX)
-lh_dir="$DIRNAME/.."
 
 cd "$tmp_dir"
-npm pack "$lh_dir"
-mv *.tgz "$lh_dir/dist/lighthouse.tgz"
+npm pack "$LH_ROOT"
+mv *.tgz "$LH_ROOT/dist/lighthouse.tgz"
 
 rmdir "$tmp_dir"

--- a/docs/recipes/auth/package.json
+++ b/docs/recipes/auth/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "express-session": "^1.16.2",
-    "lighthouse": "file:../../..",
+    "lighthouse": "file:../../../dist/lighthouse.tgz",
     "morgan": "^1.9.1"
   }
 }

--- a/docs/recipes/integration-test/package.json
+++ b/docs/recipes/integration-test/package.json
@@ -4,6 +4,6 @@
   },
   "dependencies": {
     "jest": "^24.9.0",
-    "lighthouse": "file:../../.."
+    "lighthouse": "file:../../../dist/lighthouse.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   },
   "scripts": {
     "build-all": "npm-run-posix-or-windows build-all:task",
-    "build-all:task": "yarn build-extension & yarn build-devtools & yarn build-lr & yarn build-viewer & wait",
+    "build-all:task": "(yarn build-extension & yarn build-devtools & yarn build-lr & yarn build-viewer & wait) && yarn build-pack",
     "build-all:task:windows": "yarn build-extension && yarn build-devtools && yarn build-lr && yarn build-viewer",
     "build-extension": "node ./build/build-extension.js",
     "build-devtools": "node ./build/build-bundle.js clients/devtools-entry.js dist/lighthouse-dt-bundle.js && node ./build/build-dt-report-resources.js",
     "build-lr": "node ./build/build-lightrider-bundles.js",
+    "build-pack": "sh build/build-pack.sh",
     "build-viewer": "node ./build/build-viewer.js",
     "clean": "rimraf dist proto/scripts/*.json proto/scripts/*_pb2.* proto/scripts/*_pb.* proto/scripts/__pycache__ proto/scripts/*.pyc *.report.html *.report.dom.html *.report.json *.devtoolslog.json *.trace.json lighthouse-core/lib/i18n/locales/*.ctc.json || true",
     "lint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build-extension": "node ./build/build-extension.js",
     "build-devtools": "node ./build/build-bundle.js clients/devtools-entry.js dist/lighthouse-dt-bundle.js && node ./build/build-dt-report-resources.js",
     "build-lr": "node ./build/build-lightrider-bundles.js",
-    "build-pack": "sh build/build-pack.sh",
+    "build-pack": "bash build/build-pack.sh",
     "build-viewer": "node ./build/build-viewer.js",
     "clean": "rimraf dist proto/scripts/*.json proto/scripts/*_pb2.* proto/scripts/*_pb.* proto/scripts/__pycache__ proto/scripts/*.pyc *.report.html *.report.dom.html *.report.json *.devtoolslog.json *.trace.json lighthouse-core/lib/i18n/locales/*.ctc.json || true",
     "lint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .",


### PR DESCRIPTION
For some reason the current setup for the doc integration tests, which has been working for months now, is now the root cause of an awful infinitely recursive dependency. `yarn test-docs` never finishes.

Instead, let's pack lighthouse and use the resultant tar file directly. This is much closer to what would get published to npm (there is still room for including more files than expected vs. the actual process, since we aren't in a pristine folder).