### PR TITLE
core(gather-runner): use final document when reporting non-HTML error

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -225,20 +225,20 @@ class GatherRunner {
 
   /**
    * Returns an error if we try to load a non-HTML page.
-   * @param {LH.Artifacts.NetworkRequest|undefined} mainRecord
+   * @param {LH.Artifacts.NetworkRequest|undefined} finalRecord
    * @return {LH.LighthouseError|undefined}
    */
-  static getNonHtmlError(mainRecord) {
+  static getNonHtmlError(finalRecord) {
     // MIME types are case-insenstive but Chrome normalizes MIME types to be lowercase.
     const HTML_MIME_TYPE = 'text/html';
 
     // If we never requested a document, there's no doctype error, let other cases handle it.
-    if (!mainRecord) return undefined;
+    if (!finalRecord) return undefined;
 
     // mimeType is determined by the browser, we assume Chrome is determining mimeType correctly,
     // independently of 'Content-Type' response headers, and always sending mimeType if well-formed.
-    if (HTML_MIME_TYPE !== mainRecord.mimeType) {
-      return new LHError(LHError.errors.NOT_HTML, {mimeType: mainRecord.mimeType});
+    if (HTML_MIME_TYPE !== finalRecord.mimeType) {
+      return new LHError(LHError.errors.NOT_HTML, {mimeType: finalRecord.mimeType});
     }
     return undefined;
   }
@@ -259,9 +259,14 @@ class GatherRunner {
       mainRecord = NetworkAnalyzer.findMainDocument(networkRecords, passContext.url);
     } catch (_) {}
 
+    let finalRecord;
+    try {
+      finalRecord = NetworkAnalyzer.findFinalDocument(mainRecord);
+    } catch (_) {}
+
     const networkError = GatherRunner.getNetworkError(mainRecord);
     const interstitialError = GatherRunner.getInterstitialError(mainRecord, networkRecords);
-    const nonHtmlError = GatherRunner.getNonHtmlError(mainRecord);
+    const nonHtmlError = GatherRunner.getNonHtmlError(finalRecord);
 
     // Check to see if we need to ignore the page load failure.
     // e.g. When the driver is offline, the load will fail without page offline support.

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -261,7 +261,10 @@ class GatherRunner {
     } catch (_) {}
 
     // MIME Type is only set on the final redirected document request. Use this for the HTML check instead of root.
-    const finalRecord = NetworkAnalyzer.resolveRedirects(mainRecord);
+    let finalRecord;
+    if (mainRecord) {
+      finalRecord = NetworkAnalyzer.resolveRedirects(mainRecord);
+    }
 
     const networkError = GatherRunner.getNetworkError(mainRecord);
     const interstitialError = GatherRunner.getInterstitialError(mainRecord, networkRecords);

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -259,10 +259,8 @@ class GatherRunner {
       mainRecord = NetworkAnalyzer.findMainDocument(networkRecords, passContext.url);
     } catch (_) {}
 
-    let finalRecord;
-    try {
-      finalRecord = NetworkAnalyzer.findFinalDocument(mainRecord);
-    } catch (_) {}
+    // MIME Type is only set on the final redirected document request. Use this for the HTML check instead of root.
+    const finalRecord = NetworkAnalyzer.resolveRedirects(mainRecord);
 
     const networkError = GatherRunner.getNetworkError(mainRecord);
     const interstitialError = GatherRunner.getInterstitialError(mainRecord, networkRecords);

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -225,6 +225,7 @@ class GatherRunner {
 
   /**
    * Returns an error if we try to load a non-HTML page.
+   * Expects a network request with all redirects resolved, otherwise the MIME type may be incorrect.
    * @param {LH.Artifacts.NetworkRequest|undefined} finalRecord
    * @return {LH.LighthouseError|undefined}
    */

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -454,23 +454,16 @@ class NetworkAnalyzer {
   }
 
   /**
-   * Finds the final document in a redirect chain given a main document.
+   * Resolves redirect chain given a main document.
    * See: {@link NetworkAnalyzer.findMainDocument}) for how to retrieve main document.
    *
-   * @param {LH.Artifacts.NetworkRequest|undefined} mainDocument
-   * @returns {LH.Artifacts.NetworkRequest}
+   * @param {LH.Artifacts.NetworkRequest|undefined} request
+   * @returns {LH.Artifacts.NetworkRequest|undefined}
    */
-  static findFinalDocument(mainDocument) {
-    const documentRequests = [];
-
-    while (mainDocument) {
-      documentRequests.push(mainDocument);
-      mainDocument = mainDocument.redirectDestination;
-    }
-
-    if (!documentRequests.length) throw new Error('Unable to identify the final resource');
-
-    return documentRequests[documentRequests.length - 1];
+  static resolveRedirects(request) {
+    if (!request) return undefined;
+    while (request.redirectDestination) request = request.redirectDestination;
+    return request;
   }
 }
 

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -457,11 +457,10 @@ class NetworkAnalyzer {
    * Resolves redirect chain given a main document.
    * See: {@link NetworkAnalyzer.findMainDocument}) for how to retrieve main document.
    *
-   * @param {LH.Artifacts.NetworkRequest|undefined} request
-   * @returns {LH.Artifacts.NetworkRequest|undefined}
+   * @param {LH.Artifacts.NetworkRequest} request
+   * @returns {LH.Artifacts.NetworkRequest}
    */
   static resolveRedirects(request) {
-    if (!request) return undefined;
     while (request.redirectDestination) request = request.redirectDestination;
     return request;
   }

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -452,6 +452,26 @@ class NetworkAnalyzer {
     // The main document is the earliest document request, using position in networkRecords array to break ties.
     return documentRequests.reduce((min, r) => (r.startTime < min.startTime ? r : min));
   }
+
+  /**
+   * Finds the final document in a redirect chain given a main document.
+   * See: {@link NetworkAnalyzer.findMainDocument}) for how to retrieve main document.
+   *
+   * @param {LH.Artifacts.NetworkRequest|undefined} mainDocument
+   * @returns {LH.Artifacts.NetworkRequest}
+   */
+  static findFinalDocument(mainDocument) {
+    const documentRequests = [];
+
+    while (mainDocument) {
+      documentRequests.push(mainDocument);
+      mainDocument = mainDocument.redirectDestination;
+    }
+
+    if (!documentRequests.length) throw new Error('Unable to identify the final resource');
+
+    return documentRequests[documentRequests.length - 1];
+  }
 }
 
 module.exports = NetworkAnalyzer;

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -1198,6 +1198,24 @@ describe('GatherRunner', function() {
       expect(error).toBeUndefined();
     });
 
+    it('passes when the page redirects to MIME type text/html', () => {
+      const passContext = {
+        url: 'http://the-page.com',
+        passConfig: {loadFailureMode: LoadFailureMode.fatal},
+      };
+      const mainRecord = new NetworkRequest();
+      const finalRecord = new NetworkRequest();
+      const loadData = {networkRecords: [mainRecord]};
+
+      mainRecord.url = passContext.url;
+      mainRecord.redirectDestination = finalRecord;
+      finalRecord.url = 'http://the-redirected-page.com';
+      finalRecord.mimeType = 'text/html';
+
+      const error = GatherRunner.getPageLoadError(passContext, loadData, undefined);
+      expect(error).toBeUndefined();
+    });
+
     it('fails with interstitial error first', () => {
       const passContext = {
         url: 'http://the-page.com',
@@ -1274,6 +1292,23 @@ describe('GatherRunner', function() {
 
       const error = getAndExpectError(passContext, loadData, navigationError);
       expect(error.message).toEqual('NAVIGATION_ERROR');
+    });
+
+    it('fails with non-HTML when redirect is not HTML', () => {
+      const passContext = {
+        url: 'http://the-page.com',
+        passConfig: {loadFailureMode: LoadFailureMode.fatal},
+      };
+      const mainRecord = new NetworkRequest();
+      const finalRecord = new NetworkRequest();
+      const loadData = {networkRecords: [mainRecord]};
+
+      mainRecord.url = passContext.url;
+      mainRecord.redirectDestination = finalRecord;
+      finalRecord.url = 'http://the-redirected-page.com';
+
+      const error = getAndExpectError(passContext, loadData, navigationError);
+      expect(error.message).toEqual('NOT_HTML');
     });
   });
 

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -10,6 +10,9 @@ const assert = require('assert').strict;
 const NetworkAnalyzer = require('../../../../lib/dependency-graph/simulator/network-analyzer.js');
 const NetworkRecords = require('../../../../computed/network-records.js');
 const devtoolsLog = require('../../../fixtures/traces/progressive-app-m60.devtools.log.json');
+const devtoolsLogWithRedirect = require(
+  '../../../fixtures/traces/site-with-redirect.devtools.log.json'
+);
 
 /* eslint-env jest */
 describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
@@ -383,6 +386,28 @@ describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
       ];
       const mainDocument = NetworkAnalyzer.findMainDocument(records);
       assert.equal(mainDocument.url, 'https://www.example.com');
+    });
+  });
+
+  describe('#findFinalDocument', () => {
+    it('should find the final document without redirects', async () => {
+      const records = await NetworkRecords.request(devtoolsLog, {computedCache: new Map()});
+
+      const mainDocument = NetworkAnalyzer.findMainDocument(records, 'https://pwa.rocks/');
+      const finalDocument = NetworkAnalyzer.findFinalDocument(mainDocument);
+      assert.equal(mainDocument.url, finalDocument.url);
+      assert.equal(finalDocument.url, 'https://pwa.rocks/');
+    });
+
+    it('should find the final document with redirects', async () => {
+      const records = await NetworkRecords.request(devtoolsLogWithRedirect, {
+        computedCache: new Map(),
+      });
+
+      const mainDocument = NetworkAnalyzer.findMainDocument(records, 'http://www.vkontakte.ru/');
+      const finalDocument = NetworkAnalyzer.findFinalDocument(mainDocument);
+      assert.notEqual(mainDocument.url, finalDocument.url);
+      assert.equal(finalDocument.url, 'https://m.vk.com/');
     });
   });
 });

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -409,5 +409,9 @@ describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
       assert.notEqual(mainDocument.url, finalDocument.url);
       assert.equal(finalDocument.url, 'https://m.vk.com/');
     });
+
+    it('should return undefined if not given a request', () => {
+      assert.equal(NetworkAnalyzer.resolveRedirects(), undefined);
+    });
   });
 });

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -389,23 +389,23 @@ describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
     });
   });
 
-  describe('#findFinalDocument', () => {
-    it('should find the final document without redirects', async () => {
+  describe('#resolveRedirects', () => {
+    it('should resolve to the same document when no redirect', async () => {
       const records = await NetworkRecords.request(devtoolsLog, {computedCache: new Map()});
 
       const mainDocument = NetworkAnalyzer.findMainDocument(records, 'https://pwa.rocks/');
-      const finalDocument = NetworkAnalyzer.findFinalDocument(mainDocument);
+      const finalDocument = NetworkAnalyzer.resolveRedirects(mainDocument);
       assert.equal(mainDocument.url, finalDocument.url);
       assert.equal(finalDocument.url, 'https://pwa.rocks/');
     });
 
-    it('should find the final document with redirects', async () => {
+    it('should resolve to the final document with redirects', async () => {
       const records = await NetworkRecords.request(devtoolsLogWithRedirect, {
         computedCache: new Map(),
       });
 
       const mainDocument = NetworkAnalyzer.findMainDocument(records, 'http://www.vkontakte.ru/');
-      const finalDocument = NetworkAnalyzer.findFinalDocument(mainDocument);
+      const finalDocument = NetworkAnalyzer.resolveRedirects(mainDocument);
       assert.notEqual(mainDocument.url, finalDocument.url);
       assert.equal(finalDocument.url, 'https://m.vk.com/');
     });

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -409,9 +409,5 @@ describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
       assert.notEqual(mainDocument.url, finalDocument.url);
       assert.equal(finalDocument.url, 'https://m.vk.com/');
     });
-
-    it('should return undefined if not given a request', () => {
-      assert.equal(NetworkAnalyzer.resolveRedirects(), undefined);
-    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->

<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

Fixes a bug where non-HTML page load error would be reported for sites that redirect and resolve to a valid HTML document. The main document's mime type would be checked instead of the "final" document resolved from the redirect.

This change is needed because previously, false positive errors may be reported for valid pages that ultimately respond with HTML via redirects.

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
Fixes #11585
Introduced in #11042 
