### PR TITLE
tests: update chromestatus expecatations

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa-expectations.js
@@ -90,13 +90,13 @@ const expectations = [
           score: 1,
         },
         'service-worker': {
-          score: 1,
+          score: 0,
         },
         'works-offline': {
-          score: 1,
+          score: 0,
         },
         'offline-start-url': {
-          score: 1,
+          score: 0,
         },
         'viewport': {
           score: 1,
@@ -108,16 +108,13 @@ const expectations = [
         // Ignore speed test; just verify that it ran.
         },
         'installable-manifest': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
+          score: 0,
         },
         'splash-screen': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
+          score: 0,
         },
         'themed-omnibox': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
+          score: 0,
         },
         'content-width': {
           score: 1,


### PR DESCRIPTION
**Summary**
Updates the chromestatus expectations to the [new reality](https://github.com/GoogleChrome/chromium-dashboard/pull/936).

Alternatives Considered:
- Remove chromestatus entirely
- Replace chromestatus with another PWA
- Host the old version of chromestatus somewhere else

None of those seem that much better to me, but if one of those does to you I'd be happy to debate them in a new PR once we can safely land [our growing queue](https://github.com/GoogleChrome/lighthouse/pulls?q=is%3Apr+is%3Aopen+label%3Aland-when-ci-is-green) :)

**Related Issues/PRs**
https://github.com/GoogleChrome/chromium-dashboard/pull/936
