### PR TITLE
tests: add github action w/ basic CI tasks

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -3,7 +3,7 @@
 # and it should complete quickly, giving more immediate feedback
 # than waiting for Travis
 
-name: 🧱
+name: 💡🏠
 
 on: [push]
 
@@ -13,9 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: git clone
+      uses: actions/checkout@v2
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 10.x
       uses: actions/setup-node@v1
       with:
         node-version: 10.x
@@ -24,15 +25,18 @@ jobs:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
-    - uses: actions/cache@v1
+    - name: Set up node_modules cache
+      uses: actions/cache@v1
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
+
     - run: yarn --frozen-lockfile
     - run: yarn build-all
     - run: yarn diff:sample-json
     - run: yarn lint
     - run: yarn unit-core
+    - run: yarn tsc -p .

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -1,5 +1,5 @@
-# The Travis CI is our full-fledged UI, but this Github workflow
-# runs some basics (build, lint, diff sample json and unit-core)
+# The Travis CI is our full-fledged CI, but this Github workflow
+# runs some basics (build, lint, diff sample json, and unit-core)
 # and it should complete quickly, giving more immediate feedback
 # than waiting for Travis
 

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -1,0 +1,42 @@
+# The Travis CI is our full-fledged UI, but this Github workflow
+# runs some basics (build, lint, diff sample json and unit-core)
+# and it should complete quickly, giving more immediate feedback
+# than waiting for Travis
+
+name: basics
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+   # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - uses: actions/cache@v1
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - run: yarn --frozen-lockfile
+    - run: yarn build-all
+    - run: yarn diff:sample-json
+    - run: yarn lint
+    - run: yarn unit-core

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -3,12 +3,12 @@
 # and it should complete quickly, giving more immediate feedback
 # than waiting for Travis
 
-name: basics
+name: 🧱
 
 on: [push]
 
 jobs:
-  build:
+  basics:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -12,17 +12,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
-
     steps:
     - uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 10.x
 
    # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
     - name: Get yarn cache directory path


### PR DESCRIPTION
lol i was inspired by #10416 

I'm pretty impressed with how fast these GH action VMs spin up and run things, so I think this'll give us faster and clearer feedback on the boring but typical failures (sample-json needs updating, linting, etc)

Big benefit you don't have to scroll/search to see where the failure is: 
![image](https://user-images.githubusercontent.com/39191/75794327-ebae2400-5d70-11ea-9f5d-8b0f72e2c095.png)

And this subset of our CI takes just ~5m whereas travis takes ~20min

Our travis remains our default and canonical CI.. 

