### PR TITLE
report: show overall category scores in csv output

### DIFF
--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -71,11 +71,13 @@ class ReportGenerator {
 
     // Possible TODO: tightly couple headers and row values
     const header = ['requestedUrl', 'finalUrl', 'category', 'name', 'title', 'type', 'score'];
-    const table = Object.values(lhr.categories).map(category => {
+    const table = Object.keys(lhr.categories).map(categoryId => {
       const rows = [];
+      const category = lhr.categories[categoryId];
       const overallCategoryScore = category.score === null ? -1 : category.score;
       rows.push(rowFormatter([lhr.requestedUrl, lhr.finalUrl, category.title,
-        'overall-category-score', 'Overall Category Score', 'numeric', overallCategoryScore]));
+        `${categoryId}-score`, `Overall ${category.title} Category Score`, 'numeric',
+        overallCategoryScore]));
       return rows.concat(category.auditRefs.map(auditRef => {
         const audit = lhr.audits[auditRef.id];
         // CSV validator wants all scores to be numeric, use -1 for now

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -66,19 +66,23 @@ class ReportGenerator {
     const separator = ',';
     /** @param {string} value @return {string} */
     const escape = value => `"${value.replace(/"/g, '""')}"`;
+    /** @param {Array<string | number>} row @return {string[]} */
+    const rowFormatter = row => row.map(value => value.toString()).map(escape);
 
     // Possible TODO: tightly couple headers and row values
     const header = ['requestedUrl', 'finalUrl', 'category', 'name', 'title', 'type', 'score'];
     const table = Object.values(lhr.categories).map(category => {
-      return category.auditRefs.map(auditRef => {
+      const rows = [];
+      const overallCategoryScore = category.score === null ? -1 : category.score;
+      rows.push(rowFormatter([lhr.requestedUrl, lhr.finalUrl, category.title,
+        'overall-category-score', 'Overall Category Score', 'numeric', overallCategoryScore]));
+      return rows.concat(category.auditRefs.map(auditRef => {
         const audit = lhr.audits[auditRef.id];
         // CSV validator wants all scores to be numeric, use -1 for now
         const numericScore = audit.score === null ? -1 : audit.score;
-        return [lhr.requestedUrl, lhr.finalUrl, category.title, audit.id, audit.title,
-          audit.scoreDisplayMode, numericScore]
-          .map(value => value.toString())
-          .map(escape);
-      });
+        return rowFormatter([lhr.requestedUrl, lhr.finalUrl, category.title, audit.id, audit.title,
+          audit.scoreDisplayMode, numericScore]);
+      }));
     });
 
     return [header].concat(...table)

--- a/lighthouse-core/test/report/report-generator-test.js
+++ b/lighthouse-core/test/report/report-generator-test.js
@@ -104,7 +104,7 @@ describe('ReportGenerator', () => {
       expect(lines.length).toBeGreaterThan(100);
       expect(lines.slice(0, 2).join('\n')).toMatchInlineSnapshot(`
         "requestedUrl,finalUrl,category,name,title,type,score
-        \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"first-contentful-paint\\",\\"First Contentful Paint\\",\\"numeric\\",\\"0.51\\"
+        \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"overall-category-score\\",\\"Overall Category Score\\",\\"numeric\\",\\"0.64\\"
         "
       `);
 
@@ -115,6 +115,12 @@ describe('ReportGenerator', () => {
       } finally {
         fs.unlinkSync(path);
       }
+    });
+
+    it('creates CSV for results including overall category scores', async () => {
+      const csvOutput = ReportGenerator.generateReport(sampleResults, 'csv');
+      const count = (csvOutput.match(/overall-category-score/g) || []).length;
+      expect(count).toBe(5);
     });
 
     it('writes extended info', () => {

--- a/lighthouse-core/test/report/report-generator-test.js
+++ b/lighthouse-core/test/report/report-generator-test.js
@@ -102,9 +102,10 @@ describe('ReportGenerator', () => {
 
       const lines = csvOutput.split('\n');
       expect(lines.length).toBeGreaterThan(100);
-      expect(lines.slice(0, 2).join('\n')).toMatchInlineSnapshot(`
+      expect(lines.slice(0, 3).join('\n')).toMatchInlineSnapshot(`
         "requestedUrl,finalUrl,category,name,title,type,score
-        \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"overall-category-score\\",\\"Overall Category Score\\",\\"numeric\\",\\"0.64\\"
+        \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"performance-score\\",\\"Overall Performance Category Score\\",\\"numeric\\",\\"0.64\\"
+        \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"first-contentful-paint\\",\\"First Contentful Paint\\",\\"numeric\\",\\"0.51\\"
         "
       `);
 
@@ -119,8 +120,11 @@ describe('ReportGenerator', () => {
 
     it('creates CSV for results including overall category scores', async () => {
       const csvOutput = ReportGenerator.generateReport(sampleResults, 'csv');
-      const count = (csvOutput.match(/overall-category-score/g) || []).length;
-      expect(count).toBe(5);
+      csvOutput.includes('performance-score');
+      csvOutput.includes('accessibility-score');
+      csvOutput.includes('best-practices-score');
+      csvOutput.includes('seo-score');
+      csvOutput.includes('pwa-score');
     });
 
     it('writes extended info', () => {

--- a/lighthouse-core/test/report/report-generator-test.js
+++ b/lighthouse-core/test/report/report-generator-test.js
@@ -118,13 +118,13 @@ describe('ReportGenerator', () => {
       }
     });
 
-    it('creates CSV for results including overall category scores', async () => {
+    it('creates CSV for results including overall category scores', () => {
       const csvOutput = ReportGenerator.generateReport(sampleResults, 'csv');
-      csvOutput.includes('performance-score');
-      csvOutput.includes('accessibility-score');
-      csvOutput.includes('best-practices-score');
-      csvOutput.includes('seo-score');
-      csvOutput.includes('pwa-score');
+      expect(csvOutput).toContain('performance-score');
+      expect(csvOutput).toContain('accessibility-score');
+      expect(csvOutput).toContain('best-practices-score');
+      expect(csvOutput).toContain('seo-score');
+      expect(csvOutput).toContain('pwa-score');
     });
 
     it('writes extended info', () => {


### PR DESCRIPTION
closes https://github.com/GoogleChrome/lighthouse/issues/11398
**Summary**
Added one row each for category to show `overall category score` in the output CSV report