### PR TITLE
misc: move doc link

### DIFF
--- a/lighthouse-core/audits/large-javascript-libraries.js
+++ b/lighthouse-core/audits/large-javascript-libraries.js
@@ -7,6 +7,7 @@
 /**
  * @fileoverview This audit checks a page for any large JS libraries with smaller alternatives.
  * These libraries can be replaced with functionally equivalent, smaller ones.
+ * @see https://docs.google.com/document/d/1TgKO3cWqMpcS4dn0xbjDG5fyuqgVvYYoXg--knaxJnM
  */
 
 'use strict';

--- a/lighthouse-core/lib/large-javascript-libraries/library-suggestions.js
+++ b/lighthouse-core/lib/large-javascript-libraries/library-suggestions.js
@@ -7,7 +7,6 @@
 /**
  * @fileoverview This file contains a mapping of large JavaScript libraries to smaller alternatives.
  * These suggestions have been cherry-picked from BundlePhobia's open-source list of recommendations which can be found here (https://github.com/pastelsky/bundlephobia/blob/b244a53bc55af067bb0edfa3ace867c87fec17e7/server/middlewares/similar-packages/fixtures.js).
- * Googlers: see here (https://docs.google.com/document/d/1TgKO3cWqMpcS4dn0xbjDG5fyuqgVvYYoXg--knaxJnM/edit?usp=sharing).
  */
 
 'use strict';


### PR DESCRIPTION
more accessible if linked from the audit file

@saavannanavati is working on a "suggestion formalization doc" which is probably what we'd want to link to in the library suggestions file later.