### PR TITLE
core(image-size-responsive): quantize DPRs

### DIFF
--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -36,8 +36,11 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 // A factor of 1 means the actual device pixel density will be used.
 // A factor of 0.5, means half the density is required. For example if the device pixel ratio is 3,
 // then the images should have at least a density of 1.5.
+// Note that the resulting DPR will be quantized.
 const SMALL_IMAGE_FACTOR = 1.0;
-const LARGE_IMAGE_FACTOR = 0.75;
+// After quantiation, an initial DPR of 2, will get converted to 1.5. An a DPR of 3 will transform
+// to a DPR of 2.
+const LARGE_IMAGE_FACTOR = 0.8;
 
 // An image has must have both its dimensions lower or equal to the threshold in order to be
 // considered SMALL.
@@ -137,8 +140,9 @@ function allowedImageSize(displayedWidth, displayedHeight, DPR) {
   if (displayedWidth > SMALL_IMAGE_THRESHOLD || displayedHeight > SMALL_IMAGE_THRESHOLD) {
     factor = LARGE_IMAGE_FACTOR;
   }
-  const width = Math.ceil(factor * DPR * displayedWidth);
-  const height = Math.ceil(factor * DPR * displayedHeight);
+  const allowedDpr = quantizeDpr(factor * quantizeDpr(DPR));
+  const width = Math.ceil(allowedDpr * displayedWidth);
+  const height = Math.ceil(allowedDpr * displayedHeight);
   return [width, height];
 }
 
@@ -235,6 +239,28 @@ class ImageSizeResponsive extends Audit {
       details: Audit.makeTableDetails(headings, finalResults),
     };
   }
+}
+
+/**
+ * Return a quantized version of the DPR.
+ *
+ * This is to relax the required size of the image, as there are some densities that are not that
+ * common, and the default DPR used in some contexts by lightouse is 2.625.
+ *
+ * This is also used to compute a final dpr when the image is too large. For example, if the factor
+ * is set to 0.8 and the DPR is 4, then the resulting DPR would be 3.
+ *
+ * @param {number} dpr
+ * @return {number}
+ */
+function quantizeDpr(dpr) {
+  if (dpr >= 2) {
+    return Math.floor(dpr);
+  }
+  if (dpr >= 1.5) {
+    return 1.5;
+  }
+  return 1.0;
 }
 
 module.exports = ImageSizeResponsive;

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -16,12 +16,12 @@ const i18n = require('../lib/i18n/i18n.js');
 
 const UIStrings = {
   /** Title of a Lighthouse audit that provides detail on the size of visible images on the page. This descriptive title is shown to users when all images have correct sizes. */
-  title: 'Displays images with appropriate size',
+  title: 'Serves images with appropriate resolution',
   /** Title of a Lighthouse audit that provides detail on the size of visible images on the page. This descriptive title is shown to users when not all images have correct sizes. */
-  failureTitle: 'Displays images with inappropriate size',
+  failureTitle: 'Serves images with low resolution',
   /** Description of a Lighthouse audit that tells the user why they should maintain an appropriate size for all images. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Image natural dimensions should be proportional to the display size and the ' +
-    'pixel ratio to maximize image clarity. [Learn more](https://web.dev/image-size-responsive).',
+    'pixel ratio to maximize image clarity. [Learn more](https://web.dev/serve-responsive-images/).',
   /**  Label for a column in a data table; entries in the column will be a string representing the displayed size of the image. */
   columnDisplayed: 'Displayed size',
   /**  Label for a column in a data table; entries in the column will be a string representing the actual size of the image. */
@@ -36,11 +36,8 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 // A factor of 1 means the actual device pixel density will be used.
 // A factor of 0.5, means half the density is required. For example if the device pixel ratio is 3,
 // then the images should have at least a density of 1.5.
-// Note that the resulting DPR will be quantized.
 const SMALL_IMAGE_FACTOR = 1.0;
-// After quantiation, an initial DPR of 2, will get converted to 1.5. An a DPR of 3 will transform
-// to a DPR of 2.
-const LARGE_IMAGE_FACTOR = 0.8;
+const LARGE_IMAGE_FACTOR = 0.75;
 
 // An image has must have both its dimensions lower or equal to the threshold in order to be
 // considered SMALL.
@@ -140,9 +137,9 @@ function allowedImageSize(displayedWidth, displayedHeight, DPR) {
   if (displayedWidth > SMALL_IMAGE_THRESHOLD || displayedHeight > SMALL_IMAGE_THRESHOLD) {
     factor = LARGE_IMAGE_FACTOR;
   }
-  const allowedDpr = quantizeDpr(factor * quantizeDpr(DPR));
-  const width = Math.ceil(allowedDpr * displayedWidth);
-  const height = Math.ceil(allowedDpr * displayedHeight);
+  const requiredDpr = quantizeDpr(DPR);
+  const width = Math.ceil(factor * requiredDpr * displayedWidth);
+  const height = Math.ceil(factor * requiredDpr * displayedHeight);
   return [width, height];
 }
 
@@ -247,9 +244,6 @@ class ImageSizeResponsive extends Audit {
  * This is to relax the required size of the image, as there are some densities that are not that
  * common, and the default DPR used in some contexts by lightouse is 2.625.
  *
- * This is also used to compute a final dpr when the image is too large. For example, if the factor
- * is set to 0.8 and the DPR is 4, then the resulting DPR would be 3.
- *
  * @param {number} dpr
  * @return {number}
  */
@@ -260,10 +254,7 @@ function quantizeDpr(dpr) {
   if (dpr >= 1.5) {
     return 1.5;
   }
-  if (dpr >= 1.0) {
-    return 1.0;
-  }
-  return dpr;
+  return 1.0;
 }
 
 module.exports = ImageSizeResponsive;

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -260,7 +260,10 @@ function quantizeDpr(dpr) {
   if (dpr >= 1.5) {
     return 1.5;
   }
-  return 1.0;
+  if (dpr >= 1.0) {
+    return 1.0;
+  }
+  return dpr;
 }
 
 module.exports = ImageSizeResponsive;

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -777,13 +777,13 @@
     "message": "Expected size"
   },
   "lighthouse-core/audits/image-size-responsive.js | description": {
-    "message": "Image natural dimensions should be proportional to the display size and the pixel ratio to maximize image clarity. [Learn more](https://web.dev/image-size-responsive)."
+    "message": "Image natural dimensions should be proportional to the display size and the pixel ratio to maximize image clarity. [Learn more](https://web.dev/serve-responsive-images/)."
   },
   "lighthouse-core/audits/image-size-responsive.js | failureTitle": {
-    "message": "Displays images with inappropriate size"
+    "message": "Serves images with low resolution"
   },
   "lighthouse-core/audits/image-size-responsive.js | title": {
-    "message": "Displays images with appropriate size"
+    "message": "Serves images with appropriate resolution"
   },
   "lighthouse-core/audits/installable-manifest.js | description": {
     "message": "Browsers can proactively prompt users to add your app to their homescreen, which can lead to higher engagement. [Learn more](https://web.dev/installable-manifest)."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -777,13 +777,13 @@
     "message": "Êx́p̂éĉt́êd́ ŝíẑé"
   },
   "lighthouse-core/audits/image-size-responsive.js | description": {
-    "message": "Îḿâǵê ńât́ûŕâĺ d̂ím̂én̂śîón̂ś ŝh́ôúl̂d́ b̂é p̂ŕôṕôŕt̂íôńâĺ t̂ó t̂h́ê d́îśp̂ĺâý ŝíẑé âńd̂ t́ĥé p̂íx̂él̂ ŕât́îó t̂ó m̂áx̂ím̂íẑé îḿâǵê ćl̂ár̂ít̂ý. [L̂éâŕn̂ ḿôŕê](https://web.dev/image-size-responsive)."
+    "message": "Îḿâǵê ńât́ûŕâĺ d̂ím̂én̂śîón̂ś ŝh́ôúl̂d́ b̂é p̂ŕôṕôŕt̂íôńâĺ t̂ó t̂h́ê d́îśp̂ĺâý ŝíẑé âńd̂ t́ĥé p̂íx̂él̂ ŕât́îó t̂ó m̂áx̂ím̂íẑé îḿâǵê ćl̂ár̂ít̂ý. [L̂éâŕn̂ ḿôŕê](https://web.dev/serve-responsive-images/)."
   },
   "lighthouse-core/audits/image-size-responsive.js | failureTitle": {
-    "message": "D̂íŝṕl̂áŷś îḿâǵêś ŵít̂h́ îńâṕp̂ŕôṕr̂íât́ê śîźê"
+    "message": "Ŝér̂v́êś îḿâǵêś ŵít̂h́ l̂óŵ ŕêśôĺût́îón̂"
   },
   "lighthouse-core/audits/image-size-responsive.js | title": {
-    "message": "D̂íŝṕl̂áŷś îḿâǵêś ŵít̂h́ âṕp̂ŕôṕr̂íât́ê śîźê"
+    "message": "Ŝér̂v́êś îḿâǵêś ŵít̂h́ âṕp̂ŕôṕr̂íât́ê ŕêśôĺût́îón̂"
   },
   "lighthouse-core/audits/installable-manifest.js | description": {
     "message": "B̂ŕôẃŝér̂ś ĉán̂ ṕr̂óâćt̂ív̂él̂ý p̂ŕôḿp̂t́ ûśêŕŝ t́ô ád̂d́ ŷóûŕ âṕp̂ t́ô t́ĥéîŕ ĥóm̂éŝćr̂éêń, ŵh́îćĥ ćâń l̂éâd́ t̂ó ĥíĝh́êŕ êńĝáĝém̂én̂t́. [L̂éâŕn̂ ḿôŕê](https://web.dev/installable-manifest)."

--- a/lighthouse-core/test/audits/image-size-responsive-test.js
+++ b/lighthouse-core/test/audits/image-size-responsive-test.js
@@ -279,13 +279,13 @@ describe('Images: size audit', () => {
       testImage('has right size', {
         score: 1,
         clientSize: [65, 65],
-        naturalSize: [52, 52],
+        naturalSize: [49, 49],
       });
 
       testImage('has an invalid size', {
         score: 0,
         clientSize: [65, 65],
-        naturalSize: [51, 51],
+        naturalSize: [48, 48],
       });
     });
 
@@ -316,6 +316,36 @@ describe('Images: size audit', () => {
         clientSize: [65, 65],
         naturalSize: [97, 97],
         devicePixelRatio: 2,
+      });
+    });
+
+    describe('DPR = 2.625', () => {
+      testImage('is an icon with right size', {
+        score: 1,
+        clientSize: [64, 64],
+        naturalSize: [128, 128],
+        devicePixelRatio: 2.625,
+      });
+
+      testImage('is an icon with an invalid size', {
+        score: 0,
+        clientSize: [64, 64],
+        naturalSize: [127, 127],
+        devicePixelRatio: 2.625,
+      });
+
+      testImage('has right size', {
+        score: 1,
+        clientSize: [65, 65],
+        naturalSize: [98, 98],
+        devicePixelRatio: 2.625,
+      });
+
+      testImage('has an invalid size', {
+        score: 0,
+        clientSize: [65, 65],
+        naturalSize: [97, 97],
+        devicePixelRatio: 2.625,
       });
     });
   });

--- a/lighthouse-core/test/audits/image-size-responsive-test.js
+++ b/lighthouse-core/test/audits/image-size-responsive-test.js
@@ -279,13 +279,13 @@ describe('Images: size audit', () => {
       testImage('has right size', {
         score: 1,
         clientSize: [65, 65],
-        naturalSize: [65, 65],
+        naturalSize: [52, 52],
       });
 
       testImage('has an invalid size', {
         score: 0,
         clientSize: [65, 65],
-        naturalSize: [64, 64],
+        naturalSize: [51, 51],
       });
     });
 

--- a/lighthouse-core/test/audits/image-size-responsive-test.js
+++ b/lighthouse-core/test/audits/image-size-responsive-test.js
@@ -279,13 +279,13 @@ describe('Images: size audit', () => {
       testImage('has right size', {
         score: 1,
         clientSize: [65, 65],
-        naturalSize: [49, 49],
+        naturalSize: [65, 65],
       });
 
       testImage('has an invalid size', {
         score: 0,
         clientSize: [65, 65],
-        naturalSize: [48, 48],
+        naturalSize: [64, 64],
       });
     });
 

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -632,8 +632,8 @@
     },
     "image-size-responsive": {
       "id": "image-size-responsive",
-      "title": "Displays images with inappropriate size",
-      "description": "Image natural dimensions should be proportional to the display size and the pixel ratio to maximize image clarity. [Learn more](https://web.dev/image-size-responsive).",
+      "title": "Serves images with low resolution",
+      "description": "Image natural dimensions should be proportional to the display size and the pixel ratio to maximize image clarity. [Learn more](https://web.dev/serve-responsive-images/).",
       "score": 0,
       "scoreDisplayMode": "binary",
       "details": {


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
<!-- Describe the need for this change -->
In some contexts lighthouse uses a DPR of 2.625, which is a rather uncommon DPR, so to minimize the number of failures, we will quantize the original DPR to the lowest integer (or 1.5 if in between 1.5 and 2).

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
Fixes #10434 and #10802
