### PR TITLE
core: serialize i18n instances for gather mode

### DIFF
--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -269,7 +269,16 @@ function _preformatValues(icuMessage, messageFormatter, values) {
  */
 
 /** @type {Map<string, IcuMessageInstance[]>} */
-const _icuMessageInstanceMap = new Map();
+let _icuMessageInstanceMap = new Map();
+
+function getIcuMessageInstanceMap() {
+  return _icuMessageInstanceMap;
+}
+
+/** @param {Map<string, IcuMessageInstance[]>} map */
+function setIcuMessageInstanceMap(map) {
+  _icuMessageInstanceMap = map;
+}
 
 const _ICUMsgNotFoundMsg = 'ICU message not found in destination locale';
 /**
@@ -520,4 +529,6 @@ module.exports = {
   isIcuMessage,
   collectAllCustomElementsFromICU,
   registerLocaleData,
+  getIcuMessageInstanceMap,
+  setIcuMessageInstanceMap,
 };


### PR DESCRIPTION
fixes #9269

I went with a minimally invasive change. The con is that it relies on global state (this was the case before, but now it is explicitly so via an interface).

corresponds to option 2 that Brenden mentioned https://github.com/GoogleChrome/lighthouse/issues/9269#issuecomment-512622306
> or some kind of icuMessagePaths but for artifacts and swap upon loading them

test w/
```
node lighthouse-cli http://www.paulirish.com -G
node lighthouse-cli http://www.paulirish.com -A --view # yay it works
```

(waiting for review before writing tests)