### PR TITLE
core(preconnect): ignore unimportant origins

### DIFF
--- a/lighthouse-cli/test/fixtures/perf/preload_tester.js
+++ b/lighthouse-cli/test/fixtures/perf/preload_tester.js
@@ -17,6 +17,14 @@ setTimeout(() => {
   // load another origin in a way where the `crossorigin` attribute matters
   const link = document.createElement('link');
   link.rel = 'stylesheet';
-  link.href = 'https://fonts.googleapis.com/css?family=Lobster%20Two';
+  link.href = 'https://fonts.googleapis.com/css?family=Roboto&display=block';
   document.head.appendChild(link);
+
+  link.onload = () => {
+    // Make sure LCP is waiting on the network so the above resources are considered important.
+    const lcpElement = document.createElement('div');
+    lcpElement.style.fontFamily = 'Roboto';
+    lcpElement.textContent = 'Here is some really tall text!'.repeat(50)
+    document.body.appendChild(lcpElement);
+  };
 }, 300);

--- a/lighthouse-core/audits/uses-rel-preconnect.js
+++ b/lighthouse-core/audits/uses-rel-preconnect.js
@@ -33,6 +33,12 @@ const UIStrings = {
     'Consider adding `preconnect` or `dns-prefetch` resource hints to establish early ' +
     `connections to important third-party origins. [Learn more](https://web.dev/uses-rel-preconnect/).`,
   /**
+   * @description A warning message that is shown when the user tried to follow the advice of the audit, but it's not working as expected.
+   * @example {https://example.com} securityOrigin
+   * */
+  unusedWarning: 'A preconnect <link> was found for "{securityOrigin}" but was not used ' +
+    'by the browser. Only preconnect to important origins that the page will certainly request.',
+  /**
    * @description A warning message that is shown when the user tried to follow the advice of the audit, but it's not working as expected. Forgetting to set the `crossorigin` HTML attribute, or setting it to an incorrect value, on the link is a common mistake when adding preconnect links.
    * @example {https://example.com} securityOrigin
    * */
@@ -198,6 +204,13 @@ class UsesRelPreconnectAudit extends Audit {
 
     results = results
       .sort((a, b) => b.wastedMs - a.wastedMs);
+
+    // Add warnings for any preconnect origins that aren't being used.
+    for (const origin of preconnectOrigins) {
+      if (!origin) continue;
+      if (networkRecords.some(record => origin === record.parsedURL.securityOrigin)) continue;
+      warnings.push(str_(UIStrings.unusedWarning, {securityOrigin: origin}));
+    }
 
     // Shortcut early with a pass when the user has already configured preconnect.
     // https://twitter.com/_tbansal/status/1197771385172480001

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -1337,6 +1337,9 @@
   "lighthouse-core/audits/uses-rel-preconnect.js | tooManyPreconnectLinksWarning": {
     "message": "More than 2 preconnect links were found. Preconnect links should be used sparingly and only to the most important origins."
   },
+  "lighthouse-core/audits/uses-rel-preconnect.js | unusedWarning": {
+    "message": "A preconnect <link> was found for \"{securityOrigin}\" but was not used by the browser. Only preconnect to important origins that the page will certainly request."
+  },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
     "message": "A preload <link> was found for \"{preloadURL}\" but was not used by the browser. Check that you are using the `crossorigin` attribute properly."
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -1337,6 +1337,9 @@
   "lighthouse-core/audits/uses-rel-preconnect.js | tooManyPreconnectLinksWarning": {
     "message": "M̂ór̂é t̂h́âń 2 p̂ŕêćôńn̂éĉt́ l̂ín̂ḱŝ ẃêŕê f́ôún̂d́. P̂ŕêćôńn̂éĉt́ l̂ín̂ḱŝ śĥóûĺd̂ b́ê úŝéd̂ śp̂ár̂ín̂ǵl̂ý âńd̂ ón̂ĺŷ t́ô t́ĥé m̂óŝt́ îḿp̂ór̂t́âńt̂ ór̂íĝín̂ś."
   },
+  "lighthouse-core/audits/uses-rel-preconnect.js | unusedWarning": {
+    "message": "Â ṕr̂éĉón̂ńêćt̂ <ĺîńk̂> ẃâś f̂óûńd̂ f́ôŕ \"{securityOrigin}\" b̂út̂ ẃâś n̂ót̂ úŝéd̂ b́ŷ t́ĥé b̂ŕôẃŝér̂. Ón̂ĺŷ ṕr̂éĉón̂ńêćt̂ t́ô ím̂ṕôŕt̂án̂t́ ôŕîǵîńŝ t́ĥát̂ t́ĥé p̂áĝé ŵíl̂ĺ ĉér̂t́âín̂ĺŷ ŕêq́ûéŝt́."
+  },
   "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
     "message": "Â ṕr̂él̂óâd́ <l̂ín̂ḱ> ŵáŝ f́ôún̂d́ f̂ór̂ \"{preloadURL}\" b́ût́ ŵáŝ ńôt́ ûśêd́ b̂ý t̂h́ê b́r̂óŵśêŕ. Ĉh́êćk̂ t́ĥát̂ ýôú âŕê úŝín̂ǵ t̂h́ê `crossorigin` át̂t́r̂íb̂út̂é p̂ŕôṕêŕl̂ý."
   },

--- a/lighthouse-core/test/create-test-trace.js
+++ b/lighthouse-core/test/create-test-trace.js
@@ -57,7 +57,7 @@ function getChildTask({ts, duration, url}) {
  * Creates a simple trace that fits the desired options. Useful for basic trace
  * generation, e.g a trace that will result in particular long-task quiet
  * periods. Input times should be in milliseconds.
- * @param {{timeOrigin?: number, traceEnd?: number, topLevelTasks?: Array<TopLevelTaskDef>}} options
+ * @param {{timeOrigin?: number, largestContentfulPaint?: number, traceEnd?: number, topLevelTasks?: Array<TopLevelTaskDef>}} options
  */
 function createTestTrace(options) {
   const timeOrigin = (options.timeOrigin || 0) * 1000;
@@ -116,6 +116,14 @@ function createTestTrace(options) {
   }, {
     name: 'firstMeaningfulPaint',
     ts: timeOrigin + 15,
+    pid,
+    tid,
+    ph: 'R',
+    cat: 'loading,rail,devtools.timeline',
+    args: {frame},
+  }, {
+    name: 'largestContentfulPaint::Candidate',
+    ts: options.largestContentfulPaint || (timeOrigin + 15),
     pid,
     tid,
     ph: 'R',

--- a/lighthouse-core/test/create-test-trace.js
+++ b/lighthouse-core/test/create-test-trace.js
@@ -121,15 +121,19 @@ function createTestTrace(options) {
     ph: 'R',
     cat: 'loading,rail,devtools.timeline',
     args: {frame},
-  }, {
-    name: 'largestContentfulPaint::Candidate',
-    ts: options.largestContentfulPaint || (timeOrigin + 15),
-    pid,
-    tid,
-    ph: 'R',
-    cat: 'loading,rail,devtools.timeline',
-    args: {frame},
   }];
+
+  if (options.largestContentfulPaint) {
+    traceEvents.push({
+      name: 'largestContentfulPaint::Candidate',
+      ts: options.largestContentfulPaint,
+      pid,
+      tid,
+      ph: 'R',
+      cat: 'loading,rail,devtools.timeline',
+      args: {frame},
+    });
+  }
 
   if (options.topLevelTasks) {
     for (const task of options.topLevelTasks) {


### PR DESCRIPTION
**Summary**
Filters out preconnect suggestions if the request wasn't part of the LCP graph. Given that we don't want folks to add any more than *2* preconnect links, showing a list of 40 isn't the greatest of messages to send :)



| Before | After |
| -- | -- |
|![image](https://user-images.githubusercontent.com/2301202/91089098-b2b48500-e618-11ea-9d0e-afd7292fe11f.png) | ![image](https://user-images.githubusercontent.com/2301202/91089126-bea04700-e618-11ea-86f8-8d9343083c73.png) |


**Related Issues/PRs**
closes #11283 
