### PR TITLE
misc(compare-runs): fix filter, allow for resume, reorganize output

### DIFF
--- a/lighthouse-core/scripts/compare-runs.js
+++ b/lighthouse-core/scripts/compare-runs.js
@@ -118,7 +118,7 @@ function round(value) {
  */
 function getProgressBar(i, total = argv.n * argv.urls.length) {
   const bars = new Array(Math.round(i * 40 / total)).fill('▄').join('').padEnd(40);
-  return `${i} / ${total} [${bars}]`;
+  return `${i + 1} / ${total} [${bars}]`;
 }
 
 async function gather() {
@@ -132,13 +132,16 @@ async function gather() {
   const progress = new ProgressLogger();
   progress.log('Gathering…');
 
+  let progressCount = 0;
   for (const url of argv.urls) {
     const urlFolder = `${outputDir}/${urlToFolder(url)}`;
     await mkdir(urlFolder, {recursive: true});
 
     for (let i = 0; i < argv.n; i++) {
       const gatherDir = `${urlFolder}/${i}`;
-      progress.progress(getProgressBar(i));
+
+      progressCount++;
+      progress.progress(getProgressBar(progressCount));
 
       // Skip if already gathered. Allows for restarting collection.
       if (fs.existsSync(gatherDir)) continue;

--- a/lighthouse-core/scripts/compare-runs.js
+++ b/lighthouse-core/scripts/compare-runs.js
@@ -20,7 +20,7 @@ const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 const yargs = require('yargs');
 
-const { ProgressLogger } = require('./lantern/collect/common.js');
+const {ProgressLogger} = require('./lantern/collect/common.js');
 
 const LH_ROOT = `${__dirname}/../..`;
 const ROOT_OUTPUT_DIR = `${LH_ROOT}/timings-data`;
@@ -49,7 +49,7 @@ const argv = yargs
     'desc': 'Set to override default ascending sort',
   })
   .string('filter')
-  .alias({ 'gather': 'G', 'audit': 'A' })
+  .alias({'gather': 'G', 'audit': 'A'})
   .default('report-exclude', 'key|min|max|stdev|^n$')
   .default('delta-property-sort', 'mean')
   .default('output', 'table')
@@ -127,7 +127,7 @@ async function gather() {
     // eslint-disable-next-line no-console
     console.log('Collection already started - resuming.');
   }
-  await mkdir(outputDir, { recursive: true });
+  await mkdir(outputDir, {recursive: true});
 
   const progress = new ProgressLogger();
   progress.log('Gathering…');
@@ -135,7 +135,7 @@ async function gather() {
   let progressCount = 0;
   for (const url of argv.urls) {
     const urlFolder = `${outputDir}/${urlToFolder(url)}`;
-    await mkdir(urlFolder, { recursive: true });
+    await mkdir(urlFolder, {recursive: true});
 
     for (let i = 0; i < argv.n; i++) {
       const gatherDir = `${urlFolder}/${i}`;
@@ -212,9 +212,8 @@ function aggregateResults(name) {
       {};
     const allEntries = {
       metric: Object.entries(metrics).filter(([name]) => !name.endsWith('Ts')),
-      // timing: lhr.timing.entries.map(entry => ([entry.name, entry.duration])),
+      timing: lhr.timing.entries.map(entry => ([entry.name, entry.duration])),
     };
-    console.log(Object.keys(lhr.audits))
 
     Object.entries(allEntries).forEach(([kind, entries]) => {
       // Group the durations of each entry of the same name.

--- a/lighthouse-core/scripts/compare-runs.js
+++ b/lighthouse-core/scripts/compare-runs.js
@@ -20,7 +20,7 @@ const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 const yargs = require('yargs');
 
-const {ProgressLogger} = require('./lantern/collect/common.js');
+const { ProgressLogger } = require('./lantern/collect/common.js');
 
 const LH_ROOT = `${__dirname}/../..`;
 const ROOT_OUTPUT_DIR = `${LH_ROOT}/timings-data`;
@@ -49,7 +49,7 @@ const argv = yargs
     'desc': 'Set to override default ascending sort',
   })
   .string('filter')
-  .alias({'gather': 'G', 'audit': 'A'})
+  .alias({ 'gather': 'G', 'audit': 'A' })
   .default('report-exclude', 'key|min|max|stdev|^n$')
   .default('delta-property-sort', 'mean')
   .default('output', 'table')
@@ -127,7 +127,7 @@ async function gather() {
     // eslint-disable-next-line no-console
     console.log('Collection already started - resuming.');
   }
-  await mkdir(outputDir, {recursive: true});
+  await mkdir(outputDir, { recursive: true });
 
   const progress = new ProgressLogger();
   progress.log('Gathering…');
@@ -135,7 +135,7 @@ async function gather() {
   let progressCount = 0;
   for (const url of argv.urls) {
     const urlFolder = `${outputDir}/${urlToFolder(url)}`;
-    await mkdir(urlFolder, {recursive: true});
+    await mkdir(urlFolder, { recursive: true });
 
     for (let i = 0; i < argv.n; i++) {
       const gatherDir = `${urlFolder}/${i}`;
@@ -164,11 +164,14 @@ async function audit() {
   const progress = new ProgressLogger();
   progress.log('Auditing…');
 
+  let progressCount = 0;
   for (const url of argv.urls) {
     const urlDir = `${outputDir}/${urlToFolder(url)}`;
     for (let i = 0; i < argv.n; i++) {
       const gatherDir = `${urlDir}/${i}`;
-      progress.progress(getProgressBar(i));
+
+      progress.progress(getProgressBar(progressCount));
+      progressCount++;
 
       const cmd = [
         'node',
@@ -205,8 +208,9 @@ function aggregateResults(name) {
       {};
     const allEntries = {
       metric: Object.entries(metrics).filter(([name]) => !name.endsWith('Ts')),
-      timing: lhr.timing.entries.map(entry => ([entry.name, entry.duration])),
+      // timing: lhr.timing.entries.map(entry => ([entry.name, entry.duration])),
     };
+    console.log(Object.keys(lhr.audits))
 
     Object.entries(allEntries).forEach(([kind, entries]) => {
       // Group the durations of each entry of the same name.

--- a/lighthouse-core/scripts/compare-runs.js
+++ b/lighthouse-core/scripts/compare-runs.js
@@ -140,8 +140,8 @@ async function gather() {
     for (let i = 0; i < argv.n; i++) {
       const gatherDir = `${urlFolder}/${i}`;
 
-      progressCount++;
       progress.progress(getProgressBar(progressCount));
+      progressCount++;
 
       // Skip if already gathered. Allows for restarting collection.
       if (fs.existsSync(gatherDir)) continue;
@@ -258,21 +258,21 @@ function aggregateResults(name) {
 }
 
 /**
- * @param {Array<{name: string}>} results
+ * @param {Array<{key: string, name: string}>} results
  */
 function filter(results) {
   const includeFilter = argv.filter ? new RegExp(argv.filter, 'i') : null;
 
   results.forEach((result, i) => {
+    if (includeFilter && !includeFilter.test(result.key)) {
+      delete results[i];
+    }
+
     for (const propName of Object.keys(result)) {
       if (reportExcludeRegex && reportExcludeRegex.test(propName)) {
         // @ts-ignore: propName is a key.
         delete result[propName];
       }
-    }
-
-    if (includeFilter && !includeFilter.test(result.name)) {
-      delete results[i];
     }
   });
 }
@@ -328,6 +328,7 @@ function compare() {
     const max = compareValues(baseResult && baseResult.max, otherResult && otherResult.max);
 
     return {
+      'key': someResult.key,
       'name': someResult.name,
       'url': someResult.url,
       'mean': mean.description,

--- a/lighthouse-core/scripts/compare-runs.js
+++ b/lighthouse-core/scripts/compare-runs.js
@@ -117,12 +117,14 @@ function round(value) {
  * @return {string}
  */
 function getProgressBar(i, total = argv.n * argv.urls.length) {
-  return `${i} / ${total} [` + new Array(Math.round(i * 40 / total)).fill('▄').join('').padEnd(40) + ']';
+  const bars = new Array(Math.round(i * 40 / total)).fill('▄').join('').padEnd(40);
+  return `${i} / ${total} [${bars}]`;
 }
 
 async function gather() {
   const outputDir = dir(argv.name);
   if (fs.existsSync(outputDir)) {
+    // eslint-disable-next-line no-console
     console.log('Collection already started - resuming.');
   }
   await mkdir(outputDir, {recursive: true});

--- a/lighthouse-core/scripts/compare-runs.js
+++ b/lighthouse-core/scripts/compare-runs.js
@@ -169,16 +169,20 @@ async function audit() {
     const urlDir = `${outputDir}/${urlToFolder(url)}`;
     for (let i = 0; i < argv.n; i++) {
       const gatherDir = `${urlDir}/${i}`;
+      const outputPath = `${urlDir}/lhr-${i}.json`;
 
       progress.progress(getProgressBar(progressCount));
       progressCount++;
+
+      // Skip if already audited. Allows for restarting collection.
+      if (fs.existsSync(outputPath)) continue;
 
       const cmd = [
         'node',
         `${LH_ROOT}/lighthouse-cli`,
         url,
         `--audit-mode=${gatherDir}`,
-        `--output-path=${urlDir}/lhr-${i}.json`,
+        `--output-path=${outputPath}`,
         '--output=json',
         argv.lhFlags,
       ].join(' ');


### PR DESCRIPTION
* `--filter` was broken from the last change
* progress bar didn't use the correct count
* allow collection to be resumed
* organize LHRs by url directory, instead of all in root directory. Simplifies programmatic consumption