### PR TITLE
misc(build): also run GH workflow on pull_request

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -5,7 +5,7 @@
 
 name: 💡🏠
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   basics:


### PR DESCRIPTION
goal: make sure the gh workflow runs when PRs come in from forks


https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request

> Note: By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened. To trigger workflows for more activity types, use the types keyword.

