### PR TITLE
tests: use setup-protoc bugfix branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
         node-version: 10.x
 
     - name: Set up protoc
-      uses: arduino/setup-protoc@7ad700d
+      # TODO: switch back to arduino/setup-protoc after the pagination fix lands:
+      # https://github.com/arduino/setup-protoc/pull/9
+      uses: solo-io/setup-protoc@1f5d8b5
       with:
         version: '3.7.1'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes broken unit tests in CI

Apparently `arduino/setup-protoc` gets the `protobuf` releases via the github API, but stops on the first page of results when looking for specific versions. The unit tests are failing because our 3.7.1 finally slipped out of the first page of releases into the second.

There's an [unmerged PR](https://github.com/arduino/setup-protoc/pull/9) that explains and fixes this (they faced the same issue for 3.6.1 back in July), so in the meantime we can use that branch.