### PR TITLE
misc: fix yarn install in nightly release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           node-version: 12.x
       - run: yarn --frozen-lockfile
-        working-directory: ${{ github.workspace }}/lighthouse
 
       - run: bash $GITHUB_WORKSPACE/.github/scripts/bump-nightly-version.sh
       - run: npm publish --tag next


### PR DESCRIPTION
Didn't mean to commit that "dir" change. worked without, but am surprised it breaks with it