### PR TITLE
tests: use latest windows image on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,7 @@ branches:
   only:
   - master
 
+image: Visual Studio 2019
 environment:
   fast_finish: true
   matrix:
@@ -21,8 +22,6 @@ install:
 
 before_test:
   - set "PATH=C:\MinGW\msys\1.0\bin;%PATH%"
-  - set "CHROME_PATH=%CD%\chrome-win32\chrome.exe"
-  - bash ./lighthouse-core/scripts/download-chrome.sh
   - yarn build-all
 
 test_script:
@@ -48,6 +47,5 @@ on_success:
   - yarn unlink
 
 cache:
-  #- chrome-win32 -> appveyor.yml,package.json
   - node_modules -> appveyor.yml,package.json,yarn.lock
   - '%LOCALAPPDATA%\Yarn -> appveyor.yml,package.json,yarn.lock'

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -12,6 +12,7 @@
 const expectations = [
   {
     artifacts: {
+      HostUserAgent: /Chrome\/83/,
       HostFormFactor: 'desktop',
       TestedAsMobileDevice: true,
       Stacks: [{

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -12,7 +12,6 @@
 const expectations = [
   {
     artifacts: {
-      HostUserAgent: /Chrome\/83/,
       HostFormFactor: 'desktop',
       TestedAsMobileDevice: true,
       Stacks: [{


### PR DESCRIPTION
Fixes AppVeyor being stuck on Chrome 79 (hopefully).

AppVeyor has multiple Windows images, and most of them (including the default) are currently [stuck on Chrome 79](https://www.appveyor.com/docs/windows-images-software/#web-browsers). That seems like it can't be coincidence for the issues seen in PRs like #10976, so I assume something is breaking between downloading Chrome and chrome-launcher, and the default Chrome is being used regardless of what we try to use.

So let's just update to the latest Windows image and continue to use the default :)