### PR TITLE
core: remove length check from csv report test

### DIFF
--- a/lighthouse-core/test/report/report-generator-test.js
+++ b/lighthouse-core/test/report/report-generator-test.js
@@ -101,6 +101,7 @@ describe('ReportGenerator', () => {
       fs.writeFileSync(path, csvOutput);
 
       const lines = csvOutput.split('\n');
+      expect(lines.length).toBeGreaterThan(100);
       expect(lines.slice(0, 2).join('\n')).toMatchInlineSnapshot(`
         "requestedUrl,finalUrl,category,name,title,type,score
         \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"first-contentful-paint\\",\\"First Contentful Paint\\",\\"numeric\\",\\"0.51\\"

--- a/lighthouse-core/test/report/report-generator-test.js
+++ b/lighthouse-core/test/report/report-generator-test.js
@@ -101,7 +101,6 @@ describe('ReportGenerator', () => {
       fs.writeFileSync(path, csvOutput);
 
       const lines = csvOutput.split('\n');
-      expect(lines).toHaveLength(145);
       expect(lines.slice(0, 2).join('\n')).toMatchInlineSnapshot(`
         "requestedUrl,finalUrl,category,name,title,type,score
         \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"first-contentful-paint\\",\\"First Contentful Paint\\",\\"numeric\\",\\"0.51\\"


### PR DESCRIPTION
This check would we need to be updated every time an audit is added or removed. Could become a nuisance in time. 