### PR TITLE
report: fix regression in report renderer for devtools

### DIFF
--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -195,6 +195,7 @@ class ReportRenderer {
 
     const detailsRenderer = new DetailsRenderer(this._dom);
     const categoryRenderer = new CategoryRenderer(this._dom, detailsRenderer);
+    categoryRenderer.setTemplateContext(this._templateContext);
 
     /** @type {Record<string, CategoryRenderer>} */
     const specificCategoryRenderers = {


### PR DESCRIPTION
regressed in #10763 

this has a default value but needs to be over ridden for devtools, so it only broke there.