### PR TITLE
docs: add CPU throttling guide

### DIFF
--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -105,22 +105,22 @@ Below is a table of various device classes and their approximate ranges of `benc
 | -                                   | High-End Desktop | Low-End Desktop | High-End Mobile | Mid-Tier Mobile | Low-End Mobile    |
 | ----------------------------------- | ---------------- | --------------- | --------------- | --------------- | ----------------- |
 | Example Device                      | 16" Macbook Pro  | Intel NUC i3    | Samsung S10     | Moto G4         | Samsung Galaxy J2 |
-| Lighthouse BenchmarkIndex           | 1500-2200        | 1000-1500       | 800-1200        | 125-800         | <125              |
+| Lighthouse BenchmarkIndex           | 1500-2000        | 1000-1500       | 800-1200        | 125-800         | <125              |
 | Octane 2.0                          | 30000-45000      | 20000-35000     | 15000-25000     | 2000-20000      | <2000             |
 | Speedometer 2.0                     | 90-200           | 50-90           | 20-50           | 10-20           | <10               |
 | JavaScript Execution of a News Site | 2-4s             | 4-8s            | 4-8s            | 8-20s           | 20-40s            |
 
 The amount of variation in each class is quite high. Even the same device can be purchased with multiple different processors and memory options. Lighthouse uses a constant 4x CPU multiplier by default which moves a typical run in the high-end desktop bracket somewhere into the mid-tier mobile bracket. If you notice your benchmarkIndex is in a different range though, you may want to adjust the CPU throttling settings accordingly.
 
-Below is a table of the range of `cpuSlowdownMultipliers` you might want to use to target different devices. If your device's BenchmarkIndex falls on the *higher* end of its bracket, use a *higher* multiplier from the range in the table below. If your device's BenchmarkIndex falls on the *lower* end of its bracket, use a *lower* multiplier from the range in the table below.
+Below is a table of the various `cpuSlowdownMultipliers` you might want to use to target different devices along with the possible range. If your device's BenchmarkIndex falls on the _higher_ end of its bracket, use a _higher_ multiplier from the range in the table below. If your device's BenchmarkIndex falls on the _lower_ end of its bracket, use a _lower_ multiplier from the range in the table below. If it's somewhere in the middle, use the suggested multiplier.
 
 | -                | High-End Desktop | Low-End Desktop | High-End Mobile | Mid-Tier Mobile | Low-End Mobile |
 | ---------------- | ---------------- | --------------- | --------------- | --------------- | -------------- |
-| High-End Desktop | 1                | 2-4             | 2-4             | 2-10            | 5-20           |
-| Low-End Desktop  | -                | 1               | 1               | 1-5             | 3-10           |
-| High-End Mobile  | -                | -               | 1               | 1-5             | 3-10           |
-| Mid-Tier Mobile  | -                | -               | -               | 1               | 1-5            |
-| Low-End Mobile   | -                | -               | -               | -               | 1              |
+| High-End Desktop | 1x               | 2x (1-4)        | 2x (1-4)        | 4x (2-10)       | 10x (5-20)     |
+| Low-End Desktop  | -                | 1x              | 1x              | 2x (1-5)        | 5x (3-10)      |
+| High-End Mobile  | -                | -               | 1x              | 2x (1-5)        | 5x (3-10)      |
+| Mid-Tier Mobile  | -                | -               | -               | 1x              | 2x (1-5)       |
+| Low-End Mobile   | -                | -               | -               | -               | 1x             |
 
 ## Using Lighthouse with a custom multiplier
 

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -96,7 +96,9 @@ Within web performance testing, there are two typical styles of CPU throttling:
 
 Unlike network throttling where objective criteria like RTT and throughput allow targeting of a specific environment, CPU throttling is expressed relative to the performance of the host device. This poses challenges to [variability in results across devices](./variability.md), so it's important to calibrate your device before attempting to compare different reports.
 
-Lighthouse computes and saves a `benchmarkIndex` as a rough approximation of the host device's CPU performance with every report. You can find this value under the title "CPU/Memory Power" at the bottom of every Lighthouse report.
+Lighthouse computes and saves a `benchmarkIndex` as a rough approximation of the host device's CPU performance with every report. You can find this value under the title "CPU/Memory Power" at the bottom of the Lighthouse report.
+
+**NOTE:** In Lighthouse 6.3 BenchmarkIndex changed its definition to better align with changes in Chrome 86. Benchmark index values prior to 6.3 and Chrome 86 may differ.
 
 <img src="https://user-images.githubusercontent.com/2301202/91339533-3c409000-e79c-11ea-97a1-5da33bd3da18.png" alt="Screenshot of CPU/Memory Power in Lighthouse report" />
 

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -1,3 +1,6 @@
+# Network Throttling
+
+Lighthouse applies network throttling to emulate the ~85th percentile mobile connection speed even when run on much faster fiber connections.
 
 ## The mobile network throttling preset
 
@@ -9,11 +12,11 @@ This is the standard recommendation for mobile throttling:
 
 These exact figures are used as [Lighthouse's throttling default](https://github.com/GoogleChrome/lighthouse/blob/8f500e00243e07ef0a80b39334bedcc8ddc8d3d0/lighthouse-core/config/constants.js#L19-L26) and represent roughly the bottom 25% of 4G connections and top 25% of 3G connections (In Lighthouse it is sometimes called "Slow 4G" used to be labeled as "Fast 3G"). This preset is identical to the [WebPageTest's "Mobile 3G - Fast"](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample) and, due to a lower latency, slightly faster for some pages than the [WebPageTest "4G" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample).
 
-## Types of throttling
+## Types of network throttling
 
-Within web performance testing, there are four typical styles of throttling:
+Within web performance testing, there are four typical styles of network throttling:
 
-1. **_Simulated throttling_**, which Lighthouse uses by **default**, uses a simulation of a page load, based on the data observed in the initial unthrottled load. This approach which makes it both very fast and deterministic. However, due to the imperfect nature of predicting alternate execution paths, there is inherent inaccuracy that is summarized in this doc: [Lighthouse Metric Variability and Accuracy](https://docs.google.com/document/d/1BqtL-nG53rxWOI5RO0pItSRPowZVnYJ_gBEQCJ5EeUE/edit). The TLDR: while it's roughly as accurate or better than DevTools throttling for most sites, it suffers from edge cases and a deep investigation to performance should use _Packet-level_ throttling tools.
+1. **_Simulated throttling_**, which Lighthouse uses by **default**, uses a simulation of a page load, based on the data observed in the initial unthrottled load. This approach makes it both very fast and deterministic. However, due to the imperfect nature of predicting alternate execution paths, there is inherent inaccuracy that is summarized in this doc: [Lighthouse Metric Variability and Accuracy](https://docs.google.com/document/d/1BqtL-nG53rxWOI5RO0pItSRPowZVnYJ_gBEQCJ5EeUE/edit). The TLDR: while it's roughly as accurate or better than DevTools throttling for most sites, it suffers from edge cases and a deep investigation to performance should use _Packet-level_ throttling tools.
 1. **_Request-level throttling_** , also referred to as **_Applied throttling_** in the Audits panel or _`devtools` throttling_ in Lighthouse configuration, is how throttling is implemented with Chrome DevTools. In real mobile connectivity, latency affects things at the packet level rather than the request level. As a result, this throttling isn't highly accurate. It also has a few more downsides that are summarized in [Network Throttling & Chrome - status](https://docs.google.com/document/d/1TwWLaLAfnBfbk5_ZzpGXegPapCIfyzT4MWuZgspKUAQ/edit). The TLDR: while it's a [decent approximation](https://docs.google.com/document/d/10lfVdS1iDWCRKQXPfbxEn4Or99D64mvNlugP1AQuFlE/edit), it's not a sufficient model of a slow connection. The [multipliers used in Lighthouse](https://github.com/GoogleChrome/lighthouse/blob/3be483287a530fb560c843b7299ef9cfe91ce1cc/lighthouse-core/lib/emulation.js#L33-L39) attempt to correct for the differences.
 1. **_Proxy-level_** throttling tools do not affect UDP data, so they're decent, but not ideal.
 1. **_Packet-level_** throttling tools are able to make the most accurate network simulation. While this approach can model real network conditions most effectively, it also can introduce [more variance](https://docs.google.com/document/d/1BqtL-nG53rxWOI5RO0pItSRPowZVnYJ_gBEQCJ5EeUE/edit) than request-level or simulated throttling. [WebPageTest uses](https://github.com/WPO-Foundation/wptagent/blob/master/docs/remote_trafficshaping.md) packet-level throttling.
@@ -67,9 +70,61 @@ For more information and a complete list of features visit the documentation on 
 # Enable system traffic throttling
 throttle 3gfast
 
-# Run Lighthouse with its own throttling disabled
-lighthouse --throttling-method=provided # ...
+# Run Lighthouse with its own network throttling disabled (while leaving CPU throttling)
+lighthouse --throttling-method=devtools \
+  --throttling.requestLatencyMs=0 \
+  --throttling.downloadThroughputKbps=0 \
+  --throttling.uploadThroughputKbps=0 \
+  https://example.com
 
 # Disable the traffic throttling once you see "Gathering trace"
 throttle --stop
+```
+
+# CPU Throttling
+
+Lighthouse applies CPU throttling to emulate a mid-tier mobile device even when run on far more powerful desktop hardware.
+
+## Types of CPU Throttling
+
+Within web performance testing, there are two typical styles of CPU throttling:
+
+1. **_Simulated throttling_**, which Lighthouse uses by **default**, uses a simulation of a page load, based on the data observed in the initial unthrottled load. This approach makes it very fast. However, due to the imperfect nature of predicting alternate execution paths, there is inherent inaccuracy that is summarized in this doc: [Lighthouse Metric Variability and Accuracy](https://docs.google.com/document/d/1BqtL-nG53rxWOI5RO0pItSRPowZVnYJ_gBEQCJ5EeUE/edit). The TLDR: while it's fairly accurate for most circumstances, it suffers from edge cases and a deep investigation to performance should use _applied_ CPU throttling tools.
+1. **_Applied throttling_** , also called _`devtools` throttling_ in Lighthouse configuration. This method actually interrupts execution of CPU work at periodic intervals to emulate a slower processor. It is [fairly accurate](https://docs.google.com/document/d/1jGHeGjjjzfTAE2WHXipKF3aqwF2bFA6r0B877nFtBpc/edit) and much easier than obtaining target hardware.
+
+## Calibrating Multipliers
+
+Unlike network throttling where objective criteria like RTT and throughput allow targeting of a specific environment, CPU throttling is expressed relative to the performance of the host device. This poses challenges to [variability in results across devices](./variability.md), so it's important to calibrate your device before attempting to compare different reports.
+
+Lighthouse computes and saves a `benchmarkIndex` as a rough approximation of the host device's CPU performance with every report. You can find this value under the title "CPU/Memory Power" at the bottom of every Lighthouse report.
+
+![image](https://user-images.githubusercontent.com/2301202/91339533-3c409000-e79c-11ea-97a1-5da33bd3da18.png)
+
+Below is a table of various device classes and their approximate ranges of `benchmarkIndex` as of Chrome m86 along with a few other benchmarks.
+
+| -                                   | High-End Desktop | Low-End Desktop | High-End Mobile | Mid-Tier Mobile | Low-End Mobile    |
+| ----------------------------------- | ---------------- | --------------- | --------------- | --------------- | ----------------- |
+| Example Device                      | 16" Macbook Pro  | Intel NUC i3    | Samsung S10     | Moto G4         | Samsung Galaxy J2 |
+| Lighthouse BenchmarkIndex           | 1500-2200        | 1000-1500       | 800-1200        | 125-800         | <125              |
+| Octane 2.0                          | 30000-45000      | 20000-35000     | 15000-25000     | 2000-20000      | <2000             |
+| Speedometer 2.0                     | 90-200           | 50-90           | 20-50           | 10-20           | <10               |
+| JavaScript Execution of a News Site | 2-4s             | 4-8s            | 4-8s            | 8-20s           | 20-40s            |
+
+The amount of variation in each class is quite high. Even the same device can be purchased with multiple different processors and memory options. Lighthouse uses a constant 4x CPU multiplier by default which moves a typical run in the high-end desktop bracket somewhere into the mid-tier mobile bracket. If you notice your benchmarkIndex is in a different range though, you may want to adjust the CPU throttling settings accordingly.
+
+Below is a table of the range of `cpuSlowdownMultipliers` you might want to use to target different devices. If your device's BenchmarkIndex falls on the *higher* end of its bracket, use a *higher* multiplier from the range in the table below. If your device's BenchmarkIndex falls on the *lower* end of its bracket, use a *lower* multiplier from the range in the table below.
+
+| -                | High-End Desktop | Low-End Desktop | High-End Mobile | Mid-Tier Mobile | Low-End Mobile |
+| ---------------- | ---------------- | --------------- | --------------- | --------------- | -------------- |
+| High-End Desktop | 1                | 2-4             | 2-4             | 2-10            | 5-20           |
+| Low-End Desktop  | -                | 1               | 1               | 1-5             | 3-10           |
+| High-End Mobile  | -                | -               | 1               | 1-5             | 3-10           |
+| Mid-Tier Mobile  | -                | -               | -               | 1               | 1-5            |
+| Low-End Mobile   | -                | -               | -               | -               | 1              |
+
+## Using Lighthouse with a custom multiplier
+
+```bash
+# Run Lighthouse with a custom multiplier
+lighthouse --throttling.cpuSlowdownMultiplier=6 https://example.com
 ```

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -90,7 +90,7 @@ Lighthouse applies CPU throttling to emulate a mid-tier mobile device even when 
 Within web performance testing, there are two typical styles of CPU throttling:
 
 1. **_Simulated throttling_**, which Lighthouse uses by **default**, uses a simulation of a page load, based on the data observed in the initial unthrottled load. This approach makes it very fast. However, due to the imperfect nature of predicting alternate execution paths, there is inherent inaccuracy that is summarized in this doc: [Lighthouse Metric Variability and Accuracy](https://docs.google.com/document/d/1BqtL-nG53rxWOI5RO0pItSRPowZVnYJ_gBEQCJ5EeUE/edit). The TLDR: while it's fairly accurate for most circumstances, it suffers from edge cases and a deep investigation to performance should use _applied_ CPU throttling tools.
-1. **_Applied throttling_** , also called _`devtools` throttling_ in Lighthouse configuration. This method actually interrupts execution of CPU work at periodic intervals to emulate a slower processor. It is [fairly accurate](https://docs.google.com/document/d/1jGHeGjjjzfTAE2WHXipKF3aqwF2bFA6r0B877nFtBpc/edit) and much easier than obtaining target hardware.
+1. **_Applied throttling_** , also called _`devtools` throttling_ in Lighthouse configuration. This method actually interrupts execution of CPU work at periodic intervals to emulate a slower processor. It is [fairly accurate](https://docs.google.com/document/d/1jGHeGjjjzfTAE2WHXipKF3aqwF2bFA6r0B877nFtBpc/edit) and much easier than obtaining target hardware. The same underlying principle can be used by [linux cgroups](https://www.kernel.org/doc/html/latest/scheduler/sched-bwc.html) to throttle any process, not just the browser. Other tools like [WebPageTest use applied CPU throttling](https://github.com/WPO-Foundation/wptagent/commit/f7fe0d6b5b01bd1b042a1fe3144c68a6bff846a6) offered by DevTools.
 
 ## Calibrating Multipliers
 
@@ -98,7 +98,7 @@ Unlike network throttling where objective criteria like RTT and throughput allow
 
 Lighthouse computes and saves a `benchmarkIndex` as a rough approximation of the host device's CPU performance with every report. You can find this value under the title "CPU/Memory Power" at the bottom of every Lighthouse report.
 
-![image](https://user-images.githubusercontent.com/2301202/91339533-3c409000-e79c-11ea-97a1-5da33bd3da18.png)
+<img src="https://user-images.githubusercontent.com/2301202/91339533-3c409000-e79c-11ea-97a1-5da33bd3da18.png" alt="Screenshot of CPU/Memory Power in Lighthouse report" />
 
 Below is a table of various device classes and their approximate ranges of `benchmarkIndex` as of Chrome m86 along with a few other benchmarks.
 


### PR DESCRIPTION
**Summary**
Adds a CPU throttling guide with advice on how to calibrate multipliers. The provided ranges are really big but hopefully that conveys why results can be so variable ;)

**Related Issues/PRs**
ref #9085 
