### PR TITLE
core: fix NodeDetails type mismatch

### DIFF
--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -75,8 +75,8 @@ class AxeAudit extends Audit {
     let items = [];
     if (rule && rule.nodes) {
       items = rule.nodes.map(node => ({
-        node: /** @type {LH.Audit.Details.NodeValue} */ ({
-          type: 'node',
+        node: {
+          type: /** @type {'node'} */ ('node'),
           lhId: node.lhId,
           selector: node.selector,
           path: node.devtoolsNodePath,
@@ -84,7 +84,7 @@ class AxeAudit extends Audit {
           boundingRect: node.boundingRect,
           explanation: node.failureSummary,
           nodeLabel: node.nodeLabel,
-        }),
+        },
       }));
     }
 

--- a/lighthouse-core/audits/autocomplete.js
+++ b/lighthouse-core/audits/autocomplete.js
@@ -260,11 +260,11 @@ class AutocompleteAudit extends Audit {
           continue;
         }
         failingFormsData.push({
-          node: /** @type {LH.Audit.Details.NodeValue} */ ({
-            type: 'node',
+          node: {
+            type: /** @type {'node'} */ ('node'),
             snippet: input.snippet,
             nodeLabel: input.nodeLabel,
-          }),
+          },
           suggestion: suggestion,
           current: input.autocomplete.attribute,
         });

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -98,24 +98,24 @@ class DOMSize extends Audit {
         value: stats.totalBodyElements,
       },
       {
-        node: /** @type {LH.Audit.Details.NodeValue} */ ({
-          type: 'node',
+        node: {
+          type: /** @type {'node'} */ ('node'),
           path: stats.depth.devtoolsNodePath,
           snippet: stats.depth.snippet,
           selector: stats.depth.selector,
           nodeLabel: stats.depth.nodeLabel,
-        }),
+        },
         statistic: str_(UIStrings.statisticDOMDepth),
         value: stats.depth.max,
       },
       {
-        node: /** @type {LH.Audit.Details.NodeValue} */ ({
-          type: 'node',
+        node: {
+          type: /** @type {'node'} */ ('node'),
           path: stats.width.devtoolsNodePath,
           snippet: stats.width.snippet,
           selector: stats.width.selector,
           nodeLabel: stats.width.nodeLabel,
-        }),
+        },
         statistic: str_(UIStrings.statisticDOMWidth),
         value: stats.width.max,
       },

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -69,13 +69,13 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
       })
       .map(anchor => {
         return {
-          node: /** @type {LH.Audit.Details.NodeValue} */  ({
-            type: 'node',
+          node: {
+            type: /** @type {'node'} */ ('node'),
             path: anchor.devtoolsNodePath || '',
             selector: anchor.selector || '',
             nodeLabel: anchor.nodeLabel || '',
             snippet: anchor.snippet || '',
-          }),
+          },
           href: anchor.href || 'Unknown',
           target: anchor.target || '',
           rel: anchor.rel || '',

--- a/lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
+++ b/lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
@@ -45,11 +45,11 @@ class PasswordInputsCanBePastedIntoAudit extends Audit {
     const items = [];
     passwordInputsWithPreventedPaste.forEach(input => {
       items.push({
-        node: /** @type {LH.Audit.Details.NodeValue} */ ({
-          type: 'node',
+        node: {
+          type: /** @type {'node'} */ ('node'),
           snippet: input.snippet,
           path: input.devtoolsNodePath,
-        }),
+        },
       });
     });
 

--- a/lighthouse-core/audits/largest-contentful-paint-element.js
+++ b/lighthouse-core/audits/largest-contentful-paint-element.js
@@ -39,12 +39,11 @@ class LargestContentfulPaintElement extends Audit {
   static audit(artifacts) {
     const lcpElement = artifacts.TraceElements
       .find(element => element.traceEventType === 'largest-contentful-paint');
-    /** @type {Array<{node: LH.Audit.Details.NodeValue}>} */
     const lcpElementDetails = [];
     if (lcpElement) {
       lcpElementDetails.push({
         node: {
-          type: 'node',
+          type: /** @type {'node'} */ ('node'),
           lhId: lcpElement.lhId,
           path: lcpElement.devtoolsNodePath,
           selector: lcpElement.selector,

--- a/lighthouse-core/audits/largest-contentful-paint-element.js
+++ b/lighthouse-core/audits/largest-contentful-paint-element.js
@@ -39,10 +39,11 @@ class LargestContentfulPaintElement extends Audit {
   static audit(artifacts) {
     const lcpElement = artifacts.TraceElements
       .find(element => element.traceEventType === 'largest-contentful-paint');
+    /** @type {Array<{node: LH.Audit.Details.NodeValue}>} */
     const lcpElementDetails = [];
     if (lcpElement) {
       lcpElementDetails.push({
-        node: /** @type {LH.Audit.Details.NodeValue} */ ({
+        node: {
           type: 'node',
           lhId: lcpElement.lhId,
           path: lcpElement.devtoolsNodePath,
@@ -50,7 +51,7 @@ class LargestContentfulPaintElement extends Audit {
           nodeLabel: lcpElement.nodeLabel,
           snippet: lcpElement.snippet,
           boundingRect: lcpElement.boundingRect,
-        }),
+        },
       });
     }
 

--- a/lighthouse-core/audits/layout-shift-elements.js
+++ b/lighthouse-core/audits/layout-shift-elements.js
@@ -41,11 +41,10 @@ class LayoutShiftElements extends Audit {
     const clsElements = artifacts.TraceElements
       .filter(element => element.traceEventType === 'layout-shift');
 
-    /** @type {Array<{node: LH.Audit.Details.NodeValue, score?: number}>} */
     const clsElementData = clsElements.map(element => {
       return {
         node: {
-          type: 'node',
+          type: /** @type {'node'} */ ('node'),
           lhId: element.lhId,
           path: element.devtoolsNodePath,
           selector: element.selector,

--- a/lighthouse-core/audits/layout-shift-elements.js
+++ b/lighthouse-core/audits/layout-shift-elements.js
@@ -41,9 +41,10 @@ class LayoutShiftElements extends Audit {
     const clsElements = artifacts.TraceElements
       .filter(element => element.traceEventType === 'layout-shift');
 
+    /** @type {Array<{node: LH.Audit.Details.NodeValue, score?: number}>} */
     const clsElementData = clsElements.map(element => {
       return {
-        node: /** @type {LH.Audit.Details.NodeValue} */ ({
+        node: {
           type: 'node',
           lhId: element.lhId,
           path: element.devtoolsNodePath,
@@ -51,7 +52,7 @@ class LayoutShiftElements extends Audit {
           nodeLabel: element.nodeLabel,
           snippet: element.snippet,
           boundingRect: element.boundingRect,
-        }),
+        },
         score: element.score,
       };
     });

--- a/lighthouse-core/audits/unsized-images.js
+++ b/lighthouse-core/audits/unsized-images.js
@@ -98,13 +98,13 @@ class UnsizedImages extends Audit {
       const url = URL.elideDataURI(image.src);
       unsizedImages.push({
         url,
-        node: /** @type {LH.Audit.Details.NodeValue} */ ({
-          type: 'node',
+        node: {
+          type: /** @type {'node'} */ ('node'),
           path: image.devtoolsNodePath,
           selector: image.selector,
           nodeLabel: image.nodeLabel,
           snippet: image.snippet,
-        }),
+        },
       });
     }
 

--- a/lighthouse-core/gather/gatherers/link-elements.js
+++ b/lighthouse-core/gather/gatherers/link-elements.js
@@ -123,7 +123,6 @@ class LinkElements extends Gatherer {
           devtoolsNodePath: '',
           selector: '',
           nodeLabel: '',
-          boundingRect: null,
           snippet: '',
         });
       }

--- a/lighthouse-core/gather/gatherers/script-elements.js
+++ b/lighthouse-core/gather/gatherers/script-elements.js
@@ -29,7 +29,7 @@ function collectAllScriptElements() {
       id: script.id || null,
       async: script.async,
       defer: script.defer,
-      source: /** @type {'head'|'body'} */ (script.closest('head') ? 'head' : 'body'),
+      source: script.closest('head') ? 'head' : 'body',
       // @ts-expect-error - getNodeDetails put into scope via stringification
       ...getNodeDetails(script),
       content: script.src ? null : script.text,
@@ -111,7 +111,6 @@ class ScriptElements extends Gatherer {
           snippet: '',
           selector: '',
           nodeLabel: '',
-          boundingRect: null,
           type: null,
           src: record.url,
           id: null,

--- a/lighthouse-core/test/gather/gatherers/link-elements-test.js
+++ b/lighthouse-core/test/gather/gatherers/link-elements-test.js
@@ -26,7 +26,6 @@ describe('Link Elements gatherer', () => {
       devtoolsNodePath: '',
       nodeLabel: '',
       snippet: '',
-      boundingRect: null,
       selector: '',
       ...overrides,
     };

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -161,7 +161,7 @@ declare global {
         lhId?: string,
         devtoolsNodePath: string,
         selector: string,
-        boundingRect: Rect | null,
+        boundingRect?: Rect,
         snippet: string,
         nodeLabel: string,
       }


### PR DESCRIPTION
I was reviewing some code recently, noticed we're being very aggressive in some type casts of audit details to `/** @type {LH.Audit.Details.NodeValue} */`, removed some of them, and found a type error due to the `NodeDetails` changes in #11405 that wasn't flagged due to the casts hiding the difference between types (in this case, a `null` property in the artifact being used for an optional (but not nullable) property in the audit details).

We were using that cast because if strings are nested in an object, they're typically widened by tsc from the literal value to just `string`, which means they're no longer valid `AuditDetails` (which need a specific literal). But casts are dangerous (this is a pretty mild example of how they can go wrong), so we should avoid if we can.

There are two main options instead of casting:
1. cast just the string

   `type: /** @type {'node'} */ ('node')`

   This is annoying, but it's about as painful as in the typescript world (there you could add `as const` to all of these strings)
2. type the container these are going into.

   ```
   /** @type {Array<{node: LH.Audit.Details.NodeValue}>} */
   const items = rule.nodes.map(node => ({
     node: {
       type: 'node',
       // ...
     },
   };
   ```

   This has improved since we originally added these types, where even if the string literal is several layers deep in an object literal, if it's going into e.g. this example array that's typed with that audit details, the string won't be widened

(2) seems like they better solution, and with details items like `/** @type {Array<{node: LH.Audit.Details.NodeValue}>} */` it's really not so bad. But several of these have more properties (`href`, `target`, `rel`...) and so the type starts getting excessive compared to just letting it be inferred.

As a result, I went with option 1, but completely happy to go the other way instead.

Either way, hopefully this will set the template for how to items in future audits and we can stamp out some future casting :)