### PR TITLE
core(module-duplication): ignore smaller modules

### DIFF
--- a/lighthouse-core/computed/module-duplication.js
+++ b/lighthouse-core/computed/module-duplication.js
@@ -8,6 +8,9 @@
 const makeComputedArtifact = require('./computed-artifact.js');
 const JsBundles = require('./js-bundles.js');
 
+const RELATIVE_SIZE_THRESHOLD = 0.1;
+const ABSOLUTE_SIZE_THRESHOLD_BYTES = 1024 * 0.5;
+
 class ModuleDuplication {
   /**
    * @param {string} source
@@ -48,23 +51,24 @@ class ModuleDuplication {
       sourceData.sort((a, b) => b.resourceSize - a.resourceSize);
     }
 
-    // Remove modules smaller than 10% size of largest.
+    // Remove modules smaller than a % size of largest.
     for (const [key, sourceData] of moduleNameToSourceData.entries()) {
       if (sourceData.length === 1) continue;
 
       const largestResourceSize = sourceData[0].resourceSize;
       const filteredSourceData = sourceData.filter(data => {
         const percentSize = data.resourceSize / largestResourceSize;
-        return percentSize >= 0.1;
+        return percentSize >= RELATIVE_SIZE_THRESHOLD;
       });
       moduleNameToSourceData.set(key, filteredSourceData);
     }
 
-    // Remove modules smaller than 0.5 KiB.
+    // Remove modules smaller than an absolute theshold.
     for (const [key, sourceData] of moduleNameToSourceData.entries()) {
       if (sourceData.length === 1) continue;
 
-      const filteredSourceData = sourceData.filter(data => data.resourceSize >= 0.5 * 1024);
+      const filteredSourceData =
+        sourceData.filter(data => data.resourceSize >= ABSOLUTE_SIZE_THRESHOLD_BYTES);
       moduleNameToSourceData.set(key, filteredSourceData);
     }
 

--- a/lighthouse-core/computed/module-duplication.js
+++ b/lighthouse-core/computed/module-duplication.js
@@ -45,7 +45,7 @@ class ModuleDuplication {
   static _normalizeAggregatedData(moduleNameToSourceData) {
     // Sort by resource size.
     for (const sourceData of moduleNameToSourceData.values()) {
-      if (sourceData.length > 1) sourceData.sort((a, b) => b.resourceSize - a.resourceSize);
+      sourceData.sort((a, b) => b.resourceSize - a.resourceSize);
     }
 
     // Remove modules smaller than 90% size of largest.

--- a/lighthouse-core/computed/module-duplication.js
+++ b/lighthouse-core/computed/module-duplication.js
@@ -60,11 +60,11 @@ class ModuleDuplication {
       moduleNameToSourceData.set(key, filteredSourceData);
     }
 
-    // Remove modules smaller than 1KiB.
+    // Remove modules smaller than 0.5 KiB.
     for (const [key, sourceData] of moduleNameToSourceData.entries()) {
       if (sourceData.length === 1) continue;
 
-      const filteredSourceData = sourceData.filter(data => data.resourceSize >= 1024);
+      const filteredSourceData = sourceData.filter(data => data.resourceSize >= 0.5 * 1024);
       moduleNameToSourceData.set(key, filteredSourceData);
     }
 

--- a/lighthouse-core/computed/module-duplication.js
+++ b/lighthouse-core/computed/module-duplication.js
@@ -48,14 +48,14 @@ class ModuleDuplication {
       sourceData.sort((a, b) => b.resourceSize - a.resourceSize);
     }
 
-    // Remove modules smaller than 90% size of largest.
+    // Remove modules smaller than 10% size of largest.
     for (const [key, sourceData] of moduleNameToSourceData.entries()) {
       if (sourceData.length === 1) continue;
 
       const largestResourceSize = sourceData[0].resourceSize;
       const filteredSourceData = sourceData.filter(data => {
         const diff = largestResourceSize - data.resourceSize;
-        return diff / largestResourceSize < 0.9;
+        return 1 - diff / largestResourceSize >= 0.1;
       });
       moduleNameToSourceData.set(key, filteredSourceData);
     }

--- a/lighthouse-core/computed/module-duplication.js
+++ b/lighthouse-core/computed/module-duplication.js
@@ -64,7 +64,7 @@ class ModuleDuplication {
     for (const [key, sourceData] of moduleNameToSourceData.entries()) {
       if (sourceData.length === 1) continue;
 
-      const filteredSourceData = sourceData.filter(data => data.resourceSize < 1024);
+      const filteredSourceData = sourceData.filter(data => data.resourceSize >= 1024);
       moduleNameToSourceData.set(key, filteredSourceData);
     }
 

--- a/lighthouse-core/computed/module-duplication.js
+++ b/lighthouse-core/computed/module-duplication.js
@@ -46,7 +46,9 @@ class ModuleDuplication {
    * @param {Map<string, Array<{scriptUrl: string, resourceSize: number}>>} moduleNameToSourceData
    */
   static _normalizeAggregatedData(moduleNameToSourceData) {
-    for (let [key, sourceData] of moduleNameToSourceData.entries()) {
+    for (const [key, originalSourceData] of moduleNameToSourceData.entries()) {
+      let sourceData = originalSourceData;
+
       // Sort by resource size.
       sourceData.sort((a, b) => b.resourceSize - a.resourceSize);
 

--- a/lighthouse-core/computed/module-duplication.js
+++ b/lighthouse-core/computed/module-duplication.js
@@ -54,8 +54,8 @@ class ModuleDuplication {
 
       const largestResourceSize = sourceData[0].resourceSize;
       const filteredSourceData = sourceData.filter(data => {
-        const diff = largestResourceSize - data.resourceSize;
-        return 1 - diff / largestResourceSize >= 0.1;
+        const percentSize = data.resourceSize / largestResourceSize;
+        return percentSize >= 0.1;
       });
       moduleNameToSourceData.set(key, filteredSourceData);
     }

--- a/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
@@ -131,11 +131,11 @@ describe('DuplicatedJavascript computed artifact', () => {
             "subItems": Object {
               "items": Array [
                 Object {
-                  "sourceTransferBytes": 1804,
+                  "sourceTransferBytes": 1348,
                   "url": "https://example.com/coursehero-bundle-1.js",
                 },
                 Object {
-                  "sourceTransferBytes": 1455,
+                  "sourceTransferBytes": 1227,
                   "url": "https://example.com/coursehero-bundle-2.js",
                 },
               ],
@@ -143,7 +143,7 @@ describe('DuplicatedJavascript computed artifact', () => {
             },
             "totalBytes": 0,
             "url": "",
-            "wastedBytes": 1455,
+            "wastedBytes": 1227,
           },
           Object {
             "source": "js/src/utils/service/amplitude-service.ts",
@@ -350,11 +350,11 @@ describe('DuplicatedJavascript computed artifact', () => {
             },
             "totalBytes": 0,
             "url": "",
-            "wastedBytes": 905,
+            "wastedBytes": 761,
           },
         ],
         "wastedBytesByUrl": Map {
-          "https://example.com/coursehero-bundle-2.js" => 29241,
+          "https://example.com/coursehero-bundle-2.js" => 28869,
           "https://example.com/coursehero-bundle-1.js" => 3184,
         },
       }

--- a/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
@@ -41,28 +41,8 @@ describe('DuplicatedJavascript computed artifact', () => {
     expect({items: results.items, wastedBytesByUrl: results.wastedBytesByUrl})
       .toMatchInlineSnapshot(`
       Object {
-        "items": Array [
-          Object {
-            "source": "Other",
-            "subItems": Object {
-              "items": Array [
-                Object {
-                  "url": "https://example.com/foo1.min.js",
-                },
-                Object {
-                  "url": "https://example.com/foo2.min.js",
-                },
-              ],
-              "type": "subitems",
-            },
-            "totalBytes": 0,
-            "url": "",
-            "wastedBytes": 224,
-          },
-        ],
-        "wastedBytesByUrl": Map {
-          "https://example.com/foo2.min.js" => 224,
-        },
+        "items": Array [],
+        "wastedBytesByUrl": Map {},
       }
     `);
   });
@@ -127,25 +107,6 @@ describe('DuplicatedJavascript computed artifact', () => {
             "wastedBytes": 3015,
           },
           Object {
-            "source": "node_modules/@babel/runtime",
-            "subItems": Object {
-              "items": Array [
-                Object {
-                  "sourceTransferBytes": 1804,
-                  "url": "https://example.com/coursehero-bundle-1.js",
-                },
-                Object {
-                  "sourceTransferBytes": 1455,
-                  "url": "https://example.com/coursehero-bundle-2.js",
-                },
-              ],
-              "type": "subitems",
-            },
-            "totalBytes": 0,
-            "url": "",
-            "wastedBytes": 1455,
-          },
-          Object {
             "source": "js/src/utils/service/amplitude-service.ts",
             "subItems": Object {
               "items": Array [
@@ -163,44 +124,6 @@ describe('DuplicatedJavascript computed artifact', () => {
             "totalBytes": 0,
             "url": "",
             "wastedBytes": 437,
-          },
-          Object {
-            "source": "js/src/search/results/store/filter-actions.ts",
-            "subItems": Object {
-              "items": Array [
-                Object {
-                  "sourceTransferBytes": 315,
-                  "url": "https://example.com/coursehero-bundle-2.js",
-                },
-                Object {
-                  "sourceTransferBytes": 312,
-                  "url": "https://example.com/coursehero-bundle-1.js",
-                },
-              ],
-              "type": "subitems",
-            },
-            "totalBytes": 0,
-            "url": "",
-            "wastedBytes": 312,
-          },
-          Object {
-            "source": "js/src/search/results/store/item/resource-types.ts",
-            "subItems": Object {
-              "items": Array [
-                Object {
-                  "sourceTransferBytes": 258,
-                  "url": "https://example.com/coursehero-bundle-1.js",
-                },
-                Object {
-                  "sourceTransferBytes": 256,
-                  "url": "https://example.com/coursehero-bundle-2.js",
-                },
-              ],
-              "type": "subitems",
-            },
-            "totalBytes": 0,
-            "url": "",
-            "wastedBytes": 256,
           },
           Object {
             "source": "js/src/search/results/store/filter-store.ts",
@@ -316,46 +239,10 @@ describe('DuplicatedJavascript computed artifact', () => {
             "url": "",
             "wastedBytes": 1022,
           },
-          Object {
-            "source": "node_modules/lodash-es",
-            "subItems": Object {
-              "items": Array [
-                Object {
-                  "sourceTransferBytes": 578,
-                  "url": "https://example.com/coursehero-bundle-2.js",
-                },
-                Object {
-                  "sourceTransferBytes": 564,
-                  "url": "https://example.com/coursehero-bundle-1.js",
-                },
-              ],
-              "type": "subitems",
-            },
-            "totalBytes": 0,
-            "url": "",
-            "wastedBytes": 564,
-          },
-          Object {
-            "source": "Other",
-            "subItems": Object {
-              "items": Array [
-                Object {
-                  "url": "https://example.com/coursehero-bundle-1.js",
-                },
-                Object {
-                  "url": "https://example.com/coursehero-bundle-2.js",
-                },
-              ],
-              "type": "subitems",
-            },
-            "totalBytes": 0,
-            "url": "",
-            "wastedBytes": 905,
-          },
         ],
         "wastedBytesByUrl": Map {
-          "https://example.com/coursehero-bundle-2.js" => 29241,
-          "https://example.com/coursehero-bundle-1.js" => 3184,
+          "https://example.com/coursehero-bundle-2.js" => 26805,
+          "https://example.com/coursehero-bundle-1.js" => 2128,
         },
       }
     `);

--- a/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
@@ -131,11 +131,11 @@ describe('DuplicatedJavascript computed artifact', () => {
             "subItems": Object {
               "items": Array [
                 Object {
-                  "sourceTransferBytes": 1348,
+                  "sourceTransferBytes": 1804,
                   "url": "https://example.com/coursehero-bundle-1.js",
                 },
                 Object {
-                  "sourceTransferBytes": 1227,
+                  "sourceTransferBytes": 1455,
                   "url": "https://example.com/coursehero-bundle-2.js",
                 },
               ],
@@ -143,7 +143,7 @@ describe('DuplicatedJavascript computed artifact', () => {
             },
             "totalBytes": 0,
             "url": "",
-            "wastedBytes": 1227,
+            "wastedBytes": 1455,
           },
           Object {
             "source": "js/src/utils/service/amplitude-service.ts",
@@ -350,11 +350,11 @@ describe('DuplicatedJavascript computed artifact', () => {
             },
             "totalBytes": 0,
             "url": "",
-            "wastedBytes": 761,
+            "wastedBytes": 905,
           },
         ],
         "wastedBytesByUrl": Map {
-          "https://example.com/coursehero-bundle-2.js" => 28869,
+          "https://example.com/coursehero-bundle-2.js" => 29241,
           "https://example.com/coursehero-bundle-1.js" => 3184,
         },
       }

--- a/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
@@ -107,6 +107,25 @@ describe('DuplicatedJavascript computed artifact', () => {
             "wastedBytes": 3015,
           },
           Object {
+            "source": "node_modules/@babel/runtime",
+            "subItems": Object {
+              "items": Array [
+                Object {
+                  "sourceTransferBytes": 502,
+                  "url": "https://example.com/coursehero-bundle-1.js",
+                },
+                Object {
+                  "sourceTransferBytes": 502,
+                  "url": "https://example.com/coursehero-bundle-2.js",
+                },
+              ],
+              "type": "subitems",
+            },
+            "totalBytes": 0,
+            "url": "",
+            "wastedBytes": 502,
+          },
+          Object {
             "source": "js/src/utils/service/amplitude-service.ts",
             "subItems": Object {
               "items": Array [
@@ -124,6 +143,44 @@ describe('DuplicatedJavascript computed artifact', () => {
             "totalBytes": 0,
             "url": "",
             "wastedBytes": 437,
+          },
+          Object {
+            "source": "js/src/search/results/store/filter-actions.ts",
+            "subItems": Object {
+              "items": Array [
+                Object {
+                  "sourceTransferBytes": 315,
+                  "url": "https://example.com/coursehero-bundle-2.js",
+                },
+                Object {
+                  "sourceTransferBytes": 312,
+                  "url": "https://example.com/coursehero-bundle-1.js",
+                },
+              ],
+              "type": "subitems",
+            },
+            "totalBytes": 0,
+            "url": "",
+            "wastedBytes": 312,
+          },
+          Object {
+            "source": "js/src/search/results/store/item/resource-types.ts",
+            "subItems": Object {
+              "items": Array [
+                Object {
+                  "sourceTransferBytes": 258,
+                  "url": "https://example.com/coursehero-bundle-1.js",
+                },
+                Object {
+                  "sourceTransferBytes": 256,
+                  "url": "https://example.com/coursehero-bundle-2.js",
+                },
+              ],
+              "type": "subitems",
+            },
+            "totalBytes": 0,
+            "url": "",
+            "wastedBytes": 256,
           },
           Object {
             "source": "js/src/search/results/store/filter-store.ts",
@@ -239,10 +296,27 @@ describe('DuplicatedJavascript computed artifact', () => {
             "url": "",
             "wastedBytes": 1022,
           },
+          Object {
+            "source": "Other",
+            "subItems": Object {
+              "items": Array [
+                Object {
+                  "url": "https://example.com/coursehero-bundle-1.js",
+                },
+                Object {
+                  "url": "https://example.com/coursehero-bundle-2.js",
+                },
+              ],
+              "type": "subitems",
+            },
+            "totalBytes": 0,
+            "url": "",
+            "wastedBytes": 542,
+          },
         ],
         "wastedBytesByUrl": Map {
-          "https://example.com/coursehero-bundle-2.js" => 26805,
-          "https://example.com/coursehero-bundle-1.js" => 2128,
+          "https://example.com/coursehero-bundle-2.js" => 27925,
+          "https://example.com/coursehero-bundle-1.js" => 2620,
         },
       }
     `);

--- a/lighthouse-core/test/computed/module-duplication-test.js
+++ b/lighthouse-core/test/computed/module-duplication-test.js
@@ -134,16 +134,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-1.js",
           },
         ],
-        "node_modules/@babel/runtime/helpers/applyDecoratedDescriptor.js" => Array [
-          Object {
-            "resourceSize": 892,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 446,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
         "node_modules/@babel/runtime/helpers/possibleConstructorReturn.js" => Array [
           Object {
             "resourceSize": 230,
@@ -184,16 +174,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-1.js",
           },
         ],
-        "node_modules/@babel/runtime/helpers/extends.js" => Array [
-          Object {
-            "resourceSize": 490,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 245,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
         "node_modules/@babel/runtime/helpers/typeof.js" => Array [
           Object {
             "resourceSize": 992,
@@ -212,16 +192,6 @@ describe('ModuleDuplication computed artifact', () => {
           Object {
             "resourceSize": 260,
             "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "js/src/common/base-component.ts" => Array [
-          Object {
-            "resourceSize": 459,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 216,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
         "js/src/utils/service/amplitude-service.ts" => Array [
@@ -244,16 +214,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "js/src/utils/service/api-service.ts" => Array [
-          Object {
-            "resourceSize": 116,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 54,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
         "js/src/common/decorators/throttle.ts" => Array [
           Object {
             "resourceSize": 251,
@@ -271,16 +231,6 @@ describe('ModuleDuplication computed artifact', () => {
           },
           Object {
             "resourceSize": 563,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "js/src/utils/service/global-service.ts" => Array [
-          Object {
-            "resourceSize": 336,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 167,
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
@@ -572,5 +522,61 @@ describe('ModuleDuplication computed artifact', () => {
     for (const [input, expected] of testCases) {
       expect(ModuleDuplication._normalizeSource(input)).toBe(expected);
     }
+  });
+
+  describe('_normalizeAggregatedData', () => {
+    it('removes entries with just one value', () => {
+      const data = new Map([['a.js', [{resourceSize: 100}]]]);
+      ModuleDuplication._normalizeAggregatedData(data);
+      expect(data).toMatchInlineSnapshot(`Map {}`);
+    });
+
+    it('sorts entries based on resource size', () => {
+      const data = new Map([
+        ['a.js', [{resourceSize: 250}, {resourceSize: 200}]],
+        ['b.js', [{resourceSize: 200}, {resourceSize: 250}]],
+      ]);
+      ModuleDuplication._normalizeAggregatedData(data);
+      expect(data).toMatchInlineSnapshot(`
+        Map {
+          "a.js" => Array [
+            Object {
+              "resourceSize": 250,
+            },
+            Object {
+              "resourceSize": 200,
+            },
+          ],
+          "b.js" => Array [
+            Object {
+              "resourceSize": 250,
+            },
+            Object {
+              "resourceSize": 200,
+            },
+          ],
+        }
+      `);
+    });
+
+    it('removes data if size is much smaller than the largest', () => {
+      const data = new Map([
+        ['a.js', [{resourceSize: 200}, {resourceSize: 1}, {resourceSize: 250}]],
+        ['b.js', [{resourceSize: 250}, {resourceSize: 1}]],
+      ]);
+      ModuleDuplication._normalizeAggregatedData(data);
+      expect(data).toMatchInlineSnapshot(`
+        Map {
+          "a.js" => Array [
+            Object {
+              "resourceSize": 250,
+            },
+            Object {
+              "resourceSize": 200,
+            },
+          ],
+        }
+      `);
+    });
   });
 });

--- a/lighthouse-core/test/computed/module-duplication-test.js
+++ b/lighthouse-core/test/computed/module-duplication-test.js
@@ -78,15 +78,31 @@ describe('ModuleDuplication computed artifact', () => {
           },
         ],
         "node_modules/@babel/runtime/helpers/classCallCheck.js" => Array [],
-        "node_modules/@babel/runtime/helpers/createClass.js" => Array [],
         "node_modules/@babel/runtime/helpers/assertThisInitialized.js" => Array [],
-        "node_modules/@babel/runtime/helpers/applyDecoratedDescriptor.js" => Array [],
         "node_modules/@babel/runtime/helpers/possibleConstructorReturn.js" => Array [],
         "node_modules/@babel/runtime/helpers/getPrototypeOf.js" => Array [],
-        "node_modules/@babel/runtime/helpers/inherits.js" => Array [],
+        "node_modules/@babel/runtime/helpers/inherits.js" => Array [
+          Object {
+            "resourceSize": 528,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 528,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+        ],
         "node_modules/@babel/runtime/helpers/defineProperty.js" => Array [],
         "node_modules/@babel/runtime/helpers/extends.js" => Array [],
-        "node_modules/@babel/runtime/helpers/typeof.js" => Array [],
+        "node_modules/@babel/runtime/helpers/typeof.js" => Array [
+          Object {
+            "resourceSize": 992,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 992,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+        ],
         "node_modules/@babel/runtime/helpers/setPrototypeOf.js" => Array [],
         "js/src/common/base-component.ts" => Array [],
         "js/src/utils/service/amplitude-service.ts" => Array [
@@ -102,10 +118,37 @@ describe('ModuleDuplication computed artifact', () => {
         "js/src/aged-beef.ts" => Array [],
         "js/src/utils/service/api-service.ts" => Array [],
         "js/src/common/decorators/throttle.ts" => Array [],
-        "js/src/utils/service/gsa-inmeta-tags.ts" => Array [],
+        "js/src/utils/service/gsa-inmeta-tags.ts" => Array [
+          Object {
+            "resourceSize": 591,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 563,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+        ],
         "js/src/utils/service/global-service.ts" => Array [],
-        "js/src/search/results/store/filter-actions.ts" => Array [],
-        "js/src/search/results/store/item/resource-types.ts" => Array [],
+        "js/src/search/results/store/filter-actions.ts" => Array [
+          Object {
+            "resourceSize": 956,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+          Object {
+            "resourceSize": 946,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+        ],
+        "js/src/search/results/store/item/resource-types.ts" => Array [
+          Object {
+            "resourceSize": 783,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 775,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+        ],
         "js/src/common/input/keycode.ts" => Array [],
         "js/src/search/results/store/filter-store.ts" => Array [
           Object {
@@ -147,7 +190,16 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "js/src/search/results/service/api/filter-api-service.ts" => Array [],
+        "js/src/search/results/service/api/filter-api-service.ts" => Array [
+          Object {
+            "resourceSize": 554,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 534,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+        ],
         "js/src/common/component/school-search.tsx" => Array [
           Object {
             "resourceSize": 5840,
@@ -168,7 +220,16 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "js/src/common/component/search/course-search.tsx" => Array [],
+        "js/src/common/component/search/course-search.tsx" => Array [
+          Object {
+            "resourceSize": 545,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+          Object {
+            "resourceSize": 544,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+        ],
         "node_modules/lodash-es/_freeGlobal.js" => Array [],
         "node_modules/lodash-es/_root.js" => Array [],
         "node_modules/lodash-es/_Symbol.js" => Array [],

--- a/lighthouse-core/test/computed/module-duplication-test.js
+++ b/lighthouse-core/test/computed/module-duplication-test.js
@@ -134,6 +134,16 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-1.js",
           },
         ],
+        "node_modules/@babel/runtime/helpers/applyDecoratedDescriptor.js" => Array [
+          Object {
+            "resourceSize": 892,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 446,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+        ],
         "node_modules/@babel/runtime/helpers/possibleConstructorReturn.js" => Array [
           Object {
             "resourceSize": 230,
@@ -174,6 +184,16 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-1.js",
           },
         ],
+        "node_modules/@babel/runtime/helpers/extends.js" => Array [
+          Object {
+            "resourceSize": 490,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 245,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+        ],
         "node_modules/@babel/runtime/helpers/typeof.js" => Array [
           Object {
             "resourceSize": 992,
@@ -192,6 +212,16 @@ describe('ModuleDuplication computed artifact', () => {
           Object {
             "resourceSize": 260,
             "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+        ],
+        "js/src/common/base-component.ts" => Array [
+          Object {
+            "resourceSize": 459,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 216,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
         "js/src/utils/service/amplitude-service.ts" => Array [
@@ -214,6 +244,16 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
+        "js/src/utils/service/api-service.ts" => Array [
+          Object {
+            "resourceSize": 116,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 54,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+        ],
         "js/src/common/decorators/throttle.ts" => Array [
           Object {
             "resourceSize": 251,
@@ -231,6 +271,16 @@ describe('ModuleDuplication computed artifact', () => {
           },
           Object {
             "resourceSize": 563,
+            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
+          },
+        ],
+        "js/src/utils/service/global-service.ts" => Array [
+          Object {
+            "resourceSize": 336,
+            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
+          },
+          Object {
+            "resourceSize": 167,
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],

--- a/lighthouse-core/test/computed/module-duplication-test.js
+++ b/lighthouse-core/test/computed/module-duplication-test.js
@@ -33,36 +33,9 @@ describe('ModuleDuplication computed artifact', () => {
     const results = await ModuleDuplication.request(artifacts, context);
     expect(results).toMatchInlineSnapshot(`
       Map {
-        "node_modules/browser-pack/_prelude.js" => Array [
-          Object {
-            "resourceSize": 480,
-            "scriptUrl": "https://example.com/foo1.min.js",
-          },
-          Object {
-            "resourceSize": 480,
-            "scriptUrl": "https://example.com/foo2.min.js",
-          },
-        ],
-        "src/bar.js" => Array [
-          Object {
-            "resourceSize": 104,
-            "scriptUrl": "https://example.com/foo1.min.js",
-          },
-          Object {
-            "resourceSize": 104,
-            "scriptUrl": "https://example.com/foo2.min.js",
-          },
-        ],
-        "src/foo.js" => Array [
-          Object {
-            "resourceSize": 98,
-            "scriptUrl": "https://example.com/foo1.min.js",
-          },
-          Object {
-            "resourceSize": 98,
-            "scriptUrl": "https://example.com/foo2.min.js",
-          },
-        ],
+        "node_modules/browser-pack/_prelude.js" => Array [],
+        "src/bar.js" => Array [],
+        "src/foo.js" => Array [],
       }
     `);
   });
@@ -104,126 +77,18 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "node_modules/@babel/runtime/helpers/classCallCheck.js" => Array [
-          Object {
-            "resourceSize": 358,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 236,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/createClass.js" => Array [
-          Object {
-            "resourceSize": 799,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 496,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/assertThisInitialized.js" => Array [
-          Object {
-            "resourceSize": 296,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 294,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/applyDecoratedDescriptor.js" => Array [
-          Object {
-            "resourceSize": 892,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 446,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/possibleConstructorReturn.js" => Array [
-          Object {
-            "resourceSize": 230,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 228,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/getPrototypeOf.js" => Array [
-          Object {
-            "resourceSize": 361,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 338,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/inherits.js" => Array [
-          Object {
-            "resourceSize": 528,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 528,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/defineProperty.js" => Array [
-          Object {
-            "resourceSize": 290,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 288,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/extends.js" => Array [
-          Object {
-            "resourceSize": 490,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 245,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/typeof.js" => Array [
-          Object {
-            "resourceSize": 992,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 992,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/@babel/runtime/helpers/setPrototypeOf.js" => Array [
-          Object {
-            "resourceSize": 290,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 260,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "js/src/common/base-component.ts" => Array [
-          Object {
-            "resourceSize": 459,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 216,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
+        "node_modules/@babel/runtime/helpers/classCallCheck.js" => Array [],
+        "node_modules/@babel/runtime/helpers/createClass.js" => Array [],
+        "node_modules/@babel/runtime/helpers/assertThisInitialized.js" => Array [],
+        "node_modules/@babel/runtime/helpers/applyDecoratedDescriptor.js" => Array [],
+        "node_modules/@babel/runtime/helpers/possibleConstructorReturn.js" => Array [],
+        "node_modules/@babel/runtime/helpers/getPrototypeOf.js" => Array [],
+        "node_modules/@babel/runtime/helpers/inherits.js" => Array [],
+        "node_modules/@babel/runtime/helpers/defineProperty.js" => Array [],
+        "node_modules/@babel/runtime/helpers/extends.js" => Array [],
+        "node_modules/@babel/runtime/helpers/typeof.js" => Array [],
+        "node_modules/@babel/runtime/helpers/setPrototypeOf.js" => Array [],
+        "js/src/common/base-component.ts" => Array [],
         "js/src/utils/service/amplitude-service.ts" => Array [
           Object {
             "resourceSize": 1348,
@@ -234,86 +99,14 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "js/src/aged-beef.ts" => Array [
-          Object {
-            "resourceSize": 213,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 194,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "js/src/utils/service/api-service.ts" => Array [
-          Object {
-            "resourceSize": 116,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 54,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "js/src/common/decorators/throttle.ts" => Array [
-          Object {
-            "resourceSize": 251,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 244,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "js/src/utils/service/gsa-inmeta-tags.ts" => Array [
-          Object {
-            "resourceSize": 591,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 563,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "js/src/utils/service/global-service.ts" => Array [
-          Object {
-            "resourceSize": 336,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 167,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "js/src/search/results/store/filter-actions.ts" => Array [
-          Object {
-            "resourceSize": 956,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 946,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "js/src/search/results/store/item/resource-types.ts" => Array [
-          Object {
-            "resourceSize": 783,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 775,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "js/src/common/input/keycode.ts" => Array [
-          Object {
-            "resourceSize": 237,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 223,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
+        "js/src/aged-beef.ts" => Array [],
+        "js/src/utils/service/api-service.ts" => Array [],
+        "js/src/common/decorators/throttle.ts" => Array [],
+        "js/src/utils/service/gsa-inmeta-tags.ts" => Array [],
+        "js/src/utils/service/global-service.ts" => Array [],
+        "js/src/search/results/store/filter-actions.ts" => Array [],
+        "js/src/search/results/store/item/resource-types.ts" => Array [],
+        "js/src/common/input/keycode.ts" => Array [],
         "js/src/search/results/store/filter-store.ts" => Array [
           Object {
             "resourceSize": 12717,
@@ -354,16 +147,7 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "js/src/search/results/service/api/filter-api-service.ts" => Array [
-          Object {
-            "resourceSize": 554,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 534,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
+        "js/src/search/results/service/api/filter-api-service.ts" => Array [],
         "js/src/common/component/school-search.tsx" => Array [
           Object {
             "resourceSize": 5840,
@@ -384,176 +168,23 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "js/src/common/component/search/course-search.tsx" => Array [
-          Object {
-            "resourceSize": 545,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 544,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "node_modules/lodash-es/_freeGlobal.js" => Array [
-          Object {
-            "resourceSize": 118,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 93,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "node_modules/lodash-es/_root.js" => Array [
-          Object {
-            "resourceSize": 93,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 93,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/_Symbol.js" => Array [
-          Object {
-            "resourceSize": 10,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 10,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/_arrayMap.js" => Array [
-          Object {
-            "resourceSize": 99,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 99,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/isArray.js" => Array [
-          Object {
-            "resourceSize": 16,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 16,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/_getRawTag.js" => Array [
-          Object {
-            "resourceSize": 206,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 206,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/_objectToString.js" => Array [
-          Object {
-            "resourceSize": 64,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 64,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/_baseGetTag.js" => Array [
-          Object {
-            "resourceSize": 143,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 143,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/isObjectLike.js" => Array [
-          Object {
-            "resourceSize": 54,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 54,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/isSymbol.js" => Array [
-          Object {
-            "resourceSize": 79,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 79,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/_baseToString.js" => Array [
-          Object {
-            "resourceSize": 198,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 198,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/isObject.js" => Array [
-          Object {
-            "resourceSize": 80,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 79,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "node_modules/lodash-es/toNumber.js" => Array [
-          Object {
-            "resourceSize": 370,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 354,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "node_modules/lodash-es/toFinite.js" => Array [
-          Object {
-            "resourceSize": 118,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-          Object {
-            "resourceSize": 117,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-        ],
-        "node_modules/lodash-es/toInteger.js" => Array [
-          Object {
-            "resourceSize": 60,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 60,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
-        "node_modules/lodash-es/toString.js" => Array [
-          Object {
-            "resourceSize": 43,
-            "scriptUrl": "https://example.com/coursehero-bundle-1.js",
-          },
-          Object {
-            "resourceSize": 43,
-            "scriptUrl": "https://example.com/coursehero-bundle-2.js",
-          },
-        ],
+        "js/src/common/component/search/course-search.tsx" => Array [],
+        "node_modules/lodash-es/_freeGlobal.js" => Array [],
+        "node_modules/lodash-es/_root.js" => Array [],
+        "node_modules/lodash-es/_Symbol.js" => Array [],
+        "node_modules/lodash-es/_arrayMap.js" => Array [],
+        "node_modules/lodash-es/isArray.js" => Array [],
+        "node_modules/lodash-es/_getRawTag.js" => Array [],
+        "node_modules/lodash-es/_objectToString.js" => Array [],
+        "node_modules/lodash-es/_baseGetTag.js" => Array [],
+        "node_modules/lodash-es/isObjectLike.js" => Array [],
+        "node_modules/lodash-es/isSymbol.js" => Array [],
+        "node_modules/lodash-es/_baseToString.js" => Array [],
+        "node_modules/lodash-es/isObject.js" => Array [],
+        "node_modules/lodash-es/toNumber.js" => Array [],
+        "node_modules/lodash-es/toFinite.js" => Array [],
+        "node_modules/lodash-es/toInteger.js" => Array [],
+        "node_modules/lodash-es/toString.js" => Array [],
       }
     `);
   });
@@ -589,22 +220,8 @@ describe('ModuleDuplication computed artifact', () => {
       ModuleDuplication._normalizeAggregatedData(data);
       expect(data).toMatchInlineSnapshot(`
         Map {
-          "a.js" => Array [
-            Object {
-              "resourceSize": 250,
-            },
-            Object {
-              "resourceSize": 200,
-            },
-          ],
-          "b.js" => Array [
-            Object {
-              "resourceSize": 250,
-            },
-            Object {
-              "resourceSize": 200,
-            },
-          ],
+          "a.js" => Array [],
+          "b.js" => Array [],
         }
       `);
     });
@@ -617,14 +234,7 @@ describe('ModuleDuplication computed artifact', () => {
       ModuleDuplication._normalizeAggregatedData(data);
       expect(data).toMatchInlineSnapshot(`
         Map {
-          "a.js" => Array [
-            Object {
-              "resourceSize": 250,
-            },
-            Object {
-              "resourceSize": 200,
-            },
-          ],
+          "a.js" => Array [],
         }
       `);
     });

--- a/lighthouse-core/test/computed/module-duplication-test.js
+++ b/lighthouse-core/test/computed/module-duplication-test.js
@@ -31,13 +31,7 @@ describe('ModuleDuplication computed artifact', () => {
       ],
     };
     const results = await ModuleDuplication.request(artifacts, context);
-    expect(results).toMatchInlineSnapshot(`
-      Map {
-        "node_modules/browser-pack/_prelude.js" => Array [],
-        "src/bar.js" => Array [],
-        "src/foo.js" => Array [],
-      }
-    `);
+    expect(results).toMatchInlineSnapshot(`Map {}`);
   });
 
   it('works (complex)', async () => {
@@ -77,10 +71,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "node_modules/@babel/runtime/helpers/classCallCheck.js" => Array [],
-        "node_modules/@babel/runtime/helpers/assertThisInitialized.js" => Array [],
-        "node_modules/@babel/runtime/helpers/possibleConstructorReturn.js" => Array [],
-        "node_modules/@babel/runtime/helpers/getPrototypeOf.js" => Array [],
         "node_modules/@babel/runtime/helpers/inherits.js" => Array [
           Object {
             "resourceSize": 528,
@@ -91,8 +81,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "node_modules/@babel/runtime/helpers/defineProperty.js" => Array [],
-        "node_modules/@babel/runtime/helpers/extends.js" => Array [],
         "node_modules/@babel/runtime/helpers/typeof.js" => Array [
           Object {
             "resourceSize": 992,
@@ -103,8 +91,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "node_modules/@babel/runtime/helpers/setPrototypeOf.js" => Array [],
-        "js/src/common/base-component.ts" => Array [],
         "js/src/utils/service/amplitude-service.ts" => Array [
           Object {
             "resourceSize": 1348,
@@ -115,9 +101,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "js/src/aged-beef.ts" => Array [],
-        "js/src/utils/service/api-service.ts" => Array [],
-        "js/src/common/decorators/throttle.ts" => Array [],
         "js/src/utils/service/gsa-inmeta-tags.ts" => Array [
           Object {
             "resourceSize": 591,
@@ -128,7 +111,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "js/src/utils/service/global-service.ts" => Array [],
         "js/src/search/results/store/filter-actions.ts" => Array [
           Object {
             "resourceSize": 956,
@@ -149,7 +131,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-2.js",
           },
         ],
-        "js/src/common/input/keycode.ts" => Array [],
         "js/src/search/results/store/filter-store.ts" => Array [
           Object {
             "resourceSize": 12717,
@@ -230,22 +211,6 @@ describe('ModuleDuplication computed artifact', () => {
             "scriptUrl": "https://example.com/coursehero-bundle-1.js",
           },
         ],
-        "node_modules/lodash-es/_freeGlobal.js" => Array [],
-        "node_modules/lodash-es/_root.js" => Array [],
-        "node_modules/lodash-es/_Symbol.js" => Array [],
-        "node_modules/lodash-es/_arrayMap.js" => Array [],
-        "node_modules/lodash-es/isArray.js" => Array [],
-        "node_modules/lodash-es/_getRawTag.js" => Array [],
-        "node_modules/lodash-es/_objectToString.js" => Array [],
-        "node_modules/lodash-es/_baseGetTag.js" => Array [],
-        "node_modules/lodash-es/isObjectLike.js" => Array [],
-        "node_modules/lodash-es/isSymbol.js" => Array [],
-        "node_modules/lodash-es/_baseToString.js" => Array [],
-        "node_modules/lodash-es/isObject.js" => Array [],
-        "node_modules/lodash-es/toNumber.js" => Array [],
-        "node_modules/lodash-es/toFinite.js" => Array [],
-        "node_modules/lodash-es/toInteger.js" => Array [],
-        "node_modules/lodash-es/toString.js" => Array [],
       }
     `);
   });
@@ -279,12 +244,7 @@ describe('ModuleDuplication computed artifact', () => {
         ['b.js', [{resourceSize: 200}, {resourceSize: 250}]],
       ]);
       ModuleDuplication._normalizeAggregatedData(data);
-      expect(data).toMatchInlineSnapshot(`
-        Map {
-          "a.js" => Array [],
-          "b.js" => Array [],
-        }
-      `);
+      expect(data).toMatchInlineSnapshot(`Map {}`);
     });
 
     it('removes data if size is much smaller than the largest', () => {
@@ -293,11 +253,7 @@ describe('ModuleDuplication computed artifact', () => {
         ['b.js', [{resourceSize: 250}, {resourceSize: 1}]],
       ]);
       ModuleDuplication._normalizeAggregatedData(data);
-      expect(data).toMatchInlineSnapshot(`
-        Map {
-          "a.js" => Array [],
-        }
-      `);
+      expect(data).toMatchInlineSnapshot(`Map {}`);
     });
   });
 });


### PR DESCRIPTION
avoids situations like this: 
![image](https://user-images.githubusercontent.com/4071474/90424239-64850c00-e083-11ea-8557-0a1cf009f00d.png)

which would then be shown oddly in the treemap app by highlighting just the big module, and the other modules are way too small to even see.
