### PR TITLE
core: audit.meta.__internalOptionalArtifacts

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -692,10 +692,10 @@ class Config {
 
     const gatherers = new Set();
     for (const auditDefn of audits) {
-      const {requiredArtifacts, optionalArtifacts} = auditDefn.implementation.meta;
+      const {requiredArtifacts, __internalOptionalArtifacts} = auditDefn.implementation.meta;
       requiredArtifacts.forEach(artifact => gatherers.add(artifact));
-      if (optionalArtifacts) {
-        optionalArtifacts.forEach(artifact => gatherers.add(artifact));
+      if (__internalOptionalArtifacts) {
+        __internalOptionalArtifacts.forEach(artifact => gatherers.add(artifact));
       }
     }
     return gatherers;

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -54,7 +54,7 @@ function assertValidPasses(passes, audits) {
     return;
   }
 
-  const requiredGatherers = Config.getGatherersNeededByAudits(audits);
+  const requestedGatherers = Config.getGatherersRequestedByAudits(audits);
   // Base artifacts are provided by GatherRunner, so start foundGatherers with them.
   const foundGatherers = new Set(BASE_ARTIFACT_NAMES);
 
@@ -69,7 +69,7 @@ function assertValidPasses(passes, audits) {
     pass.gatherers.forEach(gathererDefn => {
       const gatherer = gathererDefn.instance;
       foundGatherers.add(gatherer.name);
-      const isGatherRequiredByAudits = requiredGatherers.has(gatherer.name);
+      const isGatherRequiredByAudits = requestedGatherers.has(gatherer.name);
       if (!isGatherRequiredByAudits) {
         const msg = `${gatherer.name} gatherer requested, however no audit requires it.`;
         log.warn('config', msg);
@@ -573,10 +573,10 @@ class Config {
         requestedAuditNames.has(auditDefn.implementation.meta.id));
 
     // 3. Resolve which gatherers will need to run
-    const requiredGathererIds = Config.getGatherersNeededByAudits(audits);
+    const requestedGathererIds = Config.getGatherersRequestedByAudits(audits);
 
     // 4. Filter to only the neccessary passes
-    const passes = Config.generatePassesNeededByGatherers(config.passes, requiredGathererIds);
+    const passes = Config.generatePassesNeededByGatherers(config.passes, requestedGathererIds);
 
     config.categories = categories;
     config.audits = audits;
@@ -679,40 +679,45 @@ class Config {
   }
 
   /**
-   * From some requested audits, return names of all required artifacts
+   * From some requested audits, return names of all required and optional artifacts
    * @param {Config['audits']} audits
    * @return {Set<string>}
    */
-  static getGatherersNeededByAudits(audits) {
+  static getGatherersRequestedByAudits(audits) {
     // It's possible we weren't given any audits (but existing audit results), in which case
     // there is no need to do any work here.
     if (!audits) {
       return new Set();
     }
 
-    return audits.reduce((list, auditDefn) => {
-      auditDefn.implementation.meta.requiredArtifacts.forEach(artifact => list.add(artifact));
-      return list;
-    }, new Set());
+    const gatherers = new Set();
+    for (const auditDefn of audits) {
+      const {requiredArtifacts, optionalArtifacts} = auditDefn.implementation.meta;
+      requiredArtifacts.forEach(artifact => gatherers.add(artifact));
+      if (optionalArtifacts) {
+        optionalArtifacts.forEach(artifact => gatherers.add(artifact));
+      }
+    }
+    return gatherers;
   }
 
   /**
-   * Filters to only required passes and gatherers, returning a new passes array.
+   * Filters to only requested passes and gatherers, returning a new passes array.
    * @param {Config['passes']} passes
-   * @param {Set<string>} requiredGatherers
+   * @param {Set<string>} requestedGatherers
    * @return {Config['passes']}
    */
-  static generatePassesNeededByGatherers(passes, requiredGatherers) {
+  static generatePassesNeededByGatherers(passes, requestedGatherers) {
     if (!passes) {
       return null;
     }
 
-    const auditsNeedTrace = requiredGatherers.has('traces');
+    const auditsNeedTrace = requestedGatherers.has('traces');
     const filteredPasses = passes.map(pass => {
       // remove any unncessary gatherers from within the passes
       pass.gatherers = pass.gatherers.filter(gathererDefn => {
         const gatherer = gathererDefn.instance;
-        return requiredGatherers.has(gatherer.name);
+        return requestedGatherers.has(gatherer.name);
       });
 
       // disable the trace if no audit requires a trace

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -331,7 +331,7 @@ class Runner {
       // Only pass the declared `requiredArtifacts`/`optionalArtifacts` to the audit
       // The type is masquerading as `LH.Artifacts` but will only contain a subset of the keys
       // to prevent consumers from unnecessary type assertions.
-      const narrowedArtifacts = audit.meta.requiredArtifacts.concat(audit.meta.optionalArtifacts)
+      const narrowedArtifacts = audit.meta.requiredArtifacts.concat(audit.meta.optionalArtifacts || [])
         .reduce((narrowedArtifacts, artifactName) => {
           const requiredArtifact = artifacts[artifactName];
           // @ts-ignore tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -331,7 +331,9 @@ class Runner {
       // Only pass the declared `requiredArtifacts`/`optionalArtifacts` to the audit
       // The type is masquerading as `LH.Artifacts` but will only contain a subset of the keys
       // to prevent consumers from unnecessary type assertions.
-      const narrowedArtifacts = audit.meta.requiredArtifacts.concat(audit.meta.optionalArtifacts || [])
+      const requestedArtifacts = audit.meta.requiredArtifacts
+        .concat(audit.meta.optionalArtifacts || []);
+      const narrowedArtifacts = requestedArtifacts
         .reduce((narrowedArtifacts, artifactName) => {
           const requiredArtifact = artifacts[artifactName];
           // @ts-ignore tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -328,11 +328,11 @@ class Runner {
         ...sharedAuditContext,
       };
 
-      // Only pass the declared `requiredArtifacts`/`optionalArtifacts` to the audit
+      // Only pass the declared required and optional artifacts to the audit
       // The type is masquerading as `LH.Artifacts` but will only contain a subset of the keys
       // to prevent consumers from unnecessary type assertions.
       const requestedArtifacts = audit.meta.requiredArtifacts
-        .concat(audit.meta.optionalArtifacts || []);
+        .concat(audit.meta.__internalOptionalArtifacts || []);
       const narrowedArtifacts = requestedArtifacts
         .reduce((narrowedArtifacts, artifactName) => {
           const requestedArtifact = artifacts[artifactName];

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -328,17 +328,17 @@ class Runner {
         ...sharedAuditContext,
       };
 
-      // Only pass the declared `requiredArtifacts` to the audit
+      // Only pass the declared `requiredArtifacts`/`optionalArtifacts` to the audit
       // The type is masquerading as `LH.Artifacts` but will only contain a subset of the keys
       // to prevent consumers from unnecessary type assertions.
-      const requiredArtifacts = audit.meta.requiredArtifacts
-        .reduce((requiredArtifacts, artifactName) => {
+      const narrowedArtifacts = audit.meta.requiredArtifacts.concat(audit.meta.optionalArtifacts)
+        .reduce((narrowedArtifacts, artifactName) => {
           const requiredArtifact = artifacts[artifactName];
           // @ts-ignore tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.
-          requiredArtifacts[artifactName] = requiredArtifact;
-          return requiredArtifacts;
+          narrowedArtifacts[artifactName] = requiredArtifact;
+          return narrowedArtifacts;
         }, /** @type {LH.Artifacts} */ ({}));
-      const product = await audit.audit(requiredArtifacts, auditContext);
+      const product = await audit.audit(narrowedArtifacts, auditContext);
       auditResult = Audit.generateAuditResult(audit, product);
     } catch (err) {
       // Log error if it hasn't already been logged above.

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -335,9 +335,9 @@ class Runner {
         .concat(audit.meta.optionalArtifacts || []);
       const narrowedArtifacts = requestedArtifacts
         .reduce((narrowedArtifacts, artifactName) => {
-          const requiredArtifact = artifacts[artifactName];
+          const requestedArtifact = artifacts[artifactName];
           // @ts-ignore tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.
-          narrowedArtifacts[artifactName] = requiredArtifact;
+          narrowedArtifacts[artifactName] = requestedArtifact;
           return narrowedArtifacts;
         }, /** @type {LH.Artifacts} */ ({}));
       const product = await audit.audit(narrowedArtifacts, auditContext);

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -181,7 +181,7 @@ describe('Config', () => {
     expect(config.passes[0].gatherers.map(g => g.path)).toEqual(['viewport-dimensions']);
   });
 
-  it('does warn when an audit requests and receives an optional artifact', async () => {
+  it('should keep optionalArtifacts in gatherers after filter', async () => { 
     class ButWillStillTakeYourCrap extends Audit {
       static get meta() {
         return {

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -170,18 +170,16 @@ describe('Config', () => {
 
     // Shouldn't throw.
     const config = new Config({
-      passes: [{
-        passName: 'defaultPass',
-        gatherers: [
-          'viewport-dimensions',
-        ],
-      }],
+      extends: 'lighthouse:default',
       audits: [DoesntNeedYourCrap],
+    }, {
+      // Trigger filtering logic.
+      onlyAudits: ['optional-artifact-audit'],
     });
     expect(config.passes[0].gatherers.map(g => g.path)).toEqual(['viewport-dimensions']);
   });
 
-  it('should keep optionalArtifacts in gatherers after filter', async () => { 
+  it('should keep optionalArtifacts in gatherers after filter', async () => {
     class ButWillStillTakeYourCrap extends Audit {
       static get meta() {
         return {
@@ -202,17 +200,21 @@ describe('Config', () => {
     }
 
     const config = new Config({
+      extends: 'lighthouse:default',
+      // TODO(cjamcl): remove when source-maps is in default config.
       passes: [{
         passName: 'defaultPass',
         gatherers: [
           'source-maps',
-          'viewport-dimensions',
         ],
       }],
       audits: [ButWillStillTakeYourCrap],
+    }, {
+      // Trigger filtering logic.
+      onlyAudits: ['optional-artifact-audit'],
     });
     expect(config.passes[0].gatherers.map(g => g.path))
-      .toEqual(['source-maps', 'viewport-dimensions']);
+      .toEqual(['viewport-dimensions', 'source-maps']);
   });
 
   it('does not throw when an audit requires only base artifacts', () => {

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -159,7 +159,7 @@ describe('Config', () => {
             'URL', // base artifact
             'ViewportDimensions', // from gatherer
           ],
-          optionalArtifacts: [
+          __internalOptionalArtifacts: [
             'SourceMaps', // Not in the config.
           ],
         };
@@ -179,7 +179,7 @@ describe('Config', () => {
     expect(config.passes[0].gatherers.map(g => g.path)).toEqual(['viewport-dimensions']);
   });
 
-  it('should keep optionalArtifacts in gatherers after filter', async () => {
+  it('should keep optional artifacts in gatherers after filter', async () => {
     class ButWillStillTakeYourCrap extends Audit {
       static get meta() {
         return {
@@ -190,7 +190,7 @@ describe('Config', () => {
             'URL', // base artifact
             'ViewportDimensions', // from gatherer
           ],
-          optionalArtifacts: [
+          __internalOptionalArtifacts: [
             'SourceMaps', // Is in the config.
           ],
         };

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -407,7 +407,7 @@ describe('Runner', () => {
             failureTitle: 'Artifacts',
             description: 'Test for always throwing',
             requiredArtifacts: ['ArtifactA', 'ArtifactC'],
-            optionalArtifacts: ['ArtifactD'],
+            __internalOptionalArtifacts: ['ArtifactD'],
           };
         }
       }

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -366,7 +366,7 @@ describe('Runner', () => {
       rimraf.sync(resolvedPath);
     });
 
-    it('only passes the required artifacts to the audit', async () => {
+    it('only passes the requested artifacts to the audit (no optional artifacts)', async () => {
       class SimpleAudit extends Audit {
         static get meta() {
           return {
@@ -395,6 +395,40 @@ describe('Runner', () => {
       expect(auditMockFn.mock.calls[0][0]).toEqual({
         ArtifactA: 'apple',
         ArtifactC: 'cherry',
+      });
+    });
+
+    it('only passes the requested artifacts to the audit (w/ optional artifacts)', async () => {
+      class SimpleAudit extends Audit {
+        static get meta() {
+          return {
+            id: 'simple',
+            title: 'Requires some artifacts',
+            failureTitle: 'Artifacts',
+            description: 'Test for always throwing',
+            requiredArtifacts: ['ArtifactA', 'ArtifactC'],
+            optionalArtifacts: ['ArtifactD'],
+          };
+        }
+      }
+
+      const auditMockFn = SimpleAudit.audit = jest.fn().mockReturnValue({score: 1});
+      const config = new Config({
+        settings: {
+          auditMode: __dirname + '/fixtures/artifacts/alphabet-artifacts/',
+        },
+        audits: [
+          SimpleAudit,
+        ],
+      });
+
+      const results = await Runner.run({}, {config});
+      expect(results.lhr).toMatchObject({audits: {simple: {score: 1}}});
+      expect(auditMockFn).toHaveBeenCalled();
+      expect(auditMockFn.mock.calls[0][0]).toEqual({
+        ArtifactA: 'apple',
+        ArtifactC: 'cherry',
+        ArtifactD: 'date',
       });
     });
   });

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -55,7 +55,7 @@ declare global {
       description: string;
       /** A list of the members of LH.Artifacts that must be present for the audit to execute. */
       requiredArtifacts: Array<keyof Artifacts>;
-      /** A list of the members of LH.Artifacts that augment the audit, but aren't necessary. */
+      /** A list of the members of LH.Artifacts that augment the audit, but aren't necessary. For internal use only with experimental-config. */
       __internalOptionalArtifacts?: Array<keyof Artifacts>;
       /** A string identifying how the score should be interpreted for display. */
       scoreDisplayMode?: Audit.ScoreDisplayMode;

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -55,6 +55,8 @@ declare global {
       description: string;
       /** A list of the members of LH.Artifacts that must be present for the audit to execute. */
       requiredArtifacts: Array<keyof Artifacts>;
+      /** A list of the members of LH.Artifacts that augment the audit, but aren't necessary. */
+      optionalArtifacts: Array<keyof Artifacts>;
       /** A string identifying how the score should be interpreted for display. */
       scoreDisplayMode?: Audit.ScoreDisplayMode;
     }

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -56,7 +56,7 @@ declare global {
       /** A list of the members of LH.Artifacts that must be present for the audit to execute. */
       requiredArtifacts: Array<keyof Artifacts>;
       /** A list of the members of LH.Artifacts that augment the audit, but aren't necessary. */
-      optionalArtifacts: Array<keyof Artifacts>;
+      optionalArtifacts?: Array<keyof Artifacts>;
       /** A string identifying how the score should be interpreted for display. */
       scoreDisplayMode?: Audit.ScoreDisplayMode;
     }

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -56,7 +56,7 @@ declare global {
       /** A list of the members of LH.Artifacts that must be present for the audit to execute. */
       requiredArtifacts: Array<keyof Artifacts>;
       /** A list of the members of LH.Artifacts that augment the audit, but aren't necessary. */
-      optionalArtifacts?: Array<keyof Artifacts>;
+      __internalOptionalArtifacts?: Array<keyof Artifacts>;
       /** A string identifying how the score should be interpreted for display. */
       scoreDisplayMode?: Audit.ScoreDisplayMode;
     }


### PR DESCRIPTION
optionalArtifacts allow an audit to request an artifact that may enhance the analysis, but isn't necessary to get useful information. Intended for artifacts that are experimental (SourceMaps), or expensive shouldn't be required (also, maybe SourceMaps).

Changed the terminology inside `config.js` to use `requestedArtifacts`. The warning messages were already using it, so it fits well :)

see also: #10090 