### PR TITLE
core(image-elements): do not set untrusted natural dimensions

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -203,6 +203,16 @@ setTimeout(() => {
   <img class="onscreen" src="lighthouse-320x212-poor.jpg?duplicate">
 
   <!-- PASS(optimized): image is JPEG optimized -->
+  <!-- PASS(webp): image has insigificant WebP savings -->
+  <!-- PASS(responsive): image is used at full size -->
+  <!-- PASS(responsive-inverse): image accounts for DPR 2.625 in srcset *with a redirect* -->
+  <!-- PASS(offscreen): image is onscreen -->
+  <!-- PASS(unsized-images): css position is absolute -->
+  <!-- The first 320x212 should never be requested by Lighthouse. -->
+  <!-- 320x212 image just there to ensure failure of other audits if srcset is used incorrectly. -->
+  <img class="onscreen" width="240" src="lighthouse-320x212-poor.jpg?neverused" srcset="lighthouse-320x212-poor.jpg?neverused 320w, made-up-image-redirect-image.jpg?redirect=lighthouse-480x320.webp 480w">
+
+  <!-- PASS(optimized): image is JPEG optimized -->
   <!-- FAIL(webp): image is not WebP optimized -->
   <!-- PASS(responsive): image is in CSS -->
   <!-- PASS(responsive-inverse): image is in CSS -->

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -188,6 +188,7 @@ class Server {
     }
 
     function sendRedirect(url) {
+      // Redirects can only contain ASCII characters.
       if (url.split('').some(char => char.charCodeAt(0) > 256)) {
         response.writeHead(500);
         response.write(`Invalid redirect URL: ${url}`);

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -188,6 +188,13 @@ class Server {
     }
 
     function sendRedirect(url) {
+      if (url.split('').some(char => char.charCodeAt(0) > 256)) {
+        response.writeHead(500);
+        response.write(`Invalid redirect URL: ${url}`);
+        response.end();
+        return;
+      }
+
       const headers = {
         Location: url,
       };


### PR DESCRIPTION
**Summary**
A band-aid for #11450 to not set the natural dimensions if they were from a situation we know to provide incorrect natural dimensions. A proper fix for using the correct dimensions requires a much broader fixes across LH in #11454.

**Related Issues/PRs**
fixes #11450 
