### PR TITLE
tests(smoke): enable expectations now that m84 is stable

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -413,33 +413,32 @@ const expectations = [
       },
     },
   },
-  // TODO: Uncomment when Chrome m84 lands
-  // {
-  //   artifacts: {
-  //     InspectorIssues: {
-  //       mixedContent: [
-  //         {
-  //           resourceType: 'Image',
-  //           resolutionStatus: 'MixedContentWarning',
-  //           insecureURL: 'http://www.mixedcontentexamples.com/Content/Test/steveholt.jpg',
-  //           mainResourceURL: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
-  //           request: {
-  //             url: 'http://www.mixedcontentexamples.com/Content/Test/steveholt.jpg',
-  //           },
-  //         },
-  //       ],
-  //     },
-  //   },
-  //   lhr: {
-  //     requestedUrl: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
-  //     finalUrl: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
-  //     audits: {
-  //       'is-on-https': {
-  //         score: 0,
-  //       },
-  //     },
-  //   },
-  // },
+  {
+    artifacts: {
+      InspectorIssues: {
+        mixedContent: [
+          {
+            resourceType: 'Image',
+            resolutionStatus: 'MixedContentWarning',
+            insecureURL: 'http://www.mixedcontentexamples.com/Content/Test/steveholt.jpg',
+            mainResourceURL: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
+            request: {
+              url: 'http://www.mixedcontentexamples.com/Content/Test/steveholt.jpg',
+            },
+          },
+        ],
+      },
+    },
+    lhr: {
+      requestedUrl: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
+      finalUrl: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
+      audits: {
+        'is-on-https': {
+          score: 0,
+        },
+      },
+    },
+  },
 ];
 
 module.exports = expectations;

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -175,16 +175,15 @@ module.exports = [
             ],
           },
         },
-        // TODO: uncomment when Chrome m84 lands
-        // 'layout-shift-elements': {
-        //   score: null,
-        //   displayValue: '2 elements found',
-        //   details: {
-        //     items: {
-        //       length: 2,
-        //     },
-        //   },
-        // },
+        'layout-shift-elements': {
+          score: null,
+          displayValue: '2 elements found',
+          details: {
+            items: {
+              length: 2,
+            },
+          },
+        },
         'long-tasks': {
           score: null,
           details: {


### PR DESCRIPTION
It'll probably be a few days before our CI is using M84, but when it's ready we can merge this.