### PR TITLE
core(stacks): handle numeric version from library detector

### DIFF
--- a/lighthouse-core/lib/stack-collector.js
+++ b/lighthouse-core/lib/stack-collector.js
@@ -17,7 +17,7 @@ const fs = require('fs');
 const libDetectorSource = fs.readFileSync(
   require.resolve('js-library-detector/library/libraries.js'), 'utf8');
 
-/** @typedef {false | {version: string|null}} JSLibraryDetectorTestResult */
+/** @typedef {false | {version: string|number|null}} JSLibraryDetectorTestResult */
 /**
  * @typedef JSLibraryDetectorTest
  * @property {string} id
@@ -31,7 +31,7 @@ const libDetectorSource = fs.readFileSync(
  * @typedef JSLibrary
  * @property {string} id
  * @property {string} name
- * @property {string|null} version
+ * @property {string|number|null} version
  * @property {string|null} npm
  */
 
@@ -47,7 +47,7 @@ async function detectLibraries() {
   // see https://github.com/HTTPArchive/httparchive/issues/77#issuecomment-291320900
   /** @type {Record<string, JSLibraryDetectorTest>} */
   // @ts-ignore - injected libDetectorSource var
-  const libraryDetectorTests = d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests; // eslint-disable-line 
+  const libraryDetectorTests = d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests; // eslint-disable-line
 
   for (const [name, lib] of Object.entries(libraryDetectorTests)) {
     try {
@@ -83,7 +83,7 @@ async function collectStacks(passContext) {
     detector: /** @type {'js'} */ ('js'),
     id: lib.id,
     name: lib.name,
-    version: lib.version || undefined,
+    version: typeof lib.version === 'number' ? String(lib.version) : (lib.version || undefined),
     npm: lib.npm || undefined,
   }));
 }

--- a/lighthouse-core/test/lib/stack-collector-test.js
+++ b/lighthouse-core/test/lib/stack-collector-test.js
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const collectStacks = require('../../lib/stack-collector.js');
+
+describe('stack collector', () => {
+  /** @type {{driver: {evaluateAsync: jest.Mock}}} */
+  let passContext;
+
+  beforeEach(() => {
+    passContext = {driver: {evaluateAsync: jest.fn()}};
+  });
+
+  it('returns the detected stacks', async () => {
+    passContext.driver.evaluateAsync.mockResolvedValue([
+      {id: 'jquery', name: 'jQuery', version: '2.1.0', npm: 'jquery'},
+      {id: 'angular', name: 'Angular', version: '', npm: ''},
+      {id: 'magento', name: 'Magento', version: 2},
+    ]);
+
+    expect(await collectStacks(passContext)).toEqual([
+      {detector: 'js', id: 'jquery', name: 'jQuery', npm: 'jquery', version: '2.1.0'},
+      {detector: 'js', id: 'angular', name: 'Angular', npm: undefined, version: undefined},
+      {detector: 'js', id: 'magento', name: 'Magento', npm: undefined, version: '2'},
+    ]);
+  });
+});


### PR DESCRIPTION
**Summary**
Magento version is a number not a string from library detector

https://github.com/johnmichel/Library-Detector-for-Chrome/blob/357a4d49c6a177ca7df853160e270cd77beb7140/library/libraries.js#L1585-L1595

**Related Issues/PRs**
closes #10294 
