### PR TITLE
tests: move proto roundtrip json to .tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,3 @@ proto/scripts/*_processed.json
 # require any lock file to be checked in explicitly
 yarn.lock
 
-proto/sample_v2_round_trip.json

--- a/lighthouse-core/test/test-utils.js
+++ b/lighthouse-core/test/test-utils.js
@@ -57,7 +57,7 @@ function getProtoRoundTrip() {
   let itIfProtoExists;
   try {
     sampleResultsRoundtripStr =
-      fs.readFileSync(__dirname + '/../../proto/sample_v2_round_trip.json', 'utf-8');
+      fs.readFileSync(__dirname + '/../../dist/proto/sample_v2_round_trip.json', 'utf-8');
     describeIfProtoExists = describe;
     itIfProtoExists = it;
   } catch (err) {

--- a/lighthouse-core/test/test-utils.js
+++ b/lighthouse-core/test/test-utils.js
@@ -57,7 +57,7 @@ function getProtoRoundTrip() {
   let itIfProtoExists;
   try {
     sampleResultsRoundtripStr =
-      fs.readFileSync(__dirname + '/../../dist/proto/sample_v2_round_trip.json', 'utf-8');
+      fs.readFileSync(__dirname + '/../../.tmp/sample_v2_round_trip.json', 'utf-8');
     describeIfProtoExists = describe;
     itIfProtoExists = it;
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json",
     "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf ≥ 3.7.1 to compile the proto file.\" && false)",
-    "build-proto-roundtrip": "mkdir -p dist/proto && cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py",
+    "build-proto-roundtrip": "mkdir -p ./tmp && cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py",
     "static-server": "node lighthouse-cli/test/fixtures/static-server.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json",
     "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf ≥ 3.7.1 to compile the proto file.\" && false)",
-    "build-proto-roundtrip": "cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py",
+    "build-proto-roundtrip": "mkdir -p dist/proto && cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py",
     "static-server": "node lighthouse-cli/test/fixtures/static-server.js"
   },
   "devDependencies": {

--- a/proto/scripts/json_roundtrip_via_proto.py
+++ b/proto/scripts/json_roundtrip_via_proto.py
@@ -10,7 +10,7 @@ path_dir = os.path.dirname(path)
 
 path_sample_preprocessed = path_dir + '/sample_v2_processed.json'
 path_sample = path_dir + '/../../lighthouse-core/test/results/sample_v2.json'
-path_round_trip = path_dir + '/../sample_v2_round_trip.json'
+path_round_trip = path_dir + '/../../dist/proto/sample_v2_round_trip.json'
 
 def clean():
     try:

--- a/proto/scripts/json_roundtrip_via_proto.py
+++ b/proto/scripts/json_roundtrip_via_proto.py
@@ -10,7 +10,7 @@ path_dir = os.path.dirname(path)
 
 path_sample_preprocessed = path_dir + '/sample_v2_processed.json'
 path_sample = path_dir + '/../../lighthouse-core/test/results/sample_v2.json'
-path_round_trip = path_dir + '/../../dist/proto/sample_v2_round_trip.json'
+path_round_trip = path_dir + '/../../.tmp/sample_v2_round_trip.json'
 
 def clean():
     try:


### PR DESCRIPTION
#6183 added this file and at the time it was tracked in source control

in #10557 we added the file to gitignore

now that it's ignored, seems like it can be in `dist` rather than nestled amongst tracked files.

-------

~i went with `dist` because #10994 but i suppose if we're not sharing artifacts between builds.... perhaps~ this makes more semantic sense in `.tmp` ~?~