### PR TITLE
tests: fix unbound variable in download-devtools.sh

### DIFF
--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euxo pipefail
 
 ##
 # @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.

--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -18,7 +18,7 @@ then
   
   # Update to keep current.
   # Don't update in CI-defer to the weekly cache invalidation.
-  if ! [[ "$CI" ]]; then
+  if [ -n "${CI:-}" ]; then
     git reset --hard
     git clean -fd
     git pull --ff-only -f origin master


### PR DESCRIPTION
small bugfix from #11804.  this repros reliably locally

![image](https://user-images.githubusercontent.com/39191/101824689-69157a80-3ae1-11eb-8114-eb95dd1d22dc.png)

using this pattern since we're using `-u`: http://www.bnikolic.co.uk/blog/bash-unbound-variable.html


--------

also, i added `-x` to this script as i've wanted to better understand how the output matches against the commands.  but @connorjclark if you'd rather remove that, go for it. i dun care a lot.