### PR TITLE
misc: add tools to track issue response time

### DIFF
--- a/lighthouse-core/scripts/internal-analysis/analyze-issues.js
+++ b/lighthouse-core/scripts/internal-analysis/analyze-issues.js
@@ -128,16 +128,15 @@ function computeAndLogReviewResponseStats(label, issues) {
     }`
   );
   console.log('  By User');
+  /** @type {Record<string, Record<string, string | number>>} */
+  const byUser = {};
   reviewsByLogin.forEach(requests => {
     const user = requests[0].assignee;
     const reviews = requests.filter(r => r.firstCommentByAssignee);
     const medianResponseTime = requests[Math.floor(reviews.length / 2)].reviewTimeInHours;
-    console.log(
-      `    ${user} - ${requests.length} requests, ${
-        reviews.length
-      } reviews, ${medianResponseTime.toFixed(1)} hours`
-    );
+    byUser[user] = {reviews: reviews.length, medianResponse: `${medianResponseTime.toFixed(1)} h`};
   });
+  console.table(byUser);
 }
 
 /**
@@ -219,12 +218,17 @@ function computeAndLogIssueResponseStats(label, issues) {
     `  Median response time of ${log.bold}${medianResponseTime.toFixed(1)} hours${log.reset}`
   );
   console.log('  By User');
+  /** @type {Record<string, Record<string, string | number>>} */
+  const byUser = {};
   responsesByLogin.forEach(responses => {
     const user = responses[0].firstResponse.login;
-    const count = responses.length;
     const medianResponseTime = responses[Math.floor(responses.length / 2)].firstResponseTimeInHours;
-    console.log(`    ${user} - ${count} responses, ${medianResponseTime.toFixed(1)} hours`);
+    byUser[user] = {
+      responses: responses.length,
+      medianResponseTime: `${medianResponseTime.toFixed(1)} hours`,
+    };
   });
+  console.table(byUser);
 }
 
 const PRS = _ISSUES_SINCE.filter(issue => issue.pull_request);

--- a/lighthouse-core/scripts/internal-analysis/analyze-issues.js
+++ b/lighthouse-core/scripts/internal-analysis/analyze-issues.js
@@ -1,0 +1,275 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const path = require('path');
+const log = require('lighthouse-logger');
+
+/**
+ * @fileoverview Used in conjunction with `./download-issues.js` to analyze our Issue and PR response times as a team.
+ *
+ * This file analyzes GitHub data that resides in `.tmp/_issues.json` primarily around *initial* response times.
+ * Future work could do something fancier around responding to replies, followup reviews, closing issues, etc.
+ *
+ * See the download script for usage information.
+ */
+
+/** @typedef {import('./download-issues.js').AugmentedGitHubIssue} AugmentedGitHubIssue */
+
+const RESPONSE_LOGINS = new Set([
+  'adamraine',
+  'Beytoven',
+  'brendankenny',
+  'connorjclark',
+  'exterkamp',
+  'jazyan',
+  'patrickhulce',
+  'paulirish',
+]);
+
+/**
+ * @param {AugmentedGitHubIssue} issue
+ * @return {AugmentedGitHubIssue}
+ */
+function normalizeIssue(issue) {
+  if (!Array.isArray(issue.comments)) issue.comments = [];
+  if (!Array.isArray(issue.events)) issue.events = [];
+  issue.comments = issue.comments.sort(
+    (a, b) =>
+      new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+  issue.events = issue.events.sort(
+    (a, b) =>
+      new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+
+  issue.comments.forEach(comment => {
+    comment.created_at = comment.created_at || comment.submitted_at || '';
+  });
+
+  return issue;
+}
+
+const RESPONSE_EVENTS = new Set(['labeled', 'assigned', 'renamed', 'closed']);
+
+const HOUR_IN_MS = 60 * 60 * 1000;
+const DAY_FILTER = 90;
+const START_AT = new Date(
+  new Date().getTime() - DAY_FILTER * 24 * HOUR_IN_MS
+).getTime();
+
+const ISSUES_PATH = path.join(__dirname, '../../../.tmp', '_issues.json');
+/** @type {Array<AugmentedGitHubIssue>} */
+const _ISSUES = JSON.parse(fs.readFileSync(ISSUES_PATH, 'utf8')).map(
+  normalizeIssue
+);
+const _ISSUES_SINCE = _ISSUES.filter(
+  issue => new Date(issue.created_at).getTime() > START_AT
+);
+const ISSUES = _ISSUES_SINCE.filter(issue => !issue.pull_request);
+
+/** @param {number} n */
+const percent = n => `${(n * 100).toFixed(1)}%`;
+
+/**
+ * This function only logs *initial* review responses, but could conceivably log all instances of applying "waiting4reviewer".
+ * @param {string} label
+ * @param {Array<AugmentedGitHubIssue>} issues
+ */
+function computeAndLogReviewResponseStats(label, issues) {
+  const initialReviewRequests = issues
+    .map(issue => {
+      const assignEvent = issue.events.find(
+        event => event.event === 'assigned'
+      );
+      const assignee =
+        (assignEvent && assignEvent.assignee && assignEvent.assignee.login) ||
+        '';
+      const firstCommentByAssignee = issue.comments.find(
+        comment => comment.user.login === assignee
+      );
+      const reviewTimeInHours = firstCommentByAssignee
+        ? (new Date(firstCommentByAssignee.created_at).getTime() -
+            new Date(issue.created_at).getTime()) /
+          HOUR_IN_MS
+        : Infinity;
+      return {
+        issue,
+        assignEvent,
+        assignee,
+        firstCommentByAssignee,
+        reviewTimeInHours,
+      };
+    })
+    .filter(review => review.assignee)
+    .sort((a, b) => a.reviewTimeInHours - b.reviewTimeInHours);
+
+  const reviews = initialReviewRequests.filter(
+    review => review.firstCommentByAssignee
+  );
+  const reviewsByLogin = Object.values(
+    initialReviewRequests.reduce(
+      (map, view) => {
+        const reviews = map[view.assignee] || [];
+        reviews.push(view);
+        map[view.assignee] = reviews;
+        return map;
+      },
+      /** @type {Record<string, typeof reviews>} */ ({})
+    )
+  ).sort((a, b) => b.length - a.length);
+
+  const responseTimeInHours = initialReviewRequests.map(r => r.reviewTimeInHours);
+  const medianResponseTime =
+    responseTimeInHours[Math.floor(reviews.length / 2)];
+  console.log(`${log.bold}${label}${log.reset}`);
+  console.log(
+    `  ${percent(
+      initialReviewRequests.length / issues.length
+    )} of PRs requested a review`
+  );
+  console.log(
+    `  ${percent(
+      reviews.length / initialReviewRequests.length
+    )} of requests received a review`
+  );
+  console.log(
+    `  Median initial response time of ${log.bold}${medianResponseTime.toFixed(
+      1
+    )} hours${log.reset}`
+  );
+  console.log('  By User');
+  reviewsByLogin.forEach(requests => {
+    const user = requests[0].assignee;
+    const reviews = requests.filter(r => r.firstCommentByAssignee);
+    const medianResponseTime = requests[Math.floor(reviews.length / 2)].reviewTimeInHours;
+    console.log(
+      `    ${user} - ${requests.length} requests, ${
+        reviews.length
+      } reviews, ${medianResponseTime.toFixed(1)} hours`
+    );
+  });
+}
+
+/**
+ * @param {string} label
+ * @param {Array<AugmentedGitHubIssue>} issues
+ */
+function computeAndLogIssueResponseStats(label, issues) {
+  /** @param {AugmentedGitHubIssue} issue @return {(e: AugmentedGitHubIssue['events'][0]) => boolean} */
+  const isEventResponse = issue => e => {
+    const isHumanResponse =
+      RESPONSE_LOGINS.has(e.actor.login) &&
+      RESPONSE_EVENTS.has(e.event) &&
+      e.actor.login !== issue.user.login;
+    const isBotClose = e.event === 'closed' && e.actor.login === 'devtools-bot';
+    return isHumanResponse || isBotClose;
+  };
+  /** @param {AugmentedGitHubIssue} issue @return {(c: AugmentedGitHubIssue['comments'][0]) => boolean} */
+  const isCommentResponse = issue => c =>
+    RESPONSE_LOGINS.has(c.user.login) && c.user.login !== issue.user.login;
+  const withResponse = issues.filter(
+    i =>
+      i.events.some(isEventResponse(i)) || i.comments.some(isCommentResponse(i))
+  );
+
+  const firstResponses = withResponse
+    .map(issue => {
+      const labelResponse = issue.events.find(isEventResponse(issue));
+      const labelResponseTs =
+        (labelResponse && new Date(labelResponse.created_at).getTime()) ||
+        Infinity;
+      const commentResponse = issue.comments.find(isCommentResponse(issue));
+      const commentResponseTs =
+        (commentResponse && new Date(commentResponse.created_at).getTime()) ||
+        Infinity;
+
+      let firstResponse = {login: '', created_at: ''};
+      if (labelResponse && labelResponseTs < commentResponseTs) {
+        firstResponse = {
+          login: labelResponse.actor.login,
+          created_at: labelResponse.created_at,
+        };
+      } else {
+        if (!commentResponse) {
+          throw new Error(
+            `Issue did not have a response:\n${JSON.stringify(issue, null, 2)}`
+          );
+        }
+        firstResponse = {
+          login: commentResponse.user.login,
+          created_at: commentResponse.created_at,
+        };
+      }
+
+      return {
+        issue,
+        labelResponse,
+        commentResponse,
+        firstResponse,
+        firstResponseTimeInHours:
+          (new Date(firstResponse.created_at).getTime() -
+            new Date(issue.created_at).getTime()) /
+          HOUR_IN_MS,
+      };
+    })
+    .sort((a, b) => a.firstResponseTimeInHours - b.firstResponseTimeInHours);
+
+  const responseTimeInHours = firstResponses.map(
+    r => r.firstResponseTimeInHours
+  );
+  const medianResponseTime =
+    responseTimeInHours[Math.floor(withResponse.length / 2)];
+
+  const responsesByLogin = Object.values(
+    firstResponses.reduce(
+      (map, response) => {
+        const responses = map[response.firstResponse.login] || [];
+        responses.push(response);
+        map[response.firstResponse.login] = responses;
+        return map;
+      },
+      /** @type {Record<string, typeof firstResponses>} */ ({})
+    )
+  ).sort((a, b) => b.length - a.length);
+
+  console.log(`${log.bold}${label}${log.reset}`);
+  console.log(
+    `  ${percent(
+      withResponse.length / issues.length
+    )} of issues received a response`
+  );
+  console.log(
+    `  Median response time of ${log.bold}${medianResponseTime.toFixed(
+      1
+    )} hours${log.reset}`
+  );
+  console.log('  By User');
+  responsesByLogin.forEach(responses => {
+    const user = responses[0].firstResponse.login;
+    const count = responses.length;
+    const medianResponseTime =
+      responses[Math.floor(responses.length / 2)].firstResponseTimeInHours;
+    console.log(
+      `    ${user} - ${count} responses, ${medianResponseTime.toFixed(1)} hours`
+    );
+  });
+}
+
+const PRS = _ISSUES_SINCE.filter(issue => issue.pull_request);
+const EXTERNAL_ISSUES = ISSUES.filter(
+  issue => !RESPONSE_LOGINS.has(issue.user.login)
+);
+const INTERNAL_ISSUES = ISSUES.filter(issue =>
+  RESPONSE_LOGINS.has(issue.user.login)
+);
+
+computeAndLogReviewResponseStats('PRs', PRS);
+computeAndLogIssueResponseStats('External Issues', EXTERNAL_ISSUES);
+computeAndLogIssueResponseStats('Team Issues', INTERNAL_ISSUES);

--- a/lighthouse-core/scripts/internal-analysis/analyze-issues.js
+++ b/lighthouse-core/scripts/internal-analysis/analyze-issues.js
@@ -33,6 +33,14 @@ const RESPONSE_LOGINS = new Set([
   'paulirish',
 ]);
 
+const RESPONSE_EVENTS = new Set(['labeled', 'assigned', 'renamed', 'closed']);
+
+// Refilter the issues for what's been *created* in the last 90 days
+// The API will be returning everything that's been touched.
+const HOUR_IN_MS = 60 * 60 * 1000;
+const DAY_FILTER = 90;
+const START_AT = new Date(new Date().getTime() - DAY_FILTER * 24 * HOUR_IN_MS).getTime();
+
 /**
  * @param {AugmentedGitHubIssue} issue
  * @return {AugmentedGitHubIssue}
@@ -41,12 +49,10 @@ function normalizeIssue(issue) {
   if (!Array.isArray(issue.comments)) issue.comments = [];
   if (!Array.isArray(issue.events)) issue.events = [];
   issue.comments = issue.comments.sort(
-    (a, b) =>
-      new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
   );
   issue.events = issue.events.sort(
-    (a, b) =>
-      new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
   );
 
   issue.comments.forEach(comment => {
@@ -56,22 +62,10 @@ function normalizeIssue(issue) {
   return issue;
 }
 
-const RESPONSE_EVENTS = new Set(['labeled', 'assigned', 'renamed', 'closed']);
-
-const HOUR_IN_MS = 60 * 60 * 1000;
-const DAY_FILTER = 90;
-const START_AT = new Date(
-  new Date().getTime() - DAY_FILTER * 24 * HOUR_IN_MS
-).getTime();
-
 const ISSUES_PATH = path.join(__dirname, '../../../.tmp', '_issues.json');
 /** @type {Array<AugmentedGitHubIssue>} */
-const _ISSUES = JSON.parse(fs.readFileSync(ISSUES_PATH, 'utf8')).map(
-  normalizeIssue
-);
-const _ISSUES_SINCE = _ISSUES.filter(
-  issue => new Date(issue.created_at).getTime() > START_AT
-);
+const _ISSUES = JSON.parse(fs.readFileSync(ISSUES_PATH, 'utf8')).map(normalizeIssue);
+const _ISSUES_SINCE = _ISSUES.filter(issue => new Date(issue.created_at).getTime() > START_AT);
 const ISSUES = _ISSUES_SINCE.filter(issue => !issue.pull_request);
 
 /** @param {number} n */
@@ -85,12 +79,8 @@ const percent = n => `${(n * 100).toFixed(1)}%`;
 function computeAndLogReviewResponseStats(label, issues) {
   const initialReviewRequests = issues
     .map(issue => {
-      const assignEvent = issue.events.find(
-        event => event.event === 'assigned'
-      );
-      const assignee =
-        (assignEvent && assignEvent.assignee && assignEvent.assignee.login) ||
-        '';
+      const assignEvent = issue.events.find(event => event.event === 'assigned');
+      const assignee = (assignEvent && assignEvent.assignee && assignEvent.assignee.login) || '';
       const firstCommentByAssignee = issue.comments.find(
         comment => comment.user.login === assignee
       );
@@ -110,9 +100,7 @@ function computeAndLogReviewResponseStats(label, issues) {
     .filter(review => review.assignee)
     .sort((a, b) => a.reviewTimeInHours - b.reviewTimeInHours);
 
-  const reviews = initialReviewRequests.filter(
-    review => review.firstCommentByAssignee
-  );
+  const reviews = initialReviewRequests.filter(review => review.firstCommentByAssignee);
   const reviewsByLogin = Object.values(
     initialReviewRequests.reduce(
       (map, view) => {
@@ -126,23 +114,18 @@ function computeAndLogReviewResponseStats(label, issues) {
   ).sort((a, b) => b.length - a.length);
 
   const responseTimeInHours = initialReviewRequests.map(r => r.reviewTimeInHours);
-  const medianResponseTime =
-    responseTimeInHours[Math.floor(reviews.length / 2)];
+  const medianResponseTime = responseTimeInHours[Math.floor(reviews.length / 2)];
   console.log(`${log.bold}${label}${log.reset}`);
   console.log(
-    `  ${percent(
-      initialReviewRequests.length / issues.length
-    )} of PRs requested a review`
+    `  ${percent(initialReviewRequests.length / issues.length)} of PRs requested a review`
   );
   console.log(
-    `  ${percent(
-      reviews.length / initialReviewRequests.length
-    )} of requests received a review`
+    `  ${percent(reviews.length / initialReviewRequests.length)} of requests received a review`
   );
   console.log(
-    `  Median initial response time of ${log.bold}${medianResponseTime.toFixed(
-      1
-    )} hours${log.reset}`
+    `  Median initial response time of ${log.bold}${medianResponseTime.toFixed(1)} hours${
+      log.reset
+    }`
   );
   console.log('  By User');
   reviewsByLogin.forEach(requests => {
@@ -175,20 +158,17 @@ function computeAndLogIssueResponseStats(label, issues) {
   const isCommentResponse = issue => c =>
     RESPONSE_LOGINS.has(c.user.login) && c.user.login !== issue.user.login;
   const withResponse = issues.filter(
-    i =>
-      i.events.some(isEventResponse(i)) || i.comments.some(isCommentResponse(i))
+    i => i.events.some(isEventResponse(i)) || i.comments.some(isCommentResponse(i))
   );
 
   const firstResponses = withResponse
     .map(issue => {
       const labelResponse = issue.events.find(isEventResponse(issue));
       const labelResponseTs =
-        (labelResponse && new Date(labelResponse.created_at).getTime()) ||
-        Infinity;
+        (labelResponse && new Date(labelResponse.created_at).getTime()) || Infinity;
       const commentResponse = issue.comments.find(isCommentResponse(issue));
       const commentResponseTs =
-        (commentResponse && new Date(commentResponse.created_at).getTime()) ||
-        Infinity;
+        (commentResponse && new Date(commentResponse.created_at).getTime()) || Infinity;
 
       let firstResponse = {login: '', created_at: ''};
       if (labelResponse && labelResponseTs < commentResponseTs) {
@@ -198,9 +178,7 @@ function computeAndLogIssueResponseStats(label, issues) {
         };
       } else {
         if (!commentResponse) {
-          throw new Error(
-            `Issue did not have a response:\n${JSON.stringify(issue, null, 2)}`
-          );
+          throw new Error(`Issue did not have a response:\n${JSON.stringify(issue, null, 2)}`);
         }
         firstResponse = {
           login: commentResponse.user.login,
@@ -214,18 +192,14 @@ function computeAndLogIssueResponseStats(label, issues) {
         commentResponse,
         firstResponse,
         firstResponseTimeInHours:
-          (new Date(firstResponse.created_at).getTime() -
-            new Date(issue.created_at).getTime()) /
+          (new Date(firstResponse.created_at).getTime() - new Date(issue.created_at).getTime()) /
           HOUR_IN_MS,
       };
     })
     .sort((a, b) => a.firstResponseTimeInHours - b.firstResponseTimeInHours);
 
-  const responseTimeInHours = firstResponses.map(
-    r => r.firstResponseTimeInHours
-  );
-  const medianResponseTime =
-    responseTimeInHours[Math.floor(withResponse.length / 2)];
+  const responseTimeInHours = firstResponses.map(r => r.firstResponseTimeInHours);
+  const medianResponseTime = responseTimeInHours[Math.floor(withResponse.length / 2)];
 
   const responsesByLogin = Object.values(
     firstResponses.reduce(
@@ -240,35 +214,22 @@ function computeAndLogIssueResponseStats(label, issues) {
   ).sort((a, b) => b.length - a.length);
 
   console.log(`${log.bold}${label}${log.reset}`);
+  console.log(`  ${percent(withResponse.length / issues.length)} of issues received a response`);
   console.log(
-    `  ${percent(
-      withResponse.length / issues.length
-    )} of issues received a response`
-  );
-  console.log(
-    `  Median response time of ${log.bold}${medianResponseTime.toFixed(
-      1
-    )} hours${log.reset}`
+    `  Median response time of ${log.bold}${medianResponseTime.toFixed(1)} hours${log.reset}`
   );
   console.log('  By User');
   responsesByLogin.forEach(responses => {
     const user = responses[0].firstResponse.login;
     const count = responses.length;
-    const medianResponseTime =
-      responses[Math.floor(responses.length / 2)].firstResponseTimeInHours;
-    console.log(
-      `    ${user} - ${count} responses, ${medianResponseTime.toFixed(1)} hours`
-    );
+    const medianResponseTime = responses[Math.floor(responses.length / 2)].firstResponseTimeInHours;
+    console.log(`    ${user} - ${count} responses, ${medianResponseTime.toFixed(1)} hours`);
   });
 }
 
 const PRS = _ISSUES_SINCE.filter(issue => issue.pull_request);
-const EXTERNAL_ISSUES = ISSUES.filter(
-  issue => !RESPONSE_LOGINS.has(issue.user.login)
-);
-const INTERNAL_ISSUES = ISSUES.filter(issue =>
-  RESPONSE_LOGINS.has(issue.user.login)
-);
+const EXTERNAL_ISSUES = ISSUES.filter(issue => !RESPONSE_LOGINS.has(issue.user.login));
+const INTERNAL_ISSUES = ISSUES.filter(issue => RESPONSE_LOGINS.has(issue.user.login));
 
 computeAndLogReviewResponseStats('PRs', PRS);
 computeAndLogIssueResponseStats('External Issues', EXTERNAL_ISSUES);

--- a/lighthouse-core/scripts/internal-analysis/download-issues.js
+++ b/lighthouse-core/scripts/internal-analysis/download-issues.js
@@ -5,9 +5,13 @@
  */
 'use strict';
 
+/* eslint-disable no-console */
+
 /**
  * @fileoverview Used in conjunction with `./analyze-issues.js` to analyze our Issue and PR response times
  * as a team. This file downloads GitHub data to `.tmp/_issues.json` for analysis.
+ * _issues.json holds data on all issues for the last DAY_FILTER (90) days.
+ * Any comments and events are then fetched separately and added to their parent issue's object.
  *
  * Usage
  *
@@ -68,7 +72,7 @@ async function fetchAndInjectComments(issue) {
   const comments = await response.json();
   issue.comments = comments;
   if (!Array.isArray(issue.comments)) {
-    console.warn('Comments was not an array', issue.comments); // eslint-disable-line no-console
+    console.warn('Comments was not an array', issue.comments);
     issue.comments = [];
   }
 
@@ -110,12 +114,12 @@ async function downloadIssues(urlToStartAt) {
   for (const issue of issues) {
     await Promise.all([
       fetchAndInjectEvents(issue).catch(async err => {
-        console.error('Events failed! Trying again', err); // eslint-disable-line no-console
+        console.error('Events failed! Trying again', err);
         await wait(60 * 1000);
         return fetchAndInjectEvents(issue);
       }),
       fetchAndInjectComments(issue).catch(async err => {
-        console.error('Comments failed! Trying again', err); // eslint-disable-line no-console
+        console.error('Comments failed! Trying again', err);
         await wait(60 * 1000);
         return fetchAndInjectComments(issue);
       }),

--- a/lighthouse-core/scripts/internal-analysis/download-issues.js
+++ b/lighthouse-core/scripts/internal-analysis/download-issues.js
@@ -1,0 +1,136 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Used in conjunction with `./analyze-issues.js` to analyze our Issue and PR response times
+ * as a team. This file downloads GitHub data to `.tmp/_issues.json` for analysis.
+ *
+ * Usage
+ *
+ * export GH_TOKEN=<your personal github token> # needed to get around API rate limits
+ * node ./lighthouse-core/scripts/internal-analysis/download-issues.js
+ * node ./lighthouse-core/scripts/internal-analysis/analyze-issues.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const fetch = require('isomorphic-fetch');
+
+const DAY_FILTER = 90;
+const HOUR_IN_MS = 60 * 60 * 1000;
+const START_FROM = new Date(
+  new Date().getTime() - DAY_FILTER * 24 * HOUR_IN_MS
+);
+const GITHUB_API = 'https://api.github.com/';
+const HEADERS = {Authorization: `token ${process.env.GH_TOKEN}`};
+
+/**
+ * @typedef AugmentedGitHubIssue
+ * @property {string} title
+ * @property {string} url
+ * @property {string} events_url
+ * @property {string} comments_url
+ * @property {string} created_at
+ * @property {'MEMBER'|'NONE'|'FIRST_TIME_CONTRIBUTOR'} author_association
+ * @property {{login: string}} user
+ * @property {{login: string}} [assigne]
+ * @property {{}} [pull_request]
+ * @property {Array<{body: string, user: {login: string}, submitted_at?: string, created_at: string}>} comments
+ * @property {Array<{event: 'labeled'|'unlabeled'|'closed'|'assigned', actor: {login: string}, assignee?: {login: string}, label?: {name: string}, created_at: string}>} events
+ */
+
+/** @param {number} ms @return {Promise<void>} */
+function wait(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+/**
+ * @param {AugmentedGitHubIssue} issue
+ */
+async function fetchAndInjectEvents(issue) {
+  process.stdout.write(`Fetching ${issue.events_url}...\n`);
+  const response = await fetch(issue.events_url, {headers: HEADERS});
+  const events = await response.json();
+  issue.events = events;
+}
+
+/**
+ * @param {AugmentedGitHubIssue} issue
+ */
+async function fetchAndInjectComments(issue) {
+  process.stdout.write(`Fetching ${issue.comments_url}...\n`);
+  const response = await fetch(issue.comments_url, {headers: HEADERS});
+  if (!response.ok) throw new Error(`Invalid API response: ${await response.text()}`);
+  const comments = await response.json();
+  issue.comments = comments;
+  if (!Array.isArray(issue.comments)) {
+    console.warn('Comments was not an array', issue.comments); // eslint-disable-line no-console
+    issue.comments = [];
+  }
+
+  if (issue.pull_request) {
+    const prCommentsUrl = issue.comments_url
+      .replace('/issues/', '/pulls/')
+      .replace('/comments', '/reviews');
+    process.stdout.write(`Fetching ${prCommentsUrl}...\n`);
+    const response = await fetch(prCommentsUrl, {headers: HEADERS});
+    if (!response.ok) throw new Error(`Invalid API response: ${await response.text()}`);
+    const comments = await response.json();
+    issue.comments = issue.comments.concat(comments);
+  }
+}
+
+/**
+ * @param {string} [urlToStartAt]
+ * @return {Promise<Array<AugmentedGitHubIssue>>}
+ */
+async function downloadIssues(urlToStartAt) {
+  const url = new URL(`/repos/GoogleChrome/lighthouse/issues`, GITHUB_API);
+  url.searchParams.set('state', 'all');
+  url.searchParams.set('since', START_FROM.toISOString());
+  const urlToFetch = urlToStartAt || url.href;
+  process.stdout.write(`Fetching ${urlToFetch}...\n`);
+  const response = await fetch(urlToFetch, {headers: HEADERS});
+  if (!response.ok) throw new Error(`Invalid API response: ${await response.text()}`);
+  /** @type {Array<AugmentedGitHubIssue>} */
+  const issues = await response.json();
+  const linkHeader = response.headers.get('link') || '';
+  const nextLink = linkHeader
+    .split(',')
+    .find(link => link.split(';')[1].includes('rel="next"'));
+  const nextUrlMatch = (nextLink && nextLink.match(/<(https.*?)>/)) || [];
+  const nextUrl = nextUrlMatch[1] || '';
+  const restOfIssues = nextUrl ? await downloadIssues(nextUrl) : [];
+
+  // Yes really do this in series to avoid hitting abuse limits of GitHub API
+  for (const issue of issues) {
+    await Promise.all([
+      fetchAndInjectEvents(issue).catch(async err => {
+        console.error('Events failed! Trying again', err); // eslint-disable-line no-console
+        await wait(60 * 1000);
+        return fetchAndInjectEvents(issue);
+      }),
+      fetchAndInjectComments(issue).catch(async err => {
+        console.error('Comments failed! Trying again', err); // eslint-disable-line no-console
+        await wait(60 * 1000);
+        return fetchAndInjectComments(issue);
+      }),
+    ]);
+  }
+
+  return [...issues, ...restOfIssues];
+}
+
+async function go() {
+  const issues = await downloadIssues();
+  fs.writeFileSync(
+    path.join(__dirname, '../../../.tmp', '_issues.json'),
+    JSON.stringify(issues, null, 2)
+  );
+}
+
+go();


### PR DESCRIPTION
**Summary**
Adds some tooling to measure our issue and PR response times. As for OKR purposes, I'm not sure we can get much better on initial response time for external issues. Our median response time is <2 hours which for a project this size across global timezones despite a mostly US team, is pretty dang low. I suspect that followup work to handle iterative responses will be where we find room for improvement.

Limitations:
- Only measures *initial* response times.
- Can't really account for situations where someone "takes over" review of a PR before the original assignee reviews. The new reviewer doesn't get credit for that review and the old reviewer gets unfairly labeled as not responding.
- Probably more.

```bash
Example Output

PRs
  93.4% of PRs requested a review
  72.8% of requests received a review
  Median initial response time of 14.9 hours
  By User...
External Issues
  94.7% of issues received a response
  Median response time of 1.9 hours
  By User...
Team Issues
  74.1% of issues received a response
  Median response time of 2.0 hours
  By User...
```