### PR TITLE
misc: annotate version-specific logic with COMPAT comments

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -413,7 +413,7 @@ const expectations = [
       },
     },
   },
-  // TODO: Uncomment when Chrome m84 lands
+  // TODO(COMPAT): Uncomment when Chrome m84 lands
   // {
   //   artifacts: {
   //     InspectorIssues: {

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -175,7 +175,7 @@ module.exports = [
             ],
           },
         },
-        // TODO: uncomment when Chrome m84 lands
+        // TODO(COMPAT): uncomment when Chrome m84 lands
         // 'layout-shift-elements': {
         //   score: null,
         //   displayValue: '2 elements found',

--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -37,7 +37,7 @@ class CriConnection extends Connection {
     return this._runJsonCommand('new')
       .then(response => this._connectToSocket(/** @type {LH.DevToolsJsonTarget} */(response)))
       .catch(_ => {
-        // Compat: headless didn't support `/json/new` before m59. (#970, crbug.com/699392)
+        // COMPAT: headless didn't support `/json/new` before m59. (#970, crbug.com/699392)
         // If no support, we fallback and reuse an existing open tab
         log.warn('CriConnection', 'Cannot create new tab; reusing open tab.');
         return this._runJsonCommand('list').then(tabs => {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1520,7 +1520,7 @@ class Driver {
   blockUrlPatterns(urls) {
     return this.sendCommand('Network.setBlockedURLs', {urls})
       .catch(err => {
-        // TODO: remove this handler once m59 hits stable
+        // TODO(COMPAT): remove this handler once m59 hits stable
         if (!/wasn't found/.test(err.message)) {
           throw err;
         }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -516,7 +516,7 @@ class GatherRunner {
       await passContext.driver.sendCommand('Page.getInstallabilityErrors');
 
     let errors = response.installabilityErrors;
-    // Before M82, `getInstallabilityErrors` was not localized and just english
+    // COMPAT: Before M82, `getInstallabilityErrors` was not localized and just english
     // error strings were returned. Convert the values we care about to the new error id format.
     if (!errors) {
       /** @type {string[]} */

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -49,7 +49,7 @@ function registerPerformanceObserverInPage() {
   });
 
   observer.observe({entryTypes: ['longtask']});
-  // HACK: A PerformanceObserver will be GC'd if there are no more references to it, so attach it to
+  // HACK(COMPAT): A PerformanceObserver will be GC'd if there are no more references to it, so attach it to
   // window to ensure we still receive longtask notifications. See https://crbug.com/742530.
   // For an example test of this behavior see https://gist.github.com/patrickhulce/69d8bed1807e762218994b121d06fea6.
   //   FIXME COMPAT: This hack isn't neccessary as of Chrome 62.0.3176.0

--- a/lighthouse-core/lib/tracehouse/trace-processor.js
+++ b/lighthouse-core/lib/tracehouse/trace-processor.js
@@ -26,7 +26,7 @@ const ACCEPTABLE_NAVIGATION_URL_REGEX = /^(chrome|https?):/;
 // The ideal input response latency, the time between the input task and the
 // first frame of the response.
 const BASE_RESPONSE_LATENCY = 16;
-// m71+ We added RunTask to `disabled-by-default-lighthouse`
+// COMPAT: m71+ We added RunTask to `disabled-by-default-lighthouse`
 const SCHEDULABLE_TASK_TITLE_LH = 'RunTask';
 // m69-70 DoWork is different and we now need RunTask, see https://bugs.chromium.org/p/chromium/issues/detail?id=871204#c11
 const SCHEDULABLE_TASK_TITLE_ALT1 = 'ThreadControllerImpl::RunTask';

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -364,7 +364,7 @@ describe('.beginTrace', () => {
     await driver.beginTrace();
 
     const tracingStartArgs = connectionStub.sendCommand.findInvocation('Tracing.start');
-    // m70 doesn't have disabled-by-default-lighthouse, so 'toplevel' is used instead.
+    // COMPAT: m70 doesn't have disabled-by-default-lighthouse, so 'toplevel' is used instead.
     expect(tracingStartArgs.categories).toContain('toplevel');
     expect(tracingStartArgs.categories).not.toContain('disabled-by-default-lighthouse');
   });


### PR DESCRIPTION
We had a weak convention to annotate anything with branching/specific logic to handle new/old browsers with "COMPAT"

Having it makes it easier to take inventory of the special cases we have.

We were missing a few of these.


You'll also spot some stuff we can take action on. I've kept that out of this PR, but will followup with them.