### PR TITLE
new_audit: add no-unload-listeners audit

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -160,6 +160,9 @@ Object {
       "path": "long-tasks",
     },
     Object {
+      "path": "no-unload-listeners",
+    },
+    Object {
       "path": "manual/pwa-cross-browser",
     },
     Object {
@@ -745,6 +748,11 @@ Object {
         Object {
           "group": "best-practices-browser-compat",
           "id": "charset",
+          "weight": 1,
+        },
+        Object {
+          "group": "best-practices-general",
+          "id": "no-unload-listeners",
           "weight": 1,
         },
         Object {
@@ -1367,6 +1375,9 @@ Object {
         },
         Object {
           "path": "source-maps",
+        },
+        Object {
+          "path": "unload-listeners",
         },
       ],
       "loadFailureMode": "fatal",

--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -1332,6 +1332,9 @@ Object {
           "path": "main-document-content",
         },
         Object {
+          "path": "global-listeners",
+        },
+        Object {
           "path": "dobetterweb/appcache",
         },
         Object {
@@ -1375,9 +1378,6 @@ Object {
         },
         Object {
           "path": "source-maps",
-        },
-        Object {
-          "path": "unload-listeners",
         },
       ],
       "loadFailureMode": "fatal",

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -383,6 +383,12 @@ function isOnHttps() {
   document.body.appendChild(img); // PASS
 }
 
+function noUnloadListenersTest() {
+  window.addEventListener('unload', () => {
+    console.log('unload on unload');
+  });
+}
+
 // Figure out which tests to fun.
 const params = new URLSearchParams(location.search);
 if (location.search === '') {
@@ -398,6 +404,7 @@ if (location.search === '') {
   deprecationsTest();
   passwordInputsCanBePastedIntoTest();
   isOnHttps();
+  noUnloadListenersTest();
 } else {
   if (params.has('documentWrite')) {
     documentWriteTest();

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -197,6 +197,11 @@ const expectations = [
           },
         },
       ],
+      UnloadListeners: [{
+        type: 'unload',
+        scriptId: /^\d+$/,
+        lineNumber: '>300',
+      }],
     },
     lhr: {
       requestedUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
@@ -411,6 +416,15 @@ const expectations = [
                 element: {value: '<div id="shadow-root-container">'},
               },
             ],
+          },
+        },
+        'no-unload-listeners': {
+          score: 0,
+          details: {
+            items: [{
+              url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+              line: /^line: \d\d\d/,
+            }],
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -201,6 +201,7 @@ const expectations = [
         type: 'unload',
         scriptId: /^\d+$/,
         lineNumber: '>300',
+        columnNumber: '>30',
       }],
     },
     lhr: {
@@ -422,8 +423,13 @@ const expectations = [
           score: 0,
           details: {
             items: [{
-              url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-              line: /^line: \d\d\d/,
+              source: {
+                type: 'source-location',
+                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+                urlProvider: 'network',
+                line: '>300',
+                column: '>30',
+              },
             }],
           },
         },

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -197,7 +197,7 @@ const expectations = [
           },
         },
       ],
-      UnloadListeners: [{
+      GlobalListeners: [{
         type: 'unload',
         scriptId: /^\d+$/,
         lineNumber: '>300',

--- a/lighthouse-core/audits/no-unload-listeners.js
+++ b/lighthouse-core/audits/no-unload-listeners.js
@@ -1,0 +1,77 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Audit = require('./audit.js');
+const i18n = require('./../lib/i18n/i18n.js');
+
+const UIStrings = {
+  /** Descriptive title of a Lighthouse audit that checks if a web page has 'unload' event listeners and finds none.  */
+  title: 'Avoids `unload` event listeners',
+  /** Descriptive title of a Lighthouse audit that checks if a web page has 'unload' event listeners and finds that it is using them. */
+  failureTitle: 'Listens for the `unload` event',
+  /** Description of a Lighthouse audit that tells the user why pages should not use the 'unload' event. This is displayed after a user expands the section to see more. 'Learn More' becomes link text to additional documentation. */
+  description: 'The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid)',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+class NoUnloadListeners extends Audit {
+  /**
+   * @return {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'no-unload-listeners',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      requiredArtifacts: ['UnloadListeners', 'JsUsage'],
+    };
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
+   */
+  static audit(artifacts) {
+    const unloadListeners = artifacts.UnloadListeners.filter(l => l.type === 'unload');
+    if (!unloadListeners.length) {
+      return {
+        score: 1,
+      };
+    }
+
+    /** @type {LH.Audit.Details.Table['headings']} */
+    const headings = [
+      {key: 'url', itemType: 'url', text: str_(i18n.UIStrings.columnURL)},
+      {key: 'line', itemType: 'text', text: str_(i18n.UIStrings.columnLocation)},
+    ];
+
+    const jsUsageValues = Object.values(artifacts.JsUsage)
+      .reduce((acc, usage) => acc.concat(usage), []); // single-level arr.flat().
+
+    /** @type {LH.Audit.Details.Table['items']} */
+    const tableItems = unloadListeners.map(listener => {
+      // Look up scriptId to script URL via the JsUsage artifact.
+      const usageEntry = jsUsageValues.find(usage => usage.scriptId === listener.scriptId);
+      const url = usageEntry && usageEntry.url;
+
+      return {
+        url,
+        line: `line: ${listener.lineNumber}`,
+      };
+    });
+
+    return {
+      score: 0,
+      details: Audit.makeTableDetails(headings, tableItems),
+    };
+  }
+}
+
+module.exports = NoUnloadListeners;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-core/audits/no-unload-listeners.js
+++ b/lighthouse-core/audits/no-unload-listeners.js
@@ -12,9 +12,9 @@ const UIStrings = {
   /** Descriptive title of a Lighthouse audit that checks if a web page has 'unload' event listeners and finds none. */
   title: 'Avoids `unload` event listeners',
   /** Descriptive title of a Lighthouse audit that checks if a web page has 'unload' event listeners and finds that it is using them. */
-  failureTitle: 'Listens for the `unload` event',
+  failureTitle: 'Registers an `unload` listener',
   /** Description of a Lighthouse audit that tells the user why pages should not use the 'unload' event. This is displayed after a user expands the section to see more. 'Learn More' becomes link text to additional documentation. */
-  description: 'The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)',
+  description: 'The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the Back-Forward Cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);

--- a/lighthouse-core/audits/no-unload-listeners.js
+++ b/lighthouse-core/audits/no-unload-listeners.js
@@ -57,11 +57,21 @@ class NoUnloadListeners extends Audit {
       .map(usage => [usage.scriptId, usage.url]);
     const scriptIdToUrl = new Map(scriptIdToUrlEntries);
 
-    /** @type {Array<{source: LH.Audit.Details.SourceLocationValue}>} */
+    /** @type {Array<{source: LH.Audit.Details.ItemValue}>} */
     const tableItems = unloadListeners.map(listener => {
-      const url = scriptIdToUrl.get(listener.scriptId) || '(unknown)';
+      const url = scriptIdToUrl.get(listener.scriptId);
 
-      // line: `line: ${listener.lineNumber}`,
+      // If we can't find a url, still show something so the user can still
+      // manually look for where an `unload` handler is being created.
+      if (!url) {
+        return {
+          source: {
+            type: 'url',
+            value: '(unknown)',
+          },
+        };
+      }
+
       return {
         source: {
           type: 'source-location',

--- a/lighthouse-core/audits/no-unload-listeners.js
+++ b/lighthouse-core/audits/no-unload-listeners.js
@@ -61,8 +61,8 @@ class NoUnloadListeners extends Audit {
     const tableItems = unloadListeners.map(listener => {
       const url = scriptIdToUrl.get(listener.scriptId);
 
-      // If we can't find a url, still show something so the user can still
-      // manually look for where an `unload` handler is being created.
+      // If we can't find a url, still show something so the user can manually
+      // look for where an `unload` handler is being created.
       if (!url) {
         return {
           source: {

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -147,6 +147,7 @@ const defaultConfig = {
       'script-elements',
       'iframe-elements',
       'main-document-content',
+      'global-listeners',
       'dobetterweb/appcache',
       'dobetterweb/doctype',
       'dobetterweb/domstats',
@@ -162,7 +163,6 @@ const defaultConfig = {
       'trace-elements',
       'inspector-issues',
       'source-maps',
-      'unload-listeners',
     ],
   },
   {

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -162,6 +162,7 @@ const defaultConfig = {
       'trace-elements',
       'inspector-issues',
       'source-maps',
+      'unload-listeners',
     ],
   },
   {
@@ -236,6 +237,7 @@ const defaultConfig = {
     'largest-contentful-paint-element',
     'layout-shift-elements',
     'long-tasks',
+    'no-unload-listeners',
     'manual/pwa-cross-browser',
     'manual/pwa-page-transitions',
     'manual/pwa-each-page-has-url',
@@ -556,6 +558,7 @@ const defaultConfig = {
         {id: 'doctype', weight: 1, group: 'best-practices-browser-compat'},
         {id: 'charset', weight: 1, group: 'best-practices-browser-compat'},
         // General Group
+        {id: 'no-unload-listeners', weight: 1, group: 'best-practices-general'},
         {id: 'appcache-manifest', weight: 1, group: 'best-practices-general'},
         {id: 'js-libraries', weight: 0, group: 'best-practices-general'},
         {id: 'deprecations', weight: 1, group: 'best-practices-general'},

--- a/lighthouse-core/gather/gatherers/global-listeners.js
+++ b/lighthouse-core/gather/gatherers/global-listeners.js
@@ -5,9 +5,16 @@
  */
 'use strict';
 
+/**
+ * @fileoverview
+ * A gatherer to collect information about the event listeners registered on the
+ * global object. For now, the scope is narrowed to events that occur on and
+ * around page unload, but this can be expanded in the future.
+ */
+
 const Gatherer = require('./gatherer.js');
 
-class UnloadListeners extends Gatherer {
+class GlobalListeners extends Gatherer {
   /**
    * @param {LH.Crdp.DOMDebugger.EventListener} listener
    * @return {listener is {type: 'pagehide'|'unload'|'visibilitychange'} & LH.Crdp.DOMDebugger.EventListener}
@@ -20,7 +27,7 @@ class UnloadListeners extends Gatherer {
 
   /**
    * @param {LH.Gatherer.PassContext} passContext
-   * @return {Promise<LH.Artifacts['UnloadListeners']>}
+   * @return {Promise<LH.Artifacts['GlobalListeners']>}
    */
   async afterPass(passContext) {
     const driver = passContext.driver;
@@ -34,10 +41,10 @@ class UnloadListeners extends Gatherer {
       throw new Error('Error fetching information about the global object');
     }
 
-    // And get all its unload-ish listeners.
+    // And get all its listeners of interest.
     const {listeners} = await driver.sendCommand('DOMDebugger.getEventListeners', {objectId});
     return listeners
-      .filter(UnloadListeners._filterForUnloadTypes)
+      .filter(GlobalListeners._filterForUnloadTypes)
       .map(listener => {
         const {type, scriptId, lineNumber, columnNumber} = listener;
         return {
@@ -50,4 +57,4 @@ class UnloadListeners extends Gatherer {
   }
 }
 
-module.exports = UnloadListeners;
+module.exports = GlobalListeners;

--- a/lighthouse-core/gather/gatherers/global-listeners.js
+++ b/lighthouse-core/gather/gatherers/global-listeners.js
@@ -19,7 +19,7 @@ class GlobalListeners extends Gatherer {
    * @param {LH.Crdp.DOMDebugger.EventListener} listener
    * @return {listener is {type: 'pagehide'|'unload'|'visibilitychange'} & LH.Crdp.DOMDebugger.EventListener}
    */
-  static _filterForUnloadTypes(listener) {
+  static _filterForAllowlistedTypes(listener) {
     return listener.type === 'pagehide' ||
       listener.type === 'unload' ||
       listener.type === 'visibilitychange';
@@ -44,7 +44,7 @@ class GlobalListeners extends Gatherer {
     // And get all its listeners of interest.
     const {listeners} = await driver.sendCommand('DOMDebugger.getEventListeners', {objectId});
     return listeners
-      .filter(GlobalListeners._filterForUnloadTypes)
+      .filter(GlobalListeners._filterForAllowlistedTypes)
       .map(listener => {
         const {type, scriptId, lineNumber, columnNumber} = listener;
         return {

--- a/lighthouse-core/gather/gatherers/unload-listeners.js
+++ b/lighthouse-core/gather/gatherers/unload-listeners.js
@@ -39,11 +39,12 @@ class UnloadListeners extends Gatherer {
     return listeners
       .filter(UnloadListeners._filterForUnloadTypes)
       .map(listener => {
-        const {type, scriptId, lineNumber} = listener;
+        const {type, scriptId, lineNumber, columnNumber} = listener;
         return {
           type,
           scriptId,
           lineNumber,
+          columnNumber,
         };
       });
   }

--- a/lighthouse-core/gather/gatherers/unload-listeners.js
+++ b/lighthouse-core/gather/gatherers/unload-listeners.js
@@ -1,0 +1,52 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Gatherer = require('./gatherer.js');
+
+class UnloadListeners extends Gatherer {
+  /**
+   * @param {LH.Crdp.DOMDebugger.EventListener} listener
+   * @return {listener is {type: 'pagehide'|'unload'|'visibilitychange'} & LH.Crdp.DOMDebugger.EventListener}
+   */
+  static _filterForUnloadTypes(listener) {
+    return listener.type === 'pagehide' ||
+      listener.type === 'unload' ||
+      listener.type === 'visibilitychange';
+  }
+
+  /**
+   * @param {LH.Gatherer.PassContext} passContext
+   * @return {Promise<LH.Artifacts['UnloadListeners']>}
+   */
+  async afterPass(passContext) {
+    const driver = passContext.driver;
+
+    // Get a RemoteObject handle to `window`.
+    const {result: {objectId}} = await driver.sendCommand('Runtime.evaluate', {
+      expression: 'window',
+      returnByValue: false,
+    });
+    if (!objectId) {
+      throw new Error('Error fetching information about the global object');
+    }
+
+    // And get all its unload-ish listeners.
+    const {listeners} = await driver.sendCommand('DOMDebugger.getEventListeners', {objectId});
+    return listeners
+      .filter(UnloadListeners._filterForUnloadTypes)
+      .map(listener => {
+        const {type, scriptId, lineNumber} = listener;
+        return {
+          type,
+          scriptId,
+          lineNumber,
+        };
+      });
+  }
+}
+
+module.exports = UnloadListeners;

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -960,7 +960,7 @@
     "message": "Server Backend Latencies"
   },
   "lighthouse-core/audits/no-unload-listeners.js | description": {
-    "message": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid)"
+    "message": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)"
   },
   "lighthouse-core/audits/no-unload-listeners.js | failureTitle": {
     "message": "Listens for the `unload` event"

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -959,6 +959,15 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Server Backend Latencies"
   },
+  "lighthouse-core/audits/no-unload-listeners.js | description": {
+    "message": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid)"
+  },
+  "lighthouse-core/audits/no-unload-listeners.js | failureTitle": {
+    "message": "Listens for the `unload` event"
+  },
+  "lighthouse-core/audits/no-unload-listeners.js | title": {
+    "message": "Avoids `unload` event listeners"
+  },
   "lighthouse-core/audits/offline-start-url.js | description": {
     "message": "A service worker enables your web app to be reliable in unpredictable network conditions. [Learn more](https://web.dev/offline-start-url/)."
   },

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -960,10 +960,10 @@
     "message": "Server Backend Latencies"
   },
   "lighthouse-core/audits/no-unload-listeners.js | description": {
-    "message": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)"
+    "message": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the Back-Forward Cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)"
   },
   "lighthouse-core/audits/no-unload-listeners.js | failureTitle": {
-    "message": "Listens for the `unload` event"
+    "message": "Registers an `unload` listener"
   },
   "lighthouse-core/audits/no-unload-listeners.js | title": {
     "message": "Avoids `unload` event listeners"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -960,7 +960,7 @@
     "message": "Ŝér̂v́êŕ B̂áĉḱêńd̂ Ĺât́êńĉíêś"
   },
   "lighthouse-core/audits/no-unload-listeners.js | description": {
-    "message": "T̂h́ê `unload` év̂én̂t́ d̂óêś n̂ót̂ f́îŕê ŕêĺîáb̂ĺŷ án̂d́ l̂íŝt́êńîńĝ f́ôŕ ît́ ĉán̂ ṕr̂év̂én̂t́ b̂ŕôẃŝér̂ óp̂t́îḿîźât́îón̂ś l̂ík̂é t̂h́ê b́âćk̂/f́ôŕŵár̂d́ ĉáĉh́ê. Ćôńŝíd̂ér̂ úŝín̂ǵ t̂h́ê `pagehide` ór̂ `visibilitychange` év̂én̂t́ŝ ín̂śt̂éâd́. [L̂éâŕn̂ Ḿôŕê](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid)"
+    "message": "T̂h́ê `unload` év̂én̂t́ d̂óêś n̂ót̂ f́îŕê ŕêĺîáb̂ĺŷ án̂d́ l̂íŝt́êńîńĝ f́ôŕ ît́ ĉán̂ ṕr̂év̂én̂t́ b̂ŕôẃŝér̂ óp̂t́îḿîźât́îón̂ś l̂ík̂é t̂h́ê b́âćk̂/f́ôŕŵár̂d́ ĉáĉh́ê. Ćôńŝíd̂ér̂ úŝín̂ǵ t̂h́ê `pagehide` ór̂ `visibilitychange` év̂én̂t́ŝ ín̂śt̂éâd́. [L̂éâŕn̂ Ḿôŕê](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)"
   },
   "lighthouse-core/audits/no-unload-listeners.js | failureTitle": {
     "message": "L̂íŝt́êńŝ f́ôŕ t̂h́ê `unload` év̂én̂t́"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -960,10 +960,10 @@
     "message": "Ŝér̂v́êŕ B̂áĉḱêńd̂ Ĺât́êńĉíêś"
   },
   "lighthouse-core/audits/no-unload-listeners.js | description": {
-    "message": "T̂h́ê `unload` év̂én̂t́ d̂óêś n̂ót̂ f́îŕê ŕêĺîáb̂ĺŷ án̂d́ l̂íŝt́êńîńĝ f́ôŕ ît́ ĉán̂ ṕr̂év̂én̂t́ b̂ŕôẃŝér̂ óp̂t́îḿîźât́îón̂ś l̂ík̂é t̂h́ê b́âćk̂/f́ôŕŵár̂d́ ĉáĉh́ê. Ćôńŝíd̂ér̂ úŝín̂ǵ t̂h́ê `pagehide` ór̂ `visibilitychange` év̂én̂t́ŝ ín̂śt̂éâd́. [L̂éâŕn̂ Ḿôŕê](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)"
+    "message": "T̂h́ê `unload` év̂én̂t́ d̂óêś n̂ót̂ f́îŕê ŕêĺîáb̂ĺŷ án̂d́ l̂íŝt́êńîńĝ f́ôŕ ît́ ĉán̂ ṕr̂év̂én̂t́ b̂ŕôẃŝér̂ óp̂t́îḿîźât́îón̂ś l̂ík̂é t̂h́ê B́âćk̂-F́ôŕŵár̂d́ Ĉáĉh́ê. Ćôńŝíd̂ér̂ úŝín̂ǵ t̂h́ê `pagehide` ór̂ `visibilitychange` év̂én̂t́ŝ ín̂śt̂éâd́. [L̂éâŕn̂ Ḿôŕê](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)"
   },
   "lighthouse-core/audits/no-unload-listeners.js | failureTitle": {
-    "message": "L̂íŝt́êńŝ f́ôŕ t̂h́ê `unload` év̂én̂t́"
+    "message": "R̂éĝíŝt́êŕŝ án̂ `unload` ĺîśt̂én̂ér̂"
   },
   "lighthouse-core/audits/no-unload-listeners.js | title": {
     "message": "Âv́ôíd̂ś `unload` êv́êńt̂ ĺîśt̂én̂ér̂ś"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -959,6 +959,15 @@
   "lighthouse-core/audits/network-server-latency.js | title": {
     "message": "Ŝér̂v́êŕ B̂áĉḱêńd̂ Ĺât́êńĉíêś"
   },
+  "lighthouse-core/audits/no-unload-listeners.js | description": {
+    "message": "T̂h́ê `unload` év̂én̂t́ d̂óêś n̂ót̂ f́îŕê ŕêĺîáb̂ĺŷ án̂d́ l̂íŝt́êńîńĝ f́ôŕ ît́ ĉán̂ ṕr̂év̂én̂t́ b̂ŕôẃŝér̂ óp̂t́îḿîźât́îón̂ś l̂ík̂é t̂h́ê b́âćk̂/f́ôŕŵár̂d́ ĉáĉh́ê. Ćôńŝíd̂ér̂ úŝín̂ǵ t̂h́ê `pagehide` ór̂ `visibilitychange` év̂én̂t́ŝ ín̂śt̂éâd́. [L̂éâŕn̂ Ḿôŕê](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid)"
+  },
+  "lighthouse-core/audits/no-unload-listeners.js | failureTitle": {
+    "message": "L̂íŝt́êńŝ f́ôŕ t̂h́ê `unload` év̂én̂t́"
+  },
+  "lighthouse-core/audits/no-unload-listeners.js | title": {
+    "message": "Âv́ôíd̂ś `unload` êv́êńt̂ ĺîśt̂én̂ér̂ś"
+  },
   "lighthouse-core/audits/offline-start-url.js | description": {
     "message": "Â śêŕv̂íĉé ŵór̂ḱêŕ êńâb́l̂éŝ ýôúr̂ ẃêb́ âṕp̂ t́ô b́ê ŕêĺîáb̂ĺê ín̂ ún̂ṕr̂éd̂íĉt́âb́l̂é n̂ét̂ẃôŕk̂ ćôńd̂ít̂íôńŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/offline-start-url/)."
   },

--- a/lighthouse-core/test/audits/no-unload-listeners-test.js
+++ b/lighthouse-core/test/audits/no-unload-listeners-test.js
@@ -1,0 +1,77 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const NoUnloadListeners = require('../../audits/no-unload-listeners.js');
+
+/* eslint-env jest */
+
+const testJsUsage = {
+  'https://example.com/1.js': [
+    {scriptId: '12', url: 'https://example.com/1.js', functions: []},
+    {scriptId: '13', url: 'https://example.com/1.js', functions: []},
+    {scriptId: '16', url: 'https://example.com/1.js', functions: []},
+    {scriptId: '17', url: 'https://example.com/1.js', functions: []},
+  ],
+  'https://example.com/2.js': [
+    {scriptId: '22', url: 'https://example.com/2.js', functions: []},
+    {scriptId: '23', url: 'https://example.com/2.js', functions: []},
+    {scriptId: '26', url: 'https://example.com/2.js', functions: []},
+    {scriptId: '27', url: 'https://example.com/2.js', functions: []},
+  ],
+};
+
+describe('No Unload Listeners', () => {
+  it('passes when there were no listeners', () => {
+    const artifacts = {JsUsage: testJsUsage, GlobalListeners: []};
+    const result = NoUnloadListeners.audit(artifacts);
+    expect(result).toEqual({score: 1});
+  });
+
+  it('passes when there were no `unload` listeners', () => {
+    const GlobalListeners = [{
+      type: 'DOMContentLoaded', scriptId: '12', lineNumber: 5, columnNumber: 0,
+    }];
+    const artifacts = {JsUsage: testJsUsage, GlobalListeners};
+    const result = NoUnloadListeners.audit(artifacts);
+    expect(result).toEqual({score: 1});
+  });
+
+  it('fails when there are unload listeners and matches them to script locations', () => {
+    const GlobalListeners = [
+      {type: 'unload', scriptId: '16', lineNumber: 10, columnNumber: 30},
+      {type: 'unload', scriptId: '23', lineNumber: 0, columnNumber: 0},
+    ];
+    const artifacts = {JsUsage: testJsUsage, GlobalListeners};
+    const result = NoUnloadListeners.audit(artifacts);
+    expect(result.score).toEqual(0);
+    expect(result.details.items).toMatchObject([
+      {
+        source: {type: 'source-location', url: 'https://example.com/1.js', urlProvider: 'network', line: 10, column: 30},
+      }, {
+        source: {type: 'source-location', url: 'https://example.com/2.js', urlProvider: 'network', line: 0, column: 0},
+      },
+    ]);
+  });
+
+  it('fails when there are unload listeners and has a fallback if script URL is not found', () => {
+    const GlobalListeners = [
+      {type: 'DOMContentLoaded', scriptId: '12', lineNumber: 5, columnNumber: 0},
+      {type: 'unload', scriptId: 'notascriptid', lineNumber: 10, columnNumber: 30},
+      {type: 'unload', scriptId: '22', lineNumber: 1, columnNumber: 100},
+    ];
+    const artifacts = {JsUsage: testJsUsage, GlobalListeners};
+    const result = NoUnloadListeners.audit(artifacts);
+    expect(result.score).toEqual(0);
+    expect(result.details.items).toMatchObject([
+      {
+        source: {type: 'url', value: '(unknown)'},
+      }, {
+        source: {type: 'source-location', url: 'https://example.com/2.js', urlProvider: 'network', line: 1, column: 100},
+      },
+    ]);
+  });
+});

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -2410,7 +2410,7 @@
     "blockedByResponse": [],
     "mixedContent": []
   },
-  "UnloadListeners": [
+  "GlobalListeners": [
     {
       "type": "unload",
       "scriptId": "23",

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -2409,5 +2409,12 @@
   "InspectorIssues": {
     "blockedByResponse": [],
     "mixedContent": []
-  }
+  },
+  "UnloadListeners": [
+    {
+      "type": "unload",
+      "scriptId": "23",
+      "lineNumber": 386
+    }
+  ]
 }

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -2414,7 +2414,8 @@
     {
       "type": "unload",
       "scriptId": "23",
-      "lineNumber": 386
+      "lineNumber": 386,
+      "columnNumber": 36
     }
   ]
 }

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -390,7 +390,60 @@
       "requestId": "75994.22"
     }
   ],
-  "JsUsage": [],
+  "JsUsage": {
+    "http://localhost:58599/dobetterweb/dbw_tester.html": [
+      {
+        "scriptId": "12",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      },
+      {
+        "scriptId": "13",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      },
+      {
+        "scriptId": "16",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      },
+      {
+        "scriptId": "17",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      },
+      {
+        "scriptId": "19",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      },
+      {
+        "scriptId": "20",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      },
+      {
+        "scriptId": "21",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      },
+      {
+        "scriptId": "22",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      },
+      {
+        "scriptId": "23",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      },
+      {
+        "scriptId": "44",
+        "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+        "functions": []
+      }
+    ]
+  },
   "CSSUsage": {
     "rules": [
       {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1857,6 +1857,33 @@
         ]
       }
     },
+    "no-unload-listeners": {
+      "id": "no-unload-listeners",
+      "title": "Listens for the `unload` event",
+      "description": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid)",
+      "score": 0,
+      "scoreDisplayMode": "binary",
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "url",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "key": "line",
+            "itemType": "text",
+            "text": "Location"
+          }
+        ],
+        "items": [
+          {
+            "line": "line: 386"
+          }
+        ]
+      }
+    },
     "pwa-cross-browser": {
       "id": "pwa-cross-browser",
       "title": "Site works cross-browser",
@@ -4658,6 +4685,11 @@
           "group": "best-practices-browser-compat"
         },
         {
+          "id": "no-unload-listeners",
+          "weight": 1,
+          "group": "best-practices-general"
+        },
+        {
           "id": "appcache-manifest",
           "weight": 1,
           "group": "best-practices-general"
@@ -4679,7 +4711,7 @@
         }
       ],
       "id": "best-practices",
-      "score": 0.08
+      "score": 0.07
     },
     "seo": {
       "title": "SEO",
@@ -5471,6 +5503,12 @@
       {
         "startTime": 0,
         "name": "lh:audit:long-tasks",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:audit:no-unload-listeners",
         "duration": 100,
         "entryType": "measure"
       },
@@ -6335,6 +6373,7 @@
         "audits[network-rtt].details.headings[0].text",
         "audits[network-server-latency].details.headings[0].text",
         "audits[long-tasks].details.headings[0].text",
+        "audits[no-unload-listeners].details.headings[0].text",
         "audits[uses-long-cache-ttl].details.headings[0].text",
         "audits[total-byte-weight].details.headings[0].text",
         "audits[render-blocking-resources].details.headings[0].label",
@@ -6742,6 +6781,19 @@
       ],
       "lighthouse-core/lib/i18n/i18n.js | columnDuration": [
         "audits[long-tasks].details.headings[2].text"
+      ],
+      "lighthouse-core/audits/no-unload-listeners.js | failureTitle": [
+        "audits[no-unload-listeners].title"
+      ],
+      "lighthouse-core/audits/no-unload-listeners.js | description": [
+        "audits[no-unload-listeners].description"
+      ],
+      "lighthouse-core/lib/i18n/i18n.js | columnLocation": [
+        "audits[no-unload-listeners].details.headings[1].text",
+        "audits[geolocation-on-start].details.headings[1].text",
+        "audits[no-document-write].details.headings[1].text",
+        "audits[notification-on-start].details.headings[1].text",
+        "audits[uses-passive-event-listeners].details.headings[1].text"
       ],
       "lighthouse-core/audits/manual/pwa-cross-browser.js | title": [
         "audits[pwa-cross-browser].title"
@@ -7245,12 +7297,6 @@
       ],
       "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": [
         "audits[geolocation-on-start].description"
-      ],
-      "lighthouse-core/lib/i18n/i18n.js | columnLocation": [
-        "audits[geolocation-on-start].details.headings[1].text",
-        "audits[no-document-write].details.headings[1].text",
-        "audits[notification-on-start].details.headings[1].text",
-        "audits[uses-passive-event-listeners].details.headings[1].text"
       ],
       "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": [
         "audits[no-document-write].title"

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1859,8 +1859,8 @@
     },
     "no-unload-listeners": {
       "id": "no-unload-listeners",
-      "title": "Listens for the `unload` event",
-      "description": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)",
+      "title": "Registers an `unload` listener",
+      "description": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the Back-Forward Cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)",
       "score": 0,
       "scoreDisplayMode": "binary",
       "details": {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1860,26 +1860,27 @@
     "no-unload-listeners": {
       "id": "no-unload-listeners",
       "title": "Listens for the `unload` event",
-      "description": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid)",
+      "description": "The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the back/forward cache. Consider using the `pagehide` or `visibilitychange` events instead. [Learn More](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-unload-event)",
       "score": 0,
       "scoreDisplayMode": "binary",
       "details": {
         "type": "table",
         "headings": [
           {
-            "key": "url",
-            "itemType": "url",
+            "key": "source",
+            "itemType": "source-location",
             "text": "URL"
-          },
-          {
-            "key": "line",
-            "itemType": "text",
-            "text": "Location"
           }
         ],
         "items": [
           {
-            "line": "line: 386"
+            "source": {
+              "type": "source-location",
+              "url": "(unknown)",
+              "urlProvider": "network",
+              "line": 386,
+              "column": 36
+            }
           }
         ]
       }
@@ -6788,13 +6789,6 @@
       "lighthouse-core/audits/no-unload-listeners.js | description": [
         "audits[no-unload-listeners].description"
       ],
-      "lighthouse-core/lib/i18n/i18n.js | columnLocation": [
-        "audits[no-unload-listeners].details.headings[1].text",
-        "audits[geolocation-on-start].details.headings[1].text",
-        "audits[no-document-write].details.headings[1].text",
-        "audits[notification-on-start].details.headings[1].text",
-        "audits[uses-passive-event-listeners].details.headings[1].text"
-      ],
       "lighthouse-core/audits/manual/pwa-cross-browser.js | title": [
         "audits[pwa-cross-browser].title"
       ],
@@ -7297,6 +7291,12 @@
       ],
       "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": [
         "audits[geolocation-on-start].description"
+      ],
+      "lighthouse-core/lib/i18n/i18n.js | columnLocation": [
+        "audits[geolocation-on-start].details.headings[1].text",
+        "audits[no-document-write].details.headings[1].text",
+        "audits[notification-on-start].details.headings[1].text",
+        "audits[uses-passive-event-listeners].details.headings[1].text"
       ],
       "lighthouse-core/audits/dobetterweb/no-document-write.js | failureTitle": [
         "audits[no-document-write].title"

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1876,7 +1876,7 @@
           {
             "source": {
               "type": "source-location",
-              "url": "(unknown)",
+              "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
               "urlProvider": "network",
               "line": 386,
               "column": 36

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -112,12 +112,14 @@ declare global {
       FontSize: Artifacts.FontSize;
       /** Screenshot of the entire page (rather than just the above the fold content). */
       FullPageScreenshot: Artifacts.FullPageScreenshot | null;
-      /** The issues surfaced in the devtools Issues panel */
-      InspectorIssues: Artifacts.InspectorIssues;
+      /** Information about event listeners registered on the global object. */
+      GlobalListeners: Array<Artifacts.GlobalListener>;
       /** The page's document body innerText if loaded with JavaScript disabled. */
       HTMLWithoutJavaScript: {bodyText: string, hasNoScript: boolean};
       /** Whether the page ended up on an HTTPS page after attempting to load the HTTP version. */
       HTTPRedirect: {value: boolean};
+      /** The issues surfaced in the devtools Issues panel */
+      InspectorIssues: Artifacts.InspectorIssues;
       /** JS coverage information for code used during page load. Keyed by URL. */
       JsUsage: Record<string, Crdp.Profiler.ScriptCoverage[]>;
       /** Parsed version of the page's Web App Manifest, or null if none found. */
@@ -146,8 +148,6 @@ declare global {
       TapTargets: Artifacts.TapTarget[];
       /** Elements associated with metrics (ie: Largest Contentful Paint element). */
       TraceElements: Artifacts.TraceElement[];
-      /** Information about the event handlers that were registered to listen for when the page is unloaded. */
-      UnloadListeners: Array<Artifacts.UnloadListener>;
     }
 
     module Artifacts {
@@ -698,9 +698,9 @@ declare global {
         observedSpeedIndexTs: number;
       }
 
-      /** Information on a listener for an event that happens on or around page unload. */
-      export interface UnloadListener {
-        /** Event listener type. */
+      /** Information about an event listener registered on the global object. */
+      export interface GlobalListener {
+        /** Event listener type, limited to those events currently of interest. */
         type: 'pagehide'|'unload'|'visibilitychange';
         /** The DevTools protocol script identifier. */
         scriptId: string;

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -146,6 +146,8 @@ declare global {
       TapTargets: Artifacts.TapTarget[];
       /** Elements associated with metrics (ie: Largest Contentful Paint element). */
       TraceElements: Artifacts.TraceElement[];
+      /** Information about the event handlers that were registered to listen for when the page is unloaded. */
+      UnloadListeners: Array<Artifacts.UnloadListener>;
     }
 
     module Artifacts {
@@ -694,6 +696,16 @@ declare global {
         observedLastVisualChangeTs: number;
         observedSpeedIndex: number;
         observedSpeedIndexTs: number;
+      }
+
+      /** Information on a listener for an event that happens on or around page unload. */
+      export interface UnloadListener {
+        /** Event listener type. */
+        type: 'pagehide'|'unload'|'visibilitychange';
+        /** The DevTools protocol script identifier. */
+        scriptId: string;
+        /** Line number in the script (0-based). */
+        lineNumber: number;
       }
     }
   }

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -706,6 +706,8 @@ declare global {
         scriptId: string;
         /** Line number in the script (0-based). */
         lineNumber: number;
+        /** Column number in the script (0-based). */
+        columnNumber: number;
       }
     }
   }


### PR DESCRIPTION
Fixes #10848. ~~WIP for now~~ All should feel free to comment on the details to highlight and advice the audit should provide.

Right now the audit fails if any `'unload'` listener is registered, and recommends using `'pagehide'` or `'visibilitychange'` instead (leaving it up to the (eventually) linked docs to explain which of the two you might choose to use). The audit table is ~just using the plain old violations-style table~ using `source-location`, happy to iterate:

<img width="896" alt="unload event LH audit screenshot" src="https://user-images.githubusercontent.com/316891/87192723-12eba380-c2c5-11ea-8b9b-7e152429a9df.png">

live example:
https://googlechrome.github.io/lighthouse/viewer/?gist=12c8d8d522e867564a4c3a526f4981bd

<details>
<summary>old example</summary>
<img width="888" alt="unload event LH audit screenshot" src="https://user-images.githubusercontent.com/316891/87186103-e3369e80-c2b8-11ea-8f6b-32c9acb5bad3.png">

live example (scroll down to Best Practices)
https://googlechrome.github.io/lighthouse/viewer/?gist=aeb90c472c6c079e0429faf370bb83b1
</details>

<hr>

for the new gatherer, this information didn't really fit into an existing one, and I didn't really want to open us up to just collecting all the event listeners, so I kept it somewhat narrow in scope. I did include other unload-adjacent events because I get the feeling from talking to @philipwalton that there is more analysis we can do here about bfcache-worthiness, but if that doesn't materialize I can also narrow it down even more. I'm also open to completely different ideas :)