### PR TITLE
tests: add tests for networkRecordsToDevtoolsLog

### DIFF
--- a/lighthouse-core/test/network-records-to-devtools-log-test.js
+++ b/lighthouse-core/test/network-records-to-devtools-log-test.js
@@ -1,0 +1,63 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const NetworkRecorder = require('../../lighthouse-core/lib/network-recorder.js');
+const networkRecordsToDevtoolsLog = require('./network-records-to-devtools-log.js');
+const lcpDevtoolsLog = require('./fixtures/traces/lcp-m78.devtools.log.json');
+
+describe('networkRecordsToDevtoolsLog', () => {
+  it('should generate the four messages per request', () => {
+    const records = [{url: 'http://example.com'}];
+    const log = networkRecordsToDevtoolsLog(records);
+    expect(log).toMatchObject([
+      {method: 'Network.requestWillBeSent', params: {request: {url: 'http://example.com'}}},
+      {method: 'Network.responseReceived', params: {response: {url: 'http://example.com'}}},
+      {method: 'Network.dataReceived'},
+      {method: 'Network.loadingFinished'},
+    ]);
+  });
+
+  it('should set resource and transfer sizes', () => {
+    const records = [{url: 'http://example.com', resourceSize: 1024, transferSize: 2048}];
+    const log = networkRecordsToDevtoolsLog(records);
+    expect(log).toMatchObject([
+      {method: 'Network.requestWillBeSent', params: {request: {url: 'http://example.com'}}},
+      {method: 'Network.responseReceived', params: {response: {url: 'http://example.com'}}},
+      {method: 'Network.dataReceived', params: {dataLength: 1024, encodedDataLength: 2048}},
+      {method: 'Network.loadingFinished', params: {encodedDataLength: 2048}},
+    ]);
+  });
+
+  it('should handle redirects', () => {
+    const records = [
+      {requestId: '0', url: 'http://example.com/'},
+      {requestId: '0:redirect', url: 'http://www.example.com/'},
+    ];
+
+    const log = networkRecordsToDevtoolsLog(records);
+    expect(log).toMatchObject([
+      {method: 'Network.requestWillBeSent', params: {request: {url: 'http://example.com/'}}},
+      {method: 'Network.requestWillBeSent', params: {request: {url: 'http://www.example.com/'}}},
+      {method: 'Network.responseReceived', params: {response: {url: 'http://www.example.com/'}}},
+      {method: 'Network.dataReceived'},
+      {method: 'Network.loadingFinished'},
+    ]);
+  });
+
+  it('should roundtrip a real devtools log properly', () => {
+    const records = NetworkRecorder.recordsFromLogs(lcpDevtoolsLog);
+
+    // Skip verification in the method because we have circular references.
+    // We'll do our own stricter verification.
+    const roundTripLogs = networkRecordsToDevtoolsLog(records, {skipVerification: true});
+    const roundTripRecords = NetworkRecorder.recordsFromLogs(roundTripLogs);
+
+    expect(roundTripRecords).toEqual(records);
+  });
+});

--- a/lighthouse-core/test/network-records-to-devtools-log.js
+++ b/lighthouse-core/test/network-records-to-devtools-log.js
@@ -190,10 +190,11 @@ function addRedirectResponseIfNeeded(networkRecords, record) {
   // populate `redirectResponse` with original's data, more or less.
   const originalResponse = getResponseReceivedEvent(originalRecord).params.response;
   originalResponse.status = originalRecord.statusCode || 302;
-  return Object.assign({}, record, {
+  return {
+    ...record,
     redirectResponseTimestamp: originalRecord.endTime,
     redirectResponse: originalResponse,
-  });
+  };
 }
 
 /**

--- a/lighthouse-core/test/network-records-to-devtools-log.js
+++ b/lighthouse-core/test/network-records-to-devtools-log.js
@@ -63,12 +63,25 @@ function getRequestWillBeSentEvent(networkRecord, index) {
         initialPriority: networkRecord.priority || 'Low',
         isLinkPreload: networkRecord.isLinkPreload,
       },
-      timestamp: networkRecord.startTime || 0,
+      timestamp: networkRecord.redirectResponseTimestamp || networkRecord.startTime || 0,
       wallTime: 0,
       initiator: initiator || {type: 'other'},
       type: networkRecord.resourceType || 'Document',
       frameId: networkRecord.frameId || `${idBase}.1`,
       redirectResponse: networkRecord.redirectResponse,
+    },
+  };
+}
+
+/**
+ * @param {Partial<NetworkRequest>} networkRecord
+ * @return {LH.Protocol.RawEventMessage}
+ */
+function getRequestServedFromCacheEvent(networkRecord, index) {
+  return {
+    method: 'Network.requestServedFromCache',
+    params: {
+      requestId: getBaseRequestId(networkRecord) || `${idBase}.${index}`,
     },
   };
 }
@@ -97,11 +110,11 @@ function getResponseReceivedEvent(networkRecord, index) {
         url: networkRecord.url || exampleUrl,
         status: networkRecord.statusCode || 200,
         headers,
-        mimeType: networkRecord.mimeType || 'text/html',
+        mimeType: typeof networkRecord.mimeType === 'string' ? networkRecord.mimeType : 'text/html',
         connectionReused: networkRecord.connectionReused || false,
         connectionId: networkRecord.connectionId || 140,
-        fromDiskCache: networkRecord.fromDiskCache || undefined,
-        fromServiceWorker: networkRecord.fetchedViaServiceWorker || undefined,
+        fromDiskCache: networkRecord.fromDiskCache || false,
+        fromServiceWorker: networkRecord.fetchedViaServiceWorker || false,
         encodedDataLength: networkRecord.transferSize || 0,
         timing,
         protocol: networkRecord.protocol || 'http/1.1',
@@ -177,7 +190,10 @@ function addRedirectResponseIfNeeded(networkRecords, record) {
   // populate `redirectResponse` with original's data, more or less.
   const originalResponse = getResponseReceivedEvent(originalRecord).params.response;
   originalResponse.status = originalRecord.statusCode || 302;
-  return Object.assign({}, record, {redirectResponse: originalResponse});
+  return Object.assign({}, record, {
+    redirectResponseTimestamp: originalRecord.endTime,
+    redirectResponse: originalResponse,
+  });
 }
 
 /**
@@ -199,6 +215,10 @@ function networkRecordsToDevtoolsLog(networkRecords, options = {}) {
     if (willBeRedirected(networkRecords, networkRecord)) {
       // If record is going to redirect, only issue the first event.
       return;
+    }
+
+    if (networkRecord.fromMemoryCache) {
+      devtoolsLog.push(getRequestServedFromCacheEvent(networkRecord, index));
     }
 
     devtoolsLog.push(getResponseReceivedEvent(networkRecord, index));


### PR DESCRIPTION
**Summary**
While chasing down the test issues that plagued #11410 it turned out to be a problem with how redirects were expressed in those tests (and the fact that they didn't gel with our `networkRecordsToDevtoolsLog`). I went hunting for how `networkRecordsToDevtoolsLog` did the redirects and realized we didn't have explicit tests since we do the autoverification (which is awesome feature), but thought it was a good time to add a few explicit examples.

**Related Issues/PRs**
ref #11410 
ref #11408 
