### PR TITLE
report: don't dim disclaimer anchor links

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -601,9 +601,6 @@
   color: var(--color-gray-600);
   margin: var(--section-padding-vertical) 0;
 }
-.lh-metrics__disclaimer a {
-  color: var(--color-gray-700);
-}
 
 .lh-calclink {
   padding-left: calc(1ex / 3);


### PR DESCRIPTION
**Summary**
Bugfix: In the viewer it is currently hard to tell that 'See calculator' is a link, as it matches the same grey as the paragraph. PR removes this styling to mach other links in the audit results (light blue)

**Before**
![before](https://user-images.githubusercontent.com/1223960/84871012-f2d71480-b077-11ea-8933-2430cfbd1db0.png)

**After**
![after](https://user-images.githubusercontent.com/1223960/84871043-fc607c80-b077-11ea-8fb5-e797cd7be14c.png)


