### PR TITLE
docs(configuration): update some wording of the "extends" property

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,9 +46,11 @@ lighthouse('https://example.com/', {port: 9222}, config);
 | categories | <code>Object&#124;undefined</code> |
 | groups | <code>Object&#124;undefined</code> |
 
-### `extends: string|boolean|undefined`
+### `extends: "lighthouse:default"|boolean|undefined`
 
-The extends property controls if your configuration should inherit from the default Lighthouse configuration. [Learn more.](#config-extension)
+The `extends` property controls if your configuration should inherit from the default Lighthouse configuration. [Learn more.](#config-extension)
+
+Both the values `"lighthouse:default"` and `true` will enable inheritance, while `false` and `undefined` will not.
 
 #### Example
 ```js
@@ -197,7 +199,7 @@ The groups property controls how to visually group audits within a category. For
 
 The stock Lighthouse configurations can be extended if you only need to make small tweaks, such as adding an audit or skipping an audit, but wish to still run most of what Lighthouse offers. When adding the `extends: 'lighthouse:default'` property to your config, the default passes, audits, groups, and categories will be automatically included, allowing you modify settings or add additional audits to a pass.
 
-Please note that you can only extend from `lighthouse:default` using the `extends` property. Other internal configs found in the [lighthouse-core/config](https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/config) directory can be used by importing the config object from file reference, or by using the [`--preset`](https://github.com/GoogleChrome/lighthouse#cli-options) CLI flag.
+Please note that the `extends` property only allows extension of `lighthouse:default`. Other internal configs found in the [lighthouse-core/config](https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/config) directory can be used by importing the config object from file reference, or by using the [`--preset`](https://github.com/GoogleChrome/lighthouse#cli-options) CLI flag.
 
 See [more examples below](#more-examples) to view different types of extensions in action.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,7 +199,7 @@ The groups property controls how to visually group audits within a category. For
 
 The stock Lighthouse configurations can be extended if you only need to make small tweaks, such as adding an audit or skipping an audit, but wish to still run most of what Lighthouse offers. When adding the `extends: 'lighthouse:default'` property to your config, the default passes, audits, groups, and categories will be automatically included, allowing you modify settings or add additional audits to a pass.
 
-Please note that the `extends` property only allows extension of `lighthouse:default`. Other internal configs found in the [lighthouse-core/config](https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/config) directory can be used by importing the config object from file reference, or by using the [`--preset`](https://github.com/GoogleChrome/lighthouse#cli-options) CLI flag.
+Please note that the `extends` property only supports extension of `lighthouse:default`. Other internal configs found in the [lighthouse-core/config](https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/config) directory can be used by importing the config object from file reference, or by using the [`--preset`](https://github.com/GoogleChrome/lighthouse#cli-options) CLI flag.
 
 See [more examples below](#more-examples) to view different types of extensions in action.
 


### PR DESCRIPTION
From my understanding of this documentation, there is a little bit more clarity which could be offered by different wording.

<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

This change tweaks the wording and the type definition around the `extends` property of the configuration to explain exactly which values are allowed.

<!-- Describe the need for this change -->

I feel that this could be useful since I am currently investigating some issues in a deployment of lighthouse and it was not particularly clear to me if our extension was valid or not at a glance.

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->

I based this on some information I saw in #7344, including [a response](https://github.com/GoogleChrome/lighthouse/issues/7344#issuecomment-468067961_) on that issue.

There is also the (type definition)[/types/config.d.ts]. I'm trying to find the code handling this to see if any other string does have a real value or not.