### PR TITLE
misc(viewer): expose LHR as __LIGHTHOUSE_JSON__

### DIFF
--- a/lighthouse-core/report/html/report-template.html
+++ b/lighthouse-core/report/html/report-template.html
@@ -35,6 +35,7 @@ limitations under the License.
   //# sourceURL=compiled-reportrenderer.js
   </script>
   <script>window.__LIGHTHOUSE_JSON__ = %%LIGHTHOUSE_JSON%%;</script>
+  <script>console.log('window.__LIGHTHOUSE_JSON__', __LIGHTHOUSE_JSON__);</script>
   <script>
     function __initLighthouseReport__() {
       const dom = new DOM(document);

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* global DOM, ViewerUIFeatures, ReportRenderer, DragAndDrop, GithubApi, PSIApi, logger, idbKeyval, __LIGHTHOUSE_JSON__ */
+/* global DOM, ViewerUIFeatures, ReportRenderer, DragAndDrop, GithubApi, PSIApi, logger, idbKeyval */
 
 /** @typedef {import('./psi-api').PSIParams} PSIParams */
 
@@ -180,7 +180,9 @@ class LighthouseReportViewer {
     }
 
     // Install as global for easier debugging
+    // @ts-ignore
     window.__LIGHTHOUSE_JSON__ = json;
+    // eslint-disable-next-line no-console
     console.log('window.__LIGHTHOUSE_JSON__', json);
 
     this._validateReportJson(json);

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* global DOM, ViewerUIFeatures, ReportRenderer, DragAndDrop, GithubApi, PSIApi, logger, idbKeyval */
+/* global DOM, ViewerUIFeatures, ReportRenderer, DragAndDrop, GithubApi, PSIApi, logger, idbKeyval, __LIGHTHOUSE_JSON__ */
 
 /** @typedef {import('./psi-api').PSIParams} PSIParams */
 
@@ -178,6 +178,10 @@ class LighthouseReportViewer {
     if ('lhr' in json) {
       json = /** @type {LH.RunnerResult} */ (json).lhr;
     }
+
+    // Install as global for easier debugging
+    window.__LIGHTHOUSE_JSON__ = json;
+    console.log('window.__LIGHTHOUSE_JSON__', json);
 
     this._validateReportJson(json);
 


### PR DESCRIPTION
Whenever I'm hacking on the viewer i always want this feature.  

I've also added a console.log in the viewer and the normal report.  We've had users definitely appreciate learning about this global, so I think it's valuable.