### PR TITLE
tests: reset smoke transferSize expectations to reality

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -290,7 +290,7 @@ const expectations = [
               },
               {
                 url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
-                transferSize: '1100 +/- 100',
+                transferSize: '1200 +/- 150',
                 resourceSize: '53000 +/- 1000',
                 finished: true,
               },

--- a/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-config.js
@@ -14,6 +14,11 @@ module.exports = {
     // This test runs in CI and hits the outside network of a live site.
     // Be a little more forgiving on how long it takes all network requests of several nested iframes
     // to complete.
-    maxWaitForLoad: 90000,
+    maxWaitForLoad: 180000,
   },
+  passes: [
+    // CI machines are pretty weak which lead to many more long tasks than normal.
+    // Reduce our requirement for CPU quiet.
+    {cpuQuietThresholdMs: 500},
+  ],
 };

--- a/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-config.js
@@ -6,6 +6,7 @@
 'use strict';
 
 /**
+ * @type {LH.Config.Json}
  * Config file for running the OOPIF tests
  */
 module.exports = {
@@ -19,6 +20,9 @@ module.exports = {
   passes: [
     // CI machines are pretty weak which lead to many more long tasks than normal.
     // Reduce our requirement for CPU quiet.
-    {cpuQuietThresholdMs: 500},
+    {
+      passName: 'defaultPass',
+      cpuQuietThresholdMs: 500,
+    },
   ],
 };

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -72,7 +72,7 @@ module.exports = [
           details: {
             items: [
               {resourceType: 'total', requestCount: 10, transferSize: '168000±1000'},
-              {resourceType: 'font', requestCount: 2, transferSize: '80000±1000'},
+              {resourceType: 'font', requestCount: 2, transferSize: '81000±1000'},
               {resourceType: 'script', requestCount: 3, transferSize: '55000±1000'},
               {resourceType: 'image', requestCount: 2, transferSize: '28000±1000'},
               {resourceType: 'document', requestCount: 1, transferSize: '2200±100'},


### PR DESCRIPTION
**Summary**
Some of the smokes have been failing the byte expectations on node 12 and pulling them up in DevTools it appears that the expectations even on node 10 were a little close to the edge already.

Also tweaked the CPU timeout because we keep hitting that in travis and we don't care about CPU activity in that smoketest at all.

![image](https://user-images.githubusercontent.com/2301202/95390100-754f4280-08ba-11eb-8af3-024f176d9b53.png)

![image](https://user-images.githubusercontent.com/2301202/95390116-7ed8aa80-08ba-11eb-9fcd-40f42bbbb1ca.png)

This should pass every CI check we have 🤞 
