### PR TITLE
build: fix appveyor cache failures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,7 @@ test_script:
   # FIXME: Exclude Appveyor from running `lantern` smoketest until we fix the flake.
   - yarn smoke -j=1 --retries=2 a11y errors oopif pwa pwa2 pwa3 dbw redirects seo offline byte perf metrics
 
-after_test:
+on_success:
   - yarn unlink
 
 cache:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,6 +42,8 @@ test_script:
   - yarn smoke -j=1 --retries=2 a11y errors oopif pwa pwa2 pwa3 dbw redirects seo offline byte perf metrics
 
 on_success:
+  # Remove module resolution symlinks; this avoids 'Unable to save cache'
+  # errors when appveyor runs 7z.exe to save the build cache
   - yarn unlink
 
 cache:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,6 +44,7 @@ test_script:
 on_success:
   # Remove module resolution symlinks; this avoids 'Unable to save cache'
   # errors when appveyor runs 7z.exe to save the build cache
+  - yarn unlink lighthouse
   - yarn unlink
 
 cache:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,6 +41,9 @@ test_script:
   # FIXME: Exclude Appveyor from running `lantern` smoketest until we fix the flake.
   - yarn smoke -j=1 --retries=2 a11y errors oopif pwa pwa2 pwa3 dbw redirects seo offline byte perf metrics
 
+after_test:
+  - yarn unlink
+
 cache:
   #- chrome-win32 -> appveyor.yml,package.json
   - node_modules -> appveyor.yml,package.json,yarn.lock

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-all:task:windows": "yarn build-cdt-lib && yarn build-extension && yarn build-devtools && yarn build-lr && yarn build-viewer",
     "build-cdt-lib": "node ./build/build-cdt-lib.js",
     "build-extension": "node ./build/build-extension.js",
-    "build-devtools": "node ./build/build-bundle.js clients/devtools-entry.js dist/lighthouse-dt-bundle.js && node ./build/build-dt-report-resources.js",
+    "build-devtools": "yarn link && yarn link lighthouse && node ./build/build-bundle.js clients/devtools-entry.js dist/lighthouse-dt-bundle.js && node ./build/build-dt-report-resources.js",
     "build-lr": "node ./build/build-lightrider-bundles.js",
     "build-pack": "bash build/build-pack.sh",
     "build-viewer": "node ./build/build-viewer.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-all:task:windows": "yarn build-cdt-lib && yarn build-extension && yarn build-devtools && yarn build-lr && yarn build-viewer",
     "build-cdt-lib": "node ./build/build-cdt-lib.js",
     "build-extension": "node ./build/build-extension.js",
-    "build-devtools": "yarn link && yarn link lighthouse && node ./build/build-bundle.js clients/devtools-entry.js dist/lighthouse-dt-bundle.js && node ./build/build-dt-report-resources.js",
+    "build-devtools": "node ./build/build-bundle.js clients/devtools-entry.js dist/lighthouse-dt-bundle.js && node ./build/build-dt-report-resources.js",
     "build-lr": "node ./build/build-lightrider-bundles.js",
     "build-pack": "bash build/build-pack.sh",
     "build-viewer": "node ./build/build-viewer.js",


### PR DESCRIPTION
**Summary**
Noodling around with the appveyor build failures noticed [here](https://github.com/GoogleChrome/lighthouse/pull/9924#issuecomment-579330026).

This PR will become a build-related fix, if & when the root cause is discovered and a fix determined.

**Related Issues/PRs**
While entirely separate to the `lighthouse` project and codebase, a similar `7z.exe` non-zero exit code was returned after https://github.com/phenomic/phenomic/pull/1005 was merged (build logs [here](https://ci.appveyor.com/project/MoOx/phenomic/build/3480)).