### PR TITLE
core: improve resilience of nodeId-dependent gatherers

### DIFF
--- a/lighthouse-cli/test/fixtures/perf/delayed-element.js
+++ b/lighthouse-cli/test/fixtures/perf/delayed-element.js
@@ -13,15 +13,14 @@ function stall(ms) {
 }
 
 /** Render large number of elements to fill up the backend node cache. */
-function rerender(iterations) {
-  const rerender_ = (i, resolve) => {
+async function rerender(iterations) {
+  const waitForAnimationFrame = () => new Promise(r => requestAnimationFrame(r))
+
+  for (let i = 0; i < iterations; i++) {
     const filler = `<div>Filler element</div>`.repeat(4000);
     document.body.innerHTML = `<div id="div-${i}">${i} left</div>${filler}`;
-    if (i === 0) resolve();
-    if (i > 0) requestAnimationFrame(() => rerender_(i - 1, resolve));
-  };
-
-  return new Promise(resolve => rerender_(iterations, resolve));
+    await waitForAnimationFrame()
+  }
 }
 
 // largest-contentful-paint-element: add the largest element later in page load

--- a/lighthouse-cli/test/fixtures/perf/delayed-element.js
+++ b/lighthouse-cli/test/fixtures/perf/delayed-element.js
@@ -6,6 +6,24 @@
 
 /* eslint-disable */
 
+/** Create long tasks on the main thread. */
+function stall(ms) {
+  const start = performance.now();
+  while (performance.now() - start < ms) ;
+}
+
+/** Render large number of elements to fill up the backend node cache. */
+function rerender(iterations) {
+  const rerender_ = (i, resolve) => {
+    const filler = `<div>Filler element</div>`.repeat(4000);
+    document.body.innerHTML = `<div id="div-${i}">${i} left</div>${filler}`;
+    if (i === 0) resolve();
+    if (i > 0) requestAnimationFrame(() => rerender_(i - 1, resolve));
+  };
+
+  return new Promise(resolve => rerender_(iterations, resolve));
+}
+
 // largest-contentful-paint-element: add the largest element later in page load
 // layout-shift-elements: shift down the `<h1>` in the page
 setTimeout(() => {
@@ -16,10 +34,16 @@ setTimeout(() => {
   const top = document.getElementById('late-content');
   top.appendChild(imgEl);
   top.appendChild(textEl);
+
+  // layout-shift-elements: ensure we can handle missing shift elements
+  if (window.location.href.includes('?missing')) {
+    stall(100); // force a long task to ensure we reach the rerendering stage
+    setTimeout(async () => {
+      await rerender(20); // rerender a large number of nodes to evict the early layout shift node
+      document.body.textContent = 'Now it is all gone!';
+    }, 50);
+  }
 }, 1000);
 
 // long-tasks: add a very long task at least 500ms
-const start = performance.now();
-while (performance.now() - start < 800) {
-  for (let i = 0; i < 1000000; i++) ;
-}
+stall(800);

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -199,9 +199,6 @@ module.exports = [
       },
     },
   },
-];
-
-module.exports = [
   {
     lhr: {
       requestedUrl: 'http://localhost:10200/perf/trace-elements.html?missing',
@@ -215,8 +212,7 @@ module.exports = [
               {
                 node: {
                   type: 'node',
-                  nodeLabel: 'img',
-                  selector: 'body > div#late-content > img',
+                  selector: 'body',
                 },
               },
             ],
@@ -233,4 +229,5 @@ module.exports = [
         },
       },
     },
-  }];
+  },
+];

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -200,3 +200,37 @@ module.exports = [
     },
   },
 ];
+
+module.exports = [
+  {
+    lhr: {
+      requestedUrl: 'http://localhost:10200/perf/trace-elements.html?missing',
+      finalUrl: 'http://localhost:10200/perf/trace-elements.html?missing',
+      audits: {
+        'largest-contentful-paint-element': {
+          score: null,
+          displayValue: '1 element found',
+          details: {
+            items: [
+              {
+                node: {
+                  type: 'node',
+                  nodeLabel: 'img',
+                  selector: 'body > div#late-content > img',
+                },
+              },
+            ],
+          },
+        },
+        'layout-shift-elements': {
+          score: null,
+          scoreDisplayMode: 'notApplicable',
+          details: {
+            items: {
+              length: 0,
+            },
+          },
+        },
+      },
+    },
+  }];

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -206,7 +206,6 @@ module.exports = [
       audits: {
         'largest-contentful-paint-element': {
           score: null,
-          displayValue: '1 element found',
           details: {
             items: [
               {
@@ -222,9 +221,7 @@ module.exports = [
           score: null,
           scoreDisplayMode: 'notApplicable',
           details: {
-            items: {
-              length: 0,
-            },
+            items: [],
           },
         },
       },

--- a/lighthouse-core/audits/largest-contentful-paint-element.js
+++ b/lighthouse-core/audits/largest-contentful-paint-element.js
@@ -68,6 +68,7 @@ class LargestContentfulPaintElement extends Audit {
 
     return {
       score: 1,
+      notApplicable: lcpElementDetails.length === 0,
       displayValue,
       details,
     };

--- a/lighthouse-core/audits/layout-shift-elements.js
+++ b/lighthouse-core/audits/layout-shift-elements.js
@@ -69,6 +69,7 @@ class LayoutShiftElements extends Audit {
 
     return {
       score: 1,
+      notApplicable: details.items.length === 0,
       displayValue,
       details,
     };

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1218,6 +1218,41 @@ class Driver {
   }
 
   /**
+   * @param {number} backendNodeId
+   * @return {Promise<string|undefined>}
+   */
+  async resolveNodeIdToObjectId(backendNodeId) {
+    try {
+      const resolveNodeResponse = await this.sendCommand('DOM.resolveNode', {backendNodeId});
+      return resolveNodeResponse.object.objectId;
+    } catch (err) {
+      if (/No node.*found/.test(err.message)) return undefined;
+      throw err;
+    }
+  }
+
+  /**
+   * @param {string} devtoolsNodePath
+   * @return {Promise<string|undefined>}
+   */
+  async resolveDevtoolsNodePathToObjectId(devtoolsNodePath) {
+    try {
+      const {nodeId} = await this.sendCommand('DOM.pushNodeByPathToFrontend', {
+        path: devtoolsNodePath,
+      });
+
+      const {object: {objectId}} = await this.sendCommand('DOM.resolveNode', {
+        nodeId,
+      });
+
+      return objectId;
+    } catch (err) {
+      if (/No node.*found/.test(err.message)) return undefined;
+      throw err;
+    }
+  }
+
+  /**
    * @param {{x: number, y: number}} position
    * @return {Promise<void>}
    */

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1218,6 +1218,9 @@ class Driver {
   }
 
   /**
+   * Resolves a backend node ID (from a trace event, protocol, etc) to the object ID for use with
+   * `Runtime.callFunctionOn`. `undefined` means the node could not be found.
+   *
    * @param {number} backendNodeId
    * @return {Promise<string|undefined>}
    */
@@ -1232,6 +1235,10 @@ class Driver {
   }
 
   /**
+   * Resolves a proprietary devtools node path (created from page-function.js) to the object ID for use
+   * with `Runtime.callFunctionOn`. `undefined` means the node could not be found.
+   * Requires `DOM.getDocument` to have been called since the object's creation or it will always be `undefined`.
+   *
    * @param {string} devtoolsNodePath
    * @return {Promise<string|undefined>}
    */

--- a/lighthouse-core/gather/gatherers/anchor-elements.js
+++ b/lighthouse-core/gather/gatherers/anchor-elements.js
@@ -86,12 +86,23 @@ function collectAnchorElements() {
 /**
  * @param {LH.Gatherer.PassContext['driver']} driver
  * @param {string} devtoolsNodePath
+ * @return {Promise<Array<{type: string}>>}
  */
 async function getEventListeners(driver, devtoolsNodePath) {
-  const {nodeId} = await driver.sendCommand('DOM.pushNodeByPathToFrontend', {
-    path: devtoolsNodePath,
-  });
+  /** @type {number|undefined} */
+  let nodeId;
+  try {
+    const response = await driver.sendCommand('DOM.pushNodeByPathToFrontend', {
+      path: devtoolsNodePath,
+    });
 
+    nodeId = response.nodeId;
+  } catch (err) {
+    if (/No node.*found/.test(err.message)) return [];
+    throw err;
+  }
+
+  if (nodeId === undefined) return [];
   const {object: {objectId = ''}} = await driver.sendCommand('DOM.resolveNode', {
     nodeId,
   });

--- a/lighthouse-core/gather/gatherers/anchor-elements.js
+++ b/lighthouse-core/gather/gatherers/anchor-elements.js
@@ -89,23 +89,8 @@ function collectAnchorElements() {
  * @return {Promise<Array<{type: string}>>}
  */
 async function getEventListeners(driver, devtoolsNodePath) {
-  /** @type {number|undefined} */
-  let nodeId;
-  try {
-    const response = await driver.sendCommand('DOM.pushNodeByPathToFrontend', {
-      path: devtoolsNodePath,
-    });
-
-    nodeId = response.nodeId;
-  } catch (err) {
-    if (/No node.*found/.test(err.message)) return [];
-    throw err;
-  }
-
-  if (nodeId === undefined) return [];
-  const {object: {objectId = ''}} = await driver.sendCommand('DOM.resolveNode', {
-    nodeId,
-  });
+  const objectId = await driver.resolveDevtoolsNodePathToObjectId(devtoolsNodePath);
+  if (!objectId) return [];
 
   const response = await driver.sendCommand('DOMDebugger.getEventListeners', {
     objectId,

--- a/lighthouse-core/gather/gatherers/trace-elements.js
+++ b/lighthouse-core/gather/gatherers/trace-elements.js
@@ -110,21 +110,6 @@ class TraceElements extends Gatherer {
   }
 
   /**
-   * @param {LH.Gatherer.PassContext['driver']} driver
-   * @param {number} backendNodeId
-   * @return {Promise<string|undefined>}
-   */
-  async resolveNodeId(driver, backendNodeId) {
-    try {
-      const resolveNodeResponse = await driver.sendCommand('DOM.resolveNode', {backendNodeId});
-      return resolveNodeResponse.object.objectId;
-    } catch (err) {
-      if (/No node.*found/.test(err.message)) return undefined;
-      throw err;
-    }
-  }
-
-  /**
    * @param {LH.Gatherer.PassContext} passContext
    * @param {LH.Gatherer.LoadData} loadData
    * @return {Promise<LH.Artifacts['TraceElements']>}
@@ -150,7 +135,7 @@ class TraceElements extends Gatherer {
     for (let i = 0; i < backendNodeIds.length; i++) {
       const metricName =
         lcpNodeId === backendNodeIds[i] ? 'largest-contentful-paint' : 'cumulative-layout-shift';
-      const objectId = await this.resolveNodeId(driver, backendNodeIds[i]);
+      const objectId = await driver.resolveNodeIdToObjectId(backendNodeIds[i]);
       if (!objectId) continue;
       const response = await driver.sendCommand('Runtime.callFunctionOn', {
         objectId,


### PR DESCRIPTION
**Summary**
There are a few gatherers that fail if the node ID fell out of memory. Adds a smoketest for the trace elements one since the CLS case is more common and reproducible than the LCP or anchor case.

Best repro: run on https://bonusi.soft-press.com/ to see that the category scores aren't `?` anymore

**Related Issues/PRs**
inspired by but does not address #10873 
fixes #10893
