### PR TITLE
misc: ignore duplicate builds in lhci dogfood

### DIFF
--- a/lighthouse-core/scripts/dogfood-lhci.sh
+++ b/lighthouse-core/scripts/dogfood-lhci.sh
@@ -41,4 +41,8 @@ npm install -g @lhci/cli@0.3.x
 # Collect our LHCI results.
 lhci collect --staticDistDir=./dist/now/english/
 # Upload the results to our canary server.
-lhci upload --serverBaseUrl="$LHCI_CANARY_SERVER_URL" --token="$LHCI_CANARY_SERVER_TOKEN" --github-token="$BUNDLESIZE_GITHUB_TOKEN"
+lhci upload \
+  --serverBaseUrl="$LHCI_CANARY_SERVER_URL" \
+  --token="$LHCI_CANARY_SERVER_TOKEN" \
+  --github-token="$BUNDLESIZE_GITHUB_TOKEN" \
+  --ignoreDuplicateBuildFailure


### PR DESCRIPTION
**Summary**
master can't pass right now because of the lhci duplicate build problem, so thought I'd update us to use the new `--ignoreDuplicateBuildFailure` flag
