### PR TITLE
misc(build): fix devtools tests by making empty type files

### DIFF
--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -34,6 +34,7 @@ writeFile('report.css', htmlReportAssets.REPORT_CSS);
 writeFile('template.html', htmlReportAssets.REPORT_TEMPLATE);
 writeFile('templates.html', htmlReportAssets.REPORT_TEMPLATES);
 writeFile('report.d.ts', 'export {}');
+writeFile('report-generator.d.ts', 'export {}');
 
 const pathToReportAssets = require.resolve('../clients/devtools-report-assets.js');
 browserify(generatorFilename, {standalone: 'Lighthouse.ReportGenerator'})

--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -33,6 +33,7 @@ writeFile('report.js', htmlReportAssets.REPORT_JAVASCRIPT);
 writeFile('report.css', htmlReportAssets.REPORT_CSS);
 writeFile('template.html', htmlReportAssets.REPORT_TEMPLATE);
 writeFile('templates.html', htmlReportAssets.REPORT_TEMPLATES);
+writeFile('report.d.ts', 'export {}');
 
 const pathToReportAssets = require.resolve('../clients/devtools-report-assets.js');
 browserify(generatorFilename, {standalone: 'Lighthouse.ReportGenerator'})


### PR DESCRIPTION
ref https://github.com/GoogleChrome/lighthouse/issues/11414#issuecomment-691281339

these files were added manually to our third party folder in CDT, but we destroy that folder when we roll, so we must make them.