### PR TITLE
tests: fix i18n-test bugs in Node 13

### DIFF
--- a/lighthouse-core/test/lib/i18n/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n/i18n-test.js
@@ -298,7 +298,7 @@ describe('i18n', () => {
       expect(helloInfinityStr).toBeDisplayString('Hello ∞ World');
 
       const helloNaNStr = str_(UIStrings.helloBytesWorld, {in: NaN});
-      // TODO: workaround can be removed after Node 13 is retired.
+      // TODO(COMPAT): workaround can be removed after Node 13 is retired.
       // expect(helloNaNStr).toBeDisplayString('Hello NaN World');
 
       // Node 13/V8 7.9 and 8.0 have a bug where `({a: NaN}).a.toLocaleString() === "-NaN"`. It

--- a/lighthouse-core/test/lib/i18n/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n/i18n-test.js
@@ -298,7 +298,15 @@ describe('i18n', () => {
       expect(helloInfinityStr).toBeDisplayString('Hello ∞ World');
 
       const helloNaNStr = str_(UIStrings.helloBytesWorld, {in: NaN});
-      expect(helloNaNStr).toBeDisplayString('Hello NaN World');
+      // TODO: workaround can be removed after Node 13 is retired.
+      // expect(helloNaNStr).toBeDisplayString('Hello NaN World');
+
+      // Node 13/V8 7.9 and 8.0 have a bug where `({a: NaN}).a.toLocaleString() === "-NaN"`. It
+      // works correctly in Node 12 and 14, so work around it since NaN isn't essential for
+      // user-facing strings and it will eventually correct itself.
+      const formattedNaNStr = i18n.getFormatted(helloNaNStr, 'en-US');
+      expect(formattedNaNStr === 'Hello NaN World' || formattedNaNStr === 'Hello -NaN World')
+        .toBe(true);
     });
   });
 });

--- a/lighthouse-core/test/lib/i18n/swap-locale-test.js
+++ b/lighthouse-core/test/lib/i18n/swap-locale-test.js
@@ -11,27 +11,27 @@ const lhr = require('../../results/sample_v2.json');
 
 /* eslint-env jest */
 describe('swap-locale', () => {
-  it('can change golden LHR english strings into spanish', () => {
+  it('can change golden LHR english strings into german', () => {
     const lhrEn = /** @type {LH.Result} */ (JSON.parse(JSON.stringify(lhr)));
-    const lhrEs = swapLocale(lhrEn, 'es').lhr;
+    const lhrDe = swapLocale(lhrEn, 'de').lhr;
 
     // Basic replacement
     expect(lhrEn.audits.plugins.title).toEqual('Document avoids plugins');
-    expect(lhrEs.audits.plugins.title).toEqual('El documento no usa complementos');
+    expect(lhrDe.audits.plugins.title).toEqual('Dokument verwendet keine Plug-ins');
 
     // With ICU string argument values
     expect(lhrEn.audits['dom-size'].displayValue).toEqual('31 elements');
-    expect(lhrEs.audits['dom-size'].displayValue).toEqual('31 elementos');
+    expect(lhrDe.audits['dom-size'].displayValue).toEqual('31 Elemente');
 
     // Renderer formatted strings
     expect(lhrEn.i18n.rendererFormattedStrings.labDataTitle).toEqual('Lab Data');
-    expect(lhrEs.i18n.rendererFormattedStrings.labDataTitle).toEqual('Datos de prueba');
+    expect(lhrDe.i18n.rendererFormattedStrings.labDataTitle).toEqual('Labdaten');
 
     // Formatted numbers in placeholders.
     expect(lhrEn.audits['render-blocking-resources'].displayValue)
       .toEqual('Potential savings of 1,130 ms');
-    expect(lhrEs.audits['render-blocking-resources'].displayValue)
-      .toEqual('Ahorro potencial de 1.130 ms');
+    expect(lhrDe.audits['render-blocking-resources'].displayValue)
+      .toEqual('Mögliche Einsparung von 1.130 ms');
   });
 
   it('can roundtrip back to english correctly', () => {


### PR DESCRIPTION
helps check off some of #10582

Two test issues here:
1. Node 13 has a `Intl.NumberFormat` bug where a `NaN` that was stored in a property on an object will be formatted as `-NaN`, e.g. `({a: NaN}).a.toLocaleString() === '-NaN'`. This also happens in V8 7.9/8.0 (~Chrome 79 and 80) but works correctly before and after these versions.

   Formatting `NaN`s isn't exactly important to our report, we added the test to exercise the corner cases and make sure they wouldn't cause a crash, so this PR adds a narrow workaround to the test that can be removed later. Try not to put `NaN`s in the report or they'll be negative for Node 13 users :)

2. The thousands separator for Spanish was removed starting in Node 13, causing the swap-locale formatted-number test to fail. Looking for NaN bugs I ran across [this crbug](https://bugs.chromium.org/p/chromium/issues/detail?id=1019268#c5), where it turns out that "Linguist experts in CLDR require two digits before the group separator for Spanish" (so a number has to be ≥ 10000 before getting a separator) which was fixed in V8 by an ICU update at some point.

   Unfortunately we don't have any 5+ digit formatted number in `sample_v2.json` to get the separator back, so this just switches the test to swap the locale to `de`, which *does* have 1 as its [`minimumGroupingDigits`](https://unicode.org/reports/tr35/tr35-numbers.html#Examples_of_minimumGroupingDigits).