### PR TITLE
misc: eslintignore .d.ts files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,3 +18,6 @@ coverage/**
 lighthouse-core/scripts/legacy-javascript/variants
 
 third-party/chromium-webtests
+
+# ignore d.ts files until we can properly lint them
+*.d.ts


### PR DESCRIPTION
this will silence all the complaining in vscode. I can't figure out a nice way to actually turn the errors there into usable errors in `yarn lint`. Probably need to dig deeper into `@typescript-eslint/eslint-plugin`.

The alternative to completely ignoring is selectively turning off rules, as some of the remaining rules could be improvements (even if not enforced by our tests). Something like this in `.eslintrc.js`:

```js
{
  files: ['*.d.ts'],
  rules: {
    'strict': 0,
    'no-unused-vars': 0,
    'no-undef': 0,
    'max-len': 0,
  },
},
```