### PR TITLE
core(lightwallet): Add options/firstPartyOrigins to budget config

### DIFF
--- a/types/budget.d.ts
+++ b/types/budget.d.ts
@@ -46,6 +46,7 @@ declare global {
         /**
          * Origins that should be considered first-party.
          * If not supplied, only the origin of the main resource will be considered first-party.
+         * A valid origin contains: a protocol (e.g. 'http'), hostname, and (optional) port.
          */
         firstPartyOrigins?: Array<string>;
       }

--- a/types/budget.d.ts
+++ b/types/budget.d.ts
@@ -11,6 +11,8 @@ declare global {
      * More info: https://github.com/GoogleChrome/budget.json
      */
     export interface Budget {
+      /** Budget options */
+      options?: Budget.Options;
       /**
        * Indicates which pages a budget applies to. Uses the robots.txt format.
        * If it is not supplied, the budget applies to all pages.
@@ -38,6 +40,14 @@ declare global {
         metric: TimingMetric;
         /** Budget for timing measurement, in milliseconds. */
         budget: number;
+      }
+
+      export interface Options {
+        /**
+         * Origins that should be considered first-party.
+         * If not supplied, only the origin of the main resource will be considered first-party.
+         */
+        firstPartyOrigins?: Array<string>;
       }
 
       /** Supported timing metrics. */


### PR DESCRIPTION
Adds API for declaring `firstPartyOrigins` in `budget.json`.