### PR TITLE
tests: update failing trace webtest to use Tooltip module

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -33,7 +33,7 @@ jobs:
           ${{ env.DEVTOOLS_PATH }}
           ${{ env.BLINK_TOOLS_PATH }}
           ${{ github.workspace }}/lighthouse/.tmp/chromium-web-tests/content-shells
-        key: ${{ runner.os }}-${{ hashFiles('lighthouse/.github/workflows/devtools.yml', 'lighthouse/lighthouse-core/test/chromium-web-tests/*', 'lighthouse/clients/devtools-entry.js', 'lighthouse/clients/devtools-report-assets.js', 'lighthouse/build/build-bundle.js', 'lighthouse/build/build-dt-report-resources.js') }}
+        key: ${{ runner.os }}-${{ hashFiles('third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/*.js', 'lighthouse/.github/workflows/devtools.yml', 'lighthouse/lighthouse-core/test/chromium-web-tests/*', 'lighthouse/clients/devtools-entry.js', 'lighthouse/clients/devtools-report-assets.js', 'lighthouse/build/build-bundle.js', 'lighthouse/build/build-dt-report-resources.js') }}
 
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-view-trace-run.js
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-view-trace-run.js
@@ -33,8 +33,7 @@
   });
   const viewTraceButton = LighthouseTestRunner.getResultsElement().querySelector('.view-trace');
   TestRunner.addResult(`\nView Trace Button Text: "${viewTraceButton.textContent}"`);
-  const tooltip = UI.Tooltip.getContent(viewTraceButton);
-  TestRunner.addResult(`View Trace Button Title: "${tooltip}"`);
+  TestRunner.addResult(`View Trace Button Title: "${UI.Tooltip.getContent(viewTraceButton)}"`);
   viewTraceButton.click();
   const viewShown = await waitForShowView;
   TestRunner.addResult(`\nShowing view: ${viewShown}`);

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-view-trace-run.js
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-view-trace-run.js
@@ -33,7 +33,8 @@
   });
   const viewTraceButton = LighthouseTestRunner.getResultsElement().querySelector('.view-trace');
   TestRunner.addResult(`\nView Trace Button Text: "${viewTraceButton.textContent}"`);
-  TestRunner.addResult(`View Trace Button Title: "${viewTraceButton.title}"`);
+  const tooltip = UI.Tooltip.getContent(viewTraceButton);
+  TestRunner.addResult(`View Trace Button Title: "${tooltip}"`);
   viewTraceButton.click();
   const viewShown = await waitForShowView;
   TestRunner.addResult(`\nShowing view: ${viewShown}`);


### PR DESCRIPTION
Changed here: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2555060

I'd expect that change to fail this test https://source.chromium.org/chromium/chromium/src/+/master:third_party/devtools-frontend/src/test/webtests/http/tests/devtools/lighthouse/lighthouse-view-trace-run.js;l=36;drc=b736005f57eccddf8dd024872552f1bfb0264682 but it didn't. @TimvdLippe I assumed `test/webtests` run in CQ, is that true?