### PR TITLE
core(legacy-javascript): use third-party-web for scoring

### DIFF
--- a/lighthouse-core/audits/legacy-javascript.js
+++ b/lighthouse-core/audits/legacy-javascript.js
@@ -34,13 +34,13 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
 /**
  * @param {string} url
- * @param {import('third-party-web').IEntity | undefined} mainDoucumentEntity
+ * @param {import('third-party-web').IEntity | undefined} mainDocumentEntity
  */
-function isThirdParty(url, mainDoucumentEntity) {
+function isThirdParty(url, mainDocumentEntity) {
   try {
     const entity = thirdPartyWeb.getEntity(url);
     if (!entity) return false;
-    if (entity === mainDoucumentEntity) return false;
+    if (entity === mainDocumentEntity) return false;
     return true;
   } catch (_) {
     return false;

--- a/lighthouse-core/lib/third-party-web.js
+++ b/lighthouse-core/lib/third-party-web.js
@@ -1,0 +1,49 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const thirdPartyWeb = require('third-party-web/httparchive-nostats-subset');
+
+/** @typedef {import("third-party-web").IEntity} ThirdPartyEntity */
+
+/**
+ * `third-party-web` throws when the passed in string doesn't appear to have any domain whatsoever.
+ * We pass in some not-so-url-like things, so make the dependent-code simpler by making this call safe.
+ * @param {string} url
+ * @return {ThirdPartyEntity|undefined}
+ */
+function getEntity(url) {
+  try {
+    return thirdPartyWeb.getEntity(url);
+  } catch (_) {
+    return undefined;
+  }
+}
+
+/**
+ * @param {string} url
+ * @param {ThirdPartyEntity | undefined} mainDocumentEntity
+ */
+function isThirdParty(url, mainDocumentEntity) {
+  const entity = getEntity(url);
+  if (!entity) return false;
+  if (entity === mainDocumentEntity) return false;
+  return true;
+}
+
+/**
+ * @param {string} url
+ * @param {ThirdPartyEntity | undefined} mainDocumentEntity
+ */
+function isFirstParty(url, mainDocumentEntity) {
+  return !isThirdParty(url, mainDocumentEntity);
+}
+
+module.exports = {
+  getEntity,
+  isThirdParty,
+  isFirstParty,
+};

--- a/lighthouse-core/test/audits/legacy-javascript-test.js
+++ b/lighthouse-core/test/audits/legacy-javascript-test.js
@@ -19,7 +19,7 @@ const createArtifacts = (scripts) => {
     url,
   }));
   return {
-    URL: {finalUrl: '', requestedUrl: ''},
+    URL: {finalUrl: 'https://www.example.com', requestedUrl: 'https://www.example.com'},
     devtoolsLogs: {defaultPass: networkRecordsToDevtoolsLog(networkRecords)},
     ScriptElements: scripts.map(({url, code}, index) => {
       return {
@@ -81,6 +81,18 @@ describe('LegacyJavaScript audit', () => {
     const result = await LegacyJavascript.audit(artifacts, {computedCache: new Map()});
     assert.equal(result.score, 1);
     assert.equal(result.extendedInfo.signalCount, 0);
+  });
+
+  it('passes code with a legacy polyfill in third party resource', async () => {
+    const artifacts = createArtifacts([
+      {
+        code: 'String.prototype.repeat = function() {}',
+        url: 'https://www.googletagmanager.com/a.js',
+      },
+    ]);
+    const result = await LegacyJavascript.audit(artifacts, {computedCache: new Map()});
+    assert.equal(result.score, 1);
+    assert.equal(result.extendedInfo.signalCount, 1);
   });
 
   it('fails code with a legacy polyfill', async () => {

--- a/lighthouse-core/test/lib/third-party-web-test.js
+++ b/lighthouse-core/test/lib/third-party-web-test.js
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const thirdPartyWeb = require('../../lib/third-party-web.js');
+
+describe('third party web', () => {
+  it('basic', () => {
+    expect(thirdPartyWeb.isThirdParty('https://www.example.com', undefined)).toBe(false);
+    expect(thirdPartyWeb.isFirstParty('https://www.example.com', undefined)).toBe(true);
+
+    expect(thirdPartyWeb.isThirdParty('https://www.googletagmanager.com', undefined)).toBe(true);
+    expect(thirdPartyWeb.isFirstParty('https://www.googletagmanager.com', undefined)).toBe(false);
+  });
+
+  it('not third party if main document is same entity', () => {
+    const mainDocumentEntity = thirdPartyWeb.getEntity('https://www.googletagmanager.com');
+    expect(thirdPartyWeb.isThirdParty('https://www.googletagmanager.com/a.js', mainDocumentEntity)).toBe(false);
+    expect(thirdPartyWeb.isThirdParty('https://blah.atdmt.com', mainDocumentEntity)).toBe(true);
+    expect(thirdPartyWeb.isThirdParty('https://www.example.com', mainDocumentEntity)).toBe(false);
+  });
+});


### PR DESCRIPTION
part of #10369

Still an informative audit, so no real change here.

@patrickhulce you mentioned having to write a `isThirdParty` function for a couple things. where do you want to put this fn?