### PR TITLE
core(tracehouse): improve CPU profiler timing refinement

### DIFF
--- a/lighthouse-core/lib/tracehouse/cpu-profile-model.js
+++ b/lighthouse-core/lib/tracehouse/cpu-profile-model.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const MainThreadTasks = require('./main-thread-tasks.js');
+
 /**
  * @fileoverview
  *
@@ -108,22 +110,28 @@ class CpuProfilerModel {
 
   /**
    * Generates the necessary B/E-style trace events for a single transition from stack A to stack B
-   * at the given timestamp.
+   * at the given latest timestamp (includes possible range in event.args.data).
    *
    * Example:
    *
-   *    timestamp 1234
+   *    latestPossibleTimestamp 1234
    *    previousNodeIds 1,2,3
    *    currentNodeIds 1,2,4
    *
    *    yields [end 3 at ts 1234, begin 4 at ts 1234]
    *
-   * @param {number} timestamp
+   * @param {number} earliestPossibleTimestamp
+   * @param {number} latestPossibleTimestamp
    * @param {Array<number>} previousNodeIds
    * @param {Array<number>} currentNodeIds
    * @return {Array<LH.TraceEvent>}
    */
-  _synthesizeTraceEventsForTransition(timestamp, previousNodeIds, currentNodeIds) {
+  _synthesizeTraceEventsForTransition(
+      earliestPossibleTimestamp,
+      latestPossibleTimestamp,
+      previousNodeIds,
+      currentNodeIds
+  ) {
     const startNodes = currentNodeIds
       .filter(id => !previousNodeIds.includes(id))
       .map(id => this._nodesById.get(id))
@@ -135,7 +143,9 @@ class CpuProfilerModel {
 
     /** @param {CpuProfile['nodes'][0]} node @return {LH.TraceEvent} */
     const createSyntheticEvent = node => ({
-      ts: timestamp,
+      ts: Number.isFinite(latestPossibleTimestamp)
+        ? latestPossibleTimestamp
+        : earliestPossibleTimestamp,
       pid: this._profile.pid,
       tid: this._profile.tid,
       dur: 0,
@@ -144,13 +154,19 @@ class CpuProfilerModel {
       // Attribution logic in main-thread-tasks.js special cases this event.
       name: 'FunctionCall-SynthesizedByProfilerModel',
       cat: 'lighthouse',
-      args: {data: {callFrame: node.callFrame}},
+      args: {
+        data: {
+          callFrame: node.callFrame,
+          _syntheticProfilerRange: {earliestPossibleTimestamp, latestPossibleTimestamp},
+        },
+      },
     });
 
     /** @type {Array<LH.TraceEvent>} */
     const startEvents = startNodes.map(createSyntheticEvent).map(evt => ({...evt, ph: 'B'}));
     /** @type {Array<LH.TraceEvent>} */
     const endEvents = endNodes.map(createSyntheticEvent).map(evt => ({...evt, ph: 'E'}));
+    // Ensure we put end events in first to finish prior tasks before starting new ones.
     return [...endEvents.reverse(), ...startEvents];
   }
 
@@ -165,9 +181,17 @@ class CpuProfilerModel {
   static _getTasksInRange(knownTasks, options) {
     const {type, initialIndex, earliestPossibleTimestamp, latestPossibleTimestamp} = options;
 
+    // We may have overshot a little from last time, so back up to find the real starting index.
+    let startIndex = initialIndex;
+    while (startIndex > 0) {
+      const task = knownTasks[startIndex];
+      if (task && task[type] < earliestPossibleTimestamp) break;
+      startIndex--;
+    }
+
     /** @type {Array<{startTime: number, endTime: number}>} */
     const matchingTasks = [];
-    for (let i = initialIndex; i < knownTasks.length; i++) {
+    for (let i = startIndex; i < knownTasks.length; i++) {
       const task = knownTasks[i];
       // Task is before our range of interest, keep looping.
       if (task[type] < earliestPossibleTimestamp) continue;
@@ -181,7 +205,15 @@ class CpuProfilerModel {
       matchingTasks.push(task);
     }
 
-    return {tasks: matchingTasks, lastIndex: knownTasks.length};
+    // We went through all tasks before reaching the end of our range.
+    return {tasks: matchingTasks, lastIndex: knownTasks.length - 1};
+  }
+
+  /** @param {LH.TraceEvent} event */
+  static _getTimestampRange(event) {
+    const profilerRange = event.args.data && event.args.data._syntheticProfilerRange;
+    if (!profilerRange) throw new Error('Impossible - all synthetic events have range');
+    return profilerRange;
   }
 
   /**
@@ -193,26 +225,34 @@ class CpuProfilerModel {
    * range. For example, if we know that a function ended between 800ms and 810ms, we can use the
    * knowledge that a toplevel task ended at 807ms to use 807ms as the correct endtime for this function.
    *
-   * @param {{earliestPossibleTimestamp: number, latestPossibleTimestamp: number, knownTaskStartTimeIndex: number, knownTaskEndTimeIndex: number, knownTasksByStartTime: Array<{startTime: number, endTime: number}>, knownTasksByEndTime: Array<{startTime: number, endTime: number}>}} data
+   * @param {{syntheticTask: LH.Artifacts.TaskNode, eventType: 'start'|'end', allEventsAtTs: {naive: Array<LH.TraceEvent>, refined: Array<LH.TraceEvent>}, knownTaskStartTimeIndex: number, knownTaskEndTimeIndex: number, knownTasksByStartTime: Array<{startTime: number, endTime: number}>, knownTasksByEndTime: Array<{startTime: number, endTime: number}>}} data
    * @return {{timestamp: number, lastStartTimeIndex: number, lastEndTimeIndex: number}}
    */
   static _findEffectiveTimestamp(data) {
     const {
-      earliestPossibleTimestamp,
-      latestPossibleTimestamp,
+      eventType,
+      syntheticTask,
+      allEventsAtTs,
       knownTasksByStartTime,
       knownTaskStartTimeIndex,
       knownTasksByEndTime,
       knownTaskEndTimeIndex,
     } = data;
 
+    const targetEvent = eventType === 'start' ? syntheticTask.event : syntheticTask.endEvent;
+    const pairEvent = eventType === 'start' ? syntheticTask.endEvent : syntheticTask.event;
+    if (!targetEvent || !pairEvent) throw new Error('Impossible - synthetic tasks are B/E pair');
+
+    const timeRange = CpuProfilerModel._getTimestampRange(targetEvent);
+    const pairTimeRange = CpuProfilerModel._getTimestampRange(pairEvent);
+
     const {tasks: knownTasksStarting, lastIndex: lastStartTimeIndex} = this._getTasksInRange(
       knownTasksByStartTime,
       {
         type: 'startTime',
         initialIndex: knownTaskStartTimeIndex,
-        earliestPossibleTimestamp,
-        latestPossibleTimestamp,
+        earliestPossibleTimestamp: timeRange.earliestPossibleTimestamp,
+        latestPossibleTimestamp: timeRange.latestPossibleTimestamp,
       }
     );
 
@@ -221,8 +261,8 @@ class CpuProfilerModel {
       {
         type: 'endTime',
         initialIndex: knownTaskEndTimeIndex,
-        earliestPossibleTimestamp,
-        latestPossibleTimestamp,
+        earliestPossibleTimestamp: timeRange.earliestPossibleTimestamp,
+        latestPossibleTimestamp: timeRange.latestPossibleTimestamp,
       }
     );
 
@@ -232,44 +272,102 @@ class CpuProfilerModel {
     const knownTasksEndingNotContained = knownTasksEnding
       .filter(t => !knownTasksStarting.includes(t));
 
-    let effectiveTimestamp = latestPossibleTimestamp;
-    if (knownTasksStartingNotContained.length) {
-      // Tasks that started but did not finish take priority. Use the earliest of their timestamps.
-      effectiveTimestamp = Math.min(...knownTasksStartingNotContained.map(t => t.startTime));
-    } else if (knownTasksEndingNotContained.length) {
-      // Tasks that ended but did not start take next priority. Use the latest of their timestamps.
-      effectiveTimestamp = Math.max(...knownTasksEndingNotContained.map(t => t.endTime));
-    }
+    // Each one of these spanning tasks can be in one of three situations:
+    //    - Task is a parent of the sample.
+    //    - Task is a child of the sample.
+    //    - Task has no overlap with the sample.
+
+    // Parent tasks must satisfy...
+    //     knownTask.startTime <= syntheticTask.startTime
+    //                         AND
+    //     syntheticTask.endTime <= knownTask.endTime
+    const parentTasks =
+      eventType === 'start'
+        ? knownTasksStartingNotContained.filter(
+            t => t.endTime >= pairTimeRange.earliestPossibleTimestamp
+          )
+        : knownTasksEndingNotContained.filter(
+            t => t.startTime <= pairTimeRange.latestPossibleTimestamp
+          );
+
+    // Child tasks must satisfy...
+    //     syntheticTask.startTime <= knownTask.startTime
+    //                         AND
+    //     knownTask.endTime <= syntheticTask.endTime
+    const childTasks =
+      eventType === 'start'
+        ? knownTasksStartingNotContained.filter(
+            t => t.endTime < pairTimeRange.earliestPossibleTimestamp
+          )
+        : knownTasksEndingNotContained.filter(
+            t => t.startTime > pairTimeRange.latestPossibleTimestamp
+          );
+
+    // Unrelated tasks must satisfy...
+    //     knownTask.endTime <= syntheticTask.startTime
+    //                       OR
+    //     syntheticTask.endTime <= knownTask.startTime
+    const unrelatedTasks =
+          eventType === 'start' ? knownTasksEndingNotContained : knownTasksStartingNotContained;
+
+    // Now we narrow our allowable range using the three types of tasks and the other events
+    // that we've already refined.
+    const minimumTs = Math.max(
+      // Sampled event couldn't be earlier than this to begin with.
+      timeRange.earliestPossibleTimestamp,
+      // Sampled start event can't be before its parent started.
+      // Sampled end event can't be before its child ended.
+      ...(eventType === 'start'
+        ? parentTasks.map(t => t.startTime)
+        : childTasks.map(t => t.endTime)),
+      // Sampled start event can't be before unrelated tasks ended.
+      ...(eventType === 'start' ? unrelatedTasks.map(t => t.endTime) : []),
+      // Sampled start event can't be before the other `E` events at its same timestamp.
+      ...(eventType === 'start'
+        ? allEventsAtTs.refined.filter(e => e.ph === 'E').map(e => e.ts)
+        : [])
+    );
+
+    const maximumTs = Math.min(
+      // Sampled event couldn't be later than this to begin with.
+      timeRange.latestPossibleTimestamp,
+      // Sampled start event can't be after its child started.
+      // Sampled end event can't be after its parent ended.
+      ...(eventType === 'start'
+        ? childTasks.map(t => t.startTime)
+        : parentTasks.map(t => t.endTime)),
+      // Sampled end event can't be after unrelated tasks started.
+      ...(eventType === 'start' ? [] : unrelatedTasks.map(t => t.startTime))
+    );
+
+    // We want to maximize the size of the sampling tasks within our constraints, so we'll pick
+    // the _earliest_ possible time for start events and the _latest_ possible time for end events.
+    const effectiveTimestamp =
+      (eventType === 'start' && Number.isFinite(minimumTs)) || !Number.isFinite(maximumTs)
+        ? minimumTs
+        : maximumTs;
 
     return {timestamp: effectiveTimestamp, lastStartTimeIndex, lastEndTimeIndex};
   }
 
   /**
-   * Creates B/E-style trace events from a CpuProfile object created by `collectProfileEvents()`.
-   * An optional set of tasks can be passed in to refine the start/end times.
+   * Creates the B/E-style trace events using only data from the profile itself. Each B/E event will
+   * include the actual _range_ the timestamp could have been in its metadata that is used for
+   * refinement later.
    *
-   * With the sampling profiler we know that a function started/ended *sometime between* two points,
-   * but not exactly when. Using the information from other tasks gives us more information to be
-   * more precise with timings and allows us to create a valid task tree later on.
-   *
-   * @param {Array<LH.Artifacts.TaskNode>} [knownTasks]
    * @return {Array<LH.TraceEvent>}
    */
-  synthesizeTraceEvents(knownTasks = []) {
+  _synthesizeNaiveTraceEvents() {
     const profile = this._profile;
     const length = profile.samples.length;
     if (profile.timeDeltas.length !== length) throw new Error(`Invalid CPU profile length`);
-
-    const knownTasksByStartTime = knownTasks.slice().sort((a, b) => a.startTime - b.startTime);
-    const knownTasksByEndTime = knownTasks.slice().sort((a, b) => a.endTime - b.endTime);
 
     /** @type {Array<LH.TraceEvent>} */
     const events = [];
 
     let currentProfilerTimestamp = profile.startTime;
-    let lastEffectiveTimestamp = currentProfilerTimestamp;
-    let knownTaskStartTimeIndex = 0;
-    let knownTaskEndTimeIndex = 0;
+    let earliestPossibleTimestamp = -Infinity;
+
     /** @type {Array<number>} */
     let lastActiveNodeIds = [];
     for (let i = 0; i < profile.samples.length; i++) {
@@ -278,40 +376,135 @@ class CpuProfilerModel {
       const node = this._nodesById.get(nodeId);
       if (!node) throw new Error(`Missing node ${nodeId}`);
 
-      const {
-        timestamp: effectiveTimestamp,
-        lastStartTimeIndex,
-        lastEndTimeIndex,
-      } = CpuProfilerModel._findEffectiveTimestamp({
-        earliestPossibleTimestamp: lastEffectiveTimestamp,
-        latestPossibleTimestamp: currentProfilerTimestamp + timeDelta,
+      currentProfilerTimestamp += timeDelta;
+
+      const activeNodeIds = this._getActiveNodeIds(nodeId);
+      events.push(
+        ...this._synthesizeTraceEventsForTransition(
+          earliestPossibleTimestamp,
+          currentProfilerTimestamp,
+          lastActiveNodeIds,
+          activeNodeIds
+        )
+      );
+
+      earliestPossibleTimestamp = currentProfilerTimestamp;
+      lastActiveNodeIds = activeNodeIds;
+    }
+
+    events.push(
+      ...this._synthesizeTraceEventsForTransition(
+        currentProfilerTimestamp,
+        Infinity,
+        lastActiveNodeIds,
+        []
+      )
+    );
+
+    return events;
+  }
+
+  /**
+   * Creates a copy of B/E-style trace events with refined timestamps using knowledge from the
+   * tasks that have definitive timestamps.
+   *
+   * With the sampling profiler we know that a function started/ended _sometime between_ two points,
+   * but not exactly when. Using the information from other tasks gives us more information to be
+   * more precise with timings and allows us to create a valid task tree later on.
+   *
+   * @param {Array<{startTime: number, endTime: number}>} knownTasks
+   * @param {Array<LH.Artifacts.TaskNode>} syntheticTasks
+   * @param {Array<LH.TraceEvent>} syntheticEvents
+   * @return {Array<LH.TraceEvent>}
+   */
+  _refineTraceEventsWithTasks(knownTasks, syntheticTasks, syntheticEvents) {
+    /** @type {Array<LH.TraceEvent>} */
+    const refinedEvents = [];
+
+    /** @type {Map<number, {naive: Array<LH.TraceEvent>, refined: Array<LH.TraceEvent>}>} */
+    const syntheticEventsByTs = new Map();
+    for (const event of syntheticEvents) {
+      const group = syntheticEventsByTs.get(event.ts) || {naive: [], refined: []};
+      group.naive.push(event);
+      syntheticEventsByTs.set(event.ts, group);
+    }
+
+    /** @type {Map<LH.TraceEvent, LH.Artifacts.TaskNode>} */
+    const syntheticTasksByEvent = new Map();
+    for (const task of syntheticTasks) {
+      if (!task.endEvent) throw new Error(`Impossible - all synthethic events are B/E`);
+      syntheticTasksByEvent.set(task.event, task);
+      syntheticTasksByEvent.set(task.endEvent, task);
+    }
+
+    const knownTasksByStartTime = knownTasks.slice().sort((a, b) => a.startTime - b.startTime);
+    const knownTasksByEndTime = knownTasks.slice().sort((a, b) => a.endTime - b.endTime);
+
+    let knownTaskStartTimeIndex = 0;
+    let knownTaskEndTimeIndex = 0;
+
+    for (const event of syntheticEvents) {
+      const syntheticTask = syntheticTasksByEvent.get(event);
+      if (!syntheticTask) throw new Error('Impossible - all events have a task');
+      const allEventsAtTs = syntheticEventsByTs.get(event.ts);
+      if (!allEventsAtTs) throw new Error('Impossible - we just mapped every event');
+
+      const effectiveTimestampData = CpuProfilerModel._findEffectiveTimestamp({
+        eventType: event.ph === 'B' ? 'start' : 'end',
+        syntheticTask,
+        allEventsAtTs,
         knownTaskStartTimeIndex,
         knownTaskEndTimeIndex,
         knownTasksByStartTime,
         knownTasksByEndTime,
       });
 
-      currentProfilerTimestamp += timeDelta;
-      lastEffectiveTimestamp = effectiveTimestamp;
-      knownTaskStartTimeIndex = lastStartTimeIndex;
-      knownTaskEndTimeIndex = lastEndTimeIndex;
+      knownTaskStartTimeIndex = effectiveTimestampData.lastStartTimeIndex;
+      knownTaskEndTimeIndex = effectiveTimestampData.lastEndTimeIndex;
 
-      const activeNodeIds = this._getActiveNodeIds(nodeId);
-      events.push(
-        ...this._synthesizeTraceEventsForTransition(
-          effectiveTimestamp,
-          lastActiveNodeIds,
-          activeNodeIds
-        )
-      );
-      lastActiveNodeIds = activeNodeIds;
+      const refinedEvent = {...event, ts: effectiveTimestampData.timestamp};
+      refinedEvents.push(refinedEvent);
+      allEventsAtTs.refined.push(refinedEvent);
     }
 
-    events.push(
-      ...this._synthesizeTraceEventsForTransition(currentProfilerTimestamp, lastActiveNodeIds, [])
-    );
+    return refinedEvents;
+  }
 
-    return events;
+  /**
+   * Creates B/E-style trace events from a CpuProfile object created by `collectProfileEvents()`.
+   * An optional set of tasks can be passed in to refine the start/end times.
+   *
+   * @param {Array<LH.Artifacts.TaskNode>} [knownTaskNodes]
+   * @return {Array<LH.TraceEvent>}
+   */
+  synthesizeTraceEvents(knownTaskNodes = []) {
+    const naiveEvents = this._synthesizeNaiveTraceEvents();
+    if (!naiveEvents.length) return [];
+
+    let finalEvents = naiveEvents;
+    if (knownTaskNodes.length) {
+      // If we have task information, put the times back into raw trace event ts scale.
+      /** @type {(baseTs: number) => (node: LH.Artifacts.TaskNode) => LH.Artifacts.TaskNode} */
+      const rebaseTaskTime = baseTs => node => ({
+        ...node,
+        startTime: baseTs + node.startTime * 1000,
+        endTime: baseTs + node.endTime * 1000,
+        duration: node.duration * 1000,
+      });
+
+      // The first task node might not be time 0, so recompute the baseTs.
+      const baseTs = knownTaskNodes[0].event.ts - knownTaskNodes[0].startTime * 1000;
+      const knownTasks = knownTaskNodes.map(rebaseTaskTime(baseTs));
+
+      // We'll also create tasks for our naive events so we have the B/E pairs readily available.
+      const naiveProfilerTasks = MainThreadTasks.getMainThreadTasks(naiveEvents, [], Infinity).map(
+        rebaseTaskTime(naiveEvents[0].ts)
+      );
+
+      finalEvents = this._refineTraceEventsWithTasks(knownTasks, naiveProfilerTasks, naiveEvents);
+    }
+
+    return finalEvents;
   }
 
   /**

--- a/lighthouse-core/lib/tracehouse/cpu-profile-model.js
+++ b/lighthouse-core/lib/tracehouse/cpu-profile-model.js
@@ -360,7 +360,8 @@ class CpuProfilerModel {
       // Sampled end event can't be after unrelated tasks started.
       ...(eventType === 'start' ? [] : unrelatedTasks.map(t => t.startTime)),
       // Sampled end event can't be after the other `B` events at its same timestamp.
-      // This isn't _currently_ necessary, but it's an non-obvious observation and case to account for.
+      // This is _currently_ only possible in contrived scenarios due to the sorted order of processing,
+      // but it's a non-obvious observation and case to account for.
       ...(eventType === 'start'
         ? []
         : allEventsAtTs.refined.filter(e => e.ph === 'B').map(e => e.ts))

--- a/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
+++ b/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
@@ -203,7 +203,8 @@ describe('CPU Profiler Model', () => {
         ███████Task███████  ██████Task██████ █
          ██████Eval██████   ██████Eval██████
          ██████Foo███████   ██████Bar██████
-          █Fn█  █Fn█
+          █Fn█
+          █Fn█
       */
       profile = {
         id: '0x1',

--- a/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
+++ b/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
@@ -221,7 +221,7 @@ describe('CPU Profiler Model', () => {
 
       const ts = x => profile.startTime + x;
 
-      // With the sampling profiler we know that Foo switched to Bar but not when.
+      // With the sampling profiler we know that Foo switched to Bar, but we don't know when.
       // Create a set of tasks that force large changes.
       const tasks = [
         // The RunTask at the toplevel, parent of Foo execution

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -108,6 +108,7 @@ describe('Main Thread Tasks', () => {
 
       children: [taskC],
       event: traceEvents[4],
+      endEvent: traceEvents[6],
       startTime: 5,
       endTime: 55,
       duration: 50,
@@ -202,11 +203,13 @@ describe('Main Thread Tasks', () => {
     const baseTs = 1241250325;
     const url = s => ({args: {data: {url: s}}});
     const xhr = (s, readyState, stackTrace) => ({
-      args: {data: {
-        url: s,
-        readyState,
-        stackTrace: stackTrace && stackTrace.map(url => ({url})),
-      }},
+      args: {
+        data: {
+          url: s,
+          readyState,
+          stackTrace: stackTrace && stackTrace.map(url => ({url})),
+        },
+      },
     });
 
     /*
@@ -222,7 +225,13 @@ describe('Main Thread Tasks', () => {
       {ph: 'X', name: 'EvaluateScript', ts: baseTs + 10e3, dur: 30e3, ...url('urlA')},
       {ph: 'X', name: 'XHRReadyStateChange', ts: baseTs + 15e3, dur: 15e3, ...xhr('urlXHR', 1)},
       {ph: 'X', name: 'TaskB', ts: baseTs + 80e3, dur: 20e3},
-      {ph: 'X', name: 'XHRReadyStateChange', ts: baseTs + 85e3, dur: 15e3, ...xhr('urlXHR', 4, ['urlC'])}, // eslint-disable-line max-len
+      {
+        ph: 'X',
+        name: 'XHRReadyStateChange',
+        ts: baseTs + 85e3,
+        dur: 15e3,
+        ...xhr('urlXHR', 4, ['urlC']),
+      }, // eslint-disable-line max-len
       {ph: 'X', name: 'TaskC', ts: baseTs + 89e3, dur: 4e3},
     ];
 
@@ -261,7 +270,15 @@ describe('Main Thread Tasks', () => {
       {ph: 'X', name: 'TaskA', pid, tid, ts: baseTs, dur: 30e3},
       {ph: 'X', name: 'Paint', pid, tid, ts: baseTs + 10e3, dur: 10e3, ...frame('A')},
       {ph: 'X', name: 'TaskB', pid, tid, ts: baseTs + 50e3, dur: 20e3},
-      {ph: 'X', name: 'EvaluateScript', pid, tid, ts: baseTs + 51e3, dur: 15e3, ...stackTrace('B', ['urlB'])}, // eslint-disable-line max-len
+      {
+        ph: 'X',
+        name: 'EvaluateScript',
+        pid,
+        tid,
+        ts: baseTs + 51e3,
+        dur: 15e3,
+        ...stackTrace('B', ['urlB']),
+      }, // eslint-disable-line max-len
       {ph: 'X', name: 'TaskC', pid, tid, ts: baseTs + 90e3, dur: 5e3},
       {ph: 'X', name: 'Layout', pid, tid, ts: baseTs + 90e3, dur: 4e3, ...frame('B')},
     ];
@@ -345,7 +362,7 @@ describe('Main Thread Tasks', () => {
     const taskA = tasks.find(task => task.event.name === 'TaskA');
     const taskB = tasks.find(task => task.event.name === 'TaskB');
     const taskC = tasks.find(task => task.event.name === 'TaskC');
-    expect(taskA).toEqual({
+    expect(taskA).toMatchObject({
       parent: undefined,
       attributableURLs: [],
 
@@ -359,7 +376,7 @@ describe('Main Thread Tasks', () => {
       unbounded: true,
     });
 
-    expect(taskB).toEqual({
+    expect(taskB).toMatchObject({
       parent: taskA,
       attributableURLs: [],
 
@@ -496,6 +513,7 @@ describe('Main Thread Tasks', () => {
 
         children: [],
         event: traceEvents.find(event => event.name === 'TaskB'),
+        endEvent: traceEvents.find(event => event.ph === 'E' && event.name === 'TaskB'),
         startTime: 0,
         endTime: 50,
         duration: 50,
@@ -528,7 +546,8 @@ describe('Main Thread Tasks', () => {
         attributableURLs: [],
 
         children: [],
-        event: traceEvents.find(event => event.name === 'TaskA'),
+        event: traceEvents.find(evt => evt.ph === 'B' && evt.name === 'TaskA'),
+        endEvent: traceEvents.find(evt => evt.ph === 'E' && evt.name === 'TaskA'),
         startTime: 0,
         endTime: 100,
         duration: 100,
@@ -541,7 +560,8 @@ describe('Main Thread Tasks', () => {
         attributableURLs: [],
 
         children: [],
-        event: traceEvents.find(event => event.name === 'TaskB' && event.ph === 'B'),
+        event: traceEvents.find(event => event.ph === 'B' && event.name === 'TaskB'),
+        endEvent: traceEvents.find(event => event.ph === 'E' && event.name === 'TaskB'),
         startTime: 100,
         endTime: 100,
         duration: 0,
@@ -576,6 +596,7 @@ describe('Main Thread Tasks', () => {
 
         children: [tasks[1]],
         event: traceEvents.find(event => event.name === 'SameName' && event.ts === baseTs),
+        endEvent: traceEvents.find(evt => evt.name === 'SameName' && evt.ts === baseTs + 100e3),
         startTime: 0,
         endTime: 100,
         duration: 100,
@@ -589,6 +610,7 @@ describe('Main Thread Tasks', () => {
 
         children: [],
         event: traceEvents.find(event => event.ts === baseTs + 25e3),
+        endEvent: traceEvents.find(evt => evt.name === 'SameName' && evt.ts === baseTs + 75e3),
         startTime: 25,
         endTime: 75,
         duration: 50,
@@ -624,6 +646,7 @@ describe('Main Thread Tasks', () => {
 
         children: [taskB],
         event: traceEvents.find(event => event.name === 'TaskA'),
+        endEvent: traceEvents.find(evt => evt.ph === 'E' && evt.name === 'TaskA'),
         startTime: 0,
         endTime: 100,
         duration: 100,
@@ -636,7 +659,8 @@ describe('Main Thread Tasks', () => {
         attributableURLs: [],
 
         children: [],
-        event: traceEvents.find(event => event.name === 'TaskB' && event.ph === 'B'),
+        event: traceEvents.find(evt => evt.ph === 'B' && evt.name === 'TaskB'),
+        endEvent: traceEvents.find(evt => evt.ph === 'E' && evt.name === 'TaskB'),
         startTime: 25,
         endTime: 100,
         duration: 75,
@@ -665,13 +689,14 @@ describe('Main Thread Tasks', () => {
 
     const tasks = run({traceEvents});
     const [taskA, taskB] = tasks;
-    expect(tasks).toEqual([
+    expect(tasks).toMatchObject([
       {
         parent: undefined,
         attributableURLs: [],
 
         children: [taskB],
-        event: traceEvents.find(event => event.name === 'TaskA'),
+        event: traceEvents.find(evt => evt.ph === 'B' && evt.name === 'TaskA'),
+        endEvent: traceEvents.find(evt => evt.ph === 'E' && evt.name === 'TaskA'),
         startTime: 0,
         endTime: 100,
         duration: 100,
@@ -722,7 +747,8 @@ describe('Main Thread Tasks', () => {
         attributableURLs: [],
 
         children: [taskB],
-        event: traceEvents.find(event => event.name === 'TaskA'),
+        event: traceEvents.find(evt => evt.ph === 'B' && evt.name === 'TaskA'),
+        endEvent: traceEvents.find(evt => evt.ph === 'E' && evt.name === 'TaskA'),
         startTime: 0,
         endTime: 100,
         duration: 100,
@@ -735,7 +761,8 @@ describe('Main Thread Tasks', () => {
         attributableURLs: [],
 
         children: [taskC],
-        event: traceEvents.find(event => event.name === 'TaskB' && event.ph === 'B'),
+        event: traceEvents.find(evt => evt.ph === 'B' && evt.name === 'TaskB'),
+        endEvent: traceEvents.find(evt => evt.ph === 'E' && evt.name === 'TaskB'),
         startTime: 25,
         endTime: 90,
         duration: 65,
@@ -748,7 +775,8 @@ describe('Main Thread Tasks', () => {
         attributableURLs: [],
 
         children: [],
-        event: traceEvents.find(event => event.name === 'TaskC' && event.ph === 'B'),
+        event: traceEvents.find(evt => evt.ph === 'B' && evt.name === 'TaskC'),
+        endEvent: traceEvents.find(evt => evt.ph === 'E' && evt.name === 'TaskC'),
         startTime: 25,
         endTime: 60,
         duration: 35,

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -270,6 +270,11 @@ declare global {
           timeDeltas?: TraceCpuProfile['timeDeltas'];
           cpuProfile?: TraceCpuProfile;
           callFrame?: Required<TraceCpuProfile>['nodes'][0]['callFrame']
+          /** Marker for each synthetic CPU profiler event for the range of _potential_ ts values. */
+          _syntheticProfilerRange?: {
+            earliestPossibleTimestamp: number
+            latestPossibleTimestamp: number
+          }
           stackTrace?: {
             url: string
           }[];


### PR DESCRIPTION
**Summary**
Step 3 of ?? in the innocuous issue #8526 turned multi-quarter effort :)

This step further improves the timing data from CPU profiler samples by moving our `_findEffectiveTimestamp` improvements to a second pass that can utilize the *pair* of sampler events (which is required to understand parent/child relationships).

Next 4 steps in this saga...

- Proactively split continuous looking events
- Correctly handle negative timeDeltas
- Interpolate dropped samples
- Integrate the results into `main-thread-tasks` computed artifact

**Related Issues/PRs**
ref #8526 


Ultimately I'll want @paulirish to give this a final sign off but in the meantime I'd love for your eyes on this too @adamraine :)