### PR TITLE
misc: tighten RecursivePartial type

### DIFF
--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -50,10 +50,9 @@ const GatherRunner = {
 };
 
 /**
- * @param {RecursivePartial<LH.Config.Json>} json
+ * @param {LH.Config.Json} json
  */
 function makeConfig(json) {
-  // @ts-expect-error: allow recursive partial.
   const config = new Config(json);
 
   // Since the config is for `gather-runner`, ensure it has `passes`.
@@ -214,7 +213,7 @@ describe('GatherRunner', function() {
   it('collects network user agent as an artifact', async () => {
     const requestedUrl = 'https://example.com';
     const driver = fakeDriver;
-    const config = makeConfig({passes: [{}]});
+    const config = makeConfig({passes: [{passName: 'defaultPass'}]});
     const options = {requestedUrl, driver, settings: config.settings};
 
     const results = await GatherRunner.run(config.passes, options);
@@ -229,7 +228,7 @@ describe('GatherRunner', function() {
         return Promise.resolve({finalUrl, timedOut: false});
       },
     });
-    const config = makeConfig({passes: [{}]});
+    const config = makeConfig({passes: [{passName: 'defaultPass'}]});
     const options = {requestedUrl, driver, settings: config.settings};
 
     return GatherRunner.run(config.passes, options).then(artifacts => {
@@ -1361,6 +1360,7 @@ describe('GatherRunner', function() {
       ];
       const config = makeConfig({
         passes: [{
+          passName: 'defaultPass',
           gatherers: gatherers.map(G => ({instance: new G()})),
         }],
       });
@@ -1417,6 +1417,7 @@ describe('GatherRunner', function() {
       const gathererNames = gatherers.map(gatherer => gatherer.instance.name);
       const config = makeConfig({
         passes: [{
+          passName: 'defaultPass',
           gatherers,
         }],
       });
@@ -1464,7 +1465,10 @@ describe('GatherRunner', function() {
       ];
 
       const config = makeConfig({
-        passes: [{gatherers}],
+        passes: [{
+          passName: 'defaultPass',
+          gatherers,
+        }],
       });
 
       /** @type {any} Using Test-only gatherers. */
@@ -1550,6 +1554,7 @@ describe('GatherRunner', function() {
 
       const config = makeConfig({
         passes: [{
+          passName: 'defaultPass',
           gatherers: [{instance: new WarningGatherer()}],
         }],
       });
@@ -1603,6 +1608,7 @@ describe('GatherRunner', function() {
       const gathererNames = gatherers.map(gatherer => gatherer.instance.name);
       const config = makeConfig({
         passes: [{
+          passName: 'defaultPass',
           gatherers,
         }],
       });

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -7,30 +7,6 @@
 import _Crdp from 'devtools-protocol/types/protocol';
 import _CrdpMappings from 'devtools-protocol/types/protocol-mapping'
 
-// Convert unions (T1 | T2 | T3) into tuples ([T1, T2, T3]).
-// https://stackoverflow.com/a/52933137/2788187 https://stackoverflow.com/a/50375286
-type UnionToIntersection<U> =
-(U extends any ? (k: U)=>void : never) extends ((k: infer I)=>void) ? I : never
-
-type UnionToFunctions<U> =
-  U extends unknown ? (k: U) => void : never;
-
-type IntersectionOfFunctionsToType<F> =
-  F extends { (a: infer A): void; (b: infer B): void; (c: infer C): void; (d: infer D): void; } ? [A, B, C, D] :
-  F extends { (a: infer A): void; (b: infer B): void; (c: infer C): void; } ? [A, B, C] :
-  F extends { (a: infer A): void; (b: infer B): void; } ? [A, B] :
-  F extends { (a: infer A): void } ? [A] :
-  never;
-
-type SplitType<T> =
-  IntersectionOfFunctionsToType<UnionToIntersection<UnionToFunctions<T>>>;
-
-// (T1 | T2 | T3) -> [RecursivePartial(T1), RecursivePartial(T2), RecursivePartial(T3)]
-type RecursivePartialUnion<T, S=SplitType<T>> = {[P in keyof S]: RecursivePartial<S[P]>};
-
-// Return length of a tuple.
-type GetLength<T extends any[]> = T extends { length: infer L } ? L : never;
-
 declare global {
   // Augment Intl to include
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales
@@ -51,30 +27,13 @@ declare global {
   };
 
   /** Make optional all properties on T and any properties on object properties of T. */
-  type RecursivePartial<T> = {
-    [P in keyof T]+?:
-      // RE: First two conditions.
-      // If type is a union, map each individual component and transform the resultant tuple back into a union.
-      // Only up to 4 components of a union is supported (all but the last few are dropped). For more, modify the second condition
-      // and `IntersectionOfFunctionsToType`.
-      // Ex: `{passes: PassJson[] | null}` - T[P] doesn't exactly match the array-recursing condition, so without these first couple
-      // conditions, it would fall through to the last condition (would just return T[P]).
-
-      // RE: First condition.
-      // Guard against large string unions, which would be unreasonable to support (much more than 4 components is common).
-
-      SplitType<T[P]> extends string[] ? T[P] :
-      GetLength<SplitType<T[P]>> extends 2|3|4 ? RecursivePartialUnion<T[P]>[number] :
-
-      // Recurse into arrays.
-      T[P] extends (infer U)[] ? RecursivePartial<U>[] :
-
-      // Recurse into objects.
-      T[P] extends (object|undefined) ? RecursivePartial<T[P]> :
-
-      // Strings, numbers, etc. (terminal types) end here.
-      T[P];
-  };
+  type RecursivePartial<T> =
+    // Recurse into arrays and tuples: elements aren't (newly) optional, but any properties they have are.
+    T extends (infer U)[] ? RecursivePartial<U>[] :
+    // Recurse into objects: properties and any of their properties are optional.
+    T extends object ? {[P in keyof T]?: RecursivePartial<T[P]>} :
+    // Strings, numbers, etc. (terminal types) end here.
+    T;
 
   /** Recursively makes all properties of T read-only. */
   export type Immutable<T> =


### PR DESCRIPTION
Fixes an issue with `RecursivePartial<T>` and simplifies its implementation.

This came up when updating to tsc 3.9.7 in #11158 and I started playing with this `@ts-expect-error` (previously `@ts-ignore`):

https://github.com/GoogleChrome/lighthouse/blob/cc5c79547388282f51d1f517890e17ca71c5e0de/lighthouse-core/test/gather/gather-runner-test.js#L52-L57

`LH.Config.Json` is mostly optional by design, so it seemed like it shouldn't be too hard to make it work without the ignore (I failed, but let's ignore that, too :).

The current `RecursivePartial` was recursing into arrays and making the elements optional, which seems ok at first glance but it's almost never what you actually want. If you ask for an array with missing elements you (almost always) expect a shorter array, not a holey array (i.e. `RecursivePartial<Array<string>>` should be `Array<string>`, _not_ `Array<string | undefined>`).

As a more concrete example, that `@ts-expect-error` line was silencing a number of complaints about making `LH.Config.Json` recursively optional, e.g. for [`SharedFlagsSettings.output`](https://github.com/GoogleChrome/lighthouse/blob/cc5c79547388282f51d1f517890e17ca71c5e0de/types/externs.d.ts#L147), an allowed optional form of `Array<'json'|'html'|'csv'>` would be `[undefined, undefined, undefined]`, which would be totally broken.

Not necessarily a huge deal for test code, but we do use it in non-test code in `config.js` (and it's there for more use in the future), so it's worth keeping it in working order.

This PR also simplifies `RecursivePartial`. As long as we keep the conditional type distributing across unions correctly, they don't need to be split up into tuples and merged back again.

I wasn't there for the discussions in #10123 or #10215, so cc @connorjclark and @patrickhulce to make sure all the use cases from those PRs are still covered (AFAICT they are).