### PR TITLE
misc: add usesPixelArtScaling flag to images

### DIFF
--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -29,15 +29,7 @@ function getClientRect(element) {
   };
 }
 
-/**
- * @param {CSSStyleDeclaration} style
- * @return {boolean}
- */
-function usesPixelArtScaling(style) {
-  return ['pixelated', 'crisp-edges'].includes(
-    style.getPropertyValue('image-rendering')
-  );
-}
+const PIXEL_ART_RENDERING = ['pixelated', 'crisp-edges'];
 
 /**
  * @param {Array<Element>} allElements
@@ -68,7 +60,9 @@ function getHTMLImages(allElements) {
       usesObjectFit: ['cover', 'contain', 'scale-down', 'none'].includes(
         computedStyle.getPropertyValue('object-fit')
       ),
-      usesPixelArtScaling: usesPixelArtScaling(computedStyle),
+      usesPixelArtScaling: ['pixelated', 'crisp-edges'].includes(
+        computedStyle.getPropertyValue('image-rendering')
+      ),
     };
   });
 }
@@ -106,7 +100,9 @@ function getCSSImages(allElements) {
       isCss: true,
       isPicture: false,
       usesObjectFit: false,
-      usesPixelArtScaling: usesPixelArtScaling(style),
+      usesPixelArtScaling: ['pixelated', 'crisp-edges'].includes(
+        style.getPropertyValue('image-rendering')
+      ),
       resourceSize: 0, // this will get overwritten below
     });
   }

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -30,6 +30,16 @@ function getClientRect(element) {
 }
 
 /**
+ * @param {CSSStyleDeclaration} style
+ * @return {boolean}
+ */
+function usesPixelArtScaling(style) {
+  return ['pixelated', 'crisp-edges'].includes(
+    style.getPropertyValue('image-rendering')
+  );
+}
+
+/**
  * @param {Array<Element>} allElements
  * @return {Array<LH.Artifacts.ImageElement>}
  */
@@ -58,6 +68,7 @@ function getHTMLImages(allElements) {
       usesObjectFit: ['cover', 'contain', 'scale-down', 'none'].includes(
         computedStyle.getPropertyValue('object-fit')
       ),
+      usesPixelArtScaling: usesPixelArtScaling(computedStyle),
     };
   });
 }
@@ -95,6 +106,7 @@ function getCSSImages(allElements) {
       isCss: true,
       isPicture: false,
       usesObjectFit: false,
+      usesPixelArtScaling: usesPixelArtScaling(style),
       resourceSize: 0, // this will get overwritten below
     });
   }

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -29,8 +29,6 @@ function getClientRect(element) {
   };
 }
 
-const PIXEL_ART_RENDERING = ['pixelated', 'crisp-edges'];
-
 /**
  * @param {Array<Element>} allElements
  * @return {Array<LH.Artifacts.ImageElement>}
@@ -63,6 +61,8 @@ function getHTMLImages(allElements) {
       usesPixelArtScaling: ['pixelated', 'crisp-edges'].includes(
         computedStyle.getPropertyValue('image-rendering')
       ),
+      // https://html.spec.whatwg.org/multipage/images.html#pixel-density-descriptor
+      usesSrcSetDensityDescriptor: / \d+(\.\d+)?x/.test(element.srcset),
     };
   });
 }
@@ -103,6 +103,7 @@ function getCSSImages(allElements) {
       usesPixelArtScaling: ['pixelated', 'crisp-edges'].includes(
         style.getPropertyValue('image-rendering')
       ),
+      usesSrcSetDensityDescriptor: false,
       resourceSize: 0, // this will get overwritten below
     });
   }

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -399,6 +399,10 @@ declare global {
          *  details.
          */
         usesPixelArtScaling: boolean;
+        /** Flags whether the image has a srcset with density descriptors.
+         *  See https://html.spec.whatwg.org/multipage/images.html#pixel-density-descriptor
+         */
+        usesSrcSetDensityDescriptor: boolean;
         /** The size of the underlying image file in bytes. 0 if the file could not be identified. */
         resourceSize: number;
         /** The MIME type of the underlying image file. */

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -394,6 +394,11 @@ declare global {
         isPicture: boolean;
         /** Flags whether this element was sized using a non-default `object-fit` CSS property. */
         usesObjectFit: boolean;
+        /** Flags whether this element was rendered using a pixel art scaling method.
+         *  See https://developer.mozilla.org/en-US/docs/Games/Techniques/Crisp_pixel_art_look for
+         *  details.
+         */
+        usesPixelArtScaling: boolean;
         /** The size of the underlying image file in bytes. 0 if the file could not be identified. */
         resourceSize: number;
         /** The MIME type of the underlying image file. */


### PR DESCRIPTION
Two new flags are added to `ImageElement`s.

The first, `usesPixelArtScaling` will be used by the `ImageSizeResponsive` audit (#10460), as those images are intendedly displayed in a pixelated form, so the audit should not flag them.

Note that `image-rendering: -moz-crisp-edges;` is also an accepted value in Firefox, however in such case, the computed style will return `crips-edges`.

See https://developer.mozilla.org/en-US/docs/Games/Techniques/Crisp_pixel_art_look for more information.

The second is `usesSrcSetDensityDescriptor`. That flag will also be used by the `ImageSizeResponsive` and is required, as by the spec, the natural size of the image, is the actual size of the image divided by its density descriptor. Note that we cannot access the actual value of the density descriptor, so in the audit the best option will be to just skip those images.

An alternative would be to recompute the size of those images, but that may break some other assumptions about `naturalWidth`, `naturalHeight`.