### PR TITLE
tests(audits): Return type correction (LH.Audit.Result -> LH.Audit.Product)

### DIFF
--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -48,7 +48,10 @@ class AxeAudit extends Audit {
     const incomplete = artifacts.Accessibility.incomplete || [];
     const incompleteResult = incomplete.find(result => result.id === this.meta.id);
     if (incompleteResult && incompleteResult.error) {
-      return Audit.generateErrorAuditResult(this, incompleteResult.error.message);
+      return {
+        score: null,
+        errorMessage: incompleteResult.error.message,
+      };
     }
 
     const isInformative = this.meta.scoreDisplayMode === Audit.SCORING_MODES.INFORMATIVE;


### PR DESCRIPTION
**Summary**
Change #10072 used the `Audit.generateErrorAuditResult` function to generate a return value, but this return value is of type `LH.Audit.Result`, when the caller is expecting `LH.Audit.Product`.

Since the returned value we expect is a relatively simple type, here we construct the relevant fields (`score`, `errorMessage`) directly instead.

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/pull/10072