### PR TITLE
misc: close variability issues to master issue

### DIFF
--- a/lighthouse-core/scripts/git3po-rules/close-variability-issues.yaml
+++ b/lighthouse-core/scripts/git3po-rules/close-variability-issues.yaml
@@ -1,0 +1,26 @@
+repo: GoogleChrome/lighthouse
+pullRequests: false
+filters:
+  - type: issue
+    criteria:
+      state: open
+      labels:
+        $and:
+          - $includes: pending-close
+          - $includes: variability
+actions:
+  - type: add_comment
+    body: 'Thanks! Appreciate you filing this bug. :clap:
+
+
+  This is a known issue, most well described in #10657. So, **we''ll automatically
+  close this as a duplicate**.
+
+
+  :robot: Beep beep boop.
+  '
+  - type: add_label
+    label: duplicate
+  - type: close
+  - type: remove_label
+    label: pending-close


### PR DESCRIPTION
**Summary**
All ya gotta do to have the bot close these issues in the future is add "pending-close" and "variability"

Current set of issues: https://github.com/GoogleChrome/lighthouse/issues?q=is%3Aopen+is%3Aissue+label%3Avariability+label%3Apending-close

**Related Issues/PRs**
#10657 
