### PR TITLE
misc: update commitlint config to latest, loosen subject-case

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,11 +13,11 @@ module.exports = {
     'header-max-length': [2, 'always', 80],
     'scope-case': [2, 'always', 'lower-case'],
     'scope-empty': [0, 'never'],
-		'subject-case': [
-			2,
-			'never',
-			['sentence-case', 'start-case', 'pascal-case', 'upper-case']
-		],
+    'subject-case': [
+      2,
+      'never',
+      ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+    ],
     'subject-empty': [0, 'never'],
     'subject-full-stop': [2, 'never', '.'],
     'type-case': [2, 'always', 'lower-case'],

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -9,18 +9,18 @@ module.exports = {
   extends: ['cz'],
   rules: {
     'body-leading-blank': [1, 'always'],
-    'body-tense': [1, 'always', ['present-imperative']],
     'footer-leading-blank': [1, 'always'],
-    'footer-tense': [1, 'always', ['present-imperative']],
     'header-max-length': [2, 'always', 80],
-    'lang': [0, 'always', 'eng'],
-    'scope-case': [2, 'always', 'lowerCase'],
+    'scope-case': [2, 'always', 'lower-case'],
     'scope-empty': [0, 'never'],
-    'subject-case': [1, 'always', 'lowerCase'],
+		'subject-case': [
+			2,
+			'never',
+			['sentence-case', 'start-case', 'pascal-case', 'upper-case']
+		],
     'subject-empty': [0, 'never'],
     'subject-full-stop': [2, 'never', '.'],
-    'subject-tense': [1, 'always', ['present-imperative']],
-    'type-case': [2, 'always', 'lowerCase'],
+    'type-case': [2, 'always', 'lower-case'],
     'type-empty': [2, 'never'],
     // The scope-enum :  defined in the cz-config
     // The 'type-enum':  defined in the cz-config


### PR DESCRIPTION
some rules are now deprecated. and i loosened the subject-case one since that fought with us a bit.

https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md


https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md#subject-case
