### PR TITLE
docs(readme): data studio connector related project

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -371,6 +371,7 @@ Other awesome open source projects that use Lighthouse.
 * **[lighthouse-check-orb](https://circleci.com/orbs/registry/orb/foo-software/lighthouse-check)** - A CircleCI Orb to run Lighthouse in a workflow, featuring Slack notifications and report upload to S3.
 * **[andreasonny83/lighthouse-ci](https://github.com/andreasonny83/lighthouse-ci)** - Run Lighthouse and assert scores satisfy your custom thresholds.
 * **[GoogleChrome/lighthouse-ci](https://github.com/GoogleChrome/lighthouse-ci)** - (**official**) Automate running Lighthouse for every commit, viewing the changes, and preventing regressions.
+* **[Lighthouse Data Studio Connector](https://datastudio.google.com/data?search=lighthouse)** - A Data Studio Connector that connects to Foo's public API to display Lighthouse charts as seen in [this example report](https://datastudio.google.com/u/0/reporting/1J8Yz9rLDAXQWDiSEtLrJDWxq79DMmIUB/page/HP1TB).
 * **[lighthouse-ci-action](https://github.com/treosh/lighthouse-ci-action)** - A Github Action that makes it easy to run Lighthouse in CI and keep your pages small using performance budgets.
 * **[lighthouse-cron](https://github.com/thearegee/lighthouse-cron)** - Cron multiple batch Lighthouse audits and emit results for sending to remote server.
 * **[lighthouse-gh-reporter](https://github.com/carlesnunez/lighthouse-gh-reporter)** - Run Lighthouse in CI and report back in a comment on your pull requests


### PR DESCRIPTION
**Summary**

Adds a Data Studio Connector to the list of related projects. The [template referenced in this change](https://datastudio.google.com/u/0/reporting/1J8Yz9rLDAXQWDiSEtLrJDWxq79DMmIUB/page/HP1TB) is also referenced in the code of the connector, so that URL is safe in that it won't change.
