### PR TITLE
misc(benchmark): update BenchmarkIndex for m86 changes

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -160,13 +160,13 @@ class Driver {
   }
 
   /**
-   * Computes the ULTRADUMB™ benchmark index to get a rough estimate of device class.
+   * Computes the benchmark index to get a rough estimate of device class.
    * @return {Promise<number>}
    */
   async getBenchmarkIndex() {
     const status = {msg: 'Benchmarking machine', id: 'lh:gather:getBenchmarkIndex'};
     log.time(status);
-    const indexVal = await this.evaluateAsync(`(${pageFunctions.ultradumbBenchmarkString})()`);
+    const indexVal = await this.evaluateAsync(`(${pageFunctions.computeBenchmarkIndexString})()`);
     log.timeEnd(status);
     return indexVal;
   }

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -156,7 +156,7 @@ function getOuterHTMLSnippet(element, ignoreAttrs = [], snippetCharacterLimit = 
  * @see https://github.com/GoogleChrome/lighthouse/issues/9085
  * @see https://docs.google.com/spreadsheets/d/1E0gZwKsxegudkjJl8Fki_sOwHKpqgXwt8aBAfuUaB8A/edit?usp=sharing
  *
- * Historically, this benchmark created a string of length 100,000 in a loop, and returned
+ * Historically (until LH 6.3), this benchmark created a string of length 100,000 in a loop, and returned
  * the number of times per second the string can be created.
  *
  * Changes to v8 in 8.6.106 changed this number and also made Chrome more variable w.r.t GC interupts.

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -153,30 +153,74 @@ function getOuterHTMLSnippet(element, ignoreAttrs = [], snippetCharacterLimit = 
 
 /**
  * Computes a memory/CPU performance benchmark index to determine rough device class.
+ * @see https://github.com/GoogleChrome/lighthouse/issues/9085
  * @see https://docs.google.com/spreadsheets/d/1E0gZwKsxegudkjJl8Fki_sOwHKpqgXwt8aBAfuUaB8A/edit?usp=sharing
  *
- * The benchmark creates a string of length 100,000 in a loop.
- * The returned index is the number of times per second the string can be created.
+ * Historically, this benchmark created a string of length 100,000 in a loop, and returned
+ * the number of times per second the string can be created.
  *
- *  - 750+ is a desktop-class device, Core i3 PC, iPhone X, etc
- *  - 300+ is a high-end Android phone, Galaxy S8, low-end Chromebook, etc
- *  - 75+ is a mid-tier Android phone, Nexus 5X, etc
- *  - <75 is a budget Android phone, Alcatel Ideal, Galaxy J2, etc
+ * Changes to v8 in 8.6.106 changed this number and also made Chrome more variable w.r.t GC interupts.
+ * This benchmark now is a hybrid of a similar GC-heavy approach to the original benchmark and an array
+ * copy benchmark.
+ *
+ * As of Chrome m86...
+ *
+ *  - 1000+ is a desktop-class device, Core i3 PC, iPhone X, etc
+ *  - 800+ is a high-end Android phone, Galaxy S8, low-end Chromebook, etc
+ *  - 125+ is a mid-tier Android phone, Moto G4, etc
+ *  - <125 is a budget Android phone, Alcatel Ideal, Galaxy J2, etc
  */
 /* istanbul ignore next */
-function ultradumbBenchmark() {
-  const start = Date.now();
-  let iterations = 0;
+function computeBenchmarkIndex() {
+  /**
+   * The GC-heavy benchmark that creates a string of length 10000 in a loop.
+   * The returned index is the number of times per second the string can be created divided by 10.
+   * The division by 10 is to keep similar magnitudes to an earlier version of BenchmarkIndex that
+   * used a string length of 100000 instead of 10000.
+   */
+  function benchmarkIndexGC() {
+    const start = Date.now();
+    let iterations = 0;
 
-  while (Date.now() - start < 500) {
-    let s = ''; // eslint-disable-line no-unused-vars
-    for (let j = 0; j < 100000; j++) s += 'a';
+    while (Date.now() - start < 500) {
+      let s = ''; // eslint-disable-line no-unused-vars
+      for (let j = 0; j < 10000; j++) s += 'a';
 
-    iterations++;
+      iterations++;
+    }
+
+    const durationInSeconds = (Date.now() - start) / 1000;
+    return Math.round(iterations / 10 / durationInSeconds);
   }
 
-  const durationInSeconds = (Date.now() - start) / 1000;
-  return Math.round(iterations / durationInSeconds);
+  /**
+   * The non-GC-dependent benchmark that copies integers back and forth between two arrays of length 100000.
+   * The returned index is the number of times per second a copy can be made, divided by 10.
+   * The division by 10 is to keep similar magnitudes to the GC-dependent version.
+   */
+  function benchmarkIndexNoGC() {
+    const arrA = [];
+    const arrB = [];
+    for (let i = 0; i < 100000; i++) arrA[i] = arrB[i] = i;
+
+    const start = Date.now();
+    let iterations = 0;
+
+    while (Date.now() - start < 500) {
+      const src = iterations % 2 === 0 ? arrA : arrB;
+      const tgt = iterations % 2 === 0 ? arrB : arrA;
+
+      for (let j = 0; j < src.length; j++) tgt[j] = src[j];
+
+      iterations++;
+    }
+
+    const durationInSeconds = (Date.now() - start) / 1000;
+    return Math.round(iterations / 10 / durationInSeconds);
+  }
+
+  // The final BenchmarkIndex is a simple average of the two components.
+  return (benchmarkIndexGC() + benchmarkIndexNoGC()) / 2;
 }
 
 /**
@@ -379,8 +423,8 @@ module.exports = {
   getElementsInDocumentString: getElementsInDocument.toString(),
   getOuterHTMLSnippetString: getOuterHTMLSnippet.toString(),
   getOuterHTMLSnippet: getOuterHTMLSnippet,
-  ultradumbBenchmark: ultradumbBenchmark,
-  ultradumbBenchmarkString: ultradumbBenchmark.toString(),
+  computeBenchmarkIndex: computeBenchmarkIndex,
+  computeBenchmarkIndexString: computeBenchmarkIndex.toString(),
   getNodePathString: getNodePath.toString(),
   getNodeSelectorString: getNodeSelector.toString(),
   getNodeSelector: getNodeSelector,

--- a/lighthouse-core/scripts/benchmark.js
+++ b/lighthouse-core/scripts/benchmark.js
@@ -9,13 +9,13 @@
 
 /* eslint-disable no-console */
 
-const ultradumbBenchmark = require('../lib/page-functions.js').ultradumbBenchmark;
+const computeBenchmarkIndex = require('../lib/page-functions.js').computeBenchmarkIndex;
 
-console.log('Running ULTRADUMB™ benchmark 10 times...');
+console.log('Computing BenchmarkIndex 10 times...');
 
 let total = 0;
 for (let i = 0; i < 10; i++) {
-  const result = ultradumbBenchmark();
+  const result = computeBenchmarkIndex();
   console.log(`Result ${i + 1}: ${result.toFixed(0)}`);
   total += result;
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "update:sample-artifacts": "node lighthouse-core/scripts/update-report-fixtures.js",
     "update:sample-json": "yarn i18n:collect-strings && node ./lighthouse-cli -A=./lighthouse-core/test/results/artifacts --config-path=./lighthouse-core/test/results/sample-config.js --output=json --output-path=./lighthouse-core/test/results/sample_v2.json && node lighthouse-core/scripts/cleanup-LHR-for-diff.js ./lighthouse-core/test/results/sample_v2.json --only-remove-timing",
     "diff:sample-json": "yarn i18n:checks && bash lighthouse-core/scripts/assert-golden-lhr-unchanged.sh",
-    "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",
+    "computeBenchmarkIndex": "./lighthouse-core/scripts/benchmark.js",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json",
     "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf ≥ 3.7.1 to compile the proto file.\" && false)",
     "build-proto-roundtrip": "mkdir -p .tmp && cross-env PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python proto/scripts/json_roundtrip_via_proto.py",


### PR DESCRIPTION
**Summary**
tl;dr - Updates the BenchmarkIndex using advice from v8 team and research in https://github.com/GoogleChrome/lighthouse/issues/9085.

See https://github.com/GoogleChrome/lighthouse/issues/9085 for the very long, full story. We unfortunately missed the boat for m86 DevTools but at least would be nice to get it in for the CLI and LightRider.

**Related Issues/PRs**
ref https://github.com/GoogleChrome/lighthouse/issues/9085