### PR TITLE
tests: do not update devtools checkout every time in ci

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -33,7 +33,8 @@ jobs:
           ${{ env.DEVTOOLS_PATH }}
           ${{ env.BLINK_TOOLS_PATH }}
           ${{ github.workspace }}/lighthouse/.tmp/chromium-web-tests/content-shells
-        key: ${{ runner.os }}-${{ hashFiles('third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/*.js', 'lighthouse/.github/workflows/devtools.yml', 'lighthouse/lighthouse-core/test/chromium-web-tests/*', 'lighthouse/clients/devtools-entry.js', 'lighthouse/clients/devtools-report-assets.js', 'lighthouse/build/build-bundle.js', 'lighthouse/build/build-dt-report-resources.js') }}
+        # The number is how many times this hash key was manually updated to break the cache.
+        key: ${{ runner.os }}-0-${{ hashFiles('third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/*.js', 'lighthouse/.github/workflows/devtools.yml', 'lighthouse/lighthouse-core/test/chromium-web-tests/*', 'lighthouse/clients/devtools-entry.js', 'lighthouse/clients/devtools-report-assets.js', 'lighthouse/build/build-bundle.js', 'lighthouse/build/build-dt-report-resources.js') }}
 
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1

--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -16,11 +16,14 @@ then
   git status
   git --no-pager log -1
   
-  # Update to keep current
-  git reset --hard
-  git clean -fd
-  git pull --ff-only -f origin master
-  gclient sync --delete_unversioned_trees --reset
+  # Update to keep current.
+  # Don't update in CI-defer to the weekly cache invalidation.
+  if ! [[ "$CI" ]]; then
+    git reset --hard
+    git clean -fd
+    git pull --ff-only -f origin master
+    gclient sync --delete_unversioned_trees --reset
+  fi
 
   exit 0
 fi


### PR DESCRIPTION
updating this checkout everytime in GHA is proving difficult. it works locally, but for some reason errors in CI. so let's just not do it.

(before merging, verify things work by seeing GHA pass twice in a row with no code changes)