### PR TITLE
docs(auth): add setCookie example

### DIFF
--- a/docs/authenticated-pages.md
+++ b/docs/authenticated-pages.md
@@ -4,13 +4,11 @@ Default runs of Lighthouse load a page as a "new user", with no previous session
 
 ## Option 1: Script the login with Puppeteer
 
-[Puppeteer](https://pptr.dev) is the most flexible approach for running Lighthouse on pages requiring authentication. 
+[Puppeteer](https://pptr.dev) is the most flexible approach for running Lighthouse on pages requiring authentication.
 
 See [a working demo at /docs/recipes/auth](./recipes/auth).
 
 View our full documentation for using [Lighthouse along with Puppeteer](https://github.com/GoogleChrome/lighthouse/blob/master/docs/puppeteer.md).
-
-You may want to use Puppeteer's [`page.setCookie`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetcookiecookies).
 
 ## Option 2: Leverage logged-in state with Chrome DevTools
 
@@ -32,7 +30,7 @@ const result = await lighthouse('http://www.example.com', {
 });
 ```
 
-You could also set the `Cookie` header, but beware: it will [override any other Cookies you expect to be there](https://github.com/GoogleChrome/lighthouse/pull/9170).
+You could also set the `Cookie` header, but beware: it will [override any other Cookies you expect to be there](https://github.com/GoogleChrome/lighthouse/pull/9170). For a more flexible cookie-based approach, use [puppeteer (Option 1)](./recipes/auth/README.md) instead.
 
 ## Option 4: Open a debug instance of Chrome and manually log in
 

--- a/docs/puppeteer.md
+++ b/docs/puppeteer.md
@@ -1,5 +1,13 @@
 # Using Puppeteer with Lighthouse
 
+## Recipes
+
+### [Using Puppeteer for authenticated pages](./recipes/auth/README.md)
+
+### [Using Puppeteer in a custom gatherer](https://github.com/GoogleChrome/lighthouse/tree/master/docs/recipes/custom-gatherer-puppeteer)
+
+## General Process
+
 ### Option 1: Launch Chrome with Puppeteer and handoff to Lighthouse
 
 The example below shows how to inject CSS into the page before Lighthouse audits the page.
@@ -19,32 +27,16 @@ const browser = await puppeteer.launch({
   defaultViewport: null,
 });
 
-// Wait for Lighthouse to open url, then customize network conditions.
-// Note: this will re-establish these conditions when LH reloads the page. Think that's ok....
+// Wait for Lighthouse to open url, then inject our stylesheet.
 browser.on('targetchanged', async target => {
   const page = await target.page();
-
-  function addStyleContent(content) {
-    const style = document.createElement('style');
-    style.type = 'text/css';
-    style.appendChild(document.createTextNode(content));
-    document.head.appendChild(style);
-  }
-
-  const css = '* {color: red}';
-
   if (page && page.url() === url) {
-    // Note: can't use page.addStyleTag due to github.com/GoogleChrome/puppeteer/issues/1955.
-    // Do it ourselves.
-    const client = await page.target().createCDPSession();
-    await client.send('Runtime.evaluate', {
-      expression: `(${addStyleContent.toString()})('${css}')`
-    });
+    await page.addStyleTag({content: '* {color: red}'});
   }
 });
 
-// Lighthouse will open URL. Puppeteer observes `targetchanged` and sets up network conditions.
-// Possible race condition.
+// Lighthouse will open the URL.
+// Puppeteer will observe `targetchanged` and inject our stylesheet.
 const {lhr} = await lighthouse(url, {
   port: (new URL(browser.wsEndpoint())).port,
   output: 'json',
@@ -97,9 +89,6 @@ await chrome.kill();
 
 })();
 ```
-
-### [Using Puppeteer in a custom gatherer](https://github.com/GoogleChrome/lighthouse/tree/master/docs/recipes/custom-gatherer-puppeteer)
-
 
 --------------
 

--- a/docs/recipes/auth/README.md
+++ b/docs/recipes/auth/README.md
@@ -116,7 +116,7 @@ node example-lh-auth.js # login via puppeteer and run lighthouse
 
 ### [`page.setCookie`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetcookiecookies)
 
-**NOTE:** We strongly recommend your tests use the above login flow. Only directly set the token like this as a last resort.
+**NOTE:** We strongly recommend your tests use the form-based login flow above instead. Only directly set the token like this as a last resort.
 
 If you don't have user credentials to login but you do have direct access to a token for authentication, you can instead directly set a cookie.
 

--- a/docs/recipes/auth/README.md
+++ b/docs/recipes/auth/README.md
@@ -111,3 +111,19 @@ All of the above is done in the example script. To run:
 # make sure server is running (see beginning of recipe) ...
 node example-lh-auth.js # login via puppeteer and run lighthouse
 ```
+
+## Alternatives
+
+### [`page.setCookie`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetcookiecookies)
+
+**NOTE:** We strongly recommend your tests use the above login flow. Only directly set the token like this as a last resort.
+
+If you don't have user credentials to login but you do have direct access to a token for authentication, you can instead directly set a cookie.
+
+```js
+await page.setCookie({
+  name: 'myAuthCookie',
+  value: '<auth token goes here>',
+  url: 'http://localhost:10632/dashboard',
+});
+```


### PR DESCRIPTION
**Summary**
Promised followup to #9170, adds a setCookie example and updates some of our pptr docs. @paulirish's prior PR #10277 did some of this already, so just a few more minor tweaks.

**Related Issues/PRs**
closes #11470 
