### PR TITLE
deps: chrome-launcher to v0.13.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   },
   "dependencies": {
     "axe-core": "3.5.5",
-    "chrome-launcher": "^0.13.3",
+    "chrome-launcher": "^0.13.4",
     "configstore": "^5.0.1",
     "cssstyle": "1.2.1",
     "details-element-polyfill": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,10 +1955,10 @@ chrome-devtools-frontend@1.0.727089:
   resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.727089.tgz#5663edd32b445826c51a0d6332f5072b21f7b895"
   integrity sha512-+dK4dgS3Phib4SPAaF29Vn5NxoKCnyuDNh9IRxjGk+u4P09o3IQyvQKA+43zTtV2q+HmORLJUS6F1SXqfUSpfQ==
 
-chrome-launcher@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.13.3.tgz#5dd72ae4e9b3de19ce3fe1941f89551c0ceb1d30"
-  integrity sha512-ovrDuFXgXS96lzeDqFPQRsczkxla+6QMvzsF+1u0mKlD1KE8EuhjdLwiDfIFedb0FSLz18RK3y6IbKu8oqA0qw==
+chrome-launcher@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.13.4.tgz#4c7d81333c98282899c4e38256da23e00ed32f73"
+  integrity sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==
   dependencies:
     "@types/node" "*"
     escape-string-regexp "^1.0.5"


### PR DESCRIPTION
3 commits, the 2nd of which is a nice quality of life upgrade for us.  makes running LH ~5s faster on my machine.

* [`08406b28`](https://github.com/GoogleChrome/chrome-launcher/commit/08406b2804c6efba7b602fb276397df00cd0041f) fix: preserve existing getInstallations output
* `f3669f45` perf: check default paths first when running on Mac (https://github.com/GoogleChrome/chrome-launcher/pull/209)
* `aef94948` docs: update defaultFlags() example for new API (https://github.com/GoogleChrome/chrome-launcher/pull/205)