### PR TITLE
core(lantern): do not create self-dependencies via timers

### DIFF
--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -249,7 +249,7 @@ class PageDependencyGraph {
           case 'TimerFire': {
             // @ts-ignore - 'TimerFire' event means timerId exists.
             const installer = timers.get(evt.args.data.timerId);
-            if (!installer) break;
+            if (!installer || installer.endTime > node.startTime) break;
             installer.addDependent(node);
             break;
           }

--- a/lighthouse-core/lib/dependency-graph/base-node.js
+++ b/lighthouse-core/lib/dependency-graph/base-node.js
@@ -129,6 +129,9 @@ class BaseNode {
    * @param {Node} node
    */
   addDependency(node) {
+    // @ts-ignore - in checkJs, ts doesn't know that CPUNode and NetworkNode *are* BaseNodes.
+    if (node === this) throw new Error('Cannot add dependency on itself');
+
     if (this._dependencies.includes(node)) {
       return;
     }

--- a/lighthouse-core/test/computed/page-dependency-graph-test.js
+++ b/lighthouse-core/test/computed/page-dependency-graph-test.js
@@ -260,9 +260,9 @@ describe('PageDependencyGraph computed artifact:', () => {
       ]);
 
       addTaskEvents(600, 150, [
-        // CPU 1.4 should depend on Network 4 even though it ends at 410ms
+        // CPU 1.6 should depend on Network 4 even though it ends at 410ms
         {name: 'InvalidateLayout', data: {stackTrace: [{url: '4'}]}},
-        // Network 5 should not depend on CPU 1.4 because it started before CPU 1.4
+        // Network 5 should not depend on CPU 1.6 because it started before CPU 1.6
         {name: 'ResourceSendRequest', data: {requestId: 5}},
       ]);
 
@@ -280,6 +280,29 @@ describe('PageDependencyGraph computed artifact:', () => {
       assert.deepEqual(getDependencyIds(nodes[4]), [1]);
       assert.deepEqual(getDependencyIds(nodes[5]), [1]);
       assert.deepEqual(getDependencyIds(nodes[6]), [4]);
+    });
+
+    it('should not install timer dependency on itself', () => {
+      const request1 = createRequest(1, '1', 0);
+      const networkRecords = [request1];
+
+      addTaskEvents(200, 200, [
+        // CPU 1.2 should depend on Network 1
+        {name: 'EvaluateScript', data: {url: '1'}},
+        // CPU 1.2 will install and fire it's own timer, but should not depend on itself
+        {name: 'TimerInstall', data: {timerId: 'timer1'}},
+        {name: 'TimerFire', data: {timerId: 'timer1'}},
+      ]);
+
+      const graph = PageDependencyGraph.createGraph(traceOfTab, networkRecords);
+      const nodes = [];
+      graph.traverse(node => nodes.push(node));
+
+      const getDependencyIds = node => node.getDependencies().map(node => node.id);
+
+      assert.equal(nodes.length, 2);
+      assert.deepEqual(getDependencyIds(nodes[0]), []);
+      assert.deepEqual(getDependencyIds(nodes[1]), [1]);
     });
 
     it('should prune short tasks', () => {

--- a/lighthouse-core/test/lib/dependency-graph/base-node-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/base-node-test.js
@@ -80,6 +80,11 @@ describe('DependencyGraph/Node', () => {
       assert.deepEqual(nodeA.getDependencies(), [nodeB]);
       assert.deepEqual(nodeB.getDependents(), [nodeA]);
     });
+
+    it('throw when trying to add a dependency on itself', () => {
+      const nodeA = new BaseNode(1);
+      expect(() => nodeA.addDependency(nodeA)).toThrow();
+    });
   });
 
   describe('.getRootNode', () => {


### PR DESCRIPTION
**Summary**
Prevents fatal "Invalid cycle detected" error from happening when a timer was installed and fired in the same task (which shouldn't be possible but c'est la vie)

**Related Issues/PRs**
fixes #10098 
