### PR TITLE
misc(buildtracker): skip git deepen if no token

### DIFF
--- a/.github/scripts/git-get-shared-history.sh
+++ b/.github/scripts/git-get-shared-history.sh
@@ -18,15 +18,13 @@ set -euxo pipefail
 # - https://github.com/paularmstrong/build-tracker/issues/106
 # - https://github.com/paularmstrong/build-tracker/issues/200
 
+if [[ -z "$BT_API_AUTH_TOKEN" ]]; then
+  echo "Build tracker auth token not available, skipping git deepening."
+  exit 0
+fi
+
 # We can always use some more history
 git -c protocol.version=2 fetch --deepen=100
-
-# Find out if the PR is coming from a fork
-base_clone_url=$(jq --raw-output '.pull_request.head.repo.clone_url' $GITHUB_EVENT_PATH)
-# If it is, we need the fork's history, too.
-if [[ $base_clone_url != "GoogleChrome/lighthouse.git" ]]; then
-  git -c protocol.version=2 fetch --deepen=100 "$base_clone_url"
-fi
 echo "History is deepened."
 
 if git merge-base HEAD origin/master > /dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
     # buildtracker needs history and a common merge commit.
     - name: Fixup git history (for buildtracker)
       run: bash $GITHUB_WORKSPACE/.github/scripts/git-get-shared-history.sh
+      env:
+        # https://buildtracker.dev/docs/guides/github-actions#configuration
+        BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
     - name: Store in buildtracker
       # TODO(paulirish): Don't allow this to fail the build. https://github.com/paularmstrong/build-tracker/issues/200
       run: yarn bt-cli upload-build || true


### PR DESCRIPTION
**Summary**
Master is failing CI due to some [git history changes](https://github.com/GoogleChrome/lighthouse/runs/1505055315). This reverts those changes from #11698 and just skips the check when secrets aren't available instead (same result that happens now for external contributors because the next step immediately fails).

**Related Issues/PRs**
ref #11698 
