### PR TITLE
tests(ci): authenticate protoc download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: 💡🏠
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   ci:
@@ -27,6 +27,7 @@ jobs:
       uses: arduino/setup-protoc@master
       with:
         version: '3.7.1'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         node-version: 10.x
 
     - name: Setup protoc
-      uses: arduino/setup-protoc@master
+      uses: arduino/setup-protoc@7ad700d
       with:
         version: '3.7.1'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
running into github api rate limiting errors when downloading protoc, which is weird because it's github making the request. Turns out we need to supply a token :)

https://github.com/arduino/setup-protoc/issues/6

Also drops CI runs on `push`