### PR TITLE
[DRAFT] Move away from lastNavStart as timeOrigin

### DIFF
--- a/lighthouse-cli/test/fixtures/js-redirect.html
+++ b/lighthouse-cli/test/fixtures/js-redirect.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <script>
+      function stall(ms) {
+        const start = Date.now();
+        while (Date.now() - start < ms) ;
+      }
+
+      const params = new URLSearchParams(window.location.search);
+      const delay = params.get('jsDelay') || 3000;
+      const redirect = params.get('jsRedirect') || '/redirects-final.html';
+
+      if (params.get('noFcp')) {
+        // If we don't want an FCP then stall and redirect synchronously
+        stall(delay);
+        window.location = redirect;
+      }
+    </script>
+  </head>
+
+  <body>
+    Redirecting in
+    <script>
+      document.write(` ${delay}ms...`);
+      // Redirect to the location in jsDelay milliseconds.
+      setTimeout(() => window.location = redirect, delay);
+      // Create a long task every 400ms to prevent Lighthouse from moving on
+      setInterval(() => stall(55), 400);
+    </script>
+  </body>
+</html>

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -112,7 +112,11 @@ function requestHandler(request, response) {
 
       // redirect url to new url if present
       if (params.has('redirect')) {
-        return setTimeout(sendRedirect, delay, params.get('redirect'));
+        const redirectsRemaining = Math.max(Number(params.get('redirect_count') || '') - 1, 0);
+        const newRedirectsParam = `redirect_count=${redirectsRemaining}`;
+        const recursiveRedirectUrl = request.url.replace(/redirect_count=\d+/, newRedirectsParam);
+        const redirectUrl = redirectsRemaining ? recursiveRedirectUrl : params.get('redirect');
+        return setTimeout(sendRedirect, delay, redirectUrl);
       }
     }
 

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects/expectations.js
@@ -14,21 +14,87 @@ const cacheBuster = Number(new Date());
 const expectations = [
   {
     lhr: {
-      requestedUrl: `http://localhost:10200/online-only.html?delay=500&redirect=%2Foffline-only.html%3Fcb=${cacheBuster}%26delay=500%26redirect%3D%2Fredirects-final.html`,
+      requestedUrl: `http://localhost:10200/online-only.html?delay=1000&redirect_count=3&redirect=%2Fredirects-final.html`,
       finalUrl: 'http://localhost:10200/redirects-final.html',
       audits: {
+        'first-contentful-paint': {
+          numericValue: '>3000',
+        },
+        'interactive': {
+          numericValue: '>3000',
+        },
         'redirects': {
           score: '<1',
-          numericValue: '>=500',
+          numericValue: '>=3000',
           details: {
             items: {
-              length: 3,
+              length: 4,
             },
           },
         },
       },
       runWarnings: [
         /The page may not be loading as expected because your test URL \(.*online-only.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+      ],
+    },
+  },
+  {
+    lhr: {
+      // This URL waits 7s before redirecting client-side to finalUrl.
+      requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fredirects-final.html`,
+      finalUrl: 'http://localhost:10200/redirects-final.html',
+      audits: {
+        'first-contentful-paint': {
+          numericValue: '>7000',
+        },
+        'interactive': {
+          numericValue: '>7000',
+        },
+        'speed-index': {
+          numericValue: '>7000',
+        },
+        'redirects': {
+          score: 1,
+          numericValue: '>=7000',
+          details: {
+            items: {
+              length: 2,
+            },
+          },
+        },
+      },
+      runWarnings: [
+        /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+      ],
+    },
+  },
+  {
+    lhr: {
+      // This URL waits 2s to paint the js-redirect content and then waits 5s more before redirecting client-side to finalUrl.
+      requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fredirects-final.html`,
+      finalUrl: 'http://localhost:10200/redirects-final.html',
+      audits: {
+        'first-contentful-paint': {
+          numericValue: '>7000',
+        },
+        'interactive': {
+          numericValue: '>7000',
+        },
+        'speed-index': {
+          numericValue: '>7000',
+        },
+        'redirects': {
+          score: 1,
+          numericValue: '>=7000',
+          details: {
+            items: {
+              length: 2,
+            },
+          },
+        },
+      },
+      runWarnings: [
+        /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
       ],
     },
   },

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects/redirects-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects/redirects-config.js
@@ -12,7 +12,21 @@ module.exports = {
   extends: 'lighthouse:default',
   settings: {
     onlyAudits: [
+      'first-contentful-paint',
+      'interactive',
+      'speed-index',
       'redirects',
     ],
+    // Use provided throttling method to test usage of correct navStart.
+    throttlingMethod: 'provided',
+    // While we're using observed metrics, lantern is still used for opportunities.
+    precomputedLanternData: {
+      additionalRttByOrigin: {
+        'http://localhost:10200': 0,
+      },
+      serverResponseTimeByOrigin: {
+        'http://localhost:10200': 1000,
+      }
+    },
   },
 };

--- a/lighthouse-core/audits/final-screenshot.js
+++ b/lighthouse-core/audits/final-screenshot.js
@@ -33,7 +33,7 @@ class FinalScreenshot extends Audit {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const traceOfTab = await TraceOfTab.request(trace, context);
     const screenshots = await Screenshots.request(trace, context);
-    const {navigationStart} = traceOfTab.timestamps;
+    const {timeOrigin} = traceOfTab.timestamps;
     const finalScreenshot = screenshots[screenshots.length - 1];
 
     if (!finalScreenshot) {
@@ -44,7 +44,7 @@ class FinalScreenshot extends Audit {
       score: 1,
       details: {
         type: 'screenshot',
-        timing: Math.round((finalScreenshot.timestamp - navigationStart) / 1000),
+        timing: Math.round((finalScreenshot.timestamp - timeOrigin) / 1000),
         timestamp: finalScreenshot.timestamp,
         data: finalScreenshot.datauri,
       },

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -71,14 +71,6 @@ class Redirects extends Audit {
     let totalWastedMs = 0;
     const pageRedirects = [];
 
-    // Kickoff the results table (with the initial request) if there are > 1 redirects
-    if (redirectRequests.length > 1) {
-      pageRedirects.push({
-        url: `(Initial: ${redirectRequests[0].url})`,
-        wastedMs: 0,
-      });
-    }
-
     for (let i = 1; i < redirectRequests.length; i++) {
       const initialRequest = redirectRequests[i - 1];
       const redirectedRequest = redirectRequests[i];
@@ -93,8 +85,16 @@ class Redirects extends Audit {
       totalWastedMs += wastedMs;
 
       pageRedirects.push({
-        url: redirectedRequest.url,
+        url: initialRequest.url,
         wastedMs,
+      });
+    }
+
+    // If we had a redirect, push the main resource onto the end which has no `wastedMs`
+    if (redirectRequests.length > 1) {
+      pageRedirects.push({
+        url: `(Destination: ${mainResource.url})`,
+        wastedMs: 0,
       });
     }
 

--- a/lighthouse-core/computed/metrics/first-cpu-idle.js
+++ b/lighthouse-core/computed/metrics/first-cpu-idle.js
@@ -180,7 +180,7 @@ class FirstCPUIdle extends ComputedMetric {
    */
   static async computeObservedMetric(data) {
     const {traceOfTab} = data;
-    const navStart = traceOfTab.timestamps.navigationStart;
+    const timeOrigin = traceOfTab.timestamps.timeOrigin;
     const FMP = traceOfTab.timings.firstMeaningfulPaint;
     const DCL = traceOfTab.timings.domContentLoaded;
     const traceEnd = traceOfTab.timings.traceEnd;
@@ -201,7 +201,7 @@ class FirstCPUIdle extends ComputedMetric {
 
     return Promise.resolve({
       timing: valueInMs,
-      timestamp: valueInMs * 1000 + navStart,
+      timestamp: valueInMs * 1000 + timeOrigin,
     });
   }
 }

--- a/lighthouse-core/computed/metrics/interactive.js
+++ b/lighthouse-core/computed/metrics/interactive.js
@@ -44,11 +44,11 @@ class Interactive extends ComputedMetric {
   /**
    * Finds all time periods where there are no long tasks.
    * @param {Array<TimePeriod>} longTasks
-   * @param {{timestamps: {navigationStart: number, traceEnd: number}}} traceOfTab
+   * @param {{timestamps: {timeOrigin: number, traceEnd: number}}} traceOfTab
    * @return {Array<TimePeriod>}
    */
   static _findCPUQuietPeriods(longTasks, traceOfTab) {
-    const navStartTsInMs = traceOfTab.timestamps.navigationStart / 1000;
+    const timeOriginTsInMs = traceOfTab.timestamps.timeOrigin / 1000;
     const traceEndTsInMs = traceOfTab.timestamps.traceEnd / 1000;
     if (longTasks.length === 0) {
       return [{start: 0, end: traceEndTsInMs}];
@@ -60,19 +60,19 @@ class Interactive extends ComputedMetric {
       if (index === 0) {
         quietPeriods.push({
           start: 0,
-          end: task.start + navStartTsInMs,
+          end: task.start + timeOriginTsInMs,
         });
       }
 
       if (index === longTasks.length - 1) {
         quietPeriods.push({
-          start: task.end + navStartTsInMs,
+          start: task.end + timeOriginTsInMs,
           end: traceEndTsInMs,
         });
       } else {
         quietPeriods.push({
-          start: task.end + navStartTsInMs,
-          end: longTasks[index + 1].start + navStartTsInMs,
+          start: task.end + timeOriginTsInMs,
+          end: longTasks[index + 1].start + timeOriginTsInMs,
         });
       }
     });
@@ -175,7 +175,7 @@ class Interactive extends ComputedMetric {
       traceOfTab.timestamps.firstContentfulPaint / 1000,
       traceOfTab.timestamps.domContentLoaded / 1000
     ) * 1000;
-    const timing = (timestamp - traceOfTab.timestamps.navigationStart) / 1000;
+    const timing = (timestamp - traceOfTab.timestamps.timeOrigin) / 1000;
     return Promise.resolve({timing, timestamp});
   }
 }

--- a/lighthouse-core/computed/metrics/speed-index.js
+++ b/lighthouse-core/computed/metrics/speed-index.js
@@ -8,6 +8,7 @@
 const makeComputedArtifact = require('../computed-artifact.js');
 const ComputedMetric = require('./metric.js');
 const LanternSpeedIndex = require('./lantern-speed-index.js');
+const TraceOfTab = require('../trace-of-tab.js');
 const Speedline = require('../speedline.js');
 
 class SpeedIndex extends ComputedMetric {
@@ -27,7 +28,9 @@ class SpeedIndex extends ComputedMetric {
    */
   static async computeObservedMetric(data, context) {
     const speedline = await Speedline.request(data.trace, context);
-    const timing = Math.round(speedline.speedIndex);
+    const traceOfTab = await TraceOfTab.request(data.trace, context);
+    const firstPaint = traceOfTab.timings.firstPaint || 0;
+    const timing = Math.max(Math.round(speedline.speedIndex), firstPaint);
     const timestamp = (timing + speedline.beginning) * 1000;
     return Promise.resolve({timing, timestamp});
   }

--- a/lighthouse-core/computed/metrics/timing-summary.js
+++ b/lighthouse-core/computed/metrics/timing-summary.js
@@ -71,6 +71,8 @@ class TimingSummary {
       maxPotentialFID: maxPotentialFID && maxPotentialFID.timing,
 
       // Include all timestamps of interest from trace of tab
+      observedTimeOrigin: traceOfTab.timings.timeOrigin,
+      observedTimeOriginTs: traceOfTab.timestamps.timeOrigin,
       observedNavigationStart: traceOfTab.timings.navigationStart,
       observedNavigationStartTs: traceOfTab.timestamps.navigationStart,
       observedFirstPaint: traceOfTab.timings.firstPaint,

--- a/lighthouse-core/computed/speedline.js
+++ b/lighthouse-core/computed/speedline.js
@@ -25,7 +25,7 @@ class Speedline {
       const traceEvents = trace.traceEvents.slice();
       // Force use of nav start as reference point for speedline
       // See https://github.com/GoogleChrome/lighthouse/issues/2095
-      const navStart = traceOfTab.timestamps.navigationStart;
+      const navStart = traceOfTab.timestamps.timeOrigin;
       return speedline(traceEvents, {
         timeOrigin: navStart,
         fastMode: true,

--- a/lighthouse-core/computed/user-timings.js
+++ b/lighthouse-core/computed/user-timings.js
@@ -67,11 +67,11 @@ class UserTimings {
       }
     });
 
-    // baseline the timestamps against navStart, and translate to milliseconds
+    // baseline the timestamps against the timeOrigin, and translate to milliseconds
     userTimings.forEach(ut => {
-      ut.startTime = (ut.startTime - traceOfTab.navigationStartEvt.ts) / 1000;
+      ut.startTime = (ut.startTime - traceOfTab.timeOriginEvt.ts) / 1000;
       if (!ut.isMark) {
-        ut.endTime = (ut.endTime - traceOfTab.navigationStartEvt.ts) / 1000;
+        ut.endTime = (ut.endTime - traceOfTab.timeOriginEvt.ts) / 1000;
         ut.duration = ut.duration / 1000;
       }
     });

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1107,7 +1107,13 @@ class Driver {
     // Bring `Page.navigate` errors back into the promise chain. See https://github.com/GoogleChrome/lighthouse/pull/6739.
     await waitforPageNavigateCmd;
 
-    return this._endNetworkStatusMonitoring();
+    const finalUrlViaNetwork = this._endNetworkStatusMonitoring();
+    const finalUrlViaScript = this.evaluateAsync('window.location.href', {useIsolation: true})
+      .catch(err => {
+        log.error('Driver', `Failed to get URL via evaluateAsync: ${err.message}`);
+        return '';
+      });
+    return finalUrlViaScript || finalUrlViaNetwork;
   }
 
   /**

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -439,6 +439,10 @@ function _resolveIcuMessageInstanceId(icuMessageInstanceId, locale) {
   const [_, icuMessageId, icuMessageInstanceIndex] = matches;
   const icuMessageInstances = _icuMessageInstanceMap.get(icuMessageId) || [];
   const icuMessageInstance = icuMessageInstances[Number(icuMessageInstanceIndex)];
+  if (!icuMessageInstance) {
+    log.warn('i18n', `${icuMessageId} missing an instance for index ${icuMessageInstanceIndex}`);
+    return {icuMessageInstance: {icuMessageId, icuMessage: 'Unknown'}, formattedString: 'MISSING'};
+  }
 
   const {formattedString} = _formatIcuMessage(locale, icuMessageId,
     icuMessageInstance.icuMessage, icuMessageInstance.values);

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -270,7 +270,7 @@ declare global {
         /** An optional name of the generated code (the bundled code that was the result of this build process) that this source map is associated with. */
         file?: string
         /**
-         * An optional array of maps that are associated with an offset into the generated code. 
+         * An optional array of maps that are associated with an offset into the generated code.
          * `map` is optional because the spec defines that either `url` or `map` must be defined.
          * We explicitly only support `map` here.
         */
@@ -529,6 +529,7 @@ declare global {
       export type Speedline = speedline.Output<'speedIndex'>;
 
       export interface TraceTimes {
+        timeOrigin: number;
         navigationStart: number;
         firstPaint?: number;
         firstContentfulPaint: number;
@@ -552,6 +553,8 @@ declare global {
         mainFrameIds: {pid: number, tid: number, frameId: string};
         /** The list of frames committed in the trace. */
         frames: Array<{frame: string, url: string}>;
+        /** The trace event marking the time at which the page load should consider to have begun. Typically the start time of the first document request. */
+        timeOriginEvt: TraceEvent;
         /** The trace event marking navigationStart. */
         navigationStartEvt: TraceEvent;
         /** The trace event marking firstPaint, if it was found. */
@@ -606,6 +609,8 @@ declare global {
         estimatedInputLatencyTs: number | undefined;
         maxPotentialFID: number | undefined;
         totalBlockingTime: number;
+        observedTimeOrigin: number;
+        observedTimeOriginTs: number;
         observedNavigationStart: number;
         observedNavigationStartTs: number;
         observedFirstPaint: number | undefined;


### PR DESCRIPTION
## Summary
This turned out to be an absolute nightmare to leave so close to release, and I honestly might recommend punting this to 7.0 and explicitly dedicating some time to better handle client-side redirect across all of our audits before tackling this. 

We have several options here and going down the rabbit hole of my preferred approach cascades a lot of other required changes, so before I go update the world...

## Questions

### What Time Origin To Use?
1. First document `ResourceSendRequest` ts (this PR)
2. First navigationStart
3. Last navigationStart (Give up on this, and move lantern to ignore all nodes before last nav start instead)

Going with ResourceSendRequest aligns us the closest to what I feel the user cares about, the lantern simulation model, and should fix the cases where Chrome unloading `about:blank` randomly takes a long time ([navigationStart is spec-defined as fetchStart + time taken to unload previous document](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/navigationStart)), but this also involves *lots* of other changes through the codebase and affects runs even without redirects. 

Going with first navigation start would be more a gradual change, allow us to even ignore the `timeOrigin` component of this PR, and keep our existing "navstart" references (depending on the answer to the next question).

Going with last navigation start would make things consistent by changing lantern to just ignore everything before last navstart.

### How to Handle Cases Where the Redirecting Page Rendered
1. Ignore all progress and events before last navStart (This PR)
2. Consider prior page only for SI
3. Consider prior page for FCP and SI
4. Consider prior page for FCP, SI, TBT, and MPFID

Client-side redirects can render some content (and execute JS) before ultimately redirecting. Should that count for FCP? Do the long tasks that occur during that page load count toward TBT? Do we then reblack out longtasks for TBT once the next navigation starts? What about speed index?

This is the killer question primarily because it's not handled very explicitly in any of our audits at the moment, some metrics get it for free by looking after the last nav start but we don't filter main thread events for just those after navStart right now so user timings for example can contain negative timestamps, mainthread work breakdown will count those tasks, etc

I can see arguments for all sides but IMO, it's most straightforward and consistent if we just consider everything before the finalUrl page load as wasted time.

## This PR...

- Introduces a new `timeOrigin` property on trace-of-tab
- Changes all of our references to `navStart` to use `timeOrigin` instead.
- Uses the start time of the first document request as `timeOrigin`.
- Preserves last nav start as the selector for all metrics.
- Updates Speed Index to do `max(fp, speedIndex)`
- Updates `finalUrl` to use final `location.href` of the window.
- Adds client-side redirect smoke tests.
- Converts the redirect some tests to use observed metrics.
- Changes the `redirects` audit to display the time the URL took to redirect as wastedMs rather than the time the previous URL took to redirect
- [TODO] Update `redirects` audit to surface client-side redirects

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/issues/8984
