### PR TITLE
core: remove some dead code in driver.js

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1192,43 +1192,6 @@ class Driver {
   }
 
   /**
-   * @param {string} selector Selector to find in the DOM
-   * @return {Promise<Array<LHElement>>} The found elements, or [], resolved in a promise
-   */
-  async querySelectorAll(selector) {
-    const documentResponse = await this.sendCommand('DOM.getDocument');
-    const rootNodeId = documentResponse.root.nodeId;
-
-    const targetNodeList = await this.sendCommand('DOM.querySelectorAll', {
-      nodeId: rootNodeId,
-      selector,
-    });
-
-    /** @type {Array<LHElement>} */
-    const elementList = [];
-    targetNodeList.nodeIds.forEach(nodeId => {
-      if (nodeId !== 0) {
-        elementList.push(new LHElement({nodeId}, this));
-      }
-    });
-    return elementList;
-  }
-
-  /**
-   * Returns the flattened list of all DOM elements within the document.
-   * @param {boolean=} pierce Whether to pierce through shadow trees and iframes.
-   *     True by default.
-   * @return {Promise<Array<LHElement>>} The found elements, or [], resolved in a promise
-   */
-  getElementsInDocument(pierce = true) {
-    return this.getNodesInDocument(pierce)
-      .then(nodes => nodes
-        .filter(node => node.nodeType === 1)
-        .map(node => new LHElement({nodeId: node.nodeId}, this))
-      );
-  }
-
-  /**
    * Returns the flattened list of all DOM nodes within the document.
    * @param {boolean=} pierce Whether to pierce through shadow trees and iframes.
    *     True by default.

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -169,25 +169,6 @@ describe('.querySelector(All)', () => {
     const result = await driver.querySelector('meta head');
     expect(result).toBeInstanceOf(LHElement);
   });
-
-  it('returns [] when DOM.querySelectorAll finds no node', async () => {
-    connectionStub.sendCommand = createMockSendCommandFn()
-      .mockResponse('DOM.getDocument', {root: {nodeId: 249}})
-      .mockResponse('DOM.querySelectorAll', {nodeIds: []});
-
-    const result = await driver.querySelectorAll('#no.matches');
-    expect(result).toEqual([]);
-  });
-
-  it('returns element when DOM.querySelectorAll finds node', async () => {
-    connectionStub.sendCommand = createMockSendCommandFn()
-      .mockResponse('DOM.getDocument', {root: {nodeId: 249}})
-      .mockResponse('DOM.querySelectorAll', {nodeIds: [231]});
-
-    const result = await driver.querySelectorAll('#no.matches');
-    expect(result).toHaveLength(1);
-    expect(result[0]).toBeInstanceOf(LHElement);
-  });
 });
 
 describe('.getObjectProperty', () => {


### PR DESCRIPTION
Removing some unused code that I found in driver.js: `getQuerySelectorAll` and `getElementsInDocument` (has the same name as a page-functions method). 
They look to be old methods that use `LHElement`. 

----------

There are a couple more LHElement functions that could be removed by updating the one place in code that they are used. Will attempt to remove those in a follow-up PR.