### PR TITLE
core: mailto: anchor with window.open onclick is crawlable

### DIFF
--- a/lighthouse-core/audits/seo/crawlable-anchors.js
+++ b/lighthouse-core/audits/seo/crawlable-anchors.js
@@ -53,6 +53,7 @@ class CrawlableAnchors extends Audit {
       role = role.trim();
 
       if (role.length > 0) return;
+      if (rawHref.startsWith('mailto:')) return;
 
       const windowLocationRegExp = /window\.location=/;
       const windowOpenRegExp = /window\.open\(/;

--- a/lighthouse-core/audits/seo/crawlable-anchors.js
+++ b/lighthouse-core/audits/seo/crawlable-anchors.js
@@ -53,6 +53,7 @@ class CrawlableAnchors extends Audit {
       role = role.trim();
 
       if (role.length > 0) return;
+      // Ignore mailto links even if they use one of the failing patterns. See https://github.com/GoogleChrome/lighthouse/issues/11443#issuecomment-694898412
       if (rawHref.startsWith('mailto:')) return;
 
       const windowLocationRegExp = /window\.location=/;

--- a/lighthouse-core/test/audits/seo/crawlable-anchors-test.js
+++ b/lighthouse-core/test/audits/seo/crawlable-anchors-test.js
@@ -153,7 +153,7 @@ describe('SEO: Crawlable anchors audit', () => {
     }
   });
 
-  it('handles window.open in an onclick attribute and mailto: in href attribute', () => {
+  it('handles window.open in an onclick attribute and mailto: in a href attribute', () => {
     assert.equal(
         runAudit({rawHref: 'mailto:name@example.com', onclick: 'window.open()'}),
         1,

--- a/lighthouse-core/test/audits/seo/crawlable-anchors-test.js
+++ b/lighthouse-core/test/audits/seo/crawlable-anchors-test.js
@@ -152,4 +152,12 @@ describe('SEO: Crawlable anchors audit', () => {
       assert.equal(auditResult, 1, `'${onclickVariation}' should pass the audit`);
     }
   });
+
+  it('handles window.open in an onclick attribute and mailto: in href attribute', () => {
+    assert.equal(
+        runAudit({rawHref: 'mailto:name@example.com', onclick: 'window.open()'}),
+        1,
+        'window.open in an onclick and mailto: in a href is a pass'
+    );
+  });
 });


### PR DESCRIPTION
**Summary**
An anchor with `window.open` in an onclick attribute and `mailto:` in a href attribute should be crawlable.

<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
fixes https://github.com/GoogleChrome/lighthouse/issues/11443