### PR TITLE
deps: update axe-core to 3.5.1

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
@@ -323,6 +323,7 @@ const expectations = [
                   'selector': '#form-field-multiple-labels',
                   'path': '2,HTML,1,BODY,35,SECTION,2,INPUT',
                   'snippet': '<input type="checkbox" id="form-field-multiple-labels">',
+                  'explanation': 'Fix all of the following:\n  Multiple label elements is not widely supported in assistive technologies. Ensure the first label contains all necessary information.',
                   'nodeLabel': 'input',
                 },
               },

--- a/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
@@ -114,7 +114,7 @@ const expectations = [
                   'type': 'node',
                   'selector': 'div[role="foo"]',
                   'snippet': '<div role="foo"></div>',
-                  'explanation': 'Fix all of the following:\n  Role must be one of the valid ARIA roles',
+                  'explanation': 'Fix all of the following:\n  Role must be one of the valid ARIA roles: foo',
                   'nodeLabel': 'div',
                 },
               },

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -35,6 +35,7 @@ function runA11yChecks() {
       'tabindex': {enabled: true},
       'accesskeys': {enabled: true},
       'heading-order': {enabled: true},
+      'meta-viewport': {enabled: true},
       'duplicate-id': {enabled: false},
       'table-fake-caption': {enabled: false},
       'td-has-header': {enabled: false},

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -44,6 +44,9 @@ function runA11yChecks() {
       'html-xml-lang-mismatch': {enabled: false},
       'blink': {enabled: false},
       'server-side-image-map': {enabled: false},
+      'identical-links-same-purpose': {enabled: false},
+      'no-autoplay-audio': {enabled: false},
+      'svg-img-alt': {enabled: false},
     },
     // @ts-ignore
   }).then(axeResult => {

--- a/lighthouse-core/test/report/html/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-renderer-test.js
@@ -287,6 +287,8 @@ describe('ReportRenderer', () => {
           // Reports may have duplicate ids
           // https://github.com/GoogleChrome/lighthouse/issues/9432
           'duplicate-id': {enabled: false},
+          'duplicate-id-aria': {enabled: false},
+          'landmark-no-duplicate-contentinfo': {enabled: false},
           // The following rules are disable for axe-core + jsdom compatibility
           // https://github.com/dequelabs/axe-core/tree/b573b1c1/doc/examples/jest_react#to-run-the-example
           'color-contrast': {enabled: false},

--- a/lighthouse-core/test/report/html/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-renderer-test.js
@@ -278,8 +278,9 @@ describe('ReportRenderer', () => {
     });
 
     it('renders without axe violations', (done) => {
-      const container = renderer._dom._document.body;
+      const container = renderer._dom._document.createElement('main');
       const output = renderer.renderReport(sampleResults, container);
+      renderer._dom._document.body.appendChild(container);
 
       const config = {
         rules: {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "typescript": "3.5.3"
   },
   "dependencies": {
-    "axe-core": "3.4.1",
+    "axe-core": "3.5.1",
     "chrome-launcher": "^0.12.0",
     "configstore": "^3.1.1",
     "cssstyle": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     },
     {
       "path": "./dist/lighthouse-dt-bundle.js",
-      "maxSize": "450 kB"
+      "maxSize": "455 kB"
     },
     {
       "path": "./dist/lightrider/report-generator-bundle.js",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     },
     {
       "path": "./dist/lighthouse-dt-bundle.js",
-      "maxSize": "455 kB"
+      "maxSize": "450 kB"
     },
     {
       "path": "./dist/lightrider/report-generator-bundle.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,10 +1164,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.4.1.tgz#e42623918bb85b5ef674633852cb9029db0309c5"
-  integrity sha512-+EhIdwR0hF6aeMx46gFDUy6qyCfsL0DmBrV3Z+LxYbsOd8e1zBaPHa3f9Rbjsz2dEwSBkLw6TwML/CAIIAqRpw==
+axe-core@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.1.tgz#d8d5aaef73f003e8b766ea28bb078343f3622201"
+  integrity sha512-mwpDgPwWB+5kMHyLjlxh4w25ClJfqSxi+c6LQ4ix349TdCUctMwJNPTkhPD1qP9SYIjFgjeVpVZWCvK9oBGwCg==
 
 axios@0.19.0:
   version "0.19.0"


### PR DESCRIPTION
**Summary**
Updates axe-core==3.5.1 following its release on 2020-02-13 ([release tag](https://github.com/dequelabs/axe-core/releases/tag/v3.5.1)).