### PR TITLE
core(config): autocomplete to default 

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -172,6 +172,9 @@ Object {
       "path": "unsized-images",
     },
     Object {
+      "path": "autocomplete",
+    },
+    Object {
       "path": "large-javascript-libraries",
     },
     Object {
@@ -798,6 +801,11 @@ Object {
         Object {
           "group": "best-practices-general",
           "id": "valid-source-maps",
+          "weight": 0,
+        },
+        Object {
+          "group": "best-practices-ux",
+          "id": "autocomplete",
           "weight": 0,
         },
       ],

--- a/lighthouse-cli/test/smokehouse/test-definitions/forms/form-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/forms/form-config.js
@@ -5,14 +5,12 @@
  */
 'use strict';
 
-const experimentalConfig = require('../../../../../lighthouse-core/config/experimental-config.js');
-
 /**
  * @type {LH.Config.Json}
  * Config file for running form gatherer  tests.
  */
 const config = {
-  ...experimentalConfig,
+  extends: 'lighthouse:default',
   settings: {
     onlyAudits: [
       'autocomplete',

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -242,6 +242,7 @@ const defaultConfig = {
     'no-unload-listeners',
     'non-composited-animations',
     'unsized-images',
+    'autocomplete',
     'large-javascript-libraries',
     'valid-source-maps',
     'manual/pwa-cross-browser',
@@ -574,6 +575,7 @@ const defaultConfig = {
         {id: 'deprecations', weight: 1, group: 'best-practices-general'},
         {id: 'errors-in-console', weight: 1, group: 'best-practices-general'},
         {id: 'valid-source-maps', weight: 0, group: 'best-practices-general'},
+        {id: 'autocomplete', weight: 0, group: 'best-practices-ux'},
       ],
     },
     'seo': {

--- a/lighthouse-core/config/experimental-config.js
+++ b/lighthouse-core/config/experimental-config.js
@@ -14,7 +14,6 @@
 const config = {
   extends: 'lighthouse:default',
   audits: [
-    'autocomplete',
     'full-page-screenshot',
   ],
   passes: [{
@@ -24,13 +23,6 @@ const config = {
     ],
   }],
   categories: {
-    // @ts-ignore: `title` is required in CategoryJson. setting to the same value as the default
-    // config is awkward - easier to omit the property here. Will defer to default config.
-    'best-practices': {
-      auditRefs: [
-        {id: 'autocomplete', weight: 0, group: 'best-practices-ux'},
-      ],
-    },
   },
 };
 

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2032,6 +2032,14 @@
         ]
       }
     },
+    "autocomplete": {
+      "id": "autocomplete",
+      "title": "Input elements use autocomplete",
+      "description": "Autocomplete helps users submit forms quicker. To reduce user effort, consider enabling autocomplete by setting the `autocomplete` attribute to a valid value. [Learn more](https://developers.google.com/web/fundamentals/design-and-ux/input/forms#use_metadata_to_enable_auto-complete)",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required FormElements gatherer did not run."
+    },
     "large-javascript-libraries": {
       "id": "large-javascript-libraries",
       "title": "Avoids large JavaScript libraries with smaller alternatives",
@@ -4910,6 +4918,11 @@
           "id": "valid-source-maps",
           "weight": 0,
           "group": "best-practices-general"
+        },
+        {
+          "id": "autocomplete",
+          "weight": 0,
+          "group": "best-practices-ux"
         }
       ],
       "id": "best-practices",
@@ -5729,6 +5742,12 @@
       {
         "startTime": 0,
         "name": "lh:audit:unsized-images",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:audit:autocomplete",
         "duration": 100,
         "entryType": "measure"
       },
@@ -7086,6 +7105,21 @@
         "audits[link-name].details.headings[0].text",
         "audits[object-alt].details.headings[0].text",
         "audits[password-inputs-can-be-pasted-into].details.headings[0].text"
+      ],
+      "lighthouse-core/audits/autocomplete.js | title": [
+        "audits.autocomplete.title"
+      ],
+      "lighthouse-core/audits/autocomplete.js | description": [
+        "audits.autocomplete.description"
+      ],
+      "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": [
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "FormElements"
+          },
+          "path": "audits.autocomplete.errorMessage"
+        }
       ],
       "lighthouse-core/audits/large-javascript-libraries.js | title": [
         "audits[large-javascript-libraries].title"


### PR DESCRIPTION
Summary

moving the autocomplete audit from experimental to default config

build related change

to make autocomplete available on the cli

https://docs.google.com/document/d/1yiulNnV8uEy1jPaAEmWeHxHcQOzxpqvAV4hOFpXLJ1M/edit#heading=h.gjgriz8s7dlc
https://docs.google.com/document/d/1uu3rs3vX8tBhosnXTFvvZn6-UvE1lkd48WVbjbsd4Ds/edit

Related Issues/PRs

Issue #10450
Pull request #11062
Pull request #11186
Pull request #11342