### PR TITLE
core(image-elements): gather correct natural size for srcset

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -74,6 +74,7 @@ setTimeout(() => {
   <!-- FAIL(optimized): image is not JPEG optimized -->
   <!-- FAIL(webp): image is not WebP optimized -->
   <!-- PASS(responsive): image is used at full size -->
+  <!-- PASS(responsive-inverse): image is not visible -->
   <!-- FAIL(offscreen): image is offscreen -->
   <img style="position: absolute; top: -10000px;" src="lighthouse-unoptimized.jpg">
 
@@ -81,77 +82,108 @@ setTimeout(() => {
   <!-- FAIL(optimized): image is not optimized -->
   <!-- FAIL(webp): image is not WebP optimized -->
   <!-- PASS(responsive): image is used at full size -->
+  <!-- FAIL(responsive-inverse): image does not account for DPR 2.625 -->
   <!--<img src="http://localhost:10503/byte-efficiency/lighthouse-unoptimized.jpg">-->
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- FAIL(webp): image is not WebP optimized -->
   <!-- FAIL(responsive): image is 50% used at DPR 3 -->
+  <!-- PASS(responsive-inverse): image is big enough -->
   <!-- PASS(offscreen): image is onscreen -->
   <img style="width: 256px; height: 170px;" src="lighthouse-1024x680.jpg">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image is WebP optimized -->
   <!-- FAIL(responsive): image is 25% used at DPR 2.625 -->
+  <!-- PASS(responsive-inverse): image is big enough -->
   <!-- PASS(offscreen): image is offscreen but lazily loaded -->
   <img style="width: 0px; height: 0px;" src="lighthouse-2048x1356.webp?size0" loading="lazy">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- FAIL(webp): image is not WebP optimized -->
   <!-- FAIL(responsive): image is not fully used at DPR 2.625 -->
+  <!-- PASS(responsive-inverse): image is big enough -->
   <!-- PASS(offscreen): image is onscreen -->
   <img style="width: 160px; height: 110px;" src="lighthouse-480x320.jpg">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image has insigificant WebP savings -->
   <!-- PASS(responsive): image is used at full size -->
+  <!-- FAIL(responsive-inverse): image does not account for DPR 2.625 -->
   <!-- PASS(offscreen): image is onscreen -->
   <img src="lighthouse-320x212-poor.jpg">
 
   <!-- PASS(optimized): image is JPEG optimized -->
+  <!-- PASS(webp): image is WebP savings -->
+  <!-- PASS(responsive): image is used at full size with srcset -->
+  <!-- PASS(responsive-inverse): image is big enough -->
+  <!-- PASS(offscreen): image is onscreen -->
+  <img class="onscreen" sizes="(max-width: 2000px) 160px, 2048px" src="lighthouse-320x212-poor.jpg?srcset" srcset="lighthouse-480x320.webp?srcset 480w, lighthouse-2048x1356.webp?srcset 2048w">
+
+  <!-- PASS(optimized): image is JPEG optimized -->
+  <!-- PASS(webp): image is WebP savings -->
+  <!-- PASS(responsive): image is used at full size with <picture> -->
+  <!-- PASS(responsive-inverse): image is big enough -->
+  <!-- PASS(offscreen): image is onscreen -->
+  <picture class="onscreen">
+    <source media="(max-width: 2000px)" srcset="lighthouse-480x320.webp?picture">
+    <source media="(min-width: 2001px)" srcset="lighthouse-2048x1356.webp?picture">
+    <img src="lighthouse-320x212-poor.jpg?picture" height="108">
+  </picture>
+
+  <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image is WebP optimized -->
   <!-- FAIL(responsive): image is 50% used at DPR 2.625 (but small savings) -->
+  <!-- PASS(responsive-inverse): image is big enough -->
   <!-- FAIL(offscreen): image is offscreen -->
   <img style="margin-top: 4000px; width: 120px; height: 80px;" src="lighthouse-480x320.webp">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image is WebP optimized -->
   <!-- PASS(responsive): image is not visible -->
+  <!-- PASS(responsive-inverse): is not visible -->
   <!-- FAIL(offscreen): image is not visible -->
   <div class="onscreen" style="display: none;"><img class="onscreen" style="width: 120px; height: 80px;" src="lighthouse-480x320.webp?invisible"></div>
 
   <!-- PASS(optimized): image is vector -->
   <!-- PASS(webp): image is vector -->
   <!-- PASS(responsive): image is vector -->
+  <!-- PASS(responsive-inverse): is vector -->
   <!-- FAIL(offscreen): image is offscreen -->
   <img style="width: 100px; height: 100px;" src="large.svg">
 
   <!-- PASS(optimized): image is vector -->
   <!-- PASS(webp): image is vector -->
   <!-- PASS(responsive): image is vector -->
+  <!-- PASS(responsive-inverse): is vector -->
   <!-- PASS(offscreen): image is offscreen and loads before TTI, but loads lazily -->
   <img style="width: 100px; height: 100px;" src="large.svg?nativeLazyLoad" loading="lazy">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image has insigificant WebP savings -->
   <!-- PASS(responsive): image is later used at full size -->
+  <!-- PASS(responsive-inverse): image is big enough -->
   <!-- PASS(offscreen): image is later used onscreen -->
   <img style="width: 24px; height: 16px;"src="lighthouse-320x212-poor.jpg?duplicate">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- PASS(webp): image has insigificant WebP savings -->
   <!-- PASS(responsive): image is used at full size -->
+  <!-- FAIL(responsive-inverse): image does not account for DPR 2.625 -->
   <!-- PASS(offscreen): image is onscreen -->
   <img class="onscreen" src="lighthouse-320x212-poor.jpg?duplicate">
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- FAIL(webp): image is not WebP optimized -->
   <!-- PASS(responsive): image is in CSS -->
+  <!-- PASS(responsive-inverse): image is in CSS -->
   <!-- PASS(offscreen): image is onscreen -->
   <div class="onscreen" style="width: 120px; height: 80px; background: 50% 50% url(lighthouse-480x320.jpg?css);"></div>
 
   <!-- PASS(optimized): image is JPEG optimized -->
   <!-- FAIL(webp): image is not WebP optimized -->
   <!-- PASS(responsive): image is in CSS -->
+  <!-- PASS(responsive-inverse): image is in CSS -->
   <!-- PASS(offscreen): image is onscreen -->
   <div class="onscreen" style="width: 30px; height: 30px; background: 0% 50% url(lighthouse-480x320.jpg?sprite);"></div>
   <div class="onscreen" style="width: 30px; height: 30px; background: 25% 50% url(lighthouse-480x320.jpg?sprite);"></div>

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/byte-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/byte-config.js
@@ -24,6 +24,9 @@ const config = {
       'unminified-javascript',
       'unused-css-rules',
       'unused-javascript',
+      // image-size-responsive is not a byte-efficiency audit but a counterbalance to the byte-efficiency audits
+      // that makes sense to test together.
+      'image-size-responsive',
     ],
     throttlingMethod: 'devtools',
   },

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -224,13 +224,12 @@ const expectations = [
         // Checks that images aren't TOO SMALL.
         'image-size-responsive': {
           details: {
-            items: {
+            items: [
               // One of these two is the ?duplicate variant but sort order isn't guaranteed
               // since the pixel diff is equivalent for identical images.
-              0: {url: /lighthouse-320x212-poor.jpg/},
-              1: {url: /lighthouse-320x212-poor.jpg/},
-              length: 2,
-            },
+              {url: /lighthouse-320x212-poor.jpg/},
+              {url: /lighthouse-320x212-poor.jpg/},
+            ],
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -212,13 +212,12 @@ const expectations = [
         'uses-responsive-images': {
           details: {
             overallSavingsBytes: '108000 +/- 5000',
-            items: {
-              0: {wastedPercent: '56 +/- 5', url: /lighthouse-1024x680.jpg/},
-              1: {wastedPercent: '78 +/- 5', url: /lighthouse-2048x1356.webp\?size0/},
-              2: {wastedPercent: '56 +/- 5', url: /lighthouse-480x320.webp/},
-              3: {wastedPercent: '20 +/- 5', url: /lighthouse-480x320.jpg/},
-              length: 4,
-            },
+            items: [
+              {wastedPercent: '56 +/- 5', url: /lighthouse-1024x680.jpg/},
+              {wastedPercent: '78 +/- 5', url: /lighthouse-2048x1356.webp\?size0/},
+              {wastedPercent: '56 +/- 5', url: /lighthouse-480x320.webp/},
+              {wastedPercent: '20 +/- 5', url: /lighthouse-480x320.jpg/},
+            ],
           },
         },
         // Checks that images aren't TOO SMALL.

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -208,6 +208,7 @@ const expectations = [
             },
           },
         },
+        // Check that images aren't TOO BIG.
         'uses-responsive-images': {
           details: {
             overallSavingsBytes: '108000 +/- 5000',
@@ -217,6 +218,18 @@ const expectations = [
               2: {wastedPercent: '56 +/- 5', url: /lighthouse-480x320.webp/},
               3: {wastedPercent: '20 +/- 5', url: /lighthouse-480x320.jpg/},
               length: 4,
+            },
+          },
+        },
+        // Checks that images aren't TOO SMALL.
+        'image-size-responsive': {
+          details: {
+            items: {
+              // One of these two is the ?duplicate variant but sort order isn't guaranteed
+              // since the pixel diff is equivalent for identical images.
+              0: {url: /lighthouse-320x212-poor.jpg/},
+              1: {url: /lighthouse-320x212-poor.jpg/},
+              length: 2,
             },
           },
         },

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -30,7 +30,7 @@ const UIStrings = {
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
-const IGNORE_THRESHOLD_IN_BYTES = 2048;
+const IGNORE_THRESHOLD_IN_BYTES = 4096;
 
 class UsesResponsiveImages extends ByteEfficiencyAudit {
   /**

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -45,6 +45,7 @@ function getHTMLImages(allElements) {
       // currentSrc used over src to get the url as determined by the browser
       // after taking into account srcset/media/sizes/etc.
       src: element.currentSrc,
+      srcset: element.srcset,
       displayedWidth: element.width,
       displayedHeight: element.height,
       clientRect: getClientRect(element),
@@ -91,6 +92,7 @@ function getCSSImages(allElements) {
 
     images.push({
       src: url,
+      srcset: '',
       displayedWidth: element.clientWidth,
       displayedHeight: element.clientHeight,
       clientRect: getClientRect(element),
@@ -224,7 +226,7 @@ class ImageElements extends Gatherer {
       // Additional fetch is expensive; don't bother if we don't have a networkRecord for the image,
       // or it's not in the top 50 largest images.
       if (
-        (element.isPicture || element.isCss) &&
+        (element.isPicture || element.isCss || element.srcset) &&
         networkRecord &&
         top50Images.includes(networkRecord)
       ) {

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -389,7 +389,7 @@ declare global {
 
       export interface ImageElement {
         src: string;
-        /** The srcset attribtue value. @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset */
+        /** The srcset attribute value. @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset */
         srcset: string;
         /** The displayed width of the image, uses img.width when available falling back to clientWidth. See https://codepen.io/patrickhulce/pen/PXvQbM for examples. */
         displayedWidth: number;

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -389,6 +389,8 @@ declare global {
 
       export interface ImageElement {
         src: string;
+        /** The srcset attribtue value. @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset */
+        srcset: string;
         /** The displayed width of the image, uses img.width when available falling back to clientWidth. See https://codepen.io/patrickhulce/pen/PXvQbM for examples. */
         displayedWidth: number;
         /** The displayed height of the image, uses img.height when available falling back to clientHeight. See https://codepen.io/patrickhulce/pen/PXvQbM for examples. */


### PR DESCRIPTION
**Summary**
We weren't collecting the correct `naturalWidth`/`naturalHeight` for images that use `srcset`. Added a smoketest for this and other `image-size-responsive` cases to the byte efficiency tester.

**Related Issues/PRs**
fixes #11095 
