### PR TITLE
tests: update static content shell version

### DIFF
--- a/third-party/download-content-shell/download-content-shell.js
+++ b/third-party/download-content-shell/download-content-shell.js
@@ -70,7 +70,7 @@ function findMostRecentChromiumCommit() {
   // const commitPosition = commitMessage.match(/Cr-Commit-Position: refs\/heads\/master@\{#([0-9]+)\}/)[1];
   // return commitPosition;
   // TODO: make this dynamic.
-  return '791033';
+  return '822569';
 }
 
 function deleteOldContentShells() {


### PR DESCRIPTION
ref #11414 

Was 2 months old. Nothing was failing, but using an old Chromium isn't good for test validity.

Still punting on doing this in a dynamic way. Anyone know a good source to scrape this value from? One option is a shallow git copy (just the latest commit) and parse the commit message, but I think that'd be heavy duty since Chromium is so big. Maybe scrape https://chromium.googlesource.com/chromium/src.git -> click on latest commit -> parse commit position?