### PR TITLE
tests(smoke): fix preconnect flake w/ a non-locally installed font

### DIFF
--- a/lighthouse-cli/test/fixtures/perf/preload_tester.js
+++ b/lighthouse-cli/test/fixtures/perf/preload_tester.js
@@ -17,13 +17,13 @@ setTimeout(() => {
   // load another origin in a way where the `crossorigin` attribute matters
   const link = document.createElement('link');
   link.rel = 'stylesheet';
-  link.href = 'https://fonts.googleapis.com/css?family=Roboto&display=block';
+  link.href = 'https://fonts.googleapis.com/css?family=Ranchers&display=block';
   document.head.appendChild(link);
 
   link.onload = () => {
     // Make sure LCP is waiting on the network so the above resources are considered important.
     const lcpElement = document.createElement('div');
-    lcpElement.style.fontFamily = 'Roboto';
+    lcpElement.style.fontFamily = 'Ranchers';
     lcpElement.textContent = 'Here is some really tall text!'.repeat(50)
     document.body.appendChild(lcpElement);
   };


### PR DESCRIPTION
ref the flaky smokes issue: #11341 

<details>
<summary>
basically a few of us have seen this smoke failure recently..
</summary>

```
  ✘ difference at uses-rel-preconnect audit.warnings.length
              expected: 1
                 found: 2

          found result:
      {
        "id": "uses-rel-preconnect",
        "title": "Preconnect to required origins",
        "description": "Consider adding `preconnect` or `dns-prefetch` resource hints to establish early connections to important third-party origins. [Learn more](https://web.dev/uses-rel-preconnect/).",
        "score": 1,
        "scoreDisplayMode": "numeric",
        "warnings": [
          "A preconnect <link> was found for \"https://fonts.googleapis.com\" but was not used by the browser. Check that you are using the `crossorigin` attribute properly.",
          "A preconnect <link> was found for \"https://fonts.gstatic.com\" but was not used by the browser. Only preconnect to important origins that the page will certainly request."
        ]
      }
```

</details>

i think google fonts _recently_ added the `local()` directive...
![image](https://user-images.githubusercontent.com/39191/93006156-a6cc2c80-f50d-11ea-9e40-abea9f3e40a6.png)

(don't know for sure, but i vaguely recall a recent mention of this..)

some of us have `Roboto` installed locally. and if that font is installed locally, the browser wont make the network request, thus our audit will decide [the preconnect to gstatic](https://github.com/GoogleChrome/lighthouse/blob/a1571ba4bc5b7713248ea53e01db085389e634f8/lighthouse-cli/test/fixtures/preload.html#L8-L9) was unnecessary.

To test this out, I disabled Roboto using Font Book and the smoke didn't fail anymore.

To fix, I just changed to [a font](https://fonts.google.com/specimen/Ranchers) that probably isn't installed on our own machines or a CI bot. :)


------------

It's possible our users may run into this too, if:
- they are using Google Fonts on their site
- they have some of those fonts installed locally
- they've added preconnect directives to the site, following LH's advice

In that case, they'll get this audit warning locally, but wouldn't see it on PSI.  