### PR TITLE
tests(devtools): fail on unset/unbound env variable

### DIFF
--- a/lighthouse-core/scripts/download-chrome.sh
+++ b/lighthouse-core/scripts/download-chrome.sh
@@ -8,15 +8,12 @@
 
 # Download chrome inside of our CI env.
 
+set -euo pipefail
+
 if [ "$OSTYPE" == "msys" ]; then
   url="https://download-chromium.appspot.com/dl/Win?type=snapshots"
 else
   url="https://download-chromium.appspot.com/dl/Linux_x64?type=snapshots"
-fi
-
-if [ x"$CHROME_PATH" == x ]; then
-  echo "Error: Environment variable CHROME_PATH not set"
-  exit 1
 fi
 
 if [ -e "$CHROME_PATH" ]; then

--- a/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
@@ -15,11 +15,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 commit_chromium="41f18f569f022d78337f586dacc6eff0e0477e46"
 commit_catapult="95c1f426155576790a73778571c34a0f3cd6d608"
 
-if [ x"$BLINK_TOOLS_PATH" == x ]; then
-  echo "Error: Environment variable BLINK_TOOLS_PATH not set"
-  exit 1
-fi
-
 VERSIONED_DIR="$BLINK_TOOLS_PATH/$commit_chromium$commit_catapult"
 
 if [ -e "$VERSIONED_DIR" ]; then

--- a/lighthouse-core/test/chromium-web-tests/download-depot-tools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-depot-tools.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -euo pipefail
 
 ##
 # @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
@@ -14,11 +14,6 @@ if command -v fetch &> /dev/null
 then
   echo "depot_tools already installed"
   exit 0
-fi
-
-if [ x"$DEPOT_TOOLS_PATH" == x ]; then
-  echo "Error: Environment variable DEPOT_TOOLS_PATH not set"
-  exit 1
 fi
 
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "$DEPOT_TOOLS_PATH"

--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -18,8 +18,13 @@ fi
 echo "Downloading DevTools frontend at $DEVTOOLS_PATH"
 mkdir -p `dirname $DEVTOOLS_PATH`
 cd `dirname $DEVTOOLS_PATH`
+
+set -x
+
 fetch --nohooks --no-history devtools-frontend
 cd devtools-frontend
 
 gclient sync
 gn gen out/Default
+
+set +x

--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -1,17 +1,12 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -euo pipefail
 
 ##
 # @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 ##
-
-if [ x"$DEVTOOLS_PATH" == x ]; then
-  echo "Error: Environment variable DEVTOOLS_PATH not set"
-  exit 1
-fi
 
 if [ -d "$DEVTOOLS_PATH" ]
 then

--- a/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
+++ b/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
@@ -11,10 +11,9 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT="$SCRIPT_DIR/../../.."
 
-unset -v latest_content_shell
-for file in "$LH_ROOT/.tmp/chromium-web-tests/content-shells"/*/; do
-  [[ $file -nt $latest_content_shell ]] && latest_content_shell=$file
-done
+# Get newest folder
+latest_content_shell_dir=$(ls -t ./.tmp/chromium-web-tests/content-shells/ | head -n1)
+latest_content_shell="$LH_ROOT/.tmp/chromium-web-tests/content-shells/$latest_content_shell_dir"
 
 roll_devtools() {
   # Roll devtools. Besides giving DevTools the latest lighthouse source files,

--- a/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
+++ b/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
@@ -6,20 +6,10 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 ##
 
-set -eo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT="$SCRIPT_DIR/../../.."
-
-if [ x"$BLINK_TOOLS_PATH" == x ]; then
-  echo "Error: Environment variable BLINK_TOOLS_PATH not set"
-  exit 1
-fi
-
-if [ x"$DEVTOOLS_PATH" == x ]; then
-  echo "Error: Environment variable DEVTOOLS_PATH not set"
-  exit 1
-fi
 
 unset -v latest_content_shell
 for file in "$LH_ROOT/.tmp/chromium-web-tests/content-shells"/*/; do

--- a/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
+++ b/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT="$SCRIPT_DIR/../../.."
 
 # Get newest folder
-latest_content_shell_dir=$(ls -t ./.tmp/chromium-web-tests/content-shells/ | head -n1)
+latest_content_shell_dir=$(ls -t "$LH_ROOT/.tmp/chromium-web-tests/content-shells/" | head -n1)
 latest_content_shell="$LH_ROOT/.tmp/chromium-web-tests/content-shells/$latest_content_shell_dir"
 
 roll_devtools() {


### PR DESCRIPTION
This is a followup from #11328 .. well, more of a disagreement. :p  

My understanding is that `set -u` is designed to error/exit whenever it encounters a variable that isn't set.

https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/#:~:text=set%20-u
http://www.bnikolic.co.uk/blog/bash-unbound-variable.html

Without it we need to _actively_ check all env vars to make sure they're set. But it's easy to miss one.


The only downside of this PR is that `Error: Environment variable DEPOT_TOOLS_PATH not set` is slightly more friendly of an error message than `DEPOT_TOOLS_PATH: unbound variable`. But they are equivalent.

@patrickhulce sgty?

( I also sprinkled in some set -x because those fetch/gclient operations are time-consuming and i wanted some visibility locally :)

