### PR TITLE
misc(axe): rename axe types

### DIFF
--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -51,7 +51,7 @@ function runA11yChecks() {
       'audio-caption': {enabled: false},
     },
     // @ts-expect-error
-  }).then(axeResult => {
+  }).then(axeResults => {
     // axe just scrolled the page, scroll back to the top of the page so that element positions
     // are relative to the top of the page
     document.documentElement.scrollTop = 0;
@@ -88,17 +88,17 @@ function runA11yChecks() {
     };
 
     // Augment the node objects with outerHTML snippet & custom path string
-    axeResult.violations.forEach(augmentAxeNodes);
-    axeResult.incomplete.forEach(augmentAxeNodes);
+    axeResults.violations.forEach(augmentAxeNodes);
+    axeResults.incomplete.forEach(augmentAxeNodes);
 
     // We only need violations, and circular references are possible outside of violations
-    axeResult = {
-      violations: axeResult.violations,
-      notApplicable: axeResult.inapplicable,
-      incomplete: axeResult.incomplete,
-      version: axeResult.testEngine.version,
+    axeResults = {
+      violations: axeResults.violations,
+      notApplicable: axeResults.inapplicable,
+      incomplete: axeResults.incomplete,
+      version: axeResults.testEngine.version,
     };
-    return axeResult;
+    return axeResults;
   });
 }
 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -162,7 +162,7 @@ declare global {
         message: string;
       }
 
-      export interface AxeResult {
+      export interface AxeRuleResult {
         id: string;
         impact: string;
         tags: Array<string>;
@@ -181,9 +181,9 @@ declare global {
       }
 
       export interface Accessibility {
-        violations: Array<AxeResult>;
-        notApplicable: Array<Pick<AxeResult, 'id'>>;
-        incomplete: Array<AxeResult>;
+        violations: Array<AxeRuleResult>;
+        notApplicable: Array<Pick<AxeRuleResult, 'id'>>;
+        incomplete: Array<AxeRuleResult>;
         version: string;
       }
 


### PR DESCRIPTION
small tweak.

we use `axeResult` in two places for two different things. I've renamed both to differentiate more clearly.

1. in the gatherer to refer to the [return value](https://github.com/GoogleChrome/lighthouse/blob/a58510583acd2f796557175ac949932618af49e7/lighthouse-core/gather/gatherers/accessibility.js#L54) of `axe.run()`. 
   - axe-core calls this[ the "results object](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#results-object)", so i've added an s to here to align. 
2. the [artifacts.d.ts type](https://github.com/GoogleChrome/lighthouse/blob/a58510583acd2f796557175ac949932618af49e7/types/artifacts.d.ts#L165) that refers to an individual axe rule's results. 
    - I've renamed it to `AxeRuleResult` to clarify it's just a single axe rule being described. axe-core [uses this term](https://github.com/dequelabs/axe-core/blob/e48c1eb67db6182d7048a21f935db5a9416077ec/lib/core/utils/finalize-result.js#L8), too.

