### PR TITLE
misc(build): use terser on inline assets

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -19,6 +19,7 @@ const LighthouseRunner = require('../lighthouse-core/runner.js');
 const exorcist = require('exorcist');
 const browserify = require('browserify');
 const terser = require('terser');
+const {minifyFileTransform} = require('./build-utils.js');
 
 const COMMIT_HASH = require('child_process')
   .execSync('git rev-parse HEAD')
@@ -64,7 +65,11 @@ async function browserifyFile(entryPath, distPath) {
       file: require.resolve('./banner.txt'),
     })
     // Transform the fs.readFile etc into inline strings.
-    .transform('@wardpeet/brfs', {global: true, parserOpts: {ecmaVersion: 10}})
+    .transform('@wardpeet/brfs', {
+      readFileSyncTransform: minifyFileTransform,
+      global: true,
+      parserOpts: {ecmaVersion: 10},
+    })
     // Strip everything out of package.json includes except for the version.
     .transform('package-json-versionify');
 

--- a/build/build-utils.js
+++ b/build/build-utils.js
@@ -37,6 +37,7 @@ function minifyFileTransform(file) {
 
       if (result.code) {
         const saved = code.length - result.code.length;
+        // eslint-disable-next-line no-console
         console.log(`minifying ${file} saved ${saved / 1000} KB`);
         this.push(result.code);
       }

--- a/build/build-utils.js
+++ b/build/build-utils.js
@@ -14,17 +14,31 @@ const terser = require('terser');
  * @param {string} file
  */
 function minifyFileTransform(file) {
+  if (!file.endsWith('.js')) {
+    return new stream.Transform({
+      transform(chunk, enc, next) {
+        this.push(chunk);
+        next();
+      },
+    });
+  }
+
+  let code = '';
   return new stream.Transform({
     transform(chunk, enc, next) {
-      if (file.endsWith('.js')) {
-        const result = terser.minify(chunk.toString());
-        if (result.error) {
-          throw result.error;
-        }
+      code += chunk.toString();
+      next();
+    },
+    final(next) {
+      const result = terser.minify(code);
+      if (result.error) {
+        throw result.error;
+      }
 
+      if (result.code) {
+        // const saved = code.length - result.code.length;
+        // console.log(`minifying ${file} saved ${saved / 1000} KB`);
         this.push(result.code);
-      } else {
-        this.push(chunk);
       }
 
       next();

--- a/build/build-utils.js
+++ b/build/build-utils.js
@@ -14,8 +14,8 @@ const terser = require('terser');
  * @param {string} file
  */
 function minifyFileTransform(file) {
+  // Don't transform files that aren't javascript.
   if (!file.endsWith('.js')) {
-    //  Don't transform files that aren't javascript.
     return new stream.Transform({
       transform(chunk, enc, next) {
         this.push(chunk);

--- a/build/build-utils.js
+++ b/build/build-utils.js
@@ -36,8 +36,8 @@ function minifyFileTransform(file) {
       }
 
       if (result.code) {
-        // const saved = code.length - result.code.length;
-        // console.log(`minifying ${file} saved ${saved / 1000} KB`);
+        const saved = code.length - result.code.length;
+        console.log(`minifying ${file} saved ${saved / 1000} KB`);
         this.push(result.code);
       }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "node --inspect-brk ./lighthouse-cli/index.js",
     "start": "node ./lighthouse-cli/index.js",
     "test": "yarn diff:sample-json && yarn lint --quiet && yarn unit && yarn type-check",
-    "test-bundle": "yarn smoke --runner bundle -j=1 --retries=2 dbw byte",
+    "test-bundle": "yarn smoke --runner bundle -j=1 --retries=2 dbw byte a11y",
     "test-clients": "jest \"clients/\"",
     "test-viewer": "yarn unit-viewer && jest lighthouse-viewer/test/viewer-test-pptr.js",
     "test-lantern": "bash lighthouse-core/scripts/test-lantern.sh",


### PR DESCRIPTION
Saves ~32 KB in CDT bundle.

We did the same thing already for the viewer https://github.com/GoogleChrome/lighthouse/pull/9823, but the `build-bundle` never got the same treatment.

Here's what got trimmed:
```
minifying /Users/cjamcl/src/lighthouse/node_modules/axe-core/axe.min.js. saved 3.195 KB
minifying /Users/cjamcl/src/lighthouse/node_modules/js-library-detector/library/libraries.js. saved 26.963 KB
```

`axe.min.js` is quite big, and surfaced the fact that `minifyFileTransform` only worked if the amount of code fits in w/e Node decides to be the chunk size in the file streaming. Had to fix that.