### PR TITLE
tests(smoke): handle warn-not-offline-capable in smoketest

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -211,6 +211,16 @@ const expectations = [
         'errors-in-console': {
           score: 0,
           details: {
+            items: {
+              length: '6 +/- 1',
+              // COMPAT: In 89.0.4351.0 we observed one additional runtime error and it's origin is currently unknown
+              // TODO: Investigate and resolve it's presence. https://github.com/GoogleChrome/lighthouse/issues/11803
+              //     {
+              //       source: 'Runtime.exception',
+              //       description: 'TypeError: the given value is not a Promise',
+              //       url: 'http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js',
+              //     },
+            },
             // items: [
             //   {
             //     source: 'other',
@@ -243,16 +253,6 @@ const expectations = [
             //     url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
             //   },
             // ],
-            items: {
-              length: '6 +/- 1'
-              // COMPAT: In 89.0.4351.0 we observed one additional runtime error and it's origin is currently unknown
-              // TODO: Investigate and resolve it's presence
-              //     {
-              //       source: 'Runtime.exception',
-              //       description: 'TypeError: the given value is not a Promise',
-              //       url: 'http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js',
-              //     },
-            }
           },
         },
         'is-on-https': {

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -211,38 +211,48 @@ const expectations = [
         'errors-in-console': {
           score: 0,
           details: {
-            items: [
-              {
-                source: 'other',
-                description: 'Application Cache Error event: Manifest fetch failed (404) http://localhost:10200/dobetterweb/clock.appcache',
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-              },
-              {
-                source: 'Runtime.exception',
-                description: /^Error: A distinctive error\s+at http:\/\/localhost:10200\/dobetterweb\/dbw_tester.html:\d+:\d+$/,
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-              },
-              {
-                source: 'network',
-                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-                url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-              },
-              {
-                source: 'network',
-                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-                url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
-              },
-              {
-                source: 'network',
-                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-                url: 'http://localhost:10200/favicon.ico',
-              },
-              {
-                source: 'network',
-                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-                url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-              },
-            ],
+            // items: [
+            //   {
+            //     source: 'other',
+            //     description: 'Application Cache Error event: Manifest fetch failed (404) http://localhost:10200/dobetterweb/clock.appcache',
+            //     url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+            //   },
+            //   {
+            //     source: 'Runtime.exception',
+            //     description: /^Error: A distinctive error\s+at http:\/\/localhost:10200\/dobetterweb\/dbw_tester.html:\d+:\d+$/,
+            //     url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+            //   },
+            //   {
+            //     source: 'network',
+            //     description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+            //     url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
+            //   },
+            //   {
+            //     source: 'network',
+            //     description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+            //     url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
+            //   },
+            //   {
+            //     source: 'network',
+            //     description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+            //     url: 'http://localhost:10200/favicon.ico',
+            //   },
+            //   {
+            //     source: 'network',
+            //     description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+            //     url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
+            //   },
+            // ],
+            items: {
+              length: '6 +/- 1'
+              // COMPAT: In 89.0.4351.0 we observed one additional runtime error and it's origin is currently unknown
+              // TODO: Investigate and resolve it's presence
+              //     {
+              //       source: 'Runtime.exception',
+              //       description: 'TypeError: the given value is not a Promise',
+              //       url: 'http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js',
+              //     },
+            }
           },
         },
         'is-on-https': {

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -107,9 +107,15 @@ module.exports = [
         },
       },
       InstallabilityErrors: {
-        errors: [
-          {errorId: 'no-icon-available'},
-        ],
+        errors: {
+          length: '>= 1',
+          0: {
+            // In m89 the `warn-not-offline-capable` error was added.
+            // We've seen this errorId pop up there (though it is unexpected on a SW-enabled page)
+            // Our length and errorId assertions allows for just the no-icon-available error or both
+            errorId: /(no-icon-available)|(warn-not-offline-capable)/
+          }
+        }
       },
     },
     lhr: {

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -111,6 +111,7 @@ module.exports = [
           length: '>= 1',
           0: {
             // In m89 the `warn-not-offline-capable` error was added.
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=965802#c46
             // We've seen this errorId pop up there (though it is unexpected on a SW-enabled page)
             // Our length and errorId assertions allows for just the no-icon-available error or both
             errorId: /(no-icon-available)|(warn-not-offline-capable)/

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -110,7 +110,7 @@ module.exports = [
         errors: {
           length: '>= 1',
           0: {
-            // In m89 the `warn-not-offline-capable` error was added.
+            // COMPAT: In m89 the `warn-not-offline-capable` error was added.
             // https://bugs.chromium.org/p/chromium/issues/detail?id=965802#c46
             // We've seen this errorId pop up there (though it is unexpected on a SW-enabled page)
             // Our length and errorId assertions allows for just the no-icon-available error or both

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -112,7 +112,7 @@ module.exports = [
           0: {
             // COMPAT: In m89 the `warn-not-offline-capable` error was added.
             // https://bugs.chromium.org/p/chromium/issues/detail?id=965802#c46
-            // We've seen this errorId pop up there (though it is unexpected on a SW-enabled page)
+            // We've seen this errorId pop up there: https://github.com/GoogleChrome/lighthouse/issues/11800
             // Our length and errorId assertions allows for just the no-icon-available error or both
             errorId: /(no-icon-available)|(warn-not-offline-capable)/
           }

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -114,9 +114,9 @@ module.exports = [
             // https://bugs.chromium.org/p/chromium/issues/detail?id=965802#c46
             // We've seen this errorId pop up there: https://github.com/GoogleChrome/lighthouse/issues/11800
             // Our length and errorId assertions allows for just the no-icon-available error or both
-            errorId: /(no-icon-available)|(warn-not-offline-capable)/
-          }
-        }
+            errorId: /(no-icon-available)|(warn-not-offline-capable)/,
+          },
+        },
       },
     },
     lhr: {


### PR DESCRIPTION
another smoke failure with ToT chrome.. this time around the new `warn-not-offline-capable`. There's an internal thread about this installability errorId. and here's the crbug: https://bugs.chromium.org/p/chromium/issues/detail?id=965802#c46

smoke failure example from #11790:
![image](https://user-images.githubusercontent.com/39191/101690748-8a636180-3a22-11eb-8765-d613a1cbdbc5.png)


This PR doesn't do much except allow this smoketest assertion to be a bit more lenient.

fwiw i could not reproduce receiving this errorId locally