### PR TITLE
tests: reenable change-related tests in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: git clone
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
     - run: bash lighthouse-core/scripts/github-actions-commit-range.sh
       env:
         GITHUB_CONTEXT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
     - name: git clone
       uses: actions/checkout@v2
+    - run: bash lighthouse-core/scripts/github-actions-commit-range.sh
+      env:
+        GITHUB_CONTEXT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        GITHUB_CONTEXT_BASE_SHA: ${{ github.event.before }}
 
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1

--- a/lighthouse-core/scripts/dogfood-lhci.sh
+++ b/lighthouse-core/scripts/dogfood-lhci.sh
@@ -9,7 +9,8 @@ if [[ -z "$LHCI_CANARY_SERVER_TOKEN" ]]; then
   exit 0;
 fi
 
-if [[ "$TRAVIS_NODE_VERSION" != "12" ]]; then
+NODE_VERSION=$(node --version)
+if [[ "$NODE_VERSION" != "v12"* ]]; then
   echo "Not running dogfood script on node versions other than 12";
   exit 0;
 fi
@@ -21,7 +22,8 @@ LH_ROOT_DIR="$SCRIPT_DIR/../.."
 # Testing lhci takes time and the server ain't massive, we'll only run the tests if we touched files that affect the report.
 CHANGED_FILES=""
 if [[ "$CI" ]]; then
-  CHANGED_FILES=$(git --no-pager diff --name-only "$TRAVIS_COMMIT_RANGE")
+  if [[ -z "$GITHUB_ACTIONS_COMMIT_RANGE" ]]; then echo "No commit range available!" && exit 1 ; fi
+  CHANGED_FILES=$(git --no-pager diff --name-only "$GITHUB_ACTIONS_COMMIT_RANGE")
 else
   CHANGED_FILES=$(git --no-pager diff --name-only master)
 fi

--- a/lighthouse-core/scripts/github-actions-commit-range.sh
+++ b/lighthouse-core/scripts/github-actions-commit-range.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+##
+# @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+##
+
 # This script sets the environment variable `GITHUB_ACTIONS_COMMIT_RANGE` to the
 # git parseable range of changes that are being tested in GitHub actions.
 
@@ -17,9 +23,12 @@ else
   exit 1
 fi
 
+# Expose the commit range to the rest of GitHub Actions steps using environment files.
+# See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
 GITHUB_ACTIONS_COMMIT_RANGE="${BASE_SHA}..${GITHUB_SHA}"
 echo "GITHUB_ACTIONS_COMMIT_RANGE=${GITHUB_ACTIONS_COMMIT_RANGE}" >> $GITHUB_ENV
 
+# Log the commits for easier debugging.
 echo "Commit range is ${GITHUB_ACTIONS_COMMIT_RANGE}"
 git log --pretty=oneline "${GITHUB_ACTIONS_COMMIT_RANGE}"
 

--- a/lighthouse-core/scripts/github-actions-commit-range.sh
+++ b/lighthouse-core/scripts/github-actions-commit-range.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This script sets the environment variable `GITHUB_ACTIONS_COMMIT_RANGE` to the
+# git parseable range of changes that are being tested in GitHub actions.
+
+BASE_SHA=""
+if [[ -n "$GITHUB_CONTEXT_PR_BASE_SHA" ]]; then
+  echo "Pull request detected. Base SHA is ${GITHUB_CONTEXT_PR_BASE_SHA}"
+  BASE_SHA="${GITHUB_CONTEXT_PR_BASE_SHA}"
+elif [[ -n "$GITHUB_CONTEXT_BASE_SHA" ]]; then
+  echo "Push event detected. Base SHA is ${GITHUB_CONTEXT_BASE_SHA}"
+  BASE_SHA="${GITHUB_CONTEXT_BASE_SHA}"
+else
+  echo "No GitHub Actions context available. Exiting..."
+  exit 1
+fi
+
+GITHUB_ACTIONS_COMMIT_RANGE="${BASE_SHA}..${GITHUB_SHA}"
+echo "GITHUB_ACTIONS_COMMIT_RANGE=${GITHUB_ACTIONS_COMMIT_RANGE}" >> $GITHUB_ENV
+
+echo "Commit range is ${GITHUB_ACTIONS_COMMIT_RANGE}"
+git log --pretty=oneline "${GITHUB_ACTIONS_COMMIT_RANGE}"
+

--- a/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
+++ b/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
@@ -1,5 +1,5 @@
 all-legacy-polyfills
-  85169        all-legacy-polyfills-core-js-3/main.bundle.min.js
+  86520        all-legacy-polyfills-core-js-3/main.bundle.min.js
   55778        all-legacy-polyfills-core-js-2/main.bundle.min.js
 
 core-js-2-only-polyfill
@@ -62,63 +62,63 @@ core-js-2-preset-env-esmodules
    63536       true-and-bugfixes/main.bundle.min.js
 
 core-js-3-only-polyfill
-  29583        es-array-find-index/main.bundle.min.js
-  29511        es-array-find/main.bundle.min.js
-  27436        es-array-from/main.bundle.min.js
-  26903        es-array-filter/main.bundle.min.js
-  26876        es-array-map/main.bundle.min.js
-  26202        es-array-includes/main.bundle.min.js
-  26052        es-array-for-each/main.bundle.min.js
-  25876        es-array-fill/main.bundle.min.js
-  25831        es-array-some/main.bundle.min.js
-  25447        es-reflect-construct/main.bundle.min.js
-  22760        es-array-reduce-right/main.bundle.min.js
-  22722        es-array-reduce/main.bundle.min.js
-  22249        es-date-to-iso-string/main.bundle.min.js
-  21753        es-object-prevent-extensions/main.bundle.min.js
-  21691        es-reflect-get/main.bundle.min.js
-  21652        es-object-freeze/main.bundle.min.js
-  21634        es-object-seal/main.bundle.min.js
-  21391        es-object-get-prototype-of/main.bundle.min.js
-  21241        es-reflect-get-prototype-of/main.bundle.min.js
-  21114        es-object-get-own-property-descriptors/main.bundle.min.js
-  21070        es-number-parse-int/main.bundle.min.js
-  20999        es-reflect-set-prototype-of/main.bundle.min.js
-  20858        es-object-entries/main.bundle.min.js
-  20855        es-object-define-properties/main.bundle.min.js
-  20851        es-object-values/main.bundle.min.js
-  20698        es-array-of/main.bundle.min.js
-  20694        es-object-get-own-property-names/main.bundle.min.js
-  20641        es-object-set-prototype-of/main.bundle.min.js
-  20596        es-string-code-point-at/main.bundle.min.js
-  20511        es-object-keys/main.bundle.min.js
-  20453        es-reflect-apply/main.bundle.min.js
-  20434        es-reflect-define-property/main.bundle.min.js
-  20352        es-date-to-json/main.bundle.min.js
-  20303        es-reflect-prevent-extensions/main.bundle.min.js
-  20243        es-string-from-code-point/main.bundle.min.js
-  20200        es-string-repeat/main.bundle.min.js
-  20105        es-reflect-get-own-property-descriptor/main.bundle.min.js
-  20088        es-string-raw/main.bundle.min.js
-  20035        es-reflect-delete-property/main.bundle.min.js
-  20031        es-number-is-safe-integer/main.bundle.min.js
-  19993        es-object-is-extensible/main.bundle.min.js
-  19957        es-object-is-sealed/main.bundle.min.js
-  19957        es-object-is-frozen/main.bundle.min.js
-  19922        es-number-is-integer/main.bundle.min.js
-  19890        es-object-define-property/main.bundle.min.js
-  19879        es-array-is-array/main.bundle.min.js
-  19843        es-reflect-is-extensible/main.bundle.min.js
-  19685        es-reflect-own-keys/main.bundle.min.js
-  19654        es-reflect-has/main.bundle.min.js
-  19625        es-date-now/main.bundle.min.js
-  10443        es-date-to-string/main.bundle.min.js
-   4488        es-function-name/main.bundle.min.js
+  29905        es-array-find-index/main.bundle.min.js
+  29833        es-array-find/main.bundle.min.js
+  27930        es-array-from/main.bundle.min.js
+  27225        es-array-filter/main.bundle.min.js
+  27198        es-array-map/main.bundle.min.js
+  26417        es-array-includes/main.bundle.min.js
+  26374        es-array-for-each/main.bundle.min.js
+  26153        es-array-some/main.bundle.min.js
+  26091        es-array-fill/main.bundle.min.js
+  25662        es-reflect-construct/main.bundle.min.js
+  24190        es-array-reduce-right/main.bundle.min.js
+  24152        es-array-reduce/main.bundle.min.js
+  22464        es-date-to-iso-string/main.bundle.min.js
+  21968        es-object-prevent-extensions/main.bundle.min.js
+  21906        es-reflect-get/main.bundle.min.js
+  21867        es-object-freeze/main.bundle.min.js
+  21849        es-object-seal/main.bundle.min.js
+  21606        es-object-get-prototype-of/main.bundle.min.js
+  21456        es-reflect-get-prototype-of/main.bundle.min.js
+  21329        es-object-get-own-property-descriptors/main.bundle.min.js
+  21285        es-number-parse-int/main.bundle.min.js
+  21214        es-reflect-set-prototype-of/main.bundle.min.js
+  21073        es-object-entries/main.bundle.min.js
+  21070        es-object-define-properties/main.bundle.min.js
+  21066        es-object-values/main.bundle.min.js
+  20913        es-array-of/main.bundle.min.js
+  20909        es-object-get-own-property-names/main.bundle.min.js
+  20856        es-object-set-prototype-of/main.bundle.min.js
+  20811        es-string-code-point-at/main.bundle.min.js
+  20726        es-object-keys/main.bundle.min.js
+  20668        es-reflect-apply/main.bundle.min.js
+  20649        es-reflect-define-property/main.bundle.min.js
+  20567        es-date-to-json/main.bundle.min.js
+  20518        es-reflect-prevent-extensions/main.bundle.min.js
+  20458        es-string-from-code-point/main.bundle.min.js
+  20415        es-string-repeat/main.bundle.min.js
+  20320        es-reflect-get-own-property-descriptor/main.bundle.min.js
+  20303        es-string-raw/main.bundle.min.js
+  20250        es-reflect-delete-property/main.bundle.min.js
+  20246        es-number-is-safe-integer/main.bundle.min.js
+  20208        es-object-is-extensible/main.bundle.min.js
+  20172        es-object-is-sealed/main.bundle.min.js
+  20172        es-object-is-frozen/main.bundle.min.js
+  20137        es-number-is-integer/main.bundle.min.js
+  20105        es-object-define-property/main.bundle.min.js
+  20094        es-array-is-array/main.bundle.min.js
+  20058        es-reflect-is-extensible/main.bundle.min.js
+  19900        es-reflect-own-keys/main.bundle.min.js
+  19869        es-reflect-has/main.bundle.min.js
+  19840        es-date-now/main.bundle.min.js
+  10658        es-date-to-string/main.bundle.min.js
+   4515        es-function-name/main.bundle.min.js
 
 core-js-3-preset-env-esmodules
-  408418       false/main.bundle.min.js
-  303423       true/main.bundle.min.js
-  302742       true-and-bugfixes/main.bundle.min.js
+  410517       false/main.bundle.min.js
+  305001       true/main.bundle.min.js
+  304320       true-and-bugfixes/main.bundle.min.js
 
 only-plugin
   1787         -babel-plugin-transform-spread/main.bundle.min.js

--- a/lighthouse-core/scripts/test-lantern.sh
+++ b/lighthouse-core/scripts/test-lantern.sh
@@ -9,7 +9,8 @@ set -e
 # Testing lantern can be expensive, we'll only run the tests if we touched files that affect the simulations.
 CHANGED_FILES=""
 if [[ "$CI" ]]; then
-  CHANGED_FILES=$(git --no-pager diff --name-only $TRAVIS_COMMIT_RANGE)
+  if [[ -z "$GITHUB_ACTIONS_COMMIT_RANGE" ]]; then echo "No commit range available!" && exit 1 ; fi
+  CHANGED_FILES=$(git --no-pager diff --name-only "$GITHUB_ACTIONS_COMMIT_RANGE")
 else
   CHANGED_FILES=$(git --no-pager diff --name-only master)
 fi

--- a/lighthouse-core/scripts/test-legacy-javascript.sh
+++ b/lighthouse-core/scripts/test-legacy-javascript.sh
@@ -9,7 +9,8 @@ set -e
 # This test can be expensive, we'll only run the tests if we touched files that affect the simulations.
 CHANGED_FILES=""
 if [[ "$CI" ]]; then
-  CHANGED_FILES=$(git --no-pager diff --name-only $TRAVIS_COMMIT_RANGE)
+  if [[ -z "$GITHUB_ACTIONS_COMMIT_RANGE" ]]; then echo "No commit range available!" && exit 1 ; fi
+  CHANGED_FILES=$(git --no-pager diff --name-only "$GITHUB_ACTIONS_COMMIT_RANGE")
 else
   CHANGED_FILES=$(git --no-pager diff --name-only master)
 fi

--- a/lighthouse-core/scripts/test-legacy-javascript.sh
+++ b/lighthouse-core/scripts/test-legacy-javascript.sh
@@ -25,4 +25,11 @@ fi
 printf "\n\nRunning test...\n"
 cd "$LH_ROOT/lighthouse-core/scripts/legacy-javascript"
 yarn
+
+# This script will update the summary sizes file with the latest data.
 node run.js
+
+# We want to fail in CI if there are any changes.
+if [[ -n "$CI" ]]; then
+  git add summary-sizes.txt && git diff --cached --exit-code
+fi


### PR DESCRIPTION
**Summary**
None of our longer change-gated test suites have been running in GitHub Actions because we relied on `$TRAVIS_COMMIT_RANGE`. This is actually sort of a PITA to get from GitHub Actions so created a script that exports it to an env variable.

Aside: seems like there might be some overlap here with what the buildtracker git deepening script is doing?

**Related Issues/PRs**
ref https://github.com/GoogleChrome/lighthouse/pull/11767#issuecomment-741995619
