### PR TITLE
misc(build): quiet the 'npm pack' command

### DIFF
--- a/build/build-pack.sh
+++ b/build/build-pack.sh
@@ -6,7 +6,7 @@ LH_ROOT="$DIRNAME/.."
 tmp_dir=$(mktemp -d -t lh-XXXXXXXXXX)
 
 cd "$tmp_dir"
-npm pack "$LH_ROOT"
+npm pack "$LH_ROOT" 2>/dev/null
 mv *.tgz "$LH_ROOT/dist/lighthouse.tgz"
 
 rmdir "$tmp_dir"


### PR DESCRIPTION
when looking at CI logs i sometimes gotta inspect the `yarn build` output. ([example](https://github.com/GoogleChrome/lighthouse/pull/11764/checks?check_run_id=1497703846))

99% of it is all the filenames that went into the `npm pack`.  IMO these don't add value, especially not in the CI scenario.

now, no more noisy output. we just got a filename when it succeeds:

```
$ npm pack 2>/dev/null
lighthouse-6.5.0.tgz
```