### PR TITLE
cli: add support for multiple --chrome-flags

### DIFF
--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -31,14 +31,17 @@ const _PROTOCOL_TIMEOUT_EXIT_CODE = 67;
  * @return {Array<string>}
  */
 function parseChromeFlags(flags = '') {
-  const trimmedFlags = (Array.isArray(flags) ?
-      // Allow multiple --chrome-flags
-      // i.e. `lighthouse --chrome-flags="--user-agent='My Agent'" --chrome-flags="--headless"`
-      flags.join(' ') :
-      // Remove wrapping single or double quotes
-      // i.e. `lighthouse --chrome-flags="--headless --user-agent='My Agent'"
-      flags.replace(/^\s*('|")(.+)\1\s*$/, '$2')
-  ).trim();
+  // flags will be a string if there is only one chrome-flag parameter:
+  // i.e. `lighthouse --chrome-flags="--user-agent='My Agent' --headless"`
+  // flags will be an array if there are multiple chrome-flags parameters
+  // i.e. `lighthouse --chrome-flags="--user-agent='My Agent'" --chrome-flags="--headless"`
+  const trimmedFlags = (Array.isArray(flags) ? flags : [flags])
+      // `child_process.exceFile` wrappes quotes arround command line arguments to escape them
+      // in this case yargs will not be able to parse multiple flags
+      // i.e. `child_process.execFile("lighthouse", ["http://google.com", "--chrome-flags='--headless --no-sandbox'")`
+      // the following regular expression removes those wrapping quotes:
+      .map((flagsGroup) => flagsGroup.replace(/^\s*('|")(.+)\1\s*$/, '$2').trim())
+      .join(' ');
 
   const parsed = yargsParser(trimmedFlags, {
     configuration: {'camel-case-expansion': false, 'boolean-negation': false},

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -36,8 +36,10 @@ function parseChromeFlags(flags = '') {
   // flags will be an array if there are multiple chrome-flags parameters
   // i.e. `lighthouse --chrome-flags="--user-agent='My Agent'" --chrome-flags="--headless"`
   const trimmedFlags = (Array.isArray(flags) ? flags : [flags])
-      // `child_process.exceFile` wrappes quotes arround command line arguments to escape them
-      // in this case yargs will not be able to parse multiple flags
+      // `child_process.execFile` and other programmatic invocations will pass Lighthouse arguments atomically.
+      // Many developers aren't aware of this and attempt to pass arguments to LH as they would to a shell `--chromeFlags="--headless --no-sandbox"`.
+      // In this case, yargs will see `"--headless --no-sandbox"` and treat it as a single argument instead of the intended `--headless --no-sandbox`.
+      // We remove quotes that surround the entire expression to make this work.
       // i.e. `child_process.execFile("lighthouse", ["http://google.com", "--chrome-flags='--headless --no-sandbox'")`
       // the following regular expression removes those wrapping quotes:
       .map((flagsGroup) => flagsGroup.replace(/^\s*('|")(.+)\1\s*$/, '$2').trim())

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -27,12 +27,22 @@ const _PROTOCOL_TIMEOUT_EXIT_CODE = 67;
 
 /**
  * exported for testing
- * @param {string} flags
+ * @param {string|Array<string>} flags
  * @return {Array<string>}
  */
 function parseChromeFlags(flags = '') {
-  const parsed = yargsParser(
-      flags.trim(), {configuration: {'camel-case-expansion': false, 'boolean-negation': false}});
+  const trimmedFlags = (Array.isArray(flags) ?
+      // Allow multiple --chrome-flags
+      // i.e. `lighthouse --chrome-flags="--user-agent='My Agent'" --chrome-flags="--headless"`
+      flags.join(' ') :
+      // Remove wrapping single or double quotes
+      // i.e. `lighthouse --chrome-flags="--headless --user-agent='My Agent'"
+      flags.replace(/^\s*('|")(.+)\1\s*$/, '$2')
+  ).trim();
+
+  const parsed = yargsParser(trimmedFlags, {
+    configuration: {'camel-case-expansion': false, 'boolean-negation': false},
+  });
 
   return Object
       .keys(parsed)

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -145,4 +145,25 @@ describe('Parsing --chrome-flags', () => {
       ['--spaces=1 2 3 4', '--debug=false', '--verbose', '--more-spaces=9 9 9']
     );
   });
+
+  it('handles muliple --chrome-flags', () => {
+    assert.deepStrictEqual(
+      parseChromeFlags(['--no-sandbox', '--log-level=0']),
+      ['--no-sandbox', '--log-level=0']
+    );
+  });
+
+  it('removes wrapping single quotes', () => {
+    assert.deepStrictEqual(
+      parseChromeFlags('\'--no-sandbox --log-level=0\''),
+      ['--no-sandbox', '--log-level=0']
+    );
+  });
+
+  it('removes wrapping double quotes', () => {
+    assert.deepStrictEqual(
+      parseChromeFlags('"--no-sandbox --log-level=0"'),
+      ['--no-sandbox', '--log-level=0']
+    );
+  });
 });

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -166,4 +166,18 @@ describe('Parsing --chrome-flags', () => {
       ['--no-sandbox', '--log-level=0']
     );
   });
+
+  it('removes wrapping single quotes from arrays', () => {
+    assert.deepStrictEqual(
+      parseChromeFlags(['\'--no-sandbox --log-level=0\'', '--headless']),
+      ['--no-sandbox', '--log-level=0', '--headless']
+    );
+  });
+
+  it('removes wrapping double quotes from arrays', () => {
+    assert.deepStrictEqual(
+      parseChromeFlags(['"--no-sandbox --log-level=0"', '--headless']),
+      ['--no-sandbox', '--log-level=0', '--headless']
+    );
+  });
 });

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -209,7 +209,7 @@ declare global {
     export interface CliFlags extends Flags {
       _: string[];
       chromeIgnoreDefaultFlags: boolean;
-      chromeFlags: string;
+      chromeFlags: string | string[];
       /** Output path for the generated results. */
       outputPath: string;
       /** Flag to save the trace contents and screenshots to disk. */


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
`feature` and/or `bugfix`
<!-- Describe the need for this change -->

Right now lighthouse supports passing multiple cli flags to chrome:

```bash
lighthouse --chrome-flags="--headless --allow-insecure-localhost"
```

However when using [`child_process.exceFile`](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback) (or npm packages like `execa`) arguments get automatically escaped.

You can simply execute the following node code (given lighthouse is installed) and will see that chrome is **ignoring**  `--headless --allow-insecure-localhost`

```js
execFile("./node_modules/.bin/lighthouse", [
  "http://google.com",
  "--chrome-flags='--headless --allow-insecure-localhost'"
], (error, stdout, stderr) => {
  if (error) {
    console.error(stderr);
    throw error;
  }
  console.log(stdout);
});
```

The reason for this bug is that the wrapping quotes are send to `run.js` and can't be parsed correctly by `yargs` for multiple arguments.

It would also be nice to support multiple `--chrome-flags` as shown in the following example:

```js
execFile("./node_modules/.bin/lighthouse", [
  "http://google.com",
  "--chrome-flags='--headless'",
  "--chrome-flags='--allow-insecure-localhost'"
], (error, stdout, stderr) => {
  if (error) {
    console.error(stderr);
    throw error;
  }
  console.log(stdout);
});
```

Unfortunately right now this will crash `lighthouse`:

```
Error: Command failed: ./node_modules/.bin/lighthouse http://google.com --chrome-flags='--allow-insecure-localhost' --chrome-flags='--headless'
Runtime error encountered: flags.trim is not a function
TypeError: flags.trim is not a function
    at parseChromeFlags (lighthouse/lighthouse-cli/run.js:35:13)
```

The reason is that `.trim()` is called on `flag` which is an Array in this case:

https://github.com/GoogleChrome/lighthouse/blob/9a6afb37a9814be5003bee8788437a4145ec82c0/lighthouse-cli/run.js#L35

This pull request adds `Array.isArray` to cover this feature and therefore resolves the error.

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
