### PR TITLE
core(offscreen-images): loosen to 3 viewports

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -111,7 +111,7 @@ setTimeout(() => {
   <!-- PASS(webp): image is WebP optimized -->
   <!-- FAIL(responsive): image is 50% used at DPR 3 (but small savings) -->
   <!-- FAIL(offscreen): image is offscreen -->
-  <img style="margin-top: 1000px; width: 120px; height: 80px;" src="lighthouse-480x320.webp">
+  <img style="margin-top: 4000px; width: 120px; height: 80px;" src="lighthouse-480x320.webp">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image is WebP optimized -->

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -28,6 +28,7 @@ const UIStrings = {
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
+// See https://github.com/GoogleChrome/lighthouse/issues/10471 for discussion about the thresholds here.
 const ALLOWABLE_OFFSCREEN_IN_PX = 100;
 const ALLOWABLE_OFFSCREEN_BOTTOM_IN_VIEWPORTS = 3;
 

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -28,8 +28,8 @@ const UIStrings = {
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
-const ALLOWABLE_OFFSCREEN_X = 100;
-const ALLOWABLE_OFFSCREEN_Y = 200;
+const ALLOWABLE_OFFSCREEN_IN_PX = 100;
+const ALLOWABLE_OFFSCREEN_BOTTOM_IN_VIEWPORTS = 3;
 
 const IGNORE_THRESHOLD_IN_BYTES = 2048;
 const IGNORE_THRESHOLD_IN_PERCENT = 75;
@@ -59,11 +59,13 @@ class OffscreenImages extends ByteEfficiencyAudit {
   static computeVisiblePixels(imageRect, viewportDimensions) {
     const innerWidth = viewportDimensions.innerWidth;
     const innerHeight = viewportDimensions.innerHeight;
+    const allowableOffscreenBottomInPx = ALLOWABLE_OFFSCREEN_BOTTOM_IN_VIEWPORTS *
+      viewportDimensions.innerHeight;
 
-    const top = Math.max(imageRect.top, -1 * ALLOWABLE_OFFSCREEN_Y);
-    const right = Math.min(imageRect.right, innerWidth + ALLOWABLE_OFFSCREEN_X);
-    const bottom = Math.min(imageRect.bottom, innerHeight + ALLOWABLE_OFFSCREEN_Y);
-    const left = Math.max(imageRect.left, -1 * ALLOWABLE_OFFSCREEN_X);
+    const top = Math.max(imageRect.top, -1 * ALLOWABLE_OFFSCREEN_IN_PX);
+    const right = Math.min(imageRect.right, innerWidth + ALLOWABLE_OFFSCREEN_IN_PX);
+    const bottom = Math.min(imageRect.bottom, innerHeight + allowableOffscreenBottomInPx);
+    const left = Math.max(imageRect.left, -1 * ALLOWABLE_OFFSCREEN_IN_PX);
 
     return Math.max(right - left, 0) * Math.max(bottom - top, 0);
   }

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -149,7 +149,7 @@ describe('OffscreenImages audit', () => {
         generateImage({
           size: generateSize(100, 100),
           x: 0,
-          y: 4000,
+          y: 5000,
           networkRecord: networkRecords[1],
           src: url('B'),
         }),
@@ -185,7 +185,7 @@ describe('OffscreenImages audit', () => {
           networkRecord: networkRecords[5],
           src: url('F'),
         }),
-        // Offscreen to the bottom, but within 3 viewports
+        // Offscreen to the bottom but within 3 viewports, should not warn
         generateImage({
           size: generateSize(100, 100),
           x: 0,
@@ -199,7 +199,13 @@ describe('OffscreenImages audit', () => {
     };
 
     const auditResult = await UnusedImages.audit_(artifacts, networkRecords, context);
-    assert.equal(auditResult.items.length, 4);
+    expect(auditResult.items).toMatchObject([
+      {url: url('A')},
+      {url: url('B')},
+      {url: url('C')},
+      {url: url('D')},
+      {url: url('E')},
+    ]);
   });
 
   it('passes images with a specified loading attribute', async () => {

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -126,11 +126,13 @@ describe('OffscreenImages audit', () => {
     const url = s => `https://google.com/logo${s}.png`;
     const topLevelTasks = [{ts: 1900, duration: 100}];
     const networkRecords = [
-      generateRecord({url: url(''), resourceSizeInKb: 100}),
+      generateRecord({url: url('A'), resourceSizeInKb: 100}),
       generateRecord({url: url('B'), resourceSizeInKb: 100}),
       generateRecord({url: url('C'), resourceSizeInKb: 100}),
       generateRecord({url: url('D'), resourceSizeInKb: 100}),
       generateRecord({url: url('E'), resourceSizeInKb: 100}),
+      generateRecord({url: url('F'), resourceSizeInKb: 100}),
+      generateRecord({url: url('G'), resourceSizeInKb: 100}),
     ];
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
@@ -141,38 +143,55 @@ describe('OffscreenImages audit', () => {
           x: 3000,
           y: 0,
           networkRecord: networkRecords[0],
+          src: url('A'),
         }),
-        // Offscreen to the bottom.
+        // Waaay offscreen to the bottom
         generateImage({
           size: generateSize(100, 100),
           x: 0,
-          y: 2000,
+          y: 4000,
           networkRecord: networkRecords[1],
           src: url('B'),
+        }),
+        // Offscreen to the top.
+        generateImage({
+          size: generateSize(100, 100),
+          x: 0,
+          y: -400,
+          networkRecord: networkRecords[2],
+          src: url('C'),
         }),
         // Offscreen to the top-left.
         generateImage({
           size: generateSize(100, 100),
           x: -2000,
           y: -1000,
-          networkRecord: networkRecords[2],
-          src: url('C'),
+          networkRecord: networkRecords[3],
+          src: url('D'),
         }),
         // Offscreen to the bottom-right.
         generateImage({
           size: generateSize(100, 100),
           x: 3000,
           y: 2000,
-          networkRecord: networkRecords[3],
-          src: url('D'),
+          networkRecord: networkRecords[4],
+          src: url('E'),
         }),
         // Half offscreen to the top, should not warn.
         generateImage({
           size: generateSize(1000, 1000),
           x: 0,
           y: -500,
-          networkRecord: networkRecords[4],
-          src: url('E'),
+          networkRecord: networkRecords[5],
+          src: url('F'),
+        }),
+        // Offscreen to the bottom, but within 3 viewports
+        generateImage({
+          size: generateSize(100, 100),
+          x: 0,
+          y: 2000,
+          networkRecord: networkRecords[6],
+          src: url('G'),
         }),
       ],
       traces: {defaultPass: createTestTrace({topLevelTasks})},
@@ -206,7 +225,7 @@ describe('OffscreenImages audit', () => {
         generateImage({
           size: generateSize(100, 100),
           x: 0,
-          y: 2000,
+          y: 5000,
           networkRecord: networkRecords[1],
           loading: 'eager',
           src: url('B'),
@@ -244,7 +263,7 @@ describe('OffscreenImages audit', () => {
         generateImage({
           size: generateSize(100, 100),
           x: 0,
-          y: 2000,
+          y: 5000,
           networkRecord: networkRecords[1],
           loading: 'imagination',
           src: url('B'),
@@ -304,14 +323,14 @@ describe('OffscreenImages audit', () => {
         generateImage({
           size: generateSize(50, 50),
           x: 0,
-          y: 1500,
+          y: 5000,
           networkRecord: networkRecords[2],
           src: urlB,
         }),
         generateImage({
           size: generateSize(400, 400),
           x: 0,
-          y: 1500,
+          y: 5000,
           networkRecord: networkRecords[3],
           src: urlB,
         }),
@@ -365,8 +384,8 @@ describe('OffscreenImages audit', () => {
     const artifacts = {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageElements: [
-        // Offscreen to the right.
-        generateImage({size: generateSize(100, 100), x: 0, y: 2000, networkRecord}),
+        // Offscreen to the bottom.
+        generateImage({size: generateSize(100, 100), x: 0, y: 5000, networkRecord}),
       ],
       traces: {defaultPass: createTestTrace({traceEnd: 2000})},
       devtoolsLogs: {},


### PR DESCRIPTION
**Summary**
We decided to loosen to 3 viewports for offscreen image audit. This only made sense to me for images *below* the fold so kept our existing restrictions for above and left/right. Let me know if you disagree.

**Related Issues/PRs**
closes https://github.com/GoogleChrome/lighthouse/issues/6677 
closes https://github.com/GoogleChrome/lighthouse/issues/10471
