### PR TITLE
core(config): remove gatherer options support

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -798,7 +798,7 @@ class Config {
         }
       });
 
-      // De-dupe gatherers by artifact name.
+      // De-dupe gatherers by artifact name because artifact IDs must be unique at runtime.
       const mergedDefns = Array.from(
         new Map(gathererDefns.map(defn => [defn.instance.name, defn])).values()
       );

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -799,12 +799,12 @@ class Config {
       });
 
       // De-dupe gatherers by artifact name because artifact IDs must be unique at runtime.
-      const mergedDefns = Array.from(
+      const uniqueDefns = Array.from(
         new Map(gathererDefns.map(defn => [defn.instance.name, defn])).values()
       );
-      mergedDefns.forEach(gatherer => assertValidGatherer(gatherer.instance, gatherer.path));
+      uniqueDefns.forEach(gatherer => assertValidGatherer(gatherer.instance, gatherer.path));
 
-      return Object.assign(pass, {gatherers: mergedDefns});
+      return Object.assign(pass, {gatherers: uniqueDefns});
     });
     log.timeEnd(status);
     return fullPasses;

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -16,7 +16,7 @@ const path = require('path');
 const Runner = require('../runner.js');
 const ConfigPlugin = require('./config-plugin.js');
 const Budget = require('./budget.js');
-const {requireAudits, mergeOptionsOfItems, resolveModule} = require('./config-helpers.js');
+const {requireAudits, resolveModule} = require('./config-helpers.js');
 
 /** @typedef {typeof import('../gather/gatherers/gatherer.js')} GathererConstructor */
 /** @typedef {InstanceType<GathererConstructor>} Gatherer */
@@ -374,10 +374,6 @@ class Config {
           gathererDefn.implementation = undefined;
           // @ts-expect-error Breaking the Config.GathererDefn type.
           gathererDefn.instance = undefined;
-          if (Object.keys(gathererDefn.options).length === 0) {
-            // @ts-expect-error Breaking the Config.GathererDefn type.
-            gathererDefn.options = undefined;
-          }
         }
       }
     }
@@ -741,12 +737,11 @@ class Config {
 
   /**
    * @param {string} path
-   * @param {{}|undefined} options
    * @param {Array<string>} coreAuditList
    * @param {string=} configDir
    * @return {LH.Config.GathererDefn}
    */
-  static requireGathererFromPath(path, options, coreAuditList, configDir) {
+  static requireGathererFromPath(path, coreAuditList, configDir) {
     const coreGatherer = coreAuditList.find(a => a === `${path}.js`);
 
     let requirePath = `../gather/gatherers/${path}`;
@@ -761,7 +756,6 @@ class Config {
       instance: new GathererClass(),
       implementation: GathererClass,
       path,
-      options: options || {},
     };
   }
 
@@ -788,7 +782,6 @@ class Config {
             instance: gathererDefn.instance,
             implementation: gathererDefn.implementation,
             path: gathererDefn.path,
-            options: gathererDefn.options || {},
           };
         } else if (gathererDefn.implementation) {
           const GathererClass = gathererDefn.implementation;
@@ -796,18 +789,19 @@ class Config {
             instance: new GathererClass(),
             implementation: gathererDefn.implementation,
             path: gathererDefn.path,
-            options: gathererDefn.options || {},
           };
         } else if (gathererDefn.path) {
           const path = gathererDefn.path;
-          const options = gathererDefn.options;
-          return Config.requireGathererFromPath(path, options, coreList, configDir);
+          return Config.requireGathererFromPath(path, coreList, configDir);
         } else {
           throw new Error('Invalid expanded Gatherer: ' + JSON.stringify(gathererDefn));
         }
       });
 
-      const mergedDefns = mergeOptionsOfItems(gathererDefns);
+      // De-dupe gatherers by artifact name.
+      const mergedDefns = Array.from(
+        new Map(gathererDefns.map(defn => [defn.instance.name, defn])).values()
+      );
       mergedDefns.forEach(gatherer => assertValidGatherer(gatherer.instance, gatherer.path));
 
       return Object.assign(pass, {gatherers: mergedDefns});

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -382,8 +382,6 @@ class GatherRunner {
 
     for (const gathererDefn of passContext.passConfig.gatherers) {
       const gatherer = gathererDefn.instance;
-      // Abuse the passContext to pass through gatherer options
-      passContext.options = gathererDefn.options || {};
       const status = {
         msg: `Gathering setup: ${gatherer.name}`,
         id: `lh:gather:beforePass:${gatherer.name}`,
@@ -412,8 +410,6 @@ class GatherRunner {
 
     for (const gathererDefn of gatherers) {
       const gatherer = gathererDefn.instance;
-      // Abuse the passContext to pass through gatherer options
-      passContext.options = gathererDefn.options || {};
       const status = {
         msg: `Gathering in-page: ${gatherer.name}`,
         id: `lh:gather:pass:${gatherer.name}`,
@@ -457,8 +453,6 @@ class GatherRunner {
       };
       log.time(status);
 
-      // Add gatherer options to the passContext.
-      passContext.options = gathererDefn.options || {};
       const artifactPromise = Promise.resolve()
         .then(_ => gatherer.afterPass(passContext, loadData));
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -66,6 +66,7 @@ describe('Config', () => {
       }
 
       get name() {
+        // Use unique artifact name per instance so gatherers aren't deduplicated.
         return `MyGatherer${this.secret}`;
       }
     }
@@ -1210,7 +1211,7 @@ describe('Config', () => {
   });
 
   describe('#requireGatherers', () => {
-    it('should merge gatherers', () => {
+    it('should deduplicate gatherers', () => {
       const gatherers = [
         'viewport-dimensions',
         {path: 'viewport-dimensions'},

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -64,6 +64,10 @@ describe('Config', () => {
         super();
         this.secret = secretVal;
       }
+
+      get name() {
+        return `MyGatherer${this.secret}`;
+      }
     }
     const myGatherer1 = new MyGatherer(1729);
     const myGatherer2 = new MyGatherer(6);
@@ -1209,8 +1213,7 @@ describe('Config', () => {
     it('should merge gatherers', () => {
       const gatherers = [
         'viewport-dimensions',
-        {path: 'viewport-dimensions', options: {x: 1}},
-        {path: 'viewport-dimensions', options: {y: 1}},
+        {path: 'viewport-dimensions'},
       ];
 
       const merged = Config.requireGatherers([{gatherers}]);
@@ -1218,7 +1221,7 @@ describe('Config', () => {
       const mergedJson = JSON.parse(JSON.stringify(merged));
 
       assert.deepEqual(mergedJson[0].gatherers,
-        [{path: 'viewport-dimensions', options: {x: 1, y: 1}, instance: {}}]);
+        [{path: 'viewport-dimensions', instance: {}}]);
     });
 
     function loadGatherer(gathererEntry) {
@@ -1325,16 +1328,14 @@ describe('Config', () => {
   });
 
   describe('#getPrintString', () => {
-    it('doesn\'t include empty gatherer/audit options in output', () => {
-      const gOpt = 'gathererOption';
+    it('doesn\'t include empty audit options in output', () => {
       const aOpt = 'auditOption';
       const configJson = {
         extends: 'lighthouse:default',
         passes: [{
           passName: 'defaultPass',
           gatherers: [
-            // `options` merged into default `script-elements` gatherer.
-            {path: 'script-elements', options: {gOpt}},
+            {path: 'script-elements'},
           ],
         }],
         audits: [
@@ -1347,19 +1348,8 @@ describe('Config', () => {
       const printedConfig = JSON.parse(printed);
 
       // Check that options weren't completely eliminated.
-      const scriptsGatherer = printedConfig.passes[0].gatherers
-        .find(g => g.path === 'script-elements');
-      assert.strictEqual(scriptsGatherer.options.gOpt, gOpt);
       const metricsAudit = printedConfig.audits.find(a => a.path === 'metrics');
       assert.strictEqual(metricsAudit.options.aOpt, aOpt);
-
-      for (const pass of printedConfig.passes) {
-        for (const gatherer of pass.gatherers) {
-          if (gatherer.options) {
-            assert.ok(Object.keys(gatherer.options).length > 0);
-          }
-        }
-      }
 
       for (const audit of printedConfig.audits) {
         if (audit.options) {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -1464,64 +1464,6 @@ describe('GatherRunner', function() {
       });
     });
 
-    it('passes gatherer options', async () => {
-      /** @type {Record<string, any[]>} */
-      const calls = {beforePass: [], pass: [], afterPass: []};
-      /** @param {string} name */
-      const makeEavesdropGatherer = name => {
-        const C = class extends Gatherer {};
-        Object.defineProperty(C, 'name', {value: name});
-        return Object.assign(new C, {
-          /** @param {LH.Gatherer.PassContext} context */
-          beforePass(context) {
-            calls.beforePass.push(context.options);
-          },
-          /** @param {LH.Gatherer.PassContext} context */
-          pass(context) {
-            calls.pass.push(context.options);
-          },
-          /** @param {LH.Gatherer.PassContext} context */
-          afterPass(context) {
-            calls.afterPass.push(context.options);
-            // @ts-expect-error
-            return context.options.x || 'none';
-          },
-        });
-      };
-
-      const gatherers = [
-        {instance: makeEavesdropGatherer('EavesdropGatherer1'), options: {x: 1}},
-        {instance: makeEavesdropGatherer('EavesdropGatherer2'), options: {x: 2}},
-        {instance: makeEavesdropGatherer('EavesdropGatherer3')},
-      ];
-
-      const config = makeConfig({
-        passes: [{
-          passName: 'defaultPass',
-          gatherers,
-        }],
-      });
-
-      /** @type {any} Using Test-only gatherers. */
-      const artifacts = await GatherRunner.run(config.passes, {
-        driver: fakeDriver,
-        requestedUrl: 'https://example.com',
-        settings: config.settings,
-      });
-
-      assert.equal(artifacts.EavesdropGatherer1, 1);
-      assert.equal(artifacts.EavesdropGatherer2, 2);
-      assert.equal(artifacts.EavesdropGatherer3, 'none');
-
-      // assert that all three phases received the gatherer options expected
-      const expectedOptions = [{x: 1}, {x: 2}, {}];
-      for (let i = 0; i < 3; i++) {
-        assert.deepEqual(calls.beforePass[i], expectedOptions[i]);
-        assert.deepEqual(calls.pass[i], expectedOptions[i]);
-        assert.deepEqual(calls.afterPass[i], expectedOptions[i]);
-      }
-    });
-
     it('uses the last not-undefined phase result as artifact', async () => {
       const recoverableError = new Error('My recoverable error');
       const someOtherError = new Error('Bad, bad error.');

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -90,7 +90,6 @@ declare global {
         implementation?: typeof Gatherer;
         instance: InstanceType<typeof Gatherer>;
         path?: string;
-        options: {};
       }
 
       export interface AuditDefn {

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -39,7 +39,6 @@ declare global {
       disableJavaScript?: boolean;
       passConfig: Config.Pass
       settings: Config.Settings;
-      options?: object;
       /** Gatherers can push to this array to add top-level warnings to the LHR. */
       LighthouseRunWarnings: Array<string | IcuMessage>;
       baseArtifacts: BaseArtifacts;


### PR DESCRIPTION
**Summary (Why)**
Gatherer options as implemented today fundamentally clash with the more useful level of *artifact* options proposed by FR. They aren't being used anywhere in Lighthouse core and I doubt they ever caught on in custom config land (plugins can't define gatherers). Removing them now will ease the config transition plan with minimal cost.

**Summary (What)**
Removes support for gatherer options. We added them [three years ago](https://github.com/GoogleChrome/lighthouse/pull/4394) at the same time as audit options when we first started playing around with LR and originally planned to utilize them for scoped opportunities until we scrapped that plan before I/O that year and we never ended up using them since.

It's a breaking change because custom gatherers might have discovered gatherer options but they aren't particularly useful if you already own the gatherer implementation so I doubt they caught on much.

There's also a small feature improvement here that de-dupes gatherers by artifact name instead of the file path. This would result on overwriting of artifacts at runtime anyway so they're already being de-duped today, but you don't find out about it until much later. 

**Related Issues/PRs**
ref #11313 
