### PR TITLE
tests: update flaky 3p facades smoke test

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -380,7 +380,7 @@ module.exports = [
               {
                 product: 'YouTube Embedded Player (Video)',
                 blockingTime: 0,
-                transferSize: '>100000', // Transfer size varies a lot
+                transferSize: '>100000', // Transfer size is imprecise.
                 subItems: {
                   type: 'subitems',
                   items: {

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -380,7 +380,7 @@ module.exports = [
               {
                 product: 'YouTube Embedded Player (Video)',
                 blockingTime: 0,
-                transferSize: '651128 +/- 100000',
+                transferSize: '>100000', // Transfer size varies a lot
                 subItems: {
                   type: 'subitems',
                   items: {

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -380,7 +380,7 @@ module.exports = [
               {
                 product: 'YouTube Embedded Player (Video)',
                 blockingTime: 0,
-                transferSize: '>100000', // Transfer size is imprecise.
+                transferSize: '>400000', // Transfer size is imprecise.
                 subItems: {
                   type: 'subitems',
                   items: {


### PR DESCRIPTION
The third-party facades smoke test is flaky in CI. The YT embed transfer size sometimes exceeds the bounds of the expectation.

Considering the test is already lenient with the number of subresources, I think it's best to make the transfer size super lenient as well.
