### PR TITLE
i18n: remove incorrect aliases

### DIFF
--- a/lighthouse-core/lib/i18n/locales.js
+++ b/lighthouse-core/lib/i18n/locales.js
@@ -35,7 +35,6 @@ const locales = {
   'ar-XB': require('./locales/ar-XB.json'), // psuedolocalization
   'ar': require('./locales/ar.json'),
   'bg': require('./locales/bg.json'),
-  'bs': require('./locales/hr.json'), // Alias of 'hr'
   'ca': require('./locales/ca.json'),
   'cs': require('./locales/cs.json'),
   'da': require('./locales/da.json'),
@@ -83,7 +82,6 @@ const locales = {
   'iw': require('./locales/he.json'), // Alias of 'he'
   'ja': require('./locales/ja.json'),
   'ko': require('./locales/ko.json'),
-  'ln': require('./locales/fr.json'), // Alias of 'fr'
   'lt': require('./locales/lt.json'),
   'lv': require('./locales/lv.json'),
   'mo': require('./locales/ro.json'), // Alias of 'ro'

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -93,7 +93,7 @@ declare global {
       serverResponseTimeByOrigin: {[origin: string]: number};
     }
 
-    export type Locale = 'en-US'|'en'|'en-AU'|'en-GB'|'en-IE'|'en-SG'|'en-ZA'|'en-IN'|'ar-XB'|'ar'|'bg'|'bs'|'ca'|'cs'|'da'|'de'|'el'|'en-XA'|'en-XL'|'es'|'es-419'|'es-AR'|'es-BO'|'es-BR'|'es-BZ'|'es-CL'|'es-CO'|'es-CR'|'es-CU'|'es-DO'|'es-EC'|'es-GT'|'es-HN'|'es-MX'|'es-NI'|'es-PA'|'es-PE'|'es-PR'|'es-PY'|'es-SV'|'es-US'|'es-UY'|'es-VE'|'fi'|'fil'|'fr'|'he'|'hi'|'hr'|'hu'|'gsw'|'id'|'in'|'it'|'iw'|'ja'|'ko'|'ln'|'lt'|'lv'|'mo'|'nl'|'nb'|'no'|'pl'|'pt'|'pt-PT'|'ro'|'ru'|'sk'|'sl'|'sr'|'sr-Latn'|'sv'|'ta'|'te'|'th'|'tl'|'tr'|'uk'|'vi'|'zh'|'zh-HK'|'zh-TW';
+    export type Locale = 'en-US'|'en'|'en-AU'|'en-GB'|'en-IE'|'en-SG'|'en-ZA'|'en-IN'|'ar-XB'|'ar'|'bg'|'ca'|'cs'|'da'|'de'|'el'|'en-XA'|'en-XL'|'es'|'es-419'|'es-AR'|'es-BO'|'es-BR'|'es-BZ'|'es-CL'|'es-CO'|'es-CR'|'es-CU'|'es-DO'|'es-EC'|'es-GT'|'es-HN'|'es-MX'|'es-NI'|'es-PA'|'es-PE'|'es-PR'|'es-PY'|'es-SV'|'es-US'|'es-UY'|'es-VE'|'fi'|'fil'|'fr'|'he'|'hi'|'hr'|'hu'|'gsw'|'id'|'in'|'it'|'iw'|'ja'|'ko'|'lt'|'lv'|'mo'|'nl'|'nb'|'no'|'pl'|'pt'|'pt-PT'|'ro'|'ru'|'sk'|'sl'|'sr'|'sr-Latn'|'sv'|'ta'|'te'|'th'|'tl'|'tr'|'uk'|'vi'|'zh'|'zh-HK'|'zh-TW';
 
     export type OutputMode = 'json' | 'html' | 'csv';
 


### PR DESCRIPTION
bosnian and croatian are not aliases

https://unicode-org.github.io/cldr-staging/charts/37/supplemental/aliases.html

and [lingala](https://en.wikipedia.org/wiki/Lingala) isn't french.

----------

update: i'm still happy with these changes but this doc is fascinating. https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_matching.html

too bad a matching algorithm isn't available to us.