### PR TITLE
tests: refresh devtools checkout for webtests

### DIFF
--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -15,8 +15,7 @@ then
 
   # Update to keep current
   git pull -f origin master
-  gclient sync --nohooks
-  gn gen out/Default
+  gclient sync
 
   exit 0
 fi

--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -12,6 +12,12 @@ if [ -d "$DEVTOOLS_PATH" ]
 then
   echo "Directory $DEVTOOLS_PATH already exists."
   cd "$DEVTOOLS_PATH"
+
+  # Update to keep current
+  git pull -f origin master
+  gclient sync --nohooks
+  gn gen out/Default
+
   exit 0
 fi
 


### PR DESCRIPTION
locally i ended up with a stale CDT checkout that was giving me failures when running `yarn test-devtools`

this will make running  `yarn test-devtools` locally take longer, as the gclient sync/hooks take time.  however if there's been no changes to the repo since last run, it's free.

fixes #11678 
ref #11414 