### PR TITLE
cli: attempt to resolve config path from config dir

### DIFF
--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -7,6 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const {resolveModule} = require('../lighthouse-core/config/config-helpers.js');
 
 /*
  * The relationship between these CLI modules:
@@ -65,8 +66,8 @@ async function begin() {
   /** @type {LH.Config.Json|undefined} */
   let configJson;
   if (cliFlags.configPath) {
-    // Resolve the config file path relative to where cli was called.
-    cliFlags.configPath = path.resolve(process.cwd(), cliFlags.configPath);
+    cliFlags.configPath =
+      resolveModule(cliFlags.configPath, `${__dirname}/../lighthouse-core/config`);
     configJson = /** @type {LH.Config.Json} */ (require(cliFlags.configPath));
   } else if (cliFlags.preset) {
     if (cliFlags.preset === 'mixed-content') {

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -84,6 +84,14 @@ describe('CLI bin', function() {
       expect(getRunLighthouseArgs()[2]).toEqual(actualConfig);
     });
 
+    it('should load the config from the path, resolved from config folder', async () => {
+      cliFlags = {...cliFlags, configPath: 'lr-desktop-config.js'};
+      const actualConfig = require('../../../lighthouse-core/config/lr-desktop-config.js');
+      await bin.begin();
+
+      expect(getRunLighthouseArgs()[2]).toEqual(actualConfig);
+    });
+
     it('should load the config from the preset', async () => {
       cliFlags = {...cliFlags, preset: 'mixed-content'};
       const actualConfig = require('../../../lighthouse-core/config/mixed-content-config.js');


### PR DESCRIPTION
This is from a desire to be able to do:

```
lighthouse https://www.example.com --config-path=experimental-config.js
```

Currently, it requires an awful linux command hack to get the folder that `lighthouse` is installed in.

A file named `experimental-config.js` in the local directory would still take precedence, FYI.