### PR TITLE
core(non-composited-animations): add more actionable failure reasons

### DIFF
--- a/lighthouse-core/audits/non-composited-animations.js
+++ b/lighthouse-core/audits/non-composited-animations.js
@@ -5,6 +5,12 @@
  */
 'use strict';
 
+/**
+ * @fileoverview Audit which reports all animations that failed to composite along
+ * with the failure reasons. Failure reasons are only reported if they are actionable.
+ * https://docs.google.com/document/d/1XKcJP2CKmNKfOcDsVvliAQ-e1H9C1nf2H-pzTdyafAA/edit?usp=sharing
+ */
+
 const Audit = require('./audit.js');
 const i18n = require('../lib/i18n/i18n.js');
 

--- a/lighthouse-core/audits/non-composited-animations.js
+++ b/lighthouse-core/audits/non-composited-animations.js
@@ -30,7 +30,7 @@ const UIStrings = {
   /** Name of a compositor failure reason where the transform being animated depends on the box size. */
   transformDependsBoxSize: 'Transform-related property depends on box size',
   /** Name of a compositor failure reason where the filter being animated may move pixels. */
-  filterMayMovePixels: 'Filter related property may move pixels',
+  filterMayMovePixels: 'Filter-related property may move pixels',
   /** Name of a compositor failure reason where the effect has a composite mode which is not replace. */
   nonReplaceCompositeMode: 'Effect has composite mode other than "replace"',
   /** Name of a compositor failure reason where the element already has an incompatible animation. */

--- a/lighthouse-core/audits/non-composited-animations.js
+++ b/lighthouse-core/audits/non-composited-animations.js
@@ -20,22 +20,22 @@ const UIStrings = {
   other {# animated elements found}
   }`,
   /**
-   * @description [ICU Syntax] Name of a compositor failure reason where the CSS property being animated is not supported on the compositor.
+   * @description [ICU Syntax] Descriptive reason for why a user-provided animation failed to be optimized by the browser due to the animated CSS property not being supported on the compositor. Shown in a table with a list of other potential failure reasons.
    * @example {height, width} properties
    */
   unsupportedCSSProperty: `{propertyCount, plural,
     =1 {Unsupported CSS Property: {properties}}
     other {Unsupported CSS Properties: {properties}}
   }`,
-  /** Name of a compositor failure reason where the transform being animated depends on the box size. */
+  /** Descriptive reason for why a user-provided animation failed to be optimized by the browser due to a `transform` property being dependent on the size of the element itself. Shown in a table with a list of other potential failure reasons.  */
   transformDependsBoxSize: 'Transform-related property depends on box size',
-  /** Name of a compositor failure reason where the filter being animated may move pixels. */
+  /** Descriptive reason for why a user-provided animation failed to be optimized by the browser due to a `filter` property possibly moving pixels. Shown in a table with a list of other potential failure reasons.  */
   filterMayMovePixels: 'Filter-related property may move pixels',
-  /** Name of a compositor failure reason where the effect has a composite mode which is not replace. */
+  /** Descriptive reason for why a user-provided animation failed to be optimized by the browser due to an effect having a composite mode which is not `replace`. Shown in a table with a list of other potential failure reasons.  */
   nonReplaceCompositeMode: 'Effect has composite mode other than "replace"',
-  /** Name of a compositor failure reason where the element already has an incompatible animation. */
-  incompatibleAnimations: 'Target has an incompatible animation',
-  /** Name of a compositor failure reason where the effect has unsupported timing parameters. */
+  /** Descriptive reason for why a user-provided animation failed to be optimized by the browser due to another animation on the same target being incompatible. Shown in a table with a list of other potential failure reasons.  */
+  incompatibleAnimations: 'Target has another animation which is incompatible',
+  /** Descriptive reason for why a user-provided animation failed to be optimized by the browser due to an effect having unsupported timing parameters. Shown in a table with a list of other potential failure reasons.  */
   unsupportedTimingParameters: 'Effect has unsupported timing parameters',
 };
 

--- a/lighthouse-core/audits/non-composited-animations.js
+++ b/lighthouse-core/audits/non-composited-animations.js
@@ -28,7 +28,7 @@ const UIStrings = {
     other {Unsupported CSS Properties: {properties}}
   }`,
   /** Name of a compositor failure reason where the transform being animated depends on the box size. */
-  transformDependsBoxSize: 'Transform related property depends on box size',
+  transformDependsBoxSize: 'Transform-related property depends on box size',
   /** Name of a compositor failure reason where the filter being animated may move pixels. */
   filterMayMovePixels: 'Filter related property may move pixels',
   /** Name of a compositor failure reason where the effect has a composite mode which is not replace. */

--- a/lighthouse-core/audits/non-composited-animations.js
+++ b/lighthouse-core/audits/non-composited-animations.js
@@ -27,6 +27,16 @@ const UIStrings = {
     =1 {Unsupported CSS Property: {properties}}
     other {Unsupported CSS Properties: {properties}}
   }`,
+  /** Name of a compositor failure reason where the transform being animated depends on the box size. */
+  transformDependsBoxSize: 'Transform related property depends on box size',
+  /** Name of a compositor failure reason where the filter being animated may move pixels. */
+  filterMayMovePixels: 'Filter related property may move pixels',
+  /** Name of a compositor failure reason where the effect has a composite mode which is not replace. */
+  nonReplaceCompositeMode: 'Effect has composite mode other than "replace"',
+  /** Name of a compositor failure reason where the element already has an incompatible animation. */
+  incompatibleAnimations: 'Target has an incompatible animation',
+  /** Name of a compositor failure reason where the effect has unsupported timing parameters. */
+  unsupportedTimingParameters: 'Effect has unsupported timing parameters',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -40,6 +50,26 @@ const ACTIONABLE_FAILURE_REASONS = [
   {
     flag: 1 << 13,
     text: UIStrings.unsupportedCSSProperty,
+  },
+  {
+    flag: 1 << 11,
+    text: UIStrings.transformDependsBoxSize,
+  },
+  {
+    flag: 1 << 12,
+    text: UIStrings.filterMayMovePixels,
+  },
+  {
+    flag: 1 << 4,
+    text: UIStrings.nonReplaceCompositeMode,
+  },
+  {
+    flag: 1 << 6,
+    text: UIStrings.incompatibleAnimations,
+  },
+  {
+    flag: 1 << 3,
+    text: UIStrings.unsupportedTimingParameters,
   },
 ];
 

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -984,10 +984,10 @@
     "message": "{itemCount, plural,\n  =1 {# animated element found}\n  other {# animated elements found}\n  }"
   },
   "lighthouse-core/audits/non-composited-animations.js | filterMayMovePixels": {
-    "message": "Filter related property may move pixels"
+    "message": "Filter-related property may move pixels"
   },
   "lighthouse-core/audits/non-composited-animations.js | incompatibleAnimations": {
-    "message": "Target has an incompatible animation"
+    "message": "Target has another animation which is incompatible"
   },
   "lighthouse-core/audits/non-composited-animations.js | nonReplaceCompositeMode": {
     "message": "Effect has composite mode other than \"replace\""
@@ -996,7 +996,7 @@
     "message": "Avoid non-composited animations"
   },
   "lighthouse-core/audits/non-composited-animations.js | transformDependsBoxSize": {
-    "message": "Transform related property depends on box size"
+    "message": "Transform-related property depends on box size"
   },
   "lighthouse-core/audits/non-composited-animations.js | unsupportedCSSProperty": {
     "message": "{propertyCount, plural,\n    =1 {Unsupported CSS Property: {properties}}\n    other {Unsupported CSS Properties: {properties}}\n  }"

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -983,11 +983,26 @@
   "lighthouse-core/audits/non-composited-animations.js | displayValue": {
     "message": "{itemCount, plural,\n  =1 {# animated element found}\n  other {# animated elements found}\n  }"
   },
+  "lighthouse-core/audits/non-composited-animations.js | filterMayMovePixels": {
+    "message": "Filter related property may move pixels"
+  },
+  "lighthouse-core/audits/non-composited-animations.js | incompatibleAnimations": {
+    "message": "Target has an incompatible animation"
+  },
+  "lighthouse-core/audits/non-composited-animations.js | nonReplaceCompositeMode": {
+    "message": "Effect has composite mode other than \"replace\""
+  },
   "lighthouse-core/audits/non-composited-animations.js | title": {
     "message": "Avoid non-composited animations"
   },
+  "lighthouse-core/audits/non-composited-animations.js | transformDependsBoxSize": {
+    "message": "Transform related property depends on box size"
+  },
   "lighthouse-core/audits/non-composited-animations.js | unsupportedCSSProperty": {
     "message": "{propertyCount, plural,\n    =1 {Unsupported CSS Property: {properties}}\n    other {Unsupported CSS Properties: {properties}}\n  }"
+  },
+  "lighthouse-core/audits/non-composited-animations.js | unsupportedTimingParameters": {
+    "message": "Effect has unsupported timing parameters"
   },
   "lighthouse-core/audits/offline-start-url.js | description": {
     "message": "A service worker enables your web app to be reliable in unpredictable network conditions. [Learn more](https://web.dev/offline-start-url/)."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -984,10 +984,10 @@
     "message": "{itemCount, plural,\n  =1 {# âńîḿât́êd́ êĺêḿêńt̂ f́ôún̂d́}\n  other {# âńîḿât́êd́ êĺêḿêńt̂ś f̂óûńd̂}\n  }"
   },
   "lighthouse-core/audits/non-composited-animations.js | filterMayMovePixels": {
-    "message": "F̂íl̂t́êŕ r̂él̂át̂éd̂ ṕr̂óp̂ér̂t́ŷ ḿâý m̂óv̂é p̂íx̂él̂ś"
+    "message": "F̂íl̂t́êŕ-r̂él̂át̂éd̂ ṕr̂óp̂ér̂t́ŷ ḿâý m̂óv̂é p̂íx̂él̂ś"
   },
   "lighthouse-core/audits/non-composited-animations.js | incompatibleAnimations": {
-    "message": "T̂ár̂ǵêt́ ĥáŝ án̂ ín̂ćôḿp̂át̂íb̂ĺê án̂ím̂át̂íôń"
+    "message": "T̂ár̂ǵêt́ ĥáŝ án̂ót̂h́êŕ âńîḿât́îón̂ ẃĥíĉh́ îś îńĉóm̂ṕât́îb́l̂é"
   },
   "lighthouse-core/audits/non-composited-animations.js | nonReplaceCompositeMode": {
     "message": "Êf́f̂éĉt́ ĥáŝ ćôḿp̂óŝít̂é m̂ód̂é ôt́ĥér̂ t́ĥán̂ \"ŕêṕl̂áĉé\""
@@ -996,7 +996,7 @@
     "message": "Âv́ôíd̂ ńôń-ĉóm̂ṕôśît́êd́ âńîḿât́îón̂ś"
   },
   "lighthouse-core/audits/non-composited-animations.js | transformDependsBoxSize": {
-    "message": "T̂ŕâńŝf́ôŕm̂ ŕêĺât́êd́ p̂ŕôṕêŕt̂ý d̂ép̂én̂d́ŝ ón̂ b́ôx́ ŝíẑé"
+    "message": "T̂ŕâńŝf́ôŕm̂-ŕêĺât́êd́ p̂ŕôṕêŕt̂ý d̂ép̂én̂d́ŝ ón̂ b́ôx́ ŝíẑé"
   },
   "lighthouse-core/audits/non-composited-animations.js | unsupportedCSSProperty": {
     "message": "{propertyCount, plural,\n    =1 {Ûńŝúp̂ṕôŕt̂éd̂ ĆŜŚ P̂ŕôṕêŕt̂ý: {properties}}\n    other {Ûńŝúp̂ṕôŕt̂éd̂ ĆŜŚ P̂ŕôṕêŕt̂íêś: {properties}}\n  }"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -983,11 +983,26 @@
   "lighthouse-core/audits/non-composited-animations.js | displayValue": {
     "message": "{itemCount, plural,\n  =1 {# âńîḿât́êd́ êĺêḿêńt̂ f́ôún̂d́}\n  other {# âńîḿât́êd́ êĺêḿêńt̂ś f̂óûńd̂}\n  }"
   },
+  "lighthouse-core/audits/non-composited-animations.js | filterMayMovePixels": {
+    "message": "F̂íl̂t́êŕ r̂él̂át̂éd̂ ṕr̂óp̂ér̂t́ŷ ḿâý m̂óv̂é p̂íx̂él̂ś"
+  },
+  "lighthouse-core/audits/non-composited-animations.js | incompatibleAnimations": {
+    "message": "T̂ár̂ǵêt́ ĥáŝ án̂ ín̂ćôḿp̂át̂íb̂ĺê án̂ím̂át̂íôń"
+  },
+  "lighthouse-core/audits/non-composited-animations.js | nonReplaceCompositeMode": {
+    "message": "Êf́f̂éĉt́ ĥáŝ ćôḿp̂óŝít̂é m̂ód̂é ôt́ĥér̂ t́ĥán̂ \"ŕêṕl̂áĉé\""
+  },
   "lighthouse-core/audits/non-composited-animations.js | title": {
     "message": "Âv́ôíd̂ ńôń-ĉóm̂ṕôśît́êd́ âńîḿât́îón̂ś"
   },
+  "lighthouse-core/audits/non-composited-animations.js | transformDependsBoxSize": {
+    "message": "T̂ŕâńŝf́ôŕm̂ ŕêĺât́êd́ p̂ŕôṕêŕt̂ý d̂ép̂én̂d́ŝ ón̂ b́ôx́ ŝíẑé"
+  },
   "lighthouse-core/audits/non-composited-animations.js | unsupportedCSSProperty": {
     "message": "{propertyCount, plural,\n    =1 {Ûńŝúp̂ṕôŕt̂éd̂ ĆŜŚ P̂ŕôṕêŕt̂ý: {properties}}\n    other {Ûńŝúp̂ṕôŕt̂éd̂ ĆŜŚ P̂ŕôṕêŕt̂íêś: {properties}}\n  }"
+  },
+  "lighthouse-core/audits/non-composited-animations.js | unsupportedTimingParameters": {
+    "message": "Êf́f̂éĉt́ ĥáŝ ún̂śûṕp̂ór̂t́êd́ t̂ím̂ín̂ǵ p̂ár̂ám̂ét̂ér̂ś"
   },
   "lighthouse-core/audits/offline-start-url.js | description": {
     "message": "Â śêŕv̂íĉé ŵór̂ḱêŕ êńâb́l̂éŝ ýôúr̂ ẃêb́ âṕp̂ t́ô b́ê ŕêĺîáb̂ĺê ín̂ ún̂ṕr̂éd̂íĉt́âb́l̂é n̂ét̂ẃôŕk̂ ćôńd̂ít̂íôńŝ. [Ĺêár̂ń m̂ór̂é](https://web.dev/offline-start-url/)."

--- a/lighthouse-core/test/audits/non-composited-animations-test.js
+++ b/lighthouse-core/test/audits/non-composited-animations-test.js
@@ -202,11 +202,11 @@ describe('Non-composited animations audit', () => {
     expect(auditResult.details.items[0].subItems.items[0].animation)
       .toBeUndefined();
     expect(auditResult.details.items[0].subItems.items[1].failureReason)
-      .toBeDisplayString('Transform related property depends on box size');
+      .toBeDisplayString('Transform-related property depends on box size');
     expect(auditResult.details.items[0].subItems.items[1].animation)
       .toBeUndefined();
     expect(auditResult.details.items[0].subItems.items[2].failureReason)
-      .toBeDisplayString('Filter related property may move pixels');
+      .toBeDisplayString('Filter-related property may move pixels');
     expect(auditResult.details.items[0].subItems.items[2].animation)
       .toBeUndefined();
     expect(auditResult.details.items[0].subItems.items[3].failureReason)
@@ -214,7 +214,7 @@ describe('Non-composited animations audit', () => {
     expect(auditResult.details.items[0].subItems.items[3].animation)
       .toBeUndefined();
     expect(auditResult.details.items[0].subItems.items[4].failureReason)
-      .toBeDisplayString('Target has an incompatible animation');
+      .toBeDisplayString('Target has another animation which is incompatible');
     expect(auditResult.details.items[0].subItems.items[4].animation)
       .toBeUndefined();
     expect(auditResult.details.items[0].subItems.items[5].failureReason)

--- a/lighthouse-core/test/audits/non-composited-animations-test.js
+++ b/lighthouse-core/test/audits/non-composited-animations-test.js
@@ -165,4 +165,61 @@ describe('Non-composited animations audit', () => {
     expect(auditResult.score).toEqual(1);
     expect(auditResult.details.items).toHaveLength(0);
   });
+
+  it('properly reports all failure reasons', async () => {
+    const artifacts = {
+      TraceElements: [
+        {
+          traceEventType: 'animation',
+          devtoolsNodePath: '1,HTML,1,BODY,1,DIV',
+          selector: 'body > div#animated',
+          nodeLabel: 'div',
+          snippet: '<div id="animated">',
+          nodeId: 4,
+          animations: [
+            {failureReasonsMask: 0b11100001011000, unsupportedProperties: ['height']},
+          ],
+        },
+      ],
+      HostUserAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4216.0 Safari/537.36',
+    };
+
+    const auditResult = await NonCompositedAnimationsAudit.audit(artifacts);
+    expect(auditResult.score).toEqual(0);
+    expect(auditResult.details.headings).toHaveLength(1);
+    expect(auditResult.displayValue).toBeDisplayString('1 animated element found');
+    expect(auditResult.details.items).toHaveLength(1);
+    expect(auditResult.details.items[0].node).toEqual({
+      type: 'node',
+      path: '1,HTML,1,BODY,1,DIV',
+      selector: 'body > div#animated',
+      nodeLabel: 'div',
+      snippet: '<div id="animated">',
+    });
+    expect(auditResult.details.items[0].subItems.items[0].failureReason)
+      .toBeDisplayString('Unsupported CSS Property: height');
+    expect(auditResult.details.items[0].subItems.items[0].animation)
+      .toBeUndefined();
+    expect(auditResult.details.items[0].subItems.items[1].failureReason)
+      .toBeDisplayString('Transform related property depends on box size');
+    expect(auditResult.details.items[0].subItems.items[1].animation)
+      .toBeUndefined();
+    expect(auditResult.details.items[0].subItems.items[2].failureReason)
+      .toBeDisplayString('Filter related property may move pixels');
+    expect(auditResult.details.items[0].subItems.items[2].animation)
+      .toBeUndefined();
+    expect(auditResult.details.items[0].subItems.items[3].failureReason)
+      .toBeDisplayString('Effect has composite mode other than "replace"');
+    expect(auditResult.details.items[0].subItems.items[3].animation)
+      .toBeUndefined();
+    expect(auditResult.details.items[0].subItems.items[4].failureReason)
+      .toBeDisplayString('Target has an incompatible animation');
+    expect(auditResult.details.items[0].subItems.items[4].animation)
+      .toBeUndefined();
+    expect(auditResult.details.items[0].subItems.items[5].failureReason)
+      .toBeDisplayString('Effect has unsupported timing parameters');
+    expect(auditResult.details.items[0].subItems.items[5].animation)
+      .toBeUndefined();
+  });
 });


### PR DESCRIPTION
Adds more failure reasons in addition to `Unsupported CSS Property`:

<img width="892" alt="Screen Shot 2020-08-14 at 2 02 21 PM" src="https://user-images.githubusercontent.com/6752989/90279215-c866c500-de36-11ea-9db1-f7fa993adb09.png">
