### PR TITLE
misc(viewer): mention other lighthouse channels

### DIFF
--- a/lighthouse-viewer/app/index.html
+++ b/lighthouse-viewer/app/index.html
@@ -31,8 +31,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
       <h1 class="viewer-placeholder__heading">Lighthouse Report Viewer</h1>
       <div class="viewer-placeholder__help">To view a report: Paste its json or a Gist URL.<br>
       You can also drag 'n drop the file or click here to select it.<br><br>
-        Alternatively use the Lighthouse browser extension (<a href="https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk">Chrome</a>/<a href="https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/">Firefox</a>) or <a href="https://web.dev/measure>web.dev/measure</a> to get a fresh report.
-      </div>
+      Alternatively use the Lighthouse browser extension (<a href="https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk">Chrome</a> / <a href="https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/">Firefox</a>)<br>
+      or <a href="https://web.dev/measure">web.dev/measure</a> to get a fresh report.</div>
       <input type="url" class="viewer-placeholder__url js-gist-url"
              placeholder="Enter or paste Gist URL">
     </div>

--- a/lighthouse-viewer/app/index.html
+++ b/lighthouse-viewer/app/index.html
@@ -30,7 +30,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
     <div>
       <h1 class="viewer-placeholder__heading">Lighthouse Report Viewer</h1>
       <div class="viewer-placeholder__help">To view a report: Paste its json or a Gist URL.<br>
-      You can also drag 'n drop the file or click here to select it.</div>
+      You can also drag 'n drop the file or click here to select it.<br><br>
+        Alternatively use the Lighthouse browser extension (<a href="https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk">Chrome</a>/<a href="https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/">Firefox</a>) or <a href="https://web.dev/measure>web.dev/measure</a> to get a fresh report.
+      </div>
       <input type="url" class="viewer-placeholder__url js-gist-url"
              placeholder="Enter or paste Gist URL">
     </div>

--- a/lighthouse-viewer/app/index.html
+++ b/lighthouse-viewer/app/index.html
@@ -31,8 +31,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
       <h1 class="viewer-placeholder__heading">Lighthouse Report Viewer</h1>
       <div class="viewer-placeholder__help">To view a report: Paste its json or a Gist URL.<br>
       You can also drag 'n drop the file or click here to select it.<br><br>
-      Alternatively use the Lighthouse browser extension (<a href="https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk">Chrome</a> / <a href="https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/">Firefox</a>)<br>
-      or <a href="https://web.dev/measure">web.dev/measure</a> to get a fresh report.</div>
+      To get a fresh report, use the Lighthouse browser extension (<a href="https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk">Chrome</a> / <a href="https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/">Firefox</a>)<br>
+      or <a href="https://web.dev/measure">web.dev/measure</a>.</div>
       <input type="url" class="viewer-placeholder__url js-gist-url"
              placeholder="Enter or paste Gist URL">
     </div>

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -84,7 +84,7 @@ class LighthouseReportViewer {
     placeholderTarget.addEventListener('click', e => {
       const target = /** @type {?Element} */ (e.target);
 
-      if (target && target.localName !== 'input') {
+      if (target && target.localName !== 'input' && target.localName !== 'a') {
         fileInput.click();
       }
     });


### PR DESCRIPTION
after the change the site looks like:

![image](https://user-images.githubusercontent.com/120441/75357250-61b61500-58b1-11ea-8cae-e0da5f968e14.png)


closes https://github.com/GoogleChrome/lighthouse/issues/10335