### PR TITLE
tests(smokehouse): loosen wastedMs for unused-javascript

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -96,8 +96,10 @@ const expectations = [
         'unminified-javascript': {
           score: '<1',
           details: {
-            overallSavingsBytes: '>45000',
+            // the specific ms value is not meaningful for this smoketest
+            // *some largish amount* of savings should be reported
             overallSavingsMs: '>500',
+            overallSavingsBytes: '>45000',
             items: [
               {
                 url: 'http://localhost:10200/byte-efficiency/script.js',
@@ -134,8 +136,10 @@ const expectations = [
         'unused-javascript': {
           score: '<1',
           details: {
+            // the specific ms value here is not meaningful for this smoketest
+            // *some* savings should be reported
+            overallSavingsMs: '>0',
             overallSavingsBytes: '>=25000',
-            overallSavingsMs: '>300',
             items: [
               {
                 url: 'http://localhost:10200/byte-efficiency/script.js',
@@ -196,6 +200,8 @@ const expectations = [
         'uses-text-compression': {
           score: '<1',
           details: {
+            // the specific ms value is not meaningful for this smoketest
+            // *some largish amount* of savings should be reported
             overallSavingsMs: '>700',
             overallSavingsBytes: '>50000',
             items: {


### PR DESCRIPTION
**Summary**
the extra comments added to the smoketest by https://github.com/GoogleChrome/lighthouse/pull/10506 increased the document size which reduces the savings estimate

just adding those comments pushes the document size over another round trip to change the savings from 450 to 300 🙂
i.e. the document itself takes another round trip now so the JS finishing at 2.5s instead of 2.95s doesn't save .45s anymore, it saves 2.95s - max(2.5s, document finish time)

**Related Issues/PRs**
recent travis build failures introduced by https://github.com/GoogleChrome/lighthouse/pull/10506 (but only sometimes?)

I can't reliably reproduce the devtools node path failure locally anymore, so I'm not sure what's up with that
