### PR TITLE
core(benchmarkindex): add workaround for Intel microcode fixes

### DIFF
--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -210,7 +210,11 @@ function computeBenchmarkIndex() {
     const start = Date.now();
     let iterations = 0;
 
-    while (Date.now() - start < 500) {
+    // Some Intel CPUs have a performance cliff due to unlucky JCC instruction alignment.
+    // Two possible fixes: call Date.now less often, or manually unroll the inner loop a bit.
+    // We'll call Date.now less and only check the duration on every 10th iteration for simplicity.
+    // See https://bugs.chromium.org/p/v8/issues/detail?id=10954#c1.
+    while (iterations % 10 !== 0 || Date.now() - start < 500) {
       const src = iterations % 2 === 0 ? arrA : arrB;
       const tgt = iterations % 2 === 0 ? arrB : arrA;
 


### PR DESCRIPTION
**Summary**
Another [v8 change](https://chromium.googlesource.com/v8/v8/+/5c0f7219bdb6793c4bb1f480f8ecce4acbb99139) introduced some unwanted variability into BenchmarkIndex. It doesn't actually affect our use case because the first 2-5 runs of BenchmarkIndex were unaffected (and ours is always just the first), but it's worth fixing and documenting if anyone ever wants to run this more frequently.

[Example page with this PR benchmark running](https://melodic-class.glitch.me/benchmark-nogc-fewer-datenow.html)

[Example page with master branch's benchmark running](https://melodic-class.glitch.me/benchmark-nogc.html)

(use Chrome Canary to see the stark difference) 

**Related Issues/PRs**
[crbug](https://bugs.chromium.org/p/v8/issues/detail?id=10954)
