### PR TITLE
report: use dash gauge for categories with entirely n/a audits

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -352,7 +352,7 @@ class CategoryRenderer {
     if (this.hasApplicableAudits(category)) {
       wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
     } else {
-      // Render gray dash for entirely non-applicable categories.
+      // Render a gray dash for entirely non-applicable categories.
       wrapper.classList.add(`lh-gauge__wrapper--notapplicable`);
       percentageEl.textContent = '-';
       percentageEl.style.color = '#757575';

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -352,9 +352,9 @@ class CategoryRenderer {
     if (this.hasApplicableAudits(category)) {
       wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
     } else {
-      // Render gray n/a for entirely non-applicable categories.
+      // Render gray dash for entirely non-applicable categories.
       wrapper.classList.add(`lh-gauge__wrapper--notapplicable`);
-      percentageEl.textContent = 'n/a';
+      percentageEl.textContent = '-';
       percentageEl.style.color = '#757575';
       percentageEl.title = Util.i18n.strings.notApplicableAuditsGroupTitle;
     }

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -355,7 +355,6 @@ class CategoryRenderer {
       // Render a gray dash for entirely non-applicable categories.
       wrapper.classList.add(`lh-gauge__wrapper--notapplicable`);
       percentageEl.textContent = '-';
-      percentageEl.style.color = '#757575';
       percentageEl.title = Util.i18n.strings.notApplicableAuditsGroupTitle;
     }
 

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -353,6 +353,7 @@ class CategoryRenderer {
       wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
     } else {
       // Render gray n/a for entirely non-applicable categories.
+      wrapper.classList.add(`lh-gauge__wrapper--notapplicable`);
       percentageEl.textContent = 'n/a';
       percentageEl.style.color = '#757575';
       percentageEl.title = Util.i18n.strings.notApplicableAuditsGroupTitle;

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -353,7 +353,7 @@ class CategoryRenderer {
       wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
     } else {
       // Render a gray dash for entirely non-applicable categories.
-      wrapper.classList.add(`lh-gauge__wrapper--notapplicable`);
+      wrapper.classList.add(`lh-gauge__wrapper--not-applicable`);
       percentageEl.textContent = '-';
       percentageEl.title = Util.i18n.strings.notApplicableAuditsGroupTitle;
     }

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -352,7 +352,7 @@ class CategoryRenderer {
     if (this.hasApplicableAudits(category)) {
       wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
     } else {
-      // render gray n/a for entirely non-applicable categories
+      // Render gray n/a for entirely non-applicable categories.
       percentageEl.textContent = 'n/a';
       percentageEl.style.color = '#757575';
       percentageEl.title = Util.i18n.strings.notApplicableAuditsGroupTitle;
@@ -365,15 +365,10 @@ class CategoryRenderer {
   /**
    * Returns true if an LH category has any non-"notApplicable" audits.
    * @param {LH.ReportResult.Category} category
-   * @return {Boolean}
+   * @return {boolean}
    */
   hasApplicableAudits(category) {
-    for (const auditRef of category.auditRefs) {
-      if (auditRef.result.scoreDisplayMode !== 'notApplicable') {
-        return true;
-      }
-    }
-    return false;
+    return category.auditRefs.some(ref => ref.result.scoreDisplayMode !== 'notApplicable');
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -328,7 +328,6 @@ class CategoryRenderer {
     const tmpl = this.dom.cloneTemplate('#tmpl-lh-gauge', this.templateContext);
     const wrapper = /** @type {HTMLAnchorElement} */ (this.dom.find('.lh-gauge__wrapper', tmpl));
     wrapper.href = `#${category.id}`;
-    wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
 
     if (Util.isPluginCategory(category.id)) {
       wrapper.classList.add('lh-gauge__wrapper--plugin');
@@ -350,8 +349,31 @@ class CategoryRenderer {
       percentageEl.title = Util.i18n.strings.errorLabel;
     }
 
+    if (this.hasApplicableAudits(category)) {
+      wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
+    } else {
+      // render gray n/a for entirely non-applicable categories
+      percentageEl.textContent = 'n/a';
+      percentageEl.style.color = '#757575';
+      percentageEl.title = Util.i18n.strings.notApplicableAuditsGroupTitle;
+    }
+
     this.dom.find('.lh-gauge__label', tmpl).textContent = category.title;
     return tmpl;
+  }
+
+  /**
+   * Returns true if an LH category has any non-"notApplicable" audits.
+   * @param {LH.ReportResult.Category} category
+   * @return {Boolean}
+   */
+  hasApplicableAudits(category) {
+    for (const auditRef of category.auditRefs) {
+      if (auditRef.result.scoreDisplayMode !== 'notApplicable') {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -349,10 +349,10 @@ class CategoryRenderer {
       percentageEl.title = Util.i18n.strings.errorLabel;
     }
 
-    if (this.hasApplicableAudits(category)) {
+    // Render a numerical score if the category has applicable audits, or no audits whatsoever.
+    if (category.auditRefs.length === 0 || this.hasApplicableAudits(category)) {
       wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
     } else {
-      // Render a gray dash for entirely non-applicable categories.
       wrapper.classList.add(`lh-gauge__wrapper--not-applicable`);
       percentageEl.textContent = '-';
       percentageEl.title = Util.i18n.strings.notApplicableAuditsGroupTitle;

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -69,7 +69,7 @@
   --color-informative: var(--color-blue-900);
   --color-pass-secondary: var(--color-green-700);
   --color-pass: var(--color-green);
-  --color-notapplicable: var(--color-gray-600);
+  --color-not-applicable: var(--color-gray-600);
 
   /* Component variables */
   --audit-description-padding-left: calc(var(--score-icon-size) + var(--score-icon-margin-left) + var(--score-icon-margin-right));
@@ -1064,8 +1064,10 @@
   stroke: var(--color-fail);
 }
 
-.lh-gauge__wrapper--notapplicable {
-  color: var(--color-notapplicable);
+.lh-gauge__wrapper--not-applicable {
+  color: var(--color-not-applicable);
+  fill: var(--color-not-applicable);
+  stroke: var(--color-not-applicable);
 }
 
 .lh-gauge {

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -69,6 +69,7 @@
   --color-informative: var(--color-blue-900);
   --color-pass-secondary: var(--color-green-700);
   --color-pass: var(--color-green);
+  --color-notapplicable: var(--color-gray-600);
 
   /* Component variables */
   --audit-description-padding-left: calc(var(--score-icon-size) + var(--score-icon-margin-left) + var(--score-icon-margin-right));
@@ -1061,6 +1062,10 @@
   color: var(--color-fail);
   fill: var(--color-fail);
   stroke: var(--color-fail);
+}
+
+.lh-gauge__wrapper--notapplicable {
+  color: var(--color-notapplicable);
 }
 
 .lh-gauge {

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -212,24 +212,63 @@ describe('CategoryRenderer', () => {
         'no manual description');
   });
 
-  it('renders not applicable audits if the category contains them', () => {
-    const a11yCategory = sampleResults.categories.accessibility;
-    const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
-    assert.ok(categoryDOM.querySelector(
+  describe('categories with not applicable audits', () => {
+    let a11yCategory;
+
+    beforeEach(()=> {
+      a11yCategory = sampleResults.categories.accessibility;
+    });
+
+    it('renders not applicable audits if the category contains them', () => {
+      const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
+      assert.ok(categoryDOM.querySelector(
         '.lh-clump--notapplicable .lh-audit-group__summary'));
 
-    const notApplicableCount = a11yCategory.auditRefs.reduce((sum, audit) =>
+      const notApplicableCount = a11yCategory.auditRefs.reduce((sum, audit) =>
         sum += audit.result.scoreDisplayMode === 'notApplicable' ? 1 : 0, 0);
-    assert.equal(
-      categoryDOM.querySelectorAll('.lh-clump--notapplicable .lh-audit').length,
-      notApplicableCount,
-      'score shows informative and dash icon'
-    );
+      assert.equal(
+        categoryDOM.querySelectorAll('.lh-clump--notapplicable .lh-audit').length,
+        notApplicableCount,
+        'score shows informative and dash icon'
+      );
 
-    const bestPracticeCat = sampleResults.categories['best-practices'];
-    const categoryDOM2 = renderer.render(bestPracticeCat, sampleResults.categoryGroups);
-    assert.ok(!categoryDOM2.querySelector('.lh-clump--notapplicable'));
+      const bestPracticeCat = sampleResults.categories['best-practices'];
+      const categoryDOM2 = renderer.render(bestPracticeCat, sampleResults.categoryGroups);
+      assert.ok(!categoryDOM2.querySelector('.lh-clump--notapplicable'));
+    });
+
+    it('renders an n/a score if the category contains 0 applicable audits', () => {
+      for (const auditRef of a11yCategory.auditRefs) {
+        auditRef.result.scoreDisplayMode = 'notApplicable';
+      }
+
+      const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
+      const percentageEl = categoryDOM.querySelectorAll('[title="Not applicable"]');
+
+      assert.equal(
+        percentageEl[0].textContent,
+        'n/a',
+        'score shows n/a'
+      );
+    });
+
+    it('renders a non-n/a score if the category contains at least 1 applicable audit', () => {
+      for (const auditRef of a11yCategory.auditRefs) {
+        auditRef.result.scoreDisplayMode = 'notApplicable';
+      }
+      a11yCategory.auditRefs[0].result.scoreDisplayMode = 'numeric';
+
+      const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
+      const percentageEl = categoryDOM.querySelectorAll('.lh-gauge__percentage');
+
+      assert.equal(
+        percentageEl[0].textContent,
+        '65',
+        'score shows a non-n/a value'
+      );
+    });
   });
+
 
   describe('category with groups', () => {
     let category;

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -216,7 +216,7 @@ describe('CategoryRenderer', () => {
     let a11yCategory;
 
     beforeEach(()=> {
-      a11yCategory = sampleResults.categories.accessibility;
+      a11yCategory = JSON.parse(JSON.stringify(sampleResults.categories.accessibility));
     });
 
     it('renders not applicable audits if the category contains them', () => {

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -245,11 +245,7 @@ describe('CategoryRenderer', () => {
       const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
       const percentageEl = categoryDOM.querySelectorAll('[title="Not applicable"]');
 
-      assert.equal(
-        percentageEl[0].textContent,
-        'n/a',
-        'score shows n/a'
-      );
+      assert.equal(percentageEl[0].textContent, 'n/a', 'score shows n/a');
     });
 
     it('renders a non-n/a score if the category contains at least 1 applicable audit', () => {
@@ -261,11 +257,7 @@ describe('CategoryRenderer', () => {
       const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
       const percentageEl = categoryDOM.querySelectorAll('.lh-gauge__percentage');
 
-      assert.equal(
-        percentageEl[0].textContent,
-        '65',
-        'score shows a non-n/a value'
-      );
+      assert.equal(percentageEl[0].textContent, '65', 'score shows a non-n/a value');
     });
   });
 

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -237,7 +237,7 @@ describe('CategoryRenderer', () => {
       assert.ok(!categoryDOM2.querySelector('.lh-clump--notapplicable'));
     });
 
-    it('renders an n/a score if the category contains 0 applicable audits', () => {
+    it('renders a dash score if the category contains 0 applicable audits', () => {
       for (const auditRef of a11yCategory.auditRefs) {
         auditRef.result.scoreDisplayMode = 'notApplicable';
       }
@@ -245,10 +245,10 @@ describe('CategoryRenderer', () => {
       const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
       const percentageEl = categoryDOM.querySelectorAll('[title="Not applicable"]');
 
-      assert.equal(percentageEl[0].textContent, 'n/a', 'score shows n/a');
+      assert.equal(percentageEl[0].textContent, '-', 'score shows a dash');
     });
 
-    it('renders a non-n/a score if the category contains at least 1 applicable audit', () => {
+    it('renders a non-dash score if the category contains at least 1 applicable audit', () => {
       for (const auditRef of a11yCategory.auditRefs) {
         auditRef.result.scoreDisplayMode = 'notApplicable';
       }
@@ -257,7 +257,7 @@ describe('CategoryRenderer', () => {
       const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
       const percentageEl = categoryDOM.querySelectorAll('.lh-gauge__percentage');
 
-      assert.equal(percentageEl[0].textContent, '65', 'score shows a non-n/a value');
+      assert.equal(percentageEl[0].textContent, '65', 'score shows a non-dash value');
     });
   });
 

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -261,7 +261,6 @@ describe('CategoryRenderer', () => {
     });
   });
 
-
   describe('category with groups', () => {
     let category;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
This PR resolves issue [#7263 ](https://github.com/GoogleChrome/lighthouse/issues/7623) by updating the functionality of ```renderScoreGauge``` to show ```-``` in cases where all audits in a category have their ```scoreDisplayMode``` marked as ```notApplicable```. Two tests have been added to confirm the expected behavior.

Note: the screenshots below show what the dash looks like, using the plugin category as a test subject, but in actuality the plugin category will show a numerical score, not a dash, because it has no audits.

**-- Light Mode**
![image](https://user-images.githubusercontent.com/66381097/89837768-407b7500-db2f-11ea-9076-6c100e0bcaf4.png)

**-- Dark Mode**
![Dark Mode](https://user-images.githubusercontent.com/66381097/89837837-63a62480-db2f-11ea-8bab-abe1fc0ba197.PNG)

**The previous design with `n/a` instead of `-` looked like this:**
![Not Applicable Design](https://user-images.githubusercontent.com/66381097/85645371-23621400-b65f-11ea-9818-b7ae25456610.PNG)

**Related Issues/PRs**
fixes #7263
