### PR TITLE
core(non-composited-animations): update the "learn more" link

### DIFF
--- a/lighthouse-core/audits/non-composited-animations.js
+++ b/lighthouse-core/audits/non-composited-animations.js
@@ -19,8 +19,8 @@ const UIStrings = {
   title: 'Avoid non-composited animations',
   /** Description of a diagnostic LH audit that shows the user animations that are not composited. */
   description: 'Animations which are not composited can be janky and contribute to CLS. ' +
-    '[Learn more](https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count)',
-  /** [ICU Syntax] Label identifying the number of animated elements that are not composited. */
+    '[Learn more](https://web.dev/non-composited-animations)',
+  /** [ICU Syntax] Label identifying the number of animations that are not composited. */
   displayValue: `{itemCount, plural,
   =1 {# animated element found}
   other {# animated elements found}

--- a/lighthouse-core/audits/non-composited-animations.js
+++ b/lighthouse-core/audits/non-composited-animations.js
@@ -18,7 +18,7 @@ const UIStrings = {
   /** Title of a diagnostic LH audit that provides details on animations that are not composited. */
   title: 'Avoid non-composited animations',
   /** Description of a diagnostic LH audit that shows the user animations that are not composited. */
-  description: 'Animations which are not composited can be janky and contribute to CLS. ' +
+  description: 'Animations which are not composited can be janky and increase CLS. ' +
     '[Learn more](https://web.dev/non-composited-animations)',
   /** [ICU Syntax] Label identifying the number of animated elements that are not composited. */
   displayValue: `{itemCount, plural,

--- a/lighthouse-core/audits/non-composited-animations.js
+++ b/lighthouse-core/audits/non-composited-animations.js
@@ -20,7 +20,7 @@ const UIStrings = {
   /** Description of a diagnostic LH audit that shows the user animations that are not composited. */
   description: 'Animations which are not composited can be janky and contribute to CLS. ' +
     '[Learn more](https://web.dev/non-composited-animations)',
-  /** [ICU Syntax] Label identifying the number of animations that are not composited. */
+  /** [ICU Syntax] Label identifying the number of animated elements that are not composited. */
   displayValue: `{itemCount, plural,
   =1 {# animated element found}
   other {# animated elements found}

--- a/lighthouse-core/audits/non-composited-animations.js
+++ b/lighthouse-core/audits/non-composited-animations.js
@@ -17,7 +17,7 @@ const i18n = require('../lib/i18n/i18n.js');
 const UIStrings = {
   /** Title of a diagnostic LH audit that provides details on animations that are not composited. */
   title: 'Avoid non-composited animations',
-  /** Description of a diagnostic LH audit that shows the user animations that are not composited. */
+  /** Description of a diagnostic LH audit that shows the user animations that are not composited. Janky means frames may be skipped and the animation will look bad. Acceptable alternatives here might be 'poor', or 'slow'. */
   description: 'Animations which are not composited can be janky and increase CLS. ' +
     '[Learn more](https://web.dev/non-composited-animations)',
   /** [ICU Syntax] Label identifying the number of animated elements that are not composited. */

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -978,7 +978,7 @@
     "message": "Avoids `unload` event listeners"
   },
   "lighthouse-core/audits/non-composited-animations.js | description": {
-    "message": "Animations which are not composited can be janky and contribute to CLS. [Learn more](https://web.dev/non-composited-animations)"
+    "message": "Animations which are not composited can be janky and increase CLS. [Learn more](https://web.dev/non-composited-animations)"
   },
   "lighthouse-core/audits/non-composited-animations.js | displayValue": {
     "message": "{itemCount, plural,\n  =1 {# animated element found}\n  other {# animated elements found}\n  }"

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -978,7 +978,7 @@
     "message": "Avoids `unload` event listeners"
   },
   "lighthouse-core/audits/non-composited-animations.js | description": {
-    "message": "Animations which are not composited can be janky and contribute to CLS. [Learn more](https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count)"
+    "message": "Animations which are not composited can be janky and contribute to CLS. [Learn more](https://web.dev/non-composited-animations)"
   },
   "lighthouse-core/audits/non-composited-animations.js | displayValue": {
     "message": "{itemCount, plural,\n  =1 {# animated element found}\n  other {# animated elements found}\n  }"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -978,7 +978,7 @@
     "message": "Âv́ôíd̂ś `unload` êv́êńt̂ ĺîśt̂én̂ér̂ś"
   },
   "lighthouse-core/audits/non-composited-animations.js | description": {
-    "message": "Âńîḿât́îón̂ś ŵh́îćĥ ár̂é n̂ót̂ ćôḿp̂óŝít̂éd̂ ćâń b̂é ĵán̂ḱŷ án̂d́ ĉón̂t́r̂íb̂út̂é t̂ó ĈĹŜ. [Ĺêár̂ń m̂ór̂é](https://web.dev/non-composited-animations)"
+    "message": "Âńîḿât́îón̂ś ŵh́îćĥ ár̂é n̂ót̂ ćôḿp̂óŝít̂éd̂ ćâń b̂é ĵán̂ḱŷ án̂d́ îńĉŕêáŝé ĈĹŜ. [Ĺêár̂ń m̂ór̂é](https://web.dev/non-composited-animations)"
   },
   "lighthouse-core/audits/non-composited-animations.js | displayValue": {
     "message": "{itemCount, plural,\n  =1 {# âńîḿât́êd́ êĺêḿêńt̂ f́ôún̂d́}\n  other {# âńîḿât́êd́ êĺêḿêńt̂ś f̂óûńd̂}\n  }"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -978,7 +978,7 @@
     "message": "Âv́ôíd̂ś `unload` êv́êńt̂ ĺîśt̂én̂ér̂ś"
   },
   "lighthouse-core/audits/non-composited-animations.js | description": {
-    "message": "Âńîḿât́îón̂ś ŵh́îćĥ ár̂é n̂ót̂ ćôḿp̂óŝít̂éd̂ ćâń b̂é ĵán̂ḱŷ án̂d́ ĉón̂t́r̂íb̂út̂é t̂ó ĈĹŜ. [Ĺêár̂ń m̂ór̂é](https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count)"
+    "message": "Âńîḿât́îón̂ś ŵh́îćĥ ár̂é n̂ót̂ ćôḿp̂óŝít̂éd̂ ćâń b̂é ĵán̂ḱŷ án̂d́ ĉón̂t́r̂íb̂út̂é t̂ó ĈĹŜ. [Ĺêár̂ń m̂ór̂é](https://web.dev/non-composited-animations)"
   },
   "lighthouse-core/audits/non-composited-animations.js | displayValue": {
     "message": "{itemCount, plural,\n  =1 {# âńîḿât́êd́ êĺêḿêńt̂ f́ôún̂d́}\n  other {# âńîḿât́êd́ êĺêḿêńt̂ś f̂óûńd̂}\n  }"

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1879,7 +1879,7 @@
     "non-composited-animations": {
       "id": "non-composited-animations",
       "title": "Avoid non-composited animations",
-      "description": "Animations which are not composited can be janky and contribute to CLS. [Learn more](https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count)",
+      "description": "Animations which are not composited can be janky and contribute to CLS. [Learn more](https://web.dev/non-composited-animations)",
       "score": null,
       "scoreDisplayMode": "informative",
       "displayValue": "1 animated element found",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1879,7 +1879,7 @@
     "non-composited-animations": {
       "id": "non-composited-animations",
       "title": "Avoid non-composited animations",
-      "description": "Animations which are not composited can be janky and contribute to CLS. [Learn more](https://web.dev/non-composited-animations)",
+      "description": "Animations which are not composited can be janky and increase CLS. [Learn more](https://web.dev/non-composited-animations)",
       "score": null,
       "scoreDisplayMode": "informative",
       "displayValue": "1 animated element found",


### PR DESCRIPTION
**Summary**

Links the *Avoid non-composited animations* audit to https://web.dev/non-composited-animations

Also fixes #11287

**Related Issues/PRs**

* https://github.com/GoogleChrome/web.dev/issues/3569
* https://github.com/GoogleChrome/web.dev/pull/3693