### PR TITLE
misc: fix npm auth in nightly release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Publish to npm
         run: |
           cat /home/runner/work/_temp/.npmrc
-          echo ${NODE_AUTH_TOKEN:6}
+          if [ -z ${NODE_AUTH_TOKEN+x} ]; then echo "NODE_AUTH_TOKEN is unset"; else echo "NODE_AUTH_TOKEN is set to '...'"; fi
+          echo "test env ${NODE_AUTH_TOKEN:6}"
           npm whoami
           bash $GITHUB_WORKSPACE/.github/scripts/bump-nightly-version.sh
           npm publish --tag next

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,3 +23,4 @@ jobs:
           npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          CI: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Publish to npm
         run: |
           cat /home/runner/work/_temp/.npmrc
+          echo ${NODE_AUTH_TOKEN:6}
           npm whoami
           bash $GITHUB_WORKSPACE/.github/scripts/bump-nightly-version.sh
           npm publish --tag next

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch: {}
+  push: # lol
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Publish to npm
         run: |
+          ls /home/runner/work/_temp/.npmrc
           npm whoami
           bash $GITHUB_WORKSPACE/.github/scripts/bump-nightly-version.sh
           npm publish --tag next

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,10 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: yarn --frozen-lockfile
 
-      - run: bash $GITHUB_WORKSPACE/.github/scripts/bump-nightly-version.sh
-      - run: npm publish --tag next
+      - name: Publish to npm
+        run: |
+          npm whoami
+          bash $GITHUB_WORKSPACE/.github/scripts/bump-nightly-version.sh
+          npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch: {}
-  push: # lol
 
 jobs:
   publish:
@@ -13,6 +12,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
+          registry-url: https://registry.npmjs.org/
       - run: yarn --frozen-lockfile
 
       - run: bash $GITHUB_WORKSPACE/.github/scripts/bump-nightly-version.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,6 @@ jobs:
 
       - name: Publish to npm
         run: |
-          cat /home/runner/work/_temp/.npmrc
-          if [ -z ${NODE_AUTH_TOKEN+x} ]; then echo "NODE_AUTH_TOKEN is unset"; else echo "NODE_AUTH_TOKEN is set to '...'"; fi
-          echo "test env ${NODE_AUTH_TOKEN:6}"
           npm whoami
           bash $GITHUB_WORKSPACE/.github/scripts/bump-nightly-version.sh
           npm publish --tag next

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Publish to npm
         run: |
-          ls /home/runner/work/_temp/.npmrc
+          cat /home/runner/work/_temp/.npmrc
           npm whoami
           bash $GITHUB_WORKSPACE/.github/scripts/bump-nightly-version.sh
           npm publish --tag next


### PR DESCRIPTION
I manually ran this action first, and know it _actually_ works now.

couple things I learned here:

* test actions in the Actions tab, using the `workflow_dispatch` or `push:` triggers, before merging
* `npm publish --dry-run` doesn't actually verify that the auth process works. wat.
