### PR TITLE
report: normalize -0 to 0

### DIFF
--- a/lighthouse-core/report/html/renderer/i18n.js
+++ b/lighthouse-core/report/html/renderer/i18n.js
@@ -66,7 +66,9 @@ class I18n {
    */
   formatMilliseconds(ms, granularity = 10) {
     const coarseTime = Math.round(ms / granularity) * granularity;
-    return `${this._numberFormatter.format(coarseTime)}${NBSP2}ms`;
+    return coarseTime === 0
+      ? `${this._numberFormatter.format(0)}${NBSP2}ms`
+      : `${this._numberFormatter.format(coarseTime)}${NBSP2}ms`;
   }
 
   /**

--- a/lighthouse-core/test/report/html/renderer/i18n-test.js
+++ b/lighthouse-core/test/report/html/renderer/i18n-test.js
@@ -47,6 +47,8 @@ describe('util helpers', () => {
     const i18n = new I18n('en', {...Util.UIStrings});
     assert.equal(i18n.formatMilliseconds(123), `120${NBSP}ms`);
     assert.equal(i18n.formatMilliseconds(2456.5, 0.1), `2,456.5${NBSP}ms`);
+    assert.equal(i18n.formatMilliseconds(0.000001), `0${NBSP}ms`);
+    assert.equal(i18n.formatMilliseconds(-0.000001), `0${NBSP}ms`);
   });
 
   it('formats a duration', () => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
This is a bugfix.
About formatMilliseconds, Negative 0ms is displayed as 0ms.

<!-- Describe the need for this change -->
In computing, some number representations allow for the existence of two zeros, often denoted by −0 (negative zero) and +0 (positive zero). 
However, in ordinary arithmetic, −0 = +0 = 0. 

<!-- Link any documentation or information that would help understand this change -->
https://stackoverflow.com/questions/7223359/are-0-and-0-the-same

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
fixes https://github.com/GoogleChrome/lighthouse/issues/11339