### PR TITLE
misc: temporarily allow css in redirectPass

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -1463,7 +1463,6 @@ Object {
     Object {
       "blankPage": "about:blank",
       "blockedUrlPatterns": Array [
-        "*.css",
         "*.jpg",
         "*.jpeg",
         "*.png",

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -180,6 +180,7 @@ const defaultConfig = {
     passName: 'redirectPass',
     loadFailureMode: 'warn',
     // Speed up the redirect pass by blocking stylesheets, fonts, and images
+    // TODO: restore blocked *.css when https://github.com/GoogleChrome/lighthouse/issues/11803 is resolved.
     blockedUrlPatterns: ['*.jpg', '*.jpeg', '*.png', '*.gif', '*.svg', '*.ttf', '*.woff', '*.woff2'],
     gatherers: [
       'http-redirect',

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -180,7 +180,7 @@ const defaultConfig = {
     passName: 'redirectPass',
     loadFailureMode: 'warn',
     // Speed up the redirect pass by blocking stylesheets, fonts, and images
-    blockedUrlPatterns: ['*.css', '*.jpg', '*.jpeg', '*.png', '*.gif', '*.svg', '*.ttf', '*.woff', '*.woff2'],
+    blockedUrlPatterns: ['*.jpg', '*.jpeg', '*.png', '*.gif', '*.svg', '*.ttf', '*.woff', '*.woff2'],
     gatherers: [
       'http-redirect',
     ],


### PR DESCRIPTION
An alternative to #11812.

The theory is that the combo of some js and link preloading a css file is causing this load failure (see https://github.com/GoogleChrome/lighthouse/issues/11803#issuecomment-742131146). Previous to #11711 JS was blocked from running in the `redirectPass`.

Now JS is allowed, but css is still blocked from loading via `default-config`'s `blockedUrlPatterns`. Removing that one css load reliably caused ToT to "Aw, Snap!" for me locally, so we've essentially recreated that situation in redirectPass.

We can see if allowing CSS to load will go back to a bad Promise error but no Aw, Snap.