### PR TITLE
tests: use font-size for non-composited animations in smoke tests

### DIFF
--- a/lighthouse-cli/test/fixtures/perf/animations.html
+++ b/lighthouse-cli/test/fixtures/perf/animations.html
@@ -10,6 +10,7 @@
 #animated-boi {
   width: 100px;
   height: 100px;
+  font-size: 20pt;
   background-color: red;
   animation: alpha 4s, beta 2s;
 }
@@ -27,21 +28,21 @@
 }
 
 @keyframes beta {
-  from {background-color: red;}
-  to {background-color: blue;}
+  from {font-size: 20pt;}
+  to {font-size: 10pt;}
 }
 
 @keyframes gamma {
   from {opacity: 1;}
-  from {opacity: 0;}
+  to {opacity: 0;}
 }
 </style>
 </head>
 <body>
 
 <div id='composited-boi'></div>
-<div id='animated-boi'></div>
-<div>AAAAAAAAAAAAAAAAAAA</div>
+<div id='animated-boi'>This is changing font size</div>
+<div>This is getting pushed around</div>
 
 <script>
   document.getElementById("animated-boi").animate([

--- a/lighthouse-cli/test/fixtures/perf/trace-elements.html
+++ b/lighthouse-cli/test/fixtures/perf/trace-elements.html
@@ -4,18 +4,19 @@
  #animate-me {
    width: 100px;
    height: 100px;
+   font-size: 20pt;
    background-color: red;
    animation-name: anim;
    animation-duration: 1s;
  }
 
  @keyframes anim {
-   from {background-color: red;}
-   from {background-color: blue;}
+   from {font-size: 20pt;}
+   to {font-size: 10pt;}
  }
 </style>
 <body>
-  <div id="animate-me"></div>
+  <div id="animate-me">This is changing font size</div>
   <div id="late-content"></div>
   <h1>Please don't move me</h1>
   <script src="delayed-element.js"></script>

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -226,7 +226,7 @@ module.exports = [
           traceEventType: 'animation',
           node: {
             selector: 'body > div#animate-me',
-            nodeLabel: 'div',
+            nodeLabel: 'This is changing font size',
             snippet: '<div id="animate-me">',
             boundingRect: {
               top: 8,
@@ -240,11 +240,8 @@ module.exports = [
           animations: [
             {
               name: 'anim',
-              // The animation reliably gets kUnsupportedCSSProperty (1 << 13) === 8192.
-              // Sometimes it also gets kTargetHasInvalidCompositingState (1 << 5) == 32. Together they sum to 8224.
-              // Both are fine for our purposes.
-              failureReasonsMask: '8192 +/- 32',
-              unsupportedProperties: ['background-color'],
+              failureReasonsMask: 8224,
+              unsupportedProperties: ['font-size'],
             },
           ],
         },
@@ -344,7 +341,7 @@ module.exports = [
                   type: 'node',
                   path: '2,HTML,1,BODY,1,DIV',
                   selector: 'body > div#animated-boi',
-                  nodeLabel: 'div',
+                  nodeLabel: 'This is changing font size',
                   snippet: '<div id="animated-boi">',
                 },
                 subItems: {
@@ -358,7 +355,7 @@ module.exports = [
                       animation: 'alpha',
                     },
                     {
-                      failureReason: 'Unsupported CSS Property: background-color',
+                      failureReason: 'Unsupported CSS Property: font-size',
                       animation: 'beta',
                     },
                   ],


### PR DESCRIPTION
See https://github.com/GoogleChrome/lighthouse/pull/11791#issuecomment-742151090

`background-color` will have a compositor animation soon, and this will probably break our smoke tests again. Switching to `font-size` animations.
