### PR TITLE
deps: upgrade chrome-launcher@0.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "dependencies": {
     "axe-core": "3.5.3",
-    "chrome-launcher": "^0.13.2",
+    "chrome-launcher": "^0.13.3",
     "configstore": "^3.1.1",
     "cssstyle": "1.2.1",
     "details-element-polyfill": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,10 +1914,10 @@ chrome-devtools-frontend@1.0.727089:
   resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.727089.tgz#5663edd32b445826c51a0d6332f5072b21f7b895"
   integrity sha512-+dK4dgS3Phib4SPAaF29Vn5NxoKCnyuDNh9IRxjGk+u4P09o3IQyvQKA+43zTtV2q+HmORLJUS6F1SXqfUSpfQ==
 
-chrome-launcher@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.13.2.tgz#d61a94c33d616ff027b346ac20dad50d1209f8f7"
-  integrity sha512-zWD9RVVKd8Nx2xKGY4G08lb3nCD+2hmICxovvRE9QjBKQzHFvCYqGlsw15b4zUxLKq3wXEwVbR/yLtMbfk7JbQ==
+chrome-launcher@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.13.3.tgz#5dd72ae4e9b3de19ce3fe1941f89551c0ceb1d30"
+  integrity sha512-ovrDuFXgXS96lzeDqFPQRsczkxla+6QMvzsF+1u0mKlD1KE8EuhjdLwiDfIFedb0FSLz18RK3y6IbKu8oqA0qw==
   dependencies:
     "@types/node" "*"
     escape-string-regexp "^1.0.5"


### PR DESCRIPTION
changes

* `6a5d0c72` flags: disable background tracing (https://github.com/GoogleChrome/chrome-launcher/pull/203)
* `d9154291` chore(deps): update typescript and types (https://github.com/GoogleChrome/chrome-launcher/pull/202)
* `88e49686` test: use strict version of assert functions (https://github.com/GoogleChrome/chrome-launcher/pull/201)
