### PR TITLE
misc: npmignore += timings-data/

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -26,6 +26,7 @@ lighthouse-logger/
 
 results/
 lantern-data/
+timings-data/
 
 # ignore all folders named as such
 node_modules


### PR DESCRIPTION
not a risk for real publishing, but this folder slows down `build-pack` which runs as part of `build-all`
