### PR TITLE
core(font-size): remove deprecated DOM.getFlattenedDocument

### DIFF
--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -36,13 +36,15 @@ function getUniqueFailingRules(fontSizeArtifact) {
   /** @type {Map<string, FailingNodeData>} */
   const failingRules = new Map();
 
-  fontSizeArtifact.forEach(({cssRule, fontSize, textLength, node}) => {
-    const artifactId = getFontArtifactId(cssRule, node);
+  fontSizeArtifact.forEach((failingNodeData) => {
+    const {nodeId, cssRule, fontSize, textLength, parentNode} = failingNodeData;
+    const artifactId = getFontArtifactId(cssRule, parentNode, nodeId);
     const failingRule = failingRules.get(artifactId);
 
     if (!failingRule) {
       failingRules.set(artifactId, {
-        node,
+        nodeId,
+        parentNode,
         cssRule,
         fontSize,
         textLength,
@@ -76,7 +78,7 @@ function getAttributeMap(attributes = []) {
 
 /**
  * TODO: return unique selector, like axe-core does, instead of just id/class/name of a single node
- * @param {FailingNodeData['node']} node
+ * @param {FailingNodeData['parentNode']} node
  * @returns {string}
  */
 function getSelector(node) {
@@ -91,11 +93,11 @@ function getSelector(node) {
     }
   }
 
-  return node.localName.toLowerCase();
+  return node.nodeName.toLowerCase();
 }
 
 /**
- * @param {FailingNodeData['node']} node
+ * @param {FailingNodeData['parentNode']} node
  * @return {LH.Audit.Details.NodeValue}
  */
 function nodeToTableNode(node) {
@@ -107,14 +109,14 @@ function nodeToTableNode(node) {
   return {
     type: 'node',
     selector: node.parentNode ? getSelector(node.parentNode) : '',
-    snippet: `<${node.localName}${attributesString}>`,
+    snippet: `<${node.nodeName.toLowerCase()}${attributesString}>`,
   };
 }
 
 /**
  * @param {string} baseURL
  * @param {FailingNodeData['cssRule']} styleDeclaration
- * @param {FailingNodeData['node']} node
+ * @param {FailingNodeData['parentNode']} node
  * @returns {{source: LH.Audit.Details.UrlValue | LH.Audit.Details.SourceLocationValue | LH.Audit.Details.CodeValue, selector: string | LH.Audit.Details.NodeValue}}
  */
 function findStyleRuleSource(baseURL, styleDeclaration, node) {
@@ -198,16 +200,17 @@ function findStyleRuleSource(baseURL, styleDeclaration, node) {
 
 /**
  * @param {FailingNodeData['cssRule']} styleDeclaration
- * @param {FailingNodeData['node']} node
+ * @param {FailingNodeData['parentNode']} node
+ * @param {number} textNodeId
  * @return {string}
  */
-function getFontArtifactId(styleDeclaration, node) {
+function getFontArtifactId(styleDeclaration, node, textNodeId) {
   if (styleDeclaration && styleDeclaration.type === 'Regular') {
     const startLine = styleDeclaration.range ? styleDeclaration.range.startLine : 0;
     const startColumn = styleDeclaration.range ? styleDeclaration.range.startColumn : 0;
     return `${styleDeclaration.styleSheetId}@${startLine}:${startColumn}`;
   } else {
-    return `node_${node.nodeId}`;
+    return `node_${textNodeId}`;
   }
 }
 
@@ -274,9 +277,9 @@ class FontSize extends Audit {
     ];
 
     const tableData = failingRules.sort((a, b) => b.textLength - a.textLength)
-      .map(({cssRule, textLength, fontSize, node}) => {
+      .map(({cssRule, textLength, fontSize, parentNode}) => {
         const percentageOfAffectedText = textLength / totalTextLength * 100;
-        const origin = findStyleRuleSource(pageUrl, cssRule, node);
+        const origin = findStyleRuleSource(pageUrl, cssRule, parentNode);
 
         return {
           source: origin.source,

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1205,19 +1205,6 @@ class Driver {
   }
 
   /**
-   * Returns the flattened list of all DOM nodes within the document.
-   * @param {boolean=} pierce Whether to pierce through shadow trees and iframes.
-   *     True by default.
-   * @return {Promise<Array<LH.Crdp.DOM.Node>>} The found nodes, or [], resolved in a promise
-   */
-  async getNodesInDocument(pierce = true) {
-    const flattenedDocument = await this.sendCommand('DOM.getFlattenedDocument',
-        {depth: -1, pierce});
-
-    return flattenedDocument.nodes ? flattenedDocument.nodes : [];
-  }
-
-  /**
    * Resolves a backend node ID (from a trace event, protocol, etc) to the object ID for use with
    * `Runtime.callFunctionOn`. `undefined` means the node could not be found.
    *

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -24,7 +24,6 @@ const MAX_NODES_SOURCE_RULE_FETCHED = 50; // number of nodes to fetch the source
 
 /** @typedef {import('../../driver.js')} Driver */
 /** @typedef {LH.Artifacts.FontSize['analyzedFailingNodesData'][0]} NodeFontData */
-/** @typedef {LH.Artifacts.FontSize.DomNodeMaybeWithParent} DomNodeMaybeWithParent*/
 /** @typedef {Map<number, {fontSize: number, textLength: number}>} BackendIdsToFontData */
 
 /**

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -221,7 +221,7 @@ class FontSize extends Gatherer {
   }
 
   /**
-   * Maps backendNodeId of TextNodes to {fontSize, textLength}.
+   * Iterates on the TextNodes in a DOM Snapshot.
    * Every entry is associated with a TextNode in the layout tree (not display: none).
    * @param {LH.Crdp.DOMSnapshot.CaptureSnapshotResponse} snapshot
    */

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -280,9 +280,7 @@ class FontSize extends Gatherer {
   }
 
   /**
-   * The only connection between a snapshot Node and an actual Protocol Node is backendId,
-   * so that is used to join the two data structures. DOMSnapshot.captureSnapshot doesn't
-   * give the entire Node object, so DOM.getFlattenedDocument is used.
+   * Get all the failing text nodes that don't meet the legible text threshold.
    * @param {LH.Crdp.DOMSnapshot.CaptureSnapshotResponse} snapshot
    */
   findFailingNodes(snapshot) {
@@ -327,13 +325,9 @@ class FontSize extends Gatherer {
     ]);
 
     // Get the computed font-size style of every node.
-    const snapshotPromise = passContext.driver.sendCommand('DOMSnapshot.captureSnapshot', {
+    const snapshot = await passContext.driver.sendCommand('DOMSnapshot.captureSnapshot', {
       computedStyles: ['font-size'],
     });
-    // const allNodesPromise = getAllNodesFromBody(passContext.driver);
-    const snapshot = await snapshotPromise;
-    // `backendIdsToFontData` will include all non-empty TextNodes.
-    // `crdpNodes` will only contain the body node and its descendants.
 
     const {
       totalTextLength,

--- a/lighthouse-core/test/audits/seo/font-size-test.js
+++ b/lighthouse-core/test/audits/seo/font-size-test.js
@@ -44,8 +44,8 @@ describe('SEO: Font size audit', () => {
         failingTextLength: 41,
         analyzedFailingTextLength: 41,
         analyzedFailingNodesData: [
-          {textLength: 10, fontSize: 10, node: {nodeId: 1, localName: 'p', attributes: []}},
-          {textLength: 31, fontSize: 11, node: {nodeId: 2, localName: 'p', attributes: []}},
+          {nodeId: 1, textLength: 10, fontSize: 10, parentNode: {nodeName: 'p', attributes: []}},
+          {nodeId: 2, textLength: 31, fontSize: 11, parentNode: {nodeName: 'p', attributes: []}},
         ],
       },
       TestedAsMobileDevice: true,
@@ -65,7 +65,7 @@ describe('SEO: Font size audit', () => {
         failingTextLength: 0,
         analyzedFailingTextLength: 0,
         analyzedFailingNodesData: [
-          {textLength: 0, fontSize: 11, node: {nodeId: 1, localName: 'p', attributes: []}},
+          {nodeId: 1, textLength: 0, fontSize: 11, parentNode: {nodeName: 'p', attributes: []}},
         ],
       },
       TestedAsMobileDevice: true,
@@ -84,8 +84,8 @@ describe('SEO: Font size audit', () => {
         failingTextLength: 33,
         analyzedFailingTextLength: 33,
         analyzedFailingNodesData: [
-          {textLength: 11, fontSize: 10, node: {nodeId: 1, localName: 'p', attributes: []}},
-          {textLength: 22, fontSize: 11, node: {nodeId: 2, localName: 'p', attributes: []}},
+          {nodeId: 1, textLength: 11, fontSize: 10, parentNode: {nodeName: 'p', attributes: []}},
+          {nodeId: 2, textLength: 22, fontSize: 11, parentNode: {nodeName: 'p', attributes: []}},
         ],
       },
       TestedAsMobileDevice: true,
@@ -120,9 +120,9 @@ describe('SEO: Font size audit', () => {
         failingTextLength: 7,
         analyzedFailingTextLength: 7,
         analyzedFailingNodesData: [
-          {textLength: 3, fontSize: 11, node: {nodeId: 1}, cssRule: style1},
-          {textLength: 2, fontSize: 10, node: {nodeId: 2}, cssRule: style2},
-          {textLength: 2, fontSize: 10, node: {nodeId: 3}, cssRule: style2},
+          {nodeId: 1, textLength: 3, fontSize: 11, parentNode: {}, cssRule: style1},
+          {nodeId: 2, textLength: 2, fontSize: 10, parentNode: {}, cssRule: style2},
+          {nodeId: 3, textLength: 2, fontSize: 10, parentNode: {}, cssRule: style2},
         ],
       },
       TestedAsMobileDevice: true,
@@ -144,7 +144,7 @@ describe('SEO: Font size audit', () => {
         failingTextLength: 50,
         analyzedFailingTextLength: 10,
         analyzedFailingNodesData: [
-          {textLength: 10, fontSize: 10, node: {nodeId: 1, localName: 'p', attributes: []}},
+          {textLength: 10, fontSize: 10, parentNode: {nodeId: 1, nodeName: 'p', attributes: []}},
         ],
       },
       TestedAsMobileDevice: true,
@@ -169,7 +169,7 @@ describe('SEO: Font size audit', () => {
         failingTextLength: 50,
         analyzedFailingTextLength: 50,
         analyzedFailingNodesData: [
-          {textLength: 50, fontSize: 10, node: {nodeId: 1, localName: 'p', attributes: []}},
+          {textLength: 50, fontSize: 10, parentNode: {nodeId: 1, nodeName: 'p', attributes: []}},
         ],
       },
       TestedAsMobileDevice: true,
@@ -188,8 +188,8 @@ describe('SEO: Font size audit', () => {
         failingTextLength: 33,
         analyzedFailingTextLength: 33,
         analyzedFailingNodesData: [
-          {textLength: 11, fontSize: 10, node: {nodeId: 1, localName: 'p', attributes: []}},
-          {textLength: 22, fontSize: 11, node: {nodeId: 2, localName: 'p', attributes: []}},
+          {textLength: 11, fontSize: 10, parentNode: {nodeId: 1, nodeName: 'p', attributes: []}},
+          {textLength: 22, fontSize: 11, parentNode: {nodeId: 2, nodeName: 'p', attributes: []}},
         ],
       },
       TestedAsMobileDevice: true,
@@ -207,8 +207,8 @@ describe('SEO: Font size audit', () => {
         failingTextLength: 315,
         analyzedFailingTextLength: 315,
         analyzedFailingNodesData: [
-          {textLength: 311, fontSize: 10, node: {nodeId: 1, localName: 'p', attributes: []}},
-          {textLength: 4, fontSize: 11, node: {nodeId: 2, localName: 'p', attributes: []}},
+          {textLength: 311, fontSize: 10, parentNode: {nodeId: 1, nodeName: 'p', attributes: []}},
+          {textLength: 4, fontSize: 11, parentNode: {nodeId: 2, nodeName: 'p', attributes: []}},
         ],
       },
       TestedAsMobileDevice: true,
@@ -236,7 +236,7 @@ describe('SEO: Font size audit', () => {
         MetaElements: makeMetaElements(validViewport),
         FontSize: {
           analyzedFailingNodesData: [
-            {textLength: 1, fontSize: 1, node: {nodeId: 1, ...nodeProperties}, cssRule: style},
+            {textLength: 1, fontSize: 1, parentNode: {...nodeProperties}, cssRule: style},
           ],
         },
         TestedAsMobileDevice: true,
@@ -251,7 +251,7 @@ describe('SEO: Font size audit', () => {
         type: 'Inline',
       }, {
         parentNode: {attributes: ['id', 'my-parent']},
-        localName: 'p',
+        nodeName: 'p',
         attributes: ['class', 'my-p'],
       });
 
@@ -273,7 +273,7 @@ describe('SEO: Font size audit', () => {
         type: 'Attributes',
       }, {
         parentNode: {attributes: ['id', 'my-parent']},
-        localName: 'font',
+        nodeName: 'font',
         attributes: ['size', '10px'],
       });
 

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -7,48 +7,53 @@
 
 /* eslint-env jest */
 
+const assert = require('assert');
 const FontSizeGather = require('../../../../gather/gatherers/seo/font-size.js');
 let fontSizeGather;
 
 const TEXT_NODE_TYPE = 3;
 const smallText = ' body sm𝐀ll text ';
 const bigText = 'body 𝐁ig text';
-const bodyNode = {nodeId: 3, backendNodeId: 102, nodeName: 'BODY', parentId: 1, fontSize: '10px'};
+const bodyNode = {
+  nodeId: 2, backendNodeId: 102,
+  nodeName: 'BODY', parentId: 0, fontSize: '10px', attributes: ['blah', '1'],
+};
 const nodes = [
-  {nodeId: 1, backendNodeId: 100, nodeName: 'HTML'},
-  {nodeId: 2, backendNodeId: 101, nodeName: 'HEAD', parentId: 1},
+  {nodeId: 0, backendNodeId: 100, nodeName: 'HTML'},
+  {nodeId: 1, backendNodeId: 101, nodeName: 'HEAD', parentId: 0},
   bodyNode,
   {
-    nodeId: 4,
+    nodeId: 3,
     backendNodeId: 103,
     nodeValue: 'head text',
     nodeType: TEXT_NODE_TYPE,
-    parentId: 2,
+    parentId: 1,
   },
   {
-    nodeId: 5,
+    nodeId: 4,
     backendNodeId: 104,
     nodeValue: smallText,
     nodeType: TEXT_NODE_TYPE,
-    parentId: 3,
+    parentId: 2,
   },
-  {nodeId: 6, backendNodeId: 105, nodeName: 'H1', parentId: 3},
+  {nodeId: 5, backendNodeId: 105, nodeName: 'H1', parentId: 2},
   {
-    nodeId: 7,
+    nodeId: 6,
     backendNodeId: 106,
     nodeValue: bigText,
     nodeType: TEXT_NODE_TYPE,
-    parentId: 6,
+    parentId: 5,
   },
-  {nodeId: 8, backendNodeId: 107, nodeName: 'SCRIPT', parentId: 3},
+  {nodeId: 7, backendNodeId: 107, nodeName: 'SCRIPT', parentId: 2},
   {
-    nodeId: 9,
+    nodeId: 8,
     backendNodeId: 108,
     nodeValue: 'script text',
     nodeType: TEXT_NODE_TYPE,
-    parentId: 8,
+    parentId: 7,
   },
 ];
+nodes.forEach((node, i) => assert(node.nodeId === i));
 
 const stringsMap = {};
 const strings = [];
@@ -62,25 +67,45 @@ const getOrCreateStringIndex = value => {
   strings.push(value);
   return index;
 };
+
+const nodeNamesNotInLayout = ['HEAD', 'HTML', 'SCRIPT'];
+const nodeIndicesInLayout = nodes.map((node, i) => {
+  if (nodeNamesNotInLayout.includes(node.nodeName)) return null;
+
+  if (node.nodeType === TEXT_NODE_TYPE) {
+    const parentNode = nodes[node.parentId];
+    if (parentNode && nodeNamesNotInLayout.includes(parentNode.nodeName)) {
+      return null;
+    }
+  }
+
+  return i;
+}).filter(id => id !== null);
+const nodesInLayout = nodeIndicesInLayout.map(index => nodes[index]);
+
 const snapshot = {
   documents: [
     {
       nodes: {
         backendNodeId: nodes.map(node => node.backendNodeId),
+        parentIndex: nodes.map(node => node.parentId),
+        attributes: nodes.map(node =>
+          node.attributes ? node.attributes.map(getOrCreateStringIndex) : []),
+        nodeName: nodes.map(node => getOrCreateStringIndex(node.nodeName)),
       },
       layout: {
-        nodeIndex: nodes.map((_, i) => i),
-        styles: nodes.map(node => [
+        nodeIndex: nodeIndicesInLayout,
+        styles: nodesInLayout.map(node => ([
           getOrCreateStringIndex(`${node.nodeValue === smallText ? 10 : 20}px`),
-        ]),
-        text: nodes.map(node => getOrCreateStringIndex(node.nodeValue)),
+        ])),
+        text: nodesInLayout.map(node => getOrCreateStringIndex(node.nodeValue)),
       },
       textBoxes: {
-        layoutIndex: nodes.map((_, i) => i).filter(i => {
-          const node = nodes[i];
+        layoutIndex: nodeIndicesInLayout.map((_, i) => i).filter(i => {
+          const node = nodes[nodeIndicesInLayout[i]];
           if (node.nodeType !== TEXT_NODE_TYPE) return false;
 
-          const parentNode = nodes.find(n => n.nodeId === node.parentId);
+          const parentNode = nodes[node.parentId];
           return parentNode && parentNode.nodeName !== 'SCRIPT';
         }),
       },
@@ -99,7 +124,7 @@ describe('Font size gatherer', () => {
     const driver = {
       on() {},
       off() {},
-      async sendCommand(command) {
+      async sendCommand(command, args) {
         if (command === 'CSS.getMatchedStylesForNode') {
           return {
             inlineStyle: null,
@@ -109,10 +134,13 @@ describe('Font size gatherer', () => {
           };
         } else if (command === 'DOMSnapshot.captureSnapshot') {
           return snapshot;
+        } else if (command === 'DOM.pushNodesByBackendIdsToFrontend') {
+          return {
+            nodeIds: args.backendNodeIds.map(backendNodeId => {
+              return nodes.find(node => node.backendNodeId === backendNodeId).nodeId;
+            }),
+          };
         }
-      },
-      async getNodesInDocument() {
-        return nodes;
       },
     };
 
@@ -129,8 +157,19 @@ describe('Font size gatherer', () => {
       totalTextLength: expectedTotalTextLength,
       analyzedFailingNodesData: [
         {
+          // nodeId of the failing body TextNode
+          nodeId: 2,
           fontSize: 10,
-          node: bodyNode,
+          parentNode: {
+            backendNodeId: 102,
+            attributes: bodyNode.attributes,
+            nodeName: bodyNode.nodeName,
+            parentNode: {
+              backendNodeId: 100,
+              attributes: [],
+              nodeName: 'HTML',
+            },
+          },
           textLength: expectedFailingTextLength,
         },
       ],

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -393,17 +393,6 @@ declare global {
         }>
       }
 
-      export module FontSize {
-        export interface DomNodeWithParent extends Crdp.DOM.Node {
-          parentId: number;
-          parentNode: DomNodeWithParent;
-        }
-
-        export interface DomNodeMaybeWithParent extends Crdp.DOM.Node {
-          parentNode?: DomNodeMaybeWithParent;
-        }
-      }
-
       // TODO(bckenny): real type for parsed manifest.
       export type Manifest = ReturnType<typeof parseManifest>;
 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -369,9 +369,20 @@ declare global {
         analyzedFailingTextLength: number;
         /** Elements that contain a text node that failed size criteria. */
         analyzedFailingNodesData: Array<{
+          /* nodeId of the failing TextNode. */
+          nodeId: number;
           fontSize: number;
           textLength: number;
-          node: FontSize.DomNodeWithParent;
+          parentNode: {
+            backendNodeId: number;
+            attributes: string[];
+            nodeName: string;
+            parentNode?: {
+              backendNodeId: number;
+              attributes: string[];
+              nodeName: string;
+            };
+          };
           cssRule?: {
             type: 'Regular' | 'Inline' | 'Attributes';
             range?: {startLine: number, startColumn: number};


### PR DESCRIPTION
Fixes #11210 (went with option `resolve many at once using push node to frontend method`)

Reduced the scope of the FontSize artifact by exporting only what we need, not an entire CrdpNode.

Test url http://misc-hoten.surge.sh/lh-ui-location-font-size/ from https://github.com/GoogleChrome/lighthouse/pull/9354 shows that results are unchanged.

![image](https://user-images.githubusercontent.com/4071474/89835126-c0064580-db29-11ea-80b1-d8c5c4ac85fe.png)
