### PR TITLE
core(renderer): display 'n/a' as the score for categories with entirely n/a audits

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -328,7 +328,6 @@ class CategoryRenderer {
     const tmpl = this.dom.cloneTemplate('#tmpl-lh-gauge', this.templateContext);
     const wrapper = /** @type {HTMLAnchorElement} */ (this.dom.find('.lh-gauge__wrapper', tmpl));
     wrapper.href = `#${category.id}`;
-    wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
 
     if (Util.isPluginCategory(category.id)) {
       wrapper.classList.add('lh-gauge__wrapper--plugin');
@@ -350,8 +349,31 @@ class CategoryRenderer {
       percentageEl.title = Util.i18n.strings.errorLabel;
     }
 
+    if (this.hasApplicableAudits(category)) {
+      wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
+    } else {
+      // render gray n/a for entirely non-applicable categories
+      percentageEl.textContent = 'n/a';
+      percentageEl.style.color = '#757575';
+      percentageEl.title = Util.i18n.strings.notApplicableAuditsGroupTitle;
+    }
+
     this.dom.find('.lh-gauge__label', tmpl).textContent = category.title;
     return tmpl;
+  }
+
+  /**
+   * Returns true if an LH category has any non-"notApplicable" audits.
+   * @param {LH.ReportResult.Category} category
+   * @return {Boolean}
+   */
+  hasApplicableAudits(category) {
+    for (const auditRef of category.auditRefs) {
+      if (auditRef.result.scoreDisplayMode !== 'notApplicable') {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -212,24 +212,63 @@ describe('CategoryRenderer', () => {
         'no manual description');
   });
 
-  it('renders not applicable audits if the category contains them', () => {
-    const a11yCategory = sampleResults.categories.accessibility;
-    const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
-    assert.ok(categoryDOM.querySelector(
+  describe('categories with not applicable audits', () => {
+    let a11yCategory;
+
+    beforeEach(()=> {
+      a11yCategory = sampleResults.categories.accessibility;
+    });
+
+    it('renders not applicable audits if the category contains them', () => {
+      const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
+      assert.ok(categoryDOM.querySelector(
         '.lh-clump--notapplicable .lh-audit-group__summary'));
 
-    const notApplicableCount = a11yCategory.auditRefs.reduce((sum, audit) =>
+      const notApplicableCount = a11yCategory.auditRefs.reduce((sum, audit) =>
         sum += audit.result.scoreDisplayMode === 'notApplicable' ? 1 : 0, 0);
-    assert.equal(
-      categoryDOM.querySelectorAll('.lh-clump--notapplicable .lh-audit').length,
-      notApplicableCount,
-      'score shows informative and dash icon'
-    );
+      assert.equal(
+        categoryDOM.querySelectorAll('.lh-clump--notapplicable .lh-audit').length,
+        notApplicableCount,
+        'score shows informative and dash icon'
+      );
 
-    const bestPracticeCat = sampleResults.categories['best-practices'];
-    const categoryDOM2 = renderer.render(bestPracticeCat, sampleResults.categoryGroups);
-    assert.ok(!categoryDOM2.querySelector('.lh-clump--notapplicable'));
+      const bestPracticeCat = sampleResults.categories['best-practices'];
+      const categoryDOM2 = renderer.render(bestPracticeCat, sampleResults.categoryGroups);
+      assert.ok(!categoryDOM2.querySelector('.lh-clump--notapplicable'));
+    });
+
+    it('renders an n/a score if the category contains 0 applicable audits', () => {
+      for (const auditRef of a11yCategory.auditRefs) {
+        auditRef.result.scoreDisplayMode = 'notApplicable';
+      }
+
+      const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
+      const percentageEl = categoryDOM.querySelectorAll('[title="Not applicable"]');
+
+      assert.equal(
+        percentageEl[0].textContent,
+        'n/a',
+        'score shows n/a'
+      );
+    });
+
+    it('renders a non-n/a score if the category contains at least 1 applicable audit', () => {
+      for (const auditRef of a11yCategory.auditRefs) {
+        auditRef.result.scoreDisplayMode = 'notApplicable';
+      }
+      a11yCategory.auditRefs[0].result.scoreDisplayMode = 'numeric';
+
+      const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
+      const percentageEl = categoryDOM.querySelectorAll('.lh-gauge__percentage');
+
+      assert.equal(
+        percentageEl[0].textContent,
+        '65',
+        'score shows a non-n/a value'
+      );
+    });
   });
+
 
   describe('category with groups', () => {
     let category;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
This PR closes issue [#7263 ](https://github.com/GoogleChrome/lighthouse/issues/7623) by updating the functionality of ```renderScoreGauge``` to show ```n/a``` in cases where all audits in a category have their ```scoreDisplayMode``` marked as ```notApplicable```. Two tests have been added to reflect this change.

**TODO**
For the updated design, I used an arbitrary gray value for the text color, so that should be changed before this can be merged.

_Screenshot 1_
![Not Applicable Design](https://user-images.githubusercontent.com/66381097/85645371-23621400-b65f-11ea-9818-b7ae25456610.PNG)

_Screenshot 2_
![Not Applicable Design 2](https://user-images.githubusercontent.com/66381097/85645375-278e3180-b65f-11ea-8210-edc5c193a183.PNG)

**Related Issues/PRs**
[#7263 ](https://github.com/GoogleChrome/lighthouse/issues/7623)
