### PR TITLE
tests: istanbul ignore inpage function

### DIFF
--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -36,6 +36,7 @@ function getClientRect(element) {
  * @param {Element} element
  * @param {CSSStyleDeclaration} computedStyle
  */
+/* istanbul ignore next */
 function getPosition(element, computedStyle) {
   if (element.parentElement && element.parentElement.tagName === 'PICTURE') {
     const parentStyle = window.getComputedStyle(element.parentElement);


### PR DESCRIPTION
**Summary**
All in page functions need `/* istanbul ignore next */` or they will throw in CI when coverage is enabled.

Missed when I reviewed https://github.com/GoogleChrome/lighthouse/pull/11188 and not caught by CI because Travis isn't a required check and devtoolsbot autolanded it.

This should fix travis again