### PR TITLE
deps: update third-party-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "robots-parser": "^2.0.1",
     "semver": "^5.3.0",
     "speedline-core": "1.4.2",
-    "third-party-web": "^0.11.1",
+    "third-party-web": "^0.12.1",
     "update-notifier": "^2.5.0",
     "ws": "3.3.2",
     "yargs": "3.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7600,10 +7600,10 @@ text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-third-party-web@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.11.1.tgz#4b5b176f0014be696002c104d76f40692318aec9"
-  integrity sha512-PBS478cWhvCM8seuloomV5lGHvu2qMOCj8gq8wKOApdfAaGh9l2rYZkdsBDaQyQg/6plov3uodc6sZ/3c1lu/g==
+third-party-web@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.12.1.tgz#f5b09c1403000b28241f445401c590de52670ab7"
+  integrity sha512-cdZaoOuZ+lN/lPLYGBlEqgIvtQ/3dt4OcgJ6euTQ/sljUcnWj/RgLIkIdXOWdKXsJav4aPgiygOyJd/Ife813A==
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
**Summary**
Updates `third-party-web` to 0.12.1

[0.12.0](https://github.com/patrickhulce/third-party-web/releases/tag/v0.12.0) brought some nice goodies, including the breaking change of removing the examples entry from the `nostats` bundle we use (should shrink bundle size a tad). We *could* hypothetically remove the try/catch since it no longer has *strict* validation of a domain existing in the string, but we still pass in some totally non-URLs that could basic basic URL validation, so I'm inclined to leave our `getEntity` as-is.

**Related Issues/PRs**
https://github.com/patrickhulce/third-party-web/issues/106
