### PR TITLE
docs: fix typo in viewer readme for loading json from url

### DIFF
--- a/lighthouse-viewer/README.md
+++ b/lighthouse-viewer/README.md
@@ -33,7 +33,7 @@ e.g., `http://localhost:8000/?gist=bd1779783a5bbcb348564a58f80f7099`
 
 Pass the absolute URL as `jsonurl` query parameter.
 
-e.g., `http://localhost:8000/?josnurl=https://gist.githubusercontent.com/Kikobeats/d570a1aa285c5d1d97bbda10b92fb97f/raw/4b0f14a5914edd25c95b4bd9d09728ab42181c3e/lighthouse.json`
+e.g., `http://localhost:8000/?jsonurl=https://gist.githubusercontent.com/Kikobeats/d570a1aa285c5d1d97bbda10b92fb97f/raw/4b0f14a5914edd25c95b4bd9d09728ab42181c3e/lighthouse.json`
 
 ### Run and load from PageSpeed Insights
 


### PR DESCRIPTION
corrected url parameter has been tested and working