### PR TITLE
tests: use brfs when bundling smokehouse

### DIFF
--- a/build/build-smokehouse-bundle.js
+++ b/build/build-smokehouse-bundle.js
@@ -14,6 +14,7 @@ const smokehouseLibFilename = './lighthouse-cli/test/smokehouse/frontends/lib.js
 
 browserify(smokehouseLibFilename, {standalone: 'Lighthouse.Smokehouse'})
   .ignore('./lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js')
+  .transform('@wardpeet/brfs', {global: true, parserOpts: {ecmaVersion: 10}})
   .bundle((err, src) => {
     if (err) throw err;
     fs.writeFileSync(bundleOutFile, src.toString());

--- a/lighthouse-cli/test/smokehouse/test-definitions/source-maps/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/source-maps/expectations.js
@@ -7,8 +7,8 @@
 
 const fs = require('fs');
 
-const mapPath = require.resolve('../../../fixtures/source-map/script.js.map');
-const mapJson = fs.readFileSync(mapPath, 'utf-8');
+const mapJson =
+  fs.readFileSync(`${__dirname}/../../../fixtures/source-map/script.js.map`, 'utf-8');
 const map = JSON.parse(mapJson);
 
 /**


### PR DESCRIPTION
for @paulirish 

we should probably have a test for this. just doing `node dist/smokehouse-bundle.js` would have caught this and is probably enough, given that there is already `yarn test-bundle`.
