### PR TITLE
misc: flatten new service-worker audit details

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -124,6 +124,10 @@ module.exports = [
         },
         'service-worker': {
           score: 1,
+          details: {
+            scriptUrl: 'http://localhost:10503/offline-ready-sw.js',
+            scopeUrl: 'http://localhost:10503/',
+          },
         },
         'works-offline': {
           score: 1,
@@ -182,6 +186,10 @@ module.exports = [
       audits: {
         'service-worker': {
           score: 1,
+          details: {
+            scriptUrl: 'http://localhost:10503/offline-ready-sw.js?delay=5000&slow',
+            scopeUrl: 'http://localhost:10503/',
+          },
         },
         'works-offline': {
           score: 1,

--- a/lighthouse-core/audits/service-worker.js
+++ b/lighthouse-core/audits/service-worker.js
@@ -148,11 +148,13 @@ class ServiceWorker extends Audit {
       };
     }
 
-    // Include the detailed pass/fail checklist as a diagnostic.
+    // Include the SW details as diagnostic data.
+    const {scriptUrl, scopeUrl} = serviceWorkerUrls;
     /** @type {LH.Audit.Details.DebugData} */
     const details = {
       type: 'debugdata',
-      items: [serviceWorkerUrls],
+      scriptUrl,
+      scopeUrl,
     };
 
     const startUrlFailure = ServiceWorker.checkStartUrl(artifacts.WebAppManifest,
@@ -160,6 +162,7 @@ class ServiceWorker extends Audit {
     if (startUrlFailure) {
       return {
         score: 0,
+        details,
         explanation: startUrlFailure,
       };
     }

--- a/lighthouse-core/test/audits/service-worker-test.js
+++ b/lighthouse-core/test/audits/service-worker-test.js
@@ -77,8 +77,8 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     assert.deepStrictEqual(output.score, 1);
-    assert.deepStrictEqual(output.details.items[0].scopeUrl, 'https://example.com/');
-    assert.deepStrictEqual(output.details.items[0].scriptUrl, 'https://example.com/sw.js');
+    assert.deepStrictEqual(output.details.scopeUrl, 'https://example.com/');
+    assert.deepStrictEqual(output.details.scriptUrl, 'https://example.com/sw.js');
   });
 
   it('fails when controlling service worker is not activated', () => {
@@ -122,9 +122,10 @@ describe('Offline: service worker audit', () => {
 
   it('fails when start_url is out of scope', () => {
     const finalUrl = 'https://example.com/serviceworker/index.html';
+    const scriptURL = 'https://example.com/serviceworker/sw.js';
     const swOpts = [{
       status: 'activated',
-      scriptURL: 'https://example.com/serviceworker/sw.js',
+      scriptURL,
     }];
     const startUrl = 'https://example.com/';
     const manifest = {start_url: startUrl};
@@ -133,7 +134,11 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     assert.strictEqual(output.score, 0);
-    assert.ok(output.details === undefined);
+    assert.deepStrictEqual(output.details, {
+      type: 'debugdata',
+      scriptUrl: scriptURL,
+      scopeUrl: scopeURL,
+    });
     expect(output.explanation).toBeDisplayString('This page is controlled by a service worker, ' +
       `however the \`start_url\` (${startUrl}) is not in the service worker's scope (${scopeURL})`);
   });
@@ -198,8 +203,8 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     assert.deepStrictEqual(output.score, 1);
-    assert.deepStrictEqual(output.details.items[0].scopeUrl, 'https://example.com/project/');
-    assert.deepStrictEqual(output.details.items[0].scriptUrl, 'https://example.com/project/sw.js');
+    assert.deepStrictEqual(output.details.scopeUrl, 'https://example.com/project/');
+    assert.deepStrictEqual(output.details.scriptUrl, 'https://example.com/project/sw.js');
   });
 
   it('passes when multiple SWs control the origin but only one is in scope', () => {
@@ -221,8 +226,8 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     assert.deepStrictEqual(output.score, 1);
-    assert.deepStrictEqual(output.details.items[0].scopeUrl, 'https://example.com/');
-    assert.deepStrictEqual(output.details.items[0].scriptUrl, 'https://example.com/project/subproject/sw.js');
+    assert.deepStrictEqual(output.details.scopeUrl, 'https://example.com/');
+    assert.deepStrictEqual(output.details.scriptUrl, 'https://example.com/project/subproject/sw.js');
   });
 
   it('fails when multiple SWs control the origin but are all out of scope', () => {
@@ -266,7 +271,11 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     assert.strictEqual(output.score, 0);
-    assert.ok(output.details === undefined);
+    assert.deepStrictEqual(output.details, {
+      type: 'debugdata',
+      scriptUrl: 'https://example.com/project/sw.js',
+      scopeUrl: scopeURL,
+    });
     expect(output.explanation).toBeDisplayString('This page is controlled by a service worker, ' +
       `however the \`start_url\` (${startUrl}) is not in the service worker's scope (${scopeURL})`);
   });


### PR DESCRIPTION
I was adding a final comment to #9683 about how to access the SW urls added in #11329 and realized we can flatten these audit details instead of nesting them in `details.items[0]`. Though we often use an `items` array in `'debugdata'` there's no reason we have to (many audits which use a single `items` `debugdata` element are that way for historical reasons, and it hasn't been clear whether it's worth breaking downstream scripts to simplify things in a major release).

Examples of audits using flat `details` are all the [accessibility audits](https://github.com/GoogleChrome/lighthouse/blob/22f227b5f6f042a05a6f36414aae6bab53a965af/lighthouse-core/test/results/sample_v2.json#L2263-L2271) and [`js-libraries`](https://github.com/GoogleChrome/lighthouse/blob/22f227b5f6f042a05a6f36414aae6bab53a965af/lighthouse-core/test/results/sample_v2.json#L3729-L3743).

Since these `service-worker` audit details are new and there's no reason to think we'll ever need an array of details, it makes sense to flatten them before we do the next release.

Also adds two smoke test expectations for the scope/script urls.

cc @adrianaixba (sorry I didn't think of this before #11329 landed)