### PR TITLE
docs(readme): adding cypress-audit to the related projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -386,7 +386,7 @@ Other awesome open source projects that use Lighthouse.
 * **[react-lighthouse-viewer](https://www.npmjs.com/package/react-lighthouse-viewer)** - Render a Lighthouse JSON report in a React Component.
 * **[webpack-lighthouse-plugin](https://github.com/addyosmani/webpack-lighthouse-plugin)** - Run Lighthouse from a Webpack build.
 * **[is-website-vulnerable](https://github.com/lirantal/is-website-vulnerable)** - An open source Node.js CLI tool that finds publicly known security vulnerabilities in a website's frontend JavaScript libraries.
-* **[cypress-audit](https://github.com/mfrachet/cypress-audit)** - :zap: Run Lighthouse and Pa11y audits directly in your E2E test suites.
+* **[cypress-audit](https://github.com/mfrachet/cypress-audit)** - Run Lighthouse and Pa11y audits directly in your E2E test suites.
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -386,6 +386,7 @@ Other awesome open source projects that use Lighthouse.
 * **[react-lighthouse-viewer](https://www.npmjs.com/package/react-lighthouse-viewer)** - Render a Lighthouse JSON report in a React Component.
 * **[webpack-lighthouse-plugin](https://github.com/addyosmani/webpack-lighthouse-plugin)** - Run Lighthouse from a Webpack build.
 * **[is-website-vulnerable](https://github.com/lirantal/is-website-vulnerable)** - An open source Node.js CLI tool that finds publicly known security vulnerabilities in a website's frontend JavaScript libraries.
+* **[cypress-audit](https://github.com/mfrachet/cypress-audit)** - :zap: Run Lighthouse and Pa11y audits directly in your E2E test suites.
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -30,11 +30,11 @@
 
 ## Using Lighthouse in Chrome DevTools
 
-Lighthouse is integrated directly into the Chrome Developer Tools, under the "Audits" panel.
+Lighthouse is integrated directly into the Chrome DevTools, under the "Lighthouse" panel.
 
 **Installation**: install [Chrome](https://www.google.com/chrome/browser).
 
-**Run it**: open Chrome DevTools, select the Audits panel, and hit "Run audits".
+**Run it**: open Chrome DevTools, select the Lighthouse panel, and hit "Generate report".
 
 <img src="https://raw.githubusercontent.com/GoogleChrome/lighthouse/e7997b3db01de3553d8cb208a40f3d4fd350195c/assets/example_dev_tools.png" alt="Lighthouse integration in Chrome DevTools" width="500px">
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

This PR adds the [`cypress-audit`](https://github.com/mfrachet/cypress-audit) github project to the list of related projects.

The big picture:

The tools we can use nowadays to verify the quality of our applications are awesome. They help us get a huge amount of confidence about what we ship in production and alert us when some kind of regression occurs.

- [Cypress](https://cypress.io/) has made business oriented workflow verification super easy and fun
- [Lighthouse](https://developers.google.com/web/tools/lighthouse) has provided incredible tools to verify the performance of an application
- [Pa11y](https://pa11y.org/) provides multiple tool to control the accessibility state of our applications in a wonderful way

The problem is that they run in their own context and with their own internal tricks for authentication and page browsing.

The idea of `cypress-audit` is to unify all of this by providing some [Cypress Custom Commands](https://docs.cypress.io/api/cypress-api/custom-commands.html) so that you can use these tools **directly inside your Cypress tests**. Practical for auditing authenticated pages for example. 

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
N/A
