### PR TITLE
tests: update github actions to use env files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,7 @@ jobs:
         node-version: 10.x
 
     - name: Set up protoc
-      # TODO: switch back to arduino/setup-protoc after the pagination fix lands:
-      # https://github.com/arduino/setup-protoc/pull/9
-      uses: solo-io/setup-protoc@1f5d8b5
+      uses: arduino/setup-protoc@64c0c85
       with:
         version: '3.7.1'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -145,7 +143,7 @@ jobs:
 
     - name: Define ToT chrome path
       if: matrix.chrome-channel == 'ToT'
-      run: echo "::set-env name=CHROME_PATH::/home/runner/chrome-linux-tot/chrome"
+      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
 
     # Chrome Stable is already installed by default.
     - name: Install Chrome ToT

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
     - name: Set $DEPOT_TOOLS_PATH
-      run: echo ::set-env name=DEPOT_TOOLS_PATH::$GITHUB_WORKSPACE/depot-tools
+      run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
     - name: Set $DEVTOOLS_PATH
-      run: echo ::set-env name=DEVTOOLS_PATH::$GITHUB_WORKSPACE/devtools-frontend
+      run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
     - name: Set $BLINK_TOOLS_PATH
-      run: echo ::set-env name=BLINK_TOOLS_PATH::$GITHUB_WORKSPACE/blink_tools
+      run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
     - name: Set $PATH
-      run: echo ::set-env name=PATH::$DEPOT_TOOLS_PATH:$PATH
+      run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
 
     - name: git clone
       uses: actions/checkout@v2


### PR DESCRIPTION
Context: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

I don't see any other dependency actions that need to be updated due to the looser `v*` pinning on them, but I guess we'll see.