### PR TITLE
core(median-run): add computeMedianRun to lib

### DIFF
--- a/docs/variability.md
+++ b/docs/variability.md
@@ -103,21 +103,23 @@ You can then process the reports that are output to the filesystem. Read the [Li
 If you're running Lighthouse directly via node, you can also use the `computeMedianRun` function to determine the median using a blend of the performance metrics.
 
 ```js
-const lighthouse = require('lighthouse');
-const chromeLauncher = require('chrome-launcher');
+const spawnSync = require('child_process').spawnSync;
+const lighthouseCli = require.resolve('lighthouse/lighthouse-cli');
 const {computeMedianRun} = require('lighthouse/lighthouse-core/lib/median-run.js');
 
-(async () => {
-  const chrome = await chromeLauncher.launch();
-  const results = [];
-  for (let i = 0; i < 5; i++) {
-    const {lhr} = await lighthouse('http://example.com', {port: chrome.port});
-    results.push(lhr);
-  }
+const results = [];
+for (let i = 0; i < 5; i++) {
+  console.log(`Running Lighthouse attempt #${i + 1}...`);
+  const {status = -1, stdout} = spawnSync('node', [
+    lighthouseCli,
+    'https://example.com',
+    '--output=json'
+  ]);
+  results.push(JSON.parse(stdout));
+}
 
-  const median = computeMedianRun(results);
-  console.log('Median performance score was', median.categories.performance.score * 100);
-})();
+const median = computeMedianRun(results);
+console.log('Median performance score was', median.categories.performance.score * 100);
 ```
 
 ## Related Documentation

--- a/docs/variability.md
+++ b/docs/variability.md
@@ -89,9 +89,36 @@ If your machine has really limited resources or creating a clean environment has
 
 ### Run Lighthouse Multiple Times
 
-When creating your thresholds for failure, either mental or programmatic, use aggregate values like the median, 90th percentile, or even min instead of single tests.
+When creating your thresholds for failure, either mental or programmatic, use aggregate values like the median, 90th percentile, or even min/max instead of single test results.
 
-The median Lighthouse score of 5 runs is twice as stable as 1 run, and tools like [lighthouse-ci](https://github.com/GoogleChrome/lighthouse-ci/) can run Lighthouse multiple times for you automatically. Using the minimum value is also a big improvement over not testing at all and is incredibly simple to implement, just run Lighthouse up to 5 times until it passes!
+The median Lighthouse score of 5 runs is twice as stable as 1 run, and tools like [lighthouse-ci](https://github.com/GoogleChrome/lighthouse-ci/) can run Lighthouse multiple times for you automatically.
+
+```bash
+npx -p lighthouse-ci lhci collect --url https://example.com -n 5
+npx -p lighthouse-ci lhci upload --target filesystem --outputDir ./path/to/dump/reports
+```
+
+You can then process the reports that are output to the filesystem. Read the [Lighthouse CI documentation](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#outputdir) for more.
+
+If you're running Lighthouse directly via node, you can also use the `computeMedianRun` function to determine the median using a blend of the performance metrics.
+
+```js
+const lighthouse = require('lighthouse');
+const chromeLauncher = require('chrome-launcher');
+const {computeMedianRun} = require('lighthouse/lighthouse-core/lib/median-run.js');
+
+(async () => {
+  const chrome = await chromeLauncher.launch();
+  const results = [];
+  for (let i = 0; i < 5; i++) {
+    const {lhr} = await lighthouse('http://example.com', {port: chrome.port});
+    results.push(lhr);
+  }
+
+  const median = computeMedianRun(results);
+  console.log('Median performance score was', median.categories.performance.score * 100);
+})();
+```
 
 ## Related Documentation
 

--- a/docs/variability.md
+++ b/docs/variability.md
@@ -102,11 +102,10 @@ You can then process the reports that are output to the filesystem. Read the [Li
 
 ```js
 const fs = require('fs');
-const {computeMedianRun} = require('lighthouse/lighthouse-core/lib/median-run.js');
 const lhciManifest = require('./path/to/dump/reports/manifest.json');
-const results = lhciManifest.map(entry => JSON.parse(fs.readFileSync(entry.jsonPath, 'utf-8')));
-const median = computeMedianRun(results);
-console.log('Median performance score was', median.categories.performance.score * 100);
+const medianEntry = lhciManifest.find(entry => entry.isRepresentativeRun)
+const medianResult = JSON.parse(fs.readFileSync(entry.jsonPath, 'utf-8'));
+console.log('Median performance score was', medianResult.categories.performance.score * 100);
 ```
 
 If you're running Lighthouse directly via node, you can also use the `computeMedianRun` function to determine the median using a blend of the performance metrics.

--- a/docs/variability.md
+++ b/docs/variability.md
@@ -115,6 +115,10 @@ for (let i = 0; i < 5; i++) {
     'https://example.com',
     '--output=json'
   ]);
+  if (status !== 0) {
+    console.log('Lighthouse failed, skipping run...');
+    continue;
+  }
   results.push(JSON.parse(stdout));
 }
 

--- a/docs/variability.md
+++ b/docs/variability.md
@@ -94,11 +94,20 @@ When creating your thresholds for failure, either mental or programmatic, use ag
 The median Lighthouse score of 5 runs is twice as stable as 1 run, and tools like [lighthouse-ci](https://github.com/GoogleChrome/lighthouse-ci/) can run Lighthouse multiple times for you automatically.
 
 ```bash
-npx -p lighthouse-ci lhci collect --url https://example.com -n 5
-npx -p lighthouse-ci lhci upload --target filesystem --outputDir ./path/to/dump/reports
+npx -p @lhci/cli lhci collect --url https://example.com -n 5
+npx -p @lhci/cli lhci upload --target filesystem --outputDir ./path/to/dump/reports
 ```
 
 You can then process the reports that are output to the filesystem. Read the [Lighthouse CI documentation](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#outputdir) for more.
+
+```js
+const fs = require('fs');
+const {computeMedianRun} = require('lighthouse/lighthouse-core/lib/median-run.js');
+const lhciManifest = require('./path/to/dump/reports/manifest.json');
+const results = lhciManifest.map(entry => JSON.parse(fs.readFileSync(entry.jsonPath, 'utf-8')));
+const median = computeMedianRun(results);
+console.log('Median performance score was', median.categories.performance.score * 100);
+```
 
 If you're running Lighthouse directly via node, you can also use the `computeMedianRun` function to determine the median using a blend of the performance metrics.
 

--- a/lighthouse-core/lib/median-run.js
+++ b/lighthouse-core/lib/median-run.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * @license Copyright 2020 Lighthouse Authors. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
@@ -24,7 +24,7 @@ function getMedianSortValue(lhr, medianFcp, medianInteractive) {
 
 /**
  * We want the run that's closest to the median of the FCP and the median of the TTI. 
- * We're using the squared distance for that (https://en.wikipedia.org/wiki/Euclidean_distance).
+ * We're using the Euclidean distance for that (https://en.wikipedia.org/wiki/Euclidean_distance).
  * @param {Array<LH.Result>} runs
  * @return {LH.Result|undefined}
  */

--- a/lighthouse-core/lib/median-run.js
+++ b/lighthouse-core/lib/median-run.js
@@ -23,6 +23,8 @@ function getMedianSortValue(lhr, medianFcp, medianInteractive) {
 }
 
 /**
+ * We want the run that's closest to the median of the FCP and the median of the TTI. 
+ * We're using the squared distance for that (https://en.wikipedia.org/wiki/Euclidean_distance).
  * @param {Array<LH.Result>} runs
  * @return {LH.Result|undefined}
  */

--- a/lighthouse-core/lib/median-run.js
+++ b/lighthouse-core/lib/median-run.js
@@ -10,12 +10,25 @@ const getNumericValue = (lhr, auditName) =>
   (lhr.audits[auditName] && lhr.audits[auditName].numericValue) || NaN;
 
 /**
+ * @param {Array<number>} numbers
+ * @return {number}
+ */
+function getMedianValue(numbers) {
+  const sorted = numbers.slice().sort((a, b) => a - b);
+  if (sorted.length % 2 === 1) return sorted[(sorted.length - 1) / 2];
+  const lowerValue = sorted[sorted.length / 2 - 1];
+  const upperValue = sorted[sorted.length / 2];
+  return (lowerValue + upperValue) / 2;
+}
+
+/**
  * @param {LH.Result} lhr
  * @param {number} medianFcp
  * @param {number} medianInteractive
  */
 function getMedianSortValue(lhr, medianFcp, medianInteractive) {
-  const distanceFcp = medianFcp - getNumericValue(lhr, 'first-contentful-paint');
+  const distanceFcp =
+    medianFcp - getNumericValue(lhr, 'first-contentful-paint');
   const distanceInteractive =
     medianInteractive - getNumericValue(lhr, 'interactive');
 
@@ -23,49 +36,58 @@ function getMedianSortValue(lhr, medianFcp, medianInteractive) {
 }
 
 /**
- * We want the run that's closest to the median of the FCP and the median of the TTI. 
+ * We want the run that's closest to the median of the FCP and the median of the TTI.
  * We're using the Euclidean distance for that (https://en.wikipedia.org/wiki/Euclidean_distance).
+ * We use FCP and TTI because they represent the earliest and latest moments in the page lifecycle.
+ * We avoid the median of single measures like the performance score because they can still exhibit
+ * outlier behavior at the beginning or end of load.
+ *
  * @param {Array<LH.Result>} runs
- * @return {LH.Result|undefined}
+ * @return {LH.Result}
  */
 function computeMedianRun(runs) {
-  const validRuns = runs
-    .filter(run => Number.isFinite(getNumericValue(run, 'first-contentful-paint')))
-    .filter(run => Number.isFinite(getNumericValue(run, 'interactive')));
-  if (!validRuns.length) return undefined;
-
-  const sortedByFcp = validRuns
-    .slice()
-    .sort(
-      (a, b) =>
-        getNumericValue(a, 'first-contentful-paint') -
-        getNumericValue(b, 'first-contentful-paint')
-    );
-  const medianFcp = getNumericValue(
-    sortedByFcp[Math.floor(validRuns.length / 2)],
-    'first-contentful-paint'
+  const missingFcp = runs.some(run =>
+    Number.isNaN(getNumericValue(run, 'first-contentful-paint'))
+  );
+  const missingTti = runs.some(run =>
+    Number.isNaN(getNumericValue(run, 'interactive'))
   );
 
-  const sortedByInteractive = validRuns
-    .slice()
-    .sort(
-      (a, b) =>
-        getNumericValue(a, 'interactive') - getNumericValue(b, 'interactive')
-    );
-  const medianInteractive = getNumericValue(
-    sortedByInteractive[Math.floor(validRuns.length / 2)],
-    'interactive'
+  if (!runs.length) throw new Error('No runs provided');
+  if (missingFcp) throw new Error(`Some runs were missing an FCP value`);
+  if (missingTti) throw new Error(`Some runs were missing a TTI value`);
+
+  const medianFcp = getMedianValue(
+    runs.map(run => getNumericValue(run, 'first-contentful-paint'))
   );
 
-  const sortedByProximityToMedian = validRuns
+  const medianInteractive = getMedianValue(
+    runs.map(run => getNumericValue(run, 'interactive'))
+  );
+
+  // Sort by proximity to the medians, breaking ties with the minimum TTI.
+  const sortedByProximityToMedian = runs
     .slice()
     .sort(
       (a, b) =>
         getMedianSortValue(a, medianFcp, medianInteractive) -
-        getMedianSortValue(b, medianFcp, medianInteractive)
+          getMedianSortValue(b, medianFcp, medianInteractive) ||
+        getNumericValue(a, 'interactive') - getNumericValue(b, 'interactive')
     );
 
   return sortedByProximityToMedian[0];
 }
 
-module.exports = {computeMedianRun};
+/**
+ * @param {Array<LH.Result>} runs
+ * @return {Array<LH.Result>}
+ */
+function filterToValidRuns(runs) {
+  return runs
+    .filter(run =>
+      Number.isFinite(getNumericValue(run, 'first-contentful-paint'))
+    )
+    .filter(run => Number.isFinite(getNumericValue(run, 'interactive')));
+}
+
+module.exports = {computeMedianRun, filterToValidRuns};

--- a/lighthouse-core/lib/median-run.js
+++ b/lighthouse-core/lib/median-run.js
@@ -1,0 +1,69 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/** @param {LH.Result} lhr @param {string} auditName */
+const getNumericValue = (lhr, auditName) =>
+  (lhr.audits[auditName] && lhr.audits[auditName].numericValue) || NaN;
+
+/**
+ * @param {LH.Result} lhr
+ * @param {number} medianFcp
+ * @param {number} medianInteractive
+ */
+function getMedianSortValue(lhr, medianFcp, medianInteractive) {
+  const distanceFcp = medianFcp - getNumericValue(lhr, 'first-contentful-paint');
+  const distanceInteractive =
+    medianInteractive - getNumericValue(lhr, 'interactive');
+
+  return distanceFcp * distanceFcp + distanceInteractive * distanceInteractive;
+}
+
+/**
+ * @param {Array<LH.Result>} runs
+ * @return {LH.Result|undefined}
+ */
+function computeMedianRun(runs) {
+  const validRuns = runs
+    .filter(run => Number.isFinite(getNumericValue(run, 'first-contentful-paint')))
+    .filter(run => Number.isFinite(getNumericValue(run, 'interactive')));
+  if (!validRuns.length) return undefined;
+
+  const sortedByFcp = validRuns
+    .slice()
+    .sort(
+      (a, b) =>
+        getNumericValue(a, 'first-contentful-paint') -
+        getNumericValue(b, 'first-contentful-paint')
+    );
+  const medianFcp = getNumericValue(
+    sortedByFcp[Math.floor(validRuns.length / 2)],
+    'first-contentful-paint'
+  );
+
+  const sortedByInteractive = validRuns
+    .slice()
+    .sort(
+      (a, b) =>
+        getNumericValue(a, 'interactive') - getNumericValue(b, 'interactive')
+    );
+  const medianInteractive = getNumericValue(
+    sortedByInteractive[Math.floor(validRuns.length / 2)],
+    'interactive'
+  );
+
+  const sortedByProximityToMedian = validRuns
+    .slice()
+    .sort(
+      (a, b) =>
+        getMedianSortValue(a, medianFcp, medianInteractive) -
+        getMedianSortValue(b, medianFcp, medianInteractive)
+    );
+
+  return sortedByProximityToMedian[0];
+}
+
+module.exports = {computeMedianRun};

--- a/lighthouse-core/test/lib/median-run-test.js
+++ b/lighthouse-core/test/lib/median-run-test.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * @license Copyright 2020 Lighthouse Authors. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */

--- a/lighthouse-core/test/lib/median-run-test.js
+++ b/lighthouse-core/test/lib/median-run-test.js
@@ -7,7 +7,7 @@
 
 /* eslint-env jest */
 
-const {computeMedianRun} = require('../../lib/median-run.js');
+const {computeMedianRun, filterToValidRuns} = require('../../lib/median-run.js');
 
 describe('Median Runs', () => {
   function lhr(auditNumericValues) {
@@ -19,56 +19,105 @@ describe('Median Runs', () => {
     return {audits};
   }
 
-  it('should pick the median run', () => {
-    const runs = [
-      lhr({'interactive': 100, 'first-contentful-paint': 100}),
-      lhr({'interactive': 200, 'first-contentful-paint': 200}),
-      lhr({'interactive': 300, 'first-contentful-paint': 300}),
-      lhr({'interactive': 400, 'first-contentful-paint': 400}),
-      lhr({'interactive': 500, 'first-contentful-paint': 500}),
-    ];
+  describe('computeMedianRun()', () => {
+    it('should pick the median run on an odd set', () => {
+      const runs = [
+        lhr({'interactive': 100, 'first-contentful-paint': 100}),
+        lhr({'interactive': 200, 'first-contentful-paint': 200}),
+        lhr({'interactive': 300, 'first-contentful-paint': 300}),
+        lhr({'interactive': 400, 'first-contentful-paint': 400}),
+        lhr({'interactive': 500, 'first-contentful-paint': 500}),
+      ];
 
-    expect(computeMedianRun(runs)).toEqual(runs[2]);
+      expect(computeMedianRun(runs)).toEqual(runs[2]);
+    });
+
+    it('should pick the median run on an even set', () => {
+      const runs = [
+        lhr({'interactive': 1000, 'first-contentful-paint': 400}),
+        lhr({'interactive': 2000, 'first-contentful-paint': 500}),
+        lhr({'interactive': 4000, 'first-contentful-paint': 200}),
+        lhr({'interactive': 5000, 'first-contentful-paint': 100}),
+      ];
+
+      expect(computeMedianRun(runs)).toEqual(runs[2]);
+    });
+
+    it('should pick the lower median run on an even set as tiebreaker', () => {
+      const runs = [
+        lhr({'interactive': 100, 'first-contentful-paint': 100}),
+        lhr({'interactive': 200, 'first-contentful-paint': 200}),
+        lhr({'interactive': 400, 'first-contentful-paint': 400}),
+        lhr({'interactive': 500, 'first-contentful-paint': 500}),
+      ];
+
+      expect(computeMedianRun(runs)).toEqual(runs[1]);
+    });
+
+    it('should avoid FCP outliers', () => {
+      const runs = [
+        lhr({'interactive': 100, 'first-contentful-paint': 100}),
+        lhr({'interactive': 250, 'first-contentful-paint': 400}),
+        lhr({'interactive': 300, 'first-contentful-paint': 10000}),
+        lhr({'interactive': 400, 'first-contentful-paint': 400}),
+        lhr({'interactive': 500, 'first-contentful-paint': 500}),
+      ];
+
+      expect(computeMedianRun(runs)).toEqual(runs[1]);
+    });
+
+    it('should avoid TTI outliers', () => {
+      const runs = [
+        lhr({'interactive': 100, 'first-contentful-paint': 100}),
+        lhr({'interactive': 200, 'first-contentful-paint': 200}),
+        lhr({'interactive': 10000, 'first-contentful-paint': 300}),
+        lhr({'interactive': 300, 'first-contentful-paint': 400}),
+        lhr({'interactive': 500, 'first-contentful-paint': 500}),
+      ];
+
+      expect(computeMedianRun(runs)).toEqual(runs[3]);
+    });
+
+    it('should throw on empty arrays', () => {
+      expect(() => computeMedianRun([])).toThrow();
+    });
+
+    it('should throw when missing FCP', () => {
+      expect(() => computeMedianRun([lhr({interactive: 500})])).toThrow();
+    });
+
+    it('should throw when missing TTI', () => {
+      expect(() => computeMedianRun([lhr({'first-contentful-paint': 500})])).toThrow();
+    });
+
+    it('should throw on lhrs with missing audits', () => {
+      const runs = [
+        lhr({'interactive': 100, 'first-contentful-paint': 100}),
+        lhr({'interactive': 200, 'first-contentful-paint': 200}),
+        lhr({'first-contentful-paint': 300}),
+        lhr({'interactive': 450}),
+        lhr({'interactive': 500, 'first-contentful-paint': 500}),
+      ];
+
+      expect(() => computeMedianRun(runs)).toThrow();
+    });
   });
 
-  it('should avoid FCP outliers', () => {
-    const runs = [
-      lhr({'interactive': 100, 'first-contentful-paint': 100}),
-      lhr({'interactive': 250, 'first-contentful-paint': 400}),
-      lhr({'interactive': 300, 'first-contentful-paint': 10000}),
-      lhr({'interactive': 400, 'first-contentful-paint': 400}),
-      lhr({'interactive': 500, 'first-contentful-paint': 500}),
-    ];
+  describe('filterToValidRuns()', () => {
+    it('should filter down to only runs with FCP and TTI', () => {
+      const runs = [
+        lhr({'interactive': 100, 'first-contentful-paint': 100}),
+        lhr({'interactive': 200, 'first-contentful-paint': 200}),
+        lhr({'first-contentful-paint': 300}),
+        lhr({'interactive': 450}),
+        lhr({'interactive': 500, 'first-contentful-paint': 500}),
+      ];
 
-    expect(computeMedianRun(runs)).toEqual(runs[1]);
-  });
-
-  it('should avoid TTI outliers', () => {
-    const runs = [
-      lhr({'interactive': 100, 'first-contentful-paint': 100}),
-      lhr({'interactive': 200, 'first-contentful-paint': 200}),
-      lhr({'interactive': 10000, 'first-contentful-paint': 300}),
-      lhr({'interactive': 300, 'first-contentful-paint': 400}),
-      lhr({'interactive': 500, 'first-contentful-paint': 500}),
-    ];
-
-    expect(computeMedianRun(runs)).toEqual(runs[3]);
-  });
-
-  it('should support empty arrays', () => {
-    expect(computeMedianRun([])).toEqual(undefined);
-    expect(computeMedianRun([lhr({'works-offline': 1})])).toEqual(undefined);
-  });
-
-  it('should support lhrs with missing audits', () => {
-    const runs = [
-      lhr({'interactive': 100, 'first-contentful-paint': 100}),
-      lhr({'interactive': 200, 'first-contentful-paint': 200}),
-      lhr({'first-contentful-paint': 300}),
-      lhr({'interactive': 450}),
-      lhr({'interactive': 500, 'first-contentful-paint': 500}),
-    ];
-
-    expect(computeMedianRun(runs)).toEqual(runs[1]);
+      expect(filterToValidRuns(runs)).toEqual([
+        runs[0],
+        runs[1],
+        runs[4],
+      ]);
+    });
   });
 });

--- a/lighthouse-core/test/lib/median-run-test.js
+++ b/lighthouse-core/test/lib/median-run-test.js
@@ -1,0 +1,74 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const {computeMedianRun} = require('../../lib/median-run.js');
+
+describe('Median Runs', () => {
+  function lhr(auditNumericValues) {
+    const audits = {};
+    for (const [id, numericValue] of Object.entries(auditNumericValues)) {
+      audits[id] = {numericValue};
+    }
+
+    return {audits};
+  }
+
+  it('should pick the median run', () => {
+    const runs = [
+      lhr({'interactive': 100, 'first-contentful-paint': 100}),
+      lhr({'interactive': 200, 'first-contentful-paint': 200}),
+      lhr({'interactive': 300, 'first-contentful-paint': 300}),
+      lhr({'interactive': 400, 'first-contentful-paint': 400}),
+      lhr({'interactive': 500, 'first-contentful-paint': 500}),
+    ];
+
+    expect(computeMedianRun(runs)).toEqual(runs[2]);
+  });
+
+  it('should avoid FCP outliers', () => {
+    const runs = [
+      lhr({'interactive': 100, 'first-contentful-paint': 100}),
+      lhr({'interactive': 250, 'first-contentful-paint': 400}),
+      lhr({'interactive': 300, 'first-contentful-paint': 10000}),
+      lhr({'interactive': 400, 'first-contentful-paint': 400}),
+      lhr({'interactive': 500, 'first-contentful-paint': 500}),
+    ];
+
+    expect(computeMedianRun(runs)).toEqual(runs[1]);
+  });
+
+  it('should avoid TTI outliers', () => {
+    const runs = [
+      lhr({'interactive': 100, 'first-contentful-paint': 100}),
+      lhr({'interactive': 200, 'first-contentful-paint': 200}),
+      lhr({'interactive': 10000, 'first-contentful-paint': 300}),
+      lhr({'interactive': 300, 'first-contentful-paint': 400}),
+      lhr({'interactive': 500, 'first-contentful-paint': 500}),
+    ];
+
+    expect(computeMedianRun(runs)).toEqual(runs[3]);
+  });
+
+  it('should support empty arrays', () => {
+    expect(computeMedianRun([])).toEqual(undefined);
+    expect(computeMedianRun([lhr({'works-offline': 1})])).toEqual(undefined);
+  });
+
+  it('should support lhrs with missing audits', () => {
+    const runs = [
+      lhr({'interactive': 100, 'first-contentful-paint': 100}),
+      lhr({'interactive': 200, 'first-contentful-paint': 200}),
+      lhr({'first-contentful-paint': 300}),
+      lhr({'interactive': 450}),
+      lhr({'interactive': 500, 'first-contentful-paint': 500}),
+    ];
+
+    expect(computeMedianRun(runs)).toEqual(runs[1]);
+  });
+});


### PR DESCRIPTION
**Summary**
Brings the `computeMedianRun` logic over from lighthouse CI and spruces up the docs around running multiple times.

**Related Issues/PRs**
closes https://github.com/GoogleChrome/lighthouse/issues/10825
