### PR TITLE
deps: update yargs to latest

### DIFF
--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -102,21 +102,6 @@ async function begin() {
         ' Please use "--emulated-form-factor=none" instead.');
   }
 
-  if (typeof cliFlags.extraHeaders === 'string') {
-    // TODO: LH.Flags.extraHeaders is sometimes actually a string at this point, but needs to be
-    // copied over to LH.Settings.extraHeaders, which is LH.Crdp.Network.Headers. Force
-    // the conversion here, but long term either the CLI flag or the setting should have
-    // a different name.
-    /** @type {string} */
-    let extraHeadersStr = cliFlags.extraHeaders;
-    // If not a JSON object, assume it's a path to a JSON file.
-    if (extraHeadersStr.substr(0, 1) !== '{') {
-      extraHeadersStr = fs.readFileSync(extraHeadersStr, 'utf-8');
-    }
-
-    cliFlags.extraHeaders = JSON.parse(extraHeadersStr);
-  }
-
   if (cliFlags.precomputedLanternDataPath) {
     const lanternDataStr = fs.readFileSync(cliFlags.precomputedLanternDataPath, 'utf8');
     /** @type {LH.PrecomputedLanternData} */

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -8,30 +8,17 @@
 /* eslint-disable max-len */
 
 const yargs = require('yargs');
-const pkg = require('../package.json');
-const printer = require('./printer.js');
-
-/**
- * Remove in Node 11 - [].flatMap
- * @param {Array<Array<string>>} arr
- * @return {string[]}
- */
-function flatten(arr) {
-  /** @type {string[]} */
-  const result = [];
-  return result.concat(...arr);
-}
+const fs = require('fs');
 
 /**
  * @param {string=} manualArgv
  * @return {LH.CliFlags}
  */
 function getFlags(manualArgv) {
-  // @ts-expect-error yargs() is incorrectly typed as not accepting a single string.
+  // @ts-expect-error - undocumented, but yargs() supports parsing a single `string`.
   const y = manualArgv ? yargs(manualArgv) : yargs;
-  // Intentionally left as type `any` because @types/yargs doesn't chain correctly.
+
   const argv = y.help('help')
-      .version(() => pkg.version)
       .showHelpOnFail(false, 'Specify --help for available options')
 
       .usage('lighthouse <url> <options>')
@@ -61,7 +48,14 @@ function getFlags(manualArgv) {
       .example(
           'lighthouse <url> --only-categories=performance,pwa',
           'Only run the specified categories. Available categories: accessibility, best-practices, performance, pwa, seo')
-      /**
+
+      // We only have the single string positional argument, the url.
+      .option('_', {
+        array: true,
+        type: 'string',
+      })
+
+      /*
        * Also accept a file for all of these flags. Yargs will merge in and override the file-based
        * flags with the command-line flags.
        *
@@ -70,114 +64,218 @@ function getFlags(manualArgv) {
        *
        * @see https://github.com/yargs/yargs/blob/a6e67f15a61558d0ba28bfe53385332f0ce5d431/docs/api.md#config
        */
-      .config('cli-flags-path')
-
-      // List of options
-      .group(['verbose', 'quiet'], 'Logging:')
-      .describe({
-        verbose: 'Displays verbose logging',
-        quiet: 'Displays no progress, debug logs or errors',
+      .option('cli-flags-path', {
+        config: true,
+        describe: 'The path to a JSON file that contains the desired CLI flags to apply. Flags specified at the command line will still override the file-based ones.',
       })
 
-      .group(
-        [
-          'save-assets', 'list-all-audits', 'list-trace-categories', 'print-config', 'additional-trace-categories',
-          'config-path', 'preset', 'chrome-flags', 'port', 'hostname', 'emulated-form-factor',
-          'max-wait-for-load', 'enable-error-reporting', 'gather-mode', 'audit-mode',
-          'only-audits', 'only-categories', 'skip-audits', 'budget-path',
-        ],
-        'Configuration:')
+      // Logging
+      .options({
+        'verbose': {
+          type: 'boolean',
+          default: false,
+          describe: 'Displays verbose logging',
+        },
+        'quiet': {
+          type: 'boolean',
+          default: false,
+          describe: 'Displays no progress, debug logs, or errors',
+        },
+      })
+      .group(['verbose', 'quiet'], 'Logging:')
+
+      // Configuration
+      .options({
+        'save-assets': {
+          type: 'boolean',
+          default: false,
+          describe: 'Save the trace contents & devtools logs to disk',
+        },
+        'list-all-audits': {
+          type: 'boolean',
+          default: false,
+          describe: 'Prints a list of all available audits and exits',
+        },
+        'list-trace-categories': {
+          type: 'boolean',
+          default: false,
+          describe: 'Prints a list of all required trace categories and exits',
+        },
+        'print-config': {
+          type: 'boolean',
+          default: false,
+          describe: 'Print the normalized config for the given config and options, then exit.',
+        },
+        'additional-trace-categories': {
+          type: 'string',
+          describe: 'Additional categories to capture with the trace (comma-delimited).',
+        },
+        'config-path': {
+          type: 'string',
+          describe: `The path to the config JSON.
+            An example config file: lighthouse-core/config/lr-desktop-config.js`,
+        },
+        'preset': {
+          type: 'string',
+          describe: `Use a built-in configuration.
+          WARNING: If the --config-path flag is provided, this preset will be ignored.`,
+        },
+        'chrome-flags': {
+          type: 'string',
+          default: '',
+          describe: `Custom flags to pass to Chrome (space-delimited). For a full list of flags, see https://bit.ly/chrome-flags
+            Additionally, use the CHROME_PATH environment variable to use a specific Chrome binary. Requires Chromium version 66.0 or later. If omitted, any detected Chrome Canary or Chrome stable will be used.`,
+        },
+        'port': {
+          type: 'number',
+          default: 0,
+          describe: 'The port to use for the debugging protocol. Use 0 for a random port',
+        },
+        'hostname': {
+          type: 'string',
+          default: 'localhost',
+          describe: 'The hostname to use for the debugging protocol.',
+        },
+        'emulated-form-factor': {
+          type: 'string',
+          describe: 'Controls the emulated device form factor (mobile vs. desktop) if not disabled',
+        },
+        'max-wait-for-load': {
+          type: 'number',
+          describe: 'The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue. WARNING: Very high values can lead to large traces and instability',
+        },
+        'enable-error-reporting': {
+          type: 'boolean',
+          default: undefined, // Explicitly `undefined` so prompted by default.
+          describe: 'Enables error reporting, overriding any saved preference. --no-enable-error-reporting will do the opposite. More: https://git.io/vFFTO',
+        },
+        'gather-mode': {
+          alias: 'G',
+          coerce: coerceOptionalStringBoolean,
+          describe: 'Collect artifacts from a connected browser and save to disk. (Artifacts folder path may optionally be provided). If audit-mode is not also enabled, the run will quit early.',
+        },
+        'audit-mode': {
+          alias: 'A',
+          coerce: coerceOptionalStringBoolean,
+          describe: 'Process saved artifacts from disk. (Artifacts folder path may be provided, otherwise defaults to ./latest-run/)',
+        },
+        'only-audits': {
+          array: true,
+          type: 'string',
+          coerce: splitCommaSeparatedValues,
+          describe: 'Only run the specified audits',
+        },
+        'only-categories': {
+          array: true,
+          type: 'string',
+          coerce: splitCommaSeparatedValues,
+          describe: 'Only run the specified categories. Available categories: accessibility, best-practices, performance, pwa, seo',
+        },
+        'skip-audits': {
+          array: true,
+          type: 'string',
+          coerce: splitCommaSeparatedValues,
+          describe: 'Run everything except these audits',
+        },
+        'budget-path': {
+          type: 'string',
+          describe: 'The path to the budget.json file for LightWallet.',
+        },
+      })
+      .group([
+        'save-assets', 'list-all-audits', 'list-trace-categories', 'print-config', 'additional-trace-categories',
+        'config-path', 'preset', 'chrome-flags', 'port', 'hostname', 'emulated-form-factor',
+        'max-wait-for-load', 'enable-error-reporting', 'gather-mode', 'audit-mode',
+        'only-audits', 'only-categories', 'skip-audits', 'budget-path',
+      ], 'Configuration:')
+
+      // Output
+      .options({
+        'output': {
+          type: 'array',
+          default: /** @type {['html']} */ (['html']),
+          coerce: coerceOutput,
+          describe: 'Reporter for the results, supports multiple values. choices: "json", "html", "csv"',
+        },
+        'output-path': {
+          type: 'string',
+          describe: `The file path to output the results. Use 'stdout' to write to stdout.
+  If using JSON output, default is stdout.
+  If using HTML or CSV output, default is a file in the working directory with a name based on the test URL and date.
+  If using multiple outputs, --output-path is appended with the standard extension for each output type. "reports/my-run" -> "reports/my-run.report.html", "reports/my-run.report.json", etc.
+  Example: --output-path=./lighthouse-results.html`,
+        },
+        'view': {
+          type: 'boolean',
+          default: false,
+          describe: 'Open HTML report in your browser',
+        },
+      })
+      .group(['output', 'output-path', 'view'], 'Output:')
+
+      // Other options.
+      .options({
+        'locale': {
+          coerce: coerceLocale,
+          describe: 'The locale/language the report should be formatted in',
+        },
+        'blocked-url-patterns': {
+          array: true,
+          type: 'string',
+          describe: 'Block any network requests to the specified URL patterns',
+        },
+        'disable-storage-reset': {
+          type: 'boolean',
+          describe: 'Disable clearing the browser cache and other storage APIs before a run',
+        },
+        'throttling-method': {
+          type: 'string',
+          describe: 'Controls throttling method',
+        },
+      })
       .describe({
-        'cli-flags-path': 'The path to a JSON file that contains the desired CLI flags to apply. Flags specified at the command line will still override the file-based ones.',
-        // We don't allowlist specific locales. Why? So we can support the user who requests 'es-MX' (unsupported) and we'll fall back to 'es' (supported)
-        'locale': 'The locale/language the report should be formatted in',
-        'enable-error-reporting':
-            'Enables error reporting, overriding any saved preference. --no-enable-error-reporting will do the opposite. More: https://git.io/vFFTO',
-        'blocked-url-patterns': 'Block any network requests to the specified URL patterns',
-        'disable-storage-reset':
-            'Disable clearing the browser cache and other storage APIs before a run',
-        'emulated-form-factor': 'Controls the emulated device form factor (mobile vs. desktop) if not disabled',
-        'throttling-method': 'Controls throttling method',
         'throttling.rttMs': 'Controls simulated network RTT (TCP layer)',
         'throttling.throughputKbps': 'Controls simulated network download throughput',
         'throttling.requestLatencyMs': 'Controls emulated network RTT (HTTP layer)',
         'throttling.downloadThroughputKbps': 'Controls emulated network download throughput',
         'throttling.uploadThroughputKbps': 'Controls emulated network upload throughput',
         'throttling.cpuSlowdownMultiplier': 'Controls simulated + emulated CPU throttling',
-        'gather-mode':
-            'Collect artifacts from a connected browser and save to disk. (Artifacts folder path may optionally be provided). If audit-mode is not also enabled, the run will quit early.',
-        'audit-mode': 'Process saved artifacts from disk. (Artifacts folder path may be provided, otherwise defaults to ./latest-run/)',
-        'save-assets': 'Save the trace contents & devtools logs to disk',
-        'list-all-audits': 'Prints a list of all available audits and exits',
-        'list-trace-categories': 'Prints a list of all required trace categories and exits',
-        'additional-trace-categories':
-            'Additional categories to capture with the trace (comma-delimited).',
-        'config-path': `The path to the config JSON.
-            An example config file: lighthouse-core/config/lr-desktop-config.js`,
-        'budget-path': `The path to the budget.json file for LightWallet.`,
-        'preset': `Use a built-in configuration.
-            WARNING: If the --config-path flag is provided, this preset will be ignored.`,
-        'chrome-flags':
-            `Custom flags to pass to Chrome (space-delimited). For a full list of flags, see https://bit.ly/chrome-flags
-            Additionally, use the CHROME_PATH environment variable to use a specific Chrome binary. Requires Chromium version 66.0 or later. If omitted, any detected Chrome Canary or Chrome stable will be used.`,
-        'hostname': 'The hostname to use for the debugging protocol.',
-        'port': 'The port to use for the debugging protocol. Use 0 for a random port',
-        'max-wait-for-load':
-            'The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue. WARNING: Very high values can lead to large traces and instability',
-        'extra-headers': 'Set extra HTTP Headers to pass with request',
-        'precomputed-lantern-data-path': 'Path to the file where lantern simulation data should be read from, overwriting the lantern observed estimates for RTT and server latency.',
-        'lantern-data-output-path': 'Path to the file where lantern simulation data should be written to, can be used in a future run with the `precomputed-lantern-data-path` flag.',
-        'only-audits': 'Only run the specified audits',
-        'only-categories': 'Only run the specified categories. Available categories: accessibility, best-practices, performance, pwa, seo',
-        'skip-audits': 'Run everything except these audits',
-        'plugins': 'Run the specified plugins',
-        'print-config': 'Print the normalized config for the given config and options, then exit.',
       })
-      // set aliases
-      .alias({'gather-mode': 'G', 'audit-mode': 'A'})
-
-      .group(['output', 'output-path', 'view'], 'Output:')
-      .describe({
-        'output': `Reporter for the results, supports multiple values. choices: ${printer.getValidOutputOptions().map(s => `"${s}"`).join(', ')}`,
-        'output-path': `The file path to output the results. Use 'stdout' to write to stdout.
-  If using JSON output, default is stdout.
-  If using HTML or CSV output, default is a file in the working directory with a name based on the test URL and date.
-  If using multiple outputs, --output-path is appended with the standard extension for each output type. "reports/my-run" -> "reports/my-run.report.html", "reports/my-run.report.json", etc.
-  Example: --output-path=./lighthouse-results.html`,
-        'view': 'Open HTML report in your browser',
+      .options({
+        'extra-headers': {
+          coerce: coerceExtraHeaders,
+          describe: 'Set extra HTTP Headers to pass with request',
+        },
+        'precomputed-lantern-data-path': {
+          type: 'string',
+          describe: 'Path to the file where lantern simulation data should be read from, overwriting the lantern observed estimates for RTT and server latency.',
+        },
+        'lantern-data-output-path': {
+          type: 'string',
+          describe: 'Path to the file where lantern simulation data should be written to, can be used in a future run with the `precomputed-lantern-data-path` flag.',
+        },
+        'plugins': {
+          array: true,
+          type: 'string',
+          coerce: splitCommaSeparatedValues,
+          describe: 'Run the specified plugins',
+        },
+        'channel': {
+          type: 'string',
+          default: 'cli',
+        },
+        'chrome-ignore-default-flags': {
+          type: 'boolean',
+          default: false,
+        },
       })
 
-      // boolean values
-      .boolean([
-        'disable-storage-reset', 'save-assets', 'list-all-audits',
-        'list-trace-categories', 'view', 'verbose', 'quiet', 'help', 'print-config',
-        'chrome-ignore-default-flags',
-      ])
-      .choices('emulated-form-factor', ['mobile', 'desktop', 'none'])
-      .choices('throttling-method', ['devtools', 'provided', 'simulate'])
-      .choices('preset', ['perf', 'experimental'])
-      // force as an array
-      // note MUST use camelcase versions or only the kebab-case version will be forced
-      .array('blockedUrlPatterns')
-      .array('onlyAudits')
-      .array('onlyCategories')
-      .array('skipAudits')
-      .array('output')
-      .array('plugins')
-      .string('extraHeaders')
-      .string('channel')
-      .string('precomputedLanternDataPath')
-      .string('lanternDataOutputPath')
-      .string('budgetPath')
+      // Choices added outside of `options()` and cast so tsc picks them up.
+      .choices('emulated-form-factor', /** @type {['mobile', 'desktop', 'none']} */ (['mobile', 'desktop', 'none']))
+      .choices('throttling-method', /** @type {['devtools', 'provided', 'simulate']} */ (['devtools', 'provided', 'simulate']))
+      .choices('preset', /** @type {['perf', 'experimental']} */ (['perf', 'experimental']))
 
-      // default values
-      .default('chrome-flags', '')
-      .default('output', ['html'])
-      .default('port', 0)
-      .default('hostname', 'localhost')
-      .default('enable-error-reporting', undefined) // Undefined so prompted by default
-      .default('channel', 'cli')
-      .check(/** @param {LH.CliFlags} argv */ (argv) => {
+      .check(argv => {
         // Lighthouse doesn't need a URL if...
         //   - We're just listing the available options.
         //   - We're just printing the config.
@@ -193,33 +291,88 @@ function getFlags(manualArgv) {
 
         throw new Error('Please provide a url');
       })
-      .epilogue(
-          'For more information on Lighthouse, see https://developers.google.com/web/tools/lighthouse/.')
+      .epilogue('For more information on Lighthouse, see https://developers.google.com/web/tools/lighthouse/.')
       .wrap(yargs.terminalWidth())
       .argv;
 
-  // Support comma-separated values for some array flags by splitting on any ',' found.
-  /** @type {Array<keyof LH.CliFlags>} */
-  const arrayKeysThatSupportCsv = [
-    'onlyAudits',
-    'onlyCategories',
-    'output',
-    'plugins',
-    'skipAudits',
-  ];
-  arrayKeysThatSupportCsv.forEach(key => {
-    // If a key is defined as an array in yargs, the value (if provided)
-    // will always be a string array. However, we keep argv and input as any,
-    // since assigning back to argv as string[] would be unsound for enums,
-    // for example: output is LH.OutputMode[].
-    const input = argv[key];
-    // Truthy check is necessary. isArray convinces TS that this is an array.
-    if (Array.isArray(input)) {
-      argv[key] = flatten(input.map(value => value.split(',')));
-    }
-  });
+  // Augmenting yargs type with auto-camelCasing breaks in tsc@4.1.2 and @types/yargs@15.0.11,
+  // so for now cast to add yarg's camelCase properties to type.
+  const cliFlags = /** @type {typeof argv & CamelCasify<typeof argv>} */ (argv);
 
-  return argv;
+  return cliFlags;
+}
+
+/**
+ * Support comma-separated values for some array flags by splitting on any ',' found.
+ * @param {Array<string>=} strings
+ * @return {Array<string>|undefined}
+ */
+function splitCommaSeparatedValues(strings) {
+  if (!strings) return strings;
+
+  return strings.flatMap(value => value.split(','));
+}
+
+/**
+ * @param {unknown} value
+ * @return {boolean|string|undefined}
+ */
+function coerceOptionalStringBoolean(value) {
+  if (typeof value !== 'undefined' && typeof value !== 'string' && typeof value !== 'boolean') {
+    throw new Error('Invalid value: Argument must be a string or a boolean');
+  }
+  return value;
+}
+
+/**
+ * Coerce output CLI input to `LH.SharedFlagsSettings['output']` or throw if not possible.
+ * @param {Array<unknown>} values
+ * @return {Array<LH.OutputMode>}
+ */
+function coerceOutput(values) {
+  const outputTypes = ['json', 'html', 'csv'];
+  const errorMsg = `Invalid values. Argument 'output' must be an array from choices "${outputTypes.join('", "')}"`;
+  if (!values.every(/** @return {item is string} */ item => typeof item === 'string')) {
+    throw new Error(errorMsg);
+  }
+  // Allow parsing of comma-separated values.
+  const strings = values.flatMap(value => value.split(','));
+  if (!strings.every(/** @return {str is LH.OutputMode} */ str => outputTypes.includes(str))) {
+    throw new Error(errorMsg);
+  }
+  return strings;
+}
+
+/**
+ * Verifies value is a string, then coerces type to LH.Locale for convenience. However, don't
+ * allowlist specific locales. Why? So we can support the user who requests 'es-MX' (unsupported)
+ * and we'll fall back to 'es' (supported).
+ * @param {unknown} value
+ * @return {LH.Locale}
+ */
+function coerceLocale(value) {
+  if (typeof value !== 'string') throw new Error(`Invalid value: Argument 'locale' must be a string`);
+  return /** @type {LH.Locale} */ (value);
+}
+
+/**
+ * `--extra-headers` comes in as a JSON string or a path to a JSON string, but the flag value
+ * needs to be the parsed object. Load file (if necessary) and returns the parsed object.
+ * @param {unknown} value
+ * @return {LH.SharedFlagsSettings['extraHeaders']}
+ */
+function coerceExtraHeaders(value) {
+  // TODO: this function does not actually verify the object type.
+  if (value === undefined) return value;
+  if (typeof value === 'object') return /** @type {LH.SharedFlagsSettings['extraHeaders']} */ (value);
+  if (typeof value !== 'string') throw new Error('asdfasf');
+
+  // (possibly) load and parse extra headers from JSON.
+  if (!value.startsWith('{')) {
+    // If not a JSON object, assume it's a path to a JSON file.
+    return JSON.parse(fs.readFileSync(value, 'utf-8'));
+  }
+  return JSON.parse(value);
 }
 
 module.exports = {

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -52,7 +52,7 @@ function getFlags(manualArgv) {
 
       // We only have the single string positional argument, the url.
       .option('_', {
-        array: true,
+        array: true, // Always an array, but this lets the type system know.
         type: 'string',
       })
 

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -145,25 +145,6 @@ describe('CLI bin', function() {
     });
   });
 
-  describe('extraHeaders', () => {
-    it('should convert extra headers to object', async () => {
-      // @ts-expect-error - see TODO: in bin.js
-      cliFlags = {...cliFlags, extraHeaders: '{"foo": "bar"}'};
-      await bin.begin();
-
-      expect(getRunLighthouseArgs()[1]).toHaveProperty('extraHeaders', {foo: 'bar'});
-    });
-
-    it('should read extra headers from file', async () => {
-      const headersFile = require.resolve('../fixtures/extra-headers/valid.json');
-      // @ts-expect-error - see TODO: in bin.js
-      cliFlags = {...cliFlags, extraHeaders: headersFile};
-      await bin.begin();
-
-      expect(getRunLighthouseArgs()[1]).toHaveProperty('extraHeaders', require(headersFile));
-    });
-  });
-
   describe('precomputedLanternData', () => {
     it('should read lantern data from file', async () => {
       const lanternDataFile = require.resolve('../fixtures/lantern-data.json');

--- a/lighthouse-cli/test/cli/cli-flags-test.js
+++ b/lighthouse-cli/test/cli/cli-flags-test.js
@@ -73,4 +73,25 @@ describe('CLI bin', function() {
     ]);
     expect(flags.blockedUrlPatterns).toEqual(['.*x,y\\.png']);
   });
+
+  describe('extraHeaders', () => {
+    it('should convert extra headers to object', async () => {
+      const flags = getFlags([
+        'http://www.example.com',
+        '--extra-headers="{"foo": "bar"}"',
+      ].join(' '));
+
+      expect(flags).toHaveProperty('extraHeaders', {foo: 'bar'});
+    });
+
+    it('should read extra headers from file', async () => {
+      const headersFile = require.resolve('../fixtures/extra-headers/valid.json');
+      const flags = getFlags([
+        'http://www.example.com',
+        `--extra-headers=${headersFile}`,
+      ].join(' '));
+
+      expect(flags).toHaveProperty('extraHeaders', require(headersFile));
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@types/semver": "^5.5.0",
     "@types/update-notifier": "^4.1.0",
     "@types/ws": "^4.0.1",
-    "@types/yargs": "^8.0.2",
+    "@types/yargs": "^15.0.11",
     "@types/yargs-parser": "^15.0.0",
     "@typescript-eslint/parser": "^4.7.0",
     "@wardpeet/brfs": "2.1.0",
@@ -188,8 +188,8 @@
     "third-party-web": "^0.12.2",
     "update-notifier": "^4.1.0",
     "ws": "3.3.2",
-    "yargs": "3.32.0",
-    "yargs-parser": "^18.1.3"
+    "yargs": "^16.1.1",
+    "yargs-parser": "^20.2.4"
   },
   "repository": "GoogleChrome/lighthouse",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -70,79 +70,77 @@ By default, Lighthouse writes the report to an HTML file. You can control the ou
 ```
 $ lighthouse --help
 
-lighthouse <url>
+lighthouse <url> <options>
 
 Logging:
-  --verbose  Displays verbose logging                                                                                                      [boolean]
-  --quiet    Displays no progress, debug logs or errors                                                                                    [boolean]
+  --verbose  Displays verbose logging  [boolean] [default: false]
+  --quiet    Displays no progress, debug logs, or errors  [boolean] [default: false]
 
 Configuration:
-  --save-assets                  Save the trace & devtools log to disk                                                                     [boolean]
-  --list-all-audits              Prints a list of all available audits and exits                                                           [boolean]
-  --list-trace-categories        Prints a list of all required trace categories and exits                                                  [boolean]
-  --print-config                 Print the normalized config for the given config and options, then exit.                                  [boolean]
-  --additional-trace-categories  Additional categories to capture with the trace (comma-delimited).
+  --save-assets                  Save the trace contents & devtools logs to disk  [boolean] [default: false]
+  --list-all-audits              Prints a list of all available audits and exits  [boolean] [default: false]
+  --list-trace-categories        Prints a list of all required trace categories and exits  [boolean] [default: false]
+  --print-config                 Print the normalized config for the given config and options, then exit.  [boolean] [default: false]
+  --additional-trace-categories  Additional categories to capture with the trace (comma-delimited).  [string]
   --config-path                  The path to the config JSON.
-                                 An example config file: lighthouse-core/config/lr-desktop-config.js
-  --budget-path                  The path to the budget.json file for LightWallet.
-  --chrome-flags                 Custom flags to pass to Chrome (space-delimited). For a full list of flags, see
-                                 http://peter.sh/experiments/chromium-command-line-switches/.
-
-                                 Environment variables:
-                                 CHROME_PATH: Explicit path of intended Chrome binary. If set must point to an executable of a build of
-                                 Chromium version 66.0 or later. By default, any detected Chrome Canary or Chrome (stable) will be launched.
-                                                                                                                                       [default: ""]
-  --port                         The port to use for the debugging protocol. Use 0 for a random port                                    [default: 0]
-  --preset                       Use a built-in configuration.                                            [choices: "experimental", "perf"]
-                                 WARNING: If the --config-path flag is provided, this preset will be ignored.
-  --hostname                     The hostname to use for the debugging protocol.                                              [default: "localhost"]
-  --max-wait-for-load            The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue.
-                                 WARNING: Very high values can lead to large traces and instability                                 [default: 45000]
-  --emulated-form-factor         Controls the emulated device form factor (mobile vs. desktop) if not disabled                      [choices: "mobile", "desktop", "none"] [default: "mobile"]
-  --enable-error-reporting       Enables error reporting, overriding any saved preference. --no-enable-error-reporting will do the opposite. More:
-                                 https://git.io/vFFTO
-  --gather-mode, -G              Collect artifacts from a connected browser and save to disk. If audit-mode is not also enabled, the run will quit
-                                 early.                                                                                                    [boolean]
-  --audit-mode, -A               Process saved artifacts from disk                                                                         [boolean]
+                                 An example config file: lighthouse-core/config/lr-desktop-config.js  [string]
+  --preset                       Use a built-in configuration.
+                                 WARNING: If the --config-path flag is provided, this preset will be ignored.  [string] [choices: "perf", "experimental"]
+  --chrome-flags                 Custom flags to pass to Chrome (space-delimited). For a full list of flags, see https://bit.ly/chrome-flags
+                                 Additionally, use the CHROME_PATH environment variable to use a specific Chrome binary. Requires Chromium version 66.0 or later. If omitted, any detected Chrome Canary or Chrome stable will be used.  [string] [default: ""]
+  --port                         The port to use for the debugging protocol. Use 0 for a random port  [number] [default: 0]
+  --hostname                     The hostname to use for the debugging protocol.  [string] [default: "localhost"]
+  --emulated-form-factor         Controls the emulated device form factor (mobile vs. desktop) if not disabled  [string] [choices: "mobile", "desktop", "none"]
+  --max-wait-for-load            The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue. WARNING: Very high values can lead to large traces and instability  [number]
+  --enable-error-reporting       Enables error reporting, overriding any saved preference. --no-enable-error-reporting will do the opposite. More: https://git.io/vFFTO  [boolean]
+  --gather-mode, -G              Collect artifacts from a connected browser and save to disk. (Artifacts folder path may optionally be provided). If audit-mode is not also enabled, the run will quit early.
+  --audit-mode, -A               Process saved artifacts from disk. (Artifacts folder path may be provided, otherwise defaults to ./latest-run/)
+  --only-audits                  Only run the specified audits  [array]
+  --only-categories              Only run the specified categories. Available categories: accessibility, best-practices, performance, pwa, seo  [array]
+  --skip-audits                  Run everything except these audits  [array]
+  --budget-path                  The path to the budget.json file for LightWallet.  [string]
 
 Output:
-  --output       Reporter for the results, supports multiple values                        [choices: "json", "html", "csv"] [default: "html"]
+  --output       Reporter for the results, supports multiple values. choices: "json", "html", "csv"  [array] [default: ["html"]]
   --output-path  The file path to output the results. Use 'stdout' to write to stdout.
-                 If using JSON output, default is stdout.
-                 If using HTML or CSV output, default is a file in the working directory with a name based on the test URL and date.
-                 If using multiple outputs, --output-path is appended with the standard extension for each output type. "reports/my-run" -> "reports/my-run.report.html", "reports/my-run.report.json", etc.
-                 Example: --output-path=./lighthouse-results.html
-  --view         Open HTML report in your browser                                                                                          [boolean]
+                   If using JSON output, default is stdout.
+                   If using HTML or CSV output, default is a file in the working directory with a name based on the test URL and date.
+                   If using multiple outputs, --output-path is appended with the standard extension for each output type. "reports/my-run" -> "reports/my-run.report.html", "reports/my-run.report.json", etc.
+                   Example: --output-path=./lighthouse-results.html  [string]
+  --view         Open HTML report in your browser  [boolean] [default: false]
 
 Options:
-  --help                        Show help                                                                                                  [boolean]
-  --version                     Show version number                                                                                        [boolean]
-  --cli-flags-path              The path to a JSON file that contains the desired CLI flags to apply.
-                                Flags specified at the command line will still override the file-based ones.
-  --blocked-url-patterns        Block any network requests to the specified URL patterns                                                     [array]
-  --disable-storage-reset       Disable clearing the browser cache and other storage APIs before a run                                     [boolean]
-  --throttling-method                  Controls throttling method         [choices: "devtools", "provided", "simulate"]
+  --version                            Show version number  [boolean]
+  --help                               Show help  [boolean]
+  --cli-flags-path                     The path to a JSON file that contains the desired CLI flags to apply. Flags specified at the command line will still override the file-based ones.
+  --locale                             The locale/language the report should be formatted in
+  --blocked-url-patterns               Block any network requests to the specified URL patterns  [array]
+  --disable-storage-reset              Disable clearing the browser cache and other storage APIs before a run  [boolean]
+  --throttling-method                  Controls throttling method  [string] [choices: "devtools", "provided", "simulate"]
+  --throttling
   --throttling.rttMs                   Controls simulated network RTT (TCP layer)
   --throttling.throughputKbps          Controls simulated network download throughput
   --throttling.requestLatencyMs        Controls emulated network RTT (HTTP layer)
   --throttling.downloadThroughputKbps  Controls emulated network download throughput
   --throttling.uploadThroughputKbps    Controls emulated network upload throughput
   --throttling.cpuSlowdownMultiplier   Controls simulated + emulated CPU throttling
-  --extra-headers               Set extra HTTP Headers to pass with request                                                                 [string]
+  --extra-headers                      Set extra HTTP Headers to pass with request
+  --precomputed-lantern-data-path      Path to the file where lantern simulation data should be read from, overwriting the lantern observed estimates for RTT and server latency.  [string]
+  --lantern-data-output-path           Path to the file where lantern simulation data should be written to, can be used in a future run with the `precomputed-lantern-data-path` flag.  [string]
+  --plugins                            Run the specified plugins  [array]
+  --channel  [string] [default: "cli"]
+  --chrome-ignore-default-flags  [boolean] [default: false]
 
 Examples:
-  lighthouse <url> --view                                                   Opens the HTML report in a browser after the run completes
-  lighthouse <url> --config-path=./myconfig.js                              Runs Lighthouse with your own configuration: custom audits, report
-                                                                            generation, etc.
-  lighthouse <url> --output=json --output-path=./report.json --save-assets  Save trace, devtoolslog, and named JSON report.
-  lighthouse <url> --emulated-form-factor=none                              Disable device emulation and all throttling.
-    --throttling-method=provided
-  lighthouse <url> --chrome-flags="--window-size=412,660"                   Launch Chrome with a specific window size
-  lighthouse <url> --quiet --chrome-flags="--headless"                      Launch Headless Chrome, turn off logging
-  lighthouse <url> --extra-headers "{\"Cookie\":\"monster=blue\"}"          Stringify\'d JSON HTTP Header key/value pairs to send in requests
-  lighthouse <url> --extra-headers=./path/to/file.json                      Path to JSON file of HTTP Header key/value pairs to send in requests
-  lighthouse <url> --only-categories=performance,pwa                        Only run the specified categories. Available categories: accessibility,
-                                                                            best-practices, performance, pwa, seo.
+  lighthouse <url> --view                                                                    Opens the HTML report in a browser after the run completes
+  lighthouse <url> --config-path=./myconfig.js                                               Runs Lighthouse with your own configuration: custom audits, report generation, etc.
+  lighthouse <url> --output=json --output-path=./report.json --save-assets                   Save trace, screenshots, and named JSON report.
+  lighthouse <url> --emulated-form-factor=none --throttling-method=provided                  Disable device emulation and all throttling
+  lighthouse <url> --chrome-flags="--window-size=412,660"                                    Launch Chrome with a specific window size
+  lighthouse <url> --quiet --chrome-flags="--headless"                                       Launch Headless Chrome, turn off logging
+  lighthouse <url> --extra-headers "{\"Cookie\":\"monster=blue\", \"x-men\":\"wolverine\"}"  Stringify'd JSON HTTP Header key/value pairs to send in requests
+  lighthouse <url> --extra-headers=./path/to/file.json                                       Path to JSON file of HTTP Header key/value pairs to send in requests
+  lighthouse <url> --only-categories=performance,pwa                                         Only run the specified categories. Available categories: accessibility, best-practices, performance, pwa, seo
 
 For more information on Lighthouse, see https://developers.google.com/web/tools/lighthouse/.
 ```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noEmit": true,
     "module": "commonjs",
-    "target": "ES2019",
+    "target": "ES2020",
     "allowJs": true,
     "checkJs": true,
     "strict": true,

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -64,6 +64,34 @@ declare global {
   type FirstParamType<T extends (arg1: any, ...args: any[]) => any> =
     T extends (arg1: infer P, ...args: any[]) => any ? P : never;
 
+  /**
+   * Split string `S` on delimiter `D`.
+   * From https://github.com/microsoft/TypeScript/pull/40336#issue-476562046
+   */
+  type Split<S extends string, D extends string> =
+    string extends S ? string[] :
+    S extends '' ? [] :
+    S extends `${infer T}${D}${infer U}` ? [T, ...Split<U, D>] :
+    [S];
+
+  /**
+  * Join an array of strings using camelCase capitalization rules.
+  */
+  type StringsToCamelCase<T extends unknown[]> =
+    T extends [] ? '' :
+    T extends [string, ...infer U] ? `${T[0]}${Capitalize<StringsToCamelCase<U>>}` :
+    string;
+
+  /**
+  * If `S` is a kebab-style string `S`, convert to camelCase.
+  */
+  type KebabToCamelCase<S> = S extends string ? StringsToCamelCase<Split<S, '-'>> : S;
+
+  /** Returns T with any kebab-style property names rewritten as camelCase. */
+  type CamelCasify<T> = {
+    [K in keyof T as KebabToCamelCase<K>]: T[K];
+  }
+
   module LH {
     // re-export useful type modules under global LH module.
     export import Crdp = _Crdp;
@@ -170,7 +198,7 @@ declare global {
       chromeIgnoreDefaultFlags: boolean;
       chromeFlags: string | string[];
       /** Output path for the generated results. */
-      outputPath: string;
+      outputPath?: string;
       /** Flag to save the trace contents and screenshots to disk. */
       saveAssets: boolean;
       /** Flag to open the report immediately. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -713,12 +713,7 @@
     "@types/events" "*"
     "@types/node" "*"
 
-"@types/yargs-parser@*":
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"
-  integrity sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==
-
-"@types/yargs-parser@^15.0.0":
+"@types/yargs-parser@*", "@types/yargs-parser@^15.0.0":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
@@ -730,17 +725,12 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yargs@^15.0.0":
-  version "15.0.4"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.4.tgz#7e5d0f8ca25e9d5849f2ea443cf7c402decd8299"
-  integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
+"@types/yargs@^15.0.0", "@types/yargs@^15.0.11":
+  version "15.0.11"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.11.tgz#361d7579ecdac1527687bcebf9946621c12ab78c"
+  integrity sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==
   dependencies:
     "@types/yargs-parser" "*"
-
-"@types/yargs@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-8.0.2.tgz#0f9c7b236e2d78cd8f4b6502de15d0728aa29385"
-  integrity sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==
 
 "@typescript-eslint/parser@^4.7.0":
   version "4.7.0"
@@ -960,12 +950,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
-  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
-
-ansi-regex@^4.1.0:
+ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -1189,14 +1174,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async@^2.0.0, async@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
-  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
-  dependencies:
-    lodash "^4.17.10"
-
-async@^2.5.0:
+async@^2.0.0, async@^2.5.0, async@^2.6.1:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -1708,17 +1686,12 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
-camelcase@^2.0.0, camelcase@^2.0.1:
+camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
   integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
 
-camelcase@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.2.0.tgz#e7522abda5ed94cc0489e1b8466610e88404cf45"
-  integrity sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==
-
-camelcase@^5.3.1:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -1870,19 +1843,10 @@ client-request@^2.2.0:
   resolved "https://registry.yarnpkg.com/client-request/-/client-request-2.3.0.tgz#c4604f71f81c94b280659579a17bbc0446fec212"
   integrity sha1-xGBPcfgclLKAZZV5oXu8BEb+whI=
 
-cliui@^3.0.3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
-  integrity sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wrap-ansi "^2.0.0"
-
 cliui@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
-  integrity sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
@@ -1905,6 +1869,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-response@^1.0.2:
   version "1.0.2"
@@ -1988,15 +1961,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.20.0:
+commander@^2.11.0, commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-commander@^2.18.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 commander@~2.17.1:
   version "2.17.1"
@@ -2516,7 +2484,7 @@ debug@^3.0.1, debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -2880,6 +2848,11 @@ es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-goat@^2.0.0:
   version "2.1.1"
@@ -3457,11 +3430,11 @@ get-assigned-identifiers@^1.1.0, get-assigned-identifiers@^1.2.0:
   integrity sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==
 
 get-caller-file@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
-  integrity sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+  integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -3693,25 +3666,15 @@ gzip-size@^5.0.0:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
-handlebars@^4.0.2, handlebars@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+handlebars@^4.0.2, handlebars@^4.1.0, handlebars@^4.1.2:
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
+  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
   dependencies:
+    minimist "^1.2.5"
     neo-async "^2.6.0"
-    optimist "^0.6.1"
     source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-handlebars@^4.1.2:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
-  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
-  dependencies:
-    neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
+    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -3825,12 +3788,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hosted-git-info@^2.1.4:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
-  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
-
-hosted-git-info@^2.4.2:
+hosted-git-info@^2.1.4, hosted-git-info@^2.4.2:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
@@ -4111,11 +4069,6 @@ invariant@^2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
-
-invert-kv@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
-  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
 invert-kv@^2.0.0:
   version "2.0.0"
@@ -5147,13 +5100,6 @@ lazystream@^1.0.0:
   dependencies:
     readable-stream "^2.0.5"
 
-lcid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
-  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
-  dependencies:
-    invert-kv "^1.0.0"
-
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -5338,7 +5284,7 @@ lodash.union@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -5627,7 +5573,7 @@ minimist@0.0.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
   integrity sha1-16oye87PUY+RBqxrjwA/o7zqhWY=
 
-minimist@0.0.8, minimist@~0.0.1:
+minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
@@ -6063,14 +6009,6 @@ open@^6.4.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optimist@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
-  integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
-  dependencies:
-    minimist "~0.0.1"
-    wordwrap "~0.0.2"
-
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
@@ -6106,13 +6044,6 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
-os-locale@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
-  integrity sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=
-  dependencies:
-    lcid "^1.0.0"
 
 os-locale@^3.0.0:
   version "3.1.0"
@@ -7636,14 +7567,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
-  integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
-  dependencies:
-    ansi-regex "^4.0.0"
-
-strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -8385,27 +8309,18 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
-window-size@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
-  integrity sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
-  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
-
-wordwrap@~1.0.0:
+wordwrap@^1.0.0, wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wrap-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.0.0.tgz#7d30f8f873f9a5bbc3a64dabc8d177e071ae426f"
-  integrity sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
   dependencies:
     string-width "^1.0.1"
+    strip-ansi "^3.0.1"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"
@@ -8420,6 +8335,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -8509,25 +8433,20 @@ xmldom@0.1.19:
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.19.tgz#631fc07776efd84118bf25171b37ed4d075a0abc"
   integrity sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=
 
-xtend@^4.0.0, xtend@^4.0.2:
+xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-xtend@^4.0.1, xtend@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
-
-y18n@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
-
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
+  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
 
 yallist@^2.1.2:
   version "2.1.2"
@@ -8547,15 +8466,15 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^13.1.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
-  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^18.1.1, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
@@ -8563,18 +8482,10 @@ yargs-parser@^18.1.1, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs@3.32.0:
-  version "3.32.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
-  integrity sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=
-  dependencies:
-    camelcase "^2.0.1"
-    cliui "^3.0.3"
-    decamelize "^1.1.1"
-    os-locale "^1.4.0"
-    string-width "^1.0.1"
-    window-size "^0.1.4"
-    y18n "^3.2.0"
+yargs-parser@^20.2.2, yargs-parser@^20.2.4:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs@^12.0.5:
   version "12.0.5"
@@ -8595,9 +8506,9 @@ yargs@^12.0.5:
     yargs-parser "^11.1.1"
 
 yargs@^13.3.0:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
-  integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
   dependencies:
     cliui "^5.0.0"
     find-up "^3.0.0"
@@ -8608,26 +8519,9 @@ yargs@^13.3.0:
     string-width "^3.0.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^13.1.1"
+    yargs-parser "^13.1.2"
 
-yargs@^15.0.0:
-  version "15.3.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
-  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
-  dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^18.1.1"
-
-yargs@^15.3.1:
+yargs@^15.0.0, yargs@^15.3.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
@@ -8643,6 +8537,19 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.1.1:
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.1.1.tgz#5a4a095bd1ca806b0a50d0c03611d38034d219a1"
+  integrity sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
fixes #11720

Two major parts of the update:
- API updates. The biggest thing is that `.boolean()` no longer defaults to `false`, it defaults to `undefined`, while we've always relied on the default `false`. Also a bunch of other small improvements, like `.number()` and `--version` taking care of itself, etc
- Type updates. `@types/yargs` has gotten super sophisticated, accumulating type info in each step of the cli flag declarations

The combo of the two started forcing more options (e.g. `.boolean('flag').default('flag', false)` or `.option('flag', {type: 'boolean', default: false})`, then arrays+strings and choices and descriptions...I eventually just opted to switch everything over to the `options({flag1: opts, flag2: opts, ...})` format, which seems like a popular pattern looking at other projects.

DefinitelyTyped is limited to TypeScript 3.2 currently (and to [< 4.0 until mid 2022](https://github.com/DefinitelyTyped/DefinitelyTyped#older-versions-of-typescript-31-and-earlier)), so types there can't do any manipulation with type names, like representing how yargs turns `--some-flag` into property `someFlag`...but we aren't limited by that :D This also adds a type transformation to model yarg's behavior. Originally I was going to augment the `@types/yargs` type to do that but the way yargs is set up it sends the compiler into an infinite loop before it cuts itself off. As a result, it's just a cast for now.

It's fancy, but it's really just a checked version of the unchecked cast we were doing from `argv` to `LH.CliFlags` before. It's all in typescript land, no effect on what's happening at runtime. I can revert to a plain cast if folks don't like it, though.