### PR TITLE
tests(smoke): drop screenshot-too-big case

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/screenshot/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/screenshot/expectations.js
@@ -23,17 +23,6 @@ const expectations = [
       audits: {},
     },
   },
-  {
-    artifacts: {
-      FullPageScreenshot: null,
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/screenshot.html?width=5000px&height=5000px',
-      finalUrl: 'http://localhost:10200/screenshot.html?width=5000px&height=5000px',
-      runWarnings: [/Full page screenshot is too big/],
-      audits: {},
-    },
-  },
 ];
 
 module.exports = expectations;

--- a/lighthouse-core/test/gather/gatherers/full-page-screenshot-test.js
+++ b/lighthouse-core/test/gather/gatherers/full-page-screenshot-test.js
@@ -275,5 +275,6 @@ describe('Full-page screenshot gatherer', () => {
     );
 
     expect(result).toBeNull();
+    expect(passContext.LighthouseRunWarnings[0]).toMatch('Full page screenshot is too big');
   });
 });


### PR DESCRIPTION
trying to fix another smoke flake. #11341 

example happened here: https://github.com/GoogleChrome/lighthouse/pull/11402/checks?check_run_id=1098415903#step:8:622

the smoketest tries creating a page that'll end up with a TOO HUGE datauri, but sometimes it's not huge enough to hit our check.


IMO constructing smoketest for this case seems unnecessary.  The existing unit test seems fine to confirm[ the `if (screenshot.data.length > MAX_DATA_URL_SIZE)` conditional](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/gather/gatherers/full-page-screenshot.js#L82-L86) works. 