### PR TITLE
core(scoring): redefine log-normal curves with median and p10 points

### DIFF
--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -72,6 +72,7 @@ class Audit {
    * considering a log-normal distribution governed by the two control points, point of diminishing
    * returns and the median value, and returning the percentage of sites that have higher value.
    *
+   * NOTE: deprecated. Prefer `computeLogNormalScoreFrom90th()`.
    * @param {number} measuredValue
    * @param {number} diminishingReturnsValue
    * @param {number} medianValue
@@ -87,6 +88,20 @@ class Audit {
     score = Math.min(1, score);
     score = Math.max(0, score);
     return clampTo2Decimals(score);
+  }
+
+  /**
+   * Computes a score between 0 and 1 based on the measured `value`. Score is determined by
+   * considering a log-normal distribution governed by two control points (the 10th
+   * percentile value and the median value) and represents the percentage of sites that are
+   * greater than `value`.
+   * @param {{median: number, p10: number}} controlPoints
+   * @param {number} value
+   * @return {number}
+   */
+  static computeLogNormalScoreFrom10th(controlPoints, value) {
+    const percentile = statistics.getLogNormalScore(controlPoints, value);
+    return clampTo2Decimals(percentile);
   }
 
   /**

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -68,29 +68,6 @@ class Audit {
   /* eslint-enable no-unused-vars */
 
   /**
-   * Computes a clamped score between 0 and 1 based on the measured value. Score is determined by
-   * considering a log-normal distribution governed by the two control points, point of diminishing
-   * returns and the median value, and returning the percentage of sites that have higher value.
-   *
-   * NOTE: deprecated. Prefer `computeLogNormalScoreFrom90th()`.
-   * @param {number} measuredValue
-   * @param {number} diminishingReturnsValue
-   * @param {number} medianValue
-   * @return {number}
-   */
-  static computeLogNormalScore(measuredValue, diminishingReturnsValue, medianValue) {
-    const distribution = statistics.getLogNormalDistribution(
-      medianValue,
-      diminishingReturnsValue
-    );
-
-    let score = distribution.computeComplementaryPercentile(measuredValue);
-    score = Math.min(1, score);
-    score = Math.max(0, score);
-    return clampTo2Decimals(score);
-  }
-
-  /**
    * Computes a score between 0 and 1 based on the measured `value`. Score is determined by
    * considering a log-normal distribution governed by two control points (the 10th
    * percentile value and the median value) and represents the percentage of sites that are
@@ -99,7 +76,7 @@ class Audit {
    * @param {number} value
    * @return {number}
    */
-  static computeLogNormalScoreFrom10th(controlPoints, value) {
+  static computeLogNormalScore(controlPoints, value) {
     const percentile = statistics.getLogNormalScore(controlPoints, value);
     return clampTo2Decimals(percentile);
   }

--- a/lighthouse-core/audits/bootup-time.js
+++ b/lighthouse-core/audits/bootup-time.js
@@ -66,10 +66,10 @@ class BootupTime extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/rkphawothk
-      // <500ms ~= 100, >2s is yellow, >3.5s is red
-      scorePODR: 600,
-      scoreMedian: 3500,
+      // see https://www.desmos.com/calculator/ynl8fzh1wd
+      // <500ms ~= 100, >1.3s is yellow, >3.5s is red
+      p10: 1282,
+      median: 3500,
       thresholdInMs: 50,
     };
   }
@@ -199,10 +199,9 @@ class BootupTime extends Audit {
 
     const details = BootupTime.makeTableDetails(headings, results, summary);
 
-    const score = Audit.computeLogNormalScore(
-      totalBootupTime,
-      context.options.scorePODR,
-      context.options.scoreMedian
+    const score = Audit.computeLogNormalScoreFrom10th(
+      {p10: context.options.p10, median: context.options.median},
+      totalBootupTime
     );
 
     return {

--- a/lighthouse-core/audits/bootup-time.js
+++ b/lighthouse-core/audits/bootup-time.js
@@ -199,7 +199,7 @@ class BootupTime extends Audit {
 
     const details = BootupTime.makeTableDetails(headings, results, summary);
 
-    const score = Audit.computeLogNormalScoreFrom10th(
+    const score = Audit.computeLogNormalScore(
       {p10: context.options.p10, median: context.options.median},
       totalBootupTime
     );

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -45,10 +45,11 @@ class TotalByteWeight extends ByteEfficiencyAudit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/gpmjeykbwr
-      // ~75th and ~90th percentiles http://httparchive.org/interesting.php?a=All&l=Feb%201%202017&s=All#bytesTotal
-      scorePODR: 2500 * 1024,
-      scoreMedian: 4000 * 1024,
+      // see https://www.desmos.com/calculator/h7kfv68jre
+      // ~25th and ~10th percentiles, with resulting p10 computed.
+      // http://httparchive.org/interesting.php?a=All&l=Feb%201%202017&s=All#bytesTotal
+      p10: 2667 * 1024,
+      median: 4000 * 1024,
     };
   }
 
@@ -83,10 +84,9 @@ class TotalByteWeight extends ByteEfficiencyAudit {
         itemA.url.localeCompare(itemB.url);
     }).slice(0, 10);
 
-    const score = ByteEfficiencyAudit.computeLogNormalScore(
-      totalBytes,
-      context.options.scorePODR,
-      context.options.scoreMedian
+    const score = ByteEfficiencyAudit.computeLogNormalScoreFrom10th(
+      {p10: context.options.p10, median: context.options.median},
+      totalBytes
     );
 
     /** @type {LH.Audit.Details.Table['headings']} */

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -84,7 +84,7 @@ class TotalByteWeight extends ByteEfficiencyAudit {
         itemA.url.localeCompare(itemB.url);
     }).slice(0, 10);
 
-    const score = ByteEfficiencyAudit.computeLogNormalScoreFrom10th(
+    const score = ByteEfficiencyAudit.computeLogNormalScore(
       {p10: context.options.p10, median: context.options.median},
       totalBytes
     );

--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -55,11 +55,11 @@ class CacheHeaders extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 50th and 75th percentiles HTTPArchive -> 50 and 75
+      // 50th and 25th percentiles HTTPArchive -> 50 and 75, with p10 derived from them.
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-      // see https://www.desmos.com/calculator/8meohdnjbl
-      scorePODR: 4 * 1024,
-      scoreMedian: 128 * 1024,
+      // see https://www.desmos.com/calculator/uzsyl2hbcb
+      p10: 28 * 1024,
+      median: 128 * 1024,
     };
   }
 
@@ -264,10 +264,9 @@ class CacheHeaders extends Audit {
           a.url.localeCompare(b.url);
       });
 
-      const score = Audit.computeLogNormalScore(
-        totalWastedBytes,
-        context.options.scorePODR,
-        context.options.scoreMedian
+      const score = Audit.computeLogNormalScoreFrom10th(
+        {p10: context.options.p10, median: context.options.median},
+        totalWastedBytes
       );
 
       /** @type {LH.Audit.Details.Table['headings']} */

--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -264,7 +264,7 @@ class CacheHeaders extends Audit {
           a.url.localeCompare(b.url);
       });
 
-      const score = Audit.computeLogNormalScoreFrom10th(
+      const score = Audit.computeLogNormalScore(
         {p10: context.options.p10, median: context.options.median},
         totalWastedBytes
       );

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -64,11 +64,11 @@ class DOMSize extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 25th and 50th percentiles HTTPArchive -> 50 and 75
+      // 25th and 50th percentiles HTTPArchive -> median and derived p10.
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-      // see https://www.desmos.com/calculator/vqot3wci4g
-      scorePODR: 700,
-      scoreMedian: 1400,
+      // see https://www.desmos.com/calculator/tsunbwqt3f
+      p10: 818,
+      median: 1400,
     };
   }
 
@@ -81,10 +81,9 @@ class DOMSize extends Audit {
   static audit(artifacts, context) {
     const stats = artifacts.DOMStats;
 
-    const score = Audit.computeLogNormalScore(
-      stats.totalBodyElements,
-      context.options.scorePODR,
-      context.options.scoreMedian
+    const score = Audit.computeLogNormalScoreFrom10th(
+      {p10: context.options.p10, median: context.options.median},
+      stats.totalBodyElements
     );
 
     /** @type {LH.Audit.Details.Table['headings']} */

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -81,7 +81,7 @@ class DOMSize extends Audit {
   static audit(artifacts, context) {
     const stats = artifacts.DOMStats;
 
-    const score = Audit.computeLogNormalScoreFrom10th(
+    const score = Audit.computeLogNormalScore(
       {p10: context.options.p10, median: context.options.median},
       stats.totalBodyElements
     );

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -64,7 +64,6 @@ class DOMSize extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 25th and 50th percentiles HTTPArchive -> median and derived p10.
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
       // see https://www.desmos.com/calculator/tsunbwqt3f
       p10: 818,

--- a/lighthouse-core/audits/mainthread-work-breakdown.js
+++ b/lighthouse-core/audits/mainthread-work-breakdown.js
@@ -52,9 +52,9 @@ class MainThreadWorkBreakdown extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/s2eqcifkum
-      scorePODR: 1500,
-      scoreMedian: 4000,
+      // see https://www.desmos.com/calculator/vhglu1x8zv
+      p10: 2017,
+      median: 4000,
     };
   }
 
@@ -115,10 +115,9 @@ class MainThreadWorkBreakdown extends Audit {
     results.sort((a, b) => categoryTotals[b.group] - categoryTotals[a.group]);
     const tableDetails = MainThreadWorkBreakdown.makeTableDetails(headings, results);
 
-    const score = Audit.computeLogNormalScore(
-      totalExecutionTime,
-      context.options.scorePODR,
-      context.options.scoreMedian
+    const score = Audit.computeLogNormalScoreFrom10th(
+      {p10: context.options.p10, median: context.options.median},
+      totalExecutionTime
     );
 
     return {

--- a/lighthouse-core/audits/mainthread-work-breakdown.js
+++ b/lighthouse-core/audits/mainthread-work-breakdown.js
@@ -115,7 +115,7 @@ class MainThreadWorkBreakdown extends Audit {
     results.sort((a, b) => categoryTotals[b.group] - categoryTotals[a.group]);
     const tableDetails = MainThreadWorkBreakdown.makeTableDetails(headings, results);
 
-    const score = Audit.computeLogNormalScoreFrom10th(
+    const score = Audit.computeLogNormalScore(
       {p10: context.options.p10, median: context.options.median},
       totalExecutionTime
     );

--- a/lighthouse-core/audits/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/audits/metrics/cumulative-layout-shift.js
@@ -41,9 +41,9 @@ class CumulativeLayoutShift extends Audit {
     return {
       // Calibrated to assure 0.1 gets a score of 0.9. https://web.dev/cls/#what-is-a-good-cls-score
       // This 0.1 target score was determined through both manual evaluation and large-scale analysis.
-      // see https://www.desmos.com/calculator/1xtb5iz8iq
-      scorePODR: 0.054,
-      scoreMedian: 0.25,
+      // see https://www.desmos.com/calculator/ksp7q91nop
+      p10: 0.1,
+      median: 0.25,
     };
   }
 
@@ -63,10 +63,9 @@ class CumulativeLayoutShift extends Audit {
     };
 
     return {
-      score: Audit.computeLogNormalScore(
-        metricResult.value,
-        context.options.scorePODR,
-        context.options.scoreMedian
+      score: Audit.computeLogNormalScoreFrom10th(
+        {p10: context.options.p10, median: context.options.median},
+        metricResult.value
       ),
       numericValue: metricResult.value,
       numericUnit: 'unitless',

--- a/lighthouse-core/audits/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/audits/metrics/cumulative-layout-shift.js
@@ -39,7 +39,7 @@ class CumulativeLayoutShift extends Audit {
    */
   static get defaultOptions() {
     return {
-      // Calibrated to assure 0.1 gets a score of 0.9. https://web.dev/cls/#what-is-a-good-cls-score
+      // https://web.dev/cls/#what-is-a-good-cls-score
       // This 0.1 target score was determined through both manual evaluation and large-scale analysis.
       // see https://www.desmos.com/calculator/ksp7q91nop
       p10: 0.1,

--- a/lighthouse-core/audits/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/audits/metrics/cumulative-layout-shift.js
@@ -63,7 +63,7 @@ class CumulativeLayoutShift extends Audit {
     };
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         {p10: context.options.p10, median: context.options.median},
         metricResult.value
       ),

--- a/lighthouse-core/audits/metrics/estimated-input-latency.js
+++ b/lighthouse-core/audits/metrics/estimated-input-latency.js
@@ -38,9 +38,9 @@ class EstimatedInputLatency extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/srv0hqhf7d
-      scorePODR: 50,
-      scoreMedian: 100,
+      // see https://www.desmos.com/calculator/mgd0hjqnal
+      p10: 58,
+      median: 100,
     };
   }
 
@@ -59,10 +59,9 @@ class EstimatedInputLatency extends Audit {
     const metricResult = await ComputedEil.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScore(
-        metricResult.timing,
-        context.options.scorePODR,
-        context.options.scoreMedian
+      score: Audit.computeLogNormalScoreFrom10th(
+        {p10: context.options.p10, median: context.options.median},
+        metricResult.timing
       ),
       numericValue: metricResult.timing,
       numericUnit: 'millisecond',

--- a/lighthouse-core/audits/metrics/estimated-input-latency.js
+++ b/lighthouse-core/audits/metrics/estimated-input-latency.js
@@ -59,7 +59,7 @@ class EstimatedInputLatency extends Audit {
     const metricResult = await ComputedEil.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         {p10: context.options.p10, median: context.options.median},
         metricResult.timing
       ),

--- a/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
@@ -30,9 +30,11 @@ class FirstContentfulPaint3G extends Audit {
   static get defaultOptions() {
     return {
       // 75th and 95th percentiles HTTPArchive on Fast 3G -> multiply by 1.5 for RTT differential -> median and PODR
+      // p10 is then derived from them.
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-      scorePODR: 3000,
-      scoreMedian: 6000,
+      // https://www.desmos.com/calculator/fflcrsn9sj
+      p10: 3504,
+      median: 6000,
     };
   }
 
@@ -50,10 +52,9 @@ class FirstContentfulPaint3G extends Audit {
     const metricResult = await ComputedFcp.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScore(
-        metricResult.timing,
-        context.options.scorePODR,
-        context.options.scoreMedian
+      score: Audit.computeLogNormalScoreFrom10th(
+        {p10: context.options.p10, median: context.options.median},
+        metricResult.timing
       ),
       numericValue: metricResult.timing,
       numericUnit: 'millisecond',

--- a/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
@@ -29,7 +29,7 @@ class FirstContentfulPaint3G extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 75th and 95th percentiles HTTPArchive on Fast 3G -> multiply by 1.5 for RTT differential -> median and PODR
+      // 25th and 5th percentiles HTTPArchive on Fast 3G -> multiply by 1.5 for RTT differential -> median and PODR
       // p10 is then derived from them.
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
       // https://www.desmos.com/calculator/fflcrsn9sj

--- a/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
@@ -52,7 +52,7 @@ class FirstContentfulPaint3G extends Audit {
     const metricResult = await ComputedFcp.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         {p10: context.options.p10, median: context.options.median},
         metricResult.timing
       ),

--- a/lighthouse-core/audits/metrics/first-contentful-paint.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint.js
@@ -32,21 +32,21 @@ class FirstContentfulPaint extends Audit {
   }
 
   /**
-   * @return {{mobile: LH.Audit.ScoreOptions, desktop: LH.Audit.ScoreOptions}}
+   * @return {{mobileScoring: LH.Audit.ScoreOptions, desktopScoring: LH.Audit.ScoreOptions}}
    */
   static get defaultOptions() {
     return {
-      mobile: {
-        // 75th and 95th percentiles HTTPArchive -> median and PODR
+      mobileScoring: {
+        // 75th and 95th percentiles HTTPArchive -> median and PODR, then p10 is derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-        // see https://www.desmos.com/calculator/2t1ugwykrl
-        scorePODR: 2000,
-        scoreMedian: 4000,
+        // see https://www.desmos.com/calculator/oqlvmezbze
+        p10: 2336,
+        median: 4000,
       },
-      desktop: {
+      desktopScoring: {
         // SELECT QUANTILES(renderStart, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
-        scorePODR: 800,
-        scoreMedian: 1600,
+        p10: 934,
+        median: 1600,
       },
     };
   }
@@ -61,14 +61,13 @@ class FirstContentfulPaint extends Audit {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const metricComputationData = {trace, devtoolsLog, settings: context.settings};
     const metricResult = await ComputedFcp.request(metricComputationData, context);
-    const scoreOptions =
-      context.options[artifacts.TestedAsMobileDevice === false ? 'desktop' : 'mobile'];
+    const isDesktop = artifacts.TestedAsMobileDevice === false;
+    const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
 
     return {
-      score: Audit.computeLogNormalScore(
-        metricResult.timing,
-        scoreOptions.scorePODR,
-        scoreOptions.scoreMedian
+      score: Audit.computeLogNormalScoreFrom10th(
+        scoreOptions,
+        metricResult.timing
       ),
       numericValue: metricResult.timing,
       numericUnit: 'millisecond',

--- a/lighthouse-core/audits/metrics/first-contentful-paint.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint.js
@@ -65,7 +65,7 @@ class FirstContentfulPaint extends Audit {
     const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         scoreOptions,
         metricResult.timing
       ),

--- a/lighthouse-core/audits/metrics/first-contentful-paint.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint.js
@@ -32,21 +32,25 @@ class FirstContentfulPaint extends Audit {
   }
 
   /**
-   * @return {{mobileScoring: LH.Audit.ScoreOptions, desktopScoring: LH.Audit.ScoreOptions}}
+   * @return {{mobile: {scoring: LH.Audit.ScoreOptions}, desktop: {scoring: LH.Audit.ScoreOptions}}}
    */
   static get defaultOptions() {
     return {
-      mobileScoring: {
+      mobile: {
         // 25th and 5th percentiles HTTPArchive -> median and PODR, then p10 is derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
         // see https://www.desmos.com/calculator/oqlvmezbze
-        p10: 2336,
-        median: 4000,
+        scoring: {
+          p10: 2336,
+          median: 4000,
+        },
       },
-      desktopScoring: {
+      desktop: {
         // SELECT QUANTILES(renderStart, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
-        p10: 934,
-        median: 1600,
+        scoring: {
+          p10: 934,
+          median: 1600,
+        },
       },
     };
   }
@@ -62,11 +66,11 @@ class FirstContentfulPaint extends Audit {
     const metricComputationData = {trace, devtoolsLog, settings: context.settings};
     const metricResult = await ComputedFcp.request(metricComputationData, context);
     const isDesktop = artifacts.TestedAsMobileDevice === false;
-    const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
+    const options = isDesktop ? context.options.desktop : context.options.mobile;
 
     return {
       score: Audit.computeLogNormalScore(
-        scoreOptions,
+        options.scoring,
         metricResult.timing
       ),
       numericValue: metricResult.timing,

--- a/lighthouse-core/audits/metrics/first-contentful-paint.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint.js
@@ -37,7 +37,7 @@ class FirstContentfulPaint extends Audit {
   static get defaultOptions() {
     return {
       mobileScoring: {
-        // 75th and 95th percentiles HTTPArchive -> median and PODR, then p10 is derived from them.
+        // 25th and 5th percentiles HTTPArchive -> median and PODR, then p10 is derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
         // see https://www.desmos.com/calculator/oqlvmezbze
         p10: 2336,

--- a/lighthouse-core/audits/metrics/first-cpu-idle.js
+++ b/lighthouse-core/audits/metrics/first-cpu-idle.js
@@ -32,21 +32,21 @@ class FirstCPUIdle extends Audit {
   }
 
   /**
-   * @return {{mobile: LH.Audit.ScoreOptions, desktop: LH.Audit.ScoreOptions}}
+   * @return {{mobileScoring: LH.Audit.ScoreOptions, desktopScoring: LH.Audit.ScoreOptions}}
    */
   static get defaultOptions() {
     return {
-      mobile: {
-        // 75th and 95th percentiles HTTPArchive -> median and PODR
+      mobileScoring: {
+        // 75th and 95th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-        // see https://www.desmos.com/calculator/yv89gz2nwf
-        scorePODR: 2900,
-        scoreMedian: 6500,
+        // see https://www.desmos.com/calculator/yrwes8ruci
+        p10: 3572,
+        median: 6500,
       },
-      desktop: {
+      desktopScoring: {
         // SELECT QUANTILES(fullyLoaded, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
-        scorePODR: 2000,
-        scoreMedian: 4500,
+        p10: 2468,
+        median: 4500,
       },
     };
   }
@@ -64,14 +64,13 @@ class FirstCPUIdle extends Audit {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const metricComputationData = {trace, devtoolsLog, settings: context.settings};
     const metricResult = await ComputedFci.request(metricComputationData, context);
-    const scoreOptions =
-      context.options[artifacts.TestedAsMobileDevice === false ? 'desktop' : 'mobile'];
+    const isDesktop = artifacts.TestedAsMobileDevice === false;
+    const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
 
     return {
-      score: Audit.computeLogNormalScore(
-        metricResult.timing,
-        scoreOptions.scorePODR,
-        scoreOptions.scoreMedian
+      score: Audit.computeLogNormalScoreFrom10th(
+        scoreOptions,
+        metricResult.timing
       ),
       numericValue: metricResult.timing,
       numericUnit: 'millisecond',

--- a/lighthouse-core/audits/metrics/first-cpu-idle.js
+++ b/lighthouse-core/audits/metrics/first-cpu-idle.js
@@ -37,7 +37,7 @@ class FirstCPUIdle extends Audit {
   static get defaultOptions() {
     return {
       mobileScoring: {
-        // 75th and 95th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
+        // 25th and 5th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
         // see https://www.desmos.com/calculator/yrwes8ruci
         p10: 3572,

--- a/lighthouse-core/audits/metrics/first-cpu-idle.js
+++ b/lighthouse-core/audits/metrics/first-cpu-idle.js
@@ -68,7 +68,7 @@ class FirstCPUIdle extends Audit {
     const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         scoreOptions,
         metricResult.timing
       ),

--- a/lighthouse-core/audits/metrics/first-cpu-idle.js
+++ b/lighthouse-core/audits/metrics/first-cpu-idle.js
@@ -32,21 +32,25 @@ class FirstCPUIdle extends Audit {
   }
 
   /**
-   * @return {{mobileScoring: LH.Audit.ScoreOptions, desktopScoring: LH.Audit.ScoreOptions}}
+   * @return {{mobile: {scoring: LH.Audit.ScoreOptions}, desktop: {scoring: LH.Audit.ScoreOptions}}}
    */
   static get defaultOptions() {
     return {
-      mobileScoring: {
+      mobile: {
         // 25th and 5th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
         // see https://www.desmos.com/calculator/yrwes8ruci
-        p10: 3572,
-        median: 6500,
+        scoring: {
+          p10: 3572,
+          median: 6500,
+        },
       },
-      desktopScoring: {
+      desktop: {
         // SELECT QUANTILES(fullyLoaded, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
-        p10: 2468,
-        median: 4500,
+        scoring: {
+          p10: 2468,
+          median: 4500,
+        },
       },
     };
   }
@@ -65,11 +69,11 @@ class FirstCPUIdle extends Audit {
     const metricComputationData = {trace, devtoolsLog, settings: context.settings};
     const metricResult = await ComputedFci.request(metricComputationData, context);
     const isDesktop = artifacts.TestedAsMobileDevice === false;
-    const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
+    const options = isDesktop ? context.options.desktop : context.options.mobile;
 
     return {
       score: Audit.computeLogNormalScore(
-        scoreOptions,
+        options.scoring,
         metricResult.timing
       ),
       numericValue: metricResult.timing,

--- a/lighthouse-core/audits/metrics/first-meaningful-paint.js
+++ b/lighthouse-core/audits/metrics/first-meaningful-paint.js
@@ -32,21 +32,25 @@ class FirstMeaningfulPaint extends Audit {
   }
 
   /**
-   * @return {{mobileScoring: LH.Audit.ScoreOptions, desktopScoring: LH.Audit.ScoreOptions}}
+   * @return {{mobile: {scoring: LH.Audit.ScoreOptions}, desktop: {scoring: LH.Audit.ScoreOptions}}}
    */
   static get defaultOptions() {
     return {
-      mobileScoring: {
+      mobile: {
         // 25th and 5th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
         // see https://www.desmos.com/calculator/i4znkdccut
-        p10: 2336,
-        median: 4000,
+        scoring: {
+          p10: 2336,
+          median: 4000,
+        },
       },
-      desktopScoring: {
+      desktop: {
         // SELECT QUANTILES(renderStart, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
-        p10: 934,
-        median: 1600,
+        scoring: {
+          p10: 934,
+          median: 1600,
+        },
       },
     };
   }
@@ -65,11 +69,11 @@ class FirstMeaningfulPaint extends Audit {
     const metricComputationData = {trace, devtoolsLog, settings: context.settings};
     const metricResult = await ComputedFmp.request(metricComputationData, context);
     const isDesktop = artifacts.TestedAsMobileDevice === false;
-    const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
+    const options = isDesktop ? context.options.desktop : context.options.mobile;
 
     return {
       score: Audit.computeLogNormalScore(
-        scoreOptions,
+        options.scoring,
         metricResult.timing
       ),
       numericValue: metricResult.timing,

--- a/lighthouse-core/audits/metrics/first-meaningful-paint.js
+++ b/lighthouse-core/audits/metrics/first-meaningful-paint.js
@@ -68,7 +68,7 @@ class FirstMeaningfulPaint extends Audit {
     const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         scoreOptions,
         metricResult.timing
       ),

--- a/lighthouse-core/audits/metrics/interactive.js
+++ b/lighthouse-core/audits/metrics/interactive.js
@@ -38,21 +38,25 @@ class InteractiveMetric extends Audit {
   }
 
   /**
-   * @return {{mobileScoring: LH.Audit.ScoreOptions, desktopScoring: LH.Audit.ScoreOptions}}
+   * @return {{mobile: {scoring: LH.Audit.ScoreOptions}, desktop: {scoring: LH.Audit.ScoreOptions}}}
    */
   static get defaultOptions() {
     return {
-      mobileScoring: {
+      mobile: {
         // 25th and 5th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
         // see https://www.desmos.com/calculator/o98tbeyt1t
-        p10: 3785,
-        median: 7300,
+        scoring: {
+          p10: 3785,
+          median: 7300,
+        },
       },
-      desktopScoring: {
+      desktop: {
         // SELECT QUANTILES(fullyLoaded, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
-        p10: 2468,
-        median: 4500,
+        scoring: {
+          p10: 2468,
+          median: 4500,
+        },
       },
     };
   }
@@ -69,7 +73,7 @@ class InteractiveMetric extends Audit {
     const metricResult = await Interactive.request(metricComputationData, context);
     const timeInMs = metricResult.timing;
     const isDesktop = artifacts.TestedAsMobileDevice === false;
-    const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
+    const options = isDesktop ? context.options.desktop : context.options.mobile;
     const extendedInfo = {
       timeInMs,
       timestamp: metricResult.timestamp,
@@ -81,7 +85,7 @@ class InteractiveMetric extends Audit {
 
     return {
       score: Audit.computeLogNormalScore(
-        scoreOptions,
+        options.scoring,
         timeInMs
       ),
       numericValue: timeInMs,

--- a/lighthouse-core/audits/metrics/interactive.js
+++ b/lighthouse-core/audits/metrics/interactive.js
@@ -43,7 +43,7 @@ class InteractiveMetric extends Audit {
   static get defaultOptions() {
     return {
       mobileScoring: {
-        // 75th and 95th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
+        // 25th and 5th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
         // see https://www.desmos.com/calculator/o98tbeyt1t
         p10: 3785,

--- a/lighthouse-core/audits/metrics/interactive.js
+++ b/lighthouse-core/audits/metrics/interactive.js
@@ -80,7 +80,7 @@ class InteractiveMetric extends Audit {
     };
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         scoreOptions,
         timeInMs
       ),

--- a/lighthouse-core/audits/metrics/largest-contentful-paint.js
+++ b/lighthouse-core/audits/metrics/largest-contentful-paint.js
@@ -36,12 +36,12 @@ class LargestContentfulPaint extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 75th and 95th percentiles HTTPArchive -> median and PODR.
+      // 75th and 87th percentiles HTTPArchive -> median and p10 points.
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2020_02_01_mobile?pli=1
-      // Gives 2.5s roughly a score of 0.9. https://web.dev/lcp/#what-is-a-good-lcp-score
-      // see https://www.desmos.com/calculator/brcfwyox6x
-      scorePODR: 2000,
-      scoreMedian: 4000,
+      // Gives 2.5s a score of 0.9. https://web.dev/lcp/#what-is-a-good-lcp-score
+      // see https://www.desmos.com/calculator/1etesp32kt
+      p10: 2500,
+      median: 4000,
     };
   }
 
@@ -57,10 +57,9 @@ class LargestContentfulPaint extends Audit {
     const metricResult = await ComputedLcp.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScore(
-        metricResult.timing,
-        context.options.scorePODR,
-        context.options.scoreMedian
+      score: Audit.computeLogNormalScoreFrom10th(
+        {p10: context.options.p10, median: context.options.median},
+        metricResult.timing
       ),
       numericValue: metricResult.timing,
       numericUnit: 'millisecond',

--- a/lighthouse-core/audits/metrics/largest-contentful-paint.js
+++ b/lighthouse-core/audits/metrics/largest-contentful-paint.js
@@ -36,9 +36,9 @@ class LargestContentfulPaint extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 75th and 87th percentiles HTTPArchive -> median and p10 points.
+      // 25th and 13th percentiles HTTPArchive -> median and p10 points.
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2020_02_01_mobile?pli=1
-      // Gives 2.5s a score of 0.9. https://web.dev/lcp/#what-is-a-good-lcp-score
+      // https://web.dev/lcp/#what-is-a-good-lcp-score
       // see https://www.desmos.com/calculator/1etesp32kt
       p10: 2500,
       median: 4000,

--- a/lighthouse-core/audits/metrics/largest-contentful-paint.js
+++ b/lighthouse-core/audits/metrics/largest-contentful-paint.js
@@ -57,7 +57,7 @@ class LargestContentfulPaint extends Audit {
     const metricResult = await ComputedLcp.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         {p10: context.options.p10, median: context.options.median},
         metricResult.timing
       ),

--- a/lighthouse-core/audits/metrics/max-potential-fid.js
+++ b/lighthouse-core/audits/metrics/max-potential-fid.js
@@ -41,9 +41,9 @@ class MaxPotentialFID extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/g3nf1ehtnk
-      scorePODR: 100,
-      scoreMedian: 250,
+      // see https://www.desmos.com/calculator/onxmbblyqo
+      p10: 130,
+      median: 250,
     };
   }
 
@@ -59,10 +59,9 @@ class MaxPotentialFID extends Audit {
     const metricResult = await ComputedFid.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScore(
-        metricResult.timing,
-        context.options.scorePODR,
-        context.options.scoreMedian
+      score: Audit.computeLogNormalScoreFrom10th(
+        {p10: context.options.p10, median: context.options.median},
+        metricResult.timing
       ),
       numericValue: metricResult.timing,
       numericUnit: 'millisecond',

--- a/lighthouse-core/audits/metrics/max-potential-fid.js
+++ b/lighthouse-core/audits/metrics/max-potential-fid.js
@@ -59,7 +59,7 @@ class MaxPotentialFID extends Audit {
     const metricResult = await ComputedFid.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         {p10: context.options.p10, median: context.options.median},
         metricResult.timing
       ),

--- a/lighthouse-core/audits/metrics/speed-index.js
+++ b/lighthouse-core/audits/metrics/speed-index.js
@@ -32,21 +32,25 @@ class SpeedIndex extends Audit {
   }
 
   /**
-   * @return {{mobileScoring: LH.Audit.ScoreOptions, desktopScoring: LH.Audit.ScoreOptions}}
+   * @return {{mobile: {scoring: LH.Audit.ScoreOptions}, desktop: {scoring: LH.Audit.ScoreOptions}}}
    */
   static get defaultOptions() {
     return {
-      mobileScoring: {
+      mobile: {
         // 25th and 5th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
         // see https://www.desmos.com/calculator/dvuzvpl7mi
-        p10: 3387,
-        median: 5800,
+        scoring: {
+          p10: 3387,
+          median: 5800,
+        },
       },
-      desktopScoring: {
+      desktop: {
         // SELECT QUANTILES(SpeedIndex, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
-        p10: 1311,
-        median: 2300,
+        scoring: {
+          p10: 1311,
+          median: 2300,
+        },
       },
     };
   }
@@ -64,11 +68,11 @@ class SpeedIndex extends Audit {
     const metricComputationData = {trace, devtoolsLog, settings: context.settings};
     const metricResult = await ComputedSi.request(metricComputationData, context);
     const isDesktop = artifacts.TestedAsMobileDevice === false;
-    const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
+    const options = isDesktop ? context.options.desktop : context.options.mobile;
 
     return {
       score: Audit.computeLogNormalScore(
-        scoreOptions,
+        options.scoring,
         metricResult.timing
       ),
       numericValue: metricResult.timing,

--- a/lighthouse-core/audits/metrics/speed-index.js
+++ b/lighthouse-core/audits/metrics/speed-index.js
@@ -37,7 +37,7 @@ class SpeedIndex extends Audit {
   static get defaultOptions() {
     return {
       mobileScoring: {
-        // 75th and 95th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
+        // 25th and 5th percentiles HTTPArchive -> median and PODR, then p10 derived from them.
         // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
         // see https://www.desmos.com/calculator/dvuzvpl7mi
         p10: 3387,

--- a/lighthouse-core/audits/metrics/speed-index.js
+++ b/lighthouse-core/audits/metrics/speed-index.js
@@ -67,7 +67,7 @@ class SpeedIndex extends Audit {
     const scoreOptions = context.options[isDesktop ? 'desktopScoring' : 'mobileScoring'];
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         scoreOptions,
         metricResult.timing
       ),

--- a/lighthouse-core/audits/metrics/total-blocking-time.js
+++ b/lighthouse-core/audits/metrics/total-blocking-time.js
@@ -41,9 +41,9 @@ class TotalBlockingTime extends Audit {
       // thresholds according to our 25/75-th rule will be quite harsh scoring (a single 350ms task)
       // after FCP will yield a score of .5. The following coefficients are semi-arbitrarily picked
       // to give 600ms jank a score of .5 and 100ms jank a score of .999. We can tweak these numbers
-      // in the future. See https://www.desmos.com/calculator/a7ib75kq3g
-      scoreMedian: 600,
-      scorePODR: 200,
+      // in the future. See https://www.desmos.com/calculator/bbsv8fedg5
+      median: 600,
+      p10: 287,
     };
   }
 
@@ -66,10 +66,9 @@ class TotalBlockingTime extends Audit {
     const metricResult = await ComputedTBT.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScore(
-        metricResult.timing,
-        context.options.scorePODR,
-        context.options.scoreMedian
+      score: Audit.computeLogNormalScoreFrom10th(
+        {p10: context.options.p10, median: context.options.median},
+        metricResult.timing
       ),
       numericValue: metricResult.timing,
       numericUnit: 'millisecond',

--- a/lighthouse-core/audits/metrics/total-blocking-time.js
+++ b/lighthouse-core/audits/metrics/total-blocking-time.js
@@ -66,7 +66,7 @@ class TotalBlockingTime extends Audit {
     const metricResult = await ComputedTBT.request(metricComputationData, context);
 
     return {
-      score: Audit.computeLogNormalScoreFrom10th(
+      score: Audit.computeLogNormalScore(
         {p10: context.options.p10, median: context.options.median},
         metricResult.timing
       ),

--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -17,8 +17,8 @@ const LanternEil = require('../computed/metrics/lantern-estimated-input-latency.
 const LanternLcp = require('../computed/metrics/lantern-largest-contentful-paint.js');
 
 // Parameters (in ms) for log-normal CDF scoring. To see the curve:
-//   https://www.desmos.com/calculator/rjp0lbit8y
-const SCORING_POINT_OF_DIMINISHING_RETURNS = 1700;
+//   https://www.desmos.com/calculator/bksgkihhj8
+const SCORING_P10 = 3651;
 const SCORING_MEDIAN = 10000;
 
 class PredictivePerf extends Audit {
@@ -86,10 +86,9 @@ class PredictivePerf extends Audit {
       pessimisticLCP: lcp.pessimisticEstimate.timeInMs,
     };
 
-    const score = Audit.computeLogNormalScore(
-      values.roughEstimateOfTTI,
-      SCORING_POINT_OF_DIMINISHING_RETURNS,
-      SCORING_MEDIAN
+    const score = Audit.computeLogNormalScoreFrom10th(
+      {p10: SCORING_P10, median: SCORING_MEDIAN},
+      values.roughEstimateOfTTI
     );
 
     const i18n = new I18n(context.settings.locale);

--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -86,7 +86,7 @@ class PredictivePerf extends Audit {
       pessimisticLCP: lcp.pessimisticEstimate.timeInMs,
     };
 
-    const score = Audit.computeLogNormalScoreFrom10th(
+    const score = Audit.computeLogNormalScore(
       {p10: SCORING_P10, median: SCORING_MEDIAN},
       values.roughEstimateOfTTI
     );

--- a/lighthouse-core/lib/statistics.js
+++ b/lighthouse-core/lib/statistics.js
@@ -65,7 +65,7 @@ function getLogNormalDistribution(median, falloff) {
  * percentile value, at which the score will be 0.9. The score represents the
  * amount of the distribution greater than `value`. All values should be in the
  * same units (e.g. milliseconds). See
- *   https://www.desmos.com/calculator/npnmm5ptf3
+ *   https://www.desmos.com/calculator/o98tbeyt1t
  * for an interactive view of the relationship between these parameters and the
  * typical parameterization (location and shape) of the log-normal distribution.
  * @param {{median: number, p10: number}} parameters

--- a/lighthouse-core/lib/statistics.js
+++ b/lighthouse-core/lib/statistics.js
@@ -60,6 +60,43 @@ function getLogNormalDistribution(median, falloff) {
 }
 
 /**
+ * Returns the score (1 - percentile) of `value` in a log-normal distribution
+ * specified by the `median` value, at which the score will be 0.5, and a 10th
+ * percentile value, at which the score will be 0.9. The score represents the
+ * amount of the distribution greater than `value`. All values should be in the
+ * same units (e.g. milliseconds). See
+ *   https://www.desmos.com/calculator/npnmm5ptf3
+ * for an interactive view of the relationship between these parameters and the
+ * typical parameterization (location and shape) of the log-normal distribution.
+ * @param {{median: number, p10: number}} parameters
+ * @param {number} value
+ * @return {number}
+ */
+function getLogNormalScore({median, p10}, value) {
+  // Required for the log-normal distribution.
+  if (median <= 0) throw new Error('median must be greater than zero');
+  if (p10 <= 0) throw new Error('p10 must be greater than zero');
+  // Not required, but if p10 > median, it flips around and becomes the p90 point.
+  if (p10 >= median) throw new Error('p10 must be less than the median');
+
+  // Non-positive values aren't in the distribution, so always 1.
+  if (value <= 0) return 1;
+
+  // Closest double to `erfc-1(2 * 1/10)`.
+  const INVERSE_ERFC_ONE_FIFTH = 0.9061938024368232;
+
+  // Shape (σ) is `log(p10/median) / (sqrt(2)*erfc^-1(2 * 1/10))` and
+  // standardizedX is `1/2 erfc(log(value/median) / (sqrt(2)*σ))`, so simplify a bit.
+  const xLogRatio = Math.log(value / median);
+  const p10LogRatio = -Math.log(p10 / median); // negate to keep σ positive.
+  const standardizedX = xLogRatio * INVERSE_ERFC_ONE_FIFTH / p10LogRatio;
+  const complementaryPercentile = (1 - erf(standardizedX)) / 2;
+
+  // Clamp to [0, 1] to avoid any floating-point out-of-bounds issues.
+  return Math.min(1, Math.max(0, complementaryPercentile));
+}
+
+/**
  * Interpolates the y value at a point x on the line defined by (x0, y0) and (x1, y1)
  * @param {number} x0
  * @param {number} y0
@@ -76,4 +113,5 @@ function linearInterpolation(x0, y0, x1, y1, x) {
 module.exports = {
   linearInterpolation,
   getLogNormalDistribution,
+  getLogNormalScore,
 };

--- a/lighthouse-core/test/audits/audit-test.js
+++ b/lighthouse-core/test/audits/audit-test.js
@@ -270,4 +270,31 @@ describe('Audit', () => {
       });
     });
   });
+
+  describe('#computeLogNormalScoreFrom10th', () => {
+    it('clamps the score to two decimal places', () => {
+      const params = {
+        median: 1000,
+        p10: 500,
+      };
+
+      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 0), 1);
+      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 250), 0.99);
+      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 1500), 0.23);
+      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 2500), 0.05);
+      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 4000), 0.01);
+      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 4100), 0);
+    });
+  });
+
+  describe('#computeLogNormalScore', () => {
+    it('clamps the score to two decimal places', () => {
+      assert.strictEqual(Audit.computeLogNormalScore(0, 368, 1000), 1);
+      assert.strictEqual(Audit.computeLogNormalScore(250, 368, 1000), 0.99);
+      assert.strictEqual(Audit.computeLogNormalScore(1500, 368, 1000), 0.23);
+      assert.strictEqual(Audit.computeLogNormalScore(2500, 368, 1000), 0.05);
+      assert.strictEqual(Audit.computeLogNormalScore(4000, 368, 1000), 0.01);
+      assert.strictEqual(Audit.computeLogNormalScore(4100, 368, 1000), 0);
+    });
+  });
 });

--- a/lighthouse-core/test/audits/audit-test.js
+++ b/lighthouse-core/test/audits/audit-test.js
@@ -271,30 +271,19 @@ describe('Audit', () => {
     });
   });
 
-  describe('#computeLogNormalScoreFrom10th', () => {
+  describe('#computeLogNormalScore', () => {
     it('clamps the score to two decimal places', () => {
       const params = {
         median: 1000,
         p10: 500,
       };
 
-      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 0), 1);
-      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 250), 0.99);
-      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 1500), 0.23);
-      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 2500), 0.05);
-      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 4000), 0.01);
-      assert.strictEqual(Audit.computeLogNormalScoreFrom10th(params, 4100), 0);
-    });
-  });
-
-  describe('#computeLogNormalScore', () => {
-    it('clamps the score to two decimal places', () => {
-      assert.strictEqual(Audit.computeLogNormalScore(0, 368, 1000), 1);
-      assert.strictEqual(Audit.computeLogNormalScore(250, 368, 1000), 0.99);
-      assert.strictEqual(Audit.computeLogNormalScore(1500, 368, 1000), 0.23);
-      assert.strictEqual(Audit.computeLogNormalScore(2500, 368, 1000), 0.05);
-      assert.strictEqual(Audit.computeLogNormalScore(4000, 368, 1000), 0.01);
-      assert.strictEqual(Audit.computeLogNormalScore(4100, 368, 1000), 0);
+      assert.strictEqual(Audit.computeLogNormalScore(params, 0), 1);
+      assert.strictEqual(Audit.computeLogNormalScore(params, 250), 0.99);
+      assert.strictEqual(Audit.computeLogNormalScore(params, 1500), 0.23);
+      assert.strictEqual(Audit.computeLogNormalScore(params, 2500), 0.05);
+      assert.strictEqual(Audit.computeLogNormalScore(params, 4000), 0.01);
+      assert.strictEqual(Audit.computeLogNormalScore(params, 4100), 0);
     });
   });
 });

--- a/lighthouse-core/test/lib/statistics-test.js
+++ b/lighthouse-core/test/lib/statistics-test.js
@@ -7,7 +7,6 @@
 
 /* eslint-env jest */
 
-const assert = require('assert').strict;
 const statistics = require('../../lib/statistics.js');
 
 describe('statistics', () => {
@@ -18,38 +17,97 @@ describe('statistics', () => {
 
       const median = 5000;
       const pODM = 3500;
-      const distribution = statistics.getLogNormalDistribution(median, pODM);
+      const dist = statistics.getLogNormalDistribution(median, pODM);
 
-      function getPct(distribution, value) {
-        return Number(distribution.computeComplementaryPercentile(value).toFixed(2));
-      }
-      assert.equal(typeof distribution.computeComplementaryPercentile, 'function');
-      assert.equal(getPct(distribution, 2000), 1.00, 'pct for 2000 does not match');
-      assert.equal(getPct(distribution, 3000), 0.98, 'pct for 3000 does not match');
-      assert.equal(getPct(distribution, 3500), 0.92, 'pct for 3500 does not match');
-      assert.equal(getPct(distribution, 4000), 0.81, 'pct for 4000 does not match');
-      assert.equal(getPct(distribution, 5000), 0.50, 'pct for 5000 does not match');
-      assert.equal(getPct(distribution, 6000), 0.24, 'pct for 6000 does not match');
-      assert.equal(getPct(distribution, 7000), 0.09, 'pct for 7000 does not match');
-      assert.equal(getPct(distribution, 8000), 0.03, 'pct for 8000 does not match');
-      assert.equal(getPct(distribution, 9000), 0.01, 'pct for 9000 does not match');
-      assert.equal(getPct(distribution, 10000), 0.00, 'pct for 10000 does not match');
+      expect(dist.computeComplementaryPercentile(2000)).toBeCloseTo(1.00);
+      expect(dist.computeComplementaryPercentile(3000)).toBeCloseTo(0.98);
+      expect(dist.computeComplementaryPercentile(3500)).toBeCloseTo(0.92);
+      expect(dist.computeComplementaryPercentile(4000)).toBeCloseTo(0.81);
+      expect(dist.computeComplementaryPercentile(5000)).toBeCloseTo(0.50);
+      expect(dist.computeComplementaryPercentile(6000)).toBeCloseTo(0.24);
+      expect(dist.computeComplementaryPercentile(7000)).toBeCloseTo(0.09);
+      expect(dist.computeComplementaryPercentile(8000)).toBeCloseTo(0.03);
+      expect(dist.computeComplementaryPercentile(9000)).toBeCloseTo(0.01);
+      expect(dist.computeComplementaryPercentile(10000)).toBeCloseTo(0.00);
+    });
+  });
+
+  describe('#getLogNormalScore', () => {
+    it('creates a log normal distribution', () => {
+      // This curve plotted with the below parameters.
+      // https://www.desmos.com/calculator/vp2o1acdgo
+      const params = {
+        median: 7300,
+        p10: 3785,
+      };
+      const {getLogNormalScore} = statistics;
+
+      // Be stricter with the control point requirements.
+      expect(getLogNormalScore(params, 7300)).toEqual(0.5);
+      expect(getLogNormalScore(params, 3785)).toBeCloseTo(0.9, 6);
+
+      expect(getLogNormalScore(params, 0)).toEqual(1);
+      expect(getLogNormalScore(params, 1000)).toBeCloseTo(1.00);
+      expect(getLogNormalScore(params, 2500)).toBeCloseTo(0.98);
+      expect(getLogNormalScore(params, 5000)).toBeCloseTo(0.77);
+      expect(getLogNormalScore(params, 7500)).toBeCloseTo(0.48);
+      expect(getLogNormalScore(params, 10000)).toBeCloseTo(0.27);
+      expect(getLogNormalScore(params, 30000)).toBeCloseTo(0.00);
+      expect(getLogNormalScore(params, 1000000)).toEqual(0);
+    });
+
+    it('returns 1 for all non-positive values', () => {
+      const params = {
+        median: 1000,
+        p10: 500,
+      };
+      const {getLogNormalScore} = statistics;
+      expect(getLogNormalScore(params, -100000)).toEqual(1);
+      expect(getLogNormalScore(params, -1)).toEqual(1);
+      expect(getLogNormalScore(params, 0)).toEqual(1);
+    });
+
+    it('throws on a non-positive median parameter', () => {
+      expect(() => {
+        statistics.getLogNormalScore({median: 0, p10: 500}, 50);
+      }).toThrow('median must be greater than zero');
+      expect(() => {
+        statistics.getLogNormalScore({median: -100, p90: 500}, 50);
+      }).toThrow('median must be greater than zero');
+    });
+
+    it('throws on a non-positive p10 parameter', () => {
+      expect(() => {
+        statistics.getLogNormalScore({median: 500, p10: 0}, 50);
+      }).toThrow('p10 must be greater than zero');
+      expect(() => {
+        statistics.getLogNormalScore({median: 500, p10: -100}, 50);
+      }).toThrow('p10 must be greater than zero');
+    });
+
+    it('throws if p10 is not less than the median', () => {
+      expect(() => {
+        statistics.getLogNormalScore({median: 500, p10: 500}, 50);
+      }).toThrow('p10 must be less than the median');
+      expect(() => {
+        statistics.getLogNormalScore({median: 500, p10: 1000}, 50);
+      }).toThrow('p10 must be less than the median');
     });
   });
 
   describe('#linearInterpolation', () => {
     it('correctly interpolates when slope is 2', () => {
       const slopeOf2 = x => statistics.linearInterpolation(0, 0, 10, 20, x);
-      assert.equal(slopeOf2(-10), -20);
-      assert.equal(slopeOf2(5), 10);
-      assert.equal(slopeOf2(10), 20);
+      expect(slopeOf2(-10)).toEqual(-20);
+      expect(slopeOf2(5)).toEqual(10);
+      expect(slopeOf2(10)).toEqual(20);
     });
 
     it('correctly interpolates when slope is 0', () => {
       const slopeOf0 = x => statistics.linearInterpolation(0, 0, 10, 0, x);
-      assert.equal(slopeOf0(-10), 0);
-      assert.equal(slopeOf0(5), 0);
-      assert.equal(slopeOf0(10), 0);
+      expect(slopeOf0(-10)).toEqual(0);
+      expect(slopeOf0(5)).toEqual(0);
+      expect(slopeOf0(10)).toEqual(0);
     });
   });
 });

--- a/lighthouse-core/test/lib/statistics-test.js
+++ b/lighthouse-core/test/lib/statistics-test.js
@@ -35,7 +35,7 @@ describe('statistics', () => {
   describe('#getLogNormalScore', () => {
     it('creates a log normal distribution', () => {
       // This curve plotted with the below parameters.
-      // https://www.desmos.com/calculator/vp2o1acdgo
+      // https://www.desmos.com/calculator/ywkivb78cd
       const params = {
         median: 7300,
         p10: 3785,

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -85,7 +85,7 @@
       "id": "largest-contentful-paint",
       "title": "Largest Contentful Paint",
       "description": "Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn More](https://web.dev/lighthouse-largest-contentful-paint)",
-      "score": 0.31,
+      "score": 0.28,
       "scoreDisplayMode": "numeric",
       "numericValue": 4927.278,
       "numericUnit": "millisecond",

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -21,8 +21,8 @@ declare global {
     }>;
 
     export interface ScoreOptions {
-      scorePODR: number;
-      scoreMedian: number;
+      p10: number;
+      median: number;
     }
 
     export interface ScoreDisplayModes {


### PR DESCRIPTION
In theory defining our score curves with a median and the point of diminishing returns is still a really good idea. The PoDR is a distinctive point that intuitively controls the *behavior* of the curve. It also allows us to set where to stop incentivizing improvements in a particular metric when other metrics should be prioritized instead.

However, in practice it's never been useful for communicating what our uses have wanted to know :) It doesn't correspond to a particular percentile (when the score curve is fundamentally about producing percentiles) which makes it difficult to explain. And whatever behavior might be vaguely incentivized in aggregate, when actually running Lighthouse or creating a new audit you really just want to know what's going to get you a "good" score.

This PR
- creates a new method in `statistics.js` for creating a performance curve from a median point and a 10th percentile point (which will correspond to a score of 0.5 and 0.9, respectively)
- updates all the currently scored metrics to use the new method, adjusted so the score curves don't change

None of the score curves have changed at all except CLS, which was adjusted slightly to have 0.1 exactly hit a score of 0.9. CLS is new for 6.0 so this won't change anything for end users.

fixes #10706