### PR TITLE
core(cls): manually add first shift event to score if it was ignored

### DIFF
--- a/lighthouse-core/computed/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift.js
@@ -61,7 +61,6 @@ class CumulativeLayoutShift {
       const evt = traceOfTab.mainThreadEvents[i];
       if (evt.name === 'LayoutShift' && evt.args && evt.args.data && evt.args.data.is_main_frame) {
         if (!evt.args.data.had_recent_input) break;
-        if (evt.ts - traceOfTab.navigationStartEvt.ts > 500) break;
         cumulativeLayoutShift += Number(evt.args.data.score);
       }
     }

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift.js
@@ -59,7 +59,8 @@ class CumulativeLayoutShift {
       const evt = traceOfTab.mainThreadEvents[i];
       if (evt.name === 'LayoutShift' && evt.args && evt.args.data && evt.args.data.is_main_frame) {
         if (!evt.args.data.had_recent_input) break;
-        cumulativeLayoutShift += Number(evt.args.data.score);
+        if (typeof evt.args.data.score !== 'number') continue;
+        cumulativeLayoutShift += evt.args.data.score;
       }
     }
 

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift.js
@@ -19,12 +19,11 @@ class CumulativeLayoutShift {
     const traceOfTab = await TraceOfTab.request(trace, context);
 
     // Find the first and last LayoutShift event, if any.
-    let firstLayoutShift;
+    let firstLayoutShift = traceOfTab.mainThreadEvents.find(evt => evt.name === 'LayoutShift');
     let finalLayoutShift;
     for (let i = traceOfTab.mainThreadEvents.length - 1; i >= 0; i--) {
       const evt = traceOfTab.mainThreadEvents[i];
       if (evt.name === 'LayoutShift' && evt.args && evt.args.data && evt.args.data.is_main_frame) {
-        if (!firstLayoutShift) firstLayoutShift = evt;
         finalLayoutShift = evt;
         break;
       }

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift.js
@@ -30,14 +30,16 @@ class CumulativeLayoutShift {
       }
     }
 
-    const finalLayoutShiftTraceEventFound = !!finalLayoutShift;
+    const layoutShiftTraceEventFound = !!firstLayoutShift;
     // tdresser sez: In about 10% of cases, layout instability is 0, and there will be no trace events.
     // TODO: Validate that. http://crbug.com/1003459
     if (!firstLayoutShift || !finalLayoutShift) {
       return {
         value: 0,
         debugInfo: {
-          finalLayoutShiftTraceEventFound,
+          layoutShiftTraceEventFound,
+          // Historical.
+          finalLayoutShiftTraceEventFound: layoutShiftTraceEventFound,
         },
       };
     }
@@ -64,7 +66,9 @@ class CumulativeLayoutShift {
     return {
       value: cumulativeLayoutShift,
       debugInfo: {
-        finalLayoutShiftTraceEventFound,
+        layoutShiftTraceEventFound,
+        // Historical.
+        finalLayoutShiftTraceEventFound: layoutShiftTraceEventFound,
       },
     };
   }

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift.js
@@ -53,14 +53,15 @@ class CumulativeLayoutShift {
 
     // Chromium will set `had_recent_input` if there was recent user input, which
     // skips shift events from contributing to CLS. This flag is also set when Lighthouse changes
-    // the emulation size. This consistently results in the first shift event always being ignored
-    // for CLS. Since we don't expect any user input, conditionally add the first shift event to
-    // CLS if it was ignored.
+    // the emulation size. This consistently results in the first few shift event always being
+    // ignored for CLS. Since we don't expect any user input, we add the score of these
+    // shift events to CLS.
     // See https://bugs.chromium.org/p/chromium/issues/detail?id=1094974.
     for (let i = 0; i < traceOfTab.mainThreadEvents.length; i++) {
       const evt = traceOfTab.mainThreadEvents[i];
       if (evt.name === 'LayoutShift' && evt.args && evt.args.data && evt.args.data.is_main_frame) {
         if (!evt.args.data.had_recent_input) break;
+        if (evt.ts - traceOfTab.navigationStartEvt.ts > 500) break;
         cumulativeLayoutShift += Number(evt.args.data.score);
       }
     }

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift.js
@@ -28,8 +28,6 @@ class CumulativeLayoutShift {
       }
     }
 
-    console.log(traceOfTab.mainThreadEvents.filter(evt => evt.name === 'LayoutShift').map(evt => evt.args.data));
-
     const finalLayoutShiftTraceEventFound = !!finalLayoutShift;
     // tdresser sez: In about 10% of cases, layout instability is 0, and there will be no trace events.
     // TODO: Validate that. http://crbug.com/1003459

--- a/lighthouse-core/gather/gatherers/trace-elements.js
+++ b/lighthouse-core/gather/gatherers/trace-elements.js
@@ -82,10 +82,18 @@ class TraceElements extends Gatherer {
     const shiftEvents = mainThreadEvents
       .filter(e => e.name === 'LayoutShift')
       .map(e => e.args && e.args.data);
+    const indexFirstEventWithoutInput =
+      shiftEvents.findIndex(event => event && !event.had_recent_input);
 
-    shiftEvents.forEach(event => {
-      if (!event || !event.impacted_nodes || !event.score || event.had_recent_input) {
+    shiftEvents.forEach((event, index) => {
+      if (!event || !event.impacted_nodes || !event.score) {
         return;
+      }
+
+      // Ignore events with input, unless it's one of the initial events.
+      // See comment in computed/metrics/cumulative-layout-shift.js.
+      if (indexFirstEventWithoutInput !== -1 && index >= indexFirstEventWithoutInput) {
+        if (event.had_recent_input) return;
       }
 
       let totalAreaOfImpact = 0;

--- a/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
+++ b/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
@@ -1,0 +1,29 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const CumulativeLayoutShift = require('../../../computed/metrics/cumulative-layout-shift.js'); // eslint-disable-line max-len
+const trace = require('../../results/artifacts/defaultPass.trace.json');
+const invalidTrace = require('../../fixtures/traces/progressive-app-m60.json');
+
+/* eslint-env jest */
+
+describe('Metrics: CLS', () => {
+  it('should compute value', async () => {
+    const context = {computedCache: new Map()};
+    const result = await CumulativeLayoutShift.request(trace, context);
+    expect(result.value).toBe(0.42);
+    expect(result.debugInfo.finalLayoutShiftTraceEventFound).toBe(true);
+  });
+
+  it('should fail to compute a value for old trace', async () => {
+    const settings = {throttlingMethod: 'provided'};
+    const context = {settings, computedCache: new Map()};
+    const result = await CumulativeLayoutShift.request(invalidTrace, context);
+    expect(result.value).toBe(0);
+    expect(result.debugInfo.finalLayoutShiftTraceEventFound).toBe(false);
+  });
+});

--- a/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
+++ b/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
@@ -72,12 +72,13 @@ describe('Metrics: CLS', () => {
   it('should not count later shift events if input it true', async () => {
     const context = {computedCache: new Map()};
     const trace = makeTrace([
+      {score: 1, had_recent_input: true},
       {score: 1, had_recent_input: false},
       {score: 1, had_recent_input: false},
       {score: 1, had_recent_input: true},
       {score: 1, had_recent_input: true},
     ]);
     const result = await CumulativeLayoutShift.request(trace, context);
-    expect(result.value).toBe(2);
+    expect(result.value).toBe(3);
   });
 });

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -323,7 +323,7 @@ declare global {
       };
       pid: number;
       tid: number;
-      /* Microseconds. */
+      /** Timestamp of the event in microseconds. */
       ts: number;
       dur: number;
       ph: 'B'|'b'|'D'|'E'|'e'|'F'|'I'|'M'|'N'|'n'|'O'|'R'|'S'|'T'|'X';

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -323,6 +323,7 @@ declare global {
       };
       pid: number;
       tid: number;
+      /* Microseconds. */
       ts: number;
       dur: number;
       ph: 'B'|'b'|'D'|'E'|'e'|'F'|'I'|'M'|'N'|'n'|'O'|'R'|'S'|'T'|'X';


### PR DESCRIPTION
ref https://bugs.chromium.org/p/chromium/issues/detail?id=1094974