### PR TITLE
i18n: log the percentage of translated messages

### DIFF
--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -16,6 +16,7 @@ const tsc = require('typescript');
 const Util = require('../../report/html/renderer/util.js');
 const {collectAndBakeCtcStrings} = require('./bake-ctc-to-lhl.js');
 const {pruneObsoleteLhlMessages} = require('./prune-obsolete-lhl-messages.js');
+const {countTranslatedMessages} = require('./count-translated.js');
 
 const LH_ROOT = path.join(__dirname, '../../../');
 const UISTRINGS_REGEX = /UIStrings = .*?\};\n/s;
@@ -590,6 +591,17 @@ if (require.main === module) {
   // Remove any obsolete strings in existing LHL files.
   console.log('Checking for out-of-date LHL messages...');
   pruneObsoleteLhlMessages();
+
+  // Report on translation progress.
+  const progress = countTranslatedMessages();
+  console.log(`  ${progress.localeCount} translated locale files`);
+  console.log(`  ${progress.translatedCount}/${progress.messageCount} fully translated messages`);
+  if (progress.partiallyTranslatedCount) {
+    console.log(`  ${progress.partiallyTranslatedCount}/${progress.messageCount} partially translated messages`);
+  }
+  console.log(`  ${progress.notTranslatedCount}/${progress.messageCount} untranslated messages`);
+
+  console.log('✨ Complete!');
 }
 
 module.exports = {

--- a/lighthouse-core/scripts/i18n/count-translated.js
+++ b/lighthouse-core/scripts/i18n/count-translated.js
@@ -1,0 +1,71 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const fs = require('fs');
+const glob = require('glob');
+
+/** @typedef {import('../../lib/i18n/locales.js').LhlMessages} LhlMessages */
+
+const lhRoot = `${__dirname}/../../../`;
+const enUsLhlFilename = lhRoot + 'lighthouse-core/lib/i18n/locales/en-US.json';
+/** @type {LhlMessages} */
+const enUsLhl = JSON.parse(fs.readFileSync(enUsLhlFilename, 'utf8'));
+
+/**
+ * Count how many locale files have a translated version of each string found in
+ * the `en-US.json` i18n messages.
+ * @return {{localeCount: number, messageCount: number, translatedCount: number, partiallyTranslatedCount: number, notTranslatedCount: number}}
+ */
+function countTranslatedMessages() {
+  // Find all locale files, ignoring self-generated en-US and en-XL, and ctc files.
+  const ignore = [
+    '**/.ctc.json',
+    '**/en-US.json',
+    '**/en-XL.json',
+  ];
+  const globPattern = 'lighthouse-core/lib/i18n/locales/**/+([-a-zA-Z0-9]).json';
+  const localeFilenames = glob.sync(globPattern, {
+    ignore,
+    cwd: lhRoot,
+  });
+
+  /** @type {Array<[string, number]>} */
+  const enUsEntries = Object.keys(enUsLhl).map(key => [key, 0]);
+  const countPerMessage = new Map(enUsEntries);
+
+  for (const localeFilename of localeFilenames) {
+    // Use readFileSync in case other code in this process has altered the require()d form.
+    /** @type {LhlMessages} */
+    const localeLhl = JSON.parse(fs.readFileSync(lhRoot + localeFilename, 'utf-8'));
+
+    for (const localeKey of Object.keys(localeLhl)) {
+      const messageCount = countPerMessage.get(localeKey);
+      // Only care about strings in `en-US.json` (the rest should have been pruned).
+      if (messageCount !== undefined) {
+        countPerMessage.set(localeKey, messageCount + 1);
+      }
+    }
+  }
+
+  const localeCount = localeFilenames.length;
+  const messageCount = countPerMessage.size;
+  const translatedCount = [...countPerMessage.values()].filter(c => c === localeCount).length;
+  const notTranslatedCount = [...countPerMessage.values()].filter(c => c === 0).length;
+  const partiallyTranslatedCount = Math.max(0, messageCount - translatedCount - notTranslatedCount);
+
+  return {
+    localeCount,
+    messageCount,
+    translatedCount,
+    partiallyTranslatedCount,
+    notTranslatedCount,
+  };
+}
+
+module.exports = {
+  countTranslatedMessages,
+};


### PR DESCRIPTION
fixes the "`translation percentage calculation [brendankenny]`" part of https://github.com/GoogleChrome/lighthouse/issues/10791#issuecomment-630455884

for now just logs the percentage of messages that have been translated at the end of `collect-strings` (so also happens in `yarn update:sample-json`, etc), but we can follow up with bigger CI alerting or something in the future.