### PR TITLE
tests: update coveragePathIgnore jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,8 +12,10 @@ module.exports = {
     '**/lighthouse-core/**/*.js',
     '**/lighthouse-cli/**/*.js',
     '**/lighthouse-viewer/**/*.js',
-    '!**/test/',
-    '!**/scripts/',
+  ],
+  coveragePathIgnorePatterns: [
+    "/test/",
+    "/scripts/",
   ],
   setupFilesAfterEnv: ['./lighthouse-core/test/test-utils.js'],
   testEnvironment: 'node',

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,8 +14,8 @@ module.exports = {
     '**/lighthouse-viewer/**/*.js',
   ],
   coveragePathIgnorePatterns: [
-    "/test/",
-    "/scripts/",
+    '/test/',
+    '/scripts/',
   ],
   setupFilesAfterEnv: ['./lighthouse-core/test/test-utils.js'],
   testEnvironment: 'node',


### PR DESCRIPTION
this should fix the OOM that happens sometimes.


I tested this PR by commenting out `  coverageReporters: ['none'],` from jest.config.js and then running `yarn jest "byte-eff" --ci --coverage --reporters=default`
before the change i saw /test/ and fixtures/ files in the output. afterwards i didnt. seems good. 😁 




----------

apparently our negative matches stopped working at some point. my guess is via https://github.com/facebook/jest/pull/7170 when we [updated to jest 24](https://github.com/GoogleChrome/lighthouse/commit/b1d2b83bdec0090ca215fa52fa1f696f7caff12a). (march 2019)

(i didnt confirm this for sure, but it seems likely)

our coverage definitely changed when that landed....
![image](https://user-images.githubusercontent.com/39191/76357246-9031e800-62d4-11ea-9aac-e82138c4ffb9.png)
https://coveralls.io/repos/109595/builds?page=180
