### PR TITLE
misc(build): disable fail-fast on gh basics workflow

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -11,6 +11,9 @@ jobs:
   basics:
 
     runs-on: ubuntu-latest
+    strategy:
+      # e.g. if lint fails, continue to the unit tests anyway
+      fail-fast: false
 
     steps:
     - name: git clone
@@ -21,7 +24,7 @@ jobs:
       with:
         node-version: 10.x
 
-   # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
+    # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
If lint fails, do we want the workflow to continue and run unit tests?
Or should it just immediately give the red X feedback?

I'm fine with both, just wanted to ask folks what they think.