### PR TITLE
core(runner): abstract gather phase out of runner

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -26,11 +26,11 @@ const LHError = require('./lib/lh-error.js');
 
 class Runner {
   /**
-   * @param {Connection} connection
+   * @param {(runnerData: {requestedUrl: string, config: Config, driverMock?: Driver}) => Promise<LH.Artifacts>} gatherFn
    * @param {{config: Config, url?: string, driverMock?: Driver}} runOpts
    * @return {Promise<LH.RunnerResult|undefined>}
    */
-  static async run(connection, runOpts) {
+  static async run(gatherFn, runOpts) {
     const settings = runOpts.config.settings;
     try {
       const runnerStatus = {msg: 'Runner setup', id: 'lh:runner:run'};
@@ -78,7 +78,12 @@ class Runner {
           throw new LHError(LHError.errors.INVALID_URL);
         }
 
-        artifacts = await Runner._gatherArtifactsFromBrowser(requestedUrl, runOpts, connection);
+        artifacts = await gatherFn({
+          requestedUrl,
+          config: runOpts.config,
+          driverMock: runOpts.driverMock,
+        });
+
         // -G means save these to ./latest-run, etc.
         if (settings.gatherMode) {
           const path = Runner._getDataSavePath(settings);


### PR DESCRIPTION
**Summary**
The runner related changes for FR phase 1. See https://github.com/GoogleChrome/lighthouse/pull/11622 for how it will eventually come together. Goal here is to eliminate the reliance of the Runner on an explicit connection and abstract away the gathering.

**Related Issues/PRs**
ref #11313 
