### PR TITLE
core(fr): add fraggle rock driver

### DIFF
--- a/lighthouse-core/fraggle-rock/gather/driver.js
+++ b/lighthouse-core/fraggle-rock/gather/driver.js
@@ -8,29 +8,19 @@
 const ProtocolSession = require('./session.js');
 const ExecutionContext = require('../../gather/driver/execution-context.js');
 
+const throwNotConnectedFn = () => {
+  throw new Error('Session not connected');
+};
+
 /** @type {LH.Gatherer.FRProtocolSession} */
 const defaultSession = {
-  hasNextProtocolTimeout: () => {
-    throw new Error('Session not connected');
-  },
-  getNextProtocolTimeout: () => {
-    throw new Error('Session not connected');
-  },
-  setNextProtocolTimeout: () => {
-    throw new Error('Session not connected');
-  },
-  on: () => {
-    throw new Error('Session not connected');
-  },
-  once: () => {
-    throw new Error('Session not connected');
-  },
-  off: () => {
-    throw new Error('Session not connected');
-  },
-  sendCommand: () => {
-    throw new Error('Session not connected');
-  },
+  hasNextProtocolTimeout: throwNotConnectedFn,
+  getNextProtocolTimeout: throwNotConnectedFn,
+  setNextProtocolTimeout: throwNotConnectedFn,
+  on: throwNotConnectedFn,
+  once: throwNotConnectedFn,
+  off: throwNotConnectedFn,
+  sendCommand: throwNotConnectedFn,
 };
 
 /** @implements {LH.Gatherer.FRTransitionalDriver} */

--- a/lighthouse-core/fraggle-rock/gather/driver.js
+++ b/lighthouse-core/fraggle-rock/gather/driver.js
@@ -1,0 +1,70 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const ProtocolSession = require('./session.js');
+const ExecutionContext = require('../../gather/driver/execution-context.js');
+
+/** @type {LH.Gatherer.FRProtocolSession} */
+const defaultSession = {
+  hasNextProtocolTimeout: () => {
+    throw new Error('Session not connected');
+  },
+  getNextProtocolTimeout: () => {
+    throw new Error('Session not connected');
+  },
+  setNextProtocolTimeout: () => {
+    throw new Error('Session not connected');
+  },
+  on: () => {
+    throw new Error('Session not connected');
+  },
+  once: () => {
+    throw new Error('Session not connected');
+  },
+  off: () => {
+    throw new Error('Session not connected');
+  },
+  sendCommand: () => {
+    throw new Error('Session not connected');
+  },
+};
+
+/** @implements {LH.Gatherer.FRTransitionalDriver} */
+class Driver {
+  /**
+   * @param {import('puppeteer').Page} page
+   */
+  constructor(page) {
+    this._page = page;
+    /** @type {LH.Gatherer.FRProtocolSession|undefined} */
+    this._session = undefined;
+    /** @type {ExecutionContext|undefined} */
+    this._executionContext = undefined;
+
+    this.defaultSession = defaultSession;
+  }
+
+  /** @return {Promise<void>} */
+  async connect() {
+    if (this._session) return;
+    const session = await this._page.target().createCDPSession();
+    this._session = this.defaultSession = new ProtocolSession(session);
+    this._executionContext = new ExecutionContext(this._session);
+  }
+
+  /**
+   * @param {string} expression
+   * @param {{useIsolation?: boolean}} [options]
+   * @return {Promise<*>}
+   */
+  async evaluateAsync(expression, options) {
+    if (!this._executionContext) throw new Error('Driver not connected to page');
+    return this._executionContext.evaluateAsync(expression, options);
+  }
+}
+
+module.exports = Driver;

--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -42,9 +42,7 @@ class ProtocolSession {
    * @param {(...args: LH.CrdpEvents[E]) => void} callback
    */
   on(eventName, callback) {
-    /** @type {*} */
-    const callbackAsAny = callback;
-    this._session.on(eventName, callbackAsAny);
+    this._session.on(eventName, /** @type {*} */ (callback));
   }
 
   /**
@@ -54,9 +52,7 @@ class ProtocolSession {
    * @param {(...args: LH.CrdpEvents[E]) => void} callback
    */
   once(eventName, callback) {
-    /** @type {*} */
-    const callbackAsAny = callback;
-    this._session.once(eventName, callbackAsAny);
+    this._session.once(eventName, /** @type {*} */ (callback));
   }
 
   /**
@@ -66,9 +62,7 @@ class ProtocolSession {
    * @param {(...args: LH.CrdpEvents[E]) => void} callback
    */
   off(eventName, callback) {
-    /** @type {*} */
-    const callbackAsAny = callback;
-    this._session.off(eventName, callbackAsAny);
+    this._session.off(eventName, /** @type {*} */ (callback));
   }
 
   /**

--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -1,0 +1,86 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/** @implements {LH.Gatherer.FRProtocolSession} */
+class ProtocolSession {
+  /**
+   * @param {import('puppeteer').CDPSession} session
+   */
+  constructor(session) {
+    this._session = session;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  hasNextProtocolTimeout() {
+    return false;
+  }
+
+  /**
+   * @return {number}
+   */
+  getNextProtocolTimeout() {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  /**
+   * @param {number} ms
+   */
+  setNextProtocolTimeout(ms) { // eslint-disable-line no-unused-vars
+    // TODO(FR-COMPAT): support protocol timeout
+  }
+
+  /**
+   * Bind listeners for protocol events.
+   * @template {keyof LH.CrdpEvents} E
+   * @param {E} eventName
+   * @param {(...args: LH.CrdpEvents[E]) => void} callback
+   */
+  on(eventName, callback) {
+    /** @type {*} */
+    const callbackAsAny = callback;
+    this._session.on(eventName, callbackAsAny);
+  }
+
+  /**
+   * Bind listeners for protocol events.
+   * @template {keyof LH.CrdpEvents} E
+   * @param {E} eventName
+   * @param {(...args: LH.CrdpEvents[E]) => void} callback
+   */
+  once(eventName, callback) {
+    /** @type {*} */
+    const callbackAsAny = callback;
+    this._session.once(eventName, callbackAsAny);
+  }
+
+  /**
+   * Bind listeners for protocol events.
+   * @template {keyof LH.CrdpEvents} E
+   * @param {E} eventName
+   * @param {(...args: LH.CrdpEvents[E]) => void} callback
+   */
+  off(eventName, callback) {
+    /** @type {*} */
+    const callbackAsAny = callback;
+    this._session.off(eventName, callbackAsAny);
+  }
+
+  /**
+   * @template {keyof LH.CrdpCommands} C
+   * @param {C} method
+   * @param {LH.CrdpCommands[C]['paramsType']} params
+   * @return {Promise<LH.CrdpCommands[C]['returnType']>}
+   */
+  sendCommand(method, ...params) {
+    return this._session.send(method, ...params);
+  }
+}
+
+module.exports = ProtocolSession;
+

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -120,6 +120,8 @@ class Driver {
     this.fetcher = new Fetcher(this);
 
     this._executionContext = new ExecutionContext(this);
+    // Compat with new FR paradigm of session-aware protocol interaction.
+    this.defaultSession = this;
   }
 
   static get traceCategories() {

--- a/lighthouse-core/test/fraggle-rock/gather/driver-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/driver-test.js
@@ -38,9 +38,7 @@ beforeEach(() => {
   driver = new Driver(page);
 });
 
-for (const fnName_ of DELEGATED_FUNCTIONS) {
-  const fnName = /** @type {keyof LH.Gatherer.FRProtocolSession} */ (fnName_);
-
+for (const fnName of DELEGATED_FUNCTIONS) {
   describe(fnName, () => {
     it('should fail if called before connect', () => {
       expect(driver.defaultSession[fnName]).toThrow(/not connected/);

--- a/lighthouse-core/test/fraggle-rock/gather/driver-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/driver-test.js
@@ -1,0 +1,81 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Driver = require('../../../fraggle-rock/gather/driver.js');
+
+/* eslint-env jest */
+
+const DELEGATED_FUNCTIONS = [
+  'hasNextProtocolTimeout',
+  'getNextProtocolTimeout',
+  'setNextProtocolTimeout',
+  'on',
+  'off',
+  'sendCommand',
+];
+
+/** @type {import('puppeteer').Page} */
+let page;
+/** @type {import('puppeteer').Target} */
+let pageTarget;
+/** @type {import('puppeteer').CDPSession} */
+let puppeteerSession;
+/** @type {Driver} */
+let driver;
+
+beforeEach(() => {
+  // @ts-expect-error - Individual mock functions are applied as necessary.
+  page = {target: () => pageTarget};
+  // @ts-expect-error - Individual mock functions are applied as necessary.
+  pageTarget = {createCDPSession: () => puppeteerSession};
+  // @ts-expect-error - Individual mock functions are applied as necessary.
+  puppeteerSession = {on: jest.fn(), off: jest.fn(), send: jest.fn()};
+  driver = new Driver(page);
+});
+
+for (const fnName_ of DELEGATED_FUNCTIONS) {
+  const fnName = /** @type {keyof LH.Gatherer.FRProtocolSession} */ (fnName_);
+
+  describe(fnName, () => {
+    it('should fail if called before connect', () => {
+      expect(driver.defaultSession[fnName]).toThrow(/not connected/);
+    });
+
+    it('should use connected session for default', async () => {
+      await driver.connect();
+      if (!driver._session) throw new Error('Driver did not connect');
+
+      /** @type {any} */
+      const args = [1, {arg: 2}];
+      const returnValue = {foo: 'bar'};
+      driver._session[fnName] = jest.fn().mockReturnValue(returnValue);
+      // @ts-expect-error - typescript can't handle this union type.
+      const actualResult = driver.defaultSession[fnName](...args);
+      expect(driver._session[fnName]).toHaveBeenCalledWith(...args);
+      expect(actualResult).toEqual(returnValue);
+    });
+  });
+}
+
+describe('.evaluateAsync', () => {
+  it('should fail if called before connect', async () => {
+    await expect(driver.evaluateAsync('1 + 1')).rejects.toBeTruthy();
+  });
+
+  it('should delegate to execution context', async () => {
+    await driver.connect();
+    if (!driver._executionContext) throw new Error('Runtime did not connect');
+
+    const returnValue = 2;
+    const evaluateAsyncMock = driver._executionContext.evaluateAsync =
+      jest.fn().mockReturnValue(returnValue);
+
+    const actualResult = await driver.evaluateAsync('1 + 1', {useIsolation: true});
+    expect(evaluateAsyncMock).toHaveBeenCalledWith('1 + 1', {useIsolation: true});
+    expect(actualResult).toEqual(returnValue);
+  });
+});

--- a/lighthouse-core/test/fraggle-rock/gather/driver-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/driver-test.js
@@ -9,6 +9,7 @@ const Driver = require('../../../fraggle-rock/gather/driver.js');
 
 /* eslint-env jest */
 
+/** @type {Array<keyof LH.Gatherer.FRProtocolSession>} */
 const DELEGATED_FUNCTIONS = [
   'hasNextProtocolTimeout',
   'getNextProtocolTimeout',

--- a/lighthouse-core/test/fraggle-rock/gather/session-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/session-test.js
@@ -9,7 +9,7 @@ const ProtocolSession = require('../../../fraggle-rock/gather/session.js');
 
 /* eslint-env jest */
 
-describe('.sendCommand', () => {
+describe('ProtocolSession', () => {
   /** @type {import('puppeteer').CDPSession} */
   let puppeteerSession;
   /** @type {ProtocolSession} */
@@ -21,11 +21,27 @@ describe('.sendCommand', () => {
     session = new ProtocolSession(puppeteerSession);
   });
 
-  it('delegates to puppeteer', async () => {
-    const send = puppeteerSession.send = jest.fn().mockResolvedValue(123);
+  /** @type {Array<'on'|'off'|'once'>} */
+  const delegateMethods = ['on', 'once', 'off'];
+  for (const method of delegateMethods) {
+    describe(`.${method}`, () => {
+      it('delegates to puppeteer', async () => {
+        const puppeteerFn = puppeteerSession[method] = jest.fn();
+        const callback = () => undefined;
 
-    const result = await session.sendCommand('Page.navigate', {url: 'foo'});
-    expect(result).toEqual(123);
-    expect(send).toHaveBeenCalledWith('Page.navigate', {url: 'foo'});
+        session[method]('Page.frameNavigated', callback);
+        expect(puppeteerFn).toHaveBeenCalledWith('Page.frameNavigated', callback);
+      });
+    });
+  }
+
+  describe('.sendCommand', () => {
+    it('delegates to puppeteer', async () => {
+      const send = puppeteerSession.send = jest.fn().mockResolvedValue(123);
+
+      const result = await session.sendCommand('Page.navigate', {url: 'foo'});
+      expect(result).toEqual(123);
+      expect(send).toHaveBeenCalledWith('Page.navigate', {url: 'foo'});
+    });
   });
 });

--- a/lighthouse-core/test/fraggle-rock/gather/session-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/session-test.js
@@ -1,0 +1,31 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const ProtocolSession = require('../../../fraggle-rock/gather/session.js');
+
+/* eslint-env jest */
+
+describe('.sendCommand', () => {
+  /** @type {import('puppeteer').CDPSession} */
+  let puppeteerSession;
+  /** @type {ProtocolSession} */
+  let session;
+
+  beforeEach(() => {
+    // @ts-expect-error - Individual mock functions are applied as necessary.
+    puppeteerSession = {};
+    session = new ProtocolSession(puppeteerSession);
+  });
+
+  it('delegates to puppeteer', async () => {
+    const send = puppeteerSession.send = jest.fn().mockResolvedValue(123);
+
+    const result = await session.sendCommand('Page.navigate', {url: 'foo'});
+    expect(result).toEqual(123);
+    expect(send).toHaveBeenCalledWith('Page.navigate', {url: 'foo'});
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,8 @@
     // Opt-in to typechecking for some core tests.
     "lighthouse-core/test/scripts/lantern/constants-test.js",
     "lighthouse-core/test/gather/driver/execution-context-test.js",
+    "lighthouse-core/test/fraggle-rock/gather/session-test.js",
+    "lighthouse-core/test/fraggle-rock/gather/driver-test.js",
     "lighthouse-core/test/gather/driver-test.js",
     "lighthouse-core/test/gather/gather-runner-test.js",
     "lighthouse-core/test/audits/script-treemap-data-test.js"

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -23,7 +23,8 @@ declare global {
     }
 
     /** The limited driver interface shared between pre and post Fraggle Rock Lighthouse. */
-    export interface FRTransitionalDriver extends FRProtocolSession {
+    export interface FRTransitionalDriver {
+      defaultSession: FRProtocolSession;
       evaluateAsync(expression: string, options?: {useIsolation?: boolean}): Promise<any>;
     }
 


### PR DESCRIPTION
**Summary**
Builds on the work of #11623 #11633 #11685 to add the fraggle rock driver which is session aware. This is the thinnest implementation that will enable snapshot mode.

**Related Issues/PRs**
See #11622 and #11313 for the larger context.
