### PR TITLE
report: fix the width of the 3-dots menu in topbar

### DIFF
--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -268,6 +268,7 @@ limitations under the License.
     .lh-tools {
       margin-left: auto;
       will-change: transform;
+      min-width: var(--tools-icon-size);
     }
     .lh-tools__button {
       width: var(--tools-icon-size);


### PR DESCRIPTION
Fixes a bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1086442

The `lh-tools` div that wraps the `lh-tools-button` can have a smaller width than its child when the view is squished.

Before:
![Screen Shot 2020-05-27 at 4 39 53 pm](https://user-images.githubusercontent.com/7401419/83035558-e7289d00-a039-11ea-8f4a-cfde83750db7.png)

After:
![Screen Shot 2020-05-27 at 4 39 40 pm](https://user-images.githubusercontent.com/7401419/83035583-eabc2400-a039-11ea-9760-a3b6593a6e85.png)
