### PR TITLE
core(preconnect): pass without warning at 2 links

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -52,15 +52,10 @@ module.exports = [
           },
         },
         'uses-rel-preconnect': {
-          score: '<1',
+          score: 1,
           warnings: {
             0: /fonts.googleapis/,
             length: 1,
-          },
-          details: {
-            items: {
-              length: 1,
-            },
           },
         },
       },

--- a/lighthouse-core/audits/uses-rel-preconnect.js
+++ b/lighthouse-core/audits/uses-rel-preconnect.js
@@ -139,10 +139,11 @@ class UsesRelPreconnectAudit extends Audit {
     const preconnectOrigins = new Set(preconnectLinks.map(link => URL.getOrigin(link.href || '')));
 
     // https://twitter.com/_tbansal/status/1197771385172480001
-    if (preconnectLinks.length >= 3) {
+    if (preconnectLinks.length >= 2) {
       return {
         score: 1,
-        warnings: [str_(UIStrings.tooManyPreconnectLinksWarning)],
+        warnings: preconnectLinks.length >= 3 ?
+          [str_(UIStrings.tooManyPreconnectLinksWarning)] : [],
       };
     }
 

--- a/lighthouse-core/audits/uses-rel-preconnect.js
+++ b/lighthouse-core/audits/uses-rel-preconnect.js
@@ -138,15 +138,6 @@ class UsesRelPreconnectAudit extends Audit {
     const preconnectLinks = artifacts.LinkElements.filter(el => el.rel === 'preconnect');
     const preconnectOrigins = new Set(preconnectLinks.map(link => URL.getOrigin(link.href || '')));
 
-    // https://twitter.com/_tbansal/status/1197771385172480001
-    if (preconnectLinks.length >= 2) {
-      return {
-        score: 1,
-        warnings: preconnectLinks.length >= 3 ?
-          [str_(UIStrings.tooManyPreconnectLinksWarning)] : [],
-      };
-    }
-
     /** @type {Array<{url: string, wastedMs: number}>}*/
     let results = [];
     origins.forEach(records => {
@@ -192,6 +183,16 @@ class UsesRelPreconnectAudit extends Audit {
 
     results = results
       .sort((a, b) => b.wastedMs - a.wastedMs);
+
+    // Shortcut early with a pass when the user has already configured preconnect.
+    // https://twitter.com/_tbansal/status/1197771385172480001
+    if (preconnectLinks.length >= 2) {
+      return {
+        score: 1,
+        warnings: preconnectLinks.length >= 3 ?
+          [...warnings, str_(UIStrings.tooManyPreconnectLinksWarning)] : warnings,
+      };
+    }
 
     /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [

--- a/lighthouse-core/test/audits/uses-rel-preconnect-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preconnect-test.js
@@ -256,6 +256,36 @@ describe('Performance: uses-rel-preconnect audit', () => {
     assert.equal(warnings.length, 0);
   });
 
+  it('should pass if the correct number of preconnects found', async () => {
+    const networkRecords = [
+      mainResource,
+      {
+        url: 'http://cdn.example.com/first',
+        initiator: {},
+        startTime: 2,
+        timing: {
+          dnsStart: 100,
+          connectStart: 250,
+          connectEnd: 300,
+          receiveHeadersEnd: 2.3,
+        },
+      },
+    ];
+    const artifacts = {
+      LinkElements: [
+        {rel: 'preconnect', href: 'https://cdn1.example.com/'},
+        {rel: 'preconnect', href: 'https://cdn2.example.com/'},
+      ],
+      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
+      URL: {finalUrl: mainResource.url},
+    };
+
+    const context = {settings: {}, computedCache: new Map()};
+    const result = await UsesRelPreconnect.audit(artifacts, context);
+    assert.equal(result.score, 1);
+    assert.deepStrictEqual(result.warnings, []);
+  });
+
   it('should pass with a warning if too many preconnects found', async () => {
     const networkRecords = [
       mainResource,


### PR DESCRIPTION
**Summary**
https://github.com/GoogleChrome/lighthouse/pull/9903 added a warning when you went over 2 preconnect links but we didn't stop suggesting them at 2 leading to an odd UX of us telling you to add more but then warning when you do.

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/pull/9903
https://github.com/GoogleChrome/lighthouse/issues/10292
