### PR TITLE
core(driver): recover from PROTOCOL_TIMEOUT in void calls

### DIFF
--- a/lighthouse-core/gather/fetcher.js
+++ b/lighthouse-core/gather/fetcher.js
@@ -45,7 +45,7 @@ class Fetcher {
     if (this._enabled) return;
 
     this._enabled = true;
-    await this.driver.sendCommand('Fetch.enable', {
+    await this.driver.sendVoidCommand('Fetch.enable', {
       patterns: [{requestStage: 'Request'}, {requestStage: 'Response'}],
     });
     await this.driver.on('Fetch.requestPaused', this._onRequestPaused);
@@ -56,7 +56,7 @@ class Fetcher {
 
     this._enabled = false;
     await this.driver.off('Fetch.requestPaused', this._onRequestPaused);
-    await this.driver.sendCommand('Fetch.disable');
+    await this.driver.sendVoidCommand('Fetch.disable');
     this._onRequestPausedHandlers.clear();
   }
 

--- a/lighthouse-core/gather/gatherers/anchor-elements.js
+++ b/lighthouse-core/gather/gatherers/anchor-elements.js
@@ -104,10 +104,10 @@ class AnchorElements extends Gatherer {
 
     /** @type {LH.Artifacts['AnchorElements']} */
     const anchors = await driver.evaluateAsync(expression, {useIsolation: true});
-    await driver.sendCommand('DOM.enable');
+    await driver.sendVoidCommand('DOM.enable');
 
     // DOM.getDocument is necessary for pushNodesByBackendIdsToFrontend to properly retrieve nodeIds if the `DOM` domain was enabled before this gatherer, invoke it to be safe.
-    await driver.sendCommand('DOM.getDocument', {depth: -1, pierce: true});
+    await driver.sendVoidCommand('DOM.getDocument', {depth: -1, pierce: true});
     const anchorsWithEventListeners = anchors.map(async anchor => {
       const listeners = await getEventListeners(driver, anchor.devtoolsNodePath);
 
@@ -118,7 +118,7 @@ class AnchorElements extends Gatherer {
     });
 
     const result = await Promise.all(anchorsWithEventListeners);
-    await driver.sendCommand('DOM.disable');
+    await driver.sendVoidCommand('DOM.disable');
     return result;
   }
 }

--- a/lighthouse-core/gather/gatherers/console-messages.js
+++ b/lighthouse-core/gather/gatherers/console-messages.js
@@ -33,8 +33,8 @@ class ConsoleMessages extends Gatherer {
   async beforePass(passContext) {
     const driver = passContext.driver;
     driver.on('Log.entryAdded', this._onConsoleEntryAdded);
-    await driver.sendCommand('Log.enable');
-    await driver.sendCommand('Log.startViolationsReport', {
+    await driver.sendVoidCommand('Log.enable');
+    await driver.sendVoidCommand('Log.startViolationsReport', {
       config: [{name: 'discouragedAPIUse', threshold: -1}],
     });
   }
@@ -44,9 +44,9 @@ class ConsoleMessages extends Gatherer {
    * @return {Promise<LH.Artifacts['ConsoleMessages']>}
    */
   async afterPass(passContext) {
-    await passContext.driver.sendCommand('Log.stopViolationsReport');
+    await passContext.driver.sendVoidCommand('Log.stopViolationsReport');
     await passContext.driver.off('Log.entryAdded', this._onConsoleEntryAdded);
-    await passContext.driver.sendCommand('Log.disable');
+    await passContext.driver.sendVoidCommand('Log.disable');
     return this._logEntries;
   }
 }

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -24,9 +24,9 @@ class CSSUsage extends Gatherer {
     const onStylesheetAdded = sheet => stylesheets.push(sheet);
     driver.on('CSS.styleSheetAdded', onStylesheetAdded);
 
-    await driver.sendCommand('DOM.enable');
-    await driver.sendCommand('CSS.enable');
-    await driver.sendCommand('CSS.startRuleUsageTracking');
+    await driver.sendVoidCommand('DOM.enable');
+    await driver.sendVoidCommand('CSS.enable');
+    await driver.sendVoidCommand('CSS.startRuleUsageTracking');
     await driver.evaluateAsync('getComputedStyle(document.body)');
     driver.off('CSS.styleSheetAdded', onStylesheetAdded);
 
@@ -43,8 +43,8 @@ class CSSUsage extends Gatherer {
     const styleSheetInfo = await Promise.all(promises);
 
     const ruleUsageResponse = await driver.sendCommand('CSS.stopRuleUsageTracking');
-    await driver.sendCommand('CSS.disable');
-    await driver.sendCommand('DOM.disable');
+    await driver.sendVoidCommand('CSS.disable');
+    await driver.sendVoidCommand('DOM.disable');
 
     const dedupedStylesheets = new Map(styleSheetInfo.map(sheet => {
       return /** @type {[string, LH.Artifacts.CSSStyleSheetInfo]} */ ([sheet.content, sheet]);

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -59,6 +59,11 @@ const UIStrings = {
    * @example {Network.enable} protocolMethod
    * */
   protocolTimeout: 'Waiting for DevTools protocol response has exceeded the allotted time. (Method: {protocolMethod})',
+  /**
+   * @description Error message explaining that Chrome has stopped responding to protocol messages.
+   * @example {Network.enable} protocolMethod
+   * */
+  chromeNotResponding: 'Waiting for DevTools protocol response has exceeded the allotted time. (Method: {protocolMethod})',
   /** Error message explaining that the requested page could not be resolved by the DNS server. */
   dnsFailure: 'DNS servers could not resolve the provided domain.',
   /** Error message explaining that Lighthouse couldn't complete because the page has stopped responding to its instructions. */
@@ -360,11 +365,20 @@ const ERRORS = {
     message: UIStrings.urlInvalid,
   },
 
-  /* Protocol timeout failures
+  /* Protocol timeout failures for a single specific command.
+   * Most instances of this error are recoverable.
    * Requires an additional `protocolMethod` field for translation.
    */
   PROTOCOL_TIMEOUT: {
     code: 'PROTOCOL_TIMEOUT',
+    message: UIStrings.protocolTimeout,
+    lhrRuntimeError: true,
+  },
+  /* Protocol timeout failures that mean Chrome has hung and there's nothing Lighthouse can do to recover.
+   * Requires an additional `protocolMethod` field for translation.
+   */
+  CHROME_NOT_RESPONDING: {
+    code: 'CHROME_NOT_RESPONDING',
     message: UIStrings.protocolTimeout,
     lhrRuntimeError: true,
   },


### PR DESCRIPTION

**Summary**
A radical change, but one that might solve *most* of our PROTOCOL_TIMEOUT problems. Basically when we are sending Chrome a command but we don't care about the result, recover from any protocol timeouts and just keep going if Chrome still seems to be responding. Tradeoff here is that we don't know for sure whether Chrome just didn't reply to us and did what we asked it to or if it really failed to do what we asked and future results will be unexpected. Given the type of methods that frequently appear in #6512, I suspect getting *a* report would still work and be much preferred to nonsense fatal errors, but I could be wrong and this might not be worth it.

Thoughts?

**Related Issues/PRs**
fixes #6512 
