### PR TITLE
core(link-text): removing inicio from blocklist resolves

### DIFF
--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -51,8 +51,6 @@ const BLOCKLIST = new Set([
   'empezar',
   // Portuguese
   'clique aqui',
-  'inicio',
-  'início',
   'ir',
   'mais informação',
   'mais informações',


### PR DESCRIPTION
**Summary**
This change removes these Portuguese from the block list which mean "Home" or "Homepage", which seems to be a valid value for a link. I am new contributor and just signed a CLA!

**Related Issues/PRs**
This is identified from the Github issue #11026