### PR TITLE
deps(axe-core): upgrade to 3.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "typescript": "3.8.3"
   },
   "dependencies": {
-    "axe-core": "3.5.3",
+    "axe-core": "3.5.5",
     "chrome-launcher": "^0.13.3",
     "configstore": "^3.1.1",
     "cssstyle": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,10 +1237,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.3.tgz#5b7c0ee7c5197d546bd3a07c3ef701896f5773e9"
-  integrity sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==
+axe-core@3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
+  integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
 
 axios@0.19.0:
   version "0.19.0"


### PR DESCRIPTION
Fixes most of the URLs mentioned in #10908, but I noticed this one still errors: 99acres.com/aba-cherry-county-techzone-4-greater-noida-west-npxid-r4462

Closes #10948