### PR TITLE
tests: update to typescript 3.9.7

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -35,7 +35,7 @@ const locales = fs.readdirSync(__dirname + '/../lighthouse-core/lib/i18n/locales
 
 // HACK: manually include the lighthouse-plugin-publisher-ads audits.
 /** @type {Array<string>} */
-// @ts-ignore
+// @ts-expect-error
 const pubAdsAudits = require('lighthouse-plugin-publisher-ads/plugin.js').audits.map(a => a.path);
 
 /** @param {string} file */
@@ -84,7 +84,7 @@ async function browserifyFile(entryPath, distPath) {
 
   // Don't include locales in DevTools.
   if (isDevtools(entryPath)) {
-    // @ts-ignore bundle.ignore does accept an array of strings.
+    // @ts-expect-error bundle.ignore does accept an array of strings.
     bundle.ignore(locales);
   }
 
@@ -171,7 +171,7 @@ async function cli(argv) {
   build(entryPath, distPath);
 }
 
-// @ts-ignore Test if called from the CLI or as a module.
+// @ts-expect-error Test if called from the CLI or as a module.
 if (require.main === module) {
   cli(process.argv);
 } else {

--- a/clients/devtools-entry.js
+++ b/clients/devtools-entry.js
@@ -59,26 +59,25 @@ if (typeof module !== 'undefined' && module.exports) {
   // work for LH because of https://github.com/browserify/browserify/issues/968
   // Instead, since this file is only ever run in node for testing, expose a
   // bundle entry point as global.
-  // @ts-ignore
+  // @ts-expect-error
   global.runBundledLighthouse = lighthouse;
 }
 
 // Expose only in DevTools' worker
-// @ts-ignore
 if (typeof self !== 'undefined') {
   // TODO: refactor and delete `global.isDevtools`.
   global.isDevtools = true;
 
-  // @ts-ignore
+  // @ts-expect-error
   self.setUpWorkerConnection = setUpWorkerConnection;
-  // @ts-ignore
+  // @ts-expect-error
   self.runLighthouse = lighthouse;
-  // @ts-ignore
+  // @ts-expect-error
   self.createConfig = createConfig;
-  // @ts-ignore
+  // @ts-expect-error
   self.listenForStatus = listenForStatus;
-  // @ts-ignore
+  // @ts-expect-error
   self.registerLocaleData = registerLocaleData;
-  // @ts-ignore
+  // @ts-expect-error
   self.lookupLocale = lookupLocale;
 }

--- a/clients/devtools-report-assets.js
+++ b/clients/devtools-report-assets.js
@@ -13,7 +13,7 @@
 
 /* global Runtime */
 
-// @ts-ignore: Runtime.cachedResources exists in Devtools. https://source.chromium.org/chromium/chromium/src/+/master:third_party/devtools-frontend/src/front_end/root/Runtime.js;l=1169
+// @ts-expect-error: Runtime.cachedResources exists in Devtools. https://source.chromium.org/chromium/chromium/src/+/master:third_party/devtools-frontend/src/front_end/root/Runtime.js;l=1169
 const cachedResources = Runtime.cachedResources;
 
 // Getters are necessary because the DevTools bundling processes

--- a/clients/lightrider/lightrider-entry.js
+++ b/clients/lightrider/lightrider-entry.js
@@ -101,6 +101,6 @@ if (typeof module !== 'undefined' && module.exports) {
 
 // Expose on window for browser-residing consumers of file.
 if (typeof window !== 'undefined') {
-  // @ts-ignore
+  // @ts-expect-error - not worth typing a property on `window`.
   window.runLighthouseInLR = runLighthouseInLR;
 }

--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -96,7 +96,7 @@ async function begin() {
     cliFlags.outputPath = 'stdout';
   }
 
-  // @ts-ignore - deprecation message for removed disableDeviceEmulation; can remove warning in v6.
+  // @ts-expect-error - deprecation message for removed disableDeviceEmulation; can remove warning in v6.
   if (cliFlags.disableDeviceEmulation) {
     log.warn('config', 'The "--disable-device-emulation" has been removed in v5.' +
         ' Please use "--emulated-form-factor=none" instead.');
@@ -107,8 +107,8 @@ async function begin() {
     // copied over to LH.Settings.extraHeaders, which is LH.Crdp.Network.Headers. Force
     // the conversion here, but long term either the CLI flag or the setting should have
     // a different name.
-    // @ts-ignore
-    let extraHeadersStr = /** @type {string} */ (cliFlags.extraHeaders);
+    /** @type {string} */
+    let extraHeadersStr = cliFlags.extraHeaders;
     // If not a JSON object, assume it's a path to a JSON file.
     if (extraHeadersStr.substr(0, 1) !== '{') {
       extraHeadersStr = fs.readFileSync(extraHeadersStr, 'utf-8');

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -27,7 +27,7 @@ function flatten(arr) {
  * @return {LH.CliFlags}
  */
 function getFlags(manualArgv) {
-  // @ts-ignore yargs() is incorrectly typed as not accepting a single string.
+  // @ts-expect-error yargs() is incorrectly typed as not accepting a single string.
   const y = manualArgv ? yargs(manualArgv) : yargs;
   // Intentionally left as type `any` because @types/yargs doesn't chain correctly.
   const argv = y.help('help')

--- a/lighthouse-cli/sentry-prompt.js
+++ b/lighthouse-cli/sentry-prompt.js
@@ -40,7 +40,7 @@ function prompt() {
 
   const timeoutPromise = new Promise((resolve) => {
     timeout = setTimeout(() => {
-      // @ts-ignore Promise returned by prompt is decorated with `ui`
+      // @ts-expect-error Promise returned by prompt is decorated with `ui`
       prompt.ui.close();
       process.stdout.write('\n');
       log.warn('CLI', 'No response to error logging preference, errors will not be reported.');

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -147,7 +147,7 @@ describe('CLI bin', function() {
 
   describe('extraHeaders', () => {
     it('should convert extra headers to object', async () => {
-      // @ts-ignore - see TODO: in bin.js
+      // @ts-expect-error - see TODO: in bin.js
       cliFlags = {...cliFlags, extraHeaders: '{"foo": "bar"}'};
       await bin.begin();
 
@@ -156,7 +156,7 @@ describe('CLI bin', function() {
 
     it('should read extra headers from file', async () => {
       const headersFile = require.resolve('../fixtures/extra-headers/valid.json');
-      // @ts-ignore - see TODO: in bin.js
+      // @ts-expect-error - see TODO: in bin.js
       cliFlags = {...cliFlags, extraHeaders: headersFile};
       await bin.begin();
 

--- a/lighthouse-cli/test/cli/cli-flags-test.js
+++ b/lighthouse-cli/test/cli/cli-flags-test.js
@@ -14,14 +14,14 @@ describe('CLI bin', function() {
     getFlags('chrome://version');
     const yargs = require('yargs');
 
-    // @ts-ignore - getGroups is private
+    // @ts-expect-error - getGroups is private
     const optionGroups = yargs.getGroups();
     /** @type {string[]} */
     const allOptions = [];
     Object.keys(optionGroups).forEach(key => {
       allOptions.push(...optionGroups[key]);
     });
-    // @ts-ignore - getUsageInstance is private
+    // @ts-expect-error - getUsageInstance is private
     const optionsWithDescriptions = Object.keys(yargs.getUsageInstance().getDescriptions());
 
     allOptions.forEach(opt => {

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -15,11 +15,11 @@ const ChromeLauncher = require('chrome-launcher');
 const ChromeProtocol = require('../../../../lighthouse-core/gather/connections/cri.js');
 
 // Load bundle, which creates a `global.runBundledLighthouse`.
-// @ts-ignore - file won't exist until `yarn build-all`, but not used for types anyways.
+// @ts-ignore - file exists if `yarn build-all` is run, but not used for types anyways.
 require('../../../../dist/lighthouse-dt-bundle.js'); // eslint-disable-line
 
 /** @type {import('../../../../lighthouse-core/index.js')} */
-// @ts-ignore - not worth giving test global an actual type.
+// @ts-expect-error - not worth giving test global an actual type.
 const lighthouse = global.runBundledLighthouse;
 
 /**

--- a/lighthouse-cli/test/smokehouse/report-assert.js
+++ b/lighthouse-cli/test/smokehouse/report-assert.js
@@ -277,9 +277,9 @@ function isPlainObject(obj) {
  * @param {Comparison} assertion
  */
 function reportAssertion(localConsole, assertion) {
-  // @ts-ignore - this doesn't exist now but could one day, so try not to break the future
+  // @ts-expect-error - this doesn't exist now but could one day, so try not to break the future
   const _toJSON = RegExp.prototype.toJSON;
-  // @ts-ignore
+  // @ts-expect-error
   // eslint-disable-next-line no-extend-native
   RegExp.prototype.toJSON = RegExp.prototype.toString;
 
@@ -312,7 +312,7 @@ function reportAssertion(localConsole, assertion) {
     }
   }
 
-  // @ts-ignore
+  // @ts-expect-error
   // eslint-disable-next-line no-extend-native
   RegExp.prototype.toJSON = _toJSON;
 }

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -215,7 +215,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
       // Filter out images that were loaded after all CPU activity
       items = context.settings.throttlingMethod === 'simulate' ?
         OffscreenImages.filterLanternResults(unfilteredResults, lanternInteractive) :
-        // @ts-ignore - .timestamp will exist if throttlingMethod isn't lantern
+        // @ts-expect-error - .timestamp will exist if throttlingMethod isn't lantern
         OffscreenImages.filterObservedResults(unfilteredResults, interactive.timestamp);
     } catch (err) {
       // if the error is during a Lantern run, end of trace may also be inaccurate, so rethrow

--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -135,9 +135,14 @@ class RenderBlockingResources extends Audit {
     const wastedCssBytes = await RenderBlockingResources.computeWastedCSSBytes(artifacts, context);
 
     const metricSettings = {throttlingMethod: 'simulate'};
+
+    /** @type {LH.Artifacts.MetricComputationData} */
+    // @ts-expect-error - TODO(bckenny): allow optional `throttling` settings
     const metricComputationData = {trace, devtoolsLog, simulator, settings: metricSettings};
-    // @ts-ignore - TODO(bckenny): allow optional `throttling` settings
-    const fcpSimulation = await FirstContentfulPaint.request(metricComputationData, context);
+
+    // Cast to just `LanternMetric` since we explicitly set `throttlingMethod: 'simulate'`.
+    const fcpSimulation = /** @type {LH.Artifacts.LanternMetric} */
+      (await FirstContentfulPaint.request(metricComputationData, context));
     const fcpTsInMs = traceOfTab.timestamps.firstContentfulPaint / 1000;
 
     const nodesByUrl = getNodesAndTimingByUrl(fcpSimulation.optimisticEstimate.nodeTimings);

--- a/lighthouse-core/audits/font-display.js
+++ b/lighthouse-core/audits/font-display.js
@@ -83,7 +83,7 @@ class FontDisplay extends Audit {
 
         // Finally convert the raw font URLs to the absolute URLs and add them to the set.
         const relativeURLs = rawFontURLs
-          // @ts-ignore - guaranteed to match from previous regex, pull URL group out
+          // @ts-expect-error - guaranteed to match from previous regex, pull URL group out
           .map(s => s.match(CSS_URL_REGEX)[1].trim())
           .map(s => {
             // remove any quotes surrounding the URL

--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -46,7 +46,7 @@ class PredictivePerf extends Audit {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     /** @type {LH.Config.Settings} */
-    // @ts-ignore - TODO(bckenny): allow optional `throttling` settings
+    // @ts-expect-error - TODO(bckenny): allow optional `throttling` settings
     const settings = {}; // Use default settings.
     const fcp = await LanternFcp.request({trace, devtoolsLog, settings}, context);
     const fmp = await LanternFmp.request({trace, devtoolsLog, settings}, context);

--- a/lighthouse-core/audits/screenshot-thumbnails.js
+++ b/lighthouse-core/audits/screenshot-thumbnails.js
@@ -105,7 +105,7 @@ class ScreenshotThumbnails extends Audit {
       const targetTimestamp = speedline.beginning + timelineEnd * i / NUMBER_OF_THUMBNAILS;
 
       /** @type {SpeedlineFrame} */
-      // @ts-ignore - there will always be at least one frame by this point. TODO: use nonnullable assertion in TS2.9
+      // @ts-expect-error - there will always be at least one frame by this point. TODO: use nonnullable assertion in TS2.9
       let frameForTimestamp = null;
       if (i === NUMBER_OF_THUMBNAILS) {
         frameForTimestamp = analyzedFrames[analyzedFrames.length - 1];

--- a/lighthouse-core/audits/seo/hreflang.js
+++ b/lighthouse-core/audits/seo/hreflang.js
@@ -38,15 +38,15 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
  * @return {Array<string>}
  */
 function importValidLangs() {
-  // @ts-ignore - global switcheroo to load axe valid-langs
+  // @ts-expect-error - global switcheroo to load axe valid-langs
   const axeCache = global.axe;
-  // @ts-ignore
+  // @ts-expect-error
   global.axe = {utils: {}};
-  // @ts-ignore
+  // @ts-expect-error
   require('axe-core/lib/core/utils/valid-langs.js');
-  // @ts-ignore
+  // @ts-expect-error
   const validLangs = global.axe.utils.validLangs();
-  // @ts-ignore
+  // @ts-expect-error
   global.axe = axeCache;
 
   return validLangs;

--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -172,7 +172,7 @@ class UsesRelPreloadAudit extends Audit {
     // Once we've modified the dependencies, simulate the new graph with flexible ordering.
     const simulationAfterChanges = simulator.simulate(modifiedGraph, {flexibleOrdering: true});
     const originalNodesByRecord = Array.from(simulationBeforeChanges.nodeTimings.keys())
-        // @ts-ignore we don't care if all nodes without a record collect on `undefined`
+        // @ts-expect-error we don't care if all nodes without a record collect on `undefined`
         .reduce((map, node) => map.set(node.record, node), new Map());
 
     const results = [];

--- a/lighthouse-core/computed/js-bundles.js
+++ b/lighthouse-core/computed/js-bundles.js
@@ -26,14 +26,14 @@ function computeGeneratedFileSizes(map, content) {
   // denotes nothing is mapped.
   const failureResult = {files: {}, unmappedBytes, totalBytes};
 
-  // @ts-ignore: This function is added in SDK.js. This will eventually be added to CDT.
+  // @ts-expect-error: This function is added in SDK.js. This will eventually be added to CDT.
   map.computeLastGeneratedColumns();
 
   for (const mapping of map.mappings()) {
     const source = mapping.sourceURL;
     const lineNum = mapping.lineNumber;
     const colNum = mapping.columnNumber;
-    // @ts-ignore: `lastColumnNumber` is not on types yet. This will eventually be added to CDT.
+    // @ts-expect-error: `lastColumnNumber` is not on types yet. This will eventually be added to CDT.
     const lastColNum = /** @type {number=} */ (mapping.lastColumnNumber);
 
     // Webpack sometimes emits null mappings.
@@ -99,7 +99,7 @@ class JSBundles {
 
       const compiledUrl = SourceMap.scriptUrl || 'compiled.js';
       const mapUrl = SourceMap.sourceMapUrl || 'compiled.js.map';
-      // @ts-ignore: CDT expects undefined properties to be explicit.
+      // Hack: CDT expects undefined properties to be explicit.
       const rawMapForCdt = /** @type {any} */ (rawMap);
       const map = new SDK.TextSourceMap(compiledUrl, mapUrl, rawMapForCdt);
 

--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -253,12 +253,12 @@ class PageDependencyGraph {
 
         switch (evt.name) {
           case 'TimerInstall':
-            // @ts-ignore - 'TimerInstall' event means timerId exists.
+            // @ts-expect-error - 'TimerInstall' event means timerId exists.
             timers.set(evt.args.data.timerId, node);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
           case 'TimerFire': {
-            // @ts-ignore - 'TimerFire' event means timerId exists.
+            // @ts-expect-error - 'TimerFire' event means timerId exists.
             const installer = timers.get(evt.args.data.timerId);
             if (!installer || installer.endTime > node.startTime) break;
             installer.addDependent(node);
@@ -273,17 +273,17 @@ class PageDependencyGraph {
 
           case 'EvaluateScript':
             addDependencyOnFrame(node, evt.args.data.frame);
-            // @ts-ignore - 'EvaluateScript' event means argsUrl is defined.
+            // @ts-expect-error - 'EvaluateScript' event means argsUrl is defined.
             addDependencyOnUrl(node, argsUrl);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
 
           case 'XHRReadyStateChange':
             // Only create the dependency if the request was completed
-            // @ts-ignore - 'XHRReadyStateChange' event means readyState is defined.
+            // 'XHRReadyStateChange' event means readyState is defined.
             if (evt.args.data.readyState !== 4) break;
 
-            // @ts-ignore - 'XHRReadyStateChange' event means argsUrl is defined.
+            // @ts-expect-error - 'XHRReadyStateChange' event means argsUrl is defined.
             addDependencyOnUrl(node, argsUrl);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
@@ -291,19 +291,19 @@ class PageDependencyGraph {
           case 'FunctionCall':
           case 'v8.compile':
             addDependencyOnFrame(node, evt.args.data.frame);
-            // @ts-ignore - events mean argsUrl is defined.
+            // @ts-expect-error - events mean argsUrl is defined.
             addDependencyOnUrl(node, argsUrl);
             break;
 
           case 'ParseAuthorStyleSheet':
             addDependencyOnFrame(node, evt.args.data.frame);
-            // @ts-ignore - 'ParseAuthorStyleSheet' event means styleSheetUrl is defined.
+            // @ts-expect-error - 'ParseAuthorStyleSheet' event means styleSheetUrl is defined.
             addDependencyOnUrl(node, evt.args.data.styleSheetUrl);
             break;
 
           case 'ResourceSendRequest':
             addDependencyOnFrame(node, evt.args.data.frame);
-            // @ts-ignore - 'ResourceSendRequest' event means requestId is defined.
+            // @ts-expect-error - 'ResourceSendRequest' event means requestId is defined.
             addDependentNetworkRequest(node, evt.args.data.requestId);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
@@ -432,7 +432,7 @@ class PageDependencyGraph {
       const length = Math.ceil((node.endTime - node.startTime) / timePerCharacter);
       const bar = padRight('', offset) + padRight('', length, '=');
 
-      // @ts-ignore -- disambiguate displayName from across possible Node types.
+      // @ts-expect-error -- disambiguate displayName from across possible Node types.
       const displayName = node.record ? node.record.url : node.type;
       // eslint-disable-next-line
       console.log(padRight(bar, widthInCharacters), `| ${displayName.slice(0, 30)}`);

--- a/lighthouse-core/computed/unused-javascript-summary.js
+++ b/lighthouse-core/computed/unused-javascript-summary.js
@@ -121,14 +121,14 @@ class UnusedJavascriptSummary {
       return retVal;
     });
 
-    // @ts-ignore: We will upstream computeLastGeneratedColumns to CDT eventually.
+    // @ts-expect-error: We will upstream computeLastGeneratedColumns to CDT eventually.
     bundle.map.computeLastGeneratedColumns();
     for (const mapping of bundle.map.mappings()) {
       let offset = lineOffsets[mapping.lineNumber];
 
       offset += mapping.columnNumber;
       const lastColumnOfMapping =
-        // @ts-ignore: We will upstream lastColumnNumber to CDT eventually.
+        // @ts-expect-error: We will upstream lastColumnNumber to CDT eventually.
         (mapping.lastColumnNumber - 1) || lineLengths[mapping.lineNumber];
       for (let i = mapping.columnNumber; i <= lastColumnOfMapping; i++) {
         if (wasteData.every(data => data.unusedByIndex[offset] === 1)) {

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -190,7 +190,7 @@ function cleanFlagsForSettings(flags = {}) {
 
   for (const key of Object.keys(flags)) {
     if (key in constants.defaultSettings) {
-      // @ts-ignore tsc can't yet express that key is only a single type in each iteration, not a union of types.
+      // @ts-expect-error tsc can't yet express that key is only a single type in each iteration, not a union of types.
       settings[key] = flags[key];
     }
   }
@@ -297,10 +297,12 @@ function deepCloneConfigJson(json) {
   return cloned;
 }
 
+/**
+ * @implements {LH.Config.Json}
+ */
 class Config {
   /**
    * @constructor
-   * @implements {LH.Config.Json}
    * @param {LH.Config.Json=} configJSON
    * @param {LH.Flags=} flags
    */
@@ -355,9 +357,6 @@ class Config {
     assertValidPasses(this.passes, this.audits);
     assertValidCategories(this.categories, this.audits, this.groups);
 
-    // TODO(bckenny): until tsc adds @implements support, assert that Config is a ConfigJson.
-    /** @type {LH.Config.Json} */
-    const configJson = this; // eslint-disable-line no-unused-vars
     log.timeEnd(status);
   }
 
@@ -373,10 +372,10 @@ class Config {
       for (const pass of jsonConfig.passes) {
         for (const gathererDefn of pass.gatherers) {
           gathererDefn.implementation = undefined;
-          // @ts-ignore Breaking the Config.GathererDefn type.
+          // @ts-expect-error Breaking the Config.GathererDefn type.
           gathererDefn.instance = undefined;
           if (Object.keys(gathererDefn.options).length === 0) {
-            // @ts-ignore Breaking the Config.GathererDefn type.
+            // @ts-expect-error Breaking the Config.GathererDefn type.
             gathererDefn.options = undefined;
           }
         }
@@ -385,10 +384,10 @@ class Config {
 
     if (jsonConfig.audits) {
       for (const auditDefn of jsonConfig.audits) {
-        // @ts-ignore Breaking the Config.AuditDefn type.
+        // @ts-expect-error Breaking the Config.AuditDefn type.
         auditDefn.implementation = undefined;
         if (Object.keys(auditDefn.options).length === 0) {
-          // @ts-ignore Breaking the Config.AuditDefn type.
+          // @ts-expect-error Breaking the Config.AuditDefn type.
           auditDefn.options = undefined;
         }
       }

--- a/lighthouse-core/config/lr-mobile-config.js
+++ b/lighthouse-core/config/lr-mobile-config.js
@@ -18,7 +18,7 @@ const config = {
     'metrics/first-contentful-paint-3g',
   ],
   categories: {
-    // @ts-ignore TODO(bckenny): type extended Config where e.g. category.title isn't required
+    // @ts-expect-error TODO(bckenny): type extended Config where e.g. category.title isn't required
     performance: {
       auditRefs: [
         {id: 'first-contentful-paint-3g', weight: 0},

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -293,7 +293,7 @@ class Driver {
       this._networkStatusMonitor.dispatch(event);
     }
 
-    // @ts-ignore TODO(bckenny): tsc can't type event.params correctly yet,
+    // @ts-expect-error TODO(bckenny): tsc can't type event.params correctly yet,
     // typing as property of union instead of narrowing from union of
     // properties. See https://github.com/Microsoft/TypeScript/pull/22348.
     this._eventEmitter.emit(event.method, event.params);

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -477,7 +477,7 @@ class GatherRunner {
         // Take the last defined pass result as artifact. If none are defined, the undefined check below handles it.
         const definedResults = phaseResults.filter(element => element !== undefined);
         const artifact = definedResults[definedResults.length - 1];
-        // @ts-ignore tsc can't yet express that gathererName is only a single type in each iteration, not a union of types.
+        // @ts-expect-error tsc can't yet express that gathererName is only a single type in each iteration, not a union of types.
         gathererArtifacts[gathererName] = artifact;
       } catch (err) {
         // Return error to runner to handle turning it into an error audit.
@@ -545,7 +545,7 @@ class GatherRunner {
     // error strings were returned. Convert the values we care about to the new error id format.
     if (!errors) {
       /** @type {string[]} */
-      // @ts-ignore - Support older protocol data.
+      // @ts-expect-error - Support older protocol data.
       const m81StyleErrors = response.errors || [];
       errors = m81StyleErrors.map(error => {
         const englishErrorToErrorId = {
@@ -599,7 +599,7 @@ class GatherRunner {
       !!entry.params.request.headers['User-Agent']
     );
     if (userAgentEntry) {
-      // @ts-ignore - guaranteed to exist by the find above
+      // @ts-expect-error - guaranteed to exist by the find above
       baseArtifacts.NetworkUserAgent = userAgentEntry.params.request.headers['User-Agent'];
     }
   }

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -20,7 +20,7 @@ const pageFunctions = require('../../lib/page-functions.js');
  */
 /* istanbul ignore next */
 function runA11yChecks() {
-  // @ts-ignore axe defined by axeLibSource
+  // @ts-expect-error axe defined by axeLibSource
   return window.axe.run(document, {
     elementRef: true,
     runOnly: {
@@ -50,27 +50,27 @@ function runA11yChecks() {
       'svg-img-alt': {enabled: false},
       'audio-caption': {enabled: false},
     },
-    // @ts-ignore
+    // @ts-expect-error
   }).then(axeResult => {
     // axe just scrolled the page, scroll back to the top of the page so that element positions
     // are relative to the top of the page
     document.documentElement.scrollTop = 0;
 
-    // @ts-ignore
+    // @ts-expect-error
     const augmentAxeNodes = result => {
-      // @ts-ignore
+      // @ts-expect-error
       result.nodes.forEach(node => {
-        // @ts-ignore - getNodePath put into scope via stringification
+        // @ts-expect-error - getNodePath put into scope via stringification
         node.path = getNodePath(node.element);
-        // @ts-ignore - getOuterHTMLSnippet put into scope via stringification
+        // @ts-expect-error - getOuterHTMLSnippet put into scope via stringification
         node.snippet = getOuterHTMLSnippet(node.element);
-        // @ts-ignore - getBoundingClientRect put into scope via stringification
+        // @ts-expect-error - getBoundingClientRect put into scope via stringification
         const rect = getBoundingClientRect(node.element);
         if (rect.width > 0 && rect.height > 0) {
           node.boundingRect = rect;
         }
 
-        // @ts-ignore - getNodeLabel put into scope via stringification
+        // @ts-expect-error - getNodeLabel put into scope via stringification
         node.nodeLabel = getNodeLabel(node.element);
         // avoid circular JSON concerns
         node.element = node.any = node.all = node.none = undefined;

--- a/lighthouse-core/gather/gatherers/anchor-elements.js
+++ b/lighthouse-core/gather/gatherers/anchor-elements.js
@@ -37,17 +37,17 @@ function collectAnchorElements() {
   }
 
   /** @type {Array<HTMLAnchorElement|SVGAElement>} */
-  // @ts-ignore - put into scope via stringification
+  // @ts-expect-error - put into scope via stringification
   const anchorElements = getElementsInDocument('a'); // eslint-disable-line no-undef
 
   return anchorElements.map(node => {
-    // @ts-ignore - put into scope via stringification
+    // @ts-expect-error - put into scope via stringification
     const outerHTML = getOuterHTMLSnippet(node); // eslint-disable-line no-undef
-    // @ts-ignore - put into scope via stringification
+    // @ts-expect-error - put into scope via stringification
     const nodePath = getNodePath(node); // eslint-disable-line no-undef
-    // @ts-ignore - getNodeSelector put into scope via stringification
+    // @ts-expect-error - getNodeSelector put into scope via stringification
     const selector = getNodeSelector(node); // eslint-disable-line no-undef
-    // @ts-ignore - getNodeLabel put into scope via stringification
+    // @ts-expect-error - getNodeLabel put into scope via stringification
     const nodeLabel = getNodeLabel(node); // eslint-disable-line no-undef
 
     if (node instanceof HTMLAnchorElement) {

--- a/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
@@ -23,7 +23,7 @@ function findPasswordInputsWithPreventedPaste() {
       )
     )
     .map(passwordInput => ({
-      // @ts-ignore - getOuterHTMLSnippet put into scope via stringification
+      // @ts-expect-error - getOuterHTMLSnippet put into scope via stringification
       snippet: getOuterHTMLSnippet(passwordInput),
     }));
 }

--- a/lighthouse-core/gather/gatherers/gatherer.js
+++ b/lighthouse-core/gather/gatherers/gatherer.js
@@ -22,7 +22,7 @@ class Gatherer {
    * @return {keyof LH.GathererArtifacts}
    */
   get name() {
-    // @ts-ignore - assume that class name has been added to LH.GathererArtifacts.
+    // @ts-expect-error - assume that class name has been added to LH.GathererArtifacts.
     return this.constructor.name;
   }
 

--- a/lighthouse-core/gather/gatherers/iframe-elements.js
+++ b/lighthouse-core/gather/gatherers/iframe-elements.js
@@ -15,7 +15,7 @@ const pageFunctions = require('../../lib/page-functions.js');
  */
 /* istanbul ignore next */
 function collectIFrameElements() {
-  // @ts-ignore - put into scope via stringification
+  // @ts-expect-error - put into scope via stringification
   const iFrameElements = getElementsInDocument('iframe'); // eslint-disable-line no-undef
   return iFrameElements.map(/** @param {HTMLIFrameElement} node */ (node) => {
     const clientRect = node.getBoundingClientRect();
@@ -24,7 +24,7 @@ function collectIFrameElements() {
       id: node.id,
       src: node.src,
       clientRect: {top, bottom, left, right, width, height},
-      // @ts-ignore - put into scope via stringification
+      // @ts-expect-error - put into scope via stringification
       isPositionFixed: isPositionFixed(node), // eslint-disable-line no-undef
     };
   });

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -52,7 +52,7 @@ function getHTMLImages(allElements) {
       naturalWidth: element.naturalWidth,
       naturalHeight: element.naturalHeight,
       isCss: false,
-      // @ts-ignore: loading attribute not yet added to HTMLImageElement definition.
+      // @ts-expect-error: loading attribute not yet added to HTMLImageElement definition.
       loading: element.loading,
       resourceSize: 0, // this will get overwritten below
       isPicture: !!element.parentElement && element.parentElement.tagName === 'PICTURE',
@@ -87,7 +87,7 @@ function getCSSImages(allElements) {
     if (!style.backgroundImage || !CSS_URL_REGEX.test(style.backgroundImage)) continue;
 
     const imageMatch = style.backgroundImage.match(CSS_URL_REGEX);
-    // @ts-ignore test() above ensures that there is a match.
+    // @ts-expect-error test() above ensures that there is a match.
     const url = imageMatch[1];
 
     images.push({
@@ -117,7 +117,7 @@ function getCSSImages(allElements) {
 /* istanbul ignore next */
 function collectImageElementInfo() {
   /** @type {Array<Element>} */
-  // @ts-ignore - added by getElementsInDocumentFnString
+  // @ts-expect-error - added by getElementsInDocumentFnString
   const allElements = getElementsInDocument();
   return getHTMLImages(allElements).concat(getCSSImages(allElements));
 }

--- a/lighthouse-core/gather/gatherers/link-elements.js
+++ b/lighthouse-core/gather/gatherers/link-elements.js
@@ -54,7 +54,7 @@ function getCrossoriginFromHeader(value) {
 /* istanbul ignore next */
 function getLinkElementsInDOM() {
   /** @type {Array<HTMLOrSVGElement>} */
-  // @ts-ignore - getElementsInDocument put into scope via stringification
+  // @ts-expect-error - getElementsInDocument put into scope via stringification
   const browserElements = getElementsInDocument('link'); // eslint-disable-line no-undef
   /** @type {LH.Artifacts['LinkElements']} */
   const linkElements = [];
@@ -64,11 +64,11 @@ function getLinkElementsInDOM() {
     // https://github.com/GoogleChrome/lighthouse/issues/9764
     if (!(link instanceof HTMLLinkElement)) continue;
 
-    // @ts-ignore - put into scope via stringification
+    // @ts-expect-error - put into scope via stringification
     const nodePath = getNodePath(link); // eslint-disable-line no-undef
-    // @ts-ignore - getNodeSelector put into scope via stringification
+    // @ts-expect-error - getNodeSelector put into scope via stringification
     const selector = getNodeSelector(link); // eslint-disable-line no-undef
-    // @ts-ignore - getNodeLabel put into scope via stringification
+    // @ts-expect-error - getNodeLabel put into scope via stringification
     const nodeLabel = getNodeLabel(link); // eslint-disable-line no-undef
 
     const hrefRaw = link.getAttribute('href') || '';

--- a/lighthouse-core/gather/gatherers/script-elements.js
+++ b/lighthouse-core/gather/gatherers/script-elements.js
@@ -19,7 +19,7 @@ const pageFunctions = require('../../lib/page-functions.js');
 /* istanbul ignore next */
 function collectAllScriptElements() {
   /** @type {HTMLScriptElement[]} */
-  // @ts-ignore - getElementsInDocument put into scope via stringification
+  // @ts-expect-error - getElementsInDocument put into scope via stringification
   const scripts = getElementsInDocument('script'); // eslint-disable-line no-undef
 
   return scripts.map(script => {
@@ -30,7 +30,7 @@ function collectAllScriptElements() {
       async: script.async,
       defer: script.defer,
       source: /** @type {'head'|'body'} */ (script.closest('head') ? 'head' : 'body'),
-      // @ts-ignore - getNodePath put into scope via stringification
+      // @ts-expect-error - getNodePath put into scope via stringification
       devtoolsNodePath: getNodePath(script),
       content: script.src ? null : script.text,
       requestId: null,

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -355,7 +355,7 @@ class FontSize extends Gatherer {
     // the stylsheet to the data.
     analyzedFailingNodesData
       .filter(data => data.cssRule && data.cssRule.styleSheetId)
-      // @ts-ignore - guaranteed to exist from the filter immediately above
+      // @ts-expect-error - guaranteed to exist from the filter immediately above
       .forEach(data => (data.cssRule.stylesheet = stylesheets.get(data.cssRule.styleSheetId)));
 
     await Promise.all([

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -213,7 +213,7 @@ function gatherTapTargets() {
   window.scrollTo(0, 0);
 
   /** @type {HTMLElement[]} */
-  // @ts-ignore - getElementsInDocument put into scope via stringification
+  // @ts-expect-error - getElementsInDocument put into scope via stringification
   const tapTargetElements = getElementsInDocument(tapTargetsSelector);
 
   /** @type {{
@@ -283,14 +283,14 @@ function gatherTapTargets() {
   for (const {tapTargetElement, visibleClientRects} of tapTargetsWithVisibleClientRects) {
     targets.push({
       clientRects: visibleClientRects,
-      // @ts-ignore - getBoundingClientRect put into scope via stringification
+      // @ts-expect-error - getBoundingClientRect put into scope via stringification
       boundingRect: getBoundingClientRect(tapTargetElement),
       snippet: truncate(tapTargetElement.outerHTML, 300),
-      // @ts-ignore - getNodePath put into scope via stringification
+      // @ts-expect-error - getNodePath put into scope via stringification
       path: getNodePath(tapTargetElement),
-      // @ts-ignore - getNodeSelector put into scope via stringification
+      // @ts-expect-error - getNodeSelector put into scope via stringification
       selector: getNodeSelector(tapTargetElement),
-      // @ts-ignore - getNodeLabel put into scope via stringification
+      // @ts-expect-error - getNodeLabel put into scope via stringification
       nodeLabel: getNodeLabel(tapTargetElement),
       href: /** @type {HTMLAnchorElement} */(tapTargetElement)['href'] || '',
     });

--- a/lighthouse-core/gather/gatherers/trace-elements.js
+++ b/lighthouse-core/gather/gatherers/trace-elements.js
@@ -27,15 +27,15 @@ function getNodeDetailsData() {
   let traceElement;
   if (elem) {
     traceElement = {
-      // @ts-ignore - put into scope via stringification
+      // @ts-expect-error - put into scope via stringification
       devtoolsNodePath: getNodePath(elem), // eslint-disable-line no-undef
-      // @ts-ignore - put into scope via stringification
+      // @ts-expect-error - put into scope via stringification
       selector: getNodeSelector(elem), // eslint-disable-line no-undef
-      // @ts-ignore - put into scope via stringification
+      // @ts-expect-error - put into scope via stringification
       nodeLabel: getNodeLabel(elem), // eslint-disable-line no-undef
-      // @ts-ignore - put into scope via stringification
+      // @ts-expect-error - put into scope via stringification
       snippet: getOuterHTMLSnippet(elem), // eslint-disable-line no-undef
-      // @ts-ignore - put into scope via stringification
+      // @ts-expect-error - put into scope via stringification
       boundingRect: getBoundingClientRect(elem), // eslint-disable-line no-undef
     };
   }

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -274,7 +274,7 @@ async function saveAssets(artifacts, audits, pathWithBasename) {
  */
 async function saveLanternNetworkData(devtoolsLog, outputPath) {
   /** @type {LH.Audit.Context} */
-  // @ts-ignore - the full audit context isn't needed for analysis.
+  // @ts-expect-error - the full audit context isn't needed for analysis.
   const context = {computedCache: new Map()};
   const networkAnalysis = await NetworkAnalysisComputed.request(devtoolsLog, context);
   const lanternData = LoadSimulatorComputed.convertAnalysisToSaveableLanternData(networkAnalysis);

--- a/lighthouse-core/lib/cdt/SDK.js
+++ b/lighthouse-core/lib/cdt/SDK.js
@@ -17,20 +17,20 @@ const SDK = {
  * @param {unknown[]} array
  */
 function extendArray(array) {
-  // @ts-ignore
+  // @ts-expect-error
   if (array.lowerBound) return;
 
-  // @ts-ignore
+  // @ts-expect-error
   array.lowerBound = lowerBound.bind(array);
-  // @ts-ignore
+  // @ts-expect-error
   array.upperBound = upperBound.bind(array);
-  // @ts-ignore
+
   array.slice = function(start, end) {
     const retVal = Array.prototype.slice.call(array, start, end);
     extendArray(retVal);
     return retVal;
   };
-  // @ts-ignore
+  // @ts-expect-error
   array.filter = function(fn) {
     const retVal = Array.prototype.filter.call(array, fn);
     extendArray(retVal);
@@ -74,7 +74,7 @@ SDK.TextSourceMap.prototype._reversedMappings = function(sourceURL) {
  * @template T,S
  */
 function upperBound(object, comparator, left, right) {
-  // @ts-ignore
+  // @ts-expect-error
   function defaultComparator(a, b) {
     return a < b ? -1 : (a > b ? 1 : 0);
   }
@@ -109,7 +109,7 @@ function upperBound(object, comparator, left, right) {
  * @template T,S
  */
 function lowerBound(object, comparator, left, right) {
-  // @ts-ignore
+  // @ts-expect-error
   function defaultComparator(a, b) {
     return a < b ? -1 : (a > b ? 1 : 0);
   }
@@ -128,17 +128,17 @@ function lowerBound(object, comparator, left, right) {
 }
 
 // Add `lastColumnNumber` to mappings. This will eventually be added to CDT.
-// @ts-ignore
+// @ts-expect-error
 SDK.TextSourceMap.prototype.computeLastGeneratedColumns = function() {
   const mappings = this.mappings();
-  // @ts-ignore: `lastColumnNumber` is not on types yet.
+  // @ts-expect-error: `lastColumnNumber` is not on types yet.
   if (mappings.length && typeof mappings[0].lastColumnNumber !== 'undefined') return;
 
   for (let i = 0; i < mappings.length - 1; i++) {
     const mapping = mappings[i];
     const nextMapping = mappings[i + 1];
     if (mapping.lineNumber === nextMapping.lineNumber) {
-      // @ts-ignore: `lastColumnNumber` is not on types yet.
+      // @ts-expect-error: `lastColumnNumber` is not on types yet.
       mapping.lastColumnNumber = nextMapping.columnNumber;
     }
   }

--- a/lighthouse-core/lib/cdt/generated/SourceMap.js
+++ b/lighthouse-core/lib/cdt/generated/SourceMap.js
@@ -32,6 +32,7 @@ const Common = require('../Common.js')
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
+
 /**
  * @interface
  */

--- a/lighthouse-core/lib/dependency-graph/base-node.js
+++ b/lighthouse-core/lib/dependency-graph/base-node.js
@@ -129,7 +129,7 @@ class BaseNode {
    * @param {Node} node
    */
   addDependency(node) {
-    // @ts-ignore - in checkJs, ts doesn't know that CPUNode and NetworkNode *are* BaseNodes.
+    // @ts-expect-error - in checkJs, ts doesn't know that CPUNode and NetworkNode *are* BaseNodes.
     if (node === this) throw new Error('Cannot add dependency on itself');
 
     if (this._dependencies.includes(node)) {
@@ -264,13 +264,13 @@ class BaseNode {
     }
 
     /** @type {Node[][]} */
-    // @ts-ignore - only traverses graphs of Node, so force tsc to treat `this` as one
+    // @ts-expect-error - only traverses graphs of Node, so force tsc to treat `this` as one
     const queue = [[this]];
     const visited = new Set([this.id]);
 
     while (queue.length) {
       /** @type {Node[]} */
-      // @ts-ignore - queue has length so it's guaranteed to have an item
+      // @ts-expect-error - queue has length so it's guaranteed to have an item
       const traversalPath = queue.shift();
       const node = traversalPath[0];
       callback(node, traversalPath);
@@ -306,7 +306,7 @@ class BaseNode {
     while (toVisit.length) {
       // Get the last node in the stack (DFS uses stack, not queue)
       /** @type {Node} */
-      // @ts-ignore - toVisit has length so it's guaranteed to have an item
+      // @ts-expect-error - toVisit has length so it's guaranteed to have an item
       const currentNode = toVisit.pop();
 
       // We've hit a cycle if the node we're visiting is in our current dependency path
@@ -315,7 +315,7 @@ class BaseNode {
       if (visited.has(currentNode)) continue;
 
       // Since we're visiting this node, clear out any nodes in our path that we had to backtrack
-      // @ts-ignore
+      // @ts-expect-error
       while (currentPath.length > depthAdded.get(currentNode)) currentPath.pop();
 
       // Update our data structures to reflect that we're adding this node to our path

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -268,7 +268,6 @@ class NetworkAnalyzer {
 
     // Check if we can trust the connection information coming from the protocol
     if (!forceCoarseEstimates && NetworkAnalyzer.canTrustConnectionInformation(records)) {
-      // @ts-ignore
       return new Map(records.map(record => [record.requestId, !!record.connectionReused]));
     }
 

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -80,7 +80,7 @@ class Simulator {
     /** @type {Record<number, Set<Node>>} */
     this._nodes = {};
     this._dns = new DNSCache({rtt: this._rtt});
-    // @ts-ignore
+    // @ts-expect-error
     this._connectionPool = /** @type {ConnectionPool} */ (null);
 
     if (!Number.isFinite(this._rtt)) throw new Error(`Invalid rtt ${this._rtt}`);

--- a/lighthouse-core/lib/file-namer.js
+++ b/lighthouse-core/lib/file-namer.js
@@ -27,7 +27,7 @@ function getFilenamePrefix(lhr) {
   const dateParts = date.toLocaleDateString('en-US', {
     year: 'numeric', month: '2-digit', day: '2-digit',
   }).split('/');
-  // @ts-ignore - parts exists
+  // @ts-expect-error - parts exists
   dateParts.unshift(dateParts.pop());
   const dateStr = dateParts.join('-');
 

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -25,10 +25,10 @@ const MESSAGE_INSTANCE_ID_QUICK_REGEX = / # \d+$/;
   // See https://nodejs.org/api/intl.html#intl_options_for_building_node_js
 
   // Conditionally polyfills itself. Bundler removes this dep, so this will be a no-op in browsers.
-  // @ts-ignore
+  // @ts-expect-error
   require('intl-pluralrules');
 
-  // @ts-ignore
+  // @ts-expect-error
   const IntlPolyfill = require('intl');
 
   // The bundler also removes this dep, so there's nothing to do if it's empty.

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -41,7 +41,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
   // Create a fake task event ~1s after the trace ends for a sane default bounds in DT
   traceEvents.push(
     ...createFakeTaskEvents(
-      // @ts-ignore
+      // @ts-expect-error
       {childEvents: [], event: {}},
       {
         startTime: lastEventEndTime + 1000,

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -166,7 +166,7 @@ class LighthouseError extends Error {
     // Unexpected errors won't be LHErrors, but we want them serialized as well.
     if (err instanceof Error) {
       const {message, stack} = err;
-      // @ts-ignore - code can be helpful for e.g. node errors, so preserve it if it's present.
+      // @ts-expect-error - code can be helpful for e.g. node errors, so preserve it if it's present.
       const code = err.code;
       return {
         sentinel: ERROR_SENTINEL,

--- a/lighthouse-core/lib/proto-preprocessor.js
+++ b/lighthouse-core/lib/proto-preprocessor.js
@@ -31,7 +31,7 @@ function processForProto(lhr) {
     // The settings that are in both proto and LHR
     const {emulatedFormFactor, locale, onlyCategories, channel} = reportJson.configSettings;
 
-    // @ts-ignore - intentionally only a subset of settings.
+    // @ts-expect-error - intentionally only a subset of settings.
     reportJson.configSettings = {emulatedFormFactor, locale, onlyCategories, channel};
   }
 
@@ -47,7 +47,7 @@ function processForProto(lhr) {
 
       // Rewrite 'not-applicable' and 'not_applicable' scoreDisplayMode to 'notApplicable'. #6201, #6783.
       if (audit.scoreDisplayMode) {
-        // @ts-ignore ts properly flags this as invalid as it should not happen,
+        // @ts-expect-error ts properly flags this as invalid as it should not happen,
         // but remains in preprocessor to protect from proto translation errors from
         // old LHRs.
         // eslint-disable-next-line max-len
@@ -100,7 +100,7 @@ function processForProto(lhr) {
   return reportJson;
 }
 
-// @ts-ignore claims always false, but this checks if cli or module
+// @ts-expect-error claims always false, but this checks if cli or module
 if (require.main === module) {
   // read in the argv for the input & output
   const args = process.argv.slice(2);

--- a/lighthouse-core/lib/sentry.js
+++ b/lighthouse-core/lib/sentry.js
@@ -76,7 +76,7 @@ function init(opts) {
       if (!err) return;
 
       // Ignore expected errors
-      // @ts-ignore Non-standard property added to flag error as not needing capturing.
+      // @ts-expect-error Non-standard property added to flag error as not needing capturing.
       if (err.expected) return;
 
       const tags = opts.tags || {};
@@ -97,9 +97,9 @@ function init(opts) {
       if (sampledErrorMatch && sampledErrorMatch.rate <= Math.random()) return;
 
       // Protocol errors all share same stack trace, so add more to fingerprint
-      // @ts-ignore - properties added to protocol method LHErrors.
+      // @ts-expect-error - properties added to protocol method LHErrors.
       if (err.protocolMethod) {
-        // @ts-ignore - properties added to protocol method LHErrors.
+        // @ts-expect-error - properties added to protocol method LHErrors.
         opts.fingerprint = ['{{ default }}', err.protocolMethod, err.protocolError];
       }
 

--- a/lighthouse-core/lib/stack-collector.js
+++ b/lighthouse-core/lib/stack-collector.js
@@ -46,7 +46,7 @@ async function detectLibraries() {
   // d41d8cd98f00b204e9800998ecf8427e_ is a consistent prefix used by the detect libraries
   // see https://github.com/HTTPArchive/httparchive/issues/77#issuecomment-291320900
   /** @type {Record<string, JSLibraryDetectorTest>} */
-  // @ts-ignore - injected libDetectorSource var
+  // @ts-expect-error - injected libDetectorSource var
   const libraryDetectorTests = d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests; // eslint-disable-line
 
   for (const [name, lib] of Object.entries(libraryDetectorTests)) {

--- a/lighthouse-core/lib/tracehouse/main-thread-tasks.js
+++ b/lighthouse-core/lib/tracehouse/main-thread-tasks.js
@@ -107,7 +107,7 @@ class MainThreadTasks {
 
       // We're right where we need to be, point the timerId to our `currentTask`
       /** @type {string} */
-      // @ts-ignore - timerId exists on `TimerInstall` events.
+      // @ts-expect-error - timerId exists on `TimerInstall` events.
       const timerId = nextTimerInstallEvent.args.data.timerId;
       priorTaskData.timers.set(timerId, currentTask);
     }
@@ -451,7 +451,7 @@ class MainThreadTasks {
         break;
       case 'TimerFire': {
         /** @type {string} */
-        // @ts-ignore - timerId exists when name is TimerFire
+        // @ts-expect-error - timerId exists when name is TimerFire
         const timerId = task.event.args.data.timerId;
         const timerInstallerTaskNode = priorTaskData.timers.get(timerId);
         if (!timerInstallerTaskNode) break;

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -62,10 +62,11 @@ class DetailsRenderer {
       // Internal-only details, not for rendering.
       case 'screenshot':
       case 'debugdata':
+      case 'full-page-screenshot':
         return null;
 
       default: {
-        // @ts-ignore tsc thinks this is unreachable, but be forward compatible
+        // @ts-expect-error tsc thinks this is unreachable, but be forward compatible
         // with new unexpected detail types.
         return this._renderUnknown(details.type, details);
       }

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -511,7 +511,7 @@ class ReportUIFeatures {
     });
 
     // The popup's window.name is keyed by version+url+fetchTime, so we reuse/select tabs correctly
-    // @ts-ignore - If this is a v2 LHR, use old `generatedTime`.
+    // @ts-expect-error - If this is a v2 LHR, use old `generatedTime`.
     const fallbackFetchTime = /** @type {string} */ (json.generatedTime);
     const fetchTime = json.fetchTime || fallbackFetchTime;
     const windowName = `${json.lighthouseVersion}-${json.requestedUrl}-${fetchTime}`;

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -70,7 +70,7 @@ class Util {
     for (const audit of Object.values(clone.audits)) {
       // Turn 'not-applicable' (LHR <4.0) and 'not_applicable' (older proto versions)
       // into 'notApplicable' (LHR ≥4.0).
-      // @ts-ignore tsc rightly flags that these values shouldn't occur.
+      // @ts-expect-error tsc rightly flags that these values shouldn't occur.
       // eslint-disable-next-line max-len
       if (audit.scoreDisplayMode === 'not_applicable' || audit.scoreDisplayMode === 'not-applicable') {
         audit.scoreDisplayMode = 'notApplicable';
@@ -79,7 +79,7 @@ class Util {
       if (audit.details) {
         // Turn `auditDetails.type` of undefined (LHR <4.2) and 'diagnostic' (LHR <5.0)
         // into 'debugdata' (LHR ≥5.0).
-        // @ts-ignore tsc rightly flags that these values shouldn't occur.
+        // @ts-expect-error tsc rightly flags that these values shouldn't occur.
         if (audit.details.type === undefined || audit.details.type === 'diagnostic') {
           audit.details.type = 'debugdata';
         }
@@ -505,7 +505,7 @@ Util.getUniqueSuffix = (() => {
 })();
 
 /** @type {I18n} */
-// @ts-ignore: Is set in report renderer.
+// @ts-expect-error: Is set in report renderer.
 Util.i18n = null;
 
 /**

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -302,7 +302,7 @@ class Runner {
         // If artifact was an error, output error result on behalf of audit.
         if (artifacts[artifactName] instanceof Error) {
           /** @type {Error} */
-          // @ts-ignore An artifact *could* be an Error, but caught here, so ignore elsewhere.
+          // @ts-expect-error An artifact *could* be an Error, but caught here, so ignore elsewhere.
           const artifactError = artifacts[artifactName];
 
           Sentry.captureException(artifactError, {
@@ -316,7 +316,7 @@ class Runner {
           // Create a friendlier display error and mark it as expected to avoid duplicates in Sentry
           const error = new LHError(LHError.errors.ERRORED_REQUIRED_ARTIFACT,
               {artifactName, errorMessage: artifactError.message});
-          // @ts-ignore Non-standard property added to Error
+          // @ts-expect-error Non-standard property added to Error
           error.expected = true;
           throw error;
         }
@@ -337,7 +337,7 @@ class Runner {
       const narrowedArtifacts = requestedArtifacts
         .reduce((narrowedArtifacts, artifactName) => {
           const requestedArtifact = artifacts[artifactName];
-          // @ts-ignore tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.
+          // @ts-expect-error tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.
           narrowedArtifacts[artifactName] = requestedArtifact;
           return narrowedArtifacts;
         }, /** @type {LH.Artifacts} */ ({}));

--- a/lighthouse-core/scripts/cleanup-LHR-for-diff.js
+++ b/lighthouse-core/scripts/cleanup-LHR-for-diff.js
@@ -34,9 +34,9 @@ function cleanAndFormatLHR(lhrString) {
   // Set timing values, which change from run to run, to predictable values
   lhr.timing.total = 12345.6789;
   lhr.timing.entries.forEach(entry => {
-    // @ts-ignore - write to readonly property
+    // @ts-expect-error - write to readonly property
     entry.duration = 100;
-    // @ts-ignore - write to readonly property
+    // @ts-expect-error - write to readonly property
     entry.startTime = 0; // Not realsitic, but avoids a lot of diff churn
   });
 

--- a/lighthouse-core/scripts/compare-runs.js
+++ b/lighthouse-core/scripts/compare-runs.js
@@ -291,7 +291,7 @@ function filter(results) {
 
     for (const propName of Object.keys(result)) {
       if (reportExcludeRegex && reportExcludeRegex.test(propName)) {
-        // @ts-ignore: propName is a key.
+        // @ts-expect-error: propName is a key.
         delete result[propName];
       }
     }
@@ -368,9 +368,9 @@ function compare() {
 
   const sortByKey = `${argv.deltaPropertySort} Δ`;
   results.sort((a, b) => {
-    // @ts-ignore - shhh tsc.
+    // @ts-expect-error - shhh tsc.
     let aValue = a[sortByKey];
-    // @ts-ignore - shhh tsc.
+    // @ts-expect-error - shhh tsc.
     let bValue = b[sortByKey];
 
     // Always put the keys missing a result at the bottom of the table.

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -486,7 +486,7 @@ function parseUIStrings(sourceStr, liveUIStrings) {
     // Use live message to avoid having to e.g. concat strings broken into parts.
     const message = liveUIStrings[key];
 
-    // @ts-ignore - Not part of the public tsc interface yet.
+    // @ts-expect-error - Not part of the public tsc interface yet.
     const jsDocComments = tsc.getJSDocCommentsAndTags(property);
     const {description, examples} = computeDescription(jsDocComments[0], message);
 
@@ -603,7 +603,7 @@ function writeStringsToCtcFiles(locale, strings) {
   fs.writeFileSync(fullPath, JSON.stringify(output, null, 2) + '\n');
 }
 
-// @ts-ignore Test if called from the CLI or as a module.
+// @ts-expect-error Test if called from the CLI or as a module.
 if (require.main === module) {
   const coreStrings = collectAllStringsInDir(path.join(LH_ROOT, 'lighthouse-core'));
   console.log('Collected from LH core!');

--- a/lighthouse-core/scripts/lantern/assert-master-lantern-values-unchanged.js
+++ b/lighthouse-core/scripts/lantern/assert-master-lantern-values-unchanged.js
@@ -29,7 +29,7 @@ const expectedResults = require(MASTER_PATH);
 /** @type {Array<{url: string, maxDiff: number, diffsForSite: Array<DiffForSite>}>} */
 const diffs = [];
 for (const entry of computedResults.sites) {
-  // @ts-ignore - over-aggressive implicit any on candidate
+  // @ts-expect-error - over-aggressive implicit any on candidate
   const expectedLantern = expectedResults.sites.find(candidate => entry.url === candidate.url);
   const actualLantern = entry.lantern;
 

--- a/lighthouse-core/scripts/lantern/debug-url.js
+++ b/lighthouse-core/scripts/lantern/debug-url.js
@@ -20,7 +20,7 @@ const SITE_INDEX_DIR = path.dirname(SITE_INDEX_PATH);
 const RUN_ONCE_PATH = path.join(__dirname, 'run-once.js');
 
 const siteIndex = require(SITE_INDEX_PATH);
-// @ts-ignore - over-aggressive implicit any on site
+// @ts-expect-error - over-aggressive implicit any on site
 const site = siteIndex.sites.find(site => site.url === INPUT_URL);
 if (!site) throw new Error(`Could not find with site URL ${INPUT_URL}`);
 

--- a/lighthouse-core/scripts/lantern/print-correlations.js
+++ b/lighthouse-core/scripts/lantern/print-correlations.js
@@ -193,7 +193,7 @@ function findAndPrintFixesRegressions() {
       chalk.gray('(real)'),
       entry.actual,
       chalk.gray('(cur)'),
-      // @ts-ignore - baseline always exists at this point
+      // @ts-expect-error - baseline always exists at this point
       entry.baseline.actual,
       chalk.gray('(prev)')
     );
@@ -294,7 +294,7 @@ const printBucket = (label, bucketFilterFn, opts) => {
   console.log(
     `${label}:`.padEnd(10),
     actual.toString().padEnd(5),
-    // @ts-ignore - overly aggressive no implicit any
+    // @ts-expect-error - overly aggressive no implicit any
     toBaselineDiffString(actual, baseline, {...opts, format: x => x.toString()})
   );
 };

--- a/lighthouse-core/scripts/lantern/run-once.js
+++ b/lighthouse-core/scripts/lantern/run-once.js
@@ -19,10 +19,13 @@ async function run() {
   const traces = {defaultPass: require(tracePath)};
   const devtoolsLogs = {defaultPass: require(path.resolve(process.cwd(), process.argv[3]))};
   const artifacts = {traces, devtoolsLogs};
-
   const context = {computedCache: new Map(), settings: {locale: 'en-us'}};
-  // @ts-ignore - We don't need the full artifacts
+
+  // @ts-expect-error - We don't need the full artifacts or context.
   const result = await PredictivePerf.audit(artifacts, context);
+  if (!result.details || result.details.type !== 'debugdata') {
+    throw new Error('Unexpected audit details from PredictivePerf');
+  }
   process.stdout.write(JSON.stringify(result.details.items[0], null, 2));
 
   // Dump the TTI graph with simulated timings to a trace if LANTERN_DEBUG is enabled

--- a/lighthouse-core/scripts/legacy-javascript/create-polyfill-size-estimation.js
+++ b/lighthouse-core/scripts/legacy-javascript/create-polyfill-size-estimation.js
@@ -83,7 +83,7 @@ async function main() {
   const bundleMap = JSON.parse(fs.readFileSync(bundlePath + '.map', 'utf-8'));
   /** @type {Pick<LH.Artifacts, 'ScriptElements'|'SourceMaps'>} */
   const artifacts = {
-    // @ts-ignore don't need most properties on ScriptElement.
+    // @ts-expect-error don't need most properties on ScriptElement.
     ScriptElements: [{requestId: '', src: '', content: bundleContents}],
     SourceMaps: [{scriptUrl: '', map: bundleMap}],
   };

--- a/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
+++ b/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
@@ -17,7 +17,7 @@
  */
 
 const path = require('path');
-// @ts-ignore - We don't really need types for this
+// @ts-expect-error - We don't really need types for this
 const colors = require('colors');
 const LegacyJavascript = require('../../audits/byte-efficiency/legacy-javascript.js');
 

--- a/lighthouse-core/scripts/legacy-javascript/run.js
+++ b/lighthouse-core/scripts/legacy-javascript/run.js
@@ -110,12 +110,10 @@ async function createVariant(options) {
 
     legacyJavascriptResults = await getLegacyJavascriptResults(code, map, {sourceMaps: true});
     fs.writeFileSync(`${dir}/legacy-javascript.json`,
-      // @ts-ignore: Items will exist.
       JSON.stringify(legacyJavascriptResults.items, null, 2));
 
     legacyJavascriptResults = await getLegacyJavascriptResults(code, map, {sourceMaps: false});
     fs.writeFileSync(`${dir}/legacy-javascript-nomaps.json`,
-      // @ts-ignore: Items will exist.
       JSON.stringify(legacyJavascriptResults.items, null, 2));
   }
 }
@@ -144,13 +142,13 @@ function getLegacyJavascriptResults(code, map, {sourceMaps}) {
       [LegacyJavascript.DEFAULT_PASS]: devtoolsLogs,
     },
     ScriptElements: [
-      // @ts-ignore - partial ScriptElement excluding unused DOM properties
+      // @ts-expect-error - partial ScriptElement excluding unused DOM properties
       {src: scriptUrl, requestId: '1000.2', content: code},
     ],
     SourceMaps: [],
   };
   if (sourceMaps) artifacts.SourceMaps = [{scriptUrl, map}];
-  // @ts-ignore: partial Artifacts.
+  // @ts-expect-error: partial Artifacts.
   return LegacyJavascript.audit_(artifacts, networkRecords, {
     computedCache: new Map(),
   });

--- a/lighthouse-core/scripts/update-report-fixtures.js
+++ b/lighthouse-core/scripts/update-report-fixtures.js
@@ -41,7 +41,7 @@ async function update(artifactName) {
     }
     const finalArtifacts = oldArtifacts;
     const newArtifact = newArtifacts[artifactName];
-    // @ts-ignore tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.
+    // @ts-expect-error tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.
     finalArtifacts[artifactName] = newArtifact;
     await assetSaver.saveArtifacts(finalArtifacts, artifactPath);
   }

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -63,7 +63,7 @@ function createDecomposedPromise() {
     resolve = r1;
     reject = r2;
   });
-  // @ts-ignore: Ignore 'unused' error.
+  // @ts-expect-error: Ignore 'unused' error.
   return {promise, resolve, reject};
 }
 
@@ -138,13 +138,13 @@ let driver;
 let connectionStub;
 
 beforeEach(() => {
-  // @ts-ignore - connectionStub has a mocked version of sendCommand implemented in each test
+  // @ts-expect-error - connectionStub has a mocked version of sendCommand implemented in each test
   connectionStub = new Connection();
-  // @ts-ignore
+  // @ts-expect-error
   connectionStub.sendCommand = cmd => {
     throw new Error(`${cmd} not implemented`);
   };
-  // @ts-ignore - driver has a mocked version of on/once implemented in each test
+  // @ts-expect-error - driver has a mocked version of on/once implemented in each test
   driver = new Driver(connectionStub);
 });
 
@@ -205,7 +205,7 @@ describe('.getRequestContent', () => {
   it('throws if getRequestContent takes too long', async () => {
     const mockTimeout = 5000;
     const driverTimeout = 1000;
-    // @ts-ignore
+    // @ts-expect-error
     connectionStub.sendCommand = jest.fn()
       .mockImplementation(() => new Promise(r => setTimeout(r, mockTimeout)));
 
@@ -308,7 +308,7 @@ describe('.evaluateAsync', () => {
 describe('.sendCommand', () => {
   it('.sendCommand timesout when commands take too long', async () => {
     const mockTimeout = 5000;
-    // @ts-ignore
+    // @ts-expect-error
     connectionStub.sendCommand = jest.fn()
       .mockImplementation(() => new Promise(r => setTimeout(r, mockTimeout)));
 
@@ -529,7 +529,7 @@ describe('.gotoURL', () => {
         driver._waitForNetworkIdle = createMockWaitForFn();
         driver._waitForCPUIdle = createMockWaitForFn();
 
-        // @ts-ignore - dynamic property access, tests will definitely fail if the property were to change
+        // @ts-expect-error - dynamic property access, tests will definitely fail if the property were to change
         const waitForResult = driver[`_waitFor${name}`];
         const otherWaitForResults = [
           driver._waitForFcp,
@@ -974,7 +974,7 @@ describe('Multi-target management', () => {
 
     driver._eventEmitter.emit('Target.attachedToTarget', {
       sessionId: '123',
-      // @ts-ignore: Ignore partial targetInfo.
+      // @ts-expect-error: Ignore partial targetInfo.
       targetInfo: {type: 'iframe'},
     });
     await flushAllTimersAndMicrotasks();
@@ -992,7 +992,7 @@ describe('Multi-target management', () => {
 
     driver._eventEmitter.emit('Target.attachedToTarget', {
       sessionId: 'SW1',
-      // @ts-ignore: Ignore partial targetInfo.
+      // @ts-expect-error: Ignore partial targetInfo.
       targetInfo: {type: 'service_worker'},
     });
     await flushAllTimersAndMicrotasks();

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -27,7 +27,7 @@ jest.mock('../../lib/stack-collector.js', () => () => Promise.resolve([]));
  * @param {(...args: TParams) => TReturn} fn
  */
 function makeParamsOptional(fn) {
-  return /** @type {(...args: RecursivePartial<TParams>) => TReturn} */ (fn);
+  return /** @type {(...args: Nullable<RecursivePartial<TParams>>) => TReturn} */ (fn);
 }
 
 const GatherRunner = {
@@ -53,7 +53,7 @@ const GatherRunner = {
  * @param {RecursivePartial<LH.Config.Json>} json
  */
 function makeConfig(json) {
-  // @ts-ignore: allow recursive partial.
+  // @ts-expect-error: allow recursive partial.
   return new Config(json);
 }
 
@@ -131,9 +131,9 @@ function resetDefaultMockResponses() {
 }
 
 beforeEach(() => {
-  // @ts-ignore - connectionStub has a mocked version of sendCommand implemented in each test
+  // @ts-expect-error - connectionStub has a mocked version of sendCommand implemented in each test
   connectionStub = new Connection();
-  // @ts-ignore
+  // @ts-expect-error
   connectionStub.sendCommand = cmd => {
     throw new Error(`${cmd} not implemented`);
   };
@@ -496,7 +496,7 @@ describe('GatherRunner', function() {
     expect(artifacts.LighthouseRunWarnings).toHaveLength(1);
     expect(artifacts.PageLoadError).toBeInstanceOf(Error);
     expect(artifacts.PageLoadError).toMatchObject({code: 'ERRORED_DOCUMENT_REQUEST'});
-    // @ts-ignore: Test-only gatherer.
+    // @ts-expect-error: Test-only gatherer.
     expect(artifacts.TestGatherer).toBeUndefined();
   });
 
@@ -530,7 +530,7 @@ describe('GatherRunner', function() {
     expect(artifacts.LighthouseRunWarnings).toHaveLength(1);
     expect(artifacts.PageLoadError).toBeInstanceOf(Error);
     expect(artifacts.PageLoadError).toMatchObject({code: 'NO_FCP'});
-    // @ts-ignore: Test-only gatherer.
+    // @ts-expect-error: Test-only gatherer.
     expect(artifacts.TestGatherer).toBeUndefined();
   });
 
@@ -569,7 +569,7 @@ describe('GatherRunner', function() {
     const artifacts = await GatherRunner.run(config.passes, options);
     expect(artifacts.LighthouseRunWarnings).toHaveLength(1);
     expect(artifacts.PageLoadError).toEqual(null);
-    // @ts-ignore: Test-only gatherer.
+    // @ts-expect-error: Test-only gatherer.
     expect(artifacts.TestGatherer).toBeUndefined();
     expect(artifacts.devtoolsLogs).toHaveProperty('pageLoadError-nextPass');
   });
@@ -865,7 +865,7 @@ describe('GatherRunner', function() {
     const artifacts = await GatherRunner.run(config.passes, options);
 
     expect(artifacts.PageLoadError).toMatchObject({code: 'NO_DOCUMENT_REQUEST'});
-    // @ts-ignore: Test-only gatherer.
+    // @ts-expect-error: Test-only gatherer.
     expect(artifacts.TestGatherer).toBeUndefined();
 
     // The only loadData available should be prefixed with `pageLoadError-`.
@@ -917,11 +917,11 @@ describe('GatherRunner', function() {
     expect(t3.called).toBe(false);
 
     // But only t1 has a valid artifact; t2 and t3 aren't defined.
-    // @ts-ignore: Test-only gatherer.
+    // @ts-expect-error: Test-only gatherer.
     expect(artifacts.Test1).toBe('MyArtifact');
-    // @ts-ignore: Test-only gatherer.
+    // @ts-expect-error: Test-only gatherer.
     expect(artifacts.Test2).toBeUndefined();
-    // @ts-ignore: Test-only gatherer.
+    // @ts-expect-error: Test-only gatherer.
     expect(artifacts.Test3).toBeUndefined();
 
     // PageLoadError artifact has the error.
@@ -1445,7 +1445,7 @@ describe('GatherRunner', function() {
           /** @param {LH.Gatherer.PassContext} context */
           afterPass(context) {
             calls.afterPass.push(context.options);
-            // @ts-ignore
+            // @ts-expect-error
             return context.options.x || 'none';
           },
         });
@@ -1748,7 +1748,7 @@ describe('GatherRunner', function() {
     it('should transform the response from the protocol, if in <M82 format', async () => {
       connectionStub.sendCommand
         .mockResponse('Page.getInstallabilityErrors', {
-          // @ts-ignore
+          // @ts-expect-error
           errors: ['Downloaded icon was empty or corrupted'],
         });
       const result = await GatherRunner.getInstallabilityErrors(passContext);

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -27,7 +27,7 @@ jest.mock('../../lib/stack-collector.js', () => () => Promise.resolve([]));
  * @param {(...args: TParams) => TReturn} fn
  */
 function makeParamsOptional(fn) {
-  return /** @type {(...args: Nullable<RecursivePartial<TParams>>) => TReturn} */ (fn);
+  return /** @type {(...args: RecursivePartial<TParams>) => TReturn} */ (fn);
 }
 
 const GatherRunner = {
@@ -54,7 +54,13 @@ const GatherRunner = {
  */
 function makeConfig(json) {
   // @ts-expect-error: allow recursive partial.
-  return new Config(json);
+  const config = new Config(json);
+
+  // Since the config is for `gather-runner`, ensure it has `passes`.
+  if (!config.passes) {
+    throw new Error('gather-runner test configs must have `passes`');
+  }
+  return /** @type {Config & {passes: Array<LH.Config.Pass>}} */ (config);
 }
 
 const LoadFailureMode = {

--- a/lighthouse-core/test/gather/mock-commands.js
+++ b/lighthouse-core/test/gather/mock-commands.js
@@ -54,7 +54,7 @@ function createMockSendCommandFn() {
       mockResponses.splice(indexOfResponse, 1);
       const returnValue = typeof response === 'function' ? response(...args) : response;
       if (delay) return new Promise(resolve => setTimeout(() => resolve(returnValue), delay));
-      // @ts-ignore: Some covariant type stuff doesn't work here. idk, I'm not a type scientist.
+      // @ts-expect-error: Some covariant type stuff doesn't work here. idk, I'm not a type scientist.
       return Promise.resolve(returnValue);
     });
 

--- a/lighthouse-viewer/app/src/github-api.js
+++ b/lighthouse-viewer/app/src/github-api.js
@@ -147,7 +147,7 @@ class GithubApi {
       // not return a 304 and so will be overwritten.
       return idbKeyval.set(id, response).then(_ => {
         logger.hide();
-        // @ts-ignore - TODO(bckenny): tsc unable to flatten promise chain here
+        // @ts-expect-error - TODO(bckenny): tsc unable to flatten promise chain here
         return response.content;
       });
     });

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -180,7 +180,7 @@ class LighthouseReportViewer {
     }
 
     // Install as global for easier debugging
-    // @ts-ignore
+    // @ts-expect-error
     window.__LIGHTHOUSE_JSON__ = json;
     // eslint-disable-next-line no-console
     console.log('window.__LIGHTHOUSE_JSON__', json);

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "^1.19.0",
     "terser": "^4.2.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "dependencies": {
     "axe-core": "3.5.5",

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -50,6 +50,11 @@ declare global {
     [P in K]: P;
   };
 
+  /** Make all properties in T nullable. */
+  type Nullable<T> = {
+    [K in keyof T]: T[K] | null;
+  }
+
   /** Make optional all properties on T and any properties on object properties of T. */
   type RecursivePartial<T> = {
     [P in keyof T]+?:

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -50,11 +50,6 @@ declare global {
     [P in K]: P;
   };
 
-  /** Make all properties in T nullable. */
-  type Nullable<T> = {
-    [K in keyof T]: T[K] | null;
-  }
-
   /** Make optional all properties on T and any properties on object properties of T. */
   type RecursivePartial<T> = {
     [P in keyof T]+?:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7830,10 +7830,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
Updates typescript to the latest release.

The main change is [the new `@ts-expect-error` directive](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#-ts-expect-error-comments), which is a strictly better `@ts-ignore`. In general all ignored tsc errors should use `@ts-expect-error` in the future since it automatically alerts when the ignore needs to be removed if types are tightened or changed in the future, so we won't have ignored cruft sticking around. Maybe we can set up a lint rule to use `@ts-expect-error` in the future so we don't have to always remember while coding/reviewing.

This PR also
- fixes a few new places where the compiler caught us being too loose with types, but needed no functional code changes
- sets us up for the [upcoming typescript 4.0](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0-beta/), which is quite a bit stricter on optional types and is going to necessitate at least a few changes (but also has some nice new features).