### PR TITLE
report: set min-width on code table column

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1369,7 +1369,7 @@
 }
 
 .lh-table-column--code {
-  width: 80%;
+  min-width: 100px;
 }
 
 .lh-table-column--bytes,

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1368,6 +1368,10 @@
   text-align: left;
 }
 
+.lh-table-column--code {
+  width: 80%;
+}
+
 .lh-table-column--bytes,
 .lh-table-column--timespanMs,
 .lh-table-column--ms,


### PR DESCRIPTION
Without an explicit width on this column with the potential for a large amount of content, there are some audit results that become unreadable.

**Summary**
This is a bugfix, as the results from some audits become unreadable depending on the content. I noticed this when examining SEO results under the audit 'robots.txt is not valid'. Lighthouse version 6.0.0. ~A width of 80% was chosen in this instance as it allows the 'Error' column to be read.~ 

**Update**: After feedback a `min-width` solution of 100px is a much better fit. 

**Before**:
![Screenshot 2020-09-01 at 11 18 30](https://user-images.githubusercontent.com/1223960/91838210-0ccecf00-ec45-11ea-9290-58c3c1daa010.png)

**After**:
![Screenshot 2020-09-01 at 11 20 45](https://user-images.githubusercontent.com/1223960/91838325-37b92300-ec45-11ea-9d63-b2af0c1f771e.png)

**Related Issues/PRs**
None?
