### PR TITLE
report(metrics): use css grid so metrics are aligned

### DIFF
--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -132,16 +132,9 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     metricAuditsEl.append(..._toggleEl.childNodes);
 
     const metricAudits = category.auditRefs.filter(audit => audit.group === 'metrics');
-
-    const keyMetrics = metricAudits.slice(0, 3);
-    const otherMetrics = metricAudits.slice(3);
-
     const metricsBoxesEl = this.dom.createChildOf(metricAuditsEl, 'div', 'lh-metrics-container');
 
-    keyMetrics.forEach(item => {
-      metricsBoxesEl.appendChild(this._renderMetric(item));
-    });
-    otherMetrics.forEach(item => {
+    metricAudits.forEach(item => {
       metricsBoxesEl.appendChild(this._renderMetric(item));
     });
 

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -136,15 +136,13 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     const keyMetrics = metricAudits.slice(0, 3);
     const otherMetrics = metricAudits.slice(3);
 
-    const metricsBoxesEl = this.dom.createChildOf(metricAuditsEl, 'div', 'lh-columns');
-    const metricsColumn1El = this.dom.createChildOf(metricsBoxesEl, 'div', 'lh-column');
-    const metricsColumn2El = this.dom.createChildOf(metricsBoxesEl, 'div', 'lh-column');
+    const metricsBoxesEl = this.dom.createChildOf(metricAuditsEl, 'div', 'lh-metrics-container');
 
     keyMetrics.forEach(item => {
-      metricsColumn1El.appendChild(this._renderMetric(item));
+      metricsBoxesEl.appendChild(this._renderMetric(item));
     });
     otherMetrics.forEach(item => {
-      metricsColumn2El.appendChild(this._renderMetric(item));
+      metricsBoxesEl.appendChild(this._renderMetric(item));
     });
 
     // 'Values are estimated and may vary' is used as the category description for PSI

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -548,7 +548,8 @@
 
 .lh-metrics-container {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  grid-auto-flow: column;
   grid-column-gap: 24px;
 }
 

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -544,50 +544,32 @@
   display: none;
 }
 
-
 /* Perf Metric */
 
-.lh-columns {
-  display: flex;
-  width: 100%;
+.lh-metrics-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-column-gap: 24px;
 }
-@media screen and (max-width: 640px) {
-  .lh-columns {
-    flex-wrap: wrap;
-
-  }
-}
-
-.lh-column {
-  flex: 1;
-}
-.lh-column:first-of-type {
-  margin-right: 24px;
-}
-
-@media screen and (max-width: 800px) {
-  .lh-column:first-of-type {
-    margin-right: 8px;
-  }
-}
-@media screen and (max-width: 640px) {
-  .lh-column {
-    flex-basis: 100%;
-  }
-  .lh-column:first-of-type {
-    margin-right: 0px;
-  }
-  .lh-column:first-of-type .lh-metric:last-of-type {
-    border-bottom: 0;
-  }
-}
-
 
 .lh-metric {
-  border-bottom: 1px solid var(--report-border-color-secondary);
-}
-.lh-metric:first-of-type {
   border-top: 1px solid var(--report-border-color-secondary);
+}
+
+@media screen and (min-width: 640px) {
+  .lh-metric:nth-last-child(-n+2) {
+    border-bottom: 1px solid var(--report-border-color-secondary);
+  }
+}
+
+@media screen and (max-width: 640px) {
+  .lh-metrics-container {
+    display: block;
+  }
+
+  .lh-metric:nth-last-child(-n+1) {
+    border-bottom: 1px solid var(--report-border-color-secondary);
+  }
 }
 
 .lh-metric__innerwrap {
@@ -629,7 +611,7 @@
 
 /* No-JS toggle switch */
 /* Keep this selector sync'd w/ `magicSelector` in report-ui-features-test.js */
- .lh-metrics-toggle__input:checked ~ .lh-columns .lh-metric__description {
+ .lh-metrics-toggle__input:checked ~ .lh-metrics-container .lh-metric__description {
   display: block;
 }
 

--- a/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
@@ -240,7 +240,7 @@ describe('PerfCategoryRenderer', () => {
     let toggle;
     const metricsSelector = '.lh-audit-group--metrics';
     const toggleSelector = '.lh-metrics-toggle__input';
-    const magicSelector = '.lh-metrics-toggle__input:checked ~ .lh-columns .lh-metric__description';
+    const magicSelector = '.lh-metrics-toggle__input:checked ~ .lh-metrics-container .lh-metric__description';
     let getDescriptionsAfterCheckedToggle;
 
     describe('works if there is a performance category', () => {

--- a/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
@@ -240,7 +240,8 @@ describe('PerfCategoryRenderer', () => {
     let toggle;
     const metricsSelector = '.lh-audit-group--metrics';
     const toggleSelector = '.lh-metrics-toggle__input';
-    const magicSelector = '.lh-metrics-toggle__input:checked ~ .lh-metrics-container .lh-metric__description';
+    const magicSelector =
+      '.lh-metrics-toggle__input:checked ~ .lh-metrics-container .lh-metric__description';
     let getDescriptionsAfterCheckedToggle;
 
     describe('works if there is a performance category', () => {

--- a/lighthouse-viewer/test/viewer-test-pptr.js
+++ b/lighthouse-viewer/test/viewer-test-pptr.js
@@ -192,7 +192,7 @@ describe('Lighthouse Viewer', () => {
       await viewerPage.goto(url);
 
       // Wait for report to render.
-      await viewerPage.waitForSelector('.lh-columns');
+      await viewerPage.waitForSelector('.lh-metrics-container');
 
       const interceptedUrl = new URL(interceptedRequest.url());
       expect(interceptedUrl.origin + interceptedUrl.pathname)
@@ -249,7 +249,7 @@ describe('Lighthouse Viewer', () => {
       await viewerPage.goto(url);
 
       // Wait for report to render.call out to PSI with specified categories
-      await viewerPage.waitForSelector('.lh-columns');
+      await viewerPage.waitForSelector('.lh-metrics-container');
 
       const interceptedUrl = new URL(interceptedRequest.url());
       expect(interceptedUrl.origin + interceptedUrl.pathname)


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/4071474/80926167-56b4b080-8d4a-11ea-8bb4-a472c528c4ce.png)

after:

![image](https://user-images.githubusercontent.com/4071474/80926265-07bb4b00-8d4b-11ea-9149-905f62c41184.png)
