### PR TITLE
misc: use null key instead of underscore

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/duplicated-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/duplicated-javascript.js
@@ -210,7 +210,7 @@ class DuplicatedJavascript extends ByteEfficiencyAudit {
     const headings = [
       /* eslint-disable max-len */
       {key: 'source', valueType: 'code', subHeading: {key: 'url', valueType: 'url'}, label: str_(i18n.UIStrings.columnSource)},
-      {key: '_', valueType: 'bytes', subHeading: {key: 'sourceBytes'}, granularity: 0.05, label: str_(i18n.UIStrings.columnSize)},
+      {key: null, valueType: 'bytes', subHeading: {key: 'sourceBytes'}, granularity: 0.05, label: str_(i18n.UIStrings.columnSize)},
       {key: 'wastedBytes', valueType: 'bytes', granularity: 0.05, label: str_(i18n.UIStrings.columnWastedBytes)},
       /* eslint-enable max-len */
     ];


### PR DESCRIPTION
@patrickhulce pointed this out in #10746 but it hasn't landed yet so.