### PR TITLE
misc: run GitHub Actions on master and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@
 
 name: 💡🏠
 
-on: [pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   # `basics` includes all non-smoke CI, except for unit and proto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ name: 💡🏠
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
+  pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:
   # `basics` includes all non-smoke CI, except for unit and proto

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json",
     "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf ≥ 3.7.1 to compile the proto file.\" && false)",
-    "build-proto-roundtrip": "mkdir -p ./tmp && cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py",
+    "build-proto-roundtrip": "mkdir -p ./.tmp && cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py",
     "static-server": "node lighthouse-cli/test/fixtures/static-server.js"
   },
   "devDependencies": {


### PR DESCRIPTION
**Summary**
We don't run GitHub Actions on master right now which made it difficult to tell if [this failure](https://github.com/GoogleChrome/lighthouse/pull/11032/checks?check_run_id=819206666) was misconfiguration or related to the PR.

This will run our actions on master commits and all PRs with master as the base.
It also fixes the GitHub Actions failure caused by conflicting merges (https://github.com/GoogleChrome/lighthouse/pull/10995 and https://github.com/GoogleChrome/lighthouse/pull/11009)

