### PR TITLE
report: define monospace fontsize relative to report-font-size

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -113,6 +113,7 @@
   --report-font-family-monospace: 'Roboto Mono', 'Menlo', 'dejavu sans mono', 'Consolas', 'Lucida Console', monospace;
   --report-font-family: Roboto, Helvetica, Arial, sans-serif;
   --report-font-size: 16px;
+  --report-monospace-font-size: calc(var(--report-font-size) * 0.85);
   --report-line-height: 24px;
   --report-min-width: 400px;
   --report-text-color-secondary: var(--color-gray-800);
@@ -422,7 +423,7 @@
 .lh-node__snippet {
   font-family: var(--report-font-family-monospace);
   color: var(--snippet-color);
-  font-size: 14px;
+  font-size: var(--report-monospace-font-size);
   line-height: 20px;
 }
 
@@ -508,7 +509,7 @@
 
 .lh-audit__title-and-text code {
   color: var(--snippet-color);
-  font-size: 15px;
+  font-size: var(--report-monospace-font-size);
 }
 
 /* Prepend display text with em dash separator. But not in Opportunities. */
@@ -1008,7 +1009,7 @@
 .lh-code {
   white-space: normal;
   margin-top: 0;
-  font-size: 85%;
+  font-size: var(--report-monospace-font-size);
 }
 
 .lh-warnings {


### PR DESCRIPTION
theres a bunch of hardcoded monospace fontsizes, but that fails in devtools where we make the report-font-size much smaller.

two examples:
![image](https://user-images.githubusercontent.com/39191/81757360-8151e800-9473-11ea-814d-3d3bb59f6eba.png)
![image](https://user-images.githubusercontent.com/39191/81757415-aa727880-9473-11ea-9f52-11b1f53718c6.png)



this normalizes all monospace font-sizes to one thing. 