### PR TITLE
deps: bump to latest pubads plugin

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -34,7 +34,7 @@ const locales = fs.readdirSync(__dirname + '/../lighthouse-core/lib/i18n/locales
     .map(f => require.resolve(`../lighthouse-core/lib/i18n/locales/${f}`));
 
 // HACK: manually include the lighthouse-plugin-publisher-ads audits.
-const pubAdsPath = 'lighthouse-plugin-publisher-ads-alphaignore'
+const pubAdsPath = 'lighthouse-plugin-publisher-ads-alphaignore';
 /** @type {Array<string>} */
 // @ts-ignore
 const pubAdsAudits = require(`${pubAdsPath}/plugin.js`).audits.map(a => a.path);

--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -36,7 +36,7 @@ const locales = fs.readdirSync(__dirname + '/../lighthouse-core/lib/i18n/locales
 // HACK: manually include the lighthouse-plugin-publisher-ads audits.
 /** @type {Array<string>} */
 // @ts-ignore
-const pubAdsAudits = require('lighthouse-plugin-publisher-ads/plugin.js').audits.map(a => a.path);
+const pubAdsAudits = require('lighthouse-plugin-publisher-ads-alphaignore/plugin.js').audits.map(a => a.path);
 
 /** @param {string} file */
 const isDevtools = file => path.basename(file).includes('devtools');
@@ -102,7 +102,7 @@ async function browserifyFile(entryPath, distPath) {
   // HACK: manually include the lighthouse-plugin-publisher-ads audits.
   // TODO: there should be a test for this.
   if (isDevtools(entryPath)) {
-    bundle.require('lighthouse-plugin-publisher-ads');
+    bundle.require('lighthouse-plugin-publisher-ads-alphaignore');
     pubAdsAudits.forEach(pubAdAudit => {
       bundle = bundle.require(pubAdAudit);
     });

--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -34,9 +34,10 @@ const locales = fs.readdirSync(__dirname + '/../lighthouse-core/lib/i18n/locales
     .map(f => require.resolve(`../lighthouse-core/lib/i18n/locales/${f}`));
 
 // HACK: manually include the lighthouse-plugin-publisher-ads audits.
+const pubAdsPath = 'lighthouse-plugin-publisher-ads-alphaignore'
 /** @type {Array<string>} */
 // @ts-ignore
-const pubAdsAudits = require('lighthouse-plugin-publisher-ads-alphaignore/plugin.js').audits.map(a => a.path);
+const pubAdsAudits = require(`${pubAdsPath}/plugin.js`).audits.map(a => a.path);
 
 /** @param {string} file */
 const isDevtools = file => path.basename(file).includes('devtools');

--- a/clients/devtools-entry.js
+++ b/clients/devtools-entry.js
@@ -35,7 +35,7 @@ function createConfig(categoryIDs, device) {
 
   return {
     extends: 'lighthouse:default',
-    plugins: ['lighthouse-plugin-publisher-ads'],
+    plugins: ['lighthouse-plugin-publisher-ads-alphaignore'],
     settings,
   };
 }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "isomorphic-fetch": "^2.2.1",
     "jest": "^24.9.0",
     "jsdom": "^12.2.0",
-    "lighthouse-plugin-publisher-ads": "^0.4.3",
+    "lighthouse-plugin-publisher-ads-alphaignore": "1.0.1-beta.4",
     "lodash.clonedeep": "^4.5.0",
     "npm-run-posix-or-windows": "^2.0.2",
     "nyc": "^13.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,9 +358,9 @@
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@tusbar/cache-control@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@tusbar/cache-control/-/cache-control-0.3.1.tgz#2ee673c6a7166041b5d419f7e15cd9f16e21c8e1"
-  integrity sha512-qeQhWoHQqDdW+SS1TgybdOeaSo+8tZx4ZesMY0+HSLeWWa2bGDetB9wxAT/umlXuutC6QdbADd48RJ6hrYr4BQ==
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@tusbar/cache-control/-/cache-control-0.3.2.tgz#6b59cd0ba8fe376fc472012cecde556f667ae4a1"
+  integrity sha512-69QNun7QkjTAXwvO4J/dvBW19M5q/mcqAnMawPseAEv7DNEAr7flhlW3I9Cp3N4MO0RY/StZYXBq+xkik6Z+VA==
 
 "@types/archiver@^2.1.2":
   version "2.1.2"
@@ -5314,10 +5314,10 @@ lighthouse-logger@^1.0.0, lighthouse-logger@^1.2.0:
     debug "^2.6.8"
     marky "^1.2.0"
 
-lighthouse-plugin-publisher-ads@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/lighthouse-plugin-publisher-ads/-/lighthouse-plugin-publisher-ads-0.4.3.tgz#3b03e966fa18a940e9bd35380374f8b612fa0c3a"
-  integrity sha512-Ra5Xqd3EqK8mzs0YzHnk9evj9WQc2z+WbyyjK1LXcuaQIn2p8jmE7C/5NH1fqMsGiSBN2LBvbvGCgcopn1wjdg==
+lighthouse-plugin-publisher-ads-alphaignore@1.0.1-beta.4:
+  version "1.0.1-beta.4"
+  resolved "https://registry.yarnpkg.com/lighthouse-plugin-publisher-ads-alphaignore/-/lighthouse-plugin-publisher-ads-alphaignore-1.0.1-beta.4.tgz#f307510a4023065c17f9de1ea82410cdc36230c8"
+  integrity sha512-DQb8dlPk5KlwfCfWBcwbnqXetq509ykvGBmPBLefNQzyDwhE7A8ZK37PZC2IohM3kQhHC2fgyDj8iEdCjnzc2w==
   dependencies:
     "@tusbar/cache-control" "^0.3.1"
     esprima "^4.0.1"


### PR DESCRIPTION
pubads team released their 1.0 two weeks ago! 🎉 

and just in time, we had some breaking changes for them.

- `computeLogNormalScore()` changed its signature. 
   - brendan fixed this earlier. https://github.com/googleads/publisher-ads-lighthouse-plugin/pull/198
- immutable auditContext changed runWarnings. 
  - i took a stab: https://github.com/googleads/publisher-ads-lighthouse-plugin/pull/199

No one's gonna be happy with this diff, including me.

* Because the devtools integration is quite specific, I had to do pubads fixes -> pubads bump in lh -> lh roll into devtools -> test.  
* It's past working hours on the east coast so I published to npm (temporary) to get a reliable setup.
   * I had first tried with a repo#branch reference in package.json, but pubads's plugin module is in a subfolder, which made things a bit too messy for our bundling setup.
   * Also, I considered a scoped package but our `pluginName.startsWith('lighthouse-plugin-')` code breaks that.... :p 
* Anyway, this `lighthouse-plugin-publisher-ads-alphaignore` module is exactly whats in the `p10-plus-fixes` branch: https://github.com/googleads/publisher-ads-lighthouse-plugin/pull/199
