### PR TITLE
tests: split github workflow into multiple jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: 💡🏠
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,10 @@ jobs:
         BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
 
     - name: Upload dist
-        uses: actions/upload-artifact@v1
-        with:
-          name: dist
-          path: dist/
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist
+        path: dist/
 
   misc:
     needs: build
@@ -81,9 +81,9 @@ jobs:
     
     steps:
     - name: Download dist
-        uses: actions/download-artifact@v1
-        with:
-          name: dist
+      uses: actions/download-artifact@v1
+      with:
+        name: dist
 
     - name: git clone
       uses: actions/checkout@v2
@@ -110,9 +110,9 @@ jobs:
     
     steps:
     - name: Download dist
-        uses: actions/download-artifact@v1
-        with:
-          name: dist
+      uses: actions/download-artifact@v1
+      with:
+        name: dist
 
     - name: git clone
       uses: actions/checkout@v2
@@ -136,9 +136,9 @@ jobs:
     
     steps:
     - name: Download dist
-        uses: actions/download-artifact@v1
-        with:
-          name: dist
+      uses: actions/download-artifact@v1
+      with:
+        name: dist
 
     - name: git clone
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
     - run: sudo apt-get install xvfb
 
     - name: Smoke (stable)
-    if: matrix.chrome-channel == 'stable'
+      if: matrix.chrome-channel == 'stable'
       run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
 
     - name: Smoke (ToT)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: dist
+    
+    - run: ls -al dist
 
     - name: git clone
       uses: actions/checkout@v2
@@ -97,7 +99,6 @@ jobs:
     - run: yarn diff:sample-json
     - run: yarn type-check
     - run: yarn lint
-    - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
 
     - run: yarn test-lantern
     - run: yarn test-legacy-javascript
@@ -105,14 +106,14 @@ jobs:
     - run: yarn dogfood-lhci
   
   unit:
-    needs: build
+    # needs: build
     runs-on: ubuntu-latest
     
     steps:
-    - name: Download dist
-      uses: actions/download-artifact@v1
-      with:
-        name: dist
+    # - name: Download dist
+    #   uses: actions/download-artifact@v1
+    #   with:
+    #     name: dist
 
     - name: git clone
       uses: actions/checkout@v2
@@ -123,6 +124,8 @@ jobs:
         node-version: 10.x
 
     - run: yarn --frozen-lockfile
+
+    - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
 
     - run: sudo apt-get install xvfb
     - run: xvfb-run --auto-servernum yarn unit
@@ -152,6 +155,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
+
 
   # ci:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: 💡🏠
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:
@@ -38,6 +38,12 @@ jobs:
     - run: yarn --frozen-lockfile
     - run: yarn build-all
 
+    # Run tests that require headfull Chrome.
+    - run: sudo apt-get install xvfb
+    - run: xvfb-run --auto-servernum yarn test-clients
+    - run: xvfb-run --auto-servernum yarn test-bundle
+    - run: xvfb-run --auto-servernum yarn test-docs
+
     # Fail if any changes were written to source files (ex, from: build/build-cdt-lib.js).
     - run: git diff --exit-code
 
@@ -58,7 +64,6 @@ jobs:
         path: dist/
 
   misc:
-    needs: build
     runs-on: ubuntu-latest
     strategy:
       # e.g. if lint fails, continue to the unit tests anyway
@@ -68,27 +73,16 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Download dist
-      uses: actions/download-artifact@v1
-      with:
-        name: dist
-
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1
       with:
         node-version: 10.x
 
     - run: yarn --frozen-lockfile
+
     - run: yarn diff:sample-json
     - run: yarn type-check
     - run: yarn lint
-
-    # Run tests that require headfull Chrome.
-    - run: sudo apt-get install xvfb
-    - run: xvfb-run --auto-servernum yarn test-clients
-    - run: xvfb-run --auto-servernum yarn test-bundle
-    - run: xvfb-run --auto-servernum yarn test-docs
-
     - run: yarn test-lantern
     - run: yarn test-legacy-javascript
     - run: yarn i18n:checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,11 @@ jobs:
 
     # Run tests that require headfull Chrome.
     - run: sudo apt-get install xvfb
+    - run: ls dist
+    - run: ls dist/extension-chrome
+    - run: ls dist/extension-chrome/popup.html
+    # TODO: errors file not found `file:///home/runner/work/lighthouse/lighthouse/dist/extension-chrome/popup.html`
+    # why? artifact dist is downloaded ...
     - run: xvfb-run --auto-servernum yarn test-clients
     - run: xvfb-run --auto-servernum yarn test-bundle
     - run: xvfb-run --auto-servernum yarn test-docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - name: Set CHROME_PATH
-      run: echo ::set-env name=CHROME_PATH::$(node -e "console.log('${{ matrix.chrome-channel }}' === 'canary' ? '/home/runner/chrome-linux-tot' :: '')")
+      run: echo "::set-env name=CHROME_PATH::$(node -e 'console.log(`${{matrix.chrome-channel}}` === `canary` ? `/home/runner/chrome-linux-tot` :: '')')"
     - name: Smoke
       if: matrix.chrome-channel == 'ToT'
       run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,21 +22,6 @@ jobs:
       with:
         node-version: 10.x
 
-    # - name: Setup protoc
-    #   uses: arduino/setup-protoc@7ad700d
-    #   with:
-    #     version: '3.7.1'
-    #     repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-    # - name: Set up Python
-    #   uses: actions/setup-python@v1
-    #   with:
-    #     python-version: 2.7
-    # - name: Install Python dependencies
-    #   run: |
-    #     python -m pip install --upgrade pip
-    #     pip install protobuf==3.7.1
-
     # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
@@ -80,8 +65,6 @@ jobs:
       fail-fast: false
     
     steps:
-    
-
     - name: git clone
       uses: actions/checkout@v2
 
@@ -102,11 +85,6 @@ jobs:
 
     # Run tests that require headfull Chrome.
     - run: sudo apt-get install xvfb
-    - run: ls dist
-    - run: ls dist/extension-chrome
-    - run: ls dist/extension-chrome/popup.html
-    # TODO: errors file not found `file:///home/runner/work/lighthouse/lighthouse/dist/extension-chrome/popup.html`
-    # why? artifact dist is downloaded ...
     - run: xvfb-run --auto-servernum yarn test-clients
     - run: xvfb-run --auto-servernum yarn test-bundle
     - run: xvfb-run --auto-servernum yarn test-docs
@@ -117,15 +95,9 @@ jobs:
     - run: yarn dogfood-lhci
   
   unit:
-    # needs: build
     runs-on: ubuntu-latest
     
     steps:
-    # - name: Download dist
-    #   uses: actions/download-artifact@v1
-    #   with:
-    #     name: dist
-
     - name: git clone
       uses: actions/checkout@v2
 
@@ -155,20 +127,11 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - run: xvfb-run --auto-servernum yarn unit
-    # - run: xvfb-run --auto-servernum yarn test-clients
-    # - run: xvfb-run --auto-servernum yarn test-bundle
-    # - run: xvfb-run --auto-servernum yarn test-docs
 
   smoke:
-    # needs: build
     runs-on: ubuntu-latest
     
     steps:
-    # - name: Download dist
-    #   uses: actions/download-artifact@v1
-    #   with:
-    #     name: dist
-
     - name: git clone
       uses: actions/checkout@v2
 
@@ -181,80 +144,3 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
-
-
-  # ci:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     # e.g. if lint fails, continue to the unit tests anyway
-  #     fail-fast: false
-
-  #   steps:
-  #   - name: git clone
-  #     uses: actions/checkout@v2
-
-  #   - name: Use Node.js 10.x
-  #     uses: actions/setup-node@v1
-  #     with:
-  #       node-version: 10.x
-
-  #   - name: Setup protoc
-  #     uses: arduino/setup-protoc@7ad700d
-  #     with:
-  #       version: '3.7.1'
-  #       repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: 2.7
-  #   - name: Install Python dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install protobuf==3.7.1
-
-  #   # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
-  #   - name: Get yarn cache directory path
-  #     id: yarn-cache-dir-path
-  #     run: echo "::set-output name=dir::$(yarn cache dir)"
-  #   - name: Set up node_modules cache
-  #     uses: actions/cache@v1
-  #     id: yarn-cache
-  #     with:
-  #       path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-  #       key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-  #       restore-keys: |
-  #         ${{ runner.os }}-yarn-
-
-  #   - run: yarn --frozen-lockfile
-  #   - run: yarn build-all
-  #   - run: yarn diff:sample-json
-  #   - run: yarn type-check
-  #   - run: yarn lint
-  #   - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
-
-  #   # Run tests that require headfull Chrome.
-  #   - run: sudo apt-get install xvfb
-  #   - run: xvfb-run --auto-servernum yarn unit
-  #   - run: xvfb-run --auto-servernum yarn test-clients
-  #   - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
-  #   - run: xvfb-run --auto-servernum yarn test-bundle
-  #   - run: xvfb-run --auto-servernum yarn test-docs
-
-  #   - run: yarn test-lantern
-  #   - run: yarn test-legacy-javascript
-  #   - run: yarn i18n:checks
-  #   - run: yarn dogfood-lhci
-
-  #   # buildtracker runs `git merge-base HEAD origin/master` which needs more history than depth=1. https://github.com/paularmstrong/build-tracker/issues/106
-  #   - name: Deepen git fetch (for buildtracker)
-  #     run: git fetch --deepen=100
-  #   - name: Store in buildtracker
-  #     # TODO(paulirish): Don't allow this to fail the build. https://github.com/paularmstrong/build-tracker/issues/200
-  #     run: yarn bt-cli upload-build || true
-  #     env:
-  #       # https://buildtracker.dev/docs/guides/github-actions#configuration
-  #       BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
-
-  #   # Fail if any changes were written to source files (ex, from: build/build-cdt-lib.js).
-  #   - run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,14 +153,14 @@ jobs:
     # - run: xvfb-run --auto-servernum yarn test-docs
 
   smoke:
-    needs: build
+    # needs: build
     runs-on: ubuntu-latest
     
     steps:
-    - name: Download dist
-      uses: actions/download-artifact@v1
-      with:
-        name: dist
+    # - name: Download dist
+    #   uses: actions/download-artifact@v1
+    #   with:
+    #     name: dist
 
     - name: git clone
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,9 @@ jobs:
     - run: yarn --frozen-lockfile
 
     - run: sudo apt-get install xvfb
-
-    - name: Smoke (stable)
-      if: matrix.chrome-channel == 'stable'
-      run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
-
-    - name: Smoke (ToT)
+    - name: Set CHROME_PATH
+      run: echo ::set-env name=CHROME_PATH::$(node -e "console.log('${{ matrix.chrome-channel }}' === 'canary' ? '/home/runner/chrome-linux-tot' :: '')")
+    - name: Smoke
       if: matrix.chrome-channel == 'ToT'
       run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,10 @@ jobs:
 
   smoke:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chrome-channel: ['stable', 'ToT']
+      fail-fast: false
     
     steps:
     - name: git clone
@@ -136,6 +140,7 @@ jobs:
     
     # Chrome Stable is already installed by default.
     - name: Install Chrome ToT
+      if: matrix.chrome-channel == 'ToT'
       working-directory: /home/runner
       run: bash $GITHUB_WORKSPACE/lighthouse-core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
       env:
@@ -144,9 +149,13 @@ jobs:
     - run: yarn --frozen-lockfile
 
     - run: sudo apt-get install xvfb
+
+    - name: Smoke (stable)
+    if: matrix.chrome-channel == 'stable'
+      run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
+
     - name: Smoke (ToT)
+      if: matrix.chrome-channel == 'ToT'
       run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
       env:
         CHROME_PATH: /home/runner/chrome-linux-tot/chrome
-    - name: Smoke (stable)
-      run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - name: Set $CHROME_PATH
-      run: sh .github/workflows/set-chrome-path.sh ${{matrix.chrome-channel}}
+      run: bash .github/workflows/set-chrome-path.sh ${{matrix.chrome-channel}}
     - name: Smoke
       if: matrix.chrome-channel == 'ToT'
       run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: 💡🏠
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,15 @@ jobs:
       fail-fast: false
     
     steps:
+    
+
+    - name: git clone
+      uses: actions/checkout@v2
+
     - name: Download dist
       uses: actions/download-artifact@v1
       with:
         name: dist
-
-    - name: git clone
-      uses: actions/checkout@v2
 
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,5 +152,4 @@ jobs:
     - name: Set $CHROME_PATH
       run: bash .github/workflows/set-chrome-path.sh ${{matrix.chrome-channel}}
     - name: Smoke
-      if: matrix.chrome-channel == 'ToT'
       run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,8 @@ jobs:
     - run: yarn --frozen-lockfile
 
     - run: sudo apt-get install xvfb
-    - name: Set CHROME_PATH
-      run: echo "::set-env name=CHROME_PATH::$(node -e 'console.log(`${{matrix.chrome-channel}}` === `canary` ? `/home/runner/chrome-linux-tot` :: '')')"
+    - name: Set $CHROME_PATH
+      run: sh .github/workflows/set-chrome-path.sh ${{matrix.chrome-channel}}
     - name: Smoke
       if: matrix.chrome-channel == 'ToT'
       run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
-      env:
-        CHROME_PATH: /home/runner/chrome-linux-tot/chrome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,15 @@
 
 name: 💡🏠
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
-  ci:
-
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      # e.g. if lint fails, continue to the unit tests anyway
-      fail-fast: false
-
+    
+    # A lot of steps in common between all jobs. Can be done better when this feature lands:
+    # https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations/16851
+    # https://github.com/actions/runner/issues/438
     steps:
     - name: git clone
       uses: actions/checkout@v2
@@ -53,23 +52,9 @@ jobs:
 
     - run: yarn --frozen-lockfile
     - run: yarn build-all
-    - run: yarn diff:sample-json
-    - run: yarn type-check
-    - run: yarn lint
-    - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
 
-    # Run tests that require headfull Chrome.
-    - run: sudo apt-get install xvfb
-    - run: xvfb-run --auto-servernum yarn unit
-    - run: xvfb-run --auto-servernum yarn test-clients
-    - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
-    - run: xvfb-run --auto-servernum yarn test-bundle
-    - run: xvfb-run --auto-servernum yarn test-docs
-
-    - run: yarn test-lantern
-    - run: yarn test-legacy-javascript
-    - run: yarn i18n:checks
-    - run: yarn dogfood-lhci
+    # Fail if any changes were written to source files (ex, from: build/build-cdt-lib.js).
+    - run: git diff --exit-code
 
     # buildtracker runs `git merge-base HEAD origin/master` which needs more history than depth=1. https://github.com/paularmstrong/build-tracker/issues/106
     - name: Deepen git fetch (for buildtracker)
@@ -81,5 +66,165 @@ jobs:
         # https://buildtracker.dev/docs/guides/github-actions#configuration
         BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
 
-    # Fail if any changes were written to source files (ex, from: build/build-cdt-lib.js).
-    - run: git diff --exit-code
+    - name: Upload dist
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: dist/
+
+  misc:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      # e.g. if lint fails, continue to the unit tests anyway
+      fail-fast: false
+    
+    steps:
+    - name: Download dist
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+
+    - name: git clone
+      uses: actions/checkout@v2
+
+    - name: Use Node.js 10.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+
+    - run: yarn --frozen-lockfile
+    - run: yarn diff:sample-json
+    - run: yarn type-check
+    - run: yarn lint
+    - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
+
+    - run: yarn test-lantern
+    - run: yarn test-legacy-javascript
+    - run: yarn i18n:checks
+    - run: yarn dogfood-lhci
+  
+  unit:
+    needs: build
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Download dist
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+
+    - name: git clone
+      uses: actions/checkout@v2
+
+    - name: Use Node.js 10.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+
+    - run: yarn --frozen-lockfile
+
+    - run: sudo apt-get install xvfb
+    - run: xvfb-run --auto-servernum yarn unit
+    - run: xvfb-run --auto-servernum yarn test-clients
+    - run: xvfb-run --auto-servernum yarn test-bundle
+    - run: xvfb-run --auto-servernum yarn test-docs
+
+  smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Download dist
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+
+    - name: git clone
+      uses: actions/checkout@v2
+
+    - name: Use Node.js 10.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+
+    - run: yarn --frozen-lockfile
+
+    - run: sudo apt-get install xvfb
+    - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
+
+  # ci:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     # e.g. if lint fails, continue to the unit tests anyway
+  #     fail-fast: false
+
+  #   steps:
+  #   - name: git clone
+  #     uses: actions/checkout@v2
+
+  #   - name: Use Node.js 10.x
+  #     uses: actions/setup-node@v1
+  #     with:
+  #       node-version: 10.x
+
+  #   - name: Setup protoc
+  #     uses: arduino/setup-protoc@7ad700d
+  #     with:
+  #       version: '3.7.1'
+  #       repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: 2.7
+  #   - name: Install Python dependencies
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install protobuf==3.7.1
+
+  #   # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
+  #   - name: Get yarn cache directory path
+  #     id: yarn-cache-dir-path
+  #     run: echo "::set-output name=dir::$(yarn cache dir)"
+  #   - name: Set up node_modules cache
+  #     uses: actions/cache@v1
+  #     id: yarn-cache
+  #     with:
+  #       path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+  #       key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+  #       restore-keys: |
+  #         ${{ runner.os }}-yarn-
+
+  #   - run: yarn --frozen-lockfile
+  #   - run: yarn build-all
+  #   - run: yarn diff:sample-json
+  #   - run: yarn type-check
+  #   - run: yarn lint
+  #   - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
+
+  #   # Run tests that require headfull Chrome.
+  #   - run: sudo apt-get install xvfb
+  #   - run: xvfb-run --auto-servernum yarn unit
+  #   - run: xvfb-run --auto-servernum yarn test-clients
+  #   - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
+  #   - run: xvfb-run --auto-servernum yarn test-bundle
+  #   - run: xvfb-run --auto-servernum yarn test-docs
+
+  #   - run: yarn test-lantern
+  #   - run: yarn test-legacy-javascript
+  #   - run: yarn i18n:checks
+  #   - run: yarn dogfood-lhci
+
+  #   # buildtracker runs `git merge-base HEAD origin/master` which needs more history than depth=1. https://github.com/paularmstrong/build-tracker/issues/106
+  #   - name: Deepen git fetch (for buildtracker)
+  #     run: git fetch --deepen=100
+  #   - name: Store in buildtracker
+  #     # TODO(paulirish): Don't allow this to fail the build. https://github.com/paularmstrong/build-tracker/issues/200
+  #     run: yarn bt-cli upload-build || true
+  #     env:
+  #       # https://buildtracker.dev/docs/guides/github-actions#configuration
+  #       BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
+
+  #   # Fail if any changes were written to source files (ex, from: build/build-cdt-lib.js).
+  #   - run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,21 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 10.x
+    
+    - name: Setup protoc
+      uses: arduino/setup-protoc@7ad700d
+      with:
+        version: '3.7.1'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 2.7
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install protobuf==3.7.1
 
     - run: yarn --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,20 +22,20 @@ jobs:
       with:
         node-version: 10.x
 
-    - name: Setup protoc
-      uses: arduino/setup-protoc@7ad700d
-      with:
-        version: '3.7.1'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    # - name: Setup protoc
+    #   uses: arduino/setup-protoc@7ad700d
+    #   with:
+    #     version: '3.7.1'
+    #     repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 2.7
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install protobuf==3.7.1
+    # - name: Set up Python
+    #   uses: actions/setup-python@v1
+    #   with:
+    #     python-version: 2.7
+    # - name: Install Python dependencies
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     pip install protobuf==3.7.1
 
     # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
     - name: Get yarn cache directory path
@@ -84,8 +84,6 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: dist
-    
-    - run: ls -al dist
 
     - name: git clone
       uses: actions/checkout@v2
@@ -99,6 +97,12 @@ jobs:
     - run: yarn diff:sample-json
     - run: yarn type-check
     - run: yarn lint
+
+    # Run tests that require headfull Chrome.
+    - run: sudo apt-get install xvfb
+    - run: xvfb-run --auto-servernum yarn test-clients
+    - run: xvfb-run --auto-servernum yarn test-bundle
+    - run: xvfb-run --auto-servernum yarn test-docs
 
     - run: yarn test-lantern
     - run: yarn test-legacy-javascript
@@ -144,9 +148,9 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - run: xvfb-run --auto-servernum yarn unit
-    - run: xvfb-run --auto-servernum yarn test-clients
-    - run: xvfb-run --auto-servernum yarn test-bundle
-    - run: xvfb-run --auto-servernum yarn test-docs
+    # - run: xvfb-run --auto-servernum yarn test-clients
+    # - run: xvfb-run --auto-servernum yarn test-bundle
+    # - run: xvfb-run --auto-servernum yarn test-docs
 
   smoke:
     needs: build

--- a/.github/workflows/set-chrome-path.sh
+++ b/.github/workflows/set-chrome-path.sh
@@ -8,6 +8,6 @@
 
 if [[ "$1" == "stable" ]] ; then
   echo '::set-env name=CHROME_PATH::'
-elif [[ "$1" == "ToT" ]]
+elif [[ "$1" == "ToT" ]] ; then
   echo '::set-env name=CHROME_PATH::/home/runner/chrome-linux-tot/chrome'
 fi

--- a/.github/workflows/set-chrome-path.sh
+++ b/.github/workflows/set-chrome-path.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ##
-# @license Copyright 2017 The Lighthouse Authors. All Rights Reserved.
+# @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 ##

--- a/.github/workflows/set-chrome-path.sh
+++ b/.github/workflows/set-chrome-path.sh
@@ -6,7 +6,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 ##
 
-if [[ "$1" == "stable" ]]
+if [[ "$1" == "stable" ]] ; then
   echo '::set-env name=CHROME_PATH::'
 elif [[ "$1" == "ToT" ]]
   echo '::set-env name=CHROME_PATH::/home/runner/chrome-linux-tot/chrome'

--- a/.github/workflows/set-chrome-path.sh
+++ b/.github/workflows/set-chrome-path.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+##
+# @license Copyright 2017 The Lighthouse Authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+##
+
+if [[ "$1" == "stable" ]]
+  echo '::set-env name=CHROME_PATH::'
+elif [[ "$1" == "ToT" ]]
+  echo '::set-env name=CHROME_PATH::/home/runner/chrome-linux-tot/chrome'
+fi

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -15,7 +15,9 @@ const ChromeLauncher = require('chrome-launcher');
 const ChromeProtocol = require('../../../../lighthouse-core/gather/connections/cri.js');
 
 // Load bundle, which creates a `global.runBundledLighthouse`.
-require('../../../../dist/lighthouse-dt-bundle.js');
+// Add empty string to circumvent TS, otherwise a clean `dist/` folder
+// would result in `yarn type-check` failing.
+require('../../../../dist/lighthouse-dt-bundle.js' + '');
 
 /** @type {import('../../../../lighthouse-core/index.js')} */
 // @ts-ignore - not worth giving test global an actual type.


### PR DESCRIPTION
Splits into four jobs (with no dependencies):

* build
* unit
* smoke
* misc

Currently takes ~19 minutes to run our workflow. Now it takes ~10 minutes.

Also uploading `dist/` as a build artifact. Even though currently there are no dependent jobs requiring the usage of artifacts, making `dist/` downloadable may prove useful.