### PR TITLE
core(lcp): remove todo, mark score curve points as official

### DIFF
--- a/lighthouse-core/audits/metrics/largest-contentful-paint.js
+++ b/lighthouse-core/audits/metrics/largest-contentful-paint.js
@@ -38,7 +38,10 @@ class LargestContentfulPaint extends Audit {
    */
   static get defaultOptions() {
     return {
-      // TODO: Reusing FCP's scoring curve. Set correctly once distribution of results is available.
+      // 75th and 95th percentiles HTTPArchive -> median and PODR.
+      // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2020_02_01_mobile?pli=1
+      // Gives 2.5s roughly a score of 0.9. https://web.dev/lcp/#what-is-a-good-lcp-score
+      // see https://www.desmos.com/calculator/brcfwyox6x
       scorePODR: 2000,
       scoreMedian: 4000,
     };


### PR DESCRIPTION
We copied the FCP 4000ms/2000ms median/podr numbers over to LCP as placeholders until we had HTTP Archive numbers to derive an official curve...but it turns out they're pretty much exactly right (for February 2020, they are 3980ms/1912ms).

This PR just updates the comment on the numbers to make it clear they're for real now.