### PR TITLE
core(runner): make LH.Audit.Context immutable

### DIFF
--- a/lighthouse-core/audits/bootup-time.js
+++ b/lighthouse-core/audits/bootup-time.js
@@ -181,8 +181,9 @@ class BootupTime extends Audit {
 
 
     // TODO: consider moving this to core gathering so you don't need to run the audit for warning
+    let runWarnings;
     if (hadExcessiveChromeExtension) {
-      context.LighthouseRunWarnings.push(str_(UIStrings.chromeExtensionsWarning));
+      runWarnings = [str_(UIStrings.chromeExtensionsWarning)];
     }
 
     const summary = {wastedMs: totalBootupTime};
@@ -211,6 +212,7 @@ class BootupTime extends Audit {
       displayValue: totalBootupTime > 0 ?
         str_(i18n.UIStrings.seconds, {timeInMs: totalBootupTime}) : '',
       details,
+      runWarnings,
     };
   }
 }

--- a/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
@@ -44,7 +44,7 @@ class FirstContentfulPaint3G extends Audit {
   static async audit(artifacts, context) {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
-    /** @type {LH.Config.Settings} */
+    /** @type {Immutable<LH.Config.Settings>} */
     const settings = {...context.settings, throttlingMethod: 'simulate', throttling: regular3G};
     const metricComputationData = {trace, devtoolsLog, settings};
     const metricResult = await ComputedFcp.request(metricComputationData, context);

--- a/lighthouse-core/audits/performance-budget.js
+++ b/lighthouse-core/audits/performance-budget.js
@@ -64,7 +64,7 @@ class ResourceBudget extends Audit {
   }
 
   /**
-   * @param {LH.Budget} budget
+   * @param {Immutable<LH.Budget>} budget
    * @param {Record<LH.Budget.ResourceType,ResourceEntry>} summary
    * @return {Array<BudgetItem>}
    */

--- a/lighthouse-core/audits/timing-budget.js
+++ b/lighthouse-core/audits/timing-budget.js
@@ -80,7 +80,7 @@ class TimingBudget extends Audit {
   }
 
   /**
-   * @param {LH.Budget} budget
+   * @param {Immutable<LH.Budget>} budget
    * @param {LH.Artifacts.TimingSummary} summary
    * @return {Array<BudgetItem>}
    */

--- a/lighthouse-core/computed/computed-artifact.js
+++ b/lighthouse-core/computed/computed-artifact.js
@@ -25,6 +25,8 @@ function makeComputedArtifact(computableArtifact) {
    * @return {ReturnType<C['compute_']>}
    */
   const request = (artifacts, context) => {
+    /** @type {Map<string, ArbitraryEqualityMap>} */
+    // @ts-ignore - break immutability solely for this caching-controller function.
     const computedCache = context.computedCache;
     const computedName = computableArtifact.name;
 

--- a/lighthouse-core/computed/computed-artifact.js
+++ b/lighthouse-core/computed/computed-artifact.js
@@ -25,9 +25,8 @@ function makeComputedArtifact(computableArtifact) {
    * @return {ReturnType<C['compute_']>}
    */
   const request = (artifacts, context) => {
-    /** @type {Map<string, ArbitraryEqualityMap>} */
-    // @ts-ignore - break immutability solely for this caching-controller function.
-    const computedCache = context.computedCache;
+    // NOTE: break immutability solely for this caching-controller function.
+    const computedCache = /** @type {Map<string, ArbitraryEqualityMap>} */ (context.computedCache);
     const computedName = computableArtifact.name;
 
     const cache = computedCache.get(computedName) || new ArbitraryEqualityMap();

--- a/lighthouse-core/computed/load-simulator.js
+++ b/lighthouse-core/computed/load-simulator.js
@@ -12,7 +12,7 @@ const NetworkAnalysis = require('./network-analysis.js');
 
 class LoadSimulator {
   /**
-   * @param {{devtoolsLog: LH.DevtoolsLog, settings: LH.Config.Settings}} data
+   * @param {{devtoolsLog: LH.DevtoolsLog, settings: Immutable<LH.Config.Settings>}} data
    * @param {LH.Audit.Context} context
    * @return {Promise<Simulator>}
    */

--- a/lighthouse-core/computed/resource-summary.js
+++ b/lighthouse-core/computed/resource-summary.js
@@ -51,7 +51,7 @@ class ResourceSummary {
       'third-party': {count: 0, size: 0},
     };
     const budget = Budget.getMatchingBudget(context.settings.budgets, mainResourceURL);
-    let firstPartyHosts = /** @type {Array<string>} */ ([]);
+    let firstPartyHosts = /** @type {Immutable<Array<string>>} */ ([]);
     if (budget && budget.options && budget.options.firstPartyHostnames) {
       firstPartyHosts = budget.options.firstPartyHostnames;
     } else {

--- a/lighthouse-core/computed/resource-summary.js
+++ b/lighthouse-core/computed/resource-summary.js
@@ -51,7 +51,8 @@ class ResourceSummary {
       'third-party': {count: 0, size: 0},
     };
     const budget = Budget.getMatchingBudget(context.settings.budgets, mainResourceURL);
-    let firstPartyHosts = /** @type {Immutable<Array<string>>} */ ([]);
+    /** @type {ReadonlyArray<string>} */
+    let firstPartyHosts = [];
     if (budget && budget.options && budget.options.firstPartyHostnames) {
       firstPartyHosts = budget.options.firstPartyHostnames;
     } else {

--- a/lighthouse-core/config/budget.js
+++ b/lighthouse-core/config/budget.js
@@ -136,9 +136,9 @@ class Budget {
    * Returns the budget that applies to a given URL.
    * If multiple budgets match based on thier 'path' property,
    * then the last-listed of those budgets is returned.
-   * @param {Array<LH.Budget>|null} budgets
+   * @param {Immutable<Array<LH.Budget>>|null} budgets
    * @param {string} url
-   * @return {LH.Budget | undefined} budget
+   * @return {Immutable<LH.Budget> | undefined} budget
    */
   static getMatchingBudget(budgets, url) {
     if (budgets === null) return;

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -273,7 +273,9 @@ async function saveAssets(artifacts, audits, pathWithBasename) {
  * @return {Promise<void>}
  */
 async function saveLanternNetworkData(devtoolsLog, outputPath) {
-  const context = /** @type {LH.Audit.Context} */ ({computedCache: new Map()});
+  /** @type {LH.Audit.Context} */
+  // @ts-ignore - the full audit context isn't needed for analysis.
+  const context = {computedCache: new Map()};
   const networkAnalysis = await NetworkAnalysisComputed.request(devtoolsLog, context);
   const lanternData = LoadSimulatorComputed.convertAnalysisToSaveableLanternData(networkAnalysis);
 

--- a/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
+++ b/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
@@ -49,7 +49,6 @@ async function main() {
     computedCache: new Map(),
     options: {},
     settings: /** @type {any} */ ({}),
-    LighthouseRunWarnings: [],
   });
 
   const items =

--- a/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
+++ b/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
@@ -113,8 +113,8 @@ variants/core-js-2-only-polyfill
    3410 variants/core-js-2-only-polyfill/es6-function-name/main.bundle.min.js
 
 variants/core-js-2-preset-env-esmodules
-3567 total
-2259 variants/core-js-2-preset-env-esmodules/false/main.bundle.min.js
+4121 total
+2813 variants/core-js-2-preset-env-esmodules/false/main.bundle.min.js
 1308 variants/core-js-2-preset-env-esmodules/true/main.bundle.min.js
 
 variants/core-js-3-only-polyfill
@@ -232,13 +232,13 @@ variants/core-js-3-only-polyfill
    3410 variants/core-js-3-only-polyfill/es6-function-name/main.bundle.min.js
 
 variants/core-js-3-preset-env-esmodules
-3567 total
-2259 variants/core-js-3-preset-env-esmodules/false/main.bundle.min.js
+4121 total
+2813 variants/core-js-3-preset-env-esmodules/false/main.bundle.min.js
 1308 variants/core-js-3-preset-env-esmodules/true/main.bundle.min.js
 
 variants/only-plugin
-2793 total
-1152 variants/only-plugin/-babel-plugin-transform-spread/main.bundle.min.js
+3347 total
+1706 variants/only-plugin/-babel-plugin-transform-spread/main.bundle.min.js
  827 variants/only-plugin/-babel-plugin-transform-regenerator/main.bundle.min.js
  814 variants/only-plugin/-babel-plugin-transform-classes/main.bundle.min.js
 

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -654,37 +654,12 @@ describe('Runner', () => {
           static get meta() {
             return basicAuditMeta;
           }
-          static audit(artifacts, context) {
-            context.LighthouseRunWarnings.push(warningString);
+          static audit() {
             return {
               numericValue: 5,
               score: 1,
+              runWarnings: [warningString],
             };
-          }
-        },
-      ],
-    });
-
-    return Runner.run(null, {config, driverMock}).then(results => {
-      assert.deepStrictEqual(results.lhr.runWarnings, [warningString]);
-    });
-  });
-
-  it('includes any LighthouseRunWarnings from errored audits in LHR', () => {
-    const warningString = 'Audit warning just before a terrible error!';
-
-    const config = new Config({
-      settings: {
-        auditMode: __dirname + '/fixtures/artifacts/empty-artifacts/',
-      },
-      audits: [
-        class WarningAudit extends Audit {
-          static get meta() {
-            return basicAuditMeta;
-          }
-          static audit(artifacts, context) {
-            context.LighthouseRunWarnings.push(warningString);
-            throw new Error('Terrible.');
           }
         },
       ],

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -509,7 +509,7 @@ declare global {
       export interface MetricComputationDataInput {
         devtoolsLog: DevtoolsLog;
         trace: Trace;
-        settings: Config.Settings;
+        settings: Immutable<Config.Settings>;
         simulator?: LanternSimulator;
       }
 

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -8,19 +8,17 @@ import ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality
 
 declare global {
   module LH.Audit {
-    export interface Context {
+    export type Context = Immutable<{
       /** audit options */
       options: Record<string, any>;
       settings: Config.Settings;
-      /** Push to this array to add top-level warnings to the LHR. */
-      LighthouseRunWarnings: Array<string>;
       /**
        * Nested cache for already-computed computed artifacts. Keyed first on
        * the computed artifact's `name` property, then on input artifact(s).
        * Values are Promises resolving to the computedArtifact result.
        */
       computedCache: Map<string, ArbitraryEqualityMap>;
-    }
+    }>;
 
     export interface ScoreOptions {
       scorePODR: number;
@@ -85,6 +83,8 @@ declare global {
       notApplicable?: boolean;
       /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
       details?: Audit.Details;
+      /** If an audit encounters unusual execution circumstances, strings can be put in this optional array to add top-level warnings to the LHR. */
+      runWarnings?: Array<string>;
     }
 
     /** The Audit.Product type for audits that do not return a `numericValue`. */

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -76,6 +76,25 @@ declare global {
       T[P];
   };
 
+  /** Recursively makes all properties of T read-only. */
+  export type Immutable<T> =
+    T extends Function ? T :
+    T extends ReadonlyArray<infer R> ? ImmutableArray<R> :
+    T extends Map<infer K, infer V> ? ImmutableMap<K, V> :
+    T extends Set<infer M> ? ImmutableSet<M> :
+    T extends object ? ImmutableObject<T> :
+    T
+
+  // Intermediate immutable interfaces. Prefer e.g. Immutable<Set<T>> over direct use.
+  // TODO: switch to recursive type references when using tsc ≥ 3.7
+  // see https://github.com/microsoft/TypeScript/issues/13923#issuecomment-557509399
+  interface ImmutableArray<T> extends ReadonlyArray<Immutable<T>> {}
+  interface ImmutableSet<T> extends ReadonlySet<Immutable<T>> {}
+  interface ImmutableMap<K, V> extends ReadonlyMap<Immutable<K>, Immutable<V>> {}
+  type ImmutableObject<T> = {
+    readonly [P in keyof T]: Immutable<T[P]>;
+  }
+
   /**
    * Exclude void from T
    */

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -79,21 +79,19 @@ declare global {
   /** Recursively makes all properties of T read-only. */
   export type Immutable<T> =
     T extends Function ? T :
-    T extends ReadonlyArray<infer R> ? ImmutableArray<R> :
+    T extends Array<infer R> ? ImmutableArray<R> :
     T extends Map<infer K, infer V> ? ImmutableMap<K, V> :
     T extends Set<infer M> ? ImmutableSet<M> :
     T extends object ? ImmutableObject<T> :
     T
 
-  // Intermediate immutable interfaces. Prefer e.g. Immutable<Set<T>> over direct use.
-  // TODO: switch to recursive type references when using tsc ≥ 3.7
-  // see https://github.com/microsoft/TypeScript/issues/13923#issuecomment-557509399
-  interface ImmutableArray<T> extends ReadonlyArray<Immutable<T>> {}
-  interface ImmutableSet<T> extends ReadonlySet<Immutable<T>> {}
-  interface ImmutableMap<K, V> extends ReadonlyMap<Immutable<K>, Immutable<V>> {}
+  // Intermediate immutable types. Prefer e.g. Immutable<Set<T>> over direct use.
+  type ImmutableArray<T> = ReadonlyArray<Immutable<T>>;
+  type ImmutableMap<K, V> = ReadonlyMap<Immutable<K>, Immutable<V>>;
+  type ImmutableSet<T> = ReadonlySet<Immutable<T>>;
   type ImmutableObject<T> = {
-    readonly [P in keyof T]: Immutable<T[P]>;
-  }
+    readonly [K in keyof T]: Immutable<T[K]>;
+  };
 
   /**
    * Exclude void from T


### PR DESCRIPTION
**breaking change (see below for details)**
fixes #9897

tl;dr: making this change now allows us to
- trust audits a little less (handy for any model of plugins)
- make audit contexts `postMessage`able, handy for an off-main-thread/extension plugin model if we choose to go in that direction
- pursue the above without having to wait for the 7.0 release, whenever that will be

The change is very small since we only have two lines of code currently modifying an audit context outside of `runner.js` :)

The only real breaking change is that rather than audits pushing to the context to get a top-level LHR warning, they return the warning in their audit `Product`. It's very possible that existing extensions use this functionality. In core, there's only one audit doing so.

Note that `readonly` is still type-checking/advisory level enforcement, so if an audit wants to mess with things it currently can, but that's always been the case and it's useful to leave things open without a reason to do otherwise.

breaking changes:
- audits that previously pushed a string to `context.LighthouseRunWarnings` to get a top-level warning in the LHR will instead need to return a `runWarnings` property on the `Product` return value, set to an array with that string in it. ([example change from core](https://github.com/GoogleChrome/lighthouse/pull/10555/files#diff-2de4b22b2f3e9b5bd6c988afdf375747R184-R215))
- previously audits could push warnings to `context.LighthouseRunWarnings` even if they ended up throwing an error, but that is no longer possible since the run warnings are now part of the normal return value.