### PR TITLE
core(response-time): add time spent to details

### DIFF
--- a/lighthouse-core/audits/server-response-time.js
+++ b/lighthouse-core/audits/server-response-time.js
@@ -22,7 +22,10 @@ const UIStrings = {
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
-const RESPONSE_THRESHOLD = 600;
+// Due to the way that DevTools throttling works we cannot see if server response took less than ~570ms.
+// We set our failure threshold to 600ms to avoid those false positives but we want devs to shoot for 100ms.
+const TOO_SLOW_THRESHOLD_MS = 600;
+const TARGET_MS = 100;
 
 class ServerResponseTime extends Audit {
   /**
@@ -56,16 +59,20 @@ class ServerResponseTime extends Audit {
     const mainResource = await MainResource.request({devtoolsLog, URL: artifacts.URL}, context);
 
     const responseTime = ServerResponseTime.calculateResponseTime(mainResource);
-    const passed = responseTime < RESPONSE_THRESHOLD;
+    const passed = responseTime < TOO_SLOW_THRESHOLD_MS;
     const displayValue = str_(UIStrings.displayValue, {timeInMs: responseTime});
 
-    /** @type {LH.Audit.Details.Opportunity} */
-    const details = {
-      type: 'opportunity',
-      overallSavingsMs: responseTime - RESPONSE_THRESHOLD,
-      headings: [],
-      items: [],
-    };
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
+    const headings = [
+      {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
+      {key: 'responseTime', valueType: 'timespanMs', label: str_(i18n.UIStrings.columnTimeSpent)},
+    ];
+
+    const details = Audit.makeOpportunityDetails(
+      headings,
+      [{url: mainResource.url, responseTime}],
+      responseTime - TARGET_MS
+    );
 
     return {
       numericValue: responseTime,

--- a/lighthouse-core/test/audits/server-response-time-test.js
+++ b/lighthouse-core/test/audits/server-response-time-test.js
@@ -11,7 +11,7 @@ const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.
 
 /* eslint-env jest */
 describe('Performance: server-response-time audit', () => {
-  it('fails when response time of root document is higher than 600ms', () => {
+  it('fails when response time of root document is higher than 600ms', async () => {
     const mainResource = {
       url: 'https://example.com/',
       requestId: '0',
@@ -24,9 +24,14 @@ describe('Performance: server-response-time audit', () => {
       URL: {finalUrl: 'https://example.com/'},
     };
 
-    return ServerResponseTime.audit(artifacts, {computedCache: new Map()}).then(result => {
-      assert.strictEqual(result.numericValue, 630);
-      assert.strictEqual(result.score, 0);
+    const result = await ServerResponseTime.audit(artifacts, {computedCache: new Map()});
+    expect(result).toMatchObject({
+      score: 0,
+      numericValue: 630,
+      details: {
+        overallSavingsMs: 530,
+        items: [{url: 'https://example.com/', responseTime: 630}],
+      },
     });
   });
 

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -305,9 +305,25 @@
       "displayValue": "Root document took 570 ms",
       "details": {
         "type": "opportunity",
-        "overallSavingsMs": -29.436999999999898,
-        "headings": [],
-        "items": []
+        "headings": [
+          {
+            "key": "url",
+            "valueType": "url",
+            "label": "URL"
+          },
+          {
+            "key": "responseTime",
+            "valueType": "timespanMs",
+            "label": "Time Spent"
+          }
+        ],
+        "items": [
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+            "responseTime": 570.5630000000001
+          }
+        ],
+        "overallSavingsMs": 470.5630000000001
       }
     },
     "first-cpu-idle": {
@@ -6545,6 +6561,7 @@
       ],
       "lighthouse-core/lib/i18n/i18n.js | columnURL": [
         "audits[errors-in-console].details.headings[0].text",
+        "audits[server-response-time].details.headings[0].label",
         "audits[image-aspect-ratio].details.headings[1].text",
         "audits[image-size-responsive].details.headings[1].text",
         "audits.deprecations.details.headings[1].text",
@@ -6583,6 +6600,12 @@
           },
           "path": "audits[server-response-time].displayValue"
         }
+      ],
+      "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": [
+        "audits[server-response-time].details.headings[1].label",
+        "audits[mainthread-work-breakdown].details.headings[1].text",
+        "audits[network-rtt].details.headings[1].text",
+        "audits[network-server-latency].details.headings[1].text"
       ],
       "lighthouse-core/lib/i18n/i18n.js | firstCPUIdleMetric": [
         "audits[first-cpu-idle].title",
@@ -6712,11 +6735,6 @@
       ],
       "lighthouse-core/audits/mainthread-work-breakdown.js | columnCategory": [
         "audits[mainthread-work-breakdown].details.headings[0].text"
-      ],
-      "lighthouse-core/lib/i18n/i18n.js | columnTimeSpent": [
-        "audits[mainthread-work-breakdown].details.headings[1].text",
-        "audits[network-rtt].details.headings[1].text",
-        "audits[network-server-latency].details.headings[1].text"
       ],
       "lighthouse-core/audits/bootup-time.js | title": [
         "audits[bootup-time].title"


### PR DESCRIPTION
**Summary**
Adds a details entry to show how much time was spent fetching the root document.

![image](https://user-images.githubusercontent.com/2301202/91090277-6ec27f80-e61a-11ea-9cfc-512ff7ffdefc.png)


**Related Issues/PRs**
fixes #9671 
