### PR TITLE
tests(smoke): fix failureReasonsMask flake

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -240,7 +240,10 @@ module.exports = [
           animations: [
             {
               name: 'anim',
-              failureReasonsMask: 8224,
+              // The animation reliably gets kUnsupportedCSSProperty (1 << 13) === 8192.
+              // Sometimes it also gets kTargetHasInvalidCompositingState (1 << 5) == 32. Together they sum to 8224.
+              // Both are fine for our purposes.
+              failureReasonsMask: '8192 +/- 32',
               unsupportedProperties: ['background-color'],
             },
           ],


### PR DESCRIPTION
Example failure: 
![image](https://user-images.githubusercontent.com/39191/101563132-91846400-397d-11eb-9f3f-ea39d4275aed.png)

Most of the `smoke_3_ToT` failures ive been seeing this afternoon are coming from this assertion.


-----------------



The animation reliably gets `kUnsupportedCSSProperty` (1 << 13) === 8192. (which is what we want)

Sometimes it also gets `kTargetHasInvalidCompositingState` (1 << 5) == 32. (but not always) Together they sum to 8224.

@adamraine and I have investigated `kTargetHasInvalidCompositingState` a few times and it's not actionable, in part because it shows up under very hard-to-predict circumstances.. Basically its presence is flaky

so this PR changes the smoketest expectation to handle it being there and not.



---


on the impl: i stated with /(8192)|(8224)/ but our report-assert doesn't expect to apply regexes to numbers, and I didn't want to deal with that. Overall i'm happier with this anyway.