### PR TITLE
core(global-listeners): dedupe duplicate events in GlobalListener gatherer

### DIFF
--- a/lighthouse-core/test/gather/gatherers/global-listeners-test.js
+++ b/lighthouse-core/test/gather/gatherers/global-listeners-test.js
@@ -1,0 +1,62 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const GlobalListenerGatherer = require('../../../gather/gatherers/global-listeners.js');
+const {createMockSendCommandFn} = require('../mock-commands.js');
+const Connection = require('../../../gather/connections/connection.js');
+const Driver = require('../../../gather/driver.js');
+
+describe('Global Listener Gatherer', () => {
+  it('remove duplicate listeners from artifacts', async () => {
+    const globalListenerGatherer = new GlobalListenerGatherer();
+    const mockListeners = [
+      {
+        type: 'unload',
+        scriptId: 4,
+        lineNumber: 10,
+        columnNumber: 15,
+      },
+      {
+        type: 'unload',
+        scriptId: 4,
+        lineNumber: 10,
+        columnNumber: 15,
+      },
+      {
+        type: 'unload',
+        scriptId: 4,
+        lineNumber: 10,
+        columnNumber: 13,
+      },
+      {
+        type: 'unload',
+        scriptId: 5,
+        lineNumber: 10,
+        columnNumber: 13,
+      },
+    ];
+
+    const sendCommandMock = createMockSendCommandFn()
+        .mockResponse('Runtime.evaluate', {result: {objectId: 10}})
+        .mockResponse('DOMDebugger.getEventListeners', {listeners: mockListeners.slice(0)});
+
+    const expectedOutput = [
+      mockListeners[0],
+      mockListeners[2],
+      mockListeners[3],
+    ];
+
+    const connectionStub = new Connection();
+    connectionStub.sendCommand = sendCommandMock;
+    const driver = new Driver(connectionStub);
+
+    const globalListeners = await globalListenerGatherer.afterPass({driver});
+    return expect(globalListeners).toMatchObject(expectedOutput);
+  });
+});


### PR DESCRIPTION
**Summary**
This is a change to the global-listeners gatherer to stop it from producing duplicate GlobalListener objects. (bugfix)

I opted for putting the change in the gatherer rather than the no-unload-listeners audit as I don't think there would be a use-case for having multiple GlobalListener artifacts with identical values. (As a sidenote I'm not sure if this is a bug with DOMDebugger or is some type of expected behaviour) 

Apologies if there are any steps that I missed and let me know any concerns or feedback you have.

**Related Issues/PRs**
#11284
