### PR TITLE
tests: remove unnecessary jest babel transform

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,4 +27,5 @@ module.exports = {
     '**/clients/test/**/*-test.js',
     '**/docs/**/*.test.js',
   ],
+  transform: {},
 };

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -7,14 +7,14 @@
 
 /* eslint-env jest */
 
-const bin = require('../../bin.js');
-
 jest.mock('../../run.js', () => ({runLighthouse: jest.fn()}));
 jest.mock('../../cli-flags.js', () => ({getFlags: jest.fn()}));
 jest.mock('../../sentry-prompt.js', () => ({askPermission: jest.fn()}));
 jest.mock('../../../lighthouse-core/lib/sentry.js', () => ({init: jest.fn()}));
 jest.mock('lighthouse-logger', () => ({setLevel: jest.fn()}));
 jest.mock('update-notifier', () => () => ({notify: () => {}}));
+
+const bin = require('../../bin.js');
 
 /** @type {jest.Mock} */
 let getCLIFlagsFn;

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -7,6 +7,8 @@
 
 /* eslint-env jest */
 
+jest.mock('../../lib/stack-collector.js', () => () => Promise.resolve([]));
+
 const Gatherer = require('../../gather/gatherers/gatherer.js');
 const GatherRunner_ = require('../../gather/gather-runner.js');
 const assert = require('assert').strict;
@@ -19,8 +21,6 @@ const Driver = require('../../gather/driver.js');
 const Connection = require('../../gather/connections/connection.js');
 const {createMockSendCommandFn} = require('./mock-commands.js');
 const {makeParamsOptional} = require('../test-utils.js');
-
-jest.mock('../../lib/stack-collector.js', () => () => Promise.resolve([]));
 
 const GatherRunner = {
   afterPass: makeParamsOptional(GatherRunner_.afterPass),

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+jest.mock('../lib/stack-collector.js', () => () => Promise.resolve([]));
+
 const Runner = require('../runner.js');
 const GatherRunner = require('../gather/gather-runner.js');
 const driverMock = require('./gather/fake-driver.js');
@@ -20,8 +22,6 @@ const LHError = require('../lib/lh-error.js');
 const i18n = require('../lib/i18n/i18n.js');
 
 /* eslint-env jest */
-
-jest.mock('../lib/stack-collector.js', () => () => Promise.resolve([]));
 
 describe('Runner', () => {
   const defaultGatherFn = opts => Runner._gatherArtifactsFromBrowser(


### PR DESCRIPTION
I've been complaining for a long time that jest has been automatically running all our code through babel even though we don't need any transpilation help, making debugging tests slightly more annoying.

Turns out it's really easy to turn off :)

Bonus, it saves some unit test time: on my machine about 8% wall clock time, 13% total cpu time. This is skewed by the incredibly slow `report-renderer-test`; if that test is skipped, turning off the transform makes `yarn unit-core` almost 20% shorter.