### PR TITLE
deps: upgrade codecov to 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "browserify": "^16.2.3",
     "chalk": "^2.4.1",
     "chrome-devtools-frontend": "1.0.727089",
-    "codecov": "^3.2.0",
+    "codecov": "^3.7.0",
     "conventional-changelog-cli": "^1.3.4",
     "coveralls": "^3.0.3",
     "cpy": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,10 +1969,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codecov@^3.2.0:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.5.tgz#d73ce62e8a021f5249f54b073e6f2d6a513f172a"
-  integrity sha512-v48WuDMUug6JXwmmfsMzhCHRnhUf8O3duqXvltaYJKrO1OekZWpB/eH6iIoaxMl8Qli0+u3OxptdsBOYiD7VAQ==
+codecov@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.7.0.tgz#4a09939cde24447a43f36d068e8b4e0188dc3f27"
+  integrity sha512-uIixKofG099NbUDyzRk1HdGtaG8O+PBUAg3wfmjwXw2+ek+PZp+puRvbTohqrVfuudaezivJHFgTtSC3M8MXww==
   dependencies:
     argv "0.0.2"
     ignore-walk "3.0.3"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

Lighthouse's codecov integration has been [flaky](https://codecov.io/gh/GoogleChrome/lighthouse) recently, and this is likely a result of using an old version of the codecov node uploader (3.6.5) as seen in a recent commit [here](https://api.travis-ci.org/v3/job/703537171/log.txt). This PR upgrades to the latest version (3.7.0) which, codecov support says, has a critical fix to the v4 upload path, providing more stability to the uploads.

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
