### PR TITLE
misc: ignore coverage of page-functions

### DIFF
--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -325,6 +325,7 @@ function getNodeLabel(node) {
  * @param {HTMLElement} element
  * @param {LH.Artifacts.Rect}
  */
+/* istanbul ignore next */
 function getBoundingClientRect(element) {
   // The protocol does not serialize getters, so extract the values explicitly.
   const rect = element.getBoundingClientRect();


### PR DESCRIPTION
Fixes travis failures on master, and opens us up to land #11104 with coverage in GitHub actions