### PR TITLE
core(tracehouse): use tasks to improve profiler timing data

### DIFF
--- a/lighthouse-core/lib/tracehouse/cpu-profile-model.js
+++ b/lighthouse-core/lib/tracehouse/cpu-profile-model.js
@@ -232,7 +232,6 @@ class CpuProfilerModel {
     const knownTasksEndingNotContained = knownTasksEnding
       .filter(t => !knownTasksStarting.includes(t));
 
-    // if (node.callFrame.functionName === 'window.library.stall') console.log({earliestPossibleTimestamp, latestPossibleTimestamp, knownTasksStartingNotContained});
     let effectiveTimestamp = latestPossibleTimestamp;
     if (knownTasksStartingNotContained.length) {
       // Tasks that started but did not finish take priority. Use the earliest of their timestamps.

--- a/lighthouse-core/lib/tracehouse/main-thread-tasks.js
+++ b/lighthouse-core/lib/tracehouse/main-thread-tasks.js
@@ -603,13 +603,13 @@ class MainThreadTasks {
    * Prints an artistic rendering of the task tree for easier debugability.
    *
    * @param {TaskNode[]} tasks
-   * @param {{printWidth: number, startTime?: number, endTime?: number, taskLabelFn?: (node: TaskNode) => string}} options
+   * @param {{printWidth?: number, startTime?: number, endTime?: number, taskLabelFn?: (node: TaskNode) => string}} options
    * @return {string}
    */
-  static printTaskTreeToDebugString(tasks, options) {
+  static printTaskTreeToDebugString(tasks, options = {}) {
     const traceEndMs = Math.max(...tasks.map(t => t.endTime), 0);
     const {
-      printWidth,
+      printWidth = 100,
       startTime = 0,
       endTime = traceEndMs,
       taskLabelFn = node => node.event.name,

--- a/lighthouse-core/lib/tracehouse/main-thread-tasks.js
+++ b/lighthouse-core/lib/tracehouse/main-thread-tasks.js
@@ -638,6 +638,8 @@ class MainThreadTasks {
       tasksAtDepth.push(task);
       tasksByDepth.set(depth, tasksAtDepth);
 
+      // Create a user-friendly ID for new tasks using a capital letter.
+      // 65 is the ASCII code for 'A' and there are 26 letters in the english alphabet.
       const id = String.fromCharCode(65 + (taskLegend.size % 26));
       taskLegend.set(task, {id, task});
     }

--- a/lighthouse-core/lib/tracehouse/main-thread-tasks.js
+++ b/lighthouse-core/lib/tracehouse/main-thread-tasks.js
@@ -598,6 +598,83 @@ class MainThreadTasks {
 
     return tasks;
   }
+
+  /**
+   * Prints an artistic rendering of the task tree for easier debugability.
+   *
+   * @param {TaskNode[]} tasks
+   * @param {{printWidth: number, startTime?: number, endTime?: number, taskLabelFn?: (node: TaskNode) => string}} options
+   * @return {string}
+   */
+  static printTaskTreeToDebugString(tasks, options) {
+    const traceEndMs = Math.max(...tasks.map(t => t.endTime), 0);
+    const {
+      printWidth,
+      startTime = 0,
+      endTime = traceEndMs,
+      taskLabelFn = node => node.event.name,
+    } = options;
+
+    /** @param {TaskNode} task */
+    function computeTaskDepth(task) {
+      let depth = 0;
+      for (; task.parent; task = task.parent) depth++;
+      return depth;
+    }
+
+    const traceRange = endTime - startTime;
+    const characterInMs = traceRange / printWidth;
+
+    /** @type {Map<TaskNode, {id: string, task: TaskNode}>} */
+    const taskLegend = new Map();
+
+    /** @type {Map<number, TaskNode[]>} */
+    const tasksByDepth = new Map();
+    for (const task of tasks) {
+      if (task.startTime > endTime || task.endTime < startTime) continue;
+
+      const depth = computeTaskDepth(task);
+      const tasksAtDepth = tasksByDepth.get(depth) || [];
+      tasksAtDepth.push(task);
+      tasksByDepth.set(depth, tasksAtDepth);
+
+      const id = String.fromCharCode(65 + (taskLegend.size % 26));
+      taskLegend.set(task, {id, task});
+    }
+
+    const debugStringLines = [
+      `Trace Duration: ${traceEndMs.toFixed(0)}ms`,
+      `Range: [${startTime}, ${endTime}]`,
+      `█ = ${characterInMs.toFixed(2)}ms`,
+      '',
+    ];
+
+    const increasingDepth = Array.from(tasksByDepth.entries()).sort((a, b) => a[0] - b[0]);
+    for (const [, tasks] of increasingDepth) {
+      const taskRow = Array.from({length: printWidth}).map(() => ' ');
+
+      for (const task of tasks) {
+        const taskStart = Math.max(task.startTime, startTime);
+        const taskEnd = Math.min(task.endTime, endTime);
+
+        const {id} = taskLegend.get(task) || {id: '?'};
+        const startIndex = Math.floor(taskStart / characterInMs);
+        const endIndex = Math.floor(taskEnd / characterInMs);
+        const idIndex = Math.floor((startIndex + endIndex) / 2);
+        for (let i = startIndex; i <= endIndex; i++) taskRow[i] = '█';
+        for (let i = 0; i < id.length; i++) taskRow[idIndex] = id;
+      }
+
+      debugStringLines.push(taskRow.join(''));
+    }
+
+    debugStringLines.push('');
+    for (const {id, task} of taskLegend.values()) {
+      debugStringLines.push(`${id} = ${taskLabelFn(task)}`);
+    }
+
+    return debugStringLines.join('\n');
+  }
 }
 
 module.exports = MainThreadTasks;

--- a/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
+++ b/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
@@ -44,10 +44,106 @@ describe('CPU Profiler Model', () => {
     };
   });
 
-  describe('#createStartEndEvents', () => {
+  describe('#_findEffectiveTimestamp', () => {
+    it('should default to the latest possible timestamp when no task data available', () => {
+      const result = CpuProfilerModel._findEffectiveTimestamp({
+        earliestPossibleTimestamp: 0,
+        latestPossibleTimestamp: 1000,
+        knownTasksByStartTime: [],
+        knownTaskStartTimeIndex: 0,
+        knownTasksByEndTime: [],
+        knownTaskEndTimeIndex: 0,
+      });
+
+      expect(result).toEqual({timestamp: 1000, lastStartTimeIndex: 0, lastEndTimeIndex: 0});
+    });
+
+    it('should use the latest possible timestamp when tasks fully include range', () => {
+      const tasks = [{startTime: 500, endTime: 2500}];
+      const result = CpuProfilerModel._findEffectiveTimestamp({
+        earliestPossibleTimestamp: 1000,
+        latestPossibleTimestamp: 2000,
+        knownTasksByStartTime: tasks,
+        knownTaskStartTimeIndex: 0,
+        knownTasksByEndTime: tasks,
+        knownTaskEndTimeIndex: 0,
+      });
+
+      expect(result).toEqual({timestamp: 2000, lastStartTimeIndex: 1, lastEndTimeIndex: 0});
+    });
+
+    it('should use the latest possible timestamp when tasks are fully contained in range', () => {
+      const tasks = [{startTime: 250, endTime: 750}];
+      const result = CpuProfilerModel._findEffectiveTimestamp({
+        earliestPossibleTimestamp: 0,
+        latestPossibleTimestamp: 1000,
+        knownTasksByStartTime: tasks,
+        knownTaskStartTimeIndex: 0,
+        knownTasksByEndTime: tasks,
+        knownTaskEndTimeIndex: 0,
+      });
+
+      expect(result).toEqual({timestamp: 1000, lastStartTimeIndex: 1, lastEndTimeIndex: 1});
+    });
+
+    it('should use earliest of the start task timestamps when tasks started in range', () => {
+      const tasks = [{startTime: 250, endTime: 2000}];
+      const result = CpuProfilerModel._findEffectiveTimestamp({
+        earliestPossibleTimestamp: 0,
+        latestPossibleTimestamp: 1000,
+        knownTasksByStartTime: tasks,
+        knownTaskStartTimeIndex: 0,
+        knownTasksByEndTime: tasks,
+        knownTaskEndTimeIndex: 0,
+      });
+
+      expect(result).toEqual({timestamp: 250, lastStartTimeIndex: 1, lastEndTimeIndex: 0});
+    });
+
+    it('should use latest of the end task timestamps when tasks ended in range', () => {
+      const tasks = [{startTime: 250, endTime: 1500}];
+      const result = CpuProfilerModel._findEffectiveTimestamp({
+        earliestPossibleTimestamp: 1000,
+        latestPossibleTimestamp: 2000,
+        knownTasksByStartTime: tasks,
+        knownTaskStartTimeIndex: 0,
+        knownTasksByEndTime: tasks,
+        knownTaskEndTimeIndex: 0,
+      });
+
+      expect(result).toEqual({timestamp: 1500, lastStartTimeIndex: 1, lastEndTimeIndex: 1});
+    });
+
+    it('should handle multiple tasks', () => {
+      const tasks = [
+        {startTime: 250, endTime: 1500},
+        {startTime: 500, endTime: 1400},
+        {startTime: 1100, endTime: 1200},
+        {startTime: 1700, endTime: 1800},
+        {startTime: 1900, endTime: 2200},
+        {startTime: 1925, endTime: 1975},
+      ];
+
+      // TODO: eventually, this should split the start and end effective timestamps.
+      // For now it assumes both are the same timestamp which forces this to choose the latest option.
+      // Eventually the endTimestamp should be 1500 and the startTimestamp should be 1900.
+      const result = CpuProfilerModel._findEffectiveTimestamp({
+        earliestPossibleTimestamp: 1000,
+        latestPossibleTimestamp: 2000,
+        knownTasksByStartTime: tasks,
+        knownTaskStartTimeIndex: 0,
+        knownTasksByEndTime: tasks.slice().sort((a, b) => a.endTime - b.endTime),
+        knownTaskEndTimeIndex: 0,
+      });
+
+      expect(result).toEqual({timestamp: 1900, lastStartTimeIndex: 6, lastEndTimeIndex: 5});
+    });
+  });
+
+  describe('#synthesizeTraceEvents', () => {
     it('should create events in order', () => {
-      const ts = x => 9e6 + x;
-      const events = CpuProfilerModel.createStartEndEvents(profile);
+      const ts = x => profile.startTime + x;
+      const events = CpuProfilerModel.synthesizeTraceEvents(profile);
 
       expect(events).toMatchObject([
         {ph: 'B', ts: ts(10e3), args: {data: {callFrame: {functionName: '(root)'}}}},
@@ -71,37 +167,37 @@ describe('CPU Profiler Model', () => {
       // With the sampling profiler we know that Baz and Foo ended *sometime between* 17e3 and 18e3.
       // We want to make sure when additional task information is present, we refine the end time.
       const tasks = [
-        // The RunTask at the toplevel, should move start time of Foo to 80e2 and end time to 175e2
-        {startTime: ts(80e2), endTime: ts(175e2)},
+        // The RunTask at the toplevel, should move start time of Foo to 8.0e3 and end time to 17.5e3
+        {startTime: ts(8.0e3), endTime: ts(17.5e3)},
         // The EvaluateScript at the 2nd level, should not affect anything.
-        {startTime: ts(90e2), endTime: ts(174e2)},
-        // A small task inside Baz, should move the start time of Baz to 125e2.
-        {startTime: ts(125e2), endTime: ts(134e2)},
-        // A small task inside Foo, should move the end time of Bar to 157e2, start time of Baz to 168e2.
-        {startTime: ts(157e2), endTime: ts(168e2)},
+        {startTime: ts(9.0e3), endTime: ts(17.4e3)},
+        // A small task inside Baz, should move the start time of Baz to 12.5e3.
+        {startTime: ts(12.5e3), endTime: ts(13.4e3)},
+        // A small task inside Foo, should move the end time of Bar to 15.7e3, start time of Baz to 16.8e3.
+        {startTime: ts(15.7e3), endTime: ts(16.8e3)},
       ];
 
-      const events = CpuProfilerModel.createStartEndEvents(profile, tasks);
+      const events = CpuProfilerModel.synthesizeTraceEvents(profile, tasks);
 
       expect(events).toMatchObject([
-        {ph: 'B', ts: ts(80e2), args: {data: {callFrame: {functionName: '(root)'}}}},
-        {ph: 'B', ts: ts(80e2), args: {data: {callFrame: {functionName: '(program)'}}}},
-        {ph: 'B', ts: ts(80e2), args: {data: {callFrame: {functionName: 'Foo'}}}},
-        {ph: 'B', ts: ts(120e2), args: {data: {callFrame: {functionName: 'Bar'}}}},
-        {ph: 'B', ts: ts(125e2), args: {data: {callFrame: {functionName: 'Baz'}}}},
-        {ph: 'E', ts: ts(134e2), args: {data: {callFrame: {functionName: 'Baz'}}}},
-        {ph: 'E', ts: ts(157e2), args: {data: {callFrame: {functionName: 'Bar'}}}},
-        {ph: 'B', ts: ts(168e2), args: {data: {callFrame: {functionName: 'Baz'}}}},
-        {ph: 'E', ts: ts(175e2), args: {data: {callFrame: {functionName: 'Baz'}}}},
-        {ph: 'E', ts: ts(175e2), args: {data: {callFrame: {functionName: 'Foo'}}}},
-        {ph: 'E', ts: ts(190e2), args: {data: {callFrame: {functionName: '(program)'}}}},
-        {ph: 'E', ts: ts(190e2), args: {data: {callFrame: {functionName: '(root)'}}}},
+        {ph: 'B', ts: ts(8.0e3), args: {data: {callFrame: {functionName: '(root)'}}}},
+        {ph: 'B', ts: ts(8.0e3), args: {data: {callFrame: {functionName: '(program)'}}}},
+        {ph: 'B', ts: ts(8.0e3), args: {data: {callFrame: {functionName: 'Foo'}}}},
+        {ph: 'B', ts: ts(12.0e3), args: {data: {callFrame: {functionName: 'Bar'}}}},
+        {ph: 'B', ts: ts(12.5e3), args: {data: {callFrame: {functionName: 'Baz'}}}},
+        {ph: 'E', ts: ts(13.4e3), args: {data: {callFrame: {functionName: 'Baz'}}}},
+        {ph: 'E', ts: ts(15.7e3), args: {data: {callFrame: {functionName: 'Bar'}}}},
+        {ph: 'B', ts: ts(16.8e3), args: {data: {callFrame: {functionName: 'Baz'}}}},
+        {ph: 'E', ts: ts(17.5e3), args: {data: {callFrame: {functionName: 'Baz'}}}},
+        {ph: 'E', ts: ts(17.5e3), args: {data: {callFrame: {functionName: 'Foo'}}}},
+        {ph: 'E', ts: ts(19.0e3), args: {data: {callFrame: {functionName: '(program)'}}}},
+        {ph: 'E', ts: ts(19.0e3), args: {data: {callFrame: {functionName: '(root)'}}}},
       ]);
     });
 
     it('should create main-thread-task parseable events', () => {
-      const ts = x => 9e6 + x;
-      const events = CpuProfilerModel.createStartEndEvents(profile);
+      const ts = x => profile.startTime + x;
+      const events = CpuProfilerModel.synthesizeTraceEvents(profile);
 
       const tasks = MainThreadTasks.getMainThreadTasks(events, [], ts(19e3));
       expect(tasks).toHaveLength(6);
@@ -117,24 +213,52 @@ describe('CPU Profiler Model', () => {
 
       const fooTask = tasks[0].children[0].children[0];
       expect(fooTask).toMatchObject({
+        startTime: 0,
+        endTime: 8,
         event: {args: {data: {callFrame: {functionName: 'Foo'}}}},
         children: [
           {
+            startTime: 2,
+            endTime: 6,
             event: {args: {data: {callFrame: {functionName: 'Bar'}}}},
             children: [{event: {args: {data: {callFrame: {functionName: 'Baz'}}}}}],
           },
           {
+            startTime: 7,
+            endTime: 8,
             event: {args: {data: {callFrame: {functionName: 'Baz'}}}},
             children: [],
           },
         ],
       });
+
+      const visualization = MainThreadTasks.printTaskTreeToDebugString(tasks, {
+        printWidth: 80,
+      }).replace(/ +\n/g, '\n');
+      expect(visualization).toMatchInlineSnapshot(`
+        "Trace Duration: 9ms
+        Range: [0, 9]
+        █ = 0.11ms
+
+        ████████████████████████████████████████A████████████████████████████████████████
+        ████████████████████████████████████████B████████████████████████████████████████
+        ███████████████████████████████████C████████████████████████████████████
+                         ██████████████████D██████████████████        ████F█████
+                                  ████E█████
+
+        A = FunctionCall-SynthesizedByProfilerModel
+        B = FunctionCall-SynthesizedByProfilerModel
+        C = FunctionCall-SynthesizedByProfilerModel
+        D = FunctionCall-SynthesizedByProfilerModel
+        E = FunctionCall-SynthesizedByProfilerModel
+        F = FunctionCall-SynthesizedByProfilerModel"
+      `);
     });
 
     it('should work on a real trace', () => {
       const {processEvents} = TraceProcessor.computeTraceOfTab(profilerTrace);
       const profiles = CpuProfileModel.collectProfileEvents(processEvents);
-      const events = CpuProfileModel.createStartEndEvents(profiles[0]);
+      const events = CpuProfileModel.synthesizeTraceEvents(profiles[0]);
       expect(events).toHaveLength(230);
       const lastTs = events[events.length - 1].length;
       const tasks = MainThreadTasks.getMainThreadTasks(events, [], lastTs);

--- a/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
+++ b/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
@@ -66,7 +66,7 @@ describe('CPU Profiler Model', () => {
     });
 
     it('should create events while aware of other tasks', () => {
-      const ts = x => 9e6 + x;
+      const ts = x => profile.startTime + x;
 
       // With the sampling profiler we know that Baz and Foo ended *sometime between* 17e3 and 18e3.
       // We want to make sure when additional task information is present, we refine the end time.

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -827,12 +827,13 @@ describe('Main Thread Tasks', () => {
       const tasks = run({traceEvents});
       const taskTreeAsString = MainThreadTasks.printTaskTreeToDebugString(tasks, {printWidth: 50});
       expect(taskTreeAsString).toMatchInlineSnapshot(`
-        "Total Duration: 100ms
+        "Trace Duration: 100ms
+        Range: [0, 100]
         █ = 2.00ms
 
         █████████████████████████A█████████████████████████
-          ████████████B█████████████  ███████D████████
-             ███████C████████
+          ████████████B█████████████  ███████D████████    
+             ███████C████████                             
 
         A = TaskA
         B = TaskB

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -805,14 +805,40 @@ describe('Main Thread Tasks', () => {
 
   for (const invalidEvents of invalidEventSets) {
     it('should throw on invalid task input', () => {
+      const traceEvents = [...boilerplateTrace, ...invalidEvents];
+      traceEvents.forEach(evt => Object.assign(evt, {cat: 'devtools.timeline'}));
+      expect(() => run({traceEvents})).toThrow();
+    });
+  }
+
+  describe('printTaskTreeToDebugString', () => {
+    it('should print a nice-looking task tree', () => {
       const traceEvents = [
         ...boilerplateTrace,
-        ...invalidEvents,
+        {ph: 'X', name: 'TaskA', pid, tid, ts: baseTs, dur: 100e3, args},
+        {ph: 'B', name: 'TaskB', pid, tid, ts: baseTs + 5e3, args},
+        {ph: 'X', name: 'TaskC', pid, tid, ts: baseTs + 10e3, dur: 30e3, args},
+        {ph: 'E', name: 'TaskB', pid, tid, ts: baseTs + 55e3, args},
+        {ph: 'X', name: 'TaskD', pid, tid, ts: baseTs + 60e3, dur: 30e3, args},
       ];
 
       traceEvents.forEach(evt => Object.assign(evt, {cat: 'devtools.timeline'}));
 
-      expect(() => run({traceEvents})).toThrow();
+      const tasks = run({traceEvents});
+      const taskTreeAsString = MainThreadTasks.printTaskTreeToDebugString(tasks, {printWidth: 50});
+      expect(taskTreeAsString).toMatchInlineSnapshot(`
+        "Total Duration: 100ms
+        █ = 2.00ms
+
+        █████████████████████████A█████████████████████████
+          ████████████B█████████████  ███████D████████
+             ███████C████████
+
+        A = TaskA
+        B = TaskB
+        C = TaskC
+        D = TaskD"
+      `);
     });
-  }
+  });
 });


### PR DESCRIPTION
**Summary**
The next phase of CPU profiler work got really out of hand really quickly, so stopping at a reasonable checkpoint. This PR improves the timing of sampling profiler data using other task information from a trace. The sampling profiler is still out of the normal flow of Lighthouse, so the test cases are the only actual usage.

Also a nice juicy debug function for task data which should help generate those nice "artistic" rendering of traces :)

**Related Issues/PRs**
ref #8526 
