### PR TITLE
i18n: add more translator strings to font-size

### DIFF
--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -24,6 +24,10 @@ const UIStrings = {
   /** Explanatory message stating that there was a failure in an audit caused by a missing page viewport meta tag configuration. "viewport" and "meta" are HTML terms and should not be translated. */
   explanationViewport: 'Text is illegible because there\'s no viewport meta tag optimized ' +
     'for mobile screens.',
+  /** Label for the table row which summarizes all failing nodes that were not fully analyzed. This text overrides the source location field. "Add'l" is shorthand for "Additional" */
+  additionalIllegibleText: 'Add\'l illegible text',
+  /** Label for the table row which displays the percentage of nodes that have proper font size. This text overrides the source location field. */
+  legibleText: 'Legible text',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -295,7 +299,7 @@ class FontSize extends Audit {
 
       tableData.push({
         // Overrides default `source-location`
-        source: {type: 'code', value: 'Add\'l illegible text'},
+        source: {type: 'code', value: str_(UIStrings.additionalIllegibleText)},
         selector: '',
         coverage: `${percentageOfUnanalyzedFailingText.toFixed(2)}%`,
         fontSize: '< 12px',
@@ -305,7 +309,7 @@ class FontSize extends Audit {
     if (percentageOfPassingText > 0) {
       tableData.push({
         // Overrides default `source-location`
-        source: {type: 'code', value: 'Legible text'},
+        source: {type: 'code', value: str_(UIStrings.legibleText)},
         selector: '',
         coverage: `${percentageOfPassingText.toFixed(2)}%`,
         fontSize: '≥ 12px',

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -28,7 +28,7 @@ const UIStrings = {
   additionalIllegibleText: 'Add\'l illegible text',
   /** Label for the table row which displays the percentage of nodes that have proper font size. */
   legibleText: 'Legible text',
-  /** Label for a column in a data table; entries will be style rule selectors. */
+  /** Label for a column in a data table; entries will be css style rule selectors. */
   columnSelector: 'Selector',
   /** Label for a column in a data table; entries will be the percent of page text a specific CSS rule applies to. */
   columnPercentPageText: '% of Page Text',

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -24,9 +24,9 @@ const UIStrings = {
   /** Explanatory message stating that there was a failure in an audit caused by a missing page viewport meta tag configuration. "viewport" and "meta" are HTML terms and should not be translated. */
   explanationViewport: 'Text is illegible because there\'s no viewport meta tag optimized ' +
     'for mobile screens.',
-  /** Label for the table row which summarizes all failing nodes that were not fully analyzed. This text overrides the source location field. "Add'l" is shorthand for "Additional" */
+  /** Label for the table row which summarizes all failing nodes that were not fully analyzed. "Add'l" is shorthand for "Additional" */
   additionalIllegibleText: 'Add\'l illegible text',
-  /** Label for the table row which displays the percentage of nodes that have proper font size. This text overrides the source location field. */
+  /** Label for the table row which displays the percentage of nodes that have proper font size. */
   legibleText: 'Legible text',
 };
 

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -28,6 +28,12 @@ const UIStrings = {
   additionalIllegibleText: 'Add\'l illegible text',
   /** Label for the table row which displays the percentage of nodes that have proper font size. */
   legibleText: 'Legible text',
+  /** Label for a column in a data table; entries will be style rule selectors. */
+  columnSelector: 'Selector',
+  /** Label for a column in a data table; entries will be the percent of page text a specific CSS rule applies to. */
+  columnPercentPageText: '% of Page Text',
+  /** Label for a column in a data table; entries will be text font sizes. */
+  columnFontSize: 'Font Size',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -273,10 +279,10 @@ class FontSize extends Audit {
 
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [
-      {key: 'source', itemType: 'source-location', text: 'Source'},
-      {key: 'selector', itemType: 'code', text: 'Selector'},
-      {key: 'coverage', itemType: 'text', text: '% of Page Text'},
-      {key: 'fontSize', itemType: 'text', text: 'Font Size'},
+      {key: 'source', itemType: 'source-location', text: str_(i18n.UIStrings.columnSource)},
+      {key: 'selector', itemType: 'code', text: str_(UIStrings.columnSelector)},
+      {key: 'coverage', itemType: 'text', text: str_(UIStrings.columnPercentPageText)},
+      {key: 'fontSize', itemType: 'text', text: str_(UIStrings.columnFontSize)},
     ];
 
     const tableData = failingRules.sort((a, b) => b.textLength - a.textLength)

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -80,7 +80,7 @@ const UIStrings = {
   columnRequests: 'Requests',
   /** Label for a column in a data table; entries will be the names of arbitrary objects, e.g. the name of a Javascript library, or the name of a user defined timing event. */
   columnName: 'Name',
-  /** Label for a column in a data table; entries will be the names of JavaScript code, e.g. the name of a Javascript package or module. */
+  /** Label for a column in a data table; entries will be the locations of JavaScript or CSS code, e.g. the name of a Javascript package or module. */
   columnSource: 'Source',
   /** Label for a column in a data table; entries will be how much a predetermined budget has been exeeded by. Depending on the context, this number could represent an excess in quantity or size of network requests, or, an excess in the duration of time that it takes for the page to load.*/
   columnOverBudget: 'Over Budget',

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -1103,6 +1103,9 @@
   "lighthouse-core/audits/seo/crawlable-anchors.js | title": {
     "message": "Links are crawlable"
   },
+  "lighthouse-core/audits/seo/font-size.js | additionalIllegibleText": {
+    "message": "Add'l illegible text"
+  },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Font sizes less than 12px are too small to be legible and require mobile visitors to “pinch to zoom” in order to read. Strive to have >60% of page text ≥12px. [Learn more](https://web.dev/font-size/)."
   },
@@ -1114,6 +1117,9 @@
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "Document doesn't use legible font sizes"
+  },
+  "lighthouse-core/audits/seo/font-size.js | legibleText": {
+    "message": "Legible text"
   },
   "lighthouse-core/audits/seo/font-size.js | title": {
     "message": "Document uses legible font sizes"

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -1106,6 +1106,15 @@
   "lighthouse-core/audits/seo/font-size.js | additionalIllegibleText": {
     "message": "Add'l illegible text"
   },
+  "lighthouse-core/audits/seo/font-size.js | columnFontSize": {
+    "message": "Font Size"
+  },
+  "lighthouse-core/audits/seo/font-size.js | columnPercentPageText": {
+    "message": "% of Page Text"
+  },
+  "lighthouse-core/audits/seo/font-size.js | columnSelector": {
+    "message": "Selector"
+  },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "Font sizes less than 12px are too small to be legible and require mobile visitors to “pinch to zoom” in order to read. Strive to have >60% of page text ≥12px. [Learn more](https://web.dev/font-size/)."
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -1106,6 +1106,15 @@
   "lighthouse-core/audits/seo/font-size.js | additionalIllegibleText": {
     "message": "Âd́d̂'ĺ îĺl̂éĝíb̂ĺê t́êx́t̂"
   },
+  "lighthouse-core/audits/seo/font-size.js | columnFontSize": {
+    "message": "F̂ón̂t́ Ŝíẑé"
+  },
+  "lighthouse-core/audits/seo/font-size.js | columnPercentPageText": {
+    "message": "% ôf́ P̂áĝé T̂éx̂t́"
+  },
+  "lighthouse-core/audits/seo/font-size.js | columnSelector": {
+    "message": "Ŝél̂éĉt́ôŕ"
+  },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "F̂ón̂t́ ŝíẑéŝ ĺêśŝ t́ĥán̂ 12ṕx̂ ár̂é t̂óô śm̂ál̂ĺ t̂ó b̂é l̂éĝíb̂ĺê án̂d́ r̂éq̂úîŕê ḿôb́îĺê v́îśît́ôŕŝ t́ô “ṕîńĉh́ t̂ó ẑóôḿ” îń ôŕd̂ér̂ t́ô ŕêád̂. Śt̂ŕîv́ê t́ô h́âv́ê >60% óf̂ ṕâǵê t́êx́t̂ ≥12ṕx̂. [Ĺêár̂ń m̂ór̂é](https://web.dev/font-size/)."
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -1103,6 +1103,9 @@
   "lighthouse-core/audits/seo/crawlable-anchors.js | title": {
     "message": "L̂ín̂ḱŝ ár̂é ĉŕâẃl̂áb̂ĺê"
   },
+  "lighthouse-core/audits/seo/font-size.js | additionalIllegibleText": {
+    "message": "Âd́d̂'ĺ îĺl̂éĝíb̂ĺê t́êx́t̂"
+  },
   "lighthouse-core/audits/seo/font-size.js | description": {
     "message": "F̂ón̂t́ ŝíẑéŝ ĺêśŝ t́ĥán̂ 12ṕx̂ ár̂é t̂óô śm̂ál̂ĺ t̂ó b̂é l̂éĝíb̂ĺê án̂d́ r̂éq̂úîŕê ḿôb́îĺê v́îśît́ôŕŝ t́ô “ṕîńĉh́ t̂ó ẑóôḿ” îń ôŕd̂ér̂ t́ô ŕêád̂. Śt̂ŕîv́ê t́ô h́âv́ê >60% óf̂ ṕâǵê t́êx́t̂ ≥12ṕx̂. [Ĺêár̂ń m̂ór̂é](https://web.dev/font-size/)."
   },
@@ -1114,6 +1117,9 @@
   },
   "lighthouse-core/audits/seo/font-size.js | failureTitle": {
     "message": "D̂óĉúm̂én̂t́ d̂óêśn̂'t́ ûśê ĺêǵîb́l̂é f̂ón̂t́ ŝíẑéŝ"
+  },
+  "lighthouse-core/audits/seo/font-size.js | legibleText": {
+    "message": "L̂éĝíb̂ĺê t́êx́t̂"
   },
   "lighthouse-core/audits/seo/font-size.js | title": {
     "message": "D̂óĉúm̂én̂t́ ûśêś l̂éĝíb̂ĺê f́ôńt̂ śîźêś"

--- a/lighthouse-core/test/audits/seo/font-size-test.js
+++ b/lighthouse-core/test/audits/seo/font-size-test.js
@@ -152,10 +152,8 @@ describe('SEO: Font size audit', () => {
     const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
     assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 3);
-    assert.deepEqual(auditResult.details.items[1].source, {
-      type: 'code',
-      value: 'Add\'l illegible text',
-    });
+    assert.equal(auditResult.details.items[1].source.type, 'code');
+    expect(auditResult.details.items[1].source.value).toBeDisplayString('Add\'l illegible text');
     assert.equal(auditResult.details.items[1].coverage, '40.00%');
     expect(auditResult.displayValue).toBeDisplayString('50% legible text');
   });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -7655,6 +7655,18 @@
           "path": "audits[font-size].displayValue"
         }
       ],
+      "lighthouse-core/lib/i18n/i18n.js | columnSource": [
+        "audits[font-size].details.headings[0].text"
+      ],
+      "lighthouse-core/audits/seo/font-size.js | columnSelector": [
+        "audits[font-size].details.headings[1].text"
+      ],
+      "lighthouse-core/audits/seo/font-size.js | columnPercentPageText": [
+        "audits[font-size].details.headings[2].text"
+      ],
+      "lighthouse-core/audits/seo/font-size.js | columnFontSize": [
+        "audits[font-size].details.headings[3].text"
+      ],
       "lighthouse-core/audits/seo/font-size.js | legibleText": [
         "audits[font-size].details.items[0].source.value"
       ],

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -7651,6 +7651,9 @@
           "path": "audits[font-size].displayValue"
         }
       ],
+      "lighthouse-core/audits/seo/font-size.js | legibleText": [
+        "audits[font-size].details.items[0].source.value"
+      ],
       "lighthouse-core/audits/seo/link-text.js | title": [
         "audits[link-text].title"
       ],


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse/issues/9632

Follow up to https://github.com/GoogleChrome/lighthouse/pull/11327