### PR TITLE
viewer(css): cursor:wait indicator no longer blocked by pointer-events: none

### DIFF
--- a/lighthouse-viewer/app/styles/viewer.css
+++ b/lighthouse-viewer/app/styles/viewer.css
@@ -62,8 +62,10 @@
 }
 .viewer-placeholder-inner.lh-loading {
   filter: blur(2px) grayscale(1);
-  pointer-events: none;
   cursor: wait
+}
+.viewer-placeholder-inner.lh-loading>div {
+  pointer-events: none;
 }
 .viewer-placeholder-inner.dropping {
   border-color: currentColor;


### PR DESCRIPTION
Moved `pointer-events:none` from the parent wrapper for the loading screen; added it to the child instead, so that the parent retains cursor interactivity and the `cursor:wait` is correctly shown - fixes #10010
