### PR TITLE
misc: add chromium webtests to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -31,6 +31,8 @@ timings-data/
 # ignore all folders named as such
 node_modules
 latest-run
+chromium-webtests
+.tmp
 
 # generated files
 **/pages/scripts/lighthouse-report.js


### PR DESCRIPTION
**Summary**
Our shiny new chromium webtests accidentally got included in our npm bundle :) I don't know if this is worthy of a 6.4.1 all by itself since installing all our dependencies takes *15 GB*, but nice to get in for sure.

**Before**
```bash
$ pkgfiles
PKGFILES SUMMARY
Size on Disk with Dependencies  ~15 GB
Size with Dependencies          ~14.7 GB
Publishable Size                ~64.4 MB
Number of Directories           1056
Number of Files                 5773
```


**After**
```bash
$ pkgfiles
PKGFILES SUMMARY
Size on Disk with Dependencies  ~15 GB
Size with Dependencies          ~14.7 GB
Publishable Size                ~16.7 MB
Number of Directories           100
Number of Files                 633
```

**Related Issues/PRs**
fixes #11511 


