### PR TITLE
clients(devtools): use the same desktop throttling as lightrider

### DIFF
--- a/clients/devtools-entry.js
+++ b/clients/devtools-entry.js
@@ -18,6 +18,8 @@ const desktopDense4G = require('../lighthouse-core/config/constants.js').throttl
  * Varies the config to use based on device.
  * If `lighthouse-plugin-publisher-ads` is in the list of
  * `categoryIDs` the plugin will also be run.
+ * Counterpart to the CDT code that sets flags. 
+ * @see https://cs.chromium.org/chromium/src/third_party/devtools-frontend/src/front_end/lighthouse/LighthouseController.js?type=cs&q=%22const+RuntimeSettings%22+f:lighthouse+-f:out&g=0&l=250
  * @param {Array<string>} categoryIDs
  * @param {string} device
  * @return {LH.Config.Json}

--- a/clients/devtools-entry.js
+++ b/clients/devtools-entry.js
@@ -18,7 +18,7 @@ const desktopDense4G = require('../lighthouse-core/config/constants.js').throttl
  * Varies the config to use based on device.
  * If `lighthouse-plugin-publisher-ads` is in the list of
  * `categoryIDs` the plugin will also be run.
- * Counterpart to the CDT code that sets flags. 
+ * Counterpart to the CDT code that sets flags.
  * @see https://cs.chromium.org/chromium/src/third_party/devtools-frontend/src/front_end/lighthouse/LighthouseController.js?type=cs&q=%22const+RuntimeSettings%22+f:lighthouse+-f:out&g=0&l=250
  * @param {Array<string>} categoryIDs
  * @param {string} device

--- a/clients/devtools-entry.js
+++ b/clients/devtools-entry.js
@@ -9,23 +9,32 @@ const lighthouse = require('../lighthouse-core/index.js');
 const RawProtocol = require('../lighthouse-core/gather/connections/raw.js');
 const log = require('lighthouse-logger');
 const {registerLocaleData, lookupLocale} = require('../lighthouse-core/lib/i18n/i18n.js');
+const desktopDense4G = require('../lighthouse-core/config/constants.js').throttling.desktopDense4G;
 
 /** @typedef {import('../lighthouse-core/gather/connections/connection.js')} Connection */
 
 /**
- * Return a version of the default config, filtered to only run the specified
- * categories. If `lighthouse-plugin-publisher-ads` is in the list of
+ * Returns a config, which runs only certain categories.
+ * Varies the config to use based on device.
+ * If `lighthouse-plugin-publisher-ads` is in the list of
  * `categoryIDs` the plugin will also be run.
  * @param {Array<string>} categoryIDs
+ * @param {string} device
  * @return {LH.Config.Json}
  */
-function getDefaultConfigForCategories(categoryIDs) {
+function createConfig(categoryIDs, device) {
+  /** @type {LH.SharedFlagsSettings} */
+  const settings = {
+    onlyCategories: categoryIDs,
+  };
+  if (device === 'desktop') {
+    settings.throttling = desktopDense4G;
+  }
+
   return {
     extends: 'lighthouse:default',
     plugins: ['lighthouse-plugin-publisher-ads'],
-    settings: {
-      onlyCategories: categoryIDs,
-    },
+    settings,
   };
 }
 
@@ -63,7 +72,7 @@ if (typeof self !== 'undefined') {
   // @ts-ignore
   self.runLighthouse = lighthouse;
   // @ts-ignore
-  self.getDefaultConfigForCategories = getDefaultConfigForCategories;
+  self.createConfig = createConfig;
   // @ts-ignore
   self.listenForStatus = listenForStatus;
   // @ts-ignore

--- a/lighthouse-core/config/constants.js
+++ b/lighthouse-core/config/constants.js
@@ -44,6 +44,9 @@ const throttling = {
     rttMs: 40,
     throughputKbps: 10 * 1024,
     cpuSlowdownMultiplier: 1,
+    requestLatencyMs: 0, // 0 means unset
+    downloadThroughputKbps: 0,
+    uploadThroughputKbps: 0,
   },
 };
 

--- a/lighthouse-core/config/constants.js
+++ b/lighthouse-core/config/constants.js
@@ -38,6 +38,13 @@ const throttling = {
     uploadThroughputKbps: 700 * DEVTOOLS_THROUGHPUT_ADJUSTMENT_FACTOR,
     cpuSlowdownMultiplier: 4,
   },
+  // Using a "broadband" connection type
+  // Corresponds to "Dense 4G 25th percentile" in https://docs.google.com/document/d/1Ft1Bnq9-t4jK5egLSOc28IL4TvR-Tt0se_1faTA4KTY/edit#heading=h.bb7nfy2x9e5v
+  desktopDense4G: {
+    rttMs: 40,
+    throughputKbps: 10 * 1024,
+    cpuSlowdownMultiplier: 1,
+  },
 };
 
 /** @type {LH.Config.Settings} */

--- a/lighthouse-core/config/lr-desktop-config.js
+++ b/lighthouse-core/config/lr-desktop-config.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const desktopDense4G = require('./constants.js').throttling.desktopDense4G;
+
 /** @type {LH.Config.Json} */
 const config = {
   extends: 'lighthouse:default',
@@ -12,13 +14,7 @@ const config = {
     maxWaitForFcp: 15 * 1000,
     maxWaitForLoad: 35 * 1000,
     emulatedFormFactor: 'desktop',
-    throttling: {
-      // Using a "broadband" connection type
-      // Corresponds to "Dense 4G 25th percentile" in https://docs.google.com/document/d/1Ft1Bnq9-t4jK5egLSOc28IL4TvR-Tt0se_1faTA4KTY/edit#heading=h.bb7nfy2x9e5v
-      rttMs: 40,
-      throughputKbps: 10 * 1024,
-      cpuSlowdownMultiplier: 1,
-    },
+    throttling: desktopDense4G,
     // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
     skipAudits: ['uses-http2'],
   },


### PR DESCRIPTION
fixes #10315

I was going to make a shared desktop config and rely on config inheritance, but it turns out that we only support inheriting from the default config :)