### PR TITLE
tests: leverage job dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: 💡🏠
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
 
   unit:
     runs-on: ubuntu-latest
+    needs: [build]
     strategy:
       # e.g. if lint fails, continue to the unit tests anyway
       fail-fast: false
@@ -45,6 +46,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 10.x
+
+    - name: Download dist
+      uses: actions/download-artifact@v2
+      with:
+        name: dist
+        path: dist/
 
     - run: yarn --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: 💡🏠
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   build:
@@ -31,7 +31,7 @@ jobs:
         name: dist
         path: dist/
 
-  unit:
+  test:
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
@@ -62,12 +62,23 @@ jobs:
     - run: yarn test-legacy-javascript
     - run: yarn i18n:checks
 
+
+    # Run tests that require headfull Chrome.
+    - run: sudo apt-get install xvfb
+    - name: yarn unit
+      run: xvfb-run --auto-servernum yarn unit
+    - name: yarn test-clients
+      run: xvfb-run --auto-servernum yarn test-clients
+    - name: yarn test-bundle
+      run: xvfb-run --auto-servernum yarn test-bundle
+    - name: yarn test-docs
+      run: xvfb-run --auto-servernum yarn test-docs
+
     - name: Setup protoc
       uses: arduino/setup-protoc@7ad700d
       with:
         version: '3.7.1'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
@@ -76,17 +87,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install protobuf==3.7.1
-
     - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
-
-    - run: sudo apt-get install xvfb
-    - run: xvfb-run --auto-servernum yarn unit
-
-    # Run tests that require headfull Chrome.
-    - run: sudo apt-get install xvfb
-    - run: xvfb-run --auto-servernum yarn test-clients
-    - run: xvfb-run --auto-servernum yarn test-bundle
-    - run: xvfb-run --auto-servernum yarn test-docs
 
     - run: yarn dogfood-lhci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: 💡🏠
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   build:
@@ -25,27 +25,13 @@ jobs:
     - run: yarn --frozen-lockfile
     - run: yarn build-all
 
-
-    # Fail if any changes were written to source files (ex, from: build/build-cdt-lib.js).
-    - run: git diff --exit-code
-
-    # buildtracker runs `git merge-base HEAD origin/master` which needs more history than depth=1. https://github.com/paularmstrong/build-tracker/issues/106
-    - name: Deepen git fetch (for buildtracker)
-      run: git fetch --deepen=100
-    - name: Store in buildtracker
-      # TODO(paulirish): Don't allow this to fail the build. https://github.com/paularmstrong/build-tracker/issues/200
-      run: yarn bt-cli upload-build || true
-      env:
-        # https://buildtracker.dev/docs/guides/github-actions#configuration
-        BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
-
     - name: Upload dist
       uses: actions/upload-artifact@v1
       with:
         name: dist
         path: dist/
 
-  misc:
+  unit:
     runs-on: ubuntu-latest
     strategy:
       # e.g. if lint fails, continue to the unit tests anyway
@@ -62,19 +48,12 @@ jobs:
 
     - run: yarn --frozen-lockfile
 
-    # Run tests that require headfull Chrome.
-    - run: sudo apt-get install xvfb
-    - run: xvfb-run --auto-servernum yarn test-clients
-    - run: xvfb-run --auto-servernum yarn test-bundle
-    - run: xvfb-run --auto-servernum yarn test-docs
-
     - run: yarn diff:sample-json
     - run: yarn type-check
     - run: yarn lint
     - run: yarn test-lantern
     - run: yarn test-legacy-javascript
     - run: yarn i18n:checks
-    - run: yarn dogfood-lhci
 
     - name: Setup protoc
       uses: arduino/setup-protoc@7ad700d
@@ -96,19 +75,41 @@ jobs:
     - run: sudo apt-get install xvfb
     - run: xvfb-run --auto-servernum yarn unit
 
-  # smoke:
-  #   runs-on: ubuntu-latest
+    # Run tests that require headfull Chrome.
+    - run: sudo apt-get install xvfb
+    - run: xvfb-run --auto-servernum yarn test-clients
+    - run: xvfb-run --auto-servernum yarn test-bundle
+    - run: xvfb-run --auto-servernum yarn test-docs
 
-  #   steps:
-  #   - name: git clone
-  #     uses: actions/checkout@v2
+    - run: yarn dogfood-lhci
 
-  #   - name: Use Node.js 10.x
-  #     uses: actions/setup-node@v1
-  #     with:
-  #       node-version: 10.x
+    # Fail if any changes were written to source files (ex, from: build/build-cdt-lib.js).
+    - run: git diff --exit-code
 
-  #   - run: yarn --frozen-lockfile
+    # buildtracker runs `git merge-base HEAD origin/master` which needs more history than depth=1. https://github.com/paularmstrong/build-tracker/issues/106
+    - name: Deepen git fetch (for buildtracker)
+      run: git fetch --deepen=100
+    - name: Store in buildtracker
+      # TODO(paulirish): Don't allow this to fail the build. https://github.com/paularmstrong/build-tracker/issues/200
+      run: yarn bt-cli upload-build || true
+      env:
+        # https://buildtracker.dev/docs/guides/github-actions#configuration
+        BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
 
-  #   - run: sudo apt-get install xvfb
-  #   - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
+
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: git clone
+      uses: actions/checkout@v2
+
+    - name: Use Node.js 10.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+
+    - run: yarn --frozen-lockfile
+
+    - run: sudo apt-get install xvfb
+    - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@
 
 name: 💡🏠
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     # A lot of steps in common between all jobs. Can be done better when this feature lands:
     # https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations/16851
     # https://github.com/actions/runner/issues/438
@@ -22,27 +22,9 @@ jobs:
       with:
         node-version: 10.x
 
-    # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
-    - name: Set up node_modules cache
-      uses: actions/cache@v1
-      id: yarn-cache
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-
     - run: yarn --frozen-lockfile
     - run: yarn build-all
 
-    # Run tests that require headfull Chrome.
-    - run: sudo apt-get install xvfb
-    - run: xvfb-run --auto-servernum yarn test-clients
-    - run: xvfb-run --auto-servernum yarn test-bundle
-    - run: xvfb-run --auto-servernum yarn test-docs
 
     # Fail if any changes were written to source files (ex, from: build/build-cdt-lib.js).
     - run: git diff --exit-code
@@ -68,7 +50,7 @@ jobs:
     strategy:
       # e.g. if lint fails, continue to the unit tests anyway
       fail-fast: false
-    
+
     steps:
     - name: git clone
       uses: actions/checkout@v2
@@ -80,6 +62,12 @@ jobs:
 
     - run: yarn --frozen-lockfile
 
+    # Run tests that require headfull Chrome.
+    - run: sudo apt-get install xvfb
+    - run: xvfb-run --auto-servernum yarn test-clients
+    - run: xvfb-run --auto-servernum yarn test-bundle
+    - run: xvfb-run --auto-servernum yarn test-docs
+
     - run: yarn diff:sample-json
     - run: yarn type-check
     - run: yarn lint
@@ -87,19 +75,7 @@ jobs:
     - run: yarn test-legacy-javascript
     - run: yarn i18n:checks
     - run: yarn dogfood-lhci
-  
-  unit:
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: git clone
-      uses: actions/checkout@v2
 
-    - name: Use Node.js 10.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10.x
-    
     - name: Setup protoc
       uses: arduino/setup-protoc@7ad700d
       with:
@@ -115,26 +91,24 @@ jobs:
         python -m pip install --upgrade pip
         pip install protobuf==3.7.1
 
-    - run: yarn --frozen-lockfile
-
     - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
 
     - run: sudo apt-get install xvfb
     - run: xvfb-run --auto-servernum yarn unit
 
-  smoke:
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: git clone
-      uses: actions/checkout@v2
+  # smoke:
+  #   runs-on: ubuntu-latest
 
-    - name: Use Node.js 10.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10.x
+  #   steps:
+  #   - name: git clone
+  #     uses: actions/checkout@v2
 
-    - run: yarn --frozen-lockfile
+  #   - name: Use Node.js 10.x
+  #     uses: actions/setup-node@v1
+  #     with:
+  #       node-version: 10.x
 
-    - run: sudo apt-get install xvfb
-    - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2
+  #   - run: yarn --frozen-lockfile
+
+  #   - run: sudo apt-get install xvfb
+  #   - run: xvfb-run --auto-servernum yarn smoke --debug -j=1 --retries=2

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,3 @@ proto/scripts/*_processed.json
 # require any lock file to be checked in explicitly
 yarn.lock
 
-proto/sample_v2_round_trip.json

--- a/lighthouse-core/test/test-utils.js
+++ b/lighthouse-core/test/test-utils.js
@@ -57,7 +57,7 @@ function getProtoRoundTrip() {
   let itIfProtoExists;
   try {
     sampleResultsRoundtripStr =
-      fs.readFileSync(__dirname + '/../../proto/sample_v2_round_trip.json', 'utf-8');
+      fs.readFileSync(__dirname + '/../../dist/proto/sample_v2_round_trip.json', 'utf-8');
     describeIfProtoExists = describe;
     itIfProtoExists = it;
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json",
     "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf ≥ 3.7.1 to compile the proto file.\" && false)",
-    "build-proto-roundtrip": "cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py",
+    "build-proto-roundtrip": "mkdir -p dist/proto && cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py",
     "static-server": "node lighthouse-cli/test/fixtures/static-server.js"
   },
   "devDependencies": {

--- a/proto/scripts/json_roundtrip_via_proto.py
+++ b/proto/scripts/json_roundtrip_via_proto.py
@@ -10,7 +10,7 @@ path_dir = os.path.dirname(path)
 
 path_sample_preprocessed = path_dir + '/sample_v2_processed.json'
 path_sample = path_dir + '/../../lighthouse-core/test/results/sample_v2.json'
-path_round_trip = path_dir + '/../sample_v2_round_trip.json'
+path_round_trip = path_dir + '/../../dist/proto/sample_v2_round_trip.json'
 
 def clean():
     try:


### PR DESCRIPTION
(This is a PR against #10988)

I mentioned this a while ago but you can use `job.needs` plus uploading/downloading artifacts to handle file dependencies between jobs: https://github.com/treosh/lighthouse-ci-action/issues/40

so here's the setup:

* build job
  * test job
* smoke job

the diff is kinda useless but https://github.com/GoogleChrome/lighthouse/commit/f1b68c45d613bc6d891cf1c7af79147044f22768 has real meat of it.

----------

on https://github.com/GoogleChrome/lighthouse/pull/10993/:  

1. the removal of yarn cache wfm. i wasn't ever too impressed with it. so i copied that here.
1. the smoke splitting is dope. didnt carry into this branch but we'll sort that out tomorrrow.