### PR TITLE
tests: budget tests use an observed throttlingMethod

### DIFF
--- a/lighthouse-core/test/audits/timing-budget-test.js
+++ b/lighthouse-core/test/audits/timing-budget-test.js
@@ -123,6 +123,8 @@ describe('Performance: Timing budget audit', () => {
         artifacts.devtoolsLogs.defaultPass = lcpDevtoolsLog;
         artifacts.traces.defaultPass = lcpTrace;
 
+        // Use an observed throttlingMethod so we don't have to worry about the value changing in the future.
+        context.settings.throttlingMethod = 'provided';
         context.settings.budgets = [{
           path: '/',
           timings: [
@@ -134,7 +136,7 @@ describe('Performance: Timing budget audit', () => {
         }];
         const result = await TimingBudgetAudit.audit(artifacts, context);
         expect(result.details.items).toHaveLength(1);
-        expect(result.details.items[0].measurement).toEqual(3419.1035);
+        expect(result.details.items[0].measurement).toEqual(1121.711);
       });
     });
 


### PR DESCRIPTION
**Summary**
fixes master which accidentally broke due to bad merge with #10579

the last commit in #10579 was forever ago and so it never got reran after lantern changes got merged in that affected the value of LCP. there's no real reason it needs to assert on the changing lantern value so I converted it to use the observed value while we're at it to stay with `toEqual` instead of `toMatchInlineSnapshot`
