### PR TITLE
misc: add CODEOWNERS to finish codereview assignment setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+
+# This file pairs with the automated code review assignment setting to make that system work
+#   https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/managing-code-review-assignment-for-your-team
+
+# Docs: https://help.github.com/articles/about-codeowners/
+
+
+# default owners for the entire repo
+*       @paulirish @connorjclark @patrickhulce @exterkamp


### PR DESCRIPTION
funnily enough, github support informs me that codeowners is required for the codereview rotation to work. :p

ref #10265 