### PR TITLE
misc: resolve jest-haste-map naming collision warning

### DIFF
--- a/docs/recipes/custom-gatherer-puppeteer/package.json
+++ b/docs/recipes/custom-gatherer-puppeteer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "custom-lighthouse-recipe",
+  "name": "custom-lighthouse-pptr-recipe",
   "private": true,
   "scripts": {
     "test": "sh test.sh"


### PR DESCRIPTION
we've had this lil error for a bit. 

```
jest-haste-map: Haste module naming collision: custom-lighthouse-recipe
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/docs/recipes/custom-audit/package.json
    * <rootDir>/docs/recipes/custom-gatherer-puppeteer/package.json
```

it doesnt hurt anybody but this gets rid of it.