### PR TITLE
report: update onMenuFocusOut typing to remove FocusEvent cast

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -773,13 +773,10 @@ class DropDown {
 
   /**
    * Focus out handler for the drop down menu.
-   * @param {Event} e
+   * @param {FocusEvent} e
    */
   onMenuFocusOut(e) {
-    // TODO: The focusout event is not supported in our current version of typescript (3.5.3)
-    // https://github.com/microsoft/TypeScript/issues/30716
-    const focusEvent = /** @type {FocusEvent} */ (e);
-    const focusedEl = /** @type {?HTMLElement} */ (focusEvent.relatedTarget);
+    const focusedEl = /** @type {?HTMLElement} */ (e.relatedTarget);
 
     if (!this._menuEl.contains(focusedEl)) {
       this.close();


### PR DESCRIPTION
**Summary**
This is a TODO cleanup form an earlier change which added `onMenuFocusOut`, at the time our TypeScript version (3.5.3) did not properly support the `focusout` event so a cast was required.

Since we have upgraded TypeScript (3.8.3) we no longer need the cast.

**Related Issues/PRs**
#10208 