### PR TITLE
deps: bump third-party-web to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     },
     {
       "path": "./dist/lighthouse-dt-bundle.js",
-      "maxSize": "460 kB"
+      "maxSize": "470 kB"
     },
     {
       "path": "./dist/lightrider/report-generator-bundle.js",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "robots-parser": "^2.0.1",
     "semver": "^5.3.0",
     "speedline-core": "1.4.2",
-    "third-party-web": "^0.11.0",
+    "third-party-web": "^0.11.1",
     "update-notifier": "^2.5.0",
     "ws": "3.3.2",
     "yargs": "3.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7832,10 +7832,10 @@ text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-third-party-web@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.11.0.tgz#4e80dac50c26557add464742306bc392ab845352"
-  integrity sha512-R9/WoBZc0Db7qLNQ9QzMSP0YMEU/LF5X8LJqOYvDd/cDFwSc/D1YszYbyFFRzt6McDP6PO425ZBmHQZWYFDZDg==
+third-party-web@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.11.1.tgz#4b5b176f0014be696002c104d76f40692318aec9"
+  integrity sha512-PBS478cWhvCM8seuloomV5lGHvu2qMOCj8gq8wKOApdfAaGh9l2rYZkdsBDaQyQg/6plov3uodc6sZ/3c1lu/g==
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
**Summary**
Funnily enough DevTools and PSI are bitten by this even if CLI installs aren't, bitten by our own lockfile! :)

**Related Issues/PRs**
closes #10709
