### PR TITLE
core: utility function for generating eval code

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -423,9 +423,11 @@ class Driver {
    * will be evaluated in a content script that has access to the page's DOM but whose JavaScript state
    * is completely separate.
    * Returns a promise that resolves on the expression's value.
-   * @param {string} expression
+   * @template T
+   * @param {string | (string & {__taggedType: T})} expression Code as a string. Optionally include a
+   *                                                           tagged type to mark the return type.
    * @param {{useIsolation?: boolean}=} options
-   * @return {Promise<*>}
+   * @return {Promise<T>}
    */
   async evaluateAsync(expression, options = {}) {
     const contextId = options.useIsolation ? await this._getOrCreateIsolatedContextId() : undefined;

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -812,7 +812,8 @@ class Driver {
     let lastTimeout;
     let canceled = false;
 
-    const checkForQuietExpression = `(${pageFunctions.checkTimeSinceLastLongTaskString})()`;
+    const checkForQuietExpression =
+      pageFunctions.createEvalCode(pageFunctions.checkTimeSinceLastLongTask);
     /**
      * @param {Driver} driver
      * @param {() => void} resolve

--- a/lighthouse-core/gather/gatherers/link-elements.js
+++ b/lighthouse-core/gather/gatherers/link-elements.js
@@ -9,7 +9,7 @@ const Gatherer = require('./gatherer.js');
 const URL = require('../../lib/url-shim.js').URL;
 const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-analyzer.js');
 const LinkHeader = require('http-link-header');
-const {getElementsInDocumentString} = require('../../lib/page-functions.js');
+const {createEvalCode, getElementsInDocumentString} = require('../../lib/page-functions.js');
 
 /* globals HTMLLinkElement */
 
@@ -81,12 +81,20 @@ class LinkElements extends Gatherer {
   static getLinkElementsInDOM(passContext) {
     // We'll use evaluateAsync because the `node.getAttribute` method doesn't actually normalize
     // the values like access from JavaScript does.
-    return passContext.driver.evaluateAsync(`(() => {
-      ${getElementsInDocumentString};
-      ${getLinkElementsInDOM};
 
-      return getLinkElementsInDOM();
-    })()`, {useIsolation: true});
+    const code = createEvalCode(getLinkElementsInDOM, {
+      deps: [
+        getElementsInDocumentString,
+      ],
+    });
+    return passContext.driver.evaluateAsync(code, {useIsolation: true});
+    
+    // return passContext.driver.evaluateAsync(`(() => {
+    //   ${getElementsInDocumentString};
+    //   ${getLinkElementsInDOM};
+
+    //   return getLinkElementsInDOM();
+    // })()`, {useIsolation: true});
   }
 
   /**

--- a/lighthouse-core/gather/gatherers/trace-elements.js
+++ b/lighthouse-core/gather/gatherers/trace-elements.js
@@ -138,16 +138,21 @@ class TraceElements extends Gatherer {
       const resolveNodeResponse =
         await driver.sendCommand('DOM.resolveNode', {backendNodeId: backendNodeIds[i]});
       const objectId = resolveNodeResponse.object.objectId;
+
+      // TODO: driver.callFunctionOn, like for .evaluateAsync, so type is returned
+      // and the "response.result.value".... stuff + returnByValue/awaitPromise is encapsulated.
       const response = await driver.sendCommand('Runtime.callFunctionOn', {
         objectId,
-        functionDeclaration: `function () {
-          ${setAttributeMarker.toString()};
-          ${pageFunctions.getNodePathString};
-          ${pageFunctions.getNodeSelectorString};
-          ${pageFunctions.getNodeLabelString};
-          ${pageFunctions.getOuterHTMLSnippetString};
-          return setAttributeMarker.call(this, '${metricName}');
-        }`,
+        functionDeclaration: pageFunctions.createEvalCode(setAttributeMarker, {
+          mode: 'function',
+          deps: [
+            pageFunctions.getNodePathString,
+            pageFunctions.getNodeSelectorString,
+            pageFunctions.getNodeLabelString,
+            pageFunctions.getOuterHTMLSnippetString,
+          ],
+          args: [metricName],
+        }),
         returnByValue: true,
         awaitPromise: true,
       });

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -343,6 +343,7 @@ module.exports = {
   wrapRuntimeEvalErrorInBrowserString: wrapRuntimeEvalErrorInBrowser.toString(),
   registerPerformanceObserverInPageString: registerPerformanceObserverInPage.toString(),
   checkTimeSinceLastLongTask,
+  getElementsInDocument,
   getElementsInDocumentString: getElementsInDocument.toString(),
   getOuterHTMLSnippetString: getOuterHTMLSnippet.toString(),
   getOuterHTMLSnippet: getOuterHTMLSnippet,

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -12,6 +12,21 @@
  * Helper functions that are passed by `toString()` by Driver to be evaluated in target page.
  */
 
+ /**
+  * @template T
+  * @param {(...args: T) => any} mainFn
+  * @param  {{args?: T, deps?: (Function|string)[]}=}
+  */
+function createEvalCode(mainFn, {args, deps}) {
+  const argsSerialized = args ? args.map(arg => JSON.stringify(arg)).join(',') : '';
+  const depsSerialized = deps ? deps.join('\n') : '';
+  return `(() => {
+    ${depsSerialized}
+    ${mainFn}
+    return ${mainFn.name}(${argsSerialized});
+  })()`;
+}
+
 /**
  * The `exceptionDetails` provided by the debugger protocol does not contain the useful
  * information such as name, message, and stack trace of the error when it's wrapped in a
@@ -304,9 +319,10 @@ function getNodeLabel(node) {
 }
 
 module.exports = {
+  createEvalCode,
   wrapRuntimeEvalErrorInBrowserString: wrapRuntimeEvalErrorInBrowser.toString(),
   registerPerformanceObserverInPageString: registerPerformanceObserverInPage.toString(),
-  checkTimeSinceLastLongTaskString: checkTimeSinceLastLongTask.toString(),
+  checkTimeSinceLastLongTask,
   getElementsInDocumentString: getElementsInDocument.toString(),
   getOuterHTMLSnippetString: getOuterHTMLSnippet.toString(),
   getOuterHTMLSnippet: getOuterHTMLSnippet,

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -104,6 +104,10 @@ declare global {
   /** Obtain the type of the first parameter of a function. */
   type FirstParamType<T extends (arg1: any, ...args: any[]) => any> =
     T extends (arg1: infer P, ...args: any[]) => any ? P : never;
+  
+  // ignore. thought this might be needed but seems not.
+  /** Removes a type from an intersection. */
+  // type ExtractTaggedTyped<AT> = AT extends {__taggedType: infer T} ? T : never;
 
   module LH {
     // re-export useful type modules under global LH module.


### PR DESCRIPTION
The current interface for executing JavaScript in a page demands this of the developer:

1) inject the necessary dependencies, including the function you want to return the value of
2) call the function
3) serialize the parameters of the function properly
4) the return value is any, so be sure to do additional type checking, if you care to. or just coerce it.

```js
const result = await passContext.driver.evaluateAsync(`(() => {
  ${calculateLogMath};
  ${runTheNumbers};

  return runTheNumbers(`${number1}`, `${number2}`);
})()`, {useIsolation: true});
```

## Idea 1 - `createEvalCode`

step 3 is where most of the developer burden surfaces. it can be done in one of three ways, depending on necessity:

```js
`...
  return callMeMaybe(`${number}`, '${string}', ${JSON.stringify(object)});
`
```

To address the serialization woes, I propose this interface:

```js
const code = pageFunctions.createEvalCode(callMeMaybe, {
  args: [number1, aString, object],
  deps: [
    calculateLogMath,
  ],
}),
const result = await passContext.driver.evaluateAsync(code, {useIsolation: true});
```

A real-er example (from `link-elements.js`):

```js
// 1) Current way.
return passContext.driver.evaluateAsync(`(() => {
  ${getElementsInDocumentString};
  ${getLinkElementsInDOM};

  return getLinkElementsInDOM();
})()`, {useIsolation: true});

// 2) Creating code with `createEvalCode` helper.
const code = pageFunctions.createEvalCode(getLinkElementsInDOM, {
  deps: [
    pageFunctions.getElementsInDocumentString,
  ],
});
return passContext.driver.evaluateAsync(code, {useIsolation: true});
```

`trace-elements.js` must return a `function` declaration, so there should also be a `mode: 'iffe'|'function'` to control the code generation. See the diff to this draft PR for details.

I think this would be useful for many of the more complex usages of `evaluateAsync`:

https://github.com/GoogleChrome/lighthouse/blob/5f372eace962406ab377e5cff33dbc517f89b9b3/lighthouse-core/gather/gatherers/seo/tap-targets.js#L307-L331
https://github.com/GoogleChrome/lighthouse/blob/5f372eace962406ab377e5cff33dbc517f89b9b3/lighthouse-core/gather/gatherers/trace-elements.js#L141-L157
https://github.com/GoogleChrome/lighthouse/blob/5f372eace962406ab377e5cff33dbc517f89b9b3/lighthouse-core/gather/fetcher.js#L135-L161


Simple ones like [this](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/gather/driver.js#L1233) should probably just remain as-is.

I think the criteria is: if it requires more than one function or parameter serialization, it'd benefit from `pageFunction.createEvalCode`.

## Idea 2 - types

We can "tag" the return value of `createEvalCode`, which returns a string, with the return type of `mainFn`. `driver.evaluateAsync` can then attempt to pattern match for that type, and mark its return value as the same!

The nice part about this is that it's "tagged" via an intersection type `string & {__taggedType: T}`, so this value can be used in any way a string can be used, which is mighty convenient since at runtime it's only ever gonna be a string.

Instances where the type would be useful for code readability and correctness (including most of the examples already linked above):

(`tag` is `any`)
https://github.com/GoogleChrome/lighthouse/blob/5f372eace962406ab377e5cff33dbc517f89b9b3/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js#L135-L156

(`elements` is coerced)
https://github.com/GoogleChrome/lighthouse/blob/5f372eace962406ab377e5cff33dbc517f89b9b3/lighthouse-core/gather/gatherers/image-elements.js#L191-L202

(return value is coerced)
https://github.com/GoogleChrome/lighthouse/blob/5f372eace962406ab377e5cff33dbc517f89b9b3/lighthouse-core/gather/gatherers/meta-elements.js#L21-L33

(value is coerced)
https://github.com/GoogleChrome/lighthouse/blob/5f372eace962406ab377e5cff33dbc517f89b9b3/lighthouse-core/gather/gatherers/iframe-elements.js#L42-L51

(value is coerced)
https://github.com/GoogleChrome/lighthouse/blob/5f372eace962406ab377e5cff33dbc517f89b9b3/lighthouse-core/gather/gatherers/anchor-elements.js#L80-L91

There's a few more like these, where `afterPass` directly returns the result of `evaluateAsync` and the type is coerced to w/e the `@return` JSDoc says it should be.

The criteria I mentioned earlier might then become: if it requires more than one function, parameter serialization, or returns a value, it'd benefit from `pageFunction.createEvalCode`.

## Idea 3 - scope the dependency functions

Example: https://github.com/GoogleChrome/lighthouse/blob/5f372eace962406ab377e5cff33dbc517f89b9b3/lighthouse-core/gather/gatherers/meta-elements.js#L21-L33

All the logic in this gatherer is in a string, so nothing is type checked. Even if moved to a function and stringified like most other usages of `evaluateAsync`, `getElementsInDocument` would need to be ignored with eslint and tsignored because it doesn't actually exist until executed in the browser.

`page-functions.js` could export `getElementsInDocument`, and if the function referenced it then typecheck/linting would work, but would error at runtime because `pageFunctions` doesn't exist in the browser.

If instead we injected a `pageFunction = {...}` object with all the dependencies, we could import the function in Node, use it in our browser function, and maintain all the type checking. It'd look like this:

```js
const Gatherer = require('./gatherer.js');
const pageFunctions = require('../../lib/page-functions.js');

function getMetaElements() {
  return pageFunctions.getElementsInDocument('head meta').map(el => {
    const meta = /** @type {HTMLMetaElement} */ (el);
    return {
      name: meta.name.toLowerCase(),
      content: meta.content,
      property: meta.attributes.property ? meta.attributes.property.value : undefined,
      httpEquiv: meta.httpEquiv ? meta.httpEquiv.toLowerCase() : undefined,
      charset: meta.attributes.charset ? meta.attributes.charset.value : undefined,
    };
  });
}

class MetaElements extends Gatherer {
  /**
   * @param {LH.Gatherer.PassContext} passContext
   * @return {Promise<LH.Artifacts['MetaElements']>}
   */
  async afterPass(passContext) {
    const driver = passContext.driver;

    // We'll use evaluateAsync because the `node.getAttribute` method doesn't actually normalize
    // the values like access from JavaScript does.
    const code = pageFunctions.createEvalCode(getMetaElements, {
      deps: [
        pageFunctions.getElementsInDocument,
      ],
    });
    return driver.evaluateAsync(code, {useIsolation: true});
  }
}
```

As part of this, I think `page-functions.js` should always be imported like this:
```
const pageFunctions = require('../../page-function.js');
```

and stop exporting the `*String` variants of each function, just export the function.

At this point, we might even consider just injecting all the page functions in `createEvalCode`, but that may be too wasteful (this has to cost something, right?)

## Idea 4 - debugging

Debugging page functions is tedious. Best way I've found so far is to just throw an error with the data I want to log. It'd be nice if any `console.log`s executed in the code would be collected and printed when the code returns.

could do this by listening to `Console.messageAdded` during execution. could require something like `console.log('lhdebug', ...)` so that it only logs stuff we are debugging, not something else the page is doing.
