### PR TITLE
clients(extension): remove content security policy

### DIFF
--- a/clients/extension/manifest.json
+++ b/clients/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Lighthouse",
-  "version": "100.0.0.1",
+  "version": "100.0.0.2",
   "minimum_chrome_version": "72",
   "manifest_version": 2,
   "description": "Lighthouse is an open-source, automated tool for improving the performance, quality, and correctness of your web apps.",
@@ -18,6 +18,5 @@
     },
     "default_title": "Lighthouse",
     "default_popup": "popup.html"
-  },
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'none'"
+  }
 }


### PR DESCRIPTION
We don't need it. And FF reviewers don't like the unsafe eval bit.