### PR TITLE
report: handle invalid urls for source location items

### DIFF
--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -112,7 +112,7 @@ class DetailsRenderer {
     try {
       const parsed = Util.parseURL(url);
       displayedPath = parsed.file === '/' ? parsed.origin : parsed.file;
-      displayedHost = parsed.file === '/' ? '' : `(${parsed.hostname})`;
+      displayedHost = parsed.file === '/' || parsed.hostname === '' ? '' : `(${parsed.hostname})`;
       title = url;
     } catch (e) {
       displayedPath = url;

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -148,7 +148,9 @@ class DetailsRenderer {
 
     if (!url || !allowedProtocols.includes(url.protocol)) {
       // Fall back to just the link text if invalid or protocol not allowed.
-      return this._renderText(details.text);
+      const element = this._renderText(details.text);
+      element.classList.add('lh-link');
+      return element;
     }
 
     const a = this._dom.createElement('a');
@@ -156,7 +158,7 @@ class DetailsRenderer {
     a.target = '_blank';
     a.textContent = details.text;
     a.href = url.href;
-
+    a.classList.add('lh-link');
     return a;
   }
 
@@ -546,7 +548,7 @@ class DetailsRenderer {
     let element;
     if (item.urlProvider === 'network') {
       element = this.renderTextURL(item.url);
-      this._dom.find('a', element).textContent += `:${line}:${column}`;
+      this._dom.find('.lh-link', element).textContent += `:${line}:${column}`;
     } else {
       element = this._renderText(`${item.url}:${line}:${column} (from sourceURL)`);
     }

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -418,6 +418,31 @@ describe('DetailsRenderer', () => {
       assert.equal(sourceLocationEl.getAttribute('data-source-column'), `${sourceLocation.column}`);
     });
 
+    it('renders source-location with lh-link class for invalid urls', () => {
+      const sourceLocation = {
+        type: 'source-location',
+        url: 'invalid-url://www.example.com/script.js',
+        urlProvider: 'network',
+        line: 0,
+        column: 0,
+      };
+      const details = {
+        type: 'table',
+        headings: [{key: 'content', itemType: 'source-location', text: 'Heading'}],
+        items: [{content: sourceLocation}],
+      };
+
+      const el = renderer.render(details);
+      const sourceLocationEl = el.querySelector('.lh-source-location');
+      const anchorEl = sourceLocationEl.querySelector('.lh-link');
+      assert.ok(anchorEl);
+      assert.strictEqual(sourceLocationEl.localName, 'div');
+      assert.equal(sourceLocationEl.textContent, '/script.js:1:0(www.example.com)');
+      assert.equal(sourceLocationEl.getAttribute('data-source-url'), sourceLocation.url);
+      assert.equal(sourceLocationEl.getAttribute('data-source-line'), `${sourceLocation.line}`);
+      assert.equal(sourceLocationEl.getAttribute('data-source-column'), `${sourceLocation.column}`);
+    });
+
     it('renders source-location values that aren\'t network resources', () => {
       const sourceLocation = {
         type: 'source-location',

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -418,10 +418,10 @@ describe('DetailsRenderer', () => {
       assert.equal(sourceLocationEl.getAttribute('data-source-column'), `${sourceLocation.column}`);
     });
 
-    it('renders source-location with lh-link class for invalid urls', () => {
+    it('renders source-location with lh-link class for relative url', () => {
       const sourceLocation = {
         type: 'source-location',
-        url: 'invalid-url://www.example.com/script.js',
+        url: '/root-relative-url/script.js',
         urlProvider: 'network',
         line: 0,
         column: 0,
@@ -437,7 +437,32 @@ describe('DetailsRenderer', () => {
       const anchorEl = sourceLocationEl.querySelector('.lh-link');
       assert.ok(anchorEl);
       assert.strictEqual(sourceLocationEl.localName, 'div');
-      assert.equal(sourceLocationEl.textContent, '/script.js:1:0(www.example.com)');
+      assert.equal(sourceLocationEl.textContent, '/root-relative-url/script.js:1:0');
+      assert.equal(sourceLocationEl.getAttribute('data-source-url'), sourceLocation.url);
+      assert.equal(sourceLocationEl.getAttribute('data-source-line'), `${sourceLocation.line}`);
+      assert.equal(sourceLocationEl.getAttribute('data-source-column'), `${sourceLocation.column}`);
+    });
+
+    it('renders source-location with lh-link class for invalid urls', () => {
+      const sourceLocation = {
+        type: 'source-location',
+        url: 'thisisclearlynotavalidurl',
+        urlProvider: 'network',
+        line: 0,
+        column: 0,
+      };
+      const details = {
+        type: 'table',
+        headings: [{key: 'content', itemType: 'source-location', text: 'Heading'}],
+        items: [{content: sourceLocation}],
+      };
+
+      const el = renderer.render(details);
+      const sourceLocationEl = el.querySelector('.lh-source-location');
+      const anchorEl = sourceLocationEl.querySelector('.lh-link');
+      assert.ok(anchorEl);
+      assert.strictEqual(sourceLocationEl.localName, 'div');
+      assert.equal(sourceLocationEl.textContent, 'thisisclearlynotavalidurl:1:0');
       assert.equal(sourceLocationEl.getAttribute('data-source-url'), sourceLocation.url);
       assert.equal(sourceLocationEl.getAttribute('data-source-line'), `${sourceLocation.line}`);
       assert.equal(sourceLocationEl.getAttribute('data-source-column'), `${sourceLocation.column}`);

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1867,7 +1867,7 @@
           {
             "source": {
               "type": "source-location",
-              "url": "thisisnotaurl",
+              "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
               "urlProvider": "network",
               "line": 386,
               "column": 36

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1867,7 +1867,7 @@
           {
             "source": {
               "type": "source-location",
-              "url": "http://localhost:58599/dobetterweb/dbw_tester.html",
+              "url": "thisisnotaurl",
               "urlProvider": "network",
               "line": 386,
               "column": 36


### PR DESCRIPTION
For #11261

Adds lh-link class to source-location render element. Needed to handle invalid URLs that didn’t create <a> elements.
