### PR TITLE
misc(revert): core(without-javascript): remove audit (#11711)

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -19,6 +19,9 @@ Object {
       "path": "viewport",
     },
     Object {
+      "path": "without-javascript",
+    },
+    Object {
       "path": "metrics/first-contentful-paint",
     },
     Object {
@@ -1143,6 +1146,11 @@ Object {
         },
         Object {
           "group": "pwa-optimized",
+          "id": "without-javascript",
+          "weight": 1,
+        },
+        Object {
+          "group": "pwa-optimized",
           "id": "apple-touch-icon",
           "weight": 1,
         },
@@ -1477,6 +1485,9 @@ Object {
       "gatherers": Array [
         Object {
           "path": "http-redirect",
+        },
+        Object {
+          "path": "html-without-javascript",
         },
       ],
       "loadFailureMode": "warn",

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-config.js
@@ -20,6 +20,7 @@ module.exports = {
       'service-worker',
       'works-offline',
       'viewport',
+      'without-javascript',
       'user-timings',
       'critical-request-chains',
       'render-blocking-resources',

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -47,6 +47,9 @@ module.exports = [
         'viewport': {
           score: 1,
         },
+        'without-javascript': {
+          score: 1,
+        },
         'user-timings': {
           scoreDisplayMode: 'notApplicable',
         },
@@ -137,6 +140,9 @@ module.exports = [
           score: 1,
         },
         'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
           score: 1,
         },
         'user-timings': {

--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa-expectations.js
@@ -36,6 +36,9 @@ const expectations = [
         'viewport': {
           score: 1,
         },
+        'without-javascript': {
+          score: 1,
+        },
         'installable-manifest': {
           score: 1,
           details: {items: [pwaDetailsExpectations]},
@@ -93,6 +96,9 @@ const expectations = [
           score: 0,
         },
         'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
           score: 1,
         },
         'installable-manifest': {

--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa2-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa2-expectations.js
@@ -23,7 +23,9 @@ module.exports = [
           score: 1,
         },
         'redirects-http': {
-          score: 1,
+        // Note: relies on JS redirect.
+        // see https://github.com/GoogleChrome/lighthouse/issues/2383
+          score: 0,
         },
         'service-worker': {
           score: 1,
@@ -35,6 +37,9 @@ module.exports = [
           score: 1,
         },
         'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
           score: 1,
         },
         'installable-manifest': {
@@ -98,6 +103,9 @@ module.exports = [
           score: 1,
         },
         'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
           score: 1,
         },
         'installable-manifest': {

--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa3-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa3-expectations.js
@@ -39,6 +39,9 @@ module.exports = [
         'viewport': {
           score: 1,
         },
+        'without-javascript': {
+          score: 1,
+        },
         'installable-manifest': {
           score: 1,
           details: {items: [pwaRocksExpectations]},

--- a/lighthouse-core/audits/without-javascript.js
+++ b/lighthouse-core/audits/without-javascript.js
@@ -1,0 +1,62 @@
+/**
+ * @license Copyright 2016 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Audit = require('./audit.js');
+const i18n = require('../lib/i18n/i18n.js');
+
+const UIStrings = {
+  /** Title of a Lighthouse audit that provides detail on the web page's ability to return content with Javascript disabled in the browser. This descriptive title is shown to users when at least some content is shown when Javascript is not available. */
+  title: 'Contains some content when JavaScript is not available',
+  /** Title of a Lighthouse audit that provides detail on the web page's ability to return content with Javascript disabled in the browser. This descriptive title is shown to users when no content is shown when Javascript is not available. */
+  failureTitle: 'Does not provide fallback content when JavaScript is not available',
+  /** Description of a Lighthouse audit that tells the user why they should return content even if Javascript is unavailable in a browser. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  description: 'Your app should display some content when JavaScript is disabled, even if ' +
+    'it\'s just a warning to the user that JavaScript is required to use the app. ' +
+    '[Learn more](https://web.dev/without-javascript/).',
+  /** Message explaining that a website's body should render some (any) content even if the page's JavaScript cannot be loaded. */
+  explanation: 'The page body should render some content if its scripts are not available.',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+class WithoutJavaScript extends Audit {
+  /**
+   * @return {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'without-javascript',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      requiredArtifacts: ['HTMLWithoutJavaScript'],
+    };
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
+   */
+  static audit(artifacts) {
+    const artifact = artifacts.HTMLWithoutJavaScript;
+
+    // Fail pages that have empty text and are missing a noscript tag
+    if (artifact.bodyText.trim() === '' && !artifact.hasNoScript) {
+      return {
+        score: 0,
+        explanation: str_(UIStrings.explanation),
+      };
+    }
+
+    return {
+      score: 1,
+    };
+  }
+}
+
+module.exports = WithoutJavaScript;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -183,6 +183,7 @@ const defaultConfig = {
     blockedUrlPatterns: ['*.css', '*.jpg', '*.jpeg', '*.png', '*.gif', '*.svg', '*.ttf', '*.woff', '*.woff2'],
     gatherers: [
       'http-redirect',
+      'html-without-javascript',
     ],
   }],
   audits: [
@@ -191,6 +192,7 @@ const defaultConfig = {
     'service-worker',
     'works-offline',
     'viewport',
+    'without-javascript',
     'metrics/first-contentful-paint',
     'metrics/largest-contentful-paint',
     'metrics/first-meaningful-paint',
@@ -620,6 +622,7 @@ const defaultConfig = {
         {id: 'themed-omnibox', weight: 1, group: 'pwa-optimized'},
         {id: 'content-width', weight: 1, group: 'pwa-optimized'},
         {id: 'viewport', weight: 2, group: 'pwa-optimized'},
+        {id: 'without-javascript', weight: 1, group: 'pwa-optimized'},
         {id: 'apple-touch-icon', weight: 1, group: 'pwa-optimized'},
         {id: 'maskable-icon', weight: 1, group: 'pwa-optimized'},
         // Manual audits

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -682,6 +682,7 @@ class Driver {
     const waitForLoad = options.waitForLoad || false;
     /** @type {Partial<LH.Gatherer.PassContext>} */
     const passContext = options.passContext || {};
+    const disableJS = passContext.disableJavaScript || false;
 
     if (waitForNavigated && (waitForFcp || waitForLoad)) {
       throw new Error('Cannot use both waitForNavigated and another event, pick just one');
@@ -700,6 +701,7 @@ class Driver {
 
     await this.sendCommand('Page.enable');
     await this.sendCommand('Page.setLifecycleEventsEnabled', {enabled: true});
+    await this.sendCommand('Emulation.setScriptExecutionDisabled', {value: disableJS});
     // No timeout needed for Page.navigate. See https://github.com/GoogleChrome/lighthouse/pull/6413.
     const waitforPageNavigateCmd = this._innerSendCommand('Page.navigate', undefined, {url});
 

--- a/lighthouse-core/gather/gatherers/html-without-javascript.js
+++ b/lighthouse-core/gather/gatherers/html-without-javascript.js
@@ -1,0 +1,56 @@
+/**
+ * @license Copyright 2016 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Gatherer = require('./gatherer.js');
+
+/**
+ * @fileoverview Returns the innerText of the <body> element while JavaScript is
+ * disabled.
+ */
+
+/* global document */
+
+/* istanbul ignore next */
+function getBodyText() {
+  // note: we use innerText, not textContent, because textContent includes the content of <script> elements!
+  const body = document.querySelector('body');
+  return Promise.resolve({
+    bodyText: body ? body.innerText : '',
+    hasNoScript: !!document.querySelector('noscript'),
+  });
+}
+
+class HTMLWithoutJavaScript extends Gatherer {
+  /**
+   * @param {LH.Gatherer.PassContext} passContext
+   */
+  beforePass(passContext) {
+    passContext.disableJavaScript = true;
+  }
+
+  /**
+   * @param {LH.Gatherer.PassContext} passContext
+   * @return {Promise<LH.Artifacts['HTMLWithoutJavaScript']>}
+   */
+  async afterPass(passContext) {
+    // Reset the JS disable.
+    passContext.disableJavaScript = false;
+
+    const expression = `(${getBodyText.toString()}())`;
+    const {bodyText, hasNoScript} = await passContext.driver.evaluateAsync(expression);
+    if (typeof bodyText !== 'string') {
+      throw new Error('document body innerText returned by protocol was not a string');
+    }
+
+    return {
+      bodyText,
+      hasNoScript,
+    };
+  }
+}
+
+module.exports = HTMLWithoutJavaScript;

--- a/lighthouse-core/lib/i18n/locales/ar-XB.json
+++ b/lighthouse-core/lib/i18n/locales/ar-XB.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "‏‮Has‬‏ ‏‮a‬‏ `<meta name=\"viewport\">` ‏‮tag‬‏ ‏‮with‬‏ `width` ‏‮or‬‏ `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "‏‮Your‬‏ ‏‮app‬‏ ‏‮should‬‏ ‏‮display‬‏ ‏‮some‬‏ ‏‮content‬‏ ‏‮when‬‏ ‏‮JavaScript‬‏ ‏‮is‬‏ ‏‮disabled‬‏, ‏‮even‬‏ ‏‮if‬‏ ‏‮it‬‏'‏‮s‬‏ ‏‮just‬‏ ‏‮a‬‏ ‏‮warning‬‏ ‏‮to‬‏ ‏‮the‬‏ ‏‮user‬‏ ‏‮that‬‏ ‏‮JavaScript‬‏ ‏‮is‬‏ ‏‮required‬‏ ‏‮to‬‏ ‏‮use‬‏ ‏‮the‬‏ ‏‮app‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "‏‮The‬‏ ‏‮page‬‏ ‏‮body‬‏ ‏‮should‬‏ ‏‮render‬‏ ‏‮some‬‏ ‏‮content‬‏ ‏‮if‬‏ ‏‮its‬‏ ‏‮scripts‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮available‬‏."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "‏‮Does‬‏ ‏‮not‬‏ ‏‮provide‬‏ ‏‮fallback‬‏ ‏‮content‬‏ ‏‮when‬‏ ‏‮JavaScript‬‏ ‏‮is‬‏ ‏‮not‬‏ ‏‮available‬‏"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "‏‮Contains‬‏ ‏‮some‬‏ ‏‮content‬‏ ‏‮when‬‏ ‏‮JavaScript‬‏ ‏‮is‬‏ ‏‮not‬‏ ‏‮available‬‏"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "‏‮If‬‏ ‏‮you‬‏'‏‮re‬‏ ‏‮building‬‏ ‏‮a‬‏ ‏‮Progressive‬‏ ‏‮Web‬‏ ‏‮App‬‏, ‏‮consider‬‏ ‏‮using‬‏ ‏‮a‬‏ ‏‮service‬‏ ‏‮worker‬‏ ‏‮so‬‏ ‏‮that‬‏ ‏‮your‬‏ ‏‮app‬‏ ‏‮can‬‏ ‏‮work‬‏ ‏‮offline‬‏. [‏‮Learn‬‏ ‏‮more‬‏](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/ar.json
+++ b/lighthouse-core/lib/i18n/locales/ar.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "تضمين علامة `<meta name=\"viewport\">` مع `width` أو `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "يجب أن يعرض تطبيقك بعض المحتوى عند إيقاف JavaScript، حتى في حال كان مجرد تحذير للمستخدم يشير إلى ضرورة وجود JavaScript لاستخدام التطبيق. [مزيد من المعلومات](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "يجب أن يعرض نص الصفحة بعض المحتوى في حالة عدم توفر النصوص البرمجية."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "عدم تقديم المحتوى الاحتياطي عند عدم توفر JavaScript"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "تضمين بعض المحتوى عند عدم توفّر JavaScript"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "في حال كنت تنشئ \"تطبيق ويب تقدّمي\"، يمكنك استخدام مشغّل الخدمات حتى يتمكّن التطبيق من العمل بلا اتصال بالإنترنت. [مزيد من المعلومات](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/bg.json
+++ b/lighthouse-core/lib/i18n/locales/bg.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Има маркер `<meta name=\"viewport\">` с атрибут `width` или `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Когато JavaScript е деактивиран, в приложението ви трябва да се показва някакво съдържание, дори да е само предупреждение към потребителя, че за използване на приложението се изисква JavaScript. [Научете повече](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "В основната част на страницата трябва да се изобразява съдържание, ако скриптовете ѝ не могат да бъдат заредени."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Не предоставя резервно съдържание, когато JavaScript не е налице"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Показва се част от съдържанието, когато JavaScript не е налице"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Ако създавате прогресивно уеб приложение (PWA), добре е да използвате service worker, за да може то да работи офлайн. [Научете повече](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/ca.json
+++ b/lighthouse-core/lib/i18n/locales/ca.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Té una etiqueta `<meta name=\"viewport\">` amb l'atribut `width` o `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "L'aplicació ha de mostrar algun tipus de contingut quan JavaScript estigui desactivat, encara que només sigui per avisar l'usuari que es requereix JavaScript per utilitzar l'aplicació. [Obtén més informació](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "El cos de la pàgina ha de renderitzar algun tipus de contingut si els scripts no estan disponibles."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "No proporciona contingut alternatiu quan JavaScript no està disponible"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Inclou algun tipus de contingut quan JavaScript no està disponible"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Si vols crear una aplicació web progressiva, considera la possibilitat d'utilitzar un Service Worker perquè l'aplicació funcioni sense connexió. [Obtén més informació](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/cs.json
+++ b/lighthouse-core/lib/i18n/locales/cs.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Obsahuje značku `<meta name=\"viewport\">` s atributem `width` nebo `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Vaše aplikace by měla zobrazovat nějaký obsah, i v případě, že bude JavaScript zakázaný, i kdyby to mělo být jen upozornění pro uživatele, že k použití aplikace je potřeba JavaScript. [Další informace](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Pokud nejsou k dispozici skripty stránky, v hlavní části stránky by se měl vykreslit nějaký obsah."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Neposkytuje záložní obsah, když není k dispozici JavaScript"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Obsahuje určitý obsah, když není k dispozici JavaScript"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Pokud vytváříte progresivní webovou aplikaci, doporučujeme použít soubor service worker, aby aplikace fungovala i offline. [Další informace](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/da.json
+++ b/lighthouse-core/lib/i18n/locales/da.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Der er et `<meta name=\"viewport\">`-tag med `width` eller `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Din app bør vise noget indhold, når JavaScript er deaktiveret, også selvom det bare er en advarsel til brugeren om, at JavaScript er påkrævet for at bruge appen. [Få flere oplysninger](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Teksten på siden bør gengive noget indhold, hvis dens script ikke er tilgængelig."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Angiver ikke reserveindhold, når JavaScript ikke er tilgængelig"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Indeholder noget indhold, når JavaScript ikke er tilgængelig"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Hvis du er ved at udvikle en progressiv webapp, kan du overveje at bruge en scripttjeneste, så din app kan fungere offline. [Få flere oplysninger](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/de.json
+++ b/lighthouse-core/lib/i18n/locales/de.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Hat ein `<meta name=\"viewport\">`-Tag mit `width` oder `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Wenn JavaScript deaktiviert ist, sollte Ihre App dennoch einige Inhalte darstellen – auch wenn es sich dabei nur um eine Warnung handelt, dass die App JavaScript benötigt. [Weitere Informationen](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Die Body der Seite sollte einige Inhalte rendern, wenn ihre Skripts nicht verfügbar sind."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Liefert keinen Fallback-Content, wenn JavaScript nicht verfügbar ist"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Enthält einige Inhalte, wenn JavaScript nicht verfügbar ist"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Wenn Sie eine progressive Web-App entwickeln, sollten Sie einen Service Worker verwenden, damit Ihre App auch offline funktioniert. [Weitere Informationen.](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/el.json
+++ b/lighthouse-core/lib/i18n/locales/el.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Έχει ετικέτα `<meta name=\"viewport\">` με `width` ή `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Η εφαρμογή σας θα πρέπει να εμφανίζει κάποιο περιεχόμενο όταν η JavaScript είναι απενεργοποιημένη, ακόμη και αν είναι απλώς μια προειδοποίηση που ενημερώνει τον χρήστη ότι η JavaScript είναι απαραίτητη για τη χρήση της εφαρμογής. [Μάθετε περισσότερα](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Το σώμα της σελίδας θα πρέπει να αποδίδει κάποιο περιεχόμενο αν τα σενάριά του δεν είναι διαθέσιμα."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Δεν παρέχει εναλλακτικό περιεχόμενο όταν η JavaScript δεν είναι διαθέσιμη"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Περιλαμβάνει κάποιο περιεχόμενο όταν η JavaScript δεν είναι διαθέσιμη"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Εάν δημιουργείτε μια προηγμένη εφαρμογή ιστού, εξετάστε το ενδεχόμενο χρήσης ενός service worker ώστε η εφαρμογή σας να μπορεί να λειτουργεί εκτός σύνδεσης. [Μάθετε περισσότερα](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/en-GB.json
+++ b/lighthouse-core/lib/i18n/locales/en-GB.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Has a `<meta name=\"viewport\">` tag with `width` or `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "The page body should render some content if its scripts are not available."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Does not provide fallback content when JavaScript is not available"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Contains some content when JavaScript is not available"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "If you're building a progressive web app, consider using a service worker so that your app can work offline. [Learn more](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -1442,6 +1442,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Has a `<meta name=\"viewport\">` tag with `width` or `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "The page body should render some content if its scripts are not available."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Does not provide fallback content when JavaScript is not available"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Contains some content when JavaScript is not available"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "If you're building a Progressive Web App, consider using a service worker so that your app can work offline. [Learn more](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/en-XA.json
+++ b/lighthouse-core/lib/i18n/locales/en-XA.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "[Ĥåš å ᐅ`<meta name=\"viewport\">`ᐊ ţåĝ ŵîţĥ ᐅ`width`ᐊ öŕ ᐅ`initial-scale`ᐊ one two three four five six seven]"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "[Ýöûŕ åþþ šĥöûļð ðîšþļåý šömé çöñţéñţ ŵĥéñ ĴåvåŠçŕîþţ îš ðîšåбļéð, évéñ îƒ îţ'š ĵûšţ å ŵåŕñîñĝ ţö ţĥé ûšéŕ ţĥåţ ĴåvåŠçŕîþţ îš ŕéqûîŕéð ţö ûšé ţĥé åþþ. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/without-javascript/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour]"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "[Ţĥé þåĝé бöðý šĥöûļð ŕéñðéŕ šömé çöñţéñţ îƒ îţš šçŕîþţš åŕé ñöţ åvåîļåбļé. one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "[Ðöéš ñöţ þŕövîðé ƒåļļбåçķ çöñţéñţ ŵĥéñ ĴåvåŠçŕîþţ îš ñöţ åvåîļåбļé one two three four five six seven eight nine ten eleven twelve thirteen]"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "[Çöñţåîñš šömé çöñţéñţ ŵĥéñ ĴåvåŠçŕîþţ îš ñöţ åvåîļåбļé one two three four five six seven eight nine ten eleven]"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "[Îƒ ýöû'ŕé бûîļðîñĝ å Þŕöĝŕéššîvé Ŵéб Åþþ, çöñšîðéŕ ûšîñĝ å šéŕvîçé ŵöŕķéŕ šö ţĥåţ ýöûŕ åþþ çåñ ŵöŕķ öƒƒļîñé. ᐅ[ᐊĻéåŕñ möŕéᐅ](https://web.dev/works-offline/)ᐊ. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty]"
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -1442,6 +1442,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Ĥáŝ á `<meta name=\"viewport\">` t̂áĝ ẃît́ĥ `width` ór̂ `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Ŷóûŕ âṕp̂ śĥóûĺd̂ d́îśp̂ĺâý ŝóm̂é ĉón̂t́êńt̂ ẃĥén̂ J́âv́âŚĉŕîṕt̂ íŝ d́îśâb́l̂éd̂, év̂én̂ íf̂ ít̂'ś ĵúŝt́ â ẃâŕn̂ín̂ǵ t̂ó t̂h́ê úŝér̂ t́ĥát̂ J́âv́âŚĉŕîṕt̂ íŝ ŕêq́ûír̂éd̂ t́ô úŝé t̂h́ê áp̂ṕ. [L̂éâŕn̂ ḿôŕê](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "T̂h́ê ṕâǵê b́ôd́ŷ śĥóûĺd̂ ŕêńd̂ér̂ śôḿê ćôńt̂én̂t́ îf́ ît́ŝ śĉŕîṕt̂ś âŕê ńôt́ âv́âíl̂áb̂ĺê."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "D̂óêś n̂ót̂ ṕr̂óv̂íd̂é f̂ál̂ĺb̂áĉḱ ĉón̂t́êńt̂ ẃĥén̂ J́âv́âŚĉŕîṕt̂ íŝ ńôt́ âv́âíl̂áb̂ĺê"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Ĉón̂t́âín̂ś ŝóm̂é ĉón̂t́êńt̂ ẃĥén̂ J́âv́âŚĉŕîṕt̂ íŝ ńôt́ âv́âíl̂áb̂ĺê"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Îf́ ŷóû'ŕê b́ûíl̂d́îńĝ á P̂ŕôǵr̂éŝśîv́ê Ẃêb́ Âṕp̂, ćôńŝíd̂ér̂ úŝín̂ǵ â śêŕv̂íĉé ŵór̂ḱêŕ ŝó t̂h́ât́ ŷóûŕ âṕp̂ ćâń ŵór̂ḱ ôf́f̂ĺîńê. [Ĺêár̂ń m̂ór̂é](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/es-419.json
+++ b/lighthouse-core/lib/i18n/locales/es-419.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Tiene una etiqueta `<meta name=\"viewport\">` con `width` o `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Tu app debe mostrar algún contenido cuando JavaScript está inhabilitado, aunque solo sea un aviso para informar al usuario que se necesita JavaScript para usar la app. [Obtén más información](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "El cuerpo de la página debe renderizar parte del contenido aunque sus secuencias de comandos no estén disponibles."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "No se incluye contenido alternativo cuando no está disponible JavaScript"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Se incluye parte del contenido cuando no está disponible JavaScript"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Si estás creando una app web progresiva, puedes usar un service worker para que la app funcione sin conexión. [Obtén más información](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/es.json
+++ b/lighthouse-core/lib/i18n/locales/es.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Contiene una etiqueta `<meta name=\"viewport\">` con `width` o `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Tu aplicación debería mostrar algún contenido cuando JavaScript esté inhabilitado, aunque solo sea un aviso para informar al usuario de que es necesario activar JavaScript para usar la aplicación. [Más información](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "El cuerpo de la página debería renderizar parte del contenido aunque sus secuencias de comandos no estén disponibles."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "No ofrece contenido de reserva cuando JavaScript está inhabilitado"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Muestra parte del contenido cuando JavaScript está inhabilitado"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Si estás creando una aplicación web progresiva, puedes usar un service worker para que funcione sin conexión. [Más información](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/fi.json
+++ b/lighthouse-core/lib/i18n/locales/fi.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "`<meta name=\"viewport\">` ‑tagi, jossa `width` tai `initial-scale`, löytyy"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Sovelluksen tulee näyttää jotakin sisältöä, vaikka JavaScript ei ole toiminnassa. Näytä käyttäjälle vähintään varoitus, että JavaScript on pakollinen sovelluksen käyttöä varten. [Lue lisää](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Sivun runko-osan pitäisi renderöidä sisältöä, vaikka sen skriptit eivät ole saatavilla."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Ei palauta varasisältöä, kun JavaScript ei ole käytettävissä"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Palauttaa sisältöä, vaikka JavaScript ei ole käytettävissä"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Jos kehität progressiivista web-sovellusta, harkitse service workerin käyttöä tukemaan sovelluksen toimintaa offline-tilassa. [Lue lisää](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/fil.json
+++ b/lighthouse-core/lib/i18n/locales/fil.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "May tag na `<meta name=\"viewport\">` na may `width` o `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Dapat magpakita ng ilang content ang iyong app kapag naka-disable ang JavaScript, kahit isang babala lang sa user na kinakailangan ang JavaScript para magamit ang app. [Matuto pa](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Dapat mag-render ng ilang content ang nilalaman ng page kung hindi available ang mga script nito."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Hindi nagbibigay ng fallback na content kapag hindi available ang JavaScript"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Naglalaman ng ilang content kapag hindi available ang JavaScript"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Kung bumubuo ka ng Progressive Web App, pag-isipang gumamit ng service worker para gumana ang iyong app offline. [Matuto pa](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/fr.json
+++ b/lighthouse-core/lib/i18n/locales/fr.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Une balise `<meta name=\"viewport\">` ayant l'attribut `width` ou `initial-scale` est configurée"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Nous vous recommandons d'afficher du contenu même lorsque JavaScript est indisponible. Il peut s'agir d'un simple avertissement informant l'utilisateur que JavaScript est requis pour utiliser votre application. [Découvrez-en davantage](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Il est recommandé d'afficher du contenu dans le corps de la page lorsque les scripts sont indisponibles."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Aucun contenu de remplacement ne s'affiche lorsque JavaScript est indisponible"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Du contenu s'affiche lorsque JavaScript est indisponible"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Si vous développez une progressive web app, envisagez d'utiliser un service worker afin que votre application soit accessible hors connexion. [Découvrez-en davantage](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/he.json
+++ b/lighthouse-core/lib/i18n/locales/he.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "יש תג `<meta name=\"viewport\">` עם `width` או `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "האפליקציה שלך צריכה להציג תוכן כלשהו כשה-JavaScript מושבת, גם אם זו רק אזהרה למשתמש שנדרש JavaScript כדי להשתמש באפליקציה. [מידע נוסף](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "אם הסקריפטים של גוף הדף לא זמינים, הוא צריך לעבד תוכן כלשהו."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "לא מספק תוכן חלופי כש-JavaScript לא זמין"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "מכיל תוכן כלשהו כש-JavaScript לא זמין"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "אם בונים Progressive Web App, מומלץ לשקול להשתמש בקובץ שירות (service worker) כדי שהאפליקציה תוכל לעבוד במצב לא מקוון. [מידע נוסף](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/hi.json
+++ b/lighthouse-core/lib/i18n/locales/hi.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "वेब पेज पर `width` या `initial-scale` वाला `<meta name=\"viewport\">` टैग है"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "JavaScript बंद होने पर भी आपके ऐप्लिकेशन की कुछ सामग्री दिखाई देनी चाहिए. भले ही वह उपयोगकर्ता को दी जाने वाली एक चेतावनी हो कि ऐप्लिकेशन को इस्तेमाल करने के लिए JavaScript ज़रूरी है. [ज़्यादा जानें](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "अगर इसकी स्क्रिप्ट उपलब्ध नहीं हैं, तो पेज के मुख्य हिस्से को कुछ सामग्री रेंडर करनी चाहिए या उसकी इमेज बनानी चाहिए."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "यह वेब पेज, JavaScript उपलब्ध न होने पर फ़ॉलबैक सामग्री मुहैया नहीं कराता है"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "यह वेब पेज, JavaScript उपलब्ध नहीं होने पर कुछ सामग्री दिखाता है"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "अगर आप एक प्रगतिशील वेब ऐप्लिकेशन बना रहे हैं, तो सर्विस वर्कर का इस्तेमाल करें, ताकि आपका ऐप्लिकेशन ऑफ़लाइन भी काम कर सके. [ज़्यादा जानें](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/hr.json
+++ b/lighthouse-core/lib/i18n/locales/hr.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Ima oznaku `<meta name=\"viewport\">` s `width` ili `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Vaša aplikacija trebala bi prikazati bilo kakav sadržaj kada je onemogućen JavaScript, čak i ako je to samo upozorenje da je JavaScript obavezan za korištenje aplikacije. [Saznajte više](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Tijelo stranice trebalo bi generirati bilo kakav sadržaj ako skripte nisu dostupne."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Ne pruža zamjenski sadržaj kada JavaScript nije dostupan"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Prikazuje se bilo kakav sadržaj kada JavaScript nije dostupan"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Ako razvijate progresivnu web-aplikaciju, razmislite o korištenju uslužnog alata tako da aplikacija može funkcionirati offline. [Saznajte više](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/hu.json
+++ b/lighthouse-core/lib/i18n/locales/hu.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Van `width` vagy `initial-scale` beállítással rendelkező `<meta name=\"viewport\">` címkéje"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Az alkalmazásnak akkor is meg kellene jelenítenie valamilyen tartalmat, ha a JavaScript le van tiltva. Ez akár egy figyelmeztetés is lehet, mely szerint JavaScript szükséges az alkalmazás használatához. [További információ](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Az oldal törzsében meg kellene jelennie valamilyen tartalomnak, ha a szkriptek nem használhatók."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Nem biztosít tartalék tartalmat, ha a JavaScript nem használható"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Vannak benne tartalmak akkor is, amikor a JavaScript nem használható"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Ha progresszív webes alkalmazást készít, fontolja meg szolgáltató munkatárs használatát, így alkalmazása offline állapotban is működni fog. [További információ](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/id.json
+++ b/lighthouse-core/lib/i18n/locales/id.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Memiliki tag `<meta name=\"viewport\">` dengan `width` atau `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Aplikasi Anda harus menampilkan beberapa konten saat JavaScript nonaktif, meskipun hanya berupa peringatan kepada pengguna bahwa JavaScript diperlukan untuk menggunakan aplikasi. [Pelajari lebih lanjut](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Isi halaman harus merender beberapa konten jika skripnya tidak tersedia."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Tidak menyediakan konten pengganti saat JavaScript tidak tersedia"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Berisi beberapa konten saat JavaScript tidak tersedia"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Jika Anda membuat build Progressive Web App, pertimbangkan untuk menggunakan pekerja layanan agar aplikasi dapat berfungsi secara offline. [Pelajari lebih lanjut](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/it.json
+++ b/lighthouse-core/lib/i18n/locales/it.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Ha un tag `<meta name=\"viewport\">` con `width` o `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Nella tua app dovresti visualizzare alcuni contenuti quando JavaScript è disattivato, anche soltanto un avviso che comunica all'utente che è necessario JavaScript per usare l'app. [Ulteriori informazioni](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Nel corpo della pagina dovrebbero essere visualizzati alcuni contenuti se gli script della pagina non sono disponibili."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Non fornisce contenuti di riserva quando JavaScript non è disponibile"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Ha alcuni contenuti quando JavaScript non è disponibile"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Se devi creare un'app web progressiva, potresti usare un service worker per far funzionare la tua app offline. [Ulteriori informazioni](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/ja.json
+++ b/lighthouse-core/lib/i18n/locales/ja.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "`width` または `initial-scale` を指定した `<meta name=\"viewport\">` タグがあります"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "JavaScript が無効になっている場合でも、アプリではなんらかのコンテンツを表示する必要があります。「アプリの使用には JavaScript が必要」という旨の警告を表示するだけでもかまいません。[詳細](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "スクリプトを利用できない場合でも、ページの本文にはなんらかのコンテンツを表示する必要があります。"
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "JavaScript を利用できない場合の代替コンテンツが提供されていません"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "JavaScript を利用できない場合のコンテンツが含まれています"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "プログレッシブ ウェブアプリを作成している場合は、アプリがオフラインでも動作するように、Service Worker の使用を検討してください。[詳細](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/ko.json
+++ b/lighthouse-core/lib/i18n/locales/ko.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "`width` 또는 `initial-scale`이(가) 포함된 `<meta name=\"viewport\">` 태그가 있음"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "JavaScript가 사용 중지되었더라도 사용자에게 앱을 사용하려면 JavaScript가 필요하다는 경고 등의 일부 콘텐츠는 앱에 표시되어야 합니다. [자세히 알아보기](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "페이지 본문에서 스크립트를 사용할 수 없는 경우 본문에서 콘텐츠를 일부 렌더링해야 합니다."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "JavaScript를 사용할 수 없는 경우 대체 콘텐츠를 제공하지 않음"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "JavaScript를 사용할 수 없는 경우에도 일부 콘텐츠를 포함함"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "프로그레시브 웹 앱을 빌드할 경우 앱이 오프라인에서도 작동할 수 있도록 서비스 워커를 사용하는 것이 좋습니다. [자세히 알아보기](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/lt.json
+++ b/lighthouse-core/lib/i18n/locales/lt.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Yra žyma `<meta name=\"viewport\">` su `width` arba `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Kai „JavaScript“ išjungta, jūsų programoje turėtų būti rodoma turinio, net jei tai tik įspėjimas naudotojui, kad „JavaScript“ būtina norint naudoti programą. [Sužinokite daugiau](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Puslapio pagrindinėje dalyje turi būti pateikta turinio, jei scenarijus nepasiekiamas."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Atsarginis turinys neteikiamas, kai „JavaScript“ nepasiekiama"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Yra turinio, kai „JavaScript“ nepasiekiama"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Jei kuriate laipsniškąją žiniatinklio programą, apsvarstykite galimybę naudoti pagalbinį „JavaScript“ failą, kad programa veiktų neprisijungus. [Sužinokite daugiau](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/lv.json
+++ b/lighthouse-core/lib/i18n/locales/lv.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Ir tags `<meta name=\"viewport\">` ar `width` vai `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Ja JavaScript ir atspējots, lietotnē jāparāda zināms saturs — kaut vai tikai brīdinājums, ka lietotnes izmantošanai nepieciešams JavaScript. [Uzziniet vairāk](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Ja lapas skripti nav pieejami, lapas pamattekstā jātiek vismaz daļēji attēlotam saturam."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Ja JavaScript nav pieejams, netiek sniegts atkāpšanās saturs"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Ja JavaScript nav pieejams, lapas saturs zināmā mērā tiek parādīts"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Ja izstrādājat progresīvo tīmekļa lietotni, apsveriet iespēju izmantot pakalpojumu skriptu, lai lietotne varētu darboties bezsaistē. [Uzziniet vairāk](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/nl.json
+++ b/lighthouse-core/lib/i18n/locales/nl.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Bevat een `<meta name=\"viewport\">`-tag met `width` of `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Je app moet wat content weergeven wanneer JavaScript is uitgeschakeld, zelfs als het alleen maar een waarschuwing aan de gebruiker is dat JavaScript is vereist om de app te gebruiken. [Meer informatie](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Het hoofdgedeelte van de pagina moet wat content weergeven als de bijbehorende scripts niet beschikbaar zijn."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Biedt geen reservecontent wanneer JavaScript niet beschikbaar is"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Bevat wat content wanneer JavaScript niet beschikbaar is"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Als je een progressive web-app bouwt, kun je overwegen een service worker te gebruiken zodat je app offline kan worden gebruikt. [Meer informatie](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/no.json
+++ b/lighthouse-core/lib/i18n/locales/no.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Har en `<meta name=\"viewport\">`-tag med `width` eller `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Appen bør vise noe innhold når JavaScript er deaktivert, selv om det bare er en advarsel til brukeren om at JavaScript kreves for å bruke appen. [Finn ut mer](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Sidekroppen bør vise noe innhold hvis skriptene ikke er tilgjengelige."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Tilbyr ikke reserveinnhold når JavaScript ikke er tilgjengelig"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Inneholder noe innhold når JavaScript ikke er tilgjengelig"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Hvis du utvikler et progressivt nettprogram, kan du vurdere å bruke en tjenestearbeider, så appen fungerer uten nett. [Finn ut mer](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/pl.json
+++ b/lighthouse-core/lib/i18n/locales/pl.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Zawiera tag `<meta name=\"viewport\">` z elementem `width` lub `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Aplikacja powinna wyświetlać jakieś treści, jeśli JavaScript jest wyłączony. Wystarczy nawet ostrzeżenie, że JavaScript jest wymagany do korzystania z aplikacji. [Więcej informacji](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Główna część strony powinna renderować jakieś treści, kiedy jej skrypty są niedostępne"
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Nie zawiera treści zastępczych na wypadek niedostępności JavaScriptu"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Zawiera jakieś treści na wypadek niedostępności JavaScriptu"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Jeśli tworzysz progresywną aplikację internetową, rozważ użycie skryptu service worker, który pozwoli na działanie aplikacji w trybie offline. [Więcej informacji](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/pt-PT.json
+++ b/lighthouse-core/lib/i18n/locales/pt-PT.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Tem uma etiqueta `<meta name=\"viewport\">` com `width` ou `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "A sua aplicação deve apresentar algum conteúdo quando o JavaScript está desativado, mesmo que seja apenas um aviso ao utilizador de que o JavaScript é necessário para utilizar a aplicação. [Saiba mais](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "O corpo da página deve renderizar algum conteúdo se os respetivos scripts não estiverem disponíveis."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Não fornece conteúdo obsoleto quando o JavaScript não está disponível"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Contém algum conteúdo quando o JavaScript não está disponível"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Se estiver a criar uma progressive web app, considere utilizar um service worker para que a sua aplicação possa funcionar offline. [Saiba mais](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/pt.json
+++ b/lighthouse-core/lib/i18n/locales/pt.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Há uma tag `<meta name=\"viewport\">` com `width` ou `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Seu app precisa mostrar algum conteúdo quando o JavaScript está desativado, mesmo que seja somente um aviso de que o JavaScript é necessário para o uso do app. [Saiba mais](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "O corpo da página precisa renderizar algum conteúdo se os scripts não estão disponíveis."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Nenhum conteúdo substituto é exibido quando o JavaScript não está disponível."
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Algum conteúdo é exibido quando o JavaScript não está disponível."
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Se você estiver criando um Progressive Web App, é recomendável usar um service worker para que seu app possa funcionar off-line. [Saiba mais](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/ro.json
+++ b/lighthouse-core/lib/i18n/locales/ro.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Are o etichetă `<meta name=\"viewport\">` cu `width` sau `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Aplicația ta trebuie să afișeze o parte de conținut când JavaScript este dezactivat, chiar dacă este doar o atenționare pentru utilizator că JavaScript este obligatoriu pentru a folosi aplicația. [Află mai multe](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Corpul paginii trebuie să redea o parte de conținut dacă scripturile sale nu sunt disponibile."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Nu oferă conținut alternativ când JavaScript nu este disponibil"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Include o parte de conținut când JavaScript nu este disponibil"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Dacă creezi o aplicație web progresivă, poți folosi un service worker pentru ca aplicația să poată funcționa offline. [Află mai multe](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/ru.json
+++ b/lighthouse-core/lib/i18n/locales/ru.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Присутствует метатег `<meta name=\"viewport\">` со свойством `width` или `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "В приложении должен отображаться контент, даже если JavaScript отключен. Достаточно уведомления, что для работы приложения необходим JavaScript. [Подробнее…](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Даже при недоступности скриптов в теле страницы должен отображаться контент."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Не предоставляет резервный контент при недоступности JavaScript"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Содержит некоторый контент при недоступности JavaScript"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "При создании современного веб-приложения используйте Service Worker, чтобы оно продолжало работу в офлайн-режиме. [Подробнее…](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/sk.json
+++ b/lighthouse-core/lib/i18n/locales/sk.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Obsahuje značku `<meta name=\"viewport\">` s vlastnosťou `width` alebo `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Vaša aplikácia by mala zobrazovať nejaký obsah, keď je zakázaný JavaScript, aj keby malo ísť iba o upozornenie používateľa, že na používanie aplikácie sa vyžaduje JavaScript. [Ďalšie informácie](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Telo stránky by malo vykresliť nejaký obsah, ak jej skripty nie sú k dispozícii."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Neposkytuje záložný obsah, keď nie je k dispozícii JavaScript"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Obsahuje určitý obsah, keď nie je k dispozícii JavaScript"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Ak vytvárate progresívnu webovú aplikáciu, zvážte použitie obsluhy, aby aplikácia mohla fungovať offline. [Ďalšie informácie](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/sl.json
+++ b/lighthouse-core/lib/i18n/locales/sl.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Ima oznako `<meta name=\"viewport\">` s tem: `width` ali `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Aplikacija bi morala prikazati nekaj vsebine, če je JavaScript onemogočen, četudi zgolj opozorilo uporabniku, da uporaba aplikacije terja JavaScript. [Več o tem](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Telo strani bi moralo upodobiti nekaj vsebine, če njeni skripti niso na voljo."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Ne zagotavlja nadomestne vsebine, ko JavaScript ni na voljo"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Vsebuje nekaj vsebine, ko JavaScript ni na voljo"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Če ustvarjate moderno spletno aplikacijo, razmislite o uporabi procesa storitve, da lahko aplikacija deluje brez povezave. [Več o tem](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/sr-Latn.json
+++ b/lighthouse-core/lib/i18n/locales/sr-Latn.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Ima oznaku `<meta name=\"viewport\">` sa oznakom `width` ili `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Aplikacija treba da prikazuje neki sadržaj kada je JavaScript onemogućen, čak i ako je to samo upozorenje korisniku da je JavaScript obavezan za korišćenje aplikacije. [Saznajte više](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Telo stranice treba da prikazuje neki sadržaj ako joj skripte nisu dostupne."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Ne pruža rezervni sadržaj kada JavaScript nije dostupan"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Ima neki sadržaj kada JavaScript nije dostupan"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Ako pravite progresivnu veb-aplikaciju, razmislite o tome da koristite serviser kako bi aplikacija mogla da radi oflajn. [Saznajte više](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/sr.json
+++ b/lighthouse-core/lib/i18n/locales/sr.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Има ознаку `<meta name=\"viewport\">` са ознаком `width` или `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Апликација треба да приказује неки садржај када је JavaScript онемогућен, чак и ако је то само упозорење кориснику да је JavaScript обавезан за коришћење апликације. [Сазнајте више](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Тело странице треба да приказује неки садржај ако јој скрипте нису доступне."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Не пружа резервни садржај када JavaScript није доступан"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Има неки садржај када JavaScript није доступан"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Ако правите прогресивну веб-апликацију, размислите о томе да користите сервисер како би апликација могла да ради офлајн. [Сазнајте више](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/sv.json
+++ b/lighthouse-core/lib/i18n/locales/sv.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Har en `<meta name=\"viewport\">`-tagg med `width` eller `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Appen ska visa innehåll när JavaScript är inaktiverat, även om det bara är en varning till användaren om att JavaScript krävs för att använda appen. [Läs mer](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Någon form av innehåll ska renderas för sidans brödtext om dess skript inte är tillgängliga."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Visar inte reservinnehåll när JavaScript inte är tillgängligt"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Visar innehåll när JavaScript inte är tillgängligt"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Om du skapar en progressiv webbapp rekommenderar vi att du använder en tjänstefunktion så att appen kan användas offline. [Läs mer](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/ta.json
+++ b/lighthouse-core/lib/i18n/locales/ta.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "`width` அல்லது `initial-scale` உடன் `<meta name=\"viewport\">` குறிச்சொல் அமைக்கப்பட்டுள்ளது"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "JavaScript முடக்கத்தில் உள்ள போது சில உள்ளடக்கத்தை உங்கள் ஆப்ஸ் காட்ட வேண்டும். அது ஆப்ஸைப் பயன்படுத்த JavaScript தேவை என்ற எச்சரிக்கைச் செய்தியாக இருந்தாலும் பரவாயில்லை. [மேலும் அறிக](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "ஸ்கிரிப்ட்கள் இல்லாத போது பக்கம் சில உள்ளடக்கத்தை ரெண்டர் செய்ய வேண்டும்."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "JavaScript முடக்கத்தில் உள்ள போது ஃபால்பேக் உள்ளடக்கத்தை வழங்காது"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "JavaScript முடக்கத்தில் உள்ள போது சில உள்ளடக்கம் காட்டப்படும்"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "நவீன இணைய ஆப்ஸை உருவாக்குகிறீர்கள் எனில் ஆஃப்லைனில் உங்கள் ஆப்ஸ் செயல்படும் வகையில் சேவைச் செயலாக்கியைப் பயன்படுத்தும்படி பரிந்துரைக்கிறோம். [மேலும் அறிக](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/te.json
+++ b/lighthouse-core/lib/i18n/locales/te.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "'`width`' లేదా '`initial-scale`'తో '`<meta name=\"viewport\">`' ట్యాగ్‌ను కలిగి ఉంది"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "'JavaScript' నిలిపివేయబడినప్పుడు, దాని గురించి తెలియజేసే ఏదైనా సమాచారం, అంటే యాప్‌ను ఉపయోగించాలంటే 'JavaScript' కలిగి ఉండాలని వినియోగదారుకు తెలియజేసే హెచ్చరిక లాంటి ఏదొక కంటెంట్ మీ యాప్‌లో ప్రదర్శించబడాలి. [మరింత తెలుసుకోండి](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "పేజీ విషయాంశంలో స్క్రిప్ట్‌లు ఏవైనా అందుబాటులో లేనప్పుడు, కొంత కంటెంట్‌ను రెండర్ చేయాలి."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "JavaScript అందుబాటులో లేనప్పుడు ప్రత్యామ్నాయ కంటెంట్‌ను అందించలేదు"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "JavaScript అందుబాటులో లేనప్పుడు, దాని గురించి తెలియజేసే కొంత కంటెంట్‌ను కలిగి ఉంది"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "మీరు ప్రోగ్రెసివ్ వెబ్ యాప్‌ను రూపొందిస్తున్నట్లయితే, సర్వీస్ వర్కర్‌ను ఉపయోగించడం పరిగణనలోకి తీసుకోండి. దీని వలన ఆఫ్‌లైన్‌లో కూడా మీ యాప్ పని చేయగలదు. [మరింత తెలుసుకోండి](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/th.json
+++ b/lighthouse-core/lib/i18n/locales/th.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "มีแท็ก `<meta name=\"viewport\">` ที่มี `width` หรือ `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "แอปควรแสดงเนื้อหาบางอย่างเมื่อมีการปิดใช้ JavaScript แม้จะเป็นเพียงการเตือนผู้ใช้ว่าการใช้แอปจำเป็นต้องใช้ JavaScript [ดูข้อมูลเพิ่มเติม](https://web.dev/without-javascript/)"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "ส่วนเนื้อหาในหน้าควรแสดงเนื้อหาบางอย่างถ้าสคริปต์ในหน้าไม่พร้อมใช้งาน"
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "ไม่แสดงเนื้อหาทางเลือกเมื่อ JavaScript ไม่พร้อมใช้งาน"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "มีเนื้อหาบางอย่างแสดงขึ้นเมื่อ JavaScript ไม่พร้อมใช้งาน"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "หากคุณกำลังสร้าง Progressive Web App ให้พิจารณาใช้ Service Worker เพื่อให้แอปทำงานแบบออฟไลน์ได้ [ดูข้อมูลเพิ่มเติม](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/tr.json
+++ b/lighthouse-core/lib/i18n/locales/tr.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "`width` veya `initial-scale` değerleri olan bir `<meta name=\"viewport\">` etiketi var"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Uygulamanız, JavaScript devre dışı bırakıldığında bazı içerikler görüntülemelidir. Bu içerik, kullanıcıya uygulamayı kullanmak için JavaScript gerektiğini belirten bir uyarı bile olabilir. [Daha fazla bilgi](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Komut dosyaları kullanılamıyorsa sayfa gövdesi bazı içerikler oluşturmalıdır."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "JavaScript kullanılamadığında ikame içerik sağlamıyor"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "JavaScript kullanılamadığında bazı içerikler bulundurur"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Progresif Web Uygulaması oluşturuyorsanız uygulamanızın çevrimdışı da çalışabilmesi için hizmet çalışanı kullanmayı düşünün. [Daha fazla bilgi](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/uk.json
+++ b/lighthouse-core/lib/i18n/locales/uk.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Має тег `<meta name=\"viewport\">` з атрибутами `width` або `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Ваш додаток має відображати певний контент, коли JavaScript вимкнено, навіть якщо це просто сповіщення для користувачів про те, що для використання додатка потрібно ввімкнути JavaScript. [Докладніше](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Сторінка має відображати контент, навіть якщо її сценарії недоступні."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Резервний контент не відображається, коли JavaScript вимкнено"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Певний контент відображається, коли JavaScript вимкнено"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Якщо ви створюєте прогресивний веб-додаток, можете скористатися синтаксисом Service Worker, щоб додаток працював офлайн. [Докладніше](https://web.dev/works-offline/)."
   },

--- a/lighthouse-core/lib/i18n/locales/vi.json
+++ b/lighthouse-core/lib/i18n/locales/vi.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Có thẻ `<meta name=\"viewport\">` có `width` hoặc `initial-scale`"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "Ứng dụng của bạn phải hiển thị một số nội dung khi JavaScript bị tắt, ngay cả khi đó chỉ là một cảnh báo cho người dùng biết phải có JavaScript mới dùng được ứng dụng. [Tìm hiểu thêm](https://web.dev/without-javascript/)."
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "Phần nội dung trang phải hiển thị một số nội dung nếu không có sẵn tập lệnh."
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "Không cung cấp nội dung dự phòng khi JavaScript không có sẵn"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "Chứa một số nội dung khi JavaScript không có sẵn"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "Nếu bạn đang tạo một Ứng dụng web tiến bộ, hãy cân nhắc dùng trình chạy dịch vụ để ứng dụng có thể hoạt động khi không có mạng. [Tìm hiểu thêm](https://web.dev/works-offline/)"
   },

--- a/lighthouse-core/lib/i18n/locales/zh-HK.json
+++ b/lighthouse-core/lib/i18n/locales/zh-HK.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "具備包括 `<meta name=\"viewport\">` 或 `width` 的 `initial-scale` 標籤"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "當 JavaScript 停用時，您的應用程式應該要顯示一些內容，即使只是向使用者顯示「必須啟用 JavaScript 才能使用此應用程式」這類警告訊息亦可。[瞭解詳情](https://web.dev/without-javascript/)。"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "即使網頁的指令碼無法使用，網頁內文仍應顯示一些內容。"
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "當 JavaScript 無法使用時不提供備用內容"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "當 JavaScript 無法使用時包含一些內容"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "如果您正在建立漸進式網絡應用程式，請考慮使用 Service Worker，以便您的應用程式離線運作。[瞭解詳情](https://web.dev/works-offline/)。"
   },

--- a/lighthouse-core/lib/i18n/locales/zh-TW.json
+++ b/lighthouse-core/lib/i18n/locales/zh-TW.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "具備包含 `width` 或 `initial-scale` 的 `<meta name=\"viewport\">` 標記"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "當 JavaScript 停用時，你的應用程式應該要顯示一些內容，即使只是向使用者顯示「必須啟用 JavaScript 才能使用此應用程式」這類警告訊息也可以。[瞭解詳情](https://web.dev/without-javascript/)。"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "即使網頁的指令碼無法使用，網頁內文仍應顯示一些內容。"
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "當 JavaScript 無法使用時不提供備用內容"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "當 JavaScript 無法使用時包含一些內容"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "如果你正在建構漸進式網頁應用程式，請考慮使用 Service Worker，讓你的應用程式可以離線運作。[瞭解詳情](https://web.dev/works-offline/)。"
   },

--- a/lighthouse-core/lib/i18n/locales/zh.json
+++ b/lighthouse-core/lib/i18n/locales/zh.json
@@ -1397,6 +1397,18 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "具有包含 `width` 或 `initial-scale` 的 `<meta name=\"viewport\">` 标记"
   },
+  "lighthouse-core/audits/without-javascript.js | description": {
+    "message": "您的应用应该在 JavaScript 被禁用时显示一些内容，哪怕只是向用户显示一则警告（告知其必须启用 JavaScript 才能使用该应用）。[了解详情](https://web.dev/without-javascript/)。"
+  },
+  "lighthouse-core/audits/without-javascript.js | explanation": {
+    "message": "网页正文应该能在其脚本不可用时呈现一些内容。"
+  },
+  "lighthouse-core/audits/without-javascript.js | failureTitle": {
+    "message": "不提供在 JavaScript 未启用时显示的后备内容"
+  },
+  "lighthouse-core/audits/without-javascript.js | title": {
+    "message": "包含一些 JavaScript 未启用时显示的内容"
+  },
   "lighthouse-core/audits/works-offline.js | description": {
     "message": "如果您想构建渐进式 Web 应用，不妨考虑使用 Service Worker，以确保您的应用可离线工作。[了解详情](https://web.dev/works-offline/)。"
   },

--- a/lighthouse-core/test/audits/without-javascript-test.js
+++ b/lighthouse-core/test/audits/without-javascript-test.js
@@ -1,0 +1,61 @@
+/**
+ * @license Copyright 2016 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const withoutJsAudit = require('../../audits/without-javascript.js');
+const assert = require('assert').strict;
+
+describe('Progressive Enhancement: without javascript audit', () => {
+  it('fails when the js-less body is empty', () => {
+    const artifacts = {
+      HTMLWithoutJavaScript: {
+        bodyText: '',
+        hasNoScript: false,
+      },
+    };
+
+    const result = withoutJsAudit.audit(artifacts);
+    assert.equal(result.score, 0);
+    assert.ok(result.explanation);
+  });
+
+  it('fails when the js-less body is whitespace', () => {
+    const artifacts = {
+      HTMLWithoutJavaScript: {
+        bodyText: '        ',
+        hasNoScript: false,
+      },
+    };
+
+    const result = withoutJsAudit.audit(artifacts);
+    assert.equal(result.score, 0);
+    assert.ok(result.explanation);
+  });
+
+  it('succeeds when the js-less body contains some content', () => {
+    const artifacts = {
+      HTMLWithoutJavaScript: {
+        bodyText: 'test',
+        hasNoScript: false,
+      },
+    };
+
+    assert.equal(withoutJsAudit.audit(artifacts).score, 1);
+  });
+
+  it('succeeds when the js-less body contains noscript', () => {
+    const artifacts = {
+      HTMLWithoutJavaScript: {
+        bodyText: '',
+        hasNoScript: true,
+      },
+    };
+
+    assert.equal(withoutJsAudit.audit(artifacts).score, 1);
+  });
+});

--- a/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
+++ b/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
@@ -1,0 +1,68 @@
+/**
+ * @license Copyright 2016 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const HTMLWithoutJavaScriptGather = require('../../../gather/gatherers/html-without-javascript.js');
+const assert = require('assert').strict;
+let htmlWithoutJavaScriptGather;
+
+describe('HTML without JavaScript gatherer', () => {
+  // Reset the Gatherer before each test.
+  beforeEach(() => {
+    htmlWithoutJavaScriptGather = new HTMLWithoutJavaScriptGather();
+  });
+
+  it('updates the options', () => {
+    const opts = {disableJavaScript: false};
+    htmlWithoutJavaScriptGather.beforePass(opts);
+
+    return assert.equal(opts.disableJavaScript, true);
+  });
+
+  it('resets the options', () => {
+    const opts = {
+      disableJavaScript: true,
+      driver: {
+        evaluateAsync() {
+          return Promise.resolve({bodyText: 'Hello!'});
+        },
+      },
+    };
+    return htmlWithoutJavaScriptGather
+        .afterPass(opts)
+        .then(_ => {
+          assert.equal(opts.disableJavaScript, false);
+        });
+  });
+
+  it('returns an artifact', () => {
+    const bodyText = 'Hello!';
+    const hasNoScript = true;
+    return htmlWithoutJavaScriptGather.afterPass({
+      driver: {
+        evaluateAsync() {
+          return Promise.resolve({bodyText, hasNoScript});
+        },
+      },
+    }).then(artifact => {
+      assert.deepStrictEqual(artifact, {bodyText, hasNoScript});
+    });
+  });
+
+  it('throws an error when driver returns a non-string', () => {
+    return htmlWithoutJavaScriptGather.afterPass({
+      driver: {
+        evaluateAsync() {
+          return Promise.resolve(null);
+        },
+      },
+    }).then(
+      _ => assert.ok(false),
+      _ => assert.ok(true));
+  });
+});

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -394,7 +394,7 @@ describe('CategoryRenderer', () => {
       const warningAudits = elem.querySelectorAll('.lh-clump--warning .lh-audit');
       const manualAudits = elem.querySelectorAll('.lh-clump--manual .lh-audit');
 
-      assert.equal(passedAudits.length, 0);
+      assert.equal(passedAudits.length, 1);
       assert.equal(failedAudits.length, 10);
       assert.equal(warningAudits.length, 2);
       assert.equal(manualAudits.length, 3);
@@ -409,7 +409,7 @@ describe('CategoryRenderer', () => {
       const failedAudits = elem.querySelectorAll('.lh-clump--failed .lh-audit');
 
       assert.equal(passedAudits.length, 0);
-      assert.equal(failedAudits.length, 12);
+      assert.equal(failedAudits.length, 13);
     });
 
     it('expands warning audit group', () => {

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -3339,6 +3339,9 @@
   "HTTPRedirect": {
     "value": false
   },
+  "HTMLWithoutJavaScript": {
+    "bodyText": "Do better web tester page\nHi there!\ntouchmove section\n "
+  },
   "Doctype": {
     "name": "html",
     "systemId": "",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -73,6 +73,13 @@
       "scoreDisplayMode": "binary",
       "warnings": []
     },
+    "without-javascript": {
+      "id": "without-javascript",
+      "title": "Contains some content when JavaScript is not available",
+      "description": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://web.dev/without-javascript/).",
+      "score": 1,
+      "scoreDisplayMode": "binary"
+    },
     "first-contentful-paint": {
       "id": "first-contentful-paint",
       "title": "First Contentful Paint",
@@ -5267,6 +5274,11 @@
           "group": "pwa-optimized"
         },
         {
+          "id": "without-javascript",
+          "weight": 1,
+          "group": "pwa-optimized"
+        },
+        {
           "id": "apple-touch-icon",
           "weight": 1,
           "group": "pwa-optimized"
@@ -5290,7 +5302,7 @@
         }
       ],
       "id": "pwa",
-      "score": 0.15
+      "score": 0.19
     }
   },
   "categoryGroups": {
@@ -5446,6 +5458,12 @@
       {
         "startTime": 0,
         "name": "lh:computed:ViewportMeta",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:audit:without-javascript",
         "duration": 100,
         "entryType": "measure"
       },
@@ -6681,6 +6699,12 @@
       ],
       "lighthouse-core/audits/viewport.js | description": [
         "audits.viewport.description"
+      ],
+      "lighthouse-core/audits/without-javascript.js | title": [
+        "audits[without-javascript].title"
+      ],
+      "lighthouse-core/audits/without-javascript.js | description": [
+        "audits[without-javascript].description"
       ],
       "lighthouse-core/lib/i18n/i18n.js | firstContentfulPaintMetric": [
         "audits[first-contentful-paint].title",

--- a/lighthouse-treemap/app/debug.json
+++ b/lighthouse-treemap/app/debug.json
@@ -57,6 +57,13 @@
         "scoreDisplayMode": "binary",
         "warnings": []
       },
+      "without-javascript": {
+        "id": "without-javascript",
+        "title": "Contains some content when JavaScript is not available",
+        "description": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://web.dev/without-javascript/).",
+        "score": 1,
+        "scoreDisplayMode": "binary"
+      },
       "first-contentful-paint": {
         "id": "first-contentful-paint",
         "title": "First Contentful Paint",
@@ -17641,6 +17648,11 @@
             "group": "pwa-optimized"
           },
           {
+            "id": "without-javascript",
+            "weight": 1,
+            "group": "pwa-optimized"
+          },
+          {
             "id": "apple-touch-icon",
             "weight": 1,
             "group": "pwa-optimized"
@@ -18352,6 +18364,12 @@
           "entryType": "measure"
         },
         {
+          "startTime": 21128.22,
+          "name": "lh:gather:beforePass:HTMLWithoutJavaScript",
+          "duration": 0.03,
+          "entryType": "measure"
+        },
+        {
           "startTime": 21128.27,
           "name": "lh:gather:beginRecording",
           "duration": 0.07,
@@ -18385,6 +18403,12 @@
           "startTime": 21936.91,
           "name": "lh:gather:afterPass:HTTPRedirect",
           "duration": 1.73,
+          "entryType": "measure"
+        },
+        {
+          "startTime": 21938.65,
+          "name": "lh:gather:afterPass:HTMLWithoutJavaScript",
+          "duration": 2.82,
           "entryType": "measure"
         },
         {
@@ -18463,6 +18487,12 @@
           "startTime": 1080.71,
           "name": "lh:computed:ViewportMeta",
           "duration": 0.64,
+          "entryType": "measure"
+        },
+        {
+          "startTime": 1085.47,
+          "name": "lh:audit:without-javascript",
+          "duration": 4.32,
           "entryType": "measure"
         },
         {
@@ -19992,6 +20022,12 @@
         ],
         "lighthouse-core/audits/viewport.js | description": [
           "audits.viewport.description"
+        ],
+        "lighthouse-core/audits/without-javascript.js | title": [
+          "audits[without-javascript].title"
+        ],
+        "lighthouse-core/audits/without-javascript.js | description": [
+          "audits[without-javascript].description"
         ],
         "lighthouse-core/lib/i18n/i18n.js | firstContentfulPaintMetric": [
           "audits[first-contentful-paint].title"

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-export-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-export-run-expected.txt
@@ -2,11 +2,11 @@ Tests that exporting works.
 
 ++++++++ testExportHtml
 
-# of .lh-audit divs (original): 136
+# of .lh-audit divs (original): 137
 
-# of .lh-audit divs (exported html): 136
+# of .lh-audit divs (exported html): 137
 
 ++++++++ testExportJson
 
-# of audits (json): 152
+# of audits (json): 153
 

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-limited-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-limited-run-expected.txt
@@ -27,5 +27,6 @@ service-worker
 splash-screen
 themed-omnibox
 viewport
+without-javascript
 works-offline
 

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -145,13 +145,16 @@ Resetting state with about:blank
 Setting up network for the pass trace
 Running beforePass methods
 Gathering setup: HTTPRedirect
+Gathering setup: HTMLWithoutJavaScript
 Beginning devtoolsLog and trace
 Loading page & waiting for onload
 Running pass methods
 Gathering in-page: HTTPRedirect
+Gathering in-page: HTMLWithoutJavaScript
 Gathering devtoolsLog & network records
 Running afterPass methods
 Gathering: HTTPRedirect
+Gathering: HTMLWithoutJavaScript
 Disconnecting from browser...
 Analyzing and running audits...
 Auditing: Uses HTTPS
@@ -161,6 +164,7 @@ Auditing: Registers a service worker that controls page and `start_url`
 Auditing: Current page responds with a 200 when offline
 Auditing: Has a `<meta name="viewport">` tag with `width` or `initial-scale`
 Computing artifact: ViewportMeta
+Auditing: Contains some content when JavaScript is not available
 Auditing: First Contentful Paint
 Computing artifact: FirstContentfulPaint
 Computing artifact: TraceOfTab
@@ -566,9 +570,10 @@ video-description: notApplicable
 viewport: fail
 viewport-ad-density: notApplicable
 visual-order-follows-dom: manual
+without-javascript: pass
 works-offline: fail
 
-# of .lh-audit divs: 156
+# of .lh-audit divs: 157
 
 .lh-audit divs:
 accesskeys
@@ -726,5 +731,6 @@ viewport
 viewport
 viewport-ad-density
 visual-order-follows-dom
+without-javascript
 works-offline
 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -116,6 +116,8 @@ declare global {
       FullPageScreenshot: Artifacts.FullPageScreenshot | null;
       /** Information about event listeners registered on the global object. */
       GlobalListeners: Array<Artifacts.GlobalListener>;
+      /** The page's document body innerText if loaded with JavaScript disabled. */
+      HTMLWithoutJavaScript: {bodyText: string, hasNoScript: boolean};
       /** Whether the page ended up on an HTTPS page after attempting to load the HTTP version. */
       HTTPRedirect: {value: boolean};
       /** The issues surfaced in the devtools Issues panel */

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -37,6 +37,7 @@ declare global {
       /** The url of the currently loaded page. If the main document redirects, this will be updated to keep track. */
       url: string;
       driver: Driver;
+      disableJavaScript?: boolean;
       passConfig: Config.Pass
       settings: Config.Settings;
       /** Gatherers can push to this array to add top-level warnings to the LHR. */


### PR DESCRIPTION
I did a bad thing.

i was trying to [fix another smoke-devtools bug](https://github.com/GoogleChrome/lighthouse/commit/6ad47fa79cc57d451d12ec1b8d5b9fb1fd8a6e17)  and i messed up.  I let #11711 land on master even tho there was a failure with the smoketests.  


more details coming on the smoketest failure. it appears to be juicy. (which is good and also bad)


in the meantime the P0 is getting master green again.

