### PR TITLE
clients(devtools): update report-generator.js to match DevTools changes

### DIFF
--- a/clients/devtools-report-assets.js
+++ b/clients/devtools-report-assets.js
@@ -11,10 +11,10 @@
  * lighthouse-core/report/html/html-report-assets.js in Devtools.
  */
 
-/* global Runtime */
+/* global globalThis */
 
-// @ts-expect-error: Runtime.cachedResources exists in Devtools. https://source.chromium.org/chromium/chromium/src/+/master:third_party/devtools-frontend/src/front_end/root/Runtime.js;l=1169
-const cachedResources = Runtime.cachedResources;
+// @ts-expect-error: globalThis.EXPORTED_CACHED_RESOURCES_ONLY_FOR_LIGHTHOUSE exists in Devtools. https://source.chromium.org/chromium/chromium/src/+/master:third_party/devtools-frontend/src/front_end/root/Runtime.js;l=1247-1250;drc=c4e2fefe3327aa9fe5f4398a1baddb8726c230d5
+const cachedResources = globalThis.EXPORTED_CACHED_RESOURCES_ONLY_FOR_LIGHTHOUSE;
 
 // Getters are necessary because the DevTools bundling processes
 // resources after this module is resolved. These properties are not
@@ -22,15 +22,15 @@ const cachedResources = Runtime.cachedResources;
 // is going to be OK.
 module.exports = {
   get REPORT_CSS() {
-    return cachedResources['third_party/lighthouse/report-assets/report.css'];
+    return cachedResources.get('third_party/lighthouse/report-assets/report.css');
   },
   get REPORT_JAVASCRIPT() {
-    return cachedResources['third_party/lighthouse/report-assets/report.js'];
+    return cachedResources.get('third_party/lighthouse/report-assets/report.js');
   },
   get REPORT_TEMPLATE() {
-    return cachedResources['third_party/lighthouse/report-assets/template.html'];
+    return cachedResources.get('third_party/lighthouse/report-assets/template.html');
   },
   get REPORT_TEMPLATES() {
-    return cachedResources['third_party/lighthouse/report-assets/templates.html'];
+    return cachedResources.get('third_party/lighthouse/report-assets/templates.html');
   },
 };

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -14,6 +14,7 @@
 const ChromeLauncher = require('chrome-launcher');
 const ChromeProtocol = require('../../../../lighthouse-core/gather/connections/cri.js');
 
+// @ts-expect-error - `require` isn't on `global` in the node typedefs.
 const originalRequire = global.require;
 if (typeof globalThis === 'undefined') {
   // @ts-expect-error - exposing for loading of dt-bundle.

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -14,9 +14,17 @@
 const ChromeLauncher = require('chrome-launcher');
 const ChromeProtocol = require('../../../../lighthouse-core/gather/connections/cri.js');
 
+const originalRequire = global.require;
+if (typeof globalThis === 'undefined') {
+  // @ts-expect-error - exposing for loading of dt-bundle.
+  global.globalThis = global;
+}
+
 // Load bundle, which creates a `global.runBundledLighthouse`.
 // @ts-ignore - file exists if `yarn build-all` is run, but not used for types anyways.
 require('../../../../dist/lighthouse-dt-bundle.js'); // eslint-disable-line
+
+global.require = originalRequire;
 
 /** @type {import('../../../../lighthouse-core/index.js')} */
 // @ts-expect-error - not worth giving test global an actual type.

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -25,6 +25,7 @@ if (typeof globalThis === 'undefined') {
 // @ts-ignore - file exists if `yarn build-all` is run, but not used for types anyways.
 require('../../../../dist/lighthouse-dt-bundle.js'); // eslint-disable-line
 
+// @ts-expect-error - `require` isn't on `global` in the node typedefs.
 global.require = originalRequire;
 
 /** @type {import('../../../../lighthouse-core/index.js')} */


### PR DESCRIPTION
This mirrors the change made in
https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2398829/10/front_end/third_party/lighthouse/report-assets/report-generator.js

Note that there are additional changes to the devtools-dt-bundle.js header,
but I presume they are coming from Browserify. We could insert an
`globalThis.require=undefined` in the `BANNER` as specified in
`build-bundle.js`, but it is probably better if we fix that in a follow-up
PR.
