### PR TITLE
misc: remove unneeded type casts

### DIFF
--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -67,7 +67,7 @@ async function begin() {
   if (cliFlags.configPath) {
     // Resolve the config file path relative to where cli was called.
     cliFlags.configPath = path.resolve(process.cwd(), cliFlags.configPath);
-    configJson = /** @type {LH.Config.Json} */ (require(cliFlags.configPath));
+    configJson = require(cliFlags.configPath);
   } else if (cliFlags.preset) {
     configJson = require(`../lighthouse-core/config/${cliFlags.preset}-config.js`);
   }

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -123,8 +123,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
       if (node.type === 'cpu' && timing.duration >= 50) {
         lastLongTaskStartTime = Math.max(lastLongTaskStartTime, timing.startTime);
       } else if (node.type === 'network') {
-        const networkNode = /** @type {LH.Gatherer.Simulation.GraphNetworkNode} */ (node);
-        startTimesByURL.set(networkNode.record.url, timing.startTime);
+        startTimesByURL.set(node.record.url, timing.startTime);
       }
     }
 

--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -210,7 +210,7 @@ class RenderBlockingResources extends Audit {
     const adjustedNodeTimings = new Map(nodeTimings);
 
     let totalChildNetworkBytes = 0;
-    const minimalFCPGraph = /** @type {NetworkNode} */ (fcpGraph.cloneWithRelationships(node => {
+    const minimalFCPGraph = fcpGraph.cloneWithRelationships(node => {
       adjustNodeTimings(adjustedNodeTimings, node, Stacks);
 
       // If a node can be deferred, exclude it from the new FCP graph
@@ -225,7 +225,11 @@ class RenderBlockingResources extends Audit {
         totalChildNetworkBytes += (node.record.transferSize || 0) - wastedBytes;
       }
       return !canDeferRequest;
-    }));
+    });
+
+    if (minimalFCPGraph.type !== 'network') {
+      throw new Error('minimalFCPGraph not a NetworkNode');
+    }
 
     // Recalculate the "before" time based on our adjusted node timings.
     const estimateBeforeInline = Math.max(...Array.from(

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -206,7 +206,7 @@ class CriticalRequestChains extends Audit {
         notApplicable: chainCount === 0,
         displayValue: chainCount ? str_(UIStrings.displayValue, {itemCount: chainCount}) : '',
         details: {
-          type: /** @type {'criticalrequestchain'} */('criticalrequestchain'),
+          type: 'criticalrequestchain',
           chains: flattenedChains,
           longestChain,
         },

--- a/lighthouse-core/audits/errors-in-console.js
+++ b/lighthouse-core/audits/errors-in-console.js
@@ -78,7 +78,8 @@ class ErrorLogs extends Audit {
    * @return {LH.Audit.Product}
    */
   static audit(artifacts, context) {
-    const auditOptions = /** @type {AuditOptions} */ (context.options);
+    /** @type {AuditOptions} */
+    const auditOptions = context.options;
 
     const consoleEntries = artifacts.ConsoleMessages;
     const runtimeExceptions = artifacts.RuntimeExceptions;

--- a/lighthouse-core/audits/image-size-responsive.js
+++ b/lighthouse-core/audits/image-size-responsive.js
@@ -167,7 +167,8 @@ function expectedImageSize(displayedWidth, displayedHeight, DPR) {
  */
 function deduplicateResultsByUrl(results) {
   results.sort((a, b) => a.url === b.url ? 0 : (a.url < b. url ? -1 : 1));
-  const deduplicated = /** @type {Result[]} */ ([]);
+  /** @type {Result[]} */
+  const deduplicated = [];
   for (const r of results) {
     const previousResult = deduplicated[deduplicated.length - 1];
     if (previousResult && previousResult.url === r.url) {

--- a/lighthouse-core/audits/large-javascript-libraries.js
+++ b/lighthouse-core/audits/large-javascript-libraries.js
@@ -117,27 +117,27 @@ class LargeJavascriptLibraries extends Audit {
       const suggestions = libraryPairing.suggestions;
       const suggestionItems = suggestions.map(suggestion => {
         return {
-          suggestion: /** @type {LH.Audit.Details.LinkValue} */ ({
-            type: 'link',
+          suggestion: {
+            type: /** @type {'link'} */ ('link'),
             text: suggestion.name,
             url: suggestion.repository,
-          }),
+          },
           transferSize: suggestion.gzip,
           wastedBytes: original.gzip - suggestion.gzip,
         };
       });
 
       return {
-        name: /** @type {LH.Audit.Details.TableItem} */ {
-          type: 'link',
+        name: {
+          type: /** @type {'link'} */ ('link'),
           text: original.name,
           url: original.repository,
         },
         transferSize: original.gzip,
-        subItems: /** @type {LH.Audit.Details.TableSubItems} */ ({
-          type: 'subitems',
+        subItems: {
+          type: /** @type {'subitems'} */ ('subitems'),
           items: suggestionItems,
-        }),
+        },
       };
     });
 

--- a/lighthouse-core/audits/preload-lcp-image.js
+++ b/lighthouse-core/audits/preload-lcp-image.js
@@ -134,11 +134,10 @@ class PreloadLCPImageAudit extends Audit {
     for (const {node} of modifiedGraph.traverseGenerator()) {
       if (node.type !== 'network') continue;
 
-      const networkNode = /** @type {LH.Gatherer.Simulation.GraphNetworkNode} */ (node);
       if (node.isMainDocument()) {
-        mainDocumentNode = networkNode;
-      } else if (networkNode.id === lcpNode.id) {
-        modifiedLCPNode = networkNode;
+        mainDocumentNode = node;
+      } else if (node.id === lcpNode.id) {
+        modifiedLCPNode = node;
       }
     }
 

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -98,8 +98,7 @@ class Redirects extends Audit {
     const nodeTimingsByUrl = new Map();
     for (const [node, timing] of metricResult.pessimisticEstimate.nodeTimings.entries()) {
       if (node.type === 'network') {
-        const networkNode = /** @type {LH.Gatherer.Simulation.GraphNetworkNode} */ (node);
-        nodeTimingsByUrl.set(networkNode.record.url, timing);
+        nodeTimingsByUrl.set(node.record.url, timing);
       }
     }
 

--- a/lighthouse-core/audits/seo/plugins.js
+++ b/lighthouse-core/audits/seo/plugins.js
@@ -73,7 +73,7 @@ function isPluginURL(url) {
     if (parts.length < 2) {
       return false;
     }
-    const part = /** @type {string} */(parts.pop());
+    const part = parts[parts.length - 1];
     return FILE_EXTENSION_BLOCKLIST.has(part.trim().toLowerCase());
   } catch (e) {
     return false;

--- a/lighthouse-core/audits/third-party-summary.js
+++ b/lighthouse-core/audits/third-party-summary.js
@@ -217,15 +217,15 @@ class ThirdPartySummary extends Audit {
 
         return {
           ...stats,
-          entity: /** @type {LH.Audit.Details.LinkValue} */ ({
-            type: 'link',
+          entity: {
+            type: /** @type {'link'} */ ('link'),
             text: entity.name,
             url: entity.homepage || '',
-          }),
-          subItems: /** @type {LH.Audit.Details.TableSubItems} */ ({
-            type: 'subitems',
+          },
+          subItems: {
+            type: /** @type {'subitems'} */ ('subitems'),
             items: ThirdPartySummary.makeSubItems(entity, summaries, stats),
-          }),
+          },
         };
       })
       // Sort by blocking time first, then transfer size to break ties.

--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -149,11 +149,10 @@ class UsesRelPreloadAudit extends Audit {
     modifiedGraph.traverse(node => {
       if (node.type !== 'network') return;
 
-      const networkNode = /** @type {LH.Gatherer.Simulation.GraphNetworkNode} */ (node);
       if (node.isMainDocument()) {
-        mainDocumentNode = networkNode;
-      } else if (networkNode.record && urls.has(networkNode.record.url)) {
-        nodesToPreload.push(networkNode);
+        mainDocumentNode = node;
+      } else if (node.record && urls.has(node.record.url)) {
+        nodesToPreload.push(node);
       }
     });
 

--- a/lighthouse-core/audits/valid-source-maps.js
+++ b/lighthouse-core/audits/valid-source-maps.js
@@ -109,10 +109,10 @@ class ValidSourceMaps extends Audit {
         results.push({
           scriptUrl: scriptElement.src,
           sourceMapUrl: sourceMap && sourceMap.sourceMapUrl,
-          subItems: /** @type {LH.Audit.Details.TableSubItems} */ ({
-            type: 'subitems',
+          subItems: {
+            type: /** @type {'subitems'} */ ('subitems'),
             items: errors,
-          }),
+          },
         });
       }
     }

--- a/lighthouse-core/computed/metrics/first-meaningful-paint.js
+++ b/lighthouse-core/computed/metrics/first-meaningful-paint.js
@@ -31,7 +31,6 @@ class FirstMeaningfulPaint extends ComputedMetric {
     }
 
     return {
-      // FMP established as existing, so cast
       timing: traceOfTab.timings.firstMeaningfulPaint,
       timestamp: traceOfTab.timestamps.firstMeaningfulPaint,
     };

--- a/lighthouse-core/computed/metrics/first-meaningful-paint.js
+++ b/lighthouse-core/computed/metrics/first-meaningful-paint.js
@@ -26,13 +26,13 @@ class FirstMeaningfulPaint extends ComputedMetric {
    */
   static async computeObservedMetric(data) {
     const {traceOfTab} = data;
-    if (!traceOfTab.timestamps.firstMeaningfulPaint) {
+    if (traceOfTab.timings.firstMeaningfulPaint === undefined) {
       throw new LHError(LHError.errors.NO_FMP);
     }
 
     return {
       // FMP established as existing, so cast
-      timing: /** @type {number} */ (traceOfTab.timings.firstMeaningfulPaint),
+      timing: traceOfTab.timings.firstMeaningfulPaint,
       timestamp: traceOfTab.timestamps.firstMeaningfulPaint,
     };
   }

--- a/lighthouse-core/computed/metrics/largest-contentful-paint-all-frames.js
+++ b/lighthouse-core/computed/metrics/largest-contentful-paint-all-frames.js
@@ -33,7 +33,6 @@ class LargestContentfulPaintAllFrames extends ComputedMetric {
     }
 
     return {
-      // LCP established as existing, so cast
       timing: traceOfTab.timings.largestContentfulPaintAllFrames,
       timestamp: traceOfTab.timestamps.largestContentfulPaintAllFrames,
     };

--- a/lighthouse-core/computed/metrics/largest-contentful-paint-all-frames.js
+++ b/lighthouse-core/computed/metrics/largest-contentful-paint-all-frames.js
@@ -28,13 +28,13 @@ class LargestContentfulPaintAllFrames extends ComputedMetric {
    */
   static async computeObservedMetric(data) {
     const {traceOfTab} = data;
-    if (!traceOfTab.timestamps.largestContentfulPaintAllFrames) {
+    if (traceOfTab.timings.largestContentfulPaintAllFrames === undefined) {
       throw new LHError(LHError.errors.NO_LCP_ALL_FRAMES);
     }
 
     return {
       // LCP established as existing, so cast
-      timing: /** @type {number} */ (traceOfTab.timings.largestContentfulPaintAllFrames),
+      timing: traceOfTab.timings.largestContentfulPaintAllFrames,
       timestamp: traceOfTab.timestamps.largestContentfulPaintAllFrames,
     };
   }

--- a/lighthouse-core/computed/metrics/largest-contentful-paint.js
+++ b/lighthouse-core/computed/metrics/largest-contentful-paint.js
@@ -34,13 +34,13 @@ class LargestContentfulPaint extends ComputedMetric {
    */
   static async computeObservedMetric(data) {
     const {traceOfTab} = data;
-    if (!traceOfTab.timestamps.largestContentfulPaint) {
+    if (traceOfTab.timings.largestContentfulPaint === undefined) {
       throw new LHError(LHError.errors.NO_LCP);
     }
 
     return {
       // LCP established as existing, so cast
-      timing: /** @type {number} */ (traceOfTab.timings.largestContentfulPaint),
+      timing: traceOfTab.timings.largestContentfulPaint,
       timestamp: traceOfTab.timestamps.largestContentfulPaint,
     };
   }

--- a/lighthouse-core/computed/metrics/largest-contentful-paint.js
+++ b/lighthouse-core/computed/metrics/largest-contentful-paint.js
@@ -39,7 +39,6 @@ class LargestContentfulPaint extends ComputedMetric {
     }
 
     return {
-      // LCP established as existing, so cast
       timing: traceOfTab.timings.largestContentfulPaint,
       timestamp: traceOfTab.timestamps.largestContentfulPaint,
     };

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -109,10 +109,10 @@ function assertValidCategories(categories, audits, groups) {
     return;
   }
 
-  const auditsKeyedById = new Map((audits || []).map(audit =>
-    /** @type {[string, LH.Config.AuditDefn]} */
-    ([audit.implementation.meta.id, audit])
-  ));
+  /** @type {Map<string, LH.Config.AuditDefn>} */
+  const auditsKeyedById = new Map((audits || []).map(audit => {
+    return [audit.implementation.meta.id, audit];
+  }));
 
   Object.keys(categories).forEach(categoryId => {
     categories[categoryId].auditRefs.forEach((auditRef, index) => {

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -104,7 +104,8 @@ class Connection {
    * @protected
    */
   handleRawMessage(message) {
-    const object = /** @type {LH.Protocol.RawMessage} */(JSON.parse(message));
+    /** @type {LH.Protocol.RawMessage} */
+    const object = JSON.parse(message);
 
     // Responses to commands carry "id" property, while events do not.
     if (!('id' in object)) {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -680,7 +680,8 @@ class Driver {
     const waitForFcp = options.waitForFcp || false;
     const waitForNavigated = options.waitForNavigated || false;
     const waitForLoad = options.waitForLoad || false;
-    const passContext = /** @type {Partial<LH.Gatherer.PassContext>} */ (options.passContext || {});
+    /** @type {Partial<LH.Gatherer.PassContext>} */
+    const passContext = options.passContext || {};
     const disableJS = passContext.disableJavaScript || false;
 
     if (waitForNavigated && (waitForFcp || waitForLoad)) {
@@ -709,7 +710,8 @@ class Driver {
       await waitForFrameNavigated(this).promise;
     } else if (waitForLoad) {
       const networkMonitor = this._networkStatusMonitor;
-      const passConfig = /** @type {Partial<LH.Config.Pass>} */ (passContext.passConfig || {});
+      /** @type {Partial<LH.Config.Pass>} */
+      const passConfig = passContext.passConfig || {};
 
       /* eslint-disable max-len */
       let {pauseAfterFcpMs, pauseAfterLoadMs, networkQuietThresholdMs, cpuQuietThresholdMs} = passConfig;

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -46,7 +46,6 @@ class CSSUsage extends Gatherer {
     await driver.sendCommand('CSS.disable');
     await driver.sendCommand('DOM.disable');
 
-    /** @type {Map<string, LH.Artifacts.CSSStyleSheetInfo>} */
     const dedupedStylesheets = new Map(styleSheetInfo.map(sheet => {
       return [sheet.content, sheet];
     }));

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -46,8 +46,9 @@ class CSSUsage extends Gatherer {
     await driver.sendCommand('CSS.disable');
     await driver.sendCommand('DOM.disable');
 
+    /** @type {Map<string, LH.Artifacts.CSSStyleSheetInfo>} */
     const dedupedStylesheets = new Map(styleSheetInfo.map(sheet => {
-      return /** @type {[string, LH.Artifacts.CSSStyleSheetInfo]} */ ([sheet.content, sheet]);
+      return [sheet.content, sheet];
     }));
     return {
       rules: ruleUsageResponse.ruleUsage,

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -80,8 +80,9 @@ class Simulator {
     /** @type {Record<number, Set<Node>>} */
     this._nodes = {};
     this._dns = new DNSCache({rtt: this._rtt});
+    /** @type {ConnectionPool} */
     // @ts-expect-error
-    this._connectionPool = /** @type {ConnectionPool} */ (null);
+    this._connectionPool = null;
 
     if (!Number.isFinite(this._rtt)) throw new Error(`Invalid rtt ${this._rtt}`);
     if (!Number.isFinite(this._throughput)) throw new Error(`Invalid rtt ${this._throughput}`);

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -28,13 +28,11 @@ function convertNodeTimingsToTrace(nodeTimings) {
     lastEventEndTime = Math.max(lastEventEndTime, timing.endTime);
     if (node.type === 'cpu') {
       // Represent all CPU work that was bundled in a task as an EvaluateScript event
-      const cpuNode = /** @type {LH.Gatherer.Simulation.GraphCPUNode} */ (node);
-      traceEvents.push(...createFakeTaskEvents(cpuNode, timing));
+      traceEvents.push(...createFakeTaskEvents(node, timing));
     } else {
-      const networkNode = /** @type {LH.Gatherer.Simulation.GraphNetworkNode} */ (node);
       // Ignore data URIs as they don't really add much value
-      if (/^data/.test(networkNode.record.url)) continue;
-      traceEvents.push(...createFakeNetworkEvents(networkNode.record, timing));
+      if (/^data/.test(node.record.url)) continue;
+      traceEvents.push(...createFakeNetworkEvents(node.record, timing));
     }
   }
 

--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -110,7 +110,8 @@ class NetworkRequest {
     this.failed = false;
     this.localizedFailDescription = '';
 
-    this.initiator = /** @type {LH.Crdp.Network.Initiator} */ ({type: 'other'});
+    /** @type {LH.Crdp.Network.Initiator} */
+    this.initiator = {type: 'other'};
     /** @type {LH.Crdp.Network.ResourceTiming|undefined} */
     this.timing = undefined;
     /** @type {LH.Crdp.Network.ResourceType|undefined} */

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -369,7 +369,7 @@ function isPositionFixed(element) {
  * Generate a human-readable label for the given element, based on end-user facing
  * strings like the innerText or alt attribute.
  * Falls back to the tagName if no useful label is found.
- * @param {HTMLElement} node
+ * @param {Element} node
  * @return {string|null}
  */
 /* istanbul ignore next */
@@ -398,7 +398,7 @@ function getNodeLabel(node) {
       // E.g. if an a tag contains an image but no text we want the image alt/aria-label attribute.
       const nodeToUseForLabel = node.querySelector('[alt], [aria-label]');
       if (nodeToUseForLabel) {
-        return getNodeLabel(/** @type {HTMLElement} */ (nodeToUseForLabel));
+        return getNodeLabel(nodeToUseForLabel);
       }
     }
   }

--- a/lighthouse-core/lib/sd-validation/sd-validation.js
+++ b/lighthouse-core/lib/sd-validation/sd-validation.js
@@ -23,7 +23,7 @@ module.exports = async function validate(textInput) {
 
   if (parseError) {
     return [{
-      validator: /** @type {LH.StructuredData.ValidatorType} */ ('json'),
+      validator: 'json',
       lineNumber: parseError.lineNumber,
       message: parseError.message,
     }];
@@ -37,7 +37,7 @@ module.exports = async function validate(textInput) {
   if (jsonLdErrors.length) {
     return jsonLdErrors.map(error => {
       return {
-        validator: /** @type {LH.StructuredData.ValidatorType} */ ('json-ld'),
+        validator: 'json-ld',
         path: error.path,
         message: error.message,
         lineNumber: getLineNumberFromJsonLDPath(inputObject, error.path),
@@ -52,7 +52,7 @@ module.exports = async function validate(textInput) {
     expandedObj = await expandAsync(inputObject);
   } catch (error) {
     return [{
-      validator: /** @type {LH.StructuredData.ValidatorType} */ ('json-ld-expand'),
+      validator: 'json-ld-expand',
       message: error.message,
     }];
   }
@@ -63,7 +63,7 @@ module.exports = async function validate(textInput) {
   if (schemaOrgErrors.length) {
     return schemaOrgErrors.map(error => {
       return {
-        validator: /** @type {LH.StructuredData.ValidatorType} */ ('schema-org'),
+        validator: 'schema-org',
         path: error.path,
         message: error.message,
         lineNumber: error.path ? getLineNumberFromJsonLDPath(inputObject, error.path) : null,

--- a/lighthouse-core/lib/stack-collector.js
+++ b/lighthouse-core/lib/stack-collector.js
@@ -90,8 +90,9 @@ async function collectStacks(passContext) {
   /** @type {JSLibrary[]} */
   const jsLibraries = await passContext.driver.evaluateAsync(expression);
 
+  /** @type {LH.Artifacts['Stacks']} */
   const stacks = jsLibraries.map(lib => ({
-    detector: /** @type {'js'} */ ('js'),
+    detector: 'js',
     id: lib.id,
     name: lib.name,
     version: typeof lib.version === 'number' ? String(lib.version) : (lib.version || undefined),

--- a/lighthouse-core/report/html/renderer/i18n.js
+++ b/lighthouse-core/report/html/renderer/i18n.js
@@ -141,12 +141,13 @@ class I18n {
 
     /** @type {Array<string>} */
     const parts = [];
-    const unitLabels = /** @type {Object<string, number>} */ ({
+    /** @type {Record<string, number>} */
+    const unitLabels = {
       d: 60 * 60 * 24,
       h: 60 * 60,
       m: 60,
       s: 1,
-    });
+    };
 
     Object.keys(unitLabels).forEach(label => {
       const unit = unitLabels[label];

--- a/lighthouse-core/report/html/renderer/psi.js
+++ b/lighthouse-core/report/html/renderer/psi.js
@@ -85,7 +85,9 @@ function prepareLabData(LHResult, document) {
 function _getFinalScreenshot(perfCategory) {
   const auditRef = perfCategory.auditRefs.find(audit => audit.id === 'final-screenshot');
   if (!auditRef || !auditRef.result || auditRef.result.scoreDisplayMode === 'error') return null;
-  return /** @type {LH.Audit.Details.Screenshot} */ (auditRef.result.details).data;
+  const details = auditRef.result.details;
+  if (!details || details.type !== 'screenshot') return null;
+  return details.data;
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -594,10 +594,9 @@ class ReportUIFeatures {
     if ('onbeforeprint' in self) {
       self.addEventListener('afterprint', this.collapseAllDetails);
     } else {
-      const win = /** @type {Window} */ (self);
       // Note: FF implements both window.onbeforeprint and media listeners. However,
       // it doesn't matchMedia doesn't fire when matching 'print'.
-      win.matchMedia('print').addListener(mql => {
+      self.matchMedia('print').addListener(mql => {
         if (mql.matches) {
           this.expandAllDetails();
         } else {

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -200,14 +200,14 @@ class Runner {
     // Truncate timestamps to hundredths of a millisecond saves ~4KB. No need for microsecond
     // resolution.
     .map(entry => {
-      return /** @type {PerformanceEntry} */ ({
+      return {
         // Don't spread entry because browser PerformanceEntries can't be spread.
         // https://github.com/GoogleChrome/lighthouse/issues/8638
         startTime: parseFloat(entry.startTime.toFixed(2)),
         name: entry.name,
         duration: parseFloat(entry.duration.toFixed(2)),
         entryType: entry.entryType,
-      });
+      };
     });
     const runnerEntry = timingEntries.find(e => e.name === 'lh:runner:run');
     return {entries: timingEntries, total: runnerEntry && runnerEntry.duration || 0};

--- a/lighthouse-core/scripts/lantern/collect/common.js
+++ b/lighthouse-core/scripts/lantern/collect/common.js
@@ -107,8 +107,11 @@ function saveSummary(summary) {
  * @return {LH.Artifacts.TimingSummary|undefined}
  */
 function getMetrics(lhr) {
-  const metricsDetails = /** @type {LH.Audit.Details.DebugData=} */ (lhr.audits['metrics'].details);
-  if (!metricsDetails || !metricsDetails.items || !metricsDetails.items[0]) return;
+  const metricsDetails = lhr.audits['metrics'].details;
+  if (!metricsDetails || metricsDetails.type !== 'debugdata' ||
+      !metricsDetails.items || !metricsDetails.items[0]) {
+    return;
+  }
   /** @type {LH.Artifacts.TimingSummary} */
   const metrics = JSON.parse(JSON.stringify(metricsDetails.items[0]));
 

--- a/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
+++ b/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
@@ -49,7 +49,8 @@ async function main() {
   const auditResults = await LegacyJavascript.audit(artifacts, {
     computedCache: new Map(),
     options: {},
-    settings: /** @type {any} */ ({}),
+    /** @type {any} */
+    settings: {},
   });
 
   const items =

--- a/lighthouse-core/test/gather/driver/execution-context-test.js
+++ b/lighthouse-core/test/gather/driver/execution-context-test.js
@@ -21,7 +21,8 @@ const createMockSendCommandFn = createMockSendCommandFn_.bind(null, {useSessionI
 
 /** @return {LH.Gatherer.FRProtocolSession} */
 function createMockSession() {
-  const session = /** @type {*} */ ({});
+  /** @type {any} */
+  const session = {};
   session.hasNextProtocolTimeout = jest.fn().mockReturnValue(false);
   session.setNextProtocolTimeout = jest.fn();
   return session;

--- a/lighthouse-core/test/lib/i18n/swap-locale-test.js
+++ b/lighthouse-core/test/lib/i18n/swap-locale-test.js
@@ -12,7 +12,8 @@ const lhr = require('../../results/sample_v2.json');
 /* eslint-env jest */
 describe('swap-locale', () => {
   it('does not mutate the original lhr', () => {
-    const lhrClone = /** @type {LH.Result} */ (JSON.parse(JSON.stringify(lhr)));
+    /** @type {LH.Result} */
+    const lhrClone = JSON.parse(JSON.stringify(lhr));
 
     const lhrPt = swapLocale(lhr, 'pt').lhr;
     expect(lhrPt).not.toStrictEqual(lhr);
@@ -20,7 +21,8 @@ describe('swap-locale', () => {
   });
 
   it('can change golden LHR english strings into german', () => {
-    const lhrEn = /** @type {LH.Result} */ (JSON.parse(JSON.stringify(lhr)));
+    /** @type {LH.Result} */
+    const lhrEn = JSON.parse(JSON.stringify(lhr));
     const lhrDe = swapLocale(lhrEn, 'de').lhr;
 
     // Basic replacement
@@ -43,7 +45,8 @@ describe('swap-locale', () => {
   });
 
   it('can roundtrip back to english correctly', () => {
-    const lhrEn = /** @type {LH.Result} */ (JSON.parse(JSON.stringify(lhr)));
+    /** @type {LH.Result} */
+    const lhrEn = JSON.parse(JSON.stringify(lhr));
 
     // via Spanish
     const lhrEnEsRT = swapLocale(swapLocale(lhrEn, 'es').lhr, 'en-US').lhr;


### PR DESCRIPTION
follow up to #11752

I did an audit of the other casts I could find and eliminated any that were unnecessary or easy to work around. In the remaining ones, there are some that aren't really casts (typing the initial value of a `reduce` call), some that are annoyingly necessary (tuples, depending on where they come from/are going), and some ugly ones that are hard to remove but we should get around to fixing at some point.