### PR TITLE
core: experimental config

### DIFF
--- a/lighthouse-core/config/experimental-config.js
+++ b/lighthouse-core/config/experimental-config.js
@@ -5,8 +5,9 @@
  */
 'use strict';
 
-/** @fileoverview Temporary config for new source map features.
- * Allows for source map audits to land in master without being enabled by default.
+/**
+ * @fileoverview Config for new audits that aren't quite ready for
+ * being enabled by default.
  */
 
 /** @type {LH.Config.Json} */


### PR DESCRIPTION
The config made in #10311 is too restrained. A config for experiments is really what I'd want. #10303 legacy-javascript would be one such audit, along with all the source map stuff meant for the previous config.

Something like this is useful IMO because adding a line in the default-config to test a nonstandard audit (and then remembering to delete that line) is annoying. for example: when we had `unused-javascript` not in the default config.