### PR TITLE
core: delete unused driver.queryPermissionState()

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1171,21 +1171,6 @@ class Driver {
   }
 
   /**
-   * @param {string} name The name of API whose permission you wish to query
-   * @return {Promise<string>} The state of permissions, resolved in a promise.
-   *    See https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query.
-   */
-  queryPermissionState(name) {
-    const expressionToEval = `
-      navigator.permissions.query({name: '${name}'}).then(result => {
-        return result.state;
-      })
-    `;
-
-    return this.evaluateAsync(expressionToEval);
-  }
-
-  /**
    * @param {string} selector Selector to find in the DOM
    * @return {Promise<LHElement|null>} The found element, or null, resolved in a promise
    */


### PR DESCRIPTION
it was [added](https://github.com/GoogleChrome/lighthouse/pull/1064) for an audit that was [removed](d99778b4f1eb8d353ad54dc7830d286dfe30ba3e) a while ago.