### PR TITLE
tests(smoke): fork pwa.rocks

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa3-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa3-expectations.js
@@ -16,8 +16,8 @@ const pwaRocksExpectations = {...pwaDetailsExpectations, hasIconsAtLeast512px: f
 module.exports = [
   {
     lhr: {
-      requestedUrl: 'https://pwa.rocks',
-      finalUrl: 'https://pwa.rocks/',
+      requestedUrl: 'https://connorjclark.github.io/pwa.rocks/',
+      finalUrl: 'https://connorjclark.github.io/pwa.rocks/',
       audits: {
         'is-on-https': {
           score: 1,

--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa3-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa3-expectations.js
@@ -16,6 +16,8 @@ const pwaRocksExpectations = {...pwaDetailsExpectations, hasIconsAtLeast512px: f
 module.exports = [
   {
     lhr: {
+      // Archived version of https://github.com/pwarocks/pwa.rocks
+      // Fork is here: https://github.com/connorjclark/pwa.rocks
       requestedUrl: 'https://connorjclark.github.io/pwa.rocks/',
       finalUrl: 'https://connorjclark.github.io/pwa.rocks/',
       audits: {


### PR DESCRIPTION
pwa.rocks is down. Instead of trying to replace these tests, I've forked it and am hosting at https://connorjclark.github.io/pwa.rocks/