### PR TITLE
clients(devtools): fix Runtime.cachedResources reference

### DIFF
--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -17,7 +17,7 @@ const generatorFilename = `./lighthouse-core/report/report-generator.js`;
 const htmlReportAssets = require('../lighthouse-core/report/html/html-report-assets.js');
 
 /**
- * Used to save cached resources (Root.Runtime.cachedResources).
+ * Used to save cached resources (Runtime.cachedResources).
  * @param {string} name
  * @param {string} content
  */

--- a/clients/devtools-report-assets.js
+++ b/clients/devtools-report-assets.js
@@ -7,14 +7,14 @@
 
 /**
  * @fileoverview Instead of loading report assets form the filesystem, in Devtools we must load
- * them via Root.Runtime.cachedResources. We use this module to shim
+ * them via Runtime.cachedResources. We use this module to shim
  * lighthouse-core/report/html/html-report-assets.js in Devtools.
  */
 
-/* global Root */
+/* global Runtime */
 
-// @ts-ignore: Root.Runtime exists in Devtools.
-const cachedResources = Root.Runtime.cachedResources;
+// @ts-ignore: Runtime.cachedResources exists in Devtools. https://source.chromium.org/chromium/chromium/src/+/master:third_party/devtools-frontend/src/front_end/root/Runtime.js;l=1169
+const cachedResources = Runtime.cachedResources;
 
 // Getters are necessary because the DevTools bundling processes
 // resources after this module is resolved. These properties are not

--- a/lighthouse-core/report/html/html-report-assets.js
+++ b/lighthouse-core/report/html/html-report-assets.js
@@ -29,7 +29,7 @@ const REPORT_JAVASCRIPT = [
 const REPORT_CSS = fs.readFileSync(__dirname + '/report-styles.css', 'utf8');
 const REPORT_TEMPLATES = fs.readFileSync(__dirname + '/templates.html', 'utf8');
 
-// Changes to this export interface should be reflected in build/dt-report-generator-bundle.js
+// Changes to this export interface should be reflected in build/build-dt-report-resources.js
 // and clients/devtools-report-assets.js
 module.exports = {
   REPORT_TEMPLATE,


### PR DESCRIPTION
In #9758 (sept 2019), @TimvdLippe prepared us for some changes to DevTools's Runtime.

But recently (march 2020), Tim reverted those changes: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2107523  (see the diff on `front_end/third_party/lighthouse/report-assets/report-generator.js`)

So this carries over that revert diff back here.