### PR TITLE
deps(angular): update minor version of angular fixture redux

### DIFF
--- a/lighthouse-core/test/lib/minification-estimator-test.js
+++ b/lighthouse-core/test/lib/minification-estimator-test.js
@@ -214,9 +214,9 @@ describe('minification estimator', () => {
     });
 
     it('should handle large, real javscript files', () => {
-      assert.equal(angularFullScript.length, 1371888);
-      // 1 - 334968 / 1364217 = estimated 75% smaller minified
-      assert.equal(computeJSTokenLength(angularFullScript), 337959);
+      assert.equal(angularFullScript.length, 1374505);
+      // 1 - 338528 / 1374505 = estimated 75.3% smaller minified
+      assert.equal(computeJSTokenLength(angularFullScript), 338528);
     });
   });
 });

--- a/lighthouse-core/test/lib/minification-estimator-test.js
+++ b/lighthouse-core/test/lib/minification-estimator-test.js
@@ -10,6 +10,7 @@ const assert = require('assert').strict;
 const {computeCSSTokenLength, computeJSTokenLength} = require('../../lib/minification-estimator.js'); // eslint-disable-line max-len
 
 const angularFullScript = fs.readFileSync(require.resolve('angular/angular.js'), 'utf8');
+const zoneFullScript = fs.readFileSync(`${__dirname}/../../../lighthouse-cli/test/fixtures/dobetterweb/third_party/aggressive-promise-polyfill.js`, 'utf8');
 
 /* eslint-env jest */
 
@@ -214,9 +215,15 @@ describe('minification estimator', () => {
     });
 
     it('should handle large, real javscript files', () => {
-      assert.equal(angularFullScript.length, 1371888);
-      // 1 - 334968 / 1364217 = estimated 75% smaller minified
-      assert.equal(computeJSTokenLength(angularFullScript), 337959);
+      assert.equal(angularFullScript.length, 1374505);
+      // 1 - 338528 / 1374505 = estimated 75.3% smaller minified
+      assert.equal(computeJSTokenLength(angularFullScript), 338528);
+    });
+
+    it('should handle real already-minified javscript files', () => {
+      assert.equal(zoneFullScript.length, 25073);
+      // 1 - 24119 / 25073 = estimated 3.8% smaller minified
+      assert.equal(computeJSTokenLength(zoneFullScript), 24119);
     });
   });
 });

--- a/lighthouse-core/test/lib/minification-estimator-test.js
+++ b/lighthouse-core/test/lib/minification-estimator-test.js
@@ -10,7 +10,6 @@ const assert = require('assert').strict;
 const {computeCSSTokenLength, computeJSTokenLength} = require('../../lib/minification-estimator.js'); // eslint-disable-line max-len
 
 const angularFullScript = fs.readFileSync(require.resolve('angular/angular.js'), 'utf8');
-const zoneFullScript = fs.readFileSync(`${__dirname}/../../../lighthouse-cli/test/fixtures/dobetterweb/third_party/aggressive-promise-polyfill.js`, 'utf8');
 
 /* eslint-env jest */
 
@@ -215,15 +214,9 @@ describe('minification estimator', () => {
     });
 
     it('should handle large, real javscript files', () => {
-      assert.equal(angularFullScript.length, 1374505);
-      // 1 - 338528 / 1374505 = estimated 75.3% smaller minified
-      assert.equal(computeJSTokenLength(angularFullScript), 338528);
-    });
-
-    it('should handle real already-minified javscript files', () => {
-      assert.equal(zoneFullScript.length, 25073);
-      // 1 - 24119 / 25073 = estimated 3.8% smaller minified
-      assert.equal(computeJSTokenLength(zoneFullScript), 24119);
+      assert.equal(angularFullScript.length, 1371888);
+      // 1 - 334968 / 1364217 = estimated 75% smaller minified
+      assert.equal(computeJSTokenLength(angularFullScript), 337959);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,9 +950,9 @@ ajv@^5.2.3, ajv@^5.3.0:
     json-schema-traverse "^0.3.0"
 
 angular@^1.7.4:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.9.tgz#e52616e8701c17724c3c238cfe4f9446fd570bc4"
-  integrity sha512-5se7ZpcOtu0MBFlzGv5dsM1quQDoDeUTwZrWjGtTNA7O88cD8TEk5IEKCTDa3uECV9XnvKREVUr7du1ACiWGFQ==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.8.0.tgz#b1ec179887869215cab6dfd0df2e42caa65b1b51"
+  integrity sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg==
 
 ansi-align@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
same as #10086 just 7 months later.

this gets rid of the ~last~ security advisory we have.

-------------

4 weeks back i put up #11043 which looks the same but brought up all sorts of other things. It was split into this PR, #11190 and #11191 