### PR TITLE
report: fix link contrast issue in dark mode

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -342,7 +342,7 @@
 .lh-category-header__description a,
 .lh-audit__description a,
 .lh-footer a,
-.lh-table-column-link a {
+.lh-table-column--link a {
   color: var(--color-informative);
 }
 

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -341,7 +341,7 @@
 .lh-audit-group a,
 .lh-category-header__description a,
 .lh-audit__description a,
-.lh-footer a 
+.lh-footer a,
 .lh-table-column-link a {
   color: var(--color-informative);
 }

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -341,7 +341,8 @@
 .lh-audit-group a,
 .lh-category-header__description a,
 .lh-audit__description a,
-.lh-footer a {
+.lh-footer a 
+.lh-table-column-link a {
   color: var(--color-informative);
 }
 


### PR DESCRIPTION
I went with `--color-informative` which was already in use for some other links and it looks (locally) ok to me in order to fix #10363.

**Summary**
This PR styles `.lh-table-column--link a` elements with the custom color `--color-informative` instead  of the default (user agent stylesheet) color for links (see #10363 for rationale: contrast too low / a11y)

This is intended as a bugfix for #10363.

The need for this change is a better visual contrast in dark mode and respecting WCAG2.1 rules along the way.

https://www.w3.org/TR/WCAG21/#contrast-minimum

**Related Issues/PRs**
See #10363 for original issue.
