### PR TITLE
deps: lighthouse-plugin-publisher-ads@^1.1.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "isomorphic-fetch": "^2.2.1",
     "jest": "^24.9.0",
     "jsdom": "^12.2.0",
-    "lighthouse-plugin-publisher-ads": "^0.4.3",
+    "lighthouse-plugin-publisher-ads": "^1.1.0-beta.0",
     "lodash.clonedeep": "^4.5.0",
     "npm-run-posix-or-windows": "^2.0.2",
     "nyc": "^13.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5322,10 +5322,10 @@ lighthouse-logger@^1.0.0, lighthouse-logger@^1.2.0:
     debug "^2.6.8"
     marky "^1.2.0"
 
-lighthouse-plugin-publisher-ads@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/lighthouse-plugin-publisher-ads/-/lighthouse-plugin-publisher-ads-0.4.3.tgz#3b03e966fa18a940e9bd35380374f8b612fa0c3a"
-  integrity sha512-Ra5Xqd3EqK8mzs0YzHnk9evj9WQc2z+WbyyjK1LXcuaQIn2p8jmE7C/5NH1fqMsGiSBN2LBvbvGCgcopn1wjdg==
+lighthouse-plugin-publisher-ads@^1.1.0-beta.0:
+  version "1.1.0-beta.0"
+  resolved "https://registry.yarnpkg.com/lighthouse-plugin-publisher-ads/-/lighthouse-plugin-publisher-ads-1.1.0-beta.0.tgz#9279958851fde29b73fdcf96e2b36fa16a1ea5c0"
+  integrity sha512-AYNgSTYhVshp+As+Dh9NWnEXx81d/oawYQtr6qJhgM9zM+8upcO/AHuKQFmQI9vn61XOM3zmxOP4WNcDLCEYFg==
   dependencies:
     "@tusbar/cache-control" "^0.3.1"
     esprima "^4.0.1"


### PR DESCRIPTION
taking over from #10764


pubads team released their 1.0 two weeks ago! 🎉 

And we shortly broke them! But that's now fixed: https://github.com/googleads/publisher-ads-lighthouse-plugin/pull/198 & https://github.com/googleads/publisher-ads-lighthouse-plugin/pull/199

And @jburger424 _just_ released a new version: https://www.npmjs.com/package/lighthouse-plugin-publisher-ads/v/1.1.0-beta.0

I tested this out with DevTools and we're looking great.
Thanks again @brendankenny and @jburger424 
