### PR TITLE
tests: limit LCP element audit to m87 and earlier

### DIFF
--- a/lighthouse-cli/test/smokehouse/report-assert.js
+++ b/lighthouse-cli/test/smokehouse/report-assert.js
@@ -168,8 +168,9 @@ function pruneExpectations(localConsole, lhr, expected) {
    * @param {*} obj
    */
   function failsChromeVersionCheck(obj) {
-    if (!obj._minChromiumMilestone) return false;
-    return actualChromeVersion < obj._minChromiumMilestone;
+    if (obj._minChromiumMilestone && actualChromeVersion < obj._minChromiumMilestone) return true;
+    if (obj._maxChromiumMilestone && actualChromeVersion > obj._maxChromiumMilestone) return true;
+    return false;
   }
 
   /**
@@ -194,6 +195,7 @@ function pruneExpectations(localConsole, lhr, expected) {
       }
     }
     delete obj._minChromiumMilestone;
+    delete obj._maxChromiumMilestone;
   }
 
   const cloned = cloneDeep(expected);

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -289,7 +289,12 @@ module.exports = [
       audits: {
         'largest-contentful-paint-element': {
           score: null,
+          scoreDisplayMode: /(notApplicable|informative)/,
           details: {
+            // LCP in m88 was changed to allow selection of removed nodes.
+            // When this happens we aren't able to identify the LCP element anymore.
+            // https://chromiumdash.appspot.com/commit/a5484e6310a38223fde757b6f094a673ce032cc0
+            _maxChromiumMilestone: 87,
             items: [
               {
                 node: {


### PR DESCRIPTION
**Summary**
LCP in Canary has flipped to including removed elements by default.

https://chromium-review.googlesource.com/c/chromium/src/+/2480845

Long-term we should find a way to surface this element and/or potentially keep 6.x on the old LCP version, but for now we'll make PRs landable again.
