### PR TITLE
i18n: disallow invalid text outside complex ICU arguments

### DIFF
--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -13,6 +13,7 @@ const glob = require('glob');
 const path = require('path');
 const assert = require('assert').strict;
 const tsc = require('typescript');
+const MessageParser = require('intl-messageformat-parser').default;
 const Util = require('../../report/html/renderer/util.js');
 const {collectAndBakeCtcStrings} = require('./bake-ctc-to-lhl.js');
 const {pruneObsoleteLhlMessages} = require('./prune-obsolete-lhl-messages.js');
@@ -126,16 +127,18 @@ function parseExampleJsDoc(rawExample) {
  *  },
  * }
  *
- * Throws if the message violates some basic sanity checking.
+ * Throws if the message violates some basic validity checking.
  *
- * @param {string} message
+ * @param {string} lhlMessage
  * @param {Record<string, string>} examples
  * @return {IncrementalCtc}
  */
-function convertMessageToCtc(message, examples = {}) {
+function convertMessageToCtc(lhlMessage, examples = {}) {
+  _lhlValidityChecks(lhlMessage);
+
   /** @type {IncrementalCtc} */
   const ctc = {
-    message,
+    message: lhlMessage,
     placeholders: {},
   };
 
@@ -148,9 +151,48 @@ function convertMessageToCtc(message, examples = {}) {
 
   _processPlaceholderDirectIcu(ctc, examples);
 
-  _ctcSanityChecks(ctc);
+  _ctcValidityChecks(ctc);
 
   return ctc;
+}
+
+/**
+ * Do some basic checks on an lhl message to confirm that it is valid. Future
+ * lhl regression catching should go here.
+ *
+ * @param {string} lhlMessage
+ */
+function _lhlValidityChecks(lhlMessage) {
+  let parsedMessage;
+  try {
+    parsedMessage = MessageParser.parse(lhlMessage);
+  } catch (err) {
+    if (err.name !== 'SyntaxError') throw err;
+    // Improve the intl-messageformat-parser syntax error output.
+    /** @type {Array<{text: string}>} */
+    const expected = err.expected;
+    const expectedStr = expected.map(exp => `'${exp.text}'`).join(', ');
+    throw new Error(`Did not find the expected syntax (one of ${expectedStr}) in message "${lhlMessage}"`);
+  }
+
+  for (const element of parsedMessage.elements) {
+    if (element.type !== 'argumentElement' || !element.format) continue;
+
+    if (element.format.type === 'pluralFormat' || element.format.type === 'selectFormat') {
+      // `plural`/`select` arguments can't have content before or after them.
+      // See http://userguide.icu-project.org/formatparse/messages#TOC-Complex-Argument-Types
+      // e.g. https://github.com/GoogleChrome/lighthouse/pull/11068#discussion_r451682796
+      if (parsedMessage.elements.length > 1) {
+        throw new Error(`Content cannot appear outside plural or select ICU messages. Instead, repeat that content in each option (message: '${lhlMessage}')`);
+      }
+
+      // Each option value must also be valid lhlMessages.
+      for (const option of element.format.options) {
+        const optionStr = lhlMessage.slice(option.value.location.start.offset, option.value.location.end.offset);
+        _lhlValidityChecks(optionStr);
+      }
+    }
+  }
 }
 
 /**
@@ -335,12 +377,12 @@ function _processPlaceholderDirectIcu(icu, examples) {
 }
 
 /**
- * Do some basic sanity checks to a ctc object to confirm that it is valid. Future
+ * Do some basic checks on a ctc object to confirm that it is valid. Future
  * ctc regression catching should go here.
  *
  * @param {IncrementalCtc} icu the ctc output message to verify
  */
-function _ctcSanityChecks(icu) {
+function _ctcValidityChecks(icu) {
   // '$$' i.e. "Double Dollar" is always invalid in ctc.
   if (icu.message.match(/\$\$/)) {
     throw new Error(`Ctc messages cannot contain double dollar: ${icu.message}`);

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -186,7 +186,7 @@ function _lhlValidityChecks(lhlMessage) {
         throw new Error(`Content cannot appear outside plural or select ICU messages. Instead, repeat that content in each option (message: '${lhlMessage}')`);
       }
 
-      // Each option value must also be valid lhlMessages.
+      // Each option value must also be a valid lhlMessage.
       for (const option of element.format.options) {
         const optionStr = lhlMessage.slice(option.value.location.start.offset, option.value.location.end.offset);
         _lhlValidityChecks(optionStr);

--- a/lighthouse-core/test/scripts/i18n/collect-strings-test.js
+++ b/lighthouse-core/test/scripts/i18n/collect-strings-test.js
@@ -332,6 +332,56 @@ describe('parseUIStrings', () => {
   });
 });
 
+describe('#_lhlValidityChecks', () => {
+  /* eslint-disable max-len */
+  it('errors when using non-supported custom-formatted ICU format', () => {
+    const message = 'Hello World took {var, badFormat, milliseconds}.';
+    expect(() => collect.convertMessageToCtc(message)).toThrow(
+      /Did not find the expected syntax \(one of 'number', 'date', 'time', 'plural', 'selectordinal', 'select'\) in message "Hello World took {var, badFormat, milliseconds}."$/);
+  });
+
+  it('errors when there is content outside of a plural argument', () => {
+    const message = 'We found {count, plural, =1 {1 request} other {# requests}}';
+    expect(() => collect.convertMessageToCtc(message)).toThrow(
+      /Content cannot appear outside plural or select ICU messages.*=1 {1 request} other {# requests}}'\)$/);
+  });
+
+  it('errors when there is content outside of a select argument', () => {
+    const message = '{user_gender, select, female {They} male {They} other {They}} were trying to block the main thread';
+    expect(() => collect.convertMessageToCtc(message)).toThrow(
+      /Content cannot appear outside plural or select ICU messages.*were trying to block the main thread'\)$/);
+  });
+
+  it('errors when there is whitespace outside of a plural argument', () => {
+    const message = '{count, plural, =1 {1 request} other {# requests}}  ';
+    expect(() => collect.convertMessageToCtc(message)).toThrow(
+      /Content cannot appear outside plural or select ICU messages.*=1 {1 request} other {# requests}} {2}'\)$/);
+  });
+
+  it('errors when there another argument outside of a plural argument', () => {
+    const message = '{count, plural, =1 {1 request} other {# requests}}{count, plural, =1 {1 request} other {# requests}}';
+    expect(() => collect.convertMessageToCtc(message)).toThrow(
+      /Content cannot appear outside plural or select ICU messages.*=1 {1 request} other {# requests}}'\)$/);
+  });
+
+  it('errors when there is content outside of a plural argument', () => {
+    const message = 'We found {count, plural, =1 {1 request} other {# requests}}';
+    expect(() => collect.convertMessageToCtc(message)).toThrow(
+      /Content cannot appear outside plural or select ICU messages.*=1 {1 request} other {# requests}}'\)$/);
+  });
+
+  it('errors when there is content outside of nested plural aguments', () => {
+    const message = `{user_gender, select,
+      female {Ms. {name} received {count, plural, =1 {one award.} other {# awards.}}}
+      male {Mr. {name} received {count, plural, =1 {one award.} other {# awards.}}}
+      other {{name} received {count, plural, =1 {one award.} other {# awards.}}}
+    }`;
+    expect(() => collect.convertMessageToCtc(message, {name: 'Elbert'})).toThrow(
+      /Content cannot appear outside plural or select ICU messages.*\(message: 'Ms. {name} received {count, plural, =1 {one award.} other {# awards.}}'\)$/);
+  });
+  /* eslint-enable max-len */
+});
+
 describe('Convert Message to Placeholder', () => {
   it('passthroughs a basic message unchanged', () => {
     const message = 'Hello World.';
@@ -487,12 +537,6 @@ describe('Convert Message to Placeholder', () => {
         example: '2.4',
       },
     });
-  });
-
-  it('errors when using non-supported custom-formatted ICU format', () => {
-    const message = 'Hello World took {var, badFormat, milliseconds}.';
-    expect(() => collect.convertMessageToCtc(message)).toThrow(
-      /Unsupported custom-formatted ICU format var "badFormat" in message "Hello World took "/);
   });
 
   it('errors when using non-supported custom-formatted ICU type', () => {


### PR DESCRIPTION
@exterkamp pointed out in https://github.com/GoogleChrome/lighthouse/pull/11068#discussion_r451682796 that text should never appear outside complex (`plural` or `select`) ICU argument blocks (whether string, whitespace, or other ICU arguments). Depending on the language, any text outside of the argument may also need to be part of what's changed depending on the replacement value.

This is an easy thing to catch without human review, so let's do that :)

Background docs:
- http://userguide.icu-project.org/formatparse/messages#TOC-Complex-Argument-Types
- go/icu-message-migration#message-should-not-have-text-including-whitespaces-andor-placeholders-preceding-or-following-icu-complex-syntax (just for googlers, but it's basically the same thing, just turns the "**Recommendation**" to required)