### PR TITLE
new_audit: check images are big enough

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 #   Name/Organization <email address>
 
 Google Inc.
+Sebastian Kreft

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,8 +12,10 @@ module.exports = {
     '**/lighthouse-core/**/*.js',
     '**/lighthouse-cli/**/*.js',
     '**/lighthouse-viewer/**/*.js',
-    '!**/test/',
-    '!**/scripts/',
+  ],
+  coveragePathIgnorePatterns: [
+    '/test/',
+    '/scripts/',
   ],
   setupFilesAfterEnv: ['./lighthouse-core/test/test-utils.js'],
   testEnvironment: 'node',

--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -97,6 +97,9 @@ Object {
       "path": "image-aspect-ratio",
     },
     Object {
+      "path": "image-size-responsive",
+    },
+    Object {
       "path": "deprecations",
     },
     Object {
@@ -746,6 +749,10 @@ Object {
         },
         Object {
           "id": "image-aspect-ratio",
+          "weight": 1,
+        },
+        Object {
+          "id": "image-size-responsive",
           "weight": 1,
         },
       ],

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -201,9 +201,18 @@
 </template>
 
 <!-- FAIL(image-aspect-ratio): image is naturally 480x318 -->
-<img src="lighthouse-480x318.jpg" width="480" height="57">
+<img src="lighthouse-480x318.jpg?iar1" width="120" height="15">
 <!-- PASS(image-aspect-ratio) -->
-<img src="lighthouse-480x318.jpg" width="480" height="318">
+<img src="lighthouse-480x318.jpg?iar2" width="120" height="80">
+
+<!-- FAIL(image-size-responsive): image is naturally 480x318 -->
+<img src="lighthouse-480x318.jpg?isr1" width="4800" height="3180" style="position: absolute;">
+<!-- PASS(image-size-responsive) -->
+<img src="lighthouse-480x318.jpg?isr2" width="120" height="80" style="position: absolute;">
+<!-- PASS(image-size-responsive) -->
+<img src="lighthouse-480x318.jpg?isr3" width="960" height="636" style="image-rendering: pixelated; position: absolute;">
+<!-- PASS(image-size-responsive) -->
+<img src="lighthouse-480x318.jpg?isr4" srcset="lighthouse-480x318.jpg 2x" width="960" height="636" style="position: absolute;">
 
 <!-- FAIL(efficient-animated-content): animated gif found -->
 <img src="lighthouse-rotating.gif" width="811" height="462">

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -353,7 +353,19 @@ const expectations = [
           details: {
             items: {
               0: {
-                displayedAspectRatio: /^480 x 57/,
+                displayedAspectRatio: /^120 x 15/,
+                url: 'http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?iar1',
+              },
+              length: 1,
+            },
+          },
+        },
+        'image-size-responsive': {
+          score: 0,
+          details: {
+            items: {
+              0: {
+                url: 'http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?isr1',
               },
               length: 1,
             },
@@ -385,10 +397,10 @@ const expectations = [
         },
         'dom-size': {
           score: 1,
-          numericValue: 143,
+          numericValue: 147,
           details: {
             items: [
-              {statistic: 'Total DOM Elements', value: '143'},
+              {statistic: 'Total DOM Elements', value: '147'},
               {statistic: 'Maximum DOM Depth', value: '4'},
               {
                 statistic: 'Maximum Child Elements',

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright 2020 Sebastian Kreft All Rights Reserved.
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -141,6 +141,7 @@ function deduplicateAndSortResults(results) {
   const deduplicated = /** @type {Result[]} */ ([]);
   for (const r of results) {
     if (deduplicated.length > 0 && r.url === deduplicated[deduplicated.length - 1].url) {
+      // If the URL was the same, this is a duplicate. Keep the largest image.
       if (deduplicated[deduplicated.length - 1].expectedPixels < r.expectedPixels) {
         deduplicated[deduplicated.length - 1] = r;
       }

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -1,0 +1,204 @@
+/**
+ * @license Copyright 2020 Sebastian Kreft All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+/**
+ * @fileoverview Checks to see if the aspect ratio of the images used on
+ *   the page are equal to the aspect ratio of their display sizes. The
+ *   audit will list all images that don't match with their display size
+ *   aspect ratio.
+ */
+'use strict';
+
+const Audit = require('./audit.js');
+const URL = require('../lib/url-shim.js');
+const i18n = require('../lib/i18n/i18n.js');
+
+const UIStrings = {
+  /** Title of a Lighthouse audit that provides detail on the size of visible images on the page. This descriptive title is shown to users when all images have correct sizes. */
+  title: 'Displays images with correct size',
+  /** Title of a Lighthouse audit that provides detail on the size of visible images on the page. This descriptive title is shown to users when not all images have correct sizes. */
+  failureTitle: 'Displays images with incorrect size',
+  /** Description of a Lighthouse audit that tells the user why they should maintain the correct aspect ratios for all images. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  description: 'Image display dimensions should match natural aspect ratio. ' +
+    '[Learn more](https://web.dev/image-aspect-ratio).',
+  /**
+   * @description Warning that the size information for an image was nonsensical.
+   * @example {https://image.cdn.com/} url
+   */
+  warningCompute: 'Invalid image sizing information {url}',
+  /**  Label for a column in a data table; entries in the column will be the numeric aspect ratio of an image as displayed in a web page. */
+  columnDisplayed: 'Displayed size',
+  /**  Label for a column in a data table; entries in the column will be the numeric aspect ratio of the raw (actual) image. */
+  columnActual: 'Actual size',
+  /**  Label for a column in a data table; entries in the column will be the numeric aspect ratio of the raw (actual) image. */
+  columnExpected: 'Expected size',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+const TOLERANCE = 0.75;
+
+const ALLOWABLE_OFFSCREEN_X = 100;
+const ALLOWABLE_OFFSCREEN_Y = 200;
+
+/** @typedef {{url: string, elidedUrl: string, displayedSize: string, actualSize: string, expectedSize: string, expectedPixels: number}} Result */
+
+/**
+ * @param {{top: number, bottom: number, left: number, right: number}} imageRect
+ * @param {{innerWidth: number, innerHeight: number}} viewportDimensions
+ * @return {boolean}
+ */
+function isVisible(imageRect, viewportDimensions) {
+  return (
+    (imageRect.bottom - imageRect.top) * (imageRect.right - imageRect.left) > 0 &&
+    imageRect.top <= viewportDimensions.innerHeight + ALLOWABLE_OFFSCREEN_Y &&
+    imageRect.bottom >= -ALLOWABLE_OFFSCREEN_Y &&
+    imageRect.left <= viewportDimensions.innerWidth + ALLOWABLE_OFFSCREEN_X &&
+    imageRect.right >= -ALLOWABLE_OFFSCREEN_X
+  );
+}
+
+/**
+ * @param {LH.Artifacts.ImageElement} image
+ * @return {boolean}
+ */
+function isCandidate(image) {
+  if (image.displayedWidth <= 1 || image.displayedHeight <= 1) {
+    return false;
+  }
+  if (image.naturalWidth === 0 || image.naturalHeight === 0) {
+    return false;
+  }
+  if (image.mimeType === 'image/svg+xml') {
+    return false;
+  }
+  if (image.isCss) {
+    return false;
+  }
+  if (image.usesObjectFit) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @param {LH.Artifacts.ImageElement} image
+ * @param {number} DPR
+ * @return {boolean}
+ */
+function imageHasRightSize(image, DPR) {
+  const [expectedWidth, expectedHeight] =
+      expectedImageSize(image.displayedWidth, image.displayedHeight, DPR);
+  return image.naturalWidth >= expectedWidth && image.naturalHeight >= expectedHeight;
+}
+
+/**
+ * @param {LH.Artifacts.ImageElement} image
+ * @param {number} DPR
+ * @return {Result}
+ */
+function getResult(image, DPR) {
+  const [expectedWidth, expectedHeight] =
+      expectedImageSize(image.displayedWidth, image.displayedHeight, DPR);
+  return {
+    url: image.src,
+    elidedUrl: URL.elideDataURI(image.src),
+    displayedSize: `${image.displayedWidth} x ${image.displayedHeight}`,
+    actualSize: `${image.naturalWidth} x ${image.naturalHeight}`,
+    expectedSize: `${expectedWidth} x ${expectedHeight}`,
+    expectedPixels: expectedWidth * expectedHeight,
+  };
+}
+
+/**
+ * Compute the size an image should have given the display dimensions and pixel density.
+ *
+ * For smaller images, typically icons, the size must be proportional to the density.
+ * For larger images some tolerance is allowed as in thise cases the perceived degradation is not
+ * that bad.
+ *
+ * @param {number} displayedWidth
+ * @param {number} displayedHeight
+ * @param {number} DPR
+ * @return {[number, number]}
+ */
+function expectedImageSize(displayedWidth, displayedHeight, DPR) {
+  let factor = DPR;
+  if (displayedWidth > 64 || displayedHeight > 64) {
+    factor *= TOLERANCE;
+  }
+  const width = Math.ceil(factor * displayedWidth);
+  const height = Math.ceil(factor * displayedHeight);
+  return [width, height];
+}
+
+/**
+ * Remove repeated entries for the same source and sort them by source.
+ *
+ * It will keep the entry with the largest size.
+ *
+ * @param {Result[]} results
+ * @return {Result[]}
+ */
+function deduplicateAndSortResults(results) {
+  results.sort((a, b) => a.url === b.url ? 0 : (a.url < b. url ? -1 : 1));
+  const deduplicated = /** @type {Result[]} */ ([]);
+  for (const r of results) {
+    if (deduplicated.length > 0 && r.url === deduplicated[deduplicated.length - 1].url) {
+      if (deduplicated[deduplicated.length - 1].expectedPixels < r.expectedPixels) {
+        deduplicated[deduplicated.length - 1] = r;
+      }
+    } else {
+      deduplicated.push(r);
+    }
+  }
+  return deduplicated;
+}
+
+class ImageSizeResponsive extends Audit {
+  /**
+   * @return {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'image-size-responsive',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      requiredArtifacts: ['ImageElements', 'ViewportDimensions'],
+    };
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
+   */
+  static audit(artifacts) {
+    const DPR = artifacts.ViewportDimensions.devicePixelRatio;
+    const results = Array
+      .from(artifacts.ImageElements)
+      .filter(isCandidate)
+      .filter(image => !imageHasRightSize(image, DPR))
+      .filter(image => isVisible(image.clientRect, artifacts.ViewportDimensions))
+      .map(image => getResult(image, DPR));
+
+    /** @type {LH.Audit.Details.Table['headings']} */
+    const headings = [
+      {key: 'url', itemType: 'thumbnail', text: ''},
+      {key: 'elidedUrl', itemType: 'url', text: str_(i18n.UIStrings.columnURL)},
+      {key: 'displayedSize', itemType: 'text', text: str_(UIStrings.columnDisplayed)},
+      {key: 'actualSize', itemType: 'text', text: str_(UIStrings.columnActual)},
+      {key: 'expectedSize', itemType: 'text', text: str_(UIStrings.columnExpected)},
+    ];
+
+    return {
+      score: Number(results.length === 0),
+      details: Audit.makeTableDetails(headings, deduplicateAndSortResults(results)),
+    };
+  }
+}
+
+module.exports = ImageSizeResponsive;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -110,7 +110,7 @@ function getResult(image, DPR) {
  * Compute the size an image should have given the display dimensions and pixel density.
  *
  * For smaller images, typically icons, the size must be proportional to the density.
- * For larger images some tolerance is allowed as in thise cases the perceived degradation is not
+ * For larger images some tolerance is allowed as in those cases the perceived degradation is not
  * that bad.
  *
  * @param {number} displayedWidth

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -65,8 +65,6 @@ function isVisible(imageRect, viewportDimensions) {
  * @return {boolean}
  */
 function isCandidate(image) {
-  // TODO: skip images using PixelArt scaling.
-  // See PR https://github.com/GoogleChrome/lighthouse/pull/10481
   if (image.displayedWidth <= 1 || image.displayedHeight <= 1) {
     return false;
   }
@@ -82,6 +80,12 @@ function isCandidate(image) {
   if (image.usesObjectFit) {
     return false;
   }
+  if (image.usesPixelArtScaling) {
+    return false;
+  }
+  if (image.usesSrcSetDensityDescriptor) {
+    return false;
+  }
   return true;
 }
 
@@ -91,9 +95,6 @@ function isCandidate(image) {
  * @return {boolean}
  */
 function imageHasRightSize(image, DPR) {
-  // TODO: in case the image has a srcset with pixel density descriptor, the natural size will not
-  // be the actual image size but rather the image size divided by the density descriptor.
-  // We can approximate it with the devicePixelRatio.
   const [expectedWidth, expectedHeight] =
       allowedImageSize(image.displayedWidth, image.displayedHeight, DPR);
   return image.naturalWidth >= expectedWidth && image.naturalHeight >= expectedHeight;

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -43,10 +43,6 @@ const LARGE_IMAGE_FACTOR = 0.75;
 // considered SMALL.
 const SMALL_IMAGE_THRESHOLD = 64;
 
-// This constants were taken from the OffscreenImages audit.
-const ALLOWABLE_OFFSCREEN_X = 100;
-const ALLOWABLE_OFFSCREEN_Y = 200;
-
 /** @typedef {{url: string, elidedUrl: string, displayedSize: string, actualSize: string, actualPixels: number, expectedSize: string, expectedPixels: number}} Result */
 
 /**
@@ -57,10 +53,10 @@ const ALLOWABLE_OFFSCREEN_Y = 200;
 function isVisible(imageRect, viewportDimensions) {
   return (
     (imageRect.bottom - imageRect.top) * (imageRect.right - imageRect.left) > 0 &&
-    imageRect.top <= viewportDimensions.innerHeight + ALLOWABLE_OFFSCREEN_Y &&
-    imageRect.bottom >= -ALLOWABLE_OFFSCREEN_Y &&
-    imageRect.left <= viewportDimensions.innerWidth + ALLOWABLE_OFFSCREEN_X &&
-    imageRect.right >= -ALLOWABLE_OFFSCREEN_X
+    imageRect.top <= viewportDimensions.innerHeight &&
+    imageRect.bottom >= 0 &&
+    imageRect.left <= viewportDimensions.innerWidth &&
+    imageRect.right >= 0
   );
 }
 

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -65,6 +65,8 @@ function isVisible(imageRect, viewportDimensions) {
  * @return {boolean}
  */
 function isCandidate(image) {
+  // TODO: skip images using PixelArt scaling.
+  // See PR https://github.com/GoogleChrome/lighthouse/pull/10481
   if (image.displayedWidth <= 1 || image.displayedHeight <= 1) {
     return false;
   }
@@ -89,6 +91,9 @@ function isCandidate(image) {
  * @return {boolean}
  */
 function imageHasRightSize(image, DPR) {
+  // TODO: in case the image has a srcset with pixel density descriptor, the natural size will not
+  // be the actual image size but rather the image size divided by the density descriptor.
+  // We can approximate it with the devicePixelRatio.
   const [expectedWidth, expectedHeight] =
       allowedImageSize(image.displayedWidth, image.displayedHeight, DPR);
   return image.naturalWidth >= expectedWidth && image.naturalHeight >= expectedHeight;

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -21,7 +21,7 @@ const UIStrings = {
   failureTitle: 'Displays images with incorrect size',
   /** Description of a Lighthouse audit that tells the user why they should maintain the correct aspect ratios for all images. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Image natural dimensions should be proportional to the display size and the ' +
-    'pixel ratio. [Learn more](https://web.dev/image-size-responsive).',
+    'pixel ratio to maximize image clarity. [Learn more](https://web.dev/image-size-responsive).',
   /**  Label for a column in a data table; entries in the column will be a string representing the displayed size of the image. */
   columnDisplayed: 'Displayed size',
   /**  Label for a column in a data table; entries in the column will be a string representing the actual size of the image. */

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -4,10 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 /**
- * @fileoverview Checks to see if the aspect ratio of the images used on
- *   the page are equal to the aspect ratio of their display sizes. The
- *   audit will list all images that don't match with their display size
- *   aspect ratio.
+ * @fileoverview Checks to see if the size of the visible images used on
+ *   the page are large enough with respect to the pixel ratio. The
+ *   audit will list all visible images that are too small.
  */
 'use strict';
 
@@ -21,18 +20,13 @@ const UIStrings = {
   /** Title of a Lighthouse audit that provides detail on the size of visible images on the page. This descriptive title is shown to users when not all images have correct sizes. */
   failureTitle: 'Displays images with incorrect size',
   /** Description of a Lighthouse audit that tells the user why they should maintain the correct aspect ratios for all images. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
-  description: 'Image display dimensions should match natural aspect ratio. ' +
-    '[Learn more](https://web.dev/image-aspect-ratio).',
-  /**
-   * @description Warning that the size information for an image was nonsensical.
-   * @example {https://image.cdn.com/} url
-   */
-  warningCompute: 'Invalid image sizing information {url}',
-  /**  Label for a column in a data table; entries in the column will be the numeric aspect ratio of an image as displayed in a web page. */
+  description: 'Image natural dimensions should be proportional to the display size and the ' +
+    'pixel ratio. [Learn more](https://web.dev/image-size-responsive).',
+  /**  Label for a column in a data table; entries in the column will be a string representing the displayed size of the image. */
   columnDisplayed: 'Displayed size',
-  /**  Label for a column in a data table; entries in the column will be the numeric aspect ratio of the raw (actual) image. */
+  /**  Label for a column in a data table; entries in the column will be a string representing the actual size of the image. */
   columnActual: 'Actual size',
-  /**  Label for a column in a data table; entries in the column will be the numeric aspect ratio of the raw (actual) image. */
+  /**  Label for a column in a data table; entries in the column will be a string representing the expected size of the image. */
   columnExpected: 'Expected size',
 };
 

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -203,6 +203,7 @@ const defaultConfig = {
     'maskable-icon',
     'content-width',
     'image-aspect-ratio',
+    'image-size-responsive',
     'deprecations',
     'mainthread-work-breakdown',
     'bootup-time',
@@ -521,6 +522,7 @@ const defaultConfig = {
         {id: 'password-inputs-can-be-pasted-into', weight: 1},
         {id: 'errors-in-console', weight: 1},
         {id: 'image-aspect-ratio', weight: 1},
+        {id: 'image-size-responsive', weight: 1},
       ],
     },
     'seo': {

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -789,13 +789,13 @@
     "message": "Expected size"
   },
   "lighthouse-core/audits/image-size-responsive.js | description": {
-    "message": "Image natural dimensions should be proportional to the display size and the pixel ratio. [Learn more](https://web.dev/image-size-responsive)."
+    "message": "Image natural dimensions should be proportional to the display size and the pixel ratio to maximize image clarity. [Learn more](https://web.dev/image-size-responsive)."
   },
   "lighthouse-core/audits/image-size-responsive.js | failureTitle": {
-    "message": "Displays images with incorrect size"
+    "message": "Displays images with inappropriate size"
   },
   "lighthouse-core/audits/image-size-responsive.js | title": {
-    "message": "Displays images with correct size"
+    "message": "Displays images with appropriate size"
   },
   "lighthouse-core/audits/installable-manifest.js | description": {
     "message": "Browsers can proactively prompt users to add your app to their homescreen, which can lead to higher engagement. [Learn more](https://web.dev/installable-manifest)."

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -779,6 +779,24 @@
   "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
     "message": "Invalid image sizing information {url}"
   },
+  "lighthouse-core/audits/image-size-responsive.js | columnActual": {
+    "message": "Actual size"
+  },
+  "lighthouse-core/audits/image-size-responsive.js | columnDisplayed": {
+    "message": "Displayed size"
+  },
+  "lighthouse-core/audits/image-size-responsive.js | columnExpected": {
+    "message": "Expected size"
+  },
+  "lighthouse-core/audits/image-size-responsive.js | description": {
+    "message": "Image natural dimensions should be proportional to the display size and the pixel ratio. [Learn more](https://web.dev/image-size-responsive)."
+  },
+  "lighthouse-core/audits/image-size-responsive.js | failureTitle": {
+    "message": "Displays images with incorrect size"
+  },
+  "lighthouse-core/audits/image-size-responsive.js | title": {
+    "message": "Displays images with correct size"
+  },
   "lighthouse-core/audits/installable-manifest.js | description": {
     "message": "Browsers can proactively prompt users to add your app to their homescreen, which can lead to higher engagement. [Learn more](https://web.dev/installable-manifest)."
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -779,6 +779,24 @@
   "lighthouse-core/audits/image-aspect-ratio.js | warningCompute": {
     "message": "Îńv̂ál̂íd̂ ím̂áĝé ŝíẑín̂ǵ îńf̂ór̂ḿât́îón̂ {url}"
   },
+  "lighthouse-core/audits/image-size-responsive.js | columnActual": {
+    "message": "Âćt̂úâĺ ŝíẑé"
+  },
+  "lighthouse-core/audits/image-size-responsive.js | columnDisplayed": {
+    "message": "D̂íŝṕl̂áŷéd̂ śîźê"
+  },
+  "lighthouse-core/audits/image-size-responsive.js | columnExpected": {
+    "message": "Êx́p̂éĉt́êd́ ŝíẑé"
+  },
+  "lighthouse-core/audits/image-size-responsive.js | description": {
+    "message": "Îḿâǵê ńât́ûŕâĺ d̂ím̂én̂śîón̂ś ŝh́ôúl̂d́ b̂é p̂ŕôṕôŕt̂íôńâĺ t̂ó t̂h́ê d́îśp̂ĺâý ŝíẑé âńd̂ t́ĥé p̂íx̂él̂ ŕât́îó. [L̂éâŕn̂ ḿôŕê](https://web.dev/image-size-responsive)."
+  },
+  "lighthouse-core/audits/image-size-responsive.js | failureTitle": {
+    "message": "D̂íŝṕl̂áŷś îḿâǵêś ŵít̂h́ îńĉór̂ŕêćt̂ śîźê"
+  },
+  "lighthouse-core/audits/image-size-responsive.js | title": {
+    "message": "D̂íŝṕl̂áŷś îḿâǵêś ŵít̂h́ ĉór̂ŕêćt̂ śîźê"
+  },
   "lighthouse-core/audits/installable-manifest.js | description": {
     "message": "B̂ŕôẃŝér̂ś ĉán̂ ṕr̂óâćt̂ív̂él̂ý p̂ŕôḿp̂t́ ûśêŕŝ t́ô ád̂d́ ŷóûŕ âṕp̂ t́ô t́ĥéîŕ ĥóm̂éŝćr̂éêń, ŵh́îćĥ ćâń l̂éâd́ t̂ó ĥíĝh́êŕ êńĝáĝém̂én̂t́. [L̂éâŕn̂ ḿôŕê](https://web.dev/installable-manifest)."
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -789,13 +789,13 @@
     "message": "Êx́p̂éĉt́êd́ ŝíẑé"
   },
   "lighthouse-core/audits/image-size-responsive.js | description": {
-    "message": "Îḿâǵê ńât́ûŕâĺ d̂ím̂én̂śîón̂ś ŝh́ôúl̂d́ b̂é p̂ŕôṕôŕt̂íôńâĺ t̂ó t̂h́ê d́îśp̂ĺâý ŝíẑé âńd̂ t́ĥé p̂íx̂él̂ ŕât́îó. [L̂éâŕn̂ ḿôŕê](https://web.dev/image-size-responsive)."
+    "message": "Îḿâǵê ńât́ûŕâĺ d̂ím̂én̂śîón̂ś ŝh́ôúl̂d́ b̂é p̂ŕôṕôŕt̂íôńâĺ t̂ó t̂h́ê d́îśp̂ĺâý ŝíẑé âńd̂ t́ĥé p̂íx̂él̂ ŕât́îó t̂ó m̂áx̂ím̂íẑé îḿâǵê ćl̂ár̂ít̂ý. [L̂éâŕn̂ ḿôŕê](https://web.dev/image-size-responsive)."
   },
   "lighthouse-core/audits/image-size-responsive.js | failureTitle": {
-    "message": "D̂íŝṕl̂áŷś îḿâǵêś ŵít̂h́ îńĉór̂ŕêćt̂ śîźê"
+    "message": "D̂íŝṕl̂áŷś îḿâǵêś ŵít̂h́ îńâṕp̂ŕôṕr̂íât́ê śîźê"
   },
   "lighthouse-core/audits/image-size-responsive.js | title": {
-    "message": "D̂íŝṕl̂áŷś îḿâǵêś ŵít̂h́ ĉór̂ŕêćt̂ śîźê"
+    "message": "D̂íŝṕl̂áŷś îḿâǵêś ŵít̂h́ âṕp̂ŕôṕr̂íât́ê śîźê"
   },
   "lighthouse-core/audits/installable-manifest.js | description": {
     "message": "B̂ŕôẃŝér̂ś ĉán̂ ṕr̂óâćt̂ív̂él̂ý p̂ŕôḿp̂t́ ûśêŕŝ t́ô ád̂d́ ŷóûŕ âṕp̂ t́ô t́ĥéîŕ ĥóm̂éŝćr̂éêń, ŵh́îćĥ ćâń l̂éâd́ t̂ó ĥíĝh́êŕ êńĝáĝém̂én̂t́. [L̂éâŕn̂ ḿôŕê](https://web.dev/installable-manifest)."

--- a/lighthouse-core/test/audits/image-size-responsive-test.js
+++ b/lighthouse-core/test/audits/image-size-responsive-test.js
@@ -137,8 +137,8 @@ describe('Images: size audit', () => {
       naturalSize: [5, 5],
       props: {
         clientRect: {
-          top: -201 - 100,
-          bottom: -201,
+          top: -1 - 100,
+          bottom: -1,
           left: 0,
           right: 100,
         },
@@ -151,8 +151,8 @@ describe('Images: size audit', () => {
       naturalSize: [5, 5],
       props: {
         clientRect: {
-          top: -200 - 100,
-          bottom: -200,
+          top: - 100,
+          bottom: 0,
           left: 0,
           right: 100,
         },
@@ -165,8 +165,8 @@ describe('Images: size audit', () => {
       naturalSize: [5, 5],
       props: {
         clientRect: {
-          top: HEIGHT + 201,
-          bottom: HEIGHT + 201 + 100,
+          top: HEIGHT + 1,
+          bottom: HEIGHT + 1 + 100,
           left: 0,
           right: 100,
         },
@@ -179,8 +179,8 @@ describe('Images: size audit', () => {
       naturalSize: [5, 5],
       props: {
         clientRect: {
-          top: HEIGHT + 200,
-          bottom: HEIGHT + 200 + 100,
+          top: HEIGHT,
+          bottom: HEIGHT + 100,
           left: 0,
           right: 100,
         },
@@ -195,8 +195,8 @@ describe('Images: size audit', () => {
         clientRect: {
           top: 0,
           bottom: 100,
-          left: -101 - 100,
-          right: -101,
+          left: -1 - 100,
+          right: -1,
         },
       },
     });
@@ -209,8 +209,8 @@ describe('Images: size audit', () => {
         clientRect: {
           top: 0,
           bottom: 100,
-          left: -100 - 100,
-          right: -100,
+          left: -100,
+          right: 0,
         },
       },
     });
@@ -223,8 +223,8 @@ describe('Images: size audit', () => {
         clientRect: {
           top: 0,
           bottom: 100,
-          left: WIDTH + 101,
-          right: WIDTH + 101 + 100,
+          left: WIDTH + 1,
+          right: WIDTH + 1 + 100,
         },
       },
     });
@@ -237,8 +237,8 @@ describe('Images: size audit', () => {
         clientRect: {
           top: 0,
           bottom: 100,
-          left: WIDTH + 100,
-          right: WIDTH + 100 + 100,
+          left: WIDTH,
+          right: WIDTH + 100,
         },
       },
     });

--- a/lighthouse-core/test/audits/image-size-responsive-test.js
+++ b/lighthouse-core/test/audits/image-size-responsive-test.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright 2020 Sebastian Kreft All Rights Reserved.
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */

--- a/lighthouse-core/test/audits/image-size-responsive-test.js
+++ b/lighthouse-core/test/audits/image-size-responsive-test.js
@@ -116,6 +116,24 @@ describe('Images: size audit', () => {
     },
   });
 
+  testImage('uses PixelArt scaling', {
+    score: 1,
+    clientSize: [100, 100],
+    naturalSize: [5, 5],
+    props: {
+      usesPixelArtScaling: true,
+    },
+  });
+
+  testImage('uses srcset density descriptor', {
+    score: 1,
+    clientSize: [100, 100],
+    naturalSize: [5, 5],
+    props: {
+      usesSrcSetDensityDescriptor: true,
+    },
+  });
+
   describe('visibility', () => {
     testImage('has no client area', {
       score: 1,

--- a/lighthouse-core/test/audits/image-size-responsive-test.js
+++ b/lighthouse-core/test/audits/image-size-responsive-test.js
@@ -1,0 +1,363 @@
+/**
+ * @license Copyright 2020 Sebastian Kreft All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const ImageSizeResponsiveAudit = require('../../audits/image-size-responsive.js');
+const assert = require('assert');
+
+/* eslint-env jest */
+
+const WIDTH = 800;
+const HEIGHT = 600;
+
+function generateImage(clientSize, naturalSize, props, src = 'https://google.com/logo.png') {
+  const image = {src, mimeType: 'image/png'};
+  const clientRect = {
+    clientRect: {
+      top: 0,
+      bottom: clientSize.displayedHeight,
+      left: 0,
+      right: clientSize.displayedWidth,
+    },
+  };
+  Object.assign(image, clientSize, naturalSize, clientRect, props);
+  return image;
+}
+
+describe('Images: size audit', () => {
+  function testImage(condition, data) {
+    const description = `identifies when an image ${condition}`;
+    it(description, () => {
+      const result = ImageSizeResponsiveAudit.audit({
+        ImageElements: [
+          generateImage(
+            {displayedWidth: data.clientSize[0], displayedHeight: data.clientSize[1]},
+            {naturalWidth: data.naturalSize[0], naturalHeight: data.naturalSize[1]},
+            data.props
+          ),
+        ],
+        ViewportDimensions: {
+          innerWidth: WIDTH,
+          innerHeight: HEIGHT,
+          devicePixelRatio: data.devicePixelRatio || 1,
+        },
+      });
+      let details = '';
+      if (result.score === 0) {
+        const {displayedSize: displayed, actualSize: actual, expectedSize: expected} =
+            result.details.items[0];
+        details = ` (displayed: ${displayed}, actual: ${actual}, expected: ${expected})`;
+      }
+      assert.strictEqual(result.score, data.score, `score does not match${details}`);
+    });
+  }
+
+  testImage('invalid image', {
+    score: 0,
+    clientSize: [100, 100],
+    naturalSize: [5, 5],
+  });
+
+  describe('is empty', () => {
+    testImage('is empty along width', {
+      score: 1,
+      clientSize: [100, 100],
+      naturalSize: [0, 5],
+    });
+
+    testImage('is empty along height', {
+      score: 1,
+      clientSize: [100, 100],
+      naturalSize: [5, 0],
+    });
+  });
+
+  describe('too small', () => {
+    testImage('is too small along width', {
+      score: 1,
+      clientSize: [1, 100],
+      naturalSize: [5, 5],
+    });
+
+    testImage('is too small along height', {
+      score: 1,
+      clientSize: [100, 1],
+      naturalSize: [5, 5],
+    });
+  });
+
+  testImage('is an SVG image', {
+    score: 1,
+    clientSize: [100, 100],
+    naturalSize: [5, 5],
+    props: {
+      mimeType: 'image/svg+xml',
+    },
+  });
+
+  testImage('is a css image', {
+    score: 1,
+    clientSize: [100, 100],
+    naturalSize: [5, 5],
+    props: {
+      isCss: true,
+    },
+  });
+
+  testImage('uses object-fit', {
+    score: 1,
+    clientSize: [100, 100],
+    naturalSize: [5, 5],
+    props: {
+      usesObjectFit: true,
+    },
+  });
+
+  describe('visibility', () => {
+    testImage('has no client area', {
+      score: 1,
+      clientSize: [100, 100],
+      naturalSize: [5, 5],
+      props: {
+        clientRect: {
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+        },
+      },
+    });
+
+    testImage('is above the visible area', {
+      score: 1,
+      clientSize: [100, 100],
+      naturalSize: [5, 5],
+      props: {
+        clientRect: {
+          top: -201 - 100,
+          bottom: -201,
+          left: 0,
+          right: 100,
+        },
+      },
+    });
+
+    testImage('is almost above the visible area', {
+      score: 0,
+      clientSize: [100, 100],
+      naturalSize: [5, 5],
+      props: {
+        clientRect: {
+          top: -200 - 100,
+          bottom: -200,
+          left: 0,
+          right: 100,
+        },
+      },
+    });
+
+    testImage('is below the visible area', {
+      score: 1,
+      clientSize: [100, 100],
+      naturalSize: [5, 5],
+      props: {
+        clientRect: {
+          top: HEIGHT + 201,
+          bottom: HEIGHT + 201 + 100,
+          left: 0,
+          right: 100,
+        },
+      },
+    });
+
+    testImage('is almost below the visible area', {
+      score: 0,
+      clientSize: [100, 100],
+      naturalSize: [5, 5],
+      props: {
+        clientRect: {
+          top: HEIGHT + 200,
+          bottom: HEIGHT + 200 + 100,
+          left: 0,
+          right: 100,
+        },
+      },
+    });
+
+    testImage('is to the left of the visible area', {
+      score: 1,
+      clientSize: [100, 100],
+      naturalSize: [5, 5],
+      props: {
+        clientRect: {
+          top: 0,
+          bottom: 100,
+          left: -101 - 100,
+          right: -101,
+        },
+      },
+    });
+
+    testImage('is almost to the left of the visible area', {
+      score: 0,
+      clientSize: [100, 100],
+      naturalSize: [5, 5],
+      props: {
+        clientRect: {
+          top: 0,
+          bottom: 100,
+          left: -100 - 100,
+          right: -100,
+        },
+      },
+    });
+
+    testImage('is to the right of the visible area', {
+      score: 1,
+      clientSize: [100, 100],
+      naturalSize: [5, 5],
+      props: {
+        clientRect: {
+          top: 0,
+          bottom: 100,
+          left: WIDTH + 101,
+          right: WIDTH + 101 + 100,
+        },
+      },
+    });
+
+    testImage('is almost to the right of the visible area', {
+      score: 0,
+      clientSize: [100, 100],
+      naturalSize: [5, 5],
+      props: {
+        clientRect: {
+          top: 0,
+          bottom: 100,
+          left: WIDTH + 100,
+          right: WIDTH + 100 + 100,
+        },
+      },
+    });
+  });
+
+  describe('check size', () => {
+    describe('DPR = 1', () => {
+      testImage('is an icon with right size', {
+        score: 1,
+        clientSize: [64, 64],
+        naturalSize: [64, 64],
+      });
+
+      testImage('is an icon with an invalid size', {
+        score: 0,
+        clientSize: [64, 64],
+        naturalSize: [63, 63],
+      });
+
+      testImage('has right size', {
+        score: 1,
+        clientSize: [65, 65],
+        naturalSize: [49, 49],
+      });
+
+      testImage('has an invalid size', {
+        score: 0,
+        clientSize: [65, 65],
+        naturalSize: [48, 48],
+      });
+    });
+
+    describe('DPR = 2', () => {
+      testImage('is an icon with right size', {
+        score: 1,
+        clientSize: [64, 64],
+        naturalSize: [128, 128],
+        devicePixelRatio: 2,
+      });
+
+      testImage('is an icon with an invalid size', {
+        score: 0,
+        clientSize: [64, 64],
+        naturalSize: [127, 127],
+        devicePixelRatio: 2,
+      });
+
+      testImage('has right size', {
+        score: 1,
+        clientSize: [65, 65],
+        naturalSize: [98, 98],
+        devicePixelRatio: 2,
+      });
+
+      testImage('has an invalid size', {
+        score: 0,
+        clientSize: [65, 65],
+        naturalSize: [97, 97],
+        devicePixelRatio: 2,
+      });
+    });
+  });
+
+  it('de-dupes images', () => {
+    const result = ImageSizeResponsiveAudit.audit({
+      ImageElements: [
+        generateImage(
+          {displayedWidth: 80, displayedHeight: 40},
+          {naturalWidth: 40, naturalHeight: 20}
+        ),
+        generateImage(
+          {displayedWidth: 160, displayedHeight: 80},
+          {naturalWidth: 40, naturalHeight: 20}
+        ),
+        generateImage(
+          {displayedWidth: 60, displayedHeight: 30},
+          {naturalWidth: 40, naturalHeight: 20}
+        ),
+      ],
+      ViewportDimensions: {
+        innerWidth: WIDTH,
+        innerHeight: HEIGHT,
+        devicePixelRatio: 1,
+      },
+    });
+    assert.equal(result.details.items.length, 1);
+    assert.equal(result.details.items[0].expectedSize, '120 x 60');
+  });
+
+  it('sorts images', () => {
+    const result = ImageSizeResponsiveAudit.audit({
+      ImageElements: [
+        generateImage(
+          {displayedWidth: 80, displayedHeight: 40},
+          {naturalWidth: 40, naturalHeight: 20},
+          {},
+          'https://C.com/image.png'
+        ),
+        generateImage(
+          {displayedWidth: 80, displayedHeight: 40},
+          {naturalWidth: 40, naturalHeight: 20},
+          {},
+          'https://A.com/image.png'
+        ),
+        generateImage(
+          {displayedWidth: 80, displayedHeight: 40},
+          {naturalWidth: 40, naturalHeight: 20},
+          {},
+          'https://B.com/image.png'
+        ),
+      ],
+      ViewportDimensions: {
+        innerWidth: WIDTH,
+        innerHeight: HEIGHT,
+        devicePixelRatio: 1,
+      },
+    });
+    assert.equal(result.details.items.length, 3);
+    const srcs = result.details.items.map(item => item.url);
+    assert.deepEqual(Array.from(srcs), srcs.sort());
+  });
+});

--- a/lighthouse-core/test/audits/image-size-responsive-test.js
+++ b/lighthouse-core/test/audits/image-size-responsive-test.js
@@ -75,7 +75,7 @@ describe('Images: size audit', () => {
     });
   });
 
-  describe('too small', () => {
+  describe('too small to bother testing', () => {
     testImage('is too small along width', {
       score: 1,
       clientSize: [1, 100],

--- a/lighthouse-core/test/audits/image-size-responsive-test.js
+++ b/lighthouse-core/test/audits/image-size-responsive-test.js
@@ -325,29 +325,29 @@ describe('Images: size audit', () => {
       },
     });
     assert.equal(result.details.items.length, 1);
-    assert.equal(result.details.items[0].expectedSize, '120 x 60');
+    assert.equal(result.details.items[0].expectedSize, '160 x 80');
   });
 
-  it('sorts images', () => {
+  it('sorts images by size delta', () => {
     const result = ImageSizeResponsiveAudit.audit({
       ImageElements: [
         generateImage(
           {displayedWidth: 80, displayedHeight: 40},
           {naturalWidth: 40, naturalHeight: 20},
           {},
-          'https://C.com/image.png'
+          'image1.png'
         ),
         generateImage(
-          {displayedWidth: 80, displayedHeight: 40},
+          {displayedWidth: 120, displayedHeight: 60},
           {naturalWidth: 40, naturalHeight: 20},
           {},
-          'https://A.com/image.png'
+          'image2.png'
         ),
         generateImage(
-          {displayedWidth: 80, displayedHeight: 40},
+          {displayedWidth: 90, displayedHeight: 45},
           {naturalWidth: 40, naturalHeight: 20},
           {},
-          'https://B.com/image.png'
+          'image3.png'
         ),
       ],
       ViewportDimensions: {
@@ -358,6 +358,24 @@ describe('Images: size audit', () => {
     });
     assert.equal(result.details.items.length, 3);
     const srcs = result.details.items.map(item => item.url);
-    assert.deepEqual(Array.from(srcs), srcs.sort());
+    assert.deepEqual(srcs, ['image2.png', 'image3.png', 'image1.png']);
+  });
+
+  it('shows the right expected size', () => {
+    const result = ImageSizeResponsiveAudit.audit({
+      ImageElements: [
+        generateImage(
+          {displayedWidth: 80, displayedHeight: 40},
+          {naturalWidth: 40, naturalHeight: 20}
+        ),
+      ],
+      ViewportDimensions: {
+        innerWidth: WIDTH,
+        innerHeight: HEIGHT,
+        devicePixelRatio: 2.71,
+      },
+    });
+    assert.equal(result.details.items.length, 1);
+    assert.equal(result.details.items[0].expectedSize, '217 x 109');
   });
 });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -630,6 +630,54 @@
         ]
       }
     },
+    "image-size-responsive": {
+      "id": "image-size-responsive",
+      "title": "Displays images with inappropriate size",
+      "description": "Image natural dimensions should be proportional to the display size and the pixel ratio to maximize image clarity. [Learn more](https://web.dev/image-size-responsive).",
+      "score": 0,
+      "scoreDisplayMode": "binary",
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "url",
+            "itemType": "thumbnail",
+            "text": ""
+          },
+          {
+            "key": "elidedUrl",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "key": "displayedSize",
+            "itemType": "text",
+            "text": "Displayed size"
+          },
+          {
+            "key": "actualSize",
+            "itemType": "text",
+            "text": "Actual size"
+          },
+          {
+            "key": "expectedSize",
+            "itemType": "text",
+            "text": "Expected size"
+          }
+        ],
+        "items": [
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg",
+            "elidedUrl": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg",
+            "displayedSize": "480 x 318",
+            "actualSize": "480 x 318",
+            "actualPixels": 152640,
+            "expectedSize": "1260 x 835",
+            "expectedPixels": 1052100
+          }
+        ]
+      }
+    },
     "deprecations": {
       "id": "deprecations",
       "title": "Uses deprecated APIs",
@@ -4179,10 +4227,14 @@
         {
           "id": "image-aspect-ratio",
           "weight": 1
+        },
+        {
+          "id": "image-size-responsive",
+          "weight": 1
         }
       ],
       "id": "best-practices",
-      "score": 0.07
+      "score": 0.06
     },
     "seo": {
       "title": "SEO",
@@ -4807,6 +4859,12 @@
       {
         "startTime": 0,
         "name": "lh:audit:image-aspect-ratio",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:audit:image-size-responsive",
         "duration": 100,
         "entryType": "measure"
       },
@@ -5763,6 +5821,7 @@
       "lighthouse-core/lib/i18n/i18n.js | columnURL": [
         "audits[errors-in-console].details.headings[0].text",
         "audits[image-aspect-ratio].details.headings[1].text",
+        "audits[image-size-responsive].details.headings[1].text",
         "audits.deprecations.details.headings[1].text",
         "audits[bootup-time].details.headings[0].text",
         "audits[network-rtt].details.headings[0].text",
@@ -5883,6 +5942,21 @@
       ],
       "lighthouse-core/audits/image-aspect-ratio.js | columnActual": [
         "audits[image-aspect-ratio].details.headings[3].text"
+      ],
+      "lighthouse-core/audits/image-size-responsive.js | failureTitle": [
+        "audits[image-size-responsive].title"
+      ],
+      "lighthouse-core/audits/image-size-responsive.js | description": [
+        "audits[image-size-responsive].description"
+      ],
+      "lighthouse-core/audits/image-size-responsive.js | columnDisplayed": [
+        "audits[image-size-responsive].details.headings[2].text"
+      ],
+      "lighthouse-core/audits/image-size-responsive.js | columnActual": [
+        "audits[image-size-responsive].details.headings[3].text"
+      ],
+      "lighthouse-core/audits/image-size-responsive.js | columnExpected": [
+        "audits[image-size-responsive].details.headings[4].text"
       ],
       "lighthouse-core/audits/deprecations.js | failureTitle": [
         "audits.deprecations.title"

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     },
     {
       "path": "./dist/lighthouse-dt-bundle.js",
-      "maxSize": "455 kB"
+      "maxSize": "456 kB"
     },
     {
       "path": "./dist/lightrider/report-generator-bundle.js",

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -1123,6 +1123,53 @@
             "title": "Displays images with incorrect aspect ratio",
             "warnings": []
         },
+        "image-size-responsive": {
+            "description": "Image natural dimensions should be proportional to the display size and the pixel ratio to maximize image clarity. [Learn more](https://web.dev/image-size-responsive).",
+            "details": {
+                "headings": [
+                    {
+                        "itemType": "thumbnail",
+                        "key": "url"
+                    },
+                    {
+                        "itemType": "url",
+                        "key": "elidedUrl",
+                        "text": "URL"
+                    },
+                    {
+                        "itemType": "text",
+                        "key": "displayedSize",
+                        "text": "Displayed size"
+                    },
+                    {
+                        "itemType": "text",
+                        "key": "actualSize",
+                        "text": "Actual size"
+                    },
+                    {
+                        "itemType": "text",
+                        "key": "expectedSize",
+                        "text": "Expected size"
+                    }
+                ],
+                "items": [
+                    {
+                        "actualPixels": 152640.0,
+                        "actualSize": "480 x 318",
+                        "displayedSize": "480 x 318",
+                        "elidedUrl": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg",
+                        "expectedPixels": 1052100.0,
+                        "expectedSize": "1260 x 835",
+                        "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg"
+                    }
+                ],
+                "type": "table"
+            },
+            "id": "image-size-responsive",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
+            "title": "Displays images with inappropriate size"
+        },
         "input-image-alt": {
             "description": "When an image is being used as an `<input>` button, providing alternative text can help screen reader users understand the purpose of the button. [Learn more](https://web.dev/input-image-alt/).",
             "id": "input-image-alt",
@@ -3787,10 +3834,14 @@
                 {
                     "id": "image-aspect-ratio",
                     "weight": 1.0
+                },
+                {
+                    "id": "image-size-responsive",
+                    "weight": 1.0
                 }
             ],
             "id": "best-practices",
-            "score": 0.07,
+            "score": 0.06,
             "title": "Best Practices"
         },
         "performance": {
@@ -4723,6 +4774,12 @@
                 "duration": 100.0,
                 "entryType": "measure",
                 "name": "lh:audit:image-aspect-ratio",
+                "startTime": 0.0
+            },
+            {
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:image-size-responsive",
                 "startTime": 0.0
             },
             {


### PR DESCRIPTION
**Summary**
New audit checking visible images are big enough. This is a complement to `UsesResponsiveImages`.

**Related Issues/PRs**
Fixes #10434. Check that issue for the New Audit Proposal.