### PR TITLE
report: fix zebra styling, sub item rows for 3p filter

### DIFF
--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -457,7 +457,7 @@ class DetailsRenderer {
     for (const item of details.items) {
       const rowsFragment = this._renderTableRowsFromItem(item, headings);
       for (const rowEl of this._dom.findAll('tr', rowsFragment)) {
-        // For zebra striping.
+        // For zebra styling.
         rowEl.classList.add(even ? 'lh-row--even' : 'lh-row--odd');
       }
       even = !even;

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -29,7 +29,7 @@
 
 /**
  * @param {HTMLTableElement} tableEl
- * @return {Array<HTMLTableRowElement>}
+ * @return {Array<HTMLElement>}
  */
 function getTableRows(tableEl) {
   return Array.from(tableEl.tBodies[0].rows);
@@ -248,29 +248,36 @@ class ReportUIFeatures {
 
       filterInput.id = id;
       filterInput.addEventListener('change', e => {
-        // Remove rows from the dom and keep track of them to re-add on uncheck.
-        // Why removing instead of hiding? To keep nth-child(even) background-colors working.
-        if (e.target instanceof HTMLInputElement && !e.target.checked) {
-          for (const row of thirdPartyRows.values()) {
-            row.remove();
-          }
-        } else {
-          // Add row elements back to original positions.
-          for (const [position, row] of thirdPartyRows.entries()) {
-            const childrenArr = getTableRows(tableEl);
-            tableEl.tBodies[0].insertBefore(row, childrenArr[position]);
-          }
+        const shouldHideThirdParty = e.target instanceof HTMLInputElement && !e.target.checked;
+        let even = true;
+        let rowEl = rowEls[0];
+        while (rowEl) {
+          const shouldHide = shouldHideThirdParty && thirdPartyRows.includes(rowEl);
+
+          // Iterate subsequent associated sub item rows.
+          do {
+            rowEl.classList.toggle('lh-row--hidden', shouldHide);
+
+            // Adjust for zebra styling.
+            rowEl.classList.remove('lh-row--even');
+            rowEl.classList.remove('lh-row--odd');
+            if (!shouldHide) rowEl.classList.add(even ? 'lh-row--even' : 'lh-row--odd');
+
+            rowEl = /** @type {HTMLElement} */ (rowEl.nextElementSibling);
+          } while (rowEl && rowEl.classList.contains('lh-sub-item-row'));
+
+          if (!shouldHide) even = !even;
         }
       });
 
       this._dom.find('label', filterTemplate).setAttribute('for', id);
       this._dom.find('.lh-3p-filter-count', filterTemplate).textContent =
-          `${thirdPartyRows.size}`;
+          `${thirdPartyRows.length}`;
       this._dom.find('.lh-3p-ui-string', filterTemplate).textContent =
           Util.i18n.strings.thirdPartyResourcesLabel;
 
-      const allThirdParty = thirdPartyRows.size === rowEls.length;
-      const allFirstParty = !thirdPartyRows.size;
+      const allThirdParty = thirdPartyRows.length === rowEls.length;
+      const allFirstParty = !thirdPartyRows.length;
 
       // If all or none of the rows are 3rd party, disable the checkbox.
       if (allThirdParty || allFirstParty) {
@@ -293,28 +300,30 @@ class ReportUIFeatures {
 
   /**
    * From a table with URL entries, finds the rows containing third-party URLs
-   * and returns a Map of those rows, mapping from row index to row Element.
+   * and returns them.
    * @param {HTMLElement[]} rowEls
    * @param {string} finalUrl
-   * @return {Map<number, HTMLElement>}
+   * @return {Array<HTMLElement>}
    */
   _getThirdPartyRows(rowEls, finalUrl) {
-    /** @type {Map<number, HTMLElement>} */
-    const thirdPartyRows = new Map();
+    /** @type {Array<HTMLElement>} */
+    const thirdPartyRows = [];
     const finalUrlRootDomain = Util.getRootDomain(finalUrl);
 
-    rowEls.forEach((rowEl, rowPosition) => {
+    for (const rowEl of rowEls) {
+      if (rowEl.classList.contains('lh-sub-item-row')) continue;
+
       /** @type {HTMLElement|null} */
       const urlItem = rowEl.querySelector('.lh-text__url');
-      if (!urlItem) return;
+      if (!urlItem) continue;
 
       const datasetUrl = urlItem.dataset.url;
-      if (!datasetUrl) return;
+      if (!datasetUrl) continue;
       const isThirdParty = Util.getRootDomain(datasetUrl) !== finalUrlRootDomain;
-      if (!isThirdParty) return;
+      if (!isThirdParty) continue;
 
-      thirdPartyRows.set(Number(rowPosition), rowEl);
-    });
+      thirdPartyRows.push(rowEl);
+    }
 
     return thirdPartyRows;
   }

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -257,11 +257,9 @@ class ReportUIFeatures {
           // Iterate subsequent associated sub item rows.
           do {
             rowEl.classList.toggle('lh-row--hidden', shouldHide);
-
             // Adjust for zebra styling.
-            rowEl.classList.remove('lh-row--even');
-            rowEl.classList.remove('lh-row--odd');
-            if (!shouldHide) rowEl.classList.add(even ? 'lh-row--even' : 'lh-row--odd');
+            rowEl.classList.toggle('lh-row--even', !shouldHide && even);
+            rowEl.classList.toggle('lh-row--odd', !shouldHide && !even);
 
             rowEl = /** @type {HTMLElement} */ (rowEl.nextElementSibling);
           } while (rowEl && rowEl.classList.contains('lh-sub-item-row'));

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1333,6 +1333,9 @@
 .lh-row--odd {
   background-color: var(--table-higlight-background-color);
 }
+.lh-row--hidden {
+  display: none;
+}
 
 .lh-table th,
 .lh-table td {

--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -134,6 +134,7 @@ describe('ReportUIFeatures', () => {
           sampleResults.audits['render-blocking-resources'].details.items[0];
         const textCompressionAuditItemTemplate =
           sampleResults.audits['uses-text-compression'].details.items[0];
+
         // Interleave first/third party URLs to test restoring order.
         lhr.audits['uses-webp-images'].details.items = [
           {
@@ -148,6 +149,53 @@ describe('ReportUIFeatures', () => {
             ...webpAuditItemTemplate,
             url: 'http://www.notexample.com/img3.jpg', // Third party, will be filtered.
           },
+        ];
+
+        // Test sub-item rows.
+        lhr.audits['unused-javascript'].details.items = [
+          {
+            ...webpAuditItemTemplate,
+            url: 'http://www.cdn.com/script1.js', // Third party, will be filtered.
+            subItems: {
+              type: 'subitems',
+              items: [
+                {source: '1', sourceBytes: 1, sourceWastedBytes: 1},
+                {source: '2', sourceBytes: 2, sourceWastedBytes: 2},
+              ],
+            },
+          },
+          {
+            ...webpAuditItemTemplate,
+            url: 'http://www.example.com/script2.js', // First party, not filtered.
+            subItems: {
+              type: 'subitems',
+              items: [
+                {source: '3', sourceBytes: 3, sourceWastedBytes: 3},
+                {source: '4', sourceBytes: 4, sourceWastedBytes: 4},
+              ],
+            },
+          },
+          {
+            ...webpAuditItemTemplate,
+            url: 'http://www.notexample.com/script3.js', // Third party, will be filtered.
+            subItems: {
+              type: 'subitems',
+              items: [
+                {source: '5', sourceBytes: 5, sourceWastedBytes: 5},
+                {source: '6', sourceBytes: 6, sourceWastedBytes: 6},
+              ],
+            },
+          },
+        ];
+        // Sample json currently doesn't have any results for `unused-javascript`, so
+        // headings is empty. Can delete this block of code if that changes.
+        expect(lhr.audits['unused-javascript'].details.headings).toHaveLength(0);
+        lhr.audits['unused-javascript'].details.headings = [
+          /* t-disable max-len */
+          {key: 'url', valueType: 'url', subHeading: {key: 'source', valueType: 'code'}},
+          {key: 'totalBytes', valueType: 'bytes', subHeading: {key: 'sourceBytes'}},
+          {key: 'wastedBytes', valueType: 'bytes', subHeading: {key: 'sourceWastedBytes'}},
+          /* eslint-enable max-len */
         ];
 
         // Only third party URLs to test that checkbox is hidden
@@ -186,7 +234,7 @@ describe('ReportUIFeatures', () => {
         container = render(lhr);
       });
 
-      it('filters out third party resources in details tables when checkbox is clicked', () => {
+      it('filters out third party resources in on click', () => {
         const filterCheckbox = dom.find('#uses-webp-images .lh-3p-filter-input', container);
 
         function getUrlsInTable() {
@@ -201,6 +249,40 @@ describe('ReportUIFeatures', () => {
         expect(getUrlsInTable()).toEqual(['/img2.jpg']);
         filterCheckbox.click();
         expect(getUrlsInTable()).toEqual(['/img1.jpg', '/img2.jpg', '/img3.jpg']);
+      });
+
+      it('filters out sub-item rows of third party resources on click', () => {
+        dom.find('#unused-javascript', container);
+        const filterCheckbox = dom.find('#unused-javascript .lh-3p-filter-input', container);
+
+        function getRowIdentifiers() {
+          return dom
+            .findAll(
+              '#unused-javascript tbody tr:not(.lh-row--hidden)', container)
+            .map(el => el.textContent);
+        }
+
+        const initialExpected = [
+          '/script1.js(www.cdn.com)24 KiB8.8 KiB',
+          '10 KiB0 KiB',
+          '20 KiB0 KiB',
+          '/script2.js(www.example.com)24 KiB8.8 KiB',
+          '30 KiB0 KiB',
+          '40 KiB0 KiB',
+          '/script3.js(www.notexample.com)24 KiB8.8 KiB',
+          '50 KiB0 KiB',
+          '60 KiB0 KiB',
+        ];
+
+        expect(getRowIdentifiers()).toEqual(initialExpected);
+        filterCheckbox.click();
+        expect(getRowIdentifiers()).toEqual([
+          '/script2.js(www.example.com)24 KiB8.8 KiB',
+          '30 KiB0 KiB',
+          '40 KiB0 KiB',
+        ]);
+        filterCheckbox.click();
+        expect(getRowIdentifiers()).toEqual(initialExpected);
       });
 
       it('adds no filter for audits in thirdPartyFilterAuditExclusions', () => {

--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -191,7 +191,8 @@ describe('ReportUIFeatures', () => {
 
         function getUrlsInTable() {
           return dom
-            .findAll('#uses-webp-images .lh-details .lh-text__url a:first-child', container)
+            .findAll(
+              '#uses-webp-images tr:not(.lh-row--hidden) .lh-text__url a:first-child', container)
             .map(el => el.textContent);
         }
 


### PR DESCRIPTION
#10867 broke the 3p filter in two significant ways: zebra styling didn't take into account the CSS class approach we now have, and sub item rows weren't filtered w/ their 3p parent row.