### PR TITLE
core(script-treemap-data): fix sourceRoot & missing coverage bugs

### DIFF
--- a/lighthouse-core/audits/script-treemap-data.js
+++ b/lighthouse-core/audits/script-treemap-data.js
@@ -166,9 +166,9 @@ class ScriptTreemapDataAudit extends Audit {
 
       const name = scriptElement.src;
       const bundle = bundles.find(bundle => scriptElement.src === bundle.script.src);
-      const scriptCoverages = artifacts.JsUsage[scriptElement.src];
-      if (!bundle || !scriptCoverages) {
-        // No bundle or coverage information, so simply make a single node
+      const scriptCoverages = artifacts.JsUsage[scriptElement.src] || [];
+      if (!bundle && scriptCoverages.length === 0) {
+        // No bundle and no coverage information, so simply make a single node
         // detailing how big the script is.
 
         rootNodeContainers.push({
@@ -186,7 +186,7 @@ class ScriptTreemapDataAudit extends Audit {
 
       /** @type {LH.Treemap.Node} */
       let node;
-      if (unusedJavascriptSummary.sourcesWastedBytes && !('errorMessage' in bundle.sizes)) {
+      if (bundle && !('errorMessage' in bundle.sizes)) {
         // Create nodes for each module in a bundle.
 
         /** @type {Record<string, SourceData>} */
@@ -195,10 +195,21 @@ class ScriptTreemapDataAudit extends Audit {
           /** @type {SourceData} */
           const sourceData = {
             resourceBytes: bundle.sizes.files[source],
-            unusedBytes: unusedJavascriptSummary.sourcesWastedBytes[source],
           };
 
-          const key = ModuleDuplication.normalizeSource(source);
+          if (unusedJavascriptSummary.sourcesWastedBytes) {
+            sourceData.unusedBytes = unusedJavascriptSummary.sourcesWastedBytes[source];
+          }
+
+          // ModuleDuplication uses keys without the source root prepended, but
+          // bundle.sizes uses keys with it prepended, so we remove the source root before
+          // using it with duplicationByPath.
+          let sourceWithoutSourceRoot = source;
+          if (bundle.rawMap.sourceRoot && source.startsWith(bundle.rawMap.sourceRoot)) {
+            sourceWithoutSourceRoot = source.replace(bundle.rawMap.sourceRoot, '');
+          }
+
+          const key = ModuleDuplication.normalizeSource(sourceWithoutSourceRoot);
           if (duplicationByPath.has(key)) sourceData.duplicatedNormalizedModuleName = key;
 
           sourcesData[source] = sourceData;
@@ -206,7 +217,7 @@ class ScriptTreemapDataAudit extends Audit {
 
         node = this.prepareTreemapNodes(bundle.rawMap.sourceRoot || '', sourcesData);
       } else {
-        // There was no source map for this script, so we can only produce a single node.
+        // No valid source map for this script, so we can only produce a single node.
 
         node = {
           name,

--- a/lighthouse-core/test/audits/__snapshots__/script-treemap-data-test.js.snap
+++ b/lighthouse-core/test/audits/__snapshots__/script-treemap-data-test.js.snap
@@ -1,5 +1,2464 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ScriptTreemapData audit coursehero fixture has root nodes 2`] = `
+Array [
+  Object {
+    "name": "https://courshero.com/script.js",
+    "node": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "jquery.typeahead.js",
+                      "resourceBytes": 39282,
+                      "unusedBytes": 39282,
+                    },
+                    Object {
+                      "name": "jquery.magnific.popup.js",
+                      "resourceBytes": 29039,
+                      "unusedBytes": 29039,
+                    },
+                    Object {
+                      "name": "jquery.owl.carousel.js",
+                      "resourceBytes": 29798,
+                      "unusedBytes": 29798,
+                    },
+                    Object {
+                      "name": "jquery.select.js",
+                      "resourceBytes": 59038,
+                      "unusedBytes": 59038,
+                    },
+                    Object {
+                      "name": "jquery.lazyload.js",
+                      "resourceBytes": 5178,
+                      "unusedBytes": 5178,
+                    },
+                    Object {
+                      "name": "media-match.js",
+                      "resourceBytes": 4673,
+                      "unusedBytes": 4673,
+                    },
+                    Object {
+                      "name": "enquire.min.js",
+                      "resourceBytes": 2025,
+                      "unusedBytes": 2025,
+                    },
+                    Object {
+                      "name": "lab.js",
+                      "resourceBytes": 5369,
+                      "unusedBytes": 5369,
+                    },
+                    Object {
+                      "name": "moment.min.js",
+                      "resourceBytes": 34603,
+                      "unusedBytes": 34603,
+                    },
+                    Object {
+                      "name": "angular-moment.min.js",
+                      "resourceBytes": 3968,
+                      "unusedBytes": 3968,
+                    },
+                    Object {
+                      "name": "ng-infinite-scroll.min.js",
+                      "resourceBytes": 814,
+                      "unusedBytes": 814,
+                    },
+                    Object {
+                      "name": "angular.ng-modules.js",
+                      "resourceBytes": 1486,
+                      "unusedBytes": 1486,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "select.js",
+                              "resourceBytes": 48513,
+                              "unusedBytes": 48513,
+                            },
+                            Object {
+                              "name": "angular-sanitize.js",
+                              "resourceBytes": 9135,
+                              "unusedBytes": 9135,
+                            },
+                          ],
+                          "name": "select",
+                          "resourceBytes": 57648,
+                          "unusedBytes": 57648,
+                        },
+                        Object {
+                          "name": "angular-smooth-scroll.min.js",
+                          "resourceBytes": 2237,
+                          "unusedBytes": 2237,
+                        },
+                        Object {
+                          "name": "ng-file-upload.js",
+                          "resourceBytes": 13362,
+                          "unusedBytes": 13362,
+                        },
+                      ],
+                      "name": "ng",
+                      "resourceBytes": 73247,
+                      "unusedBytes": 73247,
+                    },
+                    Object {
+                      "name": "phoneparser.js",
+                      "resourceBytes": 22883,
+                      "unusedBytes": 22883,
+                    },
+                    Object {
+                      "name": "sweetalert.js",
+                      "resourceBytes": 16857,
+                      "unusedBytes": 16857,
+                    },
+                    Object {
+                      "name": "katex.min.js",
+                      "resourceBytes": 228929,
+                      "unusedBytes": 228929,
+                    },
+                  ],
+                  "name": "vendor",
+                  "resourceBytes": 557189,
+                  "unusedBytes": 557189,
+                },
+                Object {
+                  "name": "ch.global.js",
+                  "resourceBytes": 1150,
+                  "unusedBytes": 1150,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "course-hero-mq.js",
+                      "resourceBytes": 3420,
+                      "unusedBytes": 3420,
+                    },
+                    Object {
+                      "name": "course-hero-mq-transport.js",
+                      "resourceBytes": 236,
+                      "unusedBytes": 236,
+                    },
+                  ],
+                  "name": "course_hero_mq",
+                  "resourceBytes": 3656,
+                  "unusedBytes": 3656,
+                },
+                Object {
+                  "name": "workForUs.js",
+                  "resourceBytes": 715,
+                  "unusedBytes": 715,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "tag-recording.module.js",
+                      "resourceBytes": 66,
+                      "unusedBytes": 66,
+                    },
+                    Object {
+                      "name": "tag-recording.service.js",
+                      "resourceBytes": 420,
+                      "unusedBytes": 420,
+                    },
+                    Object {
+                      "name": "tag-recording.directive.js",
+                      "resourceBytes": 1511,
+                      "unusedBytes": 1511,
+                    },
+                  ],
+                  "name": "ux",
+                  "resourceBytes": 1997,
+                  "unusedBytes": 1997,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "module.js",
+                          "resourceBytes": 60,
+                          "unusedBytes": 60,
+                        },
+                        Object {
+                          "name": "qa-validator.service.js",
+                          "resourceBytes": 1322,
+                          "unusedBytes": 1322,
+                        },
+                        Object {
+                          "name": "qa-amplitude.service.js",
+                          "resourceBytes": 5141,
+                          "unusedBytes": 5141,
+                        },
+                      ],
+                      "name": "common",
+                      "resourceBytes": 6523,
+                      "unusedBytes": 6523,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "module.js",
+                          "resourceBytes": 69,
+                          "unusedBytes": 69,
+                        },
+                        Object {
+                          "name": "qa-category.dataservice.js",
+                          "resourceBytes": 596,
+                          "unusedBytes": 596,
+                        },
+                        Object {
+                          "name": "question.dataservice.js",
+                          "resourceBytes": 725,
+                          "unusedBytes": 725,
+                        },
+                        Object {
+                          "name": "tutor-questions.dataservice.js",
+                          "resourceBytes": 739,
+                          "unusedBytes": 739,
+                        },
+                        Object {
+                          "name": "qa-user-discounts.dataservice.js",
+                          "resourceBytes": 679,
+                          "unusedBytes": 679,
+                        },
+                        Object {
+                          "name": "question.datastore.js",
+                          "resourceBytes": 1004,
+                          "unusedBytes": 1004,
+                        },
+                      ],
+                      "name": "data",
+                      "resourceBytes": 3812,
+                      "unusedBytes": 3812,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "module.js",
+                          "resourceBytes": 70,
+                          "unusedBytes": 70,
+                        },
+                        Object {
+                          "name": "qa-category-autocomplete.directive.js",
+                          "resourceBytes": 973,
+                          "unusedBytes": 973,
+                        },
+                        Object {
+                          "name": "num-online-tutors.directive.js",
+                          "resourceBytes": 239,
+                          "unusedBytes": 239,
+                        },
+                      ],
+                      "name": "widgets",
+                      "resourceBytes": 1282,
+                      "unusedBytes": 1282,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "module.js",
+                          "resourceBytes": 562,
+                          "unusedBytes": 562,
+                        },
+                        Object {
+                          "name": "ask-a-question.directive.js",
+                          "resourceBytes": 14812,
+                          "unusedBytes": 14812,
+                        },
+                      ],
+                      "name": "askAQuestion",
+                      "resourceBytes": 15374,
+                      "unusedBytes": 15374,
+                    },
+                  ],
+                  "name": "qa",
+                  "resourceBytes": 26991,
+                  "unusedBytes": 26991,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "analytics/global_tracking.js",
+                  "resourceBytes": 4531,
+                  "unusedBytes": 4531,
+                },
+              ],
+              "name": "assets/js",
+              "resourceBytes": 596229,
+              "unusedBytes": 596229,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "tracker_pageview.js",
+                  "resourceBytes": 94,
+                  "unusedBytes": 94,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "widgets/product-thumbnail-stats.js",
+                  "resourceBytes": 3768,
+                  "unusedBytes": 3768,
+                },
+              ],
+              "name": "javascript",
+              "resourceBytes": 3862,
+              "unusedBytes": 3862,
+            },
+          ],
+          "name": "Control",
+          "resourceBytes": 600091,
+          "unusedBytes": 600091,
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": undefined,
+              "name": "webpack/bootstrap?",
+              "resourceBytes": 3657,
+              "unusedBytes": 3657,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "_root.js?",
+                      "resourceBytes": 131,
+                      "unusedBytes": 131,
+                    },
+                    Object {
+                      "name": "isObject.js?",
+                      "resourceBytes": 100,
+                      "unusedBytes": 100,
+                    },
+                    Object {
+                      "name": "_getNative.js?",
+                      "resourceBytes": 94,
+                      "unusedBytes": 94,
+                    },
+                    Object {
+                      "name": "isObjectLike.js?",
+                      "resourceBytes": 75,
+                      "unusedBytes": 75,
+                    },
+                    Object {
+                      "name": "_copyObject.js?",
+                      "resourceBytes": 208,
+                      "unusedBytes": 208,
+                    },
+                    Object {
+                      "name": "_baseGetTag.js?",
+                      "resourceBytes": 192,
+                      "unusedBytes": 192,
+                    },
+                    Object {
+                      "name": "isArrayLike.js?",
+                      "resourceBytes": 93,
+                      "unusedBytes": 93,
+                    },
+                    Object {
+                      "name": "eq.js?",
+                      "resourceBytes": 65,
+                      "unusedBytes": 65,
+                    },
+                    Object {
+                      "name": "_isPrototype.js?",
+                      "resourceBytes": 136,
+                      "unusedBytes": 136,
+                    },
+                    Object {
+                      "name": "keys.js?",
+                      "resourceBytes": 87,
+                      "unusedBytes": 87,
+                    },
+                    Object {
+                      "name": "isArray.js?",
+                      "resourceBytes": 49,
+                      "unusedBytes": 49,
+                    },
+                    Object {
+                      "name": "_ListCache.js?",
+                      "resourceBytes": 269,
+                      "unusedBytes": 269,
+                    },
+                    Object {
+                      "name": "_assocIndexOf.js?",
+                      "resourceBytes": 111,
+                      "unusedBytes": 111,
+                    },
+                    Object {
+                      "name": "_nativeCreate.js?",
+                      "resourceBytes": 57,
+                      "unusedBytes": 57,
+                    },
+                    Object {
+                      "name": "_getMapData.js?",
+                      "resourceBytes": 128,
+                      "unusedBytes": 128,
+                    },
+                    Object {
+                      "name": "keysIn.js?",
+                      "resourceBytes": 93,
+                      "unusedBytes": 93,
+                    },
+                    Object {
+                      "name": "_assignValue.js?",
+                      "resourceBytes": 160,
+                      "unusedBytes": 160,
+                    },
+                    Object {
+                      "name": "_baseAssignValue.js?",
+                      "resourceBytes": 140,
+                      "unusedBytes": 140,
+                    },
+                    Object {
+                      "name": "isFunction.js?",
+                      "resourceBytes": 216,
+                      "unusedBytes": 216,
+                    },
+                    Object {
+                      "name": "_Symbol.js?",
+                      "resourceBytes": 57,
+                      "unusedBytes": 57,
+                    },
+                    Object {
+                      "name": "isBuffer.js?",
+                      "resourceBytes": 196,
+                      "unusedBytes": 196,
+                    },
+                    Object {
+                      "name": "_baseUnary.js?",
+                      "resourceBytes": 82,
+                      "unusedBytes": 82,
+                    },
+                    Object {
+                      "name": "_nodeUtil.js?",
+                      "resourceBytes": 276,
+                      "unusedBytes": 276,
+                    },
+                    Object {
+                      "name": "_Map.js?",
+                      "resourceBytes": 52,
+                      "unusedBytes": 52,
+                    },
+                    Object {
+                      "name": "_getSymbols.js?",
+                      "resourceBytes": 212,
+                      "unusedBytes": 212,
+                    },
+                    Object {
+                      "name": "_getPrototype.js?",
+                      "resourceBytes": 71,
+                      "unusedBytes": 71,
+                    },
+                    Object {
+                      "name": "_getTag.js?",
+                      "resourceBytes": 578,
+                      "unusedBytes": 578,
+                    },
+                    Object {
+                      "name": "_cloneArrayBuffer.js?",
+                      "resourceBytes": 136,
+                      "unusedBytes": 136,
+                    },
+                    Object {
+                      "name": "_defineProperty.js?",
+                      "resourceBytes": 135,
+                      "unusedBytes": 135,
+                    },
+                    Object {
+                      "name": "_freeGlobal.js?",
+                      "resourceBytes": 99,
+                      "unusedBytes": 99,
+                    },
+                    Object {
+                      "name": "_toSource.js?",
+                      "resourceBytes": 153,
+                      "unusedBytes": 153,
+                    },
+                    Object {
+                      "name": "_createAssigner.js?",
+                      "resourceBytes": 289,
+                      "unusedBytes": 289,
+                    },
+                    Object {
+                      "name": "identity.js?",
+                      "resourceBytes": 47,
+                      "unusedBytes": 47,
+                    },
+                    Object {
+                      "name": "isLength.js?",
+                      "resourceBytes": 106,
+                      "unusedBytes": 106,
+                    },
+                    Object {
+                      "name": "_isIndex.js?",
+                      "resourceBytes": 183,
+                      "unusedBytes": 183,
+                    },
+                    Object {
+                      "name": "_arrayLikeKeys.js?",
+                      "resourceBytes": 395,
+                      "unusedBytes": 395,
+                    },
+                    Object {
+                      "name": "isArguments.js?",
+                      "resourceBytes": 215,
+                      "unusedBytes": 215,
+                    },
+                    Object {
+                      "name": "isTypedArray.js?",
+                      "resourceBytes": 86,
+                      "unusedBytes": 86,
+                    },
+                    Object {
+                      "name": "_overArg.js?",
+                      "resourceBytes": 77,
+                      "unusedBytes": 77,
+                    },
+                    Object {
+                      "name": "_Stack.js?",
+                      "resourceBytes": 246,
+                      "unusedBytes": 246,
+                    },
+                    Object {
+                      "name": "_cloneBuffer.js?",
+                      "resourceBytes": 285,
+                      "unusedBytes": 285,
+                    },
+                    Object {
+                      "name": "_copyArray.js?",
+                      "resourceBytes": 106,
+                      "unusedBytes": 106,
+                    },
+                    Object {
+                      "name": "stubArray.js?",
+                      "resourceBytes": 48,
+                      "unusedBytes": 48,
+                    },
+                    Object {
+                      "name": "_getSymbolsIn.js?",
+                      "resourceBytes": 151,
+                      "unusedBytes": 151,
+                    },
+                    Object {
+                      "name": "_arrayPush.js?",
+                      "resourceBytes": 105,
+                      "unusedBytes": 105,
+                    },
+                    Object {
+                      "name": "_baseGetAllKeys.js?",
+                      "resourceBytes": 99,
+                      "unusedBytes": 99,
+                    },
+                    Object {
+                      "name": "_cloneTypedArray.js?",
+                      "resourceBytes": 133,
+                      "unusedBytes": 133,
+                    },
+                    Object {
+                      "name": "_initCloneObject.js?",
+                      "resourceBytes": 124,
+                      "unusedBytes": 124,
+                    },
+                    Object {
+                      "name": "_assignMergeValue.js?",
+                      "resourceBytes": 117,
+                      "unusedBytes": 117,
+                    },
+                    Object {
+                      "name": "_safeGet.js?",
+                      "resourceBytes": 131,
+                      "unusedBytes": 131,
+                    },
+                    Object {
+                      "name": "assign.js?",
+                      "resourceBytes": 202,
+                      "unusedBytes": 202,
+                    },
+                    Object {
+                      "name": "_baseIsNative.js?",
+                      "resourceBytes": 361,
+                      "unusedBytes": 361,
+                    },
+                    Object {
+                      "name": "_getRawTag.js?",
+                      "resourceBytes": 237,
+                      "unusedBytes": 237,
+                    },
+                    Object {
+                      "name": "_objectToString.js?",
+                      "resourceBytes": 89,
+                      "unusedBytes": 89,
+                    },
+                    Object {
+                      "name": "_isMasked.js?",
+                      "resourceBytes": 146,
+                      "unusedBytes": 146,
+                    },
+                    Object {
+                      "name": "_coreJsData.js?",
+                      "resourceBytes": 60,
+                      "unusedBytes": 60,
+                    },
+                    Object {
+                      "name": "_getValue.js?",
+                      "resourceBytes": 69,
+                      "unusedBytes": 69,
+                    },
+                    Object {
+                      "name": "_baseRest.js?",
+                      "resourceBytes": 94,
+                      "unusedBytes": 94,
+                    },
+                    Object {
+                      "name": "_overRest.js?",
+                      "resourceBytes": 260,
+                      "unusedBytes": 260,
+                    },
+                    Object {
+                      "name": "_apply.js?",
+                      "resourceBytes": 207,
+                      "unusedBytes": 207,
+                    },
+                    Object {
+                      "name": "_setToString.js?",
+                      "resourceBytes": 52,
+                      "unusedBytes": 52,
+                    },
+                    Object {
+                      "name": "_baseSetToString.js?",
+                      "resourceBytes": 154,
+                      "unusedBytes": 154,
+                    },
+                    Object {
+                      "name": "constant.js?",
+                      "resourceBytes": 66,
+                      "unusedBytes": 66,
+                    },
+                    Object {
+                      "name": "_shortOut.js?",
+                      "resourceBytes": 201,
+                      "unusedBytes": 201,
+                    },
+                    Object {
+                      "name": "_isIterateeCall.js?",
+                      "resourceBytes": 181,
+                      "unusedBytes": 181,
+                    },
+                    Object {
+                      "name": "_baseTimes.js?",
+                      "resourceBytes": 92,
+                      "unusedBytes": 92,
+                    },
+                    Object {
+                      "name": "_baseIsArguments.js?",
+                      "resourceBytes": 100,
+                      "unusedBytes": 100,
+                    },
+                    Object {
+                      "name": "stubFalse.js?",
+                      "resourceBytes": 48,
+                      "unusedBytes": 48,
+                    },
+                    Object {
+                      "name": "_baseIsTypedArray.js?",
+                      "resourceBytes": 669,
+                      "unusedBytes": 669,
+                    },
+                    Object {
+                      "name": "_baseKeys.js?",
+                      "resourceBytes": 196,
+                      "unusedBytes": 196,
+                    },
+                    Object {
+                      "name": "_nativeKeys.js?",
+                      "resourceBytes": 61,
+                      "unusedBytes": 61,
+                    },
+                    Object {
+                      "name": "cloneDeepWith.js?",
+                      "resourceBytes": 110,
+                      "unusedBytes": 110,
+                    },
+                    Object {
+                      "name": "_baseClone.js?",
+                      "resourceBytes": 1444,
+                      "unusedBytes": 1444,
+                    },
+                    Object {
+                      "name": "_listCacheClear.js?",
+                      "resourceBytes": 68,
+                      "unusedBytes": 68,
+                    },
+                    Object {
+                      "name": "_listCacheDelete.js?",
+                      "resourceBytes": 173,
+                      "unusedBytes": 173,
+                    },
+                    Object {
+                      "name": "_listCacheGet.js?",
+                      "resourceBytes": 107,
+                      "unusedBytes": 107,
+                    },
+                    Object {
+                      "name": "_listCacheHas.js?",
+                      "resourceBytes": 81,
+                      "unusedBytes": 81,
+                    },
+                    Object {
+                      "name": "_listCacheSet.js?",
+                      "resourceBytes": 137,
+                      "unusedBytes": 137,
+                    },
+                    Object {
+                      "name": "_stackClear.js?",
+                      "resourceBytes": 81,
+                      "unusedBytes": 81,
+                    },
+                    Object {
+                      "name": "_stackDelete.js?",
+                      "resourceBytes": 98,
+                      "unusedBytes": 98,
+                    },
+                    Object {
+                      "name": "_stackGet.js?",
+                      "resourceBytes": 66,
+                      "unusedBytes": 66,
+                    },
+                    Object {
+                      "name": "_stackHas.js?",
+                      "resourceBytes": 68,
+                      "unusedBytes": 68,
+                    },
+                    Object {
+                      "name": "_stackSet.js?",
+                      "resourceBytes": 262,
+                      "unusedBytes": 262,
+                    },
+                    Object {
+                      "name": "_MapCache.js?",
+                      "resourceBytes": 273,
+                      "unusedBytes": 273,
+                    },
+                    Object {
+                      "name": "_mapCacheClear.js?",
+                      "resourceBytes": 133,
+                      "unusedBytes": 133,
+                    },
+                    Object {
+                      "name": "_Hash.js?",
+                      "resourceBytes": 272,
+                      "unusedBytes": 272,
+                    },
+                    Object {
+                      "name": "_hashClear.js?",
+                      "resourceBytes": 88,
+                      "unusedBytes": 88,
+                    },
+                    Object {
+                      "name": "_hashDelete.js?",
+                      "resourceBytes": 109,
+                      "unusedBytes": 109,
+                    },
+                    Object {
+                      "name": "_hashGet.js?",
+                      "resourceBytes": 206,
+                      "unusedBytes": 206,
+                    },
+                    Object {
+                      "name": "_hashHas.js?",
+                      "resourceBytes": 141,
+                      "unusedBytes": 141,
+                    },
+                    Object {
+                      "name": "_hashSet.js?",
+                      "resourceBytes": 166,
+                      "unusedBytes": 166,
+                    },
+                    Object {
+                      "name": "_mapCacheDelete.js?",
+                      "resourceBytes": 102,
+                      "unusedBytes": 102,
+                    },
+                    Object {
+                      "name": "_isKeyable.js?",
+                      "resourceBytes": 138,
+                      "unusedBytes": 138,
+                    },
+                    Object {
+                      "name": "_mapCacheGet.js?",
+                      "resourceBytes": 76,
+                      "unusedBytes": 76,
+                    },
+                    Object {
+                      "name": "_mapCacheHas.js?",
+                      "resourceBytes": 76,
+                      "unusedBytes": 76,
+                    },
+                    Object {
+                      "name": "_mapCacheSet.js?",
+                      "resourceBytes": 125,
+                      "unusedBytes": 125,
+                    },
+                    Object {
+                      "name": "_arrayEach.js?",
+                      "resourceBytes": 111,
+                      "unusedBytes": 111,
+                    },
+                    Object {
+                      "name": "_baseAssign.js?",
+                      "resourceBytes": 82,
+                      "unusedBytes": 82,
+                    },
+                    Object {
+                      "name": "_baseAssignIn.js?",
+                      "resourceBytes": 83,
+                      "unusedBytes": 83,
+                    },
+                    Object {
+                      "name": "_baseKeysIn.js?",
+                      "resourceBytes": 207,
+                      "unusedBytes": 207,
+                    },
+                    Object {
+                      "name": "_nativeKeysIn.js?",
+                      "resourceBytes": 102,
+                      "unusedBytes": 102,
+                    },
+                    Object {
+                      "name": "_copySymbols.js?",
+                      "resourceBytes": 78,
+                      "unusedBytes": 78,
+                    },
+                    Object {
+                      "name": "_arrayFilter.js?",
+                      "resourceBytes": 134,
+                      "unusedBytes": 134,
+                    },
+                    Object {
+                      "name": "_copySymbolsIn.js?",
+                      "resourceBytes": 80,
+                      "unusedBytes": 80,
+                    },
+                    Object {
+                      "name": "_getAllKeys.js?",
+                      "resourceBytes": 83,
+                      "unusedBytes": 83,
+                    },
+                    Object {
+                      "name": "_getAllKeysIn.js?",
+                      "resourceBytes": 84,
+                      "unusedBytes": 84,
+                    },
+                    Object {
+                      "name": "_DataView.js?",
+                      "resourceBytes": 57,
+                      "unusedBytes": 57,
+                    },
+                    Object {
+                      "name": "_Promise.js?",
+                      "resourceBytes": 56,
+                      "unusedBytes": 56,
+                    },
+                    Object {
+                      "name": "_Set.js?",
+                      "resourceBytes": 52,
+                      "unusedBytes": 52,
+                    },
+                    Object {
+                      "name": "_WeakMap.js?",
+                      "resourceBytes": 54,
+                      "unusedBytes": 54,
+                    },
+                    Object {
+                      "name": "_initCloneArray.js?",
+                      "resourceBytes": 204,
+                      "unusedBytes": 204,
+                    },
+                    Object {
+                      "name": "_initCloneByTag.js?",
+                      "resourceBytes": 806,
+                      "unusedBytes": 806,
+                    },
+                    Object {
+                      "name": "_Uint8Array.js?",
+                      "resourceBytes": 51,
+                      "unusedBytes": 51,
+                    },
+                    Object {
+                      "name": "_cloneDataView.js?",
+                      "resourceBytes": 135,
+                      "unusedBytes": 135,
+                    },
+                    Object {
+                      "name": "_cloneRegExp.js?",
+                      "resourceBytes": 130,
+                      "unusedBytes": 130,
+                    },
+                    Object {
+                      "name": "_cloneSymbol.js?",
+                      "resourceBytes": 126,
+                      "unusedBytes": 126,
+                    },
+                    Object {
+                      "name": "_baseCreate.js?",
+                      "resourceBytes": 195,
+                      "unusedBytes": 195,
+                    },
+                    Object {
+                      "name": "isMap.js?",
+                      "resourceBytes": 82,
+                      "unusedBytes": 82,
+                    },
+                    Object {
+                      "name": "_baseIsMap.js?",
+                      "resourceBytes": 97,
+                      "unusedBytes": 97,
+                    },
+                    Object {
+                      "name": "isSet.js?",
+                      "resourceBytes": 82,
+                      "unusedBytes": 82,
+                    },
+                    Object {
+                      "name": "_baseIsSet.js?",
+                      "resourceBytes": 97,
+                      "unusedBytes": 97,
+                    },
+                    Object {
+                      "name": "merge.js?",
+                      "resourceBytes": 77,
+                      "unusedBytes": 77,
+                    },
+                    Object {
+                      "name": "_baseMerge.js?",
+                      "resourceBytes": 249,
+                      "unusedBytes": 249,
+                    },
+                    Object {
+                      "name": "_baseFor.js?",
+                      "resourceBytes": 42,
+                      "unusedBytes": 42,
+                    },
+                    Object {
+                      "name": "_createBaseFor.js?",
+                      "resourceBytes": 165,
+                      "unusedBytes": 165,
+                    },
+                    Object {
+                      "name": "_baseMergeDeep.js?",
+                      "resourceBytes": 502,
+                      "unusedBytes": 502,
+                    },
+                    Object {
+                      "name": "isArrayLikeObject.js?",
+                      "resourceBytes": 76,
+                      "unusedBytes": 76,
+                    },
+                    Object {
+                      "name": "isPlainObject.js?",
+                      "resourceBytes": 336,
+                      "unusedBytes": 336,
+                    },
+                    Object {
+                      "name": "toPlainObject.js?",
+                      "resourceBytes": 89,
+                      "unusedBytes": 89,
+                    },
+                  ],
+                  "name": "lodash",
+                  "resourceBytes": 20343,
+                  "unusedBytes": 20343,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "extend/index.js?",
+                  "resourceBytes": 829,
+                  "unusedBytes": 829,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": undefined,
+                          "name": "component/config.js?",
+                          "resourceBytes": 354,
+                          "unusedBytes": 354,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "decorators/route-decorator.js?",
+                          "resourceBytes": 490,
+                          "unusedBytes": 490,
+                        },
+                        Object {
+                          "name": "routing-service.js?",
+                          "resourceBytes": 1677,
+                          "unusedBytes": 1677,
+                        },
+                      ],
+                      "name": "routing",
+                      "resourceBytes": 2521,
+                      "unusedBytes": 2521,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "store.js?",
+                          "resourceBytes": 8120,
+                          "unusedBytes": 8120,
+                        },
+                        Object {
+                          "name": "store-decorator.js?",
+                          "resourceBytes": 1337,
+                          "unusedBytes": 1337,
+                        },
+                      ],
+                      "name": "store",
+                      "resourceBytes": 9457,
+                      "unusedBytes": 9457,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "beef.js?",
+                          "resourceBytes": 361,
+                          "unusedBytes": 361,
+                        },
+                        Object {
+                          "name": "model.js?",
+                          "resourceBytes": 169,
+                          "unusedBytes": 169,
+                        },
+                      ],
+                      "name": "core",
+                      "resourceBytes": 530,
+                      "unusedBytes": 530,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "api/api-service.js?",
+                      "resourceBytes": 1284,
+                      "unusedBytes": 1284,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "action/actions.js?",
+                      "resourceBytes": 1486,
+                      "unusedBytes": 1486,
+                    },
+                  ],
+                  "name": "beef-flux/build",
+                  "resourceBytes": 15278,
+                  "unusedBytes": 15278,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "reqwest/reqwest.js?",
+                  "resourceBytes": 9799,
+                  "unusedBytes": 9799,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "classCallCheck.js?",
+                      "resourceBytes": 358,
+                      "unusedBytes": 358,
+                    },
+                    Object {
+                      "name": "createClass.js?",
+                      "resourceBytes": 799,
+                      "unusedBytes": 799,
+                    },
+                    Object {
+                      "name": "assertThisInitialized.js?",
+                      "resourceBytes": 294,
+                      "unusedBytes": 294,
+                    },
+                    Object {
+                      "name": "applyDecoratedDescriptor.js?",
+                      "resourceBytes": 892,
+                      "unusedBytes": 892,
+                    },
+                    Object {
+                      "name": "initializerDefineProperty.js?",
+                      "resourceBytes": 394,
+                      "unusedBytes": 394,
+                    },
+                    Object {
+                      "name": "possibleConstructorReturn.js?",
+                      "resourceBytes": 228,
+                      "unusedBytes": 228,
+                    },
+                    Object {
+                      "name": "getPrototypeOf.js?",
+                      "resourceBytes": 338,
+                      "unusedBytes": 338,
+                    },
+                    Object {
+                      "name": "inherits.js?",
+                      "resourceBytes": 528,
+                      "unusedBytes": 528,
+                    },
+                    Object {
+                      "name": "initializerWarningHelper.js?",
+                      "resourceBytes": 594,
+                      "unusedBytes": 594,
+                    },
+                    Object {
+                      "name": "defineProperty.js?",
+                      "resourceBytes": 288,
+                      "unusedBytes": 288,
+                    },
+                    Object {
+                      "name": "extends.js?",
+                      "resourceBytes": 490,
+                      "unusedBytes": 490,
+                    },
+                    Object {
+                      "name": "toConsumableArray.js?",
+                      "resourceBytes": 89,
+                      "unusedBytes": 89,
+                    },
+                    Object {
+                      "name": "typeof.js?",
+                      "resourceBytes": 992,
+                      "unusedBytes": 992,
+                    },
+                    Object {
+                      "name": "setPrototypeOf.js?",
+                      "resourceBytes": 260,
+                      "unusedBytes": 260,
+                    },
+                    Object {
+                      "name": "arrayWithoutHoles.js?",
+                      "resourceBytes": 128,
+                      "unusedBytes": 128,
+                    },
+                    Object {
+                      "name": "iterableToArray.js?",
+                      "resourceBytes": 149,
+                      "unusedBytes": 149,
+                    },
+                    Object {
+                      "name": "nonIterableSpread.js?",
+                      "resourceBytes": 108,
+                      "unusedBytes": 108,
+                    },
+                  ],
+                  "name": "@babel/runtime/helpers",
+                  "resourceBytes": 6929,
+                  "unusedBytes": 6929,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "util.js?",
+                      "resourceBytes": 7644,
+                      "unusedBytes": 7644,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "support/isBufferBrowser.js?",
+                      "resourceBytes": 153,
+                      "unusedBytes": 153,
+                    },
+                  ],
+                  "name": "node-libs-browser/node_modules/util",
+                  "resourceBytes": 7797,
+                  "unusedBytes": 7797,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "process/browser.js?",
+                  "resourceBytes": 1675,
+                  "unusedBytes": 1675,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "inherits/inherits_browser.js?",
+                  "resourceBytes": 338,
+                  "unusedBytes": 338,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "_freeGlobal.js?",
+                      "resourceBytes": 93,
+                      "unusedBytes": 93,
+                    },
+                    Object {
+                      "name": "_baseClamp.js?",
+                      "resourceBytes": 98,
+                      "unusedBytes": 98,
+                    },
+                    Object {
+                      "name": "_root.js?",
+                      "resourceBytes": 93,
+                      "unusedBytes": 93,
+                    },
+                    Object {
+                      "name": "_Symbol.js?",
+                      "resourceBytes": 10,
+                      "unusedBytes": 10,
+                    },
+                    Object {
+                      "name": "_arrayMap.js?",
+                      "resourceBytes": 99,
+                      "unusedBytes": 99,
+                    },
+                    Object {
+                      "name": "isArray.js?",
+                      "resourceBytes": 16,
+                      "unusedBytes": 16,
+                    },
+                    Object {
+                      "name": "_getRawTag.js?",
+                      "resourceBytes": 206,
+                      "unusedBytes": 206,
+                    },
+                    Object {
+                      "name": "_objectToString.js?",
+                      "resourceBytes": 64,
+                      "unusedBytes": 64,
+                    },
+                    Object {
+                      "name": "_baseGetTag.js?",
+                      "resourceBytes": 143,
+                      "unusedBytes": 143,
+                    },
+                    Object {
+                      "name": "isObjectLike.js?",
+                      "resourceBytes": 54,
+                      "unusedBytes": 54,
+                    },
+                    Object {
+                      "name": "isSymbol.js?",
+                      "resourceBytes": 79,
+                      "unusedBytes": 79,
+                    },
+                    Object {
+                      "name": "_baseToString.js?",
+                      "resourceBytes": 198,
+                      "unusedBytes": 198,
+                    },
+                    Object {
+                      "name": "isObject.js?",
+                      "resourceBytes": 79,
+                      "unusedBytes": 79,
+                    },
+                    Object {
+                      "name": "toNumber.js?",
+                      "resourceBytes": 354,
+                      "unusedBytes": 354,
+                    },
+                    Object {
+                      "name": "toFinite.js?",
+                      "resourceBytes": 117,
+                      "unusedBytes": 117,
+                    },
+                    Object {
+                      "name": "toInteger.js?",
+                      "resourceBytes": 60,
+                      "unusedBytes": 60,
+                    },
+                    Object {
+                      "name": "toString.js?",
+                      "resourceBytes": 43,
+                      "unusedBytes": 43,
+                    },
+                    Object {
+                      "name": "startsWith.js?",
+                      "resourceBytes": 683,
+                      "unusedBytes": 683,
+                    },
+                  ],
+                  "name": "lodash-es",
+                  "resourceBytes": 2489,
+                  "unusedBytes": 2489,
+                },
+              ],
+              "name": "node_modules",
+              "resourceBytes": 65477,
+              "unusedBytes": 65477,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "module.js?",
+                  "resourceBytes": 302,
+                  "unusedBytes": 302,
+                },
+                Object {
+                  "name": "global.js?",
+                  "resourceBytes": 429,
+                  "unusedBytes": 429,
+                },
+              ],
+              "name": "(webpack)/buildin",
+              "resourceBytes": 731,
+              "unusedBytes": 731,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": undefined,
+                  "name": "shims/beef-shims.ts?",
+                  "resourceBytes": 74,
+                  "unusedBytes": 74,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "dashboard-bridge.ts?",
+                      "resourceBytes": 1647,
+                      "unusedBytes": 1647,
+                    },
+                    Object {
+                      "name": "library.ts?",
+                      "resourceBytes": 999,
+                      "unusedBytes": 999,
+                    },
+                    Object {
+                      "name": "header.ts?",
+                      "resourceBytes": 3860,
+                      "unusedBytes": 3860,
+                    },
+                    Object {
+                      "name": "header-entry.ts?",
+                      "resourceBytes": 12,
+                      "unusedBytes": 12,
+                    },
+                  ],
+                  "name": "layout/header",
+                  "resourceBytes": 6518,
+                  "unusedBytes": 6518,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": undefined,
+                      "name": "helper/scroll-helper.ts?",
+                      "resourceBytes": 340,
+                      "unusedBytes": 340,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "new-marker.scss?",
+                              "resourceBytes": 76,
+                              "unusedBytes": 76,
+                            },
+                            Object {
+                              "name": "index.tsx?",
+                              "resourceBytes": 132,
+                              "unusedBytes": 132,
+                            },
+                          ],
+                          "name": "new-marker",
+                          "resourceBytes": 208,
+                          "unusedBytes": 208,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "button/button.tsx?",
+                          "resourceBytes": 1216,
+                          "unusedBytes": 1216,
+                        },
+                        Object {
+                          "name": "school-search.tsx?",
+                          "resourceBytes": 5316,
+                          "unusedBytes": 5316,
+                        },
+                        Object {
+                          "name": "checkbox.tsx?",
+                          "resourceBytes": 1194,
+                          "unusedBytes": 1194,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "abstract-taxonomy-search.tsx?",
+                              "resourceBytes": 3103,
+                              "unusedBytes": 3103,
+                            },
+                            Object {
+                              "name": "course-search.tsx?",
+                              "resourceBytes": 544,
+                              "unusedBytes": 544,
+                            },
+                            Object {
+                              "name": "subject-search.tsx?",
+                              "resourceBytes": 460,
+                              "unusedBytes": 460,
+                            },
+                          ],
+                          "name": "search",
+                          "resourceBytes": 4107,
+                          "unusedBytes": 4107,
+                        },
+                        Object {
+                          "name": "list.tsx?",
+                          "resourceBytes": 496,
+                          "unusedBytes": 496,
+                        },
+                        Object {
+                          "name": "thumbnail.tsx?",
+                          "resourceBytes": 921,
+                          "unusedBytes": 921,
+                        },
+                        Object {
+                          "name": "content-item.tsx?",
+                          "resourceBytes": 2717,
+                          "unusedBytes": 2717,
+                        },
+                        Object {
+                          "name": "generic-content-item.tsx?",
+                          "resourceBytes": 2753,
+                          "unusedBytes": 2753,
+                        },
+                        Object {
+                          "name": "pagination.tsx?",
+                          "resourceBytes": 1463,
+                          "unusedBytes": 1463,
+                        },
+                        Object {
+                          "name": "content-item-loader.tsx?",
+                          "resourceBytes": 275,
+                          "unusedBytes": 275,
+                        },
+                        Object {
+                          "name": "hodor-dropdown.tsx?",
+                          "resourceBytes": 1969,
+                          "unusedBytes": 1969,
+                        },
+                        Object {
+                          "name": "action-dropdown.tsx?",
+                          "resourceBytes": 358,
+                          "unusedBytes": 358,
+                        },
+                      ],
+                      "name": "component",
+                      "resourceBytes": 22993,
+                      "unusedBytes": 22993,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "breakpoints.ts?",
+                          "resourceBytes": 1248,
+                          "unusedBytes": 1248,
+                        },
+                        Object {
+                          "name": "image-urls.ts?",
+                          "resourceBytes": 326,
+                          "unusedBytes": 326,
+                        },
+                      ],
+                      "name": "constants",
+                      "resourceBytes": 1574,
+                      "unusedBytes": 1574,
+                    },
+                    Object {
+                      "name": "base-component.ts?",
+                      "resourceBytes": 459,
+                      "unusedBytes": 459,
+                    },
+                    Object {
+                      "name": "base-model.ts?",
+                      "resourceBytes": 246,
+                      "unusedBytes": 246,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "throttle.ts?",
+                          "resourceBytes": 251,
+                          "unusedBytes": 251,
+                        },
+                        Object {
+                          "name": "store.ts?",
+                          "resourceBytes": 793,
+                          "unusedBytes": 793,
+                        },
+                      ],
+                      "name": "decorators",
+                      "resourceBytes": 1044,
+                      "unusedBytes": 1044,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "input/keycode.ts?",
+                      "resourceBytes": 237,
+                      "unusedBytes": 237,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "content-types.ts?",
+                          "resourceBytes": 1340,
+                          "unusedBytes": 1340,
+                        },
+                        Object {
+                          "name": "content-view-types.ts?",
+                          "resourceBytes": 694,
+                          "unusedBytes": 694,
+                        },
+                      ],
+                      "name": "content/constant",
+                      "resourceBytes": 2034,
+                      "unusedBytes": 2034,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "service/content-item-service.ts?",
+                      "resourceBytes": 1480,
+                      "unusedBytes": 1480,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "actions/content-actions.ts?",
+                      "resourceBytes": 918,
+                      "unusedBytes": 918,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": undefined,
+                          "name": "model/content.ts?",
+                          "resourceBytes": 7682,
+                          "unusedBytes": 7682,
+                        },
+                        Object {
+                          "name": "content-store.ts?",
+                          "resourceBytes": 19482,
+                          "unusedBytes": 19482,
+                        },
+                      ],
+                      "name": "store",
+                      "resourceBytes": 27164,
+                      "unusedBytes": 27164,
+                    },
+                  ],
+                  "name": "common",
+                  "resourceBytes": 58489,
+                  "unusedBytes": 58489,
+                },
+                Object {
+                  "name": "bootstrap.ts?",
+                  "resourceBytes": 78,
+                  "unusedBytes": 78,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "sort-option.ts?",
+                              "resourceBytes": 242,
+                              "unusedBytes": 242,
+                            },
+                            Object {
+                              "name": "error.ts?",
+                              "resourceBytes": 501,
+                              "unusedBytes": 501,
+                            },
+                            Object {
+                              "name": "course-school-combo.ts?",
+                              "resourceBytes": 1250,
+                              "unusedBytes": 1250,
+                            },
+                            Object {
+                              "name": "subject-data.ts?",
+                              "resourceBytes": 1056,
+                              "unusedBytes": 1056,
+                            },
+                            Object {
+                              "name": "filter-data.ts?",
+                              "resourceBytes": 996,
+                              "unusedBytes": 996,
+                            },
+                            Object {
+                              "name": "location.ts?",
+                              "resourceBytes": 1078,
+                              "unusedBytes": 1078,
+                            },
+                            Object {
+                              "name": "api-metadata.ts?",
+                              "resourceBytes": 2082,
+                              "unusedBytes": 2082,
+                            },
+                            Object {
+                              "name": "filter-option.ts?",
+                              "resourceBytes": 1034,
+                              "unusedBytes": 1034,
+                            },
+                            Object {
+                              "name": "filter.ts?",
+                              "resourceBytes": 863,
+                              "unusedBytes": 863,
+                            },
+                            Object {
+                              "name": "options-data.ts?",
+                              "resourceBytes": 622,
+                              "unusedBytes": 622,
+                            },
+                            Object {
+                              "name": "core-result-data.ts?",
+                              "resourceBytes": 1081,
+                              "unusedBytes": 1081,
+                            },
+                            Object {
+                              "name": "document-data.ts?",
+                              "resourceBytes": 525,
+                              "unusedBytes": 525,
+                            },
+                            Object {
+                              "name": "question-data.ts?",
+                              "resourceBytes": 531,
+                              "unusedBytes": 531,
+                            },
+                            Object {
+                              "name": "course-study-guide-data.ts?",
+                              "resourceBytes": 527,
+                              "unusedBytes": 527,
+                            },
+                            Object {
+                              "name": "lit-study-guide-data.ts?",
+                              "resourceBytes": 391,
+                              "unusedBytes": 391,
+                            },
+                            Object {
+                              "name": "course-resource-data.ts?",
+                              "resourceBytes": 1304,
+                              "unusedBytes": 1304,
+                            },
+                            Object {
+                              "name": "course-data.ts?",
+                              "resourceBytes": 1680,
+                              "unusedBytes": 1680,
+                            },
+                            Object {
+                              "name": "dept-data.ts?",
+                              "resourceBytes": 1342,
+                              "unusedBytes": 1342,
+                            },
+                            Object {
+                              "name": "school-data.ts?",
+                              "resourceBytes": 1366,
+                              "unusedBytes": 1366,
+                            },
+                            Object {
+                              "name": "taxonomy-data.ts?",
+                              "resourceBytes": 2612,
+                              "unusedBytes": 2612,
+                            },
+                            Object {
+                              "name": "thumbnail-data.ts?",
+                              "resourceBytes": 522,
+                              "unusedBytes": 522,
+                            },
+                            Object {
+                              "name": "study-guide-video-data.ts?",
+                              "resourceBytes": 371,
+                              "unusedBytes": 371,
+                            },
+                            Object {
+                              "name": "textbook-data.ts?",
+                              "resourceBytes": 2856,
+                              "unusedBytes": 2856,
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "name": "chapter-data.ts?",
+                                  "resourceBytes": 728,
+                                  "unusedBytes": 728,
+                                },
+                                Object {
+                                  "name": "section-data.ts?",
+                                  "resourceBytes": 1016,
+                                  "unusedBytes": 1016,
+                                },
+                                Object {
+                                  "name": "heading-data.ts?",
+                                  "resourceBytes": 736,
+                                  "unusedBytes": 736,
+                                },
+                              ],
+                              "name": "textbook-exercise",
+                              "resourceBytes": 2480,
+                              "unusedBytes": 2480,
+                            },
+                            Object {
+                              "name": "textbook-exercise-data.ts?",
+                              "resourceBytes": 3470,
+                              "unusedBytes": 3470,
+                            },
+                            Object {
+                              "name": "search-result.ts?",
+                              "resourceBytes": 2844,
+                              "unusedBytes": 2844,
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "name": "textbook-callout-chapter.ts?",
+                                  "resourceBytes": 506,
+                                  "unusedBytes": 506,
+                                },
+                                Object {
+                                  "name": "textbook-callout-data.ts?",
+                                  "resourceBytes": 1721,
+                                  "unusedBytes": 1721,
+                                },
+                              ],
+                              "name": "callout",
+                              "resourceBytes": 2227,
+                              "unusedBytes": 2227,
+                            },
+                            Object {
+                              "name": "search-callout.ts?",
+                              "resourceBytes": 568,
+                              "unusedBytes": 568,
+                            },
+                            Object {
+                              "name": "api-response.ts?",
+                              "resourceBytes": 1268,
+                              "unusedBytes": 1268,
+                            },
+                            Object {
+                              "name": "search-request.ts?",
+                              "resourceBytes": 2885,
+                              "unusedBytes": 2885,
+                            },
+                            Object {
+                              "name": "suggestion-data.ts?",
+                              "resourceBytes": 1052,
+                              "unusedBytes": 1052,
+                            },
+                            Object {
+                              "name": "search-result-type.ts?",
+                              "resourceBytes": 908,
+                              "unusedBytes": 908,
+                            },
+                            Object {
+                              "name": "search-store.ts?",
+                              "resourceBytes": 1309,
+                              "unusedBytes": 1309,
+                            },
+                            Object {
+                              "name": "filter-type.ts?",
+                              "resourceBytes": 98,
+                              "unusedBytes": 98,
+                            },
+                          ],
+                          "name": "model",
+                          "resourceBytes": 43941,
+                          "unusedBytes": 43941,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "actions/search-actions.ts?",
+                          "resourceBytes": 108,
+                          "unusedBytes": 108,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "ask-question-callout.tsx?",
+                              "resourceBytes": 1185,
+                              "unusedBytes": 1185,
+                            },
+                            Object {
+                              "name": "error-page.tsx?",
+                              "resourceBytes": 274,
+                              "unusedBytes": 274,
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "name": "multi-select.tsx?",
+                                  "resourceBytes": 2946,
+                                  "unusedBytes": 2946,
+                                },
+                                Object {
+                                  "name": "filter-drop-down.tsx?",
+                                  "resourceBytes": 4546,
+                                  "unusedBytes": 4546,
+                                },
+                                Object {
+                                  "name": "top-filter-controls.tsx?",
+                                  "resourceBytes": 3590,
+                                  "unusedBytes": 3590,
+                                },
+                              ],
+                              "name": "filters",
+                              "resourceBytes": 11082,
+                              "unusedBytes": 11082,
+                            },
+                            Object {
+                              "name": "pill-list.tsx?",
+                              "resourceBytes": 293,
+                              "unusedBytes": 293,
+                            },
+                            Object {
+                              "name": "geo-info.tsx?",
+                              "resourceBytes": 284,
+                              "unusedBytes": 284,
+                            },
+                            Object {
+                              "name": "query-details.tsx?",
+                              "resourceBytes": 647,
+                              "unusedBytes": 647,
+                            },
+                            Object {
+                              "name": "no-results.tsx?",
+                              "resourceBytes": 765,
+                              "unusedBytes": 765,
+                            },
+                            Object {
+                              "name": "textbook-copyright.tsx?",
+                              "resourceBytes": 394,
+                              "unusedBytes": 394,
+                            },
+                            Object {
+                              "name": "textbook-callout.tsx?",
+                              "resourceBytes": 2473,
+                              "unusedBytes": 2473,
+                            },
+                            Object {
+                              "name": "callout.tsx?",
+                              "resourceBytes": 165,
+                              "unusedBytes": 165,
+                            },
+                            Object {
+                              "name": "search-result-container.tsx?",
+                              "resourceBytes": 750,
+                              "unusedBytes": 750,
+                            },
+                            Object {
+                              "name": "filter-controls.tsx?",
+                              "resourceBytes": 72,
+                              "unusedBytes": 72,
+                            },
+                          ],
+                          "name": "component",
+                          "resourceBytes": 18384,
+                          "unusedBytes": 18384,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "search-result-title.ts?",
+                              "resourceBytes": 147,
+                              "unusedBytes": 147,
+                            },
+                            Object {
+                              "name": "result-stat-values.ts?",
+                              "resourceBytes": 168,
+                              "unusedBytes": 168,
+                            },
+                            Object {
+                              "name": "search-trigger.ts?",
+                              "resourceBytes": 286,
+                              "unusedBytes": 286,
+                            },
+                            Object {
+                              "name": "search-view.ts?",
+                              "resourceBytes": 108,
+                              "unusedBytes": 108,
+                            },
+                            Object {
+                              "name": "callout-types.ts?",
+                              "resourceBytes": 467,
+                              "unusedBytes": 467,
+                            },
+                          ],
+                          "name": "constant",
+                          "resourceBytes": 1176,
+                          "unusedBytes": 1176,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "service/search-api.ts?",
+                          "resourceBytes": 177,
+                          "unusedBytes": 177,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "app/search-results.tsx?",
+                          "resourceBytes": 11160,
+                          "unusedBytes": 11160,
+                        },
+                      ],
+                      "name": "2018",
+                      "resourceBytes": 74946,
+                      "unusedBytes": 74946,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "events.ts?",
+                              "resourceBytes": 44,
+                              "unusedBytes": 44,
+                            },
+                            Object {
+                              "name": "search-widget-types.ts?",
+                              "resourceBytes": 113,
+                              "unusedBytes": 113,
+                            },
+                          ],
+                          "name": "constants",
+                          "resourceBytes": 157,
+                          "unusedBytes": 157,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "actions/suggestion-actions.ts?",
+                          "resourceBytes": 90,
+                          "unusedBytes": 90,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "suggestion.ts?",
+                              "resourceBytes": 794,
+                              "unusedBytes": 794,
+                            },
+                            Object {
+                              "name": "suggestion-store.ts?",
+                              "resourceBytes": 1545,
+                              "unusedBytes": 1545,
+                            },
+                          ],
+                          "name": "model",
+                          "resourceBytes": 2339,
+                          "unusedBytes": 2339,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "service/api/autocomplete-api-service.ts?",
+                          "resourceBytes": 380,
+                          "unusedBytes": 380,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "suggestion-list.tsx?",
+                              "resourceBytes": 402,
+                              "unusedBytes": 402,
+                            },
+                            Object {
+                              "name": "suggestions.tsx?",
+                              "resourceBytes": 247,
+                              "unusedBytes": 247,
+                            },
+                            Object {
+                              "name": "search-bar.tsx?",
+                              "resourceBytes": 790,
+                              "unusedBytes": 790,
+                            },
+                            Object {
+                              "name": "search-widget.tsx?",
+                              "resourceBytes": 12166,
+                              "unusedBytes": 12166,
+                            },
+                            Object {
+                              "name": "header-search-widget.tsx?",
+                              "resourceBytes": 2248,
+                              "unusedBytes": 2248,
+                            },
+                          ],
+                          "name": "component",
+                          "resourceBytes": 15853,
+                          "unusedBytes": 15853,
+                        },
+                        Object {
+                          "name": "app.tsx?",
+                          "resourceBytes": 779,
+                          "unusedBytes": 779,
+                        },
+                      ],
+                      "name": "widget",
+                      "resourceBytes": 19598,
+                      "unusedBytes": 19598,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "filter-actions.ts?",
+                              "resourceBytes": 946,
+                              "unusedBytes": 946,
+                            },
+                            Object {
+                              "children": undefined,
+                              "name": "item/resource-types.ts?",
+                              "resourceBytes": 783,
+                              "unusedBytes": 783,
+                            },
+                            Object {
+                              "name": "filter-store.ts?",
+                              "resourceBytes": 12717,
+                              "unusedBytes": 12717,
+                            },
+                          ],
+                          "name": "store",
+                          "resourceBytes": 14446,
+                          "unusedBytes": 14446,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "autocomplete-list.tsx?",
+                              "resourceBytes": 1134,
+                              "unusedBytes": 1134,
+                            },
+                            Object {
+                              "name": "autocomplete-filter.tsx?",
+                              "resourceBytes": 3823,
+                              "unusedBytes": 3823,
+                            },
+                            Object {
+                              "name": "autocomplete-filter-with-icon.tsx?",
+                              "resourceBytes": 2696,
+                              "unusedBytes": 2696,
+                            },
+                          ],
+                          "name": "view/filter",
+                          "resourceBytes": 7653,
+                          "unusedBytes": 7653,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "service/api/filter-api-service.ts?",
+                          "resourceBytes": 554,
+                          "unusedBytes": 554,
+                        },
+                      ],
+                      "name": "results",
+                      "resourceBytes": 22653,
+                      "unusedBytes": 22653,
+                    },
+                  ],
+                  "name": "search",
+                  "resourceBytes": 117197,
+                  "unusedBytes": 117197,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "amplitude-service.ts?",
+                          "resourceBytes": 1348,
+                          "unusedBytes": 1348,
+                        },
+                        Object {
+                          "name": "api-service.ts?",
+                          "resourceBytes": 116,
+                          "unusedBytes": 116,
+                        },
+                        Object {
+                          "name": "gsa-inmeta-tags.ts?",
+                          "resourceBytes": 591,
+                          "unusedBytes": 591,
+                        },
+                        Object {
+                          "name": "global-service.ts?",
+                          "resourceBytes": 336,
+                          "unusedBytes": 336,
+                        },
+                        Object {
+                          "name": "string-service.ts?",
+                          "resourceBytes": 738,
+                          "unusedBytes": 738,
+                        },
+                        Object {
+                          "name": "truncation-service.ts?",
+                          "resourceBytes": 1453,
+                          "unusedBytes": 1453,
+                        },
+                      ],
+                      "name": "service",
+                      "resourceBytes": 4582,
+                      "unusedBytes": 4582,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "helpers/classname.ts?",
+                      "resourceBytes": 75,
+                      "unusedBytes": 75,
+                    },
+                    Object {
+                      "name": "track.ts?",
+                      "resourceBytes": 138,
+                      "unusedBytes": 138,
+                    },
+                  ],
+                  "name": "utils",
+                  "resourceBytes": 4795,
+                  "unusedBytes": 4795,
+                },
+                Object {
+                  "name": "aged-beef.ts?",
+                  "resourceBytes": 213,
+                  "unusedBytes": 213,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "column.tsx?",
+                      "resourceBytes": 585,
+                      "unusedBytes": 585,
+                    },
+                    Object {
+                      "name": "grid.tsx?",
+                      "resourceBytes": 587,
+                      "unusedBytes": 587,
+                    },
+                    Object {
+                      "name": "well.tsx?",
+                      "resourceBytes": 148,
+                      "unusedBytes": 148,
+                    },
+                  ],
+                  "name": "hodor/component",
+                  "resourceBytes": 1320,
+                  "unusedBytes": 1320,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "user.ts?",
+                              "resourceBytes": 1054,
+                              "unusedBytes": 1054,
+                            },
+                            Object {
+                              "name": "user-details.ts?",
+                              "resourceBytes": 11402,
+                              "unusedBytes": 11402,
+                            },
+                          ],
+                          "name": "model",
+                          "resourceBytes": 12456,
+                          "unusedBytes": 12456,
+                        },
+                        Object {
+                          "name": "user-store.ts?",
+                          "resourceBytes": 890,
+                          "unusedBytes": 890,
+                        },
+                      ],
+                      "name": "store",
+                      "resourceBytes": 13346,
+                      "unusedBytes": 13346,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "actions/user-actions.ts?",
+                      "resourceBytes": 306,
+                      "unusedBytes": 306,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "service/api/user-api-service.ts?",
+                      "resourceBytes": 1451,
+                      "unusedBytes": 1451,
+                    },
+                  ],
+                  "name": "user",
+                  "resourceBytes": 15103,
+                  "unusedBytes": 15103,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": undefined,
+                      "name": "constant/upload-statuses.ts?",
+                      "resourceBytes": 3528,
+                      "unusedBytes": 3528,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "service/document-upload-service.ts?",
+                      "resourceBytes": 1356,
+                      "unusedBytes": 1356,
+                    },
+                  ],
+                  "name": "document/common",
+                  "resourceBytes": 4884,
+                  "unusedBytes": 4884,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": undefined,
+                      "name": "utils/amplitudeHelpers.ts?",
+                      "resourceBytes": 723,
+                      "unusedBytes": 723,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "constant/course-actions.ts?",
+                      "resourceBytes": 86,
+                      "unusedBytes": 86,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "nav-menu.tsx?",
+                          "resourceBytes": 6906,
+                          "unusedBytes": 6906,
+                        },
+                        Object {
+                          "name": "sitewide-dashboard-navigation.tsx?",
+                          "resourceBytes": 1320,
+                          "unusedBytes": 1320,
+                        },
+                      ],
+                      "name": "component",
+                      "resourceBytes": 8226,
+                      "unusedBytes": 8226,
+                    },
+                    Object {
+                      "name": "dashboard-navbar-app.tsx?",
+                      "resourceBytes": 311,
+                      "unusedBytes": 311,
+                    },
+                  ],
+                  "name": "dashboard2018",
+                  "resourceBytes": 9346,
+                  "unusedBytes": 9346,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "taxonomy/service/course-api-service.ts?",
+                  "resourceBytes": 465,
+                  "unusedBytes": 465,
+                },
+              ],
+              "name": "src",
+              "resourceBytes": 218482,
+              "unusedBytes": 218482,
+            },
+            Object {
+              "children": undefined,
+              "name": "vendor/beefjs/dist/beef.js?",
+              "resourceBytes": 11949,
+              "unusedBytes": 11949,
+            },
+            Object {
+              "name": "external \\"window.React\\"?",
+              "resourceBytes": 76,
+              "unusedBytes": 76,
+            },
+            Object {
+              "name": "external \\"window.BeefFlux\\"?",
+              "resourceBytes": 82,
+              "unusedBytes": 82,
+            },
+            Object {
+              "name": "external \\"window.moment\\"?",
+              "resourceBytes": 80,
+              "unusedBytes": 80,
+            },
+            Object {
+              "name": "external \\"window.ReactDOM\\"?",
+              "resourceBytes": 119,
+              "unusedBytes": 119,
+            },
+          ],
+          "name": "js",
+          "resourceBytes": 300653,
+          "unusedBytes": 300653,
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "name": "ResponsiveHeader.js",
+                  "resourceBytes": 466,
+                  "unusedBytes": 466,
+                },
+                Object {
+                  "name": "Utils.js",
+                  "resourceBytes": 857,
+                  "unusedBytes": 857,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "vendor/jquery.ba-throttle-debounce.js",
+                  "resourceBytes": 973,
+                  "unusedBytes": 973,
+                },
+              ],
+              "name": "LayoutBundle/Resources/assets/js",
+              "resourceBytes": 2296,
+              "unusedBytes": 2296,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "jquery.iframe-transport.js",
+                  "resourceBytes": 2505,
+                  "unusedBytes": 2505,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "util.common.services.js",
+                      "resourceBytes": 784,
+                      "unusedBytes": 784,
+                    },
+                    Object {
+                      "name": "util.common.dispatcher.js",
+                      "resourceBytes": 463,
+                      "unusedBytes": 463,
+                    },
+                    Object {
+                      "name": "util.common.store.js",
+                      "resourceBytes": 18595,
+                      "unusedBytes": 18595,
+                    },
+                    Object {
+                      "name": "util.common.api.js",
+                      "resourceBytes": 1306,
+                      "unusedBytes": 1306,
+                    },
+                    Object {
+                      "name": "util.common.notifications.js",
+                      "resourceBytes": 4684,
+                      "unusedBytes": 4684,
+                    },
+                    Object {
+                      "name": "util.common.locale.js",
+                      "resourceBytes": 9092,
+                      "unusedBytes": 9092,
+                    },
+                  ],
+                  "name": "Common",
+                  "resourceBytes": 34924,
+                  "unusedBytes": 34924,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "Widgets/util.widgets.loader.js",
+                  "resourceBytes": 308,
+                  "unusedBytes": 308,
+                },
+              ],
+              "name": "UtilsBundle/Resources/assets/js",
+              "resourceBytes": 37737,
+              "unusedBytes": 37737,
+            },
+            Object {
+              "children": undefined,
+              "name": "SearchBundle/Resources/assets/js/Smart/search.smart.widget.js",
+              "resourceBytes": 10247,
+              "unusedBytes": 10247,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "productThumbnailStatsService.js",
+                  "resourceBytes": 186,
+                  "unusedBytes": 186,
+                },
+                Object {
+                  "name": "productThumbnailStats.js",
+                  "resourceBytes": 582,
+                  "unusedBytes": 582,
+                },
+              ],
+              "name": "AnalyticsBundle/Resources/assets/js",
+              "resourceBytes": 768,
+              "unusedBytes": 768,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "payment.common.services.js",
+                  "resourceBytes": 693,
+                  "unusedBytes": 693,
+                },
+                Object {
+                  "name": "payment.common.actions.js",
+                  "resourceBytes": 7165,
+                  "unusedBytes": 7165,
+                },
+                Object {
+                  "name": "payment.common.store.js",
+                  "resourceBytes": 3240,
+                  "unusedBytes": 3240,
+                },
+              ],
+              "name": "PaymentBundle/Resources/assets/js/Common",
+              "resourceBytes": 11098,
+              "unusedBytes": 11098,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "user.common.services.js",
+                  "resourceBytes": 175,
+                  "unusedBytes": 175,
+                },
+                Object {
+                  "name": "user.common.store.js",
+                  "resourceBytes": 4601,
+                  "unusedBytes": 4601,
+                },
+                Object {
+                  "name": "user.common.actions.js",
+                  "resourceBytes": 5561,
+                  "unusedBytes": 5561,
+                },
+              ],
+              "name": "UserBundle/Resources/assets/js/Common",
+              "resourceBytes": 10337,
+              "unusedBytes": 10337,
+            },
+          ],
+          "name": "Symfony/src/CourseHero",
+          "resourceBytes": 72483,
+          "unusedBytes": 72483,
+        },
+        Object {
+          "children": undefined,
+          "name": "cdn/ajax/libs/angular.js/1.3.20/angular-route.min.js",
+          "resourceBytes": 4247,
+          "unusedBytes": 4247,
+        },
+      ],
+      "name": "coursehero:///",
+      "resourceBytes": 977474,
+      "unusedBytes": 977474,
+    },
+  },
+]
+`;
+
 exports[`ScriptTreemapData audit squoosh fixture has root nodes 3`] = `
 Array [
   Object {

--- a/lighthouse-core/test/audits/__snapshots__/script-treemap-data-test.js.snap
+++ b/lighthouse-core/test/audits/__snapshots__/script-treemap-data-test.js.snap
@@ -3,7 +3,7 @@
 exports[`ScriptTreemapData audit coursehero fixture has root nodes 2`] = `
 Array [
   Object {
-    "name": "https://courshero.com/script.js",
+    "name": "https://courshero.com/script1.js",
     "node": Object {
       "children": Array [
         Object {
@@ -13,61 +13,73 @@ Array [
                 Object {
                   "children": Array [
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.typeahead.js",
                       "name": "jquery.typeahead.js",
                       "resourceBytes": 39282,
                       "unusedBytes": 39282,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.magnific.popup.js",
                       "name": "jquery.magnific.popup.js",
                       "resourceBytes": 29039,
                       "unusedBytes": 29039,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.owl.carousel.js",
                       "name": "jquery.owl.carousel.js",
                       "resourceBytes": 29798,
                       "unusedBytes": 29798,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.select.js",
                       "name": "jquery.select.js",
                       "resourceBytes": 59038,
                       "unusedBytes": 59038,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.lazyload.js",
                       "name": "jquery.lazyload.js",
                       "resourceBytes": 5178,
                       "unusedBytes": 5178,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/media-match.js",
                       "name": "media-match.js",
                       "resourceBytes": 4673,
                       "unusedBytes": 4673,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/enquire.min.js",
                       "name": "enquire.min.js",
                       "resourceBytes": 2025,
                       "unusedBytes": 2025,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/lab.js",
                       "name": "lab.js",
                       "resourceBytes": 5369,
                       "unusedBytes": 5369,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/moment.min.js",
                       "name": "moment.min.js",
                       "resourceBytes": 34603,
                       "unusedBytes": 34603,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/angular-moment.min.js",
                       "name": "angular-moment.min.js",
                       "resourceBytes": 3968,
                       "unusedBytes": 3968,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng-infinite-scroll.min.js",
                       "name": "ng-infinite-scroll.min.js",
                       "resourceBytes": 814,
                       "unusedBytes": 814,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/angular.ng-modules.js",
                       "name": "angular.ng-modules.js",
                       "resourceBytes": 1486,
                       "unusedBytes": 1486,
@@ -77,11 +89,13 @@ Array [
                         Object {
                           "children": Array [
                             Object {
+                              "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/select/select.js",
                               "name": "select.js",
                               "resourceBytes": 48513,
                               "unusedBytes": 48513,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/select/angular-sanitize.js",
                               "name": "angular-sanitize.js",
                               "resourceBytes": 9135,
                               "unusedBytes": 9135,
@@ -92,11 +106,13 @@ Array [
                           "unusedBytes": 57648,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/angular-smooth-scroll.min.js",
                           "name": "angular-smooth-scroll.min.js",
                           "resourceBytes": 2237,
                           "unusedBytes": 2237,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/ng-file-upload.js",
                           "name": "ng-file-upload.js",
                           "resourceBytes": 13362,
                           "unusedBytes": 13362,
@@ -107,16 +123,19 @@ Array [
                       "unusedBytes": 73247,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/phoneparser.js",
                       "name": "phoneparser.js",
                       "resourceBytes": 22883,
                       "unusedBytes": 22883,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/sweetalert.js",
                       "name": "sweetalert.js",
                       "resourceBytes": 16857,
                       "unusedBytes": 16857,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/katex.min.js",
                       "name": "katex.min.js",
                       "resourceBytes": 228929,
                       "unusedBytes": 228929,
@@ -127,6 +146,7 @@ Array [
                   "unusedBytes": 557189,
                 },
                 Object {
+                  "duplicatedNormalizedModuleName": "Control/assets/js/ch.global.js",
                   "name": "ch.global.js",
                   "resourceBytes": 1150,
                   "unusedBytes": 1150,
@@ -134,6 +154,7 @@ Array [
                 Object {
                   "children": Array [
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/course_hero_mq/course-hero-mq.js",
                       "name": "course-hero-mq.js",
                       "resourceBytes": 3420,
                       "unusedBytes": 3420,
@@ -149,6 +170,7 @@ Array [
                   "unusedBytes": 3656,
                 },
                 Object {
+                  "duplicatedNormalizedModuleName": "Control/assets/js/workForUs.js",
                   "name": "workForUs.js",
                   "resourceBytes": 715,
                   "unusedBytes": 715,
@@ -166,6 +188,7 @@ Array [
                       "unusedBytes": 420,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/ux/tag-recording.directive.js",
                       "name": "tag-recording.directive.js",
                       "resourceBytes": 1511,
                       "unusedBytes": 1511,
@@ -185,11 +208,13 @@ Array [
                           "unusedBytes": 60,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/common/qa-validator.service.js",
                           "name": "qa-validator.service.js",
                           "resourceBytes": 1322,
                           "unusedBytes": 1322,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/common/qa-amplitude.service.js",
                           "name": "qa-amplitude.service.js",
                           "resourceBytes": 5141,
                           "unusedBytes": 5141,
@@ -207,26 +232,31 @@ Array [
                           "unusedBytes": 69,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/qa-category.dataservice.js",
                           "name": "qa-category.dataservice.js",
                           "resourceBytes": 596,
                           "unusedBytes": 596,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/question.dataservice.js",
                           "name": "question.dataservice.js",
                           "resourceBytes": 725,
                           "unusedBytes": 725,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/tutor-questions.dataservice.js",
                           "name": "tutor-questions.dataservice.js",
                           "resourceBytes": 739,
                           "unusedBytes": 739,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/qa-user-discounts.dataservice.js",
                           "name": "qa-user-discounts.dataservice.js",
                           "resourceBytes": 679,
                           "unusedBytes": 679,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/question.datastore.js",
                           "name": "question.datastore.js",
                           "resourceBytes": 1004,
                           "unusedBytes": 1004,
@@ -244,6 +274,7 @@ Array [
                           "unusedBytes": 70,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/widgets/qa-category-autocomplete.directive.js",
                           "name": "qa-category-autocomplete.directive.js",
                           "resourceBytes": 973,
                           "unusedBytes": 973,
@@ -261,11 +292,13 @@ Array [
                     Object {
                       "children": Array [
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/askAQuestion/module.js",
                           "name": "module.js",
                           "resourceBytes": 562,
                           "unusedBytes": 562,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/askAQuestion/ask-a-question.directive.js",
                           "name": "ask-a-question.directive.js",
                           "resourceBytes": 14812,
                           "unusedBytes": 14812,
@@ -457,6 +490,7 @@ Array [
                       "unusedBytes": 71,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash/_getTag.js",
                       "name": "_getTag.js?",
                       "resourceBytes": 578,
                       "unusedBytes": 578,
@@ -667,6 +701,7 @@ Array [
                       "unusedBytes": 48,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash/_baseIsTypedArray.js",
                       "name": "_baseIsTypedArray.js?",
                       "resourceBytes": 669,
                       "unusedBytes": 669,
@@ -687,6 +722,7 @@ Array [
                       "unusedBytes": 110,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash/_baseClone.js",
                       "name": "_baseClone.js?",
                       "resourceBytes": 1444,
                       "unusedBytes": 1444,
@@ -882,6 +918,7 @@ Array [
                       "unusedBytes": 204,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash/_initCloneByTag.js",
                       "name": "_initCloneByTag.js?",
                       "resourceBytes": 806,
                       "unusedBytes": 806,
@@ -999,6 +1036,7 @@ Array [
                           "unusedBytes": 490,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/routing/routing-service.js",
                           "name": "routing-service.js?",
                           "resourceBytes": 1677,
                           "unusedBytes": 1677,
@@ -1011,11 +1049,13 @@ Array [
                     Object {
                       "children": Array [
                         Object {
+                          "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/store/store.js",
                           "name": "store.js?",
                           "resourceBytes": 8120,
                           "unusedBytes": 8120,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/store/store-decorator.js",
                           "name": "store-decorator.js?",
                           "resourceBytes": 1337,
                           "unusedBytes": 1337,
@@ -1073,6 +1113,7 @@ Array [
                       "unusedBytes": 358,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/createClass.js",
                       "name": "createClass.js?",
                       "resourceBytes": 799,
                       "unusedBytes": 799,
@@ -1083,6 +1124,7 @@ Array [
                       "unusedBytes": 294,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/applyDecoratedDescriptor.js",
                       "name": "applyDecoratedDescriptor.js?",
                       "resourceBytes": 892,
                       "unusedBytes": 892,
@@ -1103,11 +1145,13 @@ Array [
                       "unusedBytes": 338,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/inherits.js",
                       "name": "inherits.js?",
                       "resourceBytes": 528,
                       "unusedBytes": 528,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/initializerWarningHelper.js",
                       "name": "initializerWarningHelper.js?",
                       "resourceBytes": 594,
                       "unusedBytes": 594,
@@ -1128,6 +1172,7 @@ Array [
                       "unusedBytes": 89,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/typeof.js",
                       "name": "typeof.js?",
                       "resourceBytes": 992,
                       "unusedBytes": 992,
@@ -1160,6 +1205,7 @@ Array [
                 Object {
                   "children": Array [
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/util/util.js",
                       "name": "util.js?",
                       "resourceBytes": 7644,
                       "unusedBytes": 7644,
@@ -1275,6 +1321,7 @@ Array [
                       "unusedBytes": 43,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash-es/startsWith.js",
                       "name": "startsWith.js?",
                       "resourceBytes": 683,
                       "unusedBytes": 683,
@@ -1317,16 +1364,19 @@ Array [
                 Object {
                   "children": Array [
                     Object {
+                      "duplicatedNormalizedModuleName": "js/src/layout/header/dashboard-bridge.ts",
                       "name": "dashboard-bridge.ts?",
                       "resourceBytes": 1647,
                       "unusedBytes": 1647,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "js/src/layout/header/library.ts",
                       "name": "library.ts?",
                       "resourceBytes": 999,
                       "unusedBytes": 999,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "js/src/layout/header/header.ts",
                       "name": "header.ts?",
                       "resourceBytes": 3860,
                       "unusedBytes": 3860,
@@ -1375,11 +1425,13 @@ Array [
                           "unusedBytes": 1216,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/school-search.tsx",
                           "name": "school-search.tsx?",
                           "resourceBytes": 5316,
                           "unusedBytes": 5316,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/checkbox.tsx",
                           "name": "checkbox.tsx?",
                           "resourceBytes": 1194,
                           "unusedBytes": 1194,
@@ -1387,11 +1439,13 @@ Array [
                         Object {
                           "children": Array [
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/common/component/search/abstract-taxonomy-search.tsx",
                               "name": "abstract-taxonomy-search.tsx?",
                               "resourceBytes": 3103,
                               "unusedBytes": 3103,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/common/component/search/course-search.tsx",
                               "name": "course-search.tsx?",
                               "resourceBytes": 544,
                               "unusedBytes": 544,
@@ -1412,21 +1466,25 @@ Array [
                           "unusedBytes": 496,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/thumbnail.tsx",
                           "name": "thumbnail.tsx?",
                           "resourceBytes": 921,
                           "unusedBytes": 921,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/content-item.tsx",
                           "name": "content-item.tsx?",
                           "resourceBytes": 2717,
                           "unusedBytes": 2717,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/generic-content-item.tsx",
                           "name": "generic-content-item.tsx?",
                           "resourceBytes": 2753,
                           "unusedBytes": 2753,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/pagination.tsx",
                           "name": "pagination.tsx?",
                           "resourceBytes": 1463,
                           "unusedBytes": 1463,
@@ -1437,6 +1495,7 @@ Array [
                           "unusedBytes": 275,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/hodor-dropdown.tsx",
                           "name": "hodor-dropdown.tsx?",
                           "resourceBytes": 1969,
                           "unusedBytes": 1969,
@@ -1454,6 +1513,7 @@ Array [
                     Object {
                       "children": Array [
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/constants/breakpoints.ts",
                           "name": "breakpoints.ts?",
                           "resourceBytes": 1248,
                           "unusedBytes": 1248,
@@ -1486,6 +1546,7 @@ Array [
                           "unusedBytes": 251,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/decorators/store.ts",
                           "name": "store.ts?",
                           "resourceBytes": 793,
                           "unusedBytes": 793,
@@ -1504,11 +1565,13 @@ Array [
                     Object {
                       "children": Array [
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/content/constant/content-types.ts",
                           "name": "content-types.ts?",
                           "resourceBytes": 1340,
                           "unusedBytes": 1340,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/content/constant/content-view-types.ts",
                           "name": "content-view-types.ts?",
                           "resourceBytes": 694,
                           "unusedBytes": 694,
@@ -1539,6 +1602,7 @@ Array [
                           "unusedBytes": 7682,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/store/content-store.ts",
                           "name": "content-store.ts?",
                           "resourceBytes": 19482,
                           "unusedBytes": 19482,
@@ -1575,61 +1639,73 @@ Array [
                               "unusedBytes": 501,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/course-school-combo.ts",
                               "name": "course-school-combo.ts?",
                               "resourceBytes": 1250,
                               "unusedBytes": 1250,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/subject-data.ts",
                               "name": "subject-data.ts?",
                               "resourceBytes": 1056,
                               "unusedBytes": 1056,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/filter-data.ts",
                               "name": "filter-data.ts?",
                               "resourceBytes": 996,
                               "unusedBytes": 996,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/location.ts",
                               "name": "location.ts?",
                               "resourceBytes": 1078,
                               "unusedBytes": 1078,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/api-metadata.ts",
                               "name": "api-metadata.ts?",
                               "resourceBytes": 2082,
                               "unusedBytes": 2082,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/filter-option.ts",
                               "name": "filter-option.ts?",
                               "resourceBytes": 1034,
                               "unusedBytes": 1034,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/filter.ts",
                               "name": "filter.ts?",
                               "resourceBytes": 863,
                               "unusedBytes": 863,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/options-data.ts",
                               "name": "options-data.ts?",
                               "resourceBytes": 622,
                               "unusedBytes": 622,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/core-result-data.ts",
                               "name": "core-result-data.ts?",
                               "resourceBytes": 1081,
                               "unusedBytes": 1081,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/document-data.ts",
                               "name": "document-data.ts?",
                               "resourceBytes": 525,
                               "unusedBytes": 525,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/question-data.ts",
                               "name": "question-data.ts?",
                               "resourceBytes": 531,
                               "unusedBytes": 531,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/course-study-guide-data.ts",
                               "name": "course-study-guide-data.ts?",
                               "resourceBytes": 527,
                               "unusedBytes": 527,
@@ -1640,31 +1716,37 @@ Array [
                               "unusedBytes": 391,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/course-resource-data.ts",
                               "name": "course-resource-data.ts?",
                               "resourceBytes": 1304,
                               "unusedBytes": 1304,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/course-data.ts",
                               "name": "course-data.ts?",
                               "resourceBytes": 1680,
                               "unusedBytes": 1680,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/dept-data.ts",
                               "name": "dept-data.ts?",
                               "resourceBytes": 1342,
                               "unusedBytes": 1342,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/school-data.ts",
                               "name": "school-data.ts?",
                               "resourceBytes": 1366,
                               "unusedBytes": 1366,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/taxonomy-data.ts",
                               "name": "taxonomy-data.ts?",
                               "resourceBytes": 2612,
                               "unusedBytes": 2612,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/thumbnail-data.ts",
                               "name": "thumbnail-data.ts?",
                               "resourceBytes": 522,
                               "unusedBytes": 522,
@@ -1675,6 +1757,7 @@ Array [
                               "unusedBytes": 371,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-data.ts",
                               "name": "textbook-data.ts?",
                               "resourceBytes": 2856,
                               "unusedBytes": 2856,
@@ -1682,16 +1765,19 @@ Array [
                             Object {
                               "children": Array [
                                 Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-exercise/chapter-data.ts",
                                   "name": "chapter-data.ts?",
                                   "resourceBytes": 728,
                                   "unusedBytes": 728,
                                 },
                                 Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-exercise/section-data.ts",
                                   "name": "section-data.ts?",
                                   "resourceBytes": 1016,
                                   "unusedBytes": 1016,
                                 },
                                 Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-exercise/heading-data.ts",
                                   "name": "heading-data.ts?",
                                   "resourceBytes": 736,
                                   "unusedBytes": 736,
@@ -1702,11 +1788,13 @@ Array [
                               "unusedBytes": 2480,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-exercise-data.ts",
                               "name": "textbook-exercise-data.ts?",
                               "resourceBytes": 3470,
                               "unusedBytes": 3470,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-result.ts",
                               "name": "search-result.ts?",
                               "resourceBytes": 2844,
                               "unusedBytes": 2844,
@@ -1719,6 +1807,7 @@ Array [
                                   "unusedBytes": 506,
                                 },
                                 Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/model/callout/textbook-callout-data.ts",
                                   "name": "textbook-callout-data.ts?",
                                   "resourceBytes": 1721,
                                   "unusedBytes": 1721,
@@ -1729,31 +1818,37 @@ Array [
                               "unusedBytes": 2227,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-callout.ts",
                               "name": "search-callout.ts?",
                               "resourceBytes": 568,
                               "unusedBytes": 568,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/api-response.ts",
                               "name": "api-response.ts?",
                               "resourceBytes": 1268,
                               "unusedBytes": 1268,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-request.ts",
                               "name": "search-request.ts?",
                               "resourceBytes": 2885,
                               "unusedBytes": 2885,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/suggestion-data.ts",
                               "name": "suggestion-data.ts?",
                               "resourceBytes": 1052,
                               "unusedBytes": 1052,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-result-type.ts",
                               "name": "search-result-type.ts?",
                               "resourceBytes": 908,
                               "unusedBytes": 908,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-store.ts",
                               "name": "search-store.ts?",
                               "resourceBytes": 1309,
                               "unusedBytes": 1309,
@@ -1777,6 +1872,7 @@ Array [
                         Object {
                           "children": Array [
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/ask-question-callout.tsx",
                               "name": "ask-question-callout.tsx?",
                               "resourceBytes": 1185,
                               "unusedBytes": 1185,
@@ -1789,16 +1885,19 @@ Array [
                             Object {
                               "children": Array [
                                 Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/component/filters/multi-select.tsx",
                                   "name": "multi-select.tsx?",
                                   "resourceBytes": 2946,
                                   "unusedBytes": 2946,
                                 },
                                 Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/component/filters/filter-drop-down.tsx",
                                   "name": "filter-drop-down.tsx?",
                                   "resourceBytes": 4546,
                                   "unusedBytes": 4546,
                                 },
                                 Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/component/filters/top-filter-controls.tsx",
                                   "name": "top-filter-controls.tsx?",
                                   "resourceBytes": 3590,
                                   "unusedBytes": 3590,
@@ -1819,11 +1918,13 @@ Array [
                               "unusedBytes": 284,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/query-details.tsx",
                               "name": "query-details.tsx?",
                               "resourceBytes": 647,
                               "unusedBytes": 647,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/no-results.tsx",
                               "name": "no-results.tsx?",
                               "resourceBytes": 765,
                               "unusedBytes": 765,
@@ -1834,6 +1935,7 @@ Array [
                               "unusedBytes": 394,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/textbook-callout.tsx",
                               "name": "textbook-callout.tsx?",
                               "resourceBytes": 2473,
                               "unusedBytes": 2473,
@@ -1844,6 +1946,7 @@ Array [
                               "unusedBytes": 165,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/search-result-container.tsx",
                               "name": "search-result-container.tsx?",
                               "resourceBytes": 750,
                               "unusedBytes": 750,
@@ -1935,11 +2038,13 @@ Array [
                         Object {
                           "children": Array [
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/model/suggestion.ts",
                               "name": "suggestion.ts?",
                               "resourceBytes": 794,
                               "unusedBytes": 794,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/model/suggestion-store.ts",
                               "name": "suggestion-store.ts?",
                               "resourceBytes": 1545,
                               "unusedBytes": 1545,
@@ -1968,16 +2073,19 @@ Array [
                               "unusedBytes": 247,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/component/search-bar.tsx",
                               "name": "search-bar.tsx?",
                               "resourceBytes": 790,
                               "unusedBytes": 790,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/component/search-widget.tsx",
                               "name": "search-widget.tsx?",
                               "resourceBytes": 12166,
                               "unusedBytes": 12166,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/component/header-search-widget.tsx",
                               "name": "header-search-widget.tsx?",
                               "resourceBytes": 2248,
                               "unusedBytes": 2248,
@@ -1988,6 +2096,7 @@ Array [
                           "unusedBytes": 15853,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/search/widget/app.tsx",
                           "name": "app.tsx?",
                           "resourceBytes": 779,
                           "unusedBytes": 779,
@@ -2002,6 +2111,7 @@ Array [
                         Object {
                           "children": Array [
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/store/filter-actions.ts",
                               "name": "filter-actions.ts?",
                               "resourceBytes": 946,
                               "unusedBytes": 946,
@@ -2013,6 +2123,7 @@ Array [
                               "unusedBytes": 783,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/store/filter-store.ts",
                               "name": "filter-store.ts?",
                               "resourceBytes": 12717,
                               "unusedBytes": 12717,
@@ -2025,16 +2136,19 @@ Array [
                         Object {
                           "children": Array [
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-list.tsx",
                               "name": "autocomplete-list.tsx?",
                               "resourceBytes": 1134,
                               "unusedBytes": 1134,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-filter.tsx",
                               "name": "autocomplete-filter.tsx?",
                               "resourceBytes": 3823,
                               "unusedBytes": 3823,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-filter-with-icon.tsx",
                               "name": "autocomplete-filter-with-icon.tsx?",
                               "resourceBytes": 2696,
                               "unusedBytes": 2696,
@@ -2065,6 +2179,7 @@ Array [
                     Object {
                       "children": Array [
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/utils/service/amplitude-service.ts",
                           "name": "amplitude-service.ts?",
                           "resourceBytes": 1348,
                           "unusedBytes": 1348,
@@ -2075,6 +2190,7 @@ Array [
                           "unusedBytes": 116,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/utils/service/gsa-inmeta-tags.ts",
                           "name": "gsa-inmeta-tags.ts?",
                           "resourceBytes": 591,
                           "unusedBytes": 591,
@@ -2085,11 +2201,13 @@ Array [
                           "unusedBytes": 336,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/utils/service/string-service.ts",
                           "name": "string-service.ts?",
                           "resourceBytes": 738,
                           "unusedBytes": 738,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/utils/service/truncation-service.ts",
                           "name": "truncation-service.ts?",
                           "resourceBytes": 1453,
                           "unusedBytes": 1453,
@@ -2123,11 +2241,13 @@ Array [
                 Object {
                   "children": Array [
                     Object {
+                      "duplicatedNormalizedModuleName": "js/src/hodor/component/column.tsx",
                       "name": "column.tsx?",
                       "resourceBytes": 585,
                       "unusedBytes": 585,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "js/src/hodor/component/grid.tsx",
                       "name": "grid.tsx?",
                       "resourceBytes": 587,
                       "unusedBytes": 587,
@@ -2149,11 +2269,13 @@ Array [
                         Object {
                           "children": Array [
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/user/store/model/user.ts",
                               "name": "user.ts?",
                               "resourceBytes": 1054,
                               "unusedBytes": 1054,
                             },
                             Object {
+                              "duplicatedNormalizedModuleName": "js/src/user/store/model/user-details.ts",
                               "name": "user-details.ts?",
                               "resourceBytes": 11402,
                               "unusedBytes": 11402,
@@ -2164,6 +2286,7 @@ Array [
                           "unusedBytes": 12456,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/user/store/user-store.ts",
                           "name": "user-store.ts?",
                           "resourceBytes": 890,
                           "unusedBytes": 890,
@@ -2226,11 +2349,13 @@ Array [
                     Object {
                       "children": Array [
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/dashboard2018/component/nav-menu.tsx",
                           "name": "nav-menu.tsx?",
                           "resourceBytes": 6906,
                           "unusedBytes": 6906,
                         },
                         Object {
+                          "duplicatedNormalizedModuleName": "js/src/dashboard2018/component/sitewide-dashboard-navigation.tsx",
                           "name": "sitewide-dashboard-navigation.tsx?",
                           "resourceBytes": 1320,
                           "unusedBytes": 1320,
@@ -2302,6 +2427,7 @@ Array [
                   "unusedBytes": 466,
                 },
                 Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/LayoutBundle/Resources/assets/js/Utils.js",
                   "name": "Utils.js",
                   "resourceBytes": 857,
                   "unusedBytes": 857,
@@ -2320,6 +2446,7 @@ Array [
             Object {
               "children": Array [
                 Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/jquery.iframe-transport.js",
                   "name": "jquery.iframe-transport.js",
                   "resourceBytes": 2505,
                   "unusedBytes": 2505,
@@ -2327,6 +2454,7 @@ Array [
                 Object {
                   "children": Array [
                     Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.services.js",
                       "name": "util.common.services.js",
                       "resourceBytes": 784,
                       "unusedBytes": 784,
@@ -2337,21 +2465,25 @@ Array [
                       "unusedBytes": 463,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.store.js",
                       "name": "util.common.store.js",
                       "resourceBytes": 18595,
                       "unusedBytes": 18595,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.api.js",
                       "name": "util.common.api.js",
                       "resourceBytes": 1306,
                       "unusedBytes": 1306,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.notifications.js",
                       "name": "util.common.notifications.js",
                       "resourceBytes": 4684,
                       "unusedBytes": 4684,
                     },
                     Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.locale.js",
                       "name": "util.common.locale.js",
                       "resourceBytes": 9092,
                       "unusedBytes": 9092,
@@ -2386,6 +2518,7 @@ Array [
                   "unusedBytes": 186,
                 },
                 Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/AnalyticsBundle/Resources/assets/js/productThumbnailStats.js",
                   "name": "productThumbnailStats.js",
                   "resourceBytes": 582,
                   "unusedBytes": 582,
@@ -2398,16 +2531,19 @@ Array [
             Object {
               "children": Array [
                 Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/PaymentBundle/Resources/assets/js/Common/payment.common.services.js",
                   "name": "payment.common.services.js",
                   "resourceBytes": 693,
                   "unusedBytes": 693,
                 },
                 Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/PaymentBundle/Resources/assets/js/Common/payment.common.actions.js",
                   "name": "payment.common.actions.js",
                   "resourceBytes": 7165,
                   "unusedBytes": 7165,
                 },
                 Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/PaymentBundle/Resources/assets/js/Common/payment.common.store.js",
                   "name": "payment.common.store.js",
                   "resourceBytes": 3240,
                   "unusedBytes": 3240,
@@ -2425,11 +2561,2605 @@ Array [
                   "unusedBytes": 175,
                 },
                 Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UserBundle/Resources/assets/js/Common/user.common.store.js",
                   "name": "user.common.store.js",
                   "resourceBytes": 4601,
                   "unusedBytes": 4601,
                 },
                 Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UserBundle/Resources/assets/js/Common/user.common.actions.js",
+                  "name": "user.common.actions.js",
+                  "resourceBytes": 5561,
+                  "unusedBytes": 5561,
+                },
+              ],
+              "name": "UserBundle/Resources/assets/js/Common",
+              "resourceBytes": 10337,
+              "unusedBytes": 10337,
+            },
+          ],
+          "name": "Symfony/src/CourseHero",
+          "resourceBytes": 72483,
+          "unusedBytes": 72483,
+        },
+        Object {
+          "children": undefined,
+          "name": "cdn/ajax/libs/angular.js/1.3.20/angular-route.min.js",
+          "resourceBytes": 4247,
+          "unusedBytes": 4247,
+        },
+      ],
+      "name": "coursehero:///",
+      "resourceBytes": 977474,
+      "unusedBytes": 977474,
+    },
+  },
+  Object {
+    "name": "https://courshero.com/script2.js",
+    "node": Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.typeahead.js",
+                      "name": "jquery.typeahead.js",
+                      "resourceBytes": 39282,
+                      "unusedBytes": 39282,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.magnific.popup.js",
+                      "name": "jquery.magnific.popup.js",
+                      "resourceBytes": 29039,
+                      "unusedBytes": 29039,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.owl.carousel.js",
+                      "name": "jquery.owl.carousel.js",
+                      "resourceBytes": 29798,
+                      "unusedBytes": 29798,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.select.js",
+                      "name": "jquery.select.js",
+                      "resourceBytes": 59038,
+                      "unusedBytes": 59038,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/jquery.lazyload.js",
+                      "name": "jquery.lazyload.js",
+                      "resourceBytes": 5178,
+                      "unusedBytes": 5178,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/media-match.js",
+                      "name": "media-match.js",
+                      "resourceBytes": 4673,
+                      "unusedBytes": 4673,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/enquire.min.js",
+                      "name": "enquire.min.js",
+                      "resourceBytes": 2025,
+                      "unusedBytes": 2025,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/lab.js",
+                      "name": "lab.js",
+                      "resourceBytes": 5369,
+                      "unusedBytes": 5369,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/moment.min.js",
+                      "name": "moment.min.js",
+                      "resourceBytes": 34603,
+                      "unusedBytes": 34603,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/angular-moment.min.js",
+                      "name": "angular-moment.min.js",
+                      "resourceBytes": 3968,
+                      "unusedBytes": 3968,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng-infinite-scroll.min.js",
+                      "name": "ng-infinite-scroll.min.js",
+                      "resourceBytes": 814,
+                      "unusedBytes": 814,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/angular.ng-modules.js",
+                      "name": "angular.ng-modules.js",
+                      "resourceBytes": 1486,
+                      "unusedBytes": 1486,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/select/select.js",
+                              "name": "select.js",
+                              "resourceBytes": 48513,
+                              "unusedBytes": 48513,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/select/angular-sanitize.js",
+                              "name": "angular-sanitize.js",
+                              "resourceBytes": 9135,
+                              "unusedBytes": 9135,
+                            },
+                          ],
+                          "name": "select",
+                          "resourceBytes": 57648,
+                          "unusedBytes": 57648,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/angular-smooth-scroll.min.js",
+                          "name": "angular-smooth-scroll.min.js",
+                          "resourceBytes": 2237,
+                          "unusedBytes": 2237,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/ng-file-upload.js",
+                          "name": "ng-file-upload.js",
+                          "resourceBytes": 13362,
+                          "unusedBytes": 13362,
+                        },
+                      ],
+                      "name": "ng",
+                      "resourceBytes": 73247,
+                      "unusedBytes": 73247,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/phoneparser.js",
+                      "name": "phoneparser.js",
+                      "resourceBytes": 22883,
+                      "unusedBytes": 22883,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/sweetalert.js",
+                      "name": "sweetalert.js",
+                      "resourceBytes": 16857,
+                      "unusedBytes": 16857,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/katex.min.js",
+                      "name": "katex.min.js",
+                      "resourceBytes": 228929,
+                      "unusedBytes": 228929,
+                    },
+                  ],
+                  "name": "vendor",
+                  "resourceBytes": 557189,
+                  "unusedBytes": 557189,
+                },
+                Object {
+                  "duplicatedNormalizedModuleName": "Control/assets/js/ch.global.js",
+                  "name": "ch.global.js",
+                  "resourceBytes": 1150,
+                  "unusedBytes": 1150,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/course_hero_mq/course-hero-mq.js",
+                      "name": "course-hero-mq.js",
+                      "resourceBytes": 3420,
+                      "unusedBytes": 3420,
+                    },
+                    Object {
+                      "name": "course-hero-mq-transport.js",
+                      "resourceBytes": 236,
+                      "unusedBytes": 236,
+                    },
+                  ],
+                  "name": "course_hero_mq",
+                  "resourceBytes": 3656,
+                  "unusedBytes": 3656,
+                },
+                Object {
+                  "duplicatedNormalizedModuleName": "Control/assets/js/workForUs.js",
+                  "name": "workForUs.js",
+                  "resourceBytes": 715,
+                  "unusedBytes": 715,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "tag-recording.module.js",
+                      "resourceBytes": 66,
+                      "unusedBytes": 66,
+                    },
+                    Object {
+                      "name": "tag-recording.service.js",
+                      "resourceBytes": 420,
+                      "unusedBytes": 420,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Control/assets/js/ux/tag-recording.directive.js",
+                      "name": "tag-recording.directive.js",
+                      "resourceBytes": 1511,
+                      "unusedBytes": 1511,
+                    },
+                  ],
+                  "name": "ux",
+                  "resourceBytes": 1997,
+                  "unusedBytes": 1997,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "module.js",
+                          "resourceBytes": 60,
+                          "unusedBytes": 60,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/common/qa-validator.service.js",
+                          "name": "qa-validator.service.js",
+                          "resourceBytes": 1322,
+                          "unusedBytes": 1322,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/common/qa-amplitude.service.js",
+                          "name": "qa-amplitude.service.js",
+                          "resourceBytes": 5141,
+                          "unusedBytes": 5141,
+                        },
+                      ],
+                      "name": "common",
+                      "resourceBytes": 6523,
+                      "unusedBytes": 6523,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "module.js",
+                          "resourceBytes": 69,
+                          "unusedBytes": 69,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/qa-category.dataservice.js",
+                          "name": "qa-category.dataservice.js",
+                          "resourceBytes": 596,
+                          "unusedBytes": 596,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/question.dataservice.js",
+                          "name": "question.dataservice.js",
+                          "resourceBytes": 725,
+                          "unusedBytes": 725,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/tutor-questions.dataservice.js",
+                          "name": "tutor-questions.dataservice.js",
+                          "resourceBytes": 739,
+                          "unusedBytes": 739,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/qa-user-discounts.dataservice.js",
+                          "name": "qa-user-discounts.dataservice.js",
+                          "resourceBytes": 679,
+                          "unusedBytes": 679,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/data/question.datastore.js",
+                          "name": "question.datastore.js",
+                          "resourceBytes": 1004,
+                          "unusedBytes": 1004,
+                        },
+                      ],
+                      "name": "data",
+                      "resourceBytes": 3812,
+                      "unusedBytes": 3812,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "module.js",
+                          "resourceBytes": 70,
+                          "unusedBytes": 70,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/widgets/qa-category-autocomplete.directive.js",
+                          "name": "qa-category-autocomplete.directive.js",
+                          "resourceBytes": 973,
+                          "unusedBytes": 973,
+                        },
+                        Object {
+                          "name": "num-online-tutors.directive.js",
+                          "resourceBytes": 239,
+                          "unusedBytes": 239,
+                        },
+                      ],
+                      "name": "widgets",
+                      "resourceBytes": 1282,
+                      "unusedBytes": 1282,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/askAQuestion/module.js",
+                          "name": "module.js",
+                          "resourceBytes": 562,
+                          "unusedBytes": 562,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "Control/assets/js/qa/askAQuestion/ask-a-question.directive.js",
+                          "name": "ask-a-question.directive.js",
+                          "resourceBytes": 14812,
+                          "unusedBytes": 14812,
+                        },
+                      ],
+                      "name": "askAQuestion",
+                      "resourceBytes": 15374,
+                      "unusedBytes": 15374,
+                    },
+                  ],
+                  "name": "qa",
+                  "resourceBytes": 26991,
+                  "unusedBytes": 26991,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "analytics/global_tracking.js",
+                  "resourceBytes": 4531,
+                  "unusedBytes": 4531,
+                },
+              ],
+              "name": "assets/js",
+              "resourceBytes": 596229,
+              "unusedBytes": 596229,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "tracker_pageview.js",
+                  "resourceBytes": 94,
+                  "unusedBytes": 94,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "widgets/product-thumbnail-stats.js",
+                  "resourceBytes": 3768,
+                  "unusedBytes": 3768,
+                },
+              ],
+              "name": "javascript",
+              "resourceBytes": 3862,
+              "unusedBytes": 3862,
+            },
+          ],
+          "name": "Control",
+          "resourceBytes": 600091,
+          "unusedBytes": 600091,
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": undefined,
+              "name": "webpack/bootstrap?",
+              "resourceBytes": 3657,
+              "unusedBytes": 3657,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "_root.js?",
+                      "resourceBytes": 131,
+                      "unusedBytes": 131,
+                    },
+                    Object {
+                      "name": "isObject.js?",
+                      "resourceBytes": 100,
+                      "unusedBytes": 100,
+                    },
+                    Object {
+                      "name": "_getNative.js?",
+                      "resourceBytes": 94,
+                      "unusedBytes": 94,
+                    },
+                    Object {
+                      "name": "isObjectLike.js?",
+                      "resourceBytes": 75,
+                      "unusedBytes": 75,
+                    },
+                    Object {
+                      "name": "_copyObject.js?",
+                      "resourceBytes": 208,
+                      "unusedBytes": 208,
+                    },
+                    Object {
+                      "name": "_baseGetTag.js?",
+                      "resourceBytes": 192,
+                      "unusedBytes": 192,
+                    },
+                    Object {
+                      "name": "isArrayLike.js?",
+                      "resourceBytes": 93,
+                      "unusedBytes": 93,
+                    },
+                    Object {
+                      "name": "eq.js?",
+                      "resourceBytes": 65,
+                      "unusedBytes": 65,
+                    },
+                    Object {
+                      "name": "_isPrototype.js?",
+                      "resourceBytes": 136,
+                      "unusedBytes": 136,
+                    },
+                    Object {
+                      "name": "keys.js?",
+                      "resourceBytes": 87,
+                      "unusedBytes": 87,
+                    },
+                    Object {
+                      "name": "isArray.js?",
+                      "resourceBytes": 49,
+                      "unusedBytes": 49,
+                    },
+                    Object {
+                      "name": "_ListCache.js?",
+                      "resourceBytes": 269,
+                      "unusedBytes": 269,
+                    },
+                    Object {
+                      "name": "_assocIndexOf.js?",
+                      "resourceBytes": 111,
+                      "unusedBytes": 111,
+                    },
+                    Object {
+                      "name": "_nativeCreate.js?",
+                      "resourceBytes": 57,
+                      "unusedBytes": 57,
+                    },
+                    Object {
+                      "name": "_getMapData.js?",
+                      "resourceBytes": 128,
+                      "unusedBytes": 128,
+                    },
+                    Object {
+                      "name": "keysIn.js?",
+                      "resourceBytes": 93,
+                      "unusedBytes": 93,
+                    },
+                    Object {
+                      "name": "_assignValue.js?",
+                      "resourceBytes": 160,
+                      "unusedBytes": 160,
+                    },
+                    Object {
+                      "name": "_baseAssignValue.js?",
+                      "resourceBytes": 140,
+                      "unusedBytes": 140,
+                    },
+                    Object {
+                      "name": "isFunction.js?",
+                      "resourceBytes": 216,
+                      "unusedBytes": 216,
+                    },
+                    Object {
+                      "name": "_Symbol.js?",
+                      "resourceBytes": 57,
+                      "unusedBytes": 57,
+                    },
+                    Object {
+                      "name": "isBuffer.js?",
+                      "resourceBytes": 196,
+                      "unusedBytes": 196,
+                    },
+                    Object {
+                      "name": "_baseUnary.js?",
+                      "resourceBytes": 82,
+                      "unusedBytes": 82,
+                    },
+                    Object {
+                      "name": "_nodeUtil.js?",
+                      "resourceBytes": 276,
+                      "unusedBytes": 276,
+                    },
+                    Object {
+                      "name": "_Map.js?",
+                      "resourceBytes": 52,
+                      "unusedBytes": 52,
+                    },
+                    Object {
+                      "name": "_getSymbols.js?",
+                      "resourceBytes": 212,
+                      "unusedBytes": 212,
+                    },
+                    Object {
+                      "name": "_getPrototype.js?",
+                      "resourceBytes": 71,
+                      "unusedBytes": 71,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash/_getTag.js",
+                      "name": "_getTag.js?",
+                      "resourceBytes": 578,
+                      "unusedBytes": 578,
+                    },
+                    Object {
+                      "name": "_cloneArrayBuffer.js?",
+                      "resourceBytes": 136,
+                      "unusedBytes": 136,
+                    },
+                    Object {
+                      "name": "_defineProperty.js?",
+                      "resourceBytes": 135,
+                      "unusedBytes": 135,
+                    },
+                    Object {
+                      "name": "_freeGlobal.js?",
+                      "resourceBytes": 99,
+                      "unusedBytes": 99,
+                    },
+                    Object {
+                      "name": "_toSource.js?",
+                      "resourceBytes": 153,
+                      "unusedBytes": 153,
+                    },
+                    Object {
+                      "name": "_createAssigner.js?",
+                      "resourceBytes": 289,
+                      "unusedBytes": 289,
+                    },
+                    Object {
+                      "name": "identity.js?",
+                      "resourceBytes": 47,
+                      "unusedBytes": 47,
+                    },
+                    Object {
+                      "name": "isLength.js?",
+                      "resourceBytes": 106,
+                      "unusedBytes": 106,
+                    },
+                    Object {
+                      "name": "_isIndex.js?",
+                      "resourceBytes": 183,
+                      "unusedBytes": 183,
+                    },
+                    Object {
+                      "name": "_arrayLikeKeys.js?",
+                      "resourceBytes": 395,
+                      "unusedBytes": 395,
+                    },
+                    Object {
+                      "name": "isArguments.js?",
+                      "resourceBytes": 215,
+                      "unusedBytes": 215,
+                    },
+                    Object {
+                      "name": "isTypedArray.js?",
+                      "resourceBytes": 86,
+                      "unusedBytes": 86,
+                    },
+                    Object {
+                      "name": "_overArg.js?",
+                      "resourceBytes": 77,
+                      "unusedBytes": 77,
+                    },
+                    Object {
+                      "name": "_Stack.js?",
+                      "resourceBytes": 246,
+                      "unusedBytes": 246,
+                    },
+                    Object {
+                      "name": "_cloneBuffer.js?",
+                      "resourceBytes": 285,
+                      "unusedBytes": 285,
+                    },
+                    Object {
+                      "name": "_copyArray.js?",
+                      "resourceBytes": 106,
+                      "unusedBytes": 106,
+                    },
+                    Object {
+                      "name": "stubArray.js?",
+                      "resourceBytes": 48,
+                      "unusedBytes": 48,
+                    },
+                    Object {
+                      "name": "_getSymbolsIn.js?",
+                      "resourceBytes": 151,
+                      "unusedBytes": 151,
+                    },
+                    Object {
+                      "name": "_arrayPush.js?",
+                      "resourceBytes": 105,
+                      "unusedBytes": 105,
+                    },
+                    Object {
+                      "name": "_baseGetAllKeys.js?",
+                      "resourceBytes": 99,
+                      "unusedBytes": 99,
+                    },
+                    Object {
+                      "name": "_cloneTypedArray.js?",
+                      "resourceBytes": 133,
+                      "unusedBytes": 133,
+                    },
+                    Object {
+                      "name": "_initCloneObject.js?",
+                      "resourceBytes": 124,
+                      "unusedBytes": 124,
+                    },
+                    Object {
+                      "name": "_assignMergeValue.js?",
+                      "resourceBytes": 117,
+                      "unusedBytes": 117,
+                    },
+                    Object {
+                      "name": "_safeGet.js?",
+                      "resourceBytes": 131,
+                      "unusedBytes": 131,
+                    },
+                    Object {
+                      "name": "assign.js?",
+                      "resourceBytes": 202,
+                      "unusedBytes": 202,
+                    },
+                    Object {
+                      "name": "_baseIsNative.js?",
+                      "resourceBytes": 361,
+                      "unusedBytes": 361,
+                    },
+                    Object {
+                      "name": "_getRawTag.js?",
+                      "resourceBytes": 237,
+                      "unusedBytes": 237,
+                    },
+                    Object {
+                      "name": "_objectToString.js?",
+                      "resourceBytes": 89,
+                      "unusedBytes": 89,
+                    },
+                    Object {
+                      "name": "_isMasked.js?",
+                      "resourceBytes": 146,
+                      "unusedBytes": 146,
+                    },
+                    Object {
+                      "name": "_coreJsData.js?",
+                      "resourceBytes": 60,
+                      "unusedBytes": 60,
+                    },
+                    Object {
+                      "name": "_getValue.js?",
+                      "resourceBytes": 69,
+                      "unusedBytes": 69,
+                    },
+                    Object {
+                      "name": "_baseRest.js?",
+                      "resourceBytes": 94,
+                      "unusedBytes": 94,
+                    },
+                    Object {
+                      "name": "_overRest.js?",
+                      "resourceBytes": 260,
+                      "unusedBytes": 260,
+                    },
+                    Object {
+                      "name": "_apply.js?",
+                      "resourceBytes": 207,
+                      "unusedBytes": 207,
+                    },
+                    Object {
+                      "name": "_setToString.js?",
+                      "resourceBytes": 52,
+                      "unusedBytes": 52,
+                    },
+                    Object {
+                      "name": "_baseSetToString.js?",
+                      "resourceBytes": 154,
+                      "unusedBytes": 154,
+                    },
+                    Object {
+                      "name": "constant.js?",
+                      "resourceBytes": 66,
+                      "unusedBytes": 66,
+                    },
+                    Object {
+                      "name": "_shortOut.js?",
+                      "resourceBytes": 201,
+                      "unusedBytes": 201,
+                    },
+                    Object {
+                      "name": "_isIterateeCall.js?",
+                      "resourceBytes": 181,
+                      "unusedBytes": 181,
+                    },
+                    Object {
+                      "name": "_baseTimes.js?",
+                      "resourceBytes": 92,
+                      "unusedBytes": 92,
+                    },
+                    Object {
+                      "name": "_baseIsArguments.js?",
+                      "resourceBytes": 100,
+                      "unusedBytes": 100,
+                    },
+                    Object {
+                      "name": "stubFalse.js?",
+                      "resourceBytes": 48,
+                      "unusedBytes": 48,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash/_baseIsTypedArray.js",
+                      "name": "_baseIsTypedArray.js?",
+                      "resourceBytes": 669,
+                      "unusedBytes": 669,
+                    },
+                    Object {
+                      "name": "_baseKeys.js?",
+                      "resourceBytes": 196,
+                      "unusedBytes": 196,
+                    },
+                    Object {
+                      "name": "_nativeKeys.js?",
+                      "resourceBytes": 61,
+                      "unusedBytes": 61,
+                    },
+                    Object {
+                      "name": "cloneDeepWith.js?",
+                      "resourceBytes": 110,
+                      "unusedBytes": 110,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash/_baseClone.js",
+                      "name": "_baseClone.js?",
+                      "resourceBytes": 1444,
+                      "unusedBytes": 1444,
+                    },
+                    Object {
+                      "name": "_listCacheClear.js?",
+                      "resourceBytes": 68,
+                      "unusedBytes": 68,
+                    },
+                    Object {
+                      "name": "_listCacheDelete.js?",
+                      "resourceBytes": 173,
+                      "unusedBytes": 173,
+                    },
+                    Object {
+                      "name": "_listCacheGet.js?",
+                      "resourceBytes": 107,
+                      "unusedBytes": 107,
+                    },
+                    Object {
+                      "name": "_listCacheHas.js?",
+                      "resourceBytes": 81,
+                      "unusedBytes": 81,
+                    },
+                    Object {
+                      "name": "_listCacheSet.js?",
+                      "resourceBytes": 137,
+                      "unusedBytes": 137,
+                    },
+                    Object {
+                      "name": "_stackClear.js?",
+                      "resourceBytes": 81,
+                      "unusedBytes": 81,
+                    },
+                    Object {
+                      "name": "_stackDelete.js?",
+                      "resourceBytes": 98,
+                      "unusedBytes": 98,
+                    },
+                    Object {
+                      "name": "_stackGet.js?",
+                      "resourceBytes": 66,
+                      "unusedBytes": 66,
+                    },
+                    Object {
+                      "name": "_stackHas.js?",
+                      "resourceBytes": 68,
+                      "unusedBytes": 68,
+                    },
+                    Object {
+                      "name": "_stackSet.js?",
+                      "resourceBytes": 262,
+                      "unusedBytes": 262,
+                    },
+                    Object {
+                      "name": "_MapCache.js?",
+                      "resourceBytes": 273,
+                      "unusedBytes": 273,
+                    },
+                    Object {
+                      "name": "_mapCacheClear.js?",
+                      "resourceBytes": 133,
+                      "unusedBytes": 133,
+                    },
+                    Object {
+                      "name": "_Hash.js?",
+                      "resourceBytes": 272,
+                      "unusedBytes": 272,
+                    },
+                    Object {
+                      "name": "_hashClear.js?",
+                      "resourceBytes": 88,
+                      "unusedBytes": 88,
+                    },
+                    Object {
+                      "name": "_hashDelete.js?",
+                      "resourceBytes": 109,
+                      "unusedBytes": 109,
+                    },
+                    Object {
+                      "name": "_hashGet.js?",
+                      "resourceBytes": 206,
+                      "unusedBytes": 206,
+                    },
+                    Object {
+                      "name": "_hashHas.js?",
+                      "resourceBytes": 141,
+                      "unusedBytes": 141,
+                    },
+                    Object {
+                      "name": "_hashSet.js?",
+                      "resourceBytes": 166,
+                      "unusedBytes": 166,
+                    },
+                    Object {
+                      "name": "_mapCacheDelete.js?",
+                      "resourceBytes": 102,
+                      "unusedBytes": 102,
+                    },
+                    Object {
+                      "name": "_isKeyable.js?",
+                      "resourceBytes": 138,
+                      "unusedBytes": 138,
+                    },
+                    Object {
+                      "name": "_mapCacheGet.js?",
+                      "resourceBytes": 76,
+                      "unusedBytes": 76,
+                    },
+                    Object {
+                      "name": "_mapCacheHas.js?",
+                      "resourceBytes": 76,
+                      "unusedBytes": 76,
+                    },
+                    Object {
+                      "name": "_mapCacheSet.js?",
+                      "resourceBytes": 125,
+                      "unusedBytes": 125,
+                    },
+                    Object {
+                      "name": "_arrayEach.js?",
+                      "resourceBytes": 111,
+                      "unusedBytes": 111,
+                    },
+                    Object {
+                      "name": "_baseAssign.js?",
+                      "resourceBytes": 82,
+                      "unusedBytes": 82,
+                    },
+                    Object {
+                      "name": "_baseAssignIn.js?",
+                      "resourceBytes": 83,
+                      "unusedBytes": 83,
+                    },
+                    Object {
+                      "name": "_baseKeysIn.js?",
+                      "resourceBytes": 207,
+                      "unusedBytes": 207,
+                    },
+                    Object {
+                      "name": "_nativeKeysIn.js?",
+                      "resourceBytes": 102,
+                      "unusedBytes": 102,
+                    },
+                    Object {
+                      "name": "_copySymbols.js?",
+                      "resourceBytes": 78,
+                      "unusedBytes": 78,
+                    },
+                    Object {
+                      "name": "_arrayFilter.js?",
+                      "resourceBytes": 134,
+                      "unusedBytes": 134,
+                    },
+                    Object {
+                      "name": "_copySymbolsIn.js?",
+                      "resourceBytes": 80,
+                      "unusedBytes": 80,
+                    },
+                    Object {
+                      "name": "_getAllKeys.js?",
+                      "resourceBytes": 83,
+                      "unusedBytes": 83,
+                    },
+                    Object {
+                      "name": "_getAllKeysIn.js?",
+                      "resourceBytes": 84,
+                      "unusedBytes": 84,
+                    },
+                    Object {
+                      "name": "_DataView.js?",
+                      "resourceBytes": 57,
+                      "unusedBytes": 57,
+                    },
+                    Object {
+                      "name": "_Promise.js?",
+                      "resourceBytes": 56,
+                      "unusedBytes": 56,
+                    },
+                    Object {
+                      "name": "_Set.js?",
+                      "resourceBytes": 52,
+                      "unusedBytes": 52,
+                    },
+                    Object {
+                      "name": "_WeakMap.js?",
+                      "resourceBytes": 54,
+                      "unusedBytes": 54,
+                    },
+                    Object {
+                      "name": "_initCloneArray.js?",
+                      "resourceBytes": 204,
+                      "unusedBytes": 204,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash/_initCloneByTag.js",
+                      "name": "_initCloneByTag.js?",
+                      "resourceBytes": 806,
+                      "unusedBytes": 806,
+                    },
+                    Object {
+                      "name": "_Uint8Array.js?",
+                      "resourceBytes": 51,
+                      "unusedBytes": 51,
+                    },
+                    Object {
+                      "name": "_cloneDataView.js?",
+                      "resourceBytes": 135,
+                      "unusedBytes": 135,
+                    },
+                    Object {
+                      "name": "_cloneRegExp.js?",
+                      "resourceBytes": 130,
+                      "unusedBytes": 130,
+                    },
+                    Object {
+                      "name": "_cloneSymbol.js?",
+                      "resourceBytes": 126,
+                      "unusedBytes": 126,
+                    },
+                    Object {
+                      "name": "_baseCreate.js?",
+                      "resourceBytes": 195,
+                      "unusedBytes": 195,
+                    },
+                    Object {
+                      "name": "isMap.js?",
+                      "resourceBytes": 82,
+                      "unusedBytes": 82,
+                    },
+                    Object {
+                      "name": "_baseIsMap.js?",
+                      "resourceBytes": 97,
+                      "unusedBytes": 97,
+                    },
+                    Object {
+                      "name": "isSet.js?",
+                      "resourceBytes": 82,
+                      "unusedBytes": 82,
+                    },
+                    Object {
+                      "name": "_baseIsSet.js?",
+                      "resourceBytes": 97,
+                      "unusedBytes": 97,
+                    },
+                    Object {
+                      "name": "merge.js?",
+                      "resourceBytes": 77,
+                      "unusedBytes": 77,
+                    },
+                    Object {
+                      "name": "_baseMerge.js?",
+                      "resourceBytes": 249,
+                      "unusedBytes": 249,
+                    },
+                    Object {
+                      "name": "_baseFor.js?",
+                      "resourceBytes": 42,
+                      "unusedBytes": 42,
+                    },
+                    Object {
+                      "name": "_createBaseFor.js?",
+                      "resourceBytes": 165,
+                      "unusedBytes": 165,
+                    },
+                    Object {
+                      "name": "_baseMergeDeep.js?",
+                      "resourceBytes": 502,
+                      "unusedBytes": 502,
+                    },
+                    Object {
+                      "name": "isArrayLikeObject.js?",
+                      "resourceBytes": 76,
+                      "unusedBytes": 76,
+                    },
+                    Object {
+                      "name": "isPlainObject.js?",
+                      "resourceBytes": 336,
+                      "unusedBytes": 336,
+                    },
+                    Object {
+                      "name": "toPlainObject.js?",
+                      "resourceBytes": 89,
+                      "unusedBytes": 89,
+                    },
+                  ],
+                  "name": "lodash",
+                  "resourceBytes": 20343,
+                  "unusedBytes": 20343,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "extend/index.js?",
+                  "resourceBytes": 829,
+                  "unusedBytes": 829,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": undefined,
+                          "name": "component/config.js?",
+                          "resourceBytes": 354,
+                          "unusedBytes": 354,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "decorators/route-decorator.js?",
+                          "resourceBytes": 490,
+                          "unusedBytes": 490,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/routing/routing-service.js",
+                          "name": "routing-service.js?",
+                          "resourceBytes": 1677,
+                          "unusedBytes": 1677,
+                        },
+                      ],
+                      "name": "routing",
+                      "resourceBytes": 2521,
+                      "unusedBytes": 2521,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/store/store.js",
+                          "name": "store.js?",
+                          "resourceBytes": 8120,
+                          "unusedBytes": 8120,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/store/store-decorator.js",
+                          "name": "store-decorator.js?",
+                          "resourceBytes": 1337,
+                          "unusedBytes": 1337,
+                        },
+                      ],
+                      "name": "store",
+                      "resourceBytes": 9457,
+                      "unusedBytes": 9457,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "beef.js?",
+                          "resourceBytes": 361,
+                          "unusedBytes": 361,
+                        },
+                        Object {
+                          "name": "model.js?",
+                          "resourceBytes": 169,
+                          "unusedBytes": 169,
+                        },
+                      ],
+                      "name": "core",
+                      "resourceBytes": 530,
+                      "unusedBytes": 530,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "api/api-service.js?",
+                      "resourceBytes": 1284,
+                      "unusedBytes": 1284,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "action/actions.js?",
+                      "resourceBytes": 1486,
+                      "unusedBytes": 1486,
+                    },
+                  ],
+                  "name": "beef-flux/build",
+                  "resourceBytes": 15278,
+                  "unusedBytes": 15278,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "reqwest/reqwest.js?",
+                  "resourceBytes": 9799,
+                  "unusedBytes": 9799,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "classCallCheck.js?",
+                      "resourceBytes": 358,
+                      "unusedBytes": 358,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/createClass.js",
+                      "name": "createClass.js?",
+                      "resourceBytes": 799,
+                      "unusedBytes": 799,
+                    },
+                    Object {
+                      "name": "assertThisInitialized.js?",
+                      "resourceBytes": 294,
+                      "unusedBytes": 294,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/applyDecoratedDescriptor.js",
+                      "name": "applyDecoratedDescriptor.js?",
+                      "resourceBytes": 892,
+                      "unusedBytes": 892,
+                    },
+                    Object {
+                      "name": "initializerDefineProperty.js?",
+                      "resourceBytes": 394,
+                      "unusedBytes": 394,
+                    },
+                    Object {
+                      "name": "possibleConstructorReturn.js?",
+                      "resourceBytes": 228,
+                      "unusedBytes": 228,
+                    },
+                    Object {
+                      "name": "getPrototypeOf.js?",
+                      "resourceBytes": 338,
+                      "unusedBytes": 338,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/inherits.js",
+                      "name": "inherits.js?",
+                      "resourceBytes": 528,
+                      "unusedBytes": 528,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/initializerWarningHelper.js",
+                      "name": "initializerWarningHelper.js?",
+                      "resourceBytes": 594,
+                      "unusedBytes": 594,
+                    },
+                    Object {
+                      "name": "defineProperty.js?",
+                      "resourceBytes": 288,
+                      "unusedBytes": 288,
+                    },
+                    Object {
+                      "name": "extends.js?",
+                      "resourceBytes": 490,
+                      "unusedBytes": 490,
+                    },
+                    Object {
+                      "name": "toConsumableArray.js?",
+                      "resourceBytes": 89,
+                      "unusedBytes": 89,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/@babel/runtime/helpers/typeof.js",
+                      "name": "typeof.js?",
+                      "resourceBytes": 992,
+                      "unusedBytes": 992,
+                    },
+                    Object {
+                      "name": "setPrototypeOf.js?",
+                      "resourceBytes": 260,
+                      "unusedBytes": 260,
+                    },
+                    Object {
+                      "name": "arrayWithoutHoles.js?",
+                      "resourceBytes": 128,
+                      "unusedBytes": 128,
+                    },
+                    Object {
+                      "name": "iterableToArray.js?",
+                      "resourceBytes": 149,
+                      "unusedBytes": 149,
+                    },
+                    Object {
+                      "name": "nonIterableSpread.js?",
+                      "resourceBytes": 108,
+                      "unusedBytes": 108,
+                    },
+                  ],
+                  "name": "@babel/runtime/helpers",
+                  "resourceBytes": 6929,
+                  "unusedBytes": 6929,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/util/util.js",
+                      "name": "util.js?",
+                      "resourceBytes": 7644,
+                      "unusedBytes": 7644,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "support/isBufferBrowser.js?",
+                      "resourceBytes": 153,
+                      "unusedBytes": 153,
+                    },
+                  ],
+                  "name": "node-libs-browser/node_modules/util",
+                  "resourceBytes": 7797,
+                  "unusedBytes": 7797,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "process/browser.js?",
+                  "resourceBytes": 1675,
+                  "unusedBytes": 1675,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "inherits/inherits_browser.js?",
+                  "resourceBytes": 338,
+                  "unusedBytes": 338,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "name": "_freeGlobal.js?",
+                      "resourceBytes": 93,
+                      "unusedBytes": 93,
+                    },
+                    Object {
+                      "name": "_baseClamp.js?",
+                      "resourceBytes": 98,
+                      "unusedBytes": 98,
+                    },
+                    Object {
+                      "name": "_root.js?",
+                      "resourceBytes": 93,
+                      "unusedBytes": 93,
+                    },
+                    Object {
+                      "name": "_Symbol.js?",
+                      "resourceBytes": 10,
+                      "unusedBytes": 10,
+                    },
+                    Object {
+                      "name": "_arrayMap.js?",
+                      "resourceBytes": 99,
+                      "unusedBytes": 99,
+                    },
+                    Object {
+                      "name": "isArray.js?",
+                      "resourceBytes": 16,
+                      "unusedBytes": 16,
+                    },
+                    Object {
+                      "name": "_getRawTag.js?",
+                      "resourceBytes": 206,
+                      "unusedBytes": 206,
+                    },
+                    Object {
+                      "name": "_objectToString.js?",
+                      "resourceBytes": 64,
+                      "unusedBytes": 64,
+                    },
+                    Object {
+                      "name": "_baseGetTag.js?",
+                      "resourceBytes": 143,
+                      "unusedBytes": 143,
+                    },
+                    Object {
+                      "name": "isObjectLike.js?",
+                      "resourceBytes": 54,
+                      "unusedBytes": 54,
+                    },
+                    Object {
+                      "name": "isSymbol.js?",
+                      "resourceBytes": 79,
+                      "unusedBytes": 79,
+                    },
+                    Object {
+                      "name": "_baseToString.js?",
+                      "resourceBytes": 198,
+                      "unusedBytes": 198,
+                    },
+                    Object {
+                      "name": "isObject.js?",
+                      "resourceBytes": 79,
+                      "unusedBytes": 79,
+                    },
+                    Object {
+                      "name": "toNumber.js?",
+                      "resourceBytes": 354,
+                      "unusedBytes": 354,
+                    },
+                    Object {
+                      "name": "toFinite.js?",
+                      "resourceBytes": 117,
+                      "unusedBytes": 117,
+                    },
+                    Object {
+                      "name": "toInteger.js?",
+                      "resourceBytes": 60,
+                      "unusedBytes": 60,
+                    },
+                    Object {
+                      "name": "toString.js?",
+                      "resourceBytes": 43,
+                      "unusedBytes": 43,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "node_modules/lodash-es/startsWith.js",
+                      "name": "startsWith.js?",
+                      "resourceBytes": 683,
+                      "unusedBytes": 683,
+                    },
+                  ],
+                  "name": "lodash-es",
+                  "resourceBytes": 2489,
+                  "unusedBytes": 2489,
+                },
+              ],
+              "name": "node_modules",
+              "resourceBytes": 65477,
+              "unusedBytes": 65477,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "module.js?",
+                  "resourceBytes": 302,
+                  "unusedBytes": 302,
+                },
+                Object {
+                  "name": "global.js?",
+                  "resourceBytes": 429,
+                  "unusedBytes": 429,
+                },
+              ],
+              "name": "(webpack)/buildin",
+              "resourceBytes": 731,
+              "unusedBytes": 731,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "children": undefined,
+                  "name": "shims/beef-shims.ts?",
+                  "resourceBytes": 74,
+                  "unusedBytes": 74,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "duplicatedNormalizedModuleName": "js/src/layout/header/dashboard-bridge.ts",
+                      "name": "dashboard-bridge.ts?",
+                      "resourceBytes": 1647,
+                      "unusedBytes": 1647,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "js/src/layout/header/library.ts",
+                      "name": "library.ts?",
+                      "resourceBytes": 999,
+                      "unusedBytes": 999,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "js/src/layout/header/header.ts",
+                      "name": "header.ts?",
+                      "resourceBytes": 3860,
+                      "unusedBytes": 3860,
+                    },
+                    Object {
+                      "name": "header-entry.ts?",
+                      "resourceBytes": 12,
+                      "unusedBytes": 12,
+                    },
+                  ],
+                  "name": "layout/header",
+                  "resourceBytes": 6518,
+                  "unusedBytes": 6518,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": undefined,
+                      "name": "helper/scroll-helper.ts?",
+                      "resourceBytes": 340,
+                      "unusedBytes": 340,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "new-marker.scss?",
+                              "resourceBytes": 76,
+                              "unusedBytes": 76,
+                            },
+                            Object {
+                              "name": "index.tsx?",
+                              "resourceBytes": 132,
+                              "unusedBytes": 132,
+                            },
+                          ],
+                          "name": "new-marker",
+                          "resourceBytes": 208,
+                          "unusedBytes": 208,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "button/button.tsx?",
+                          "resourceBytes": 1216,
+                          "unusedBytes": 1216,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/school-search.tsx",
+                          "name": "school-search.tsx?",
+                          "resourceBytes": 5316,
+                          "unusedBytes": 5316,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/checkbox.tsx",
+                          "name": "checkbox.tsx?",
+                          "resourceBytes": 1194,
+                          "unusedBytes": 1194,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/common/component/search/abstract-taxonomy-search.tsx",
+                              "name": "abstract-taxonomy-search.tsx?",
+                              "resourceBytes": 3103,
+                              "unusedBytes": 3103,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/common/component/search/course-search.tsx",
+                              "name": "course-search.tsx?",
+                              "resourceBytes": 544,
+                              "unusedBytes": 544,
+                            },
+                            Object {
+                              "name": "subject-search.tsx?",
+                              "resourceBytes": 460,
+                              "unusedBytes": 460,
+                            },
+                          ],
+                          "name": "search",
+                          "resourceBytes": 4107,
+                          "unusedBytes": 4107,
+                        },
+                        Object {
+                          "name": "list.tsx?",
+                          "resourceBytes": 496,
+                          "unusedBytes": 496,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/thumbnail.tsx",
+                          "name": "thumbnail.tsx?",
+                          "resourceBytes": 921,
+                          "unusedBytes": 921,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/content-item.tsx",
+                          "name": "content-item.tsx?",
+                          "resourceBytes": 2717,
+                          "unusedBytes": 2717,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/generic-content-item.tsx",
+                          "name": "generic-content-item.tsx?",
+                          "resourceBytes": 2753,
+                          "unusedBytes": 2753,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/pagination.tsx",
+                          "name": "pagination.tsx?",
+                          "resourceBytes": 1463,
+                          "unusedBytes": 1463,
+                        },
+                        Object {
+                          "name": "content-item-loader.tsx?",
+                          "resourceBytes": 275,
+                          "unusedBytes": 275,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/component/hodor-dropdown.tsx",
+                          "name": "hodor-dropdown.tsx?",
+                          "resourceBytes": 1969,
+                          "unusedBytes": 1969,
+                        },
+                        Object {
+                          "name": "action-dropdown.tsx?",
+                          "resourceBytes": 358,
+                          "unusedBytes": 358,
+                        },
+                      ],
+                      "name": "component",
+                      "resourceBytes": 22993,
+                      "unusedBytes": 22993,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/constants/breakpoints.ts",
+                          "name": "breakpoints.ts?",
+                          "resourceBytes": 1248,
+                          "unusedBytes": 1248,
+                        },
+                        Object {
+                          "name": "image-urls.ts?",
+                          "resourceBytes": 326,
+                          "unusedBytes": 326,
+                        },
+                      ],
+                      "name": "constants",
+                      "resourceBytes": 1574,
+                      "unusedBytes": 1574,
+                    },
+                    Object {
+                      "name": "base-component.ts?",
+                      "resourceBytes": 459,
+                      "unusedBytes": 459,
+                    },
+                    Object {
+                      "name": "base-model.ts?",
+                      "resourceBytes": 246,
+                      "unusedBytes": 246,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "name": "throttle.ts?",
+                          "resourceBytes": 251,
+                          "unusedBytes": 251,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/decorators/store.ts",
+                          "name": "store.ts?",
+                          "resourceBytes": 793,
+                          "unusedBytes": 793,
+                        },
+                      ],
+                      "name": "decorators",
+                      "resourceBytes": 1044,
+                      "unusedBytes": 1044,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "input/keycode.ts?",
+                      "resourceBytes": 237,
+                      "unusedBytes": 237,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/content/constant/content-types.ts",
+                          "name": "content-types.ts?",
+                          "resourceBytes": 1340,
+                          "unusedBytes": 1340,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/content/constant/content-view-types.ts",
+                          "name": "content-view-types.ts?",
+                          "resourceBytes": 694,
+                          "unusedBytes": 694,
+                        },
+                      ],
+                      "name": "content/constant",
+                      "resourceBytes": 2034,
+                      "unusedBytes": 2034,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "service/content-item-service.ts?",
+                      "resourceBytes": 1480,
+                      "unusedBytes": 1480,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "actions/content-actions.ts?",
+                      "resourceBytes": 918,
+                      "unusedBytes": 918,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": undefined,
+                          "name": "model/content.ts?",
+                          "resourceBytes": 7682,
+                          "unusedBytes": 7682,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/common/store/content-store.ts",
+                          "name": "content-store.ts?",
+                          "resourceBytes": 19482,
+                          "unusedBytes": 19482,
+                        },
+                      ],
+                      "name": "store",
+                      "resourceBytes": 27164,
+                      "unusedBytes": 27164,
+                    },
+                  ],
+                  "name": "common",
+                  "resourceBytes": 58489,
+                  "unusedBytes": 58489,
+                },
+                Object {
+                  "name": "bootstrap.ts?",
+                  "resourceBytes": 78,
+                  "unusedBytes": 78,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "sort-option.ts?",
+                              "resourceBytes": 242,
+                              "unusedBytes": 242,
+                            },
+                            Object {
+                              "name": "error.ts?",
+                              "resourceBytes": 501,
+                              "unusedBytes": 501,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/course-school-combo.ts",
+                              "name": "course-school-combo.ts?",
+                              "resourceBytes": 1250,
+                              "unusedBytes": 1250,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/subject-data.ts",
+                              "name": "subject-data.ts?",
+                              "resourceBytes": 1056,
+                              "unusedBytes": 1056,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/filter-data.ts",
+                              "name": "filter-data.ts?",
+                              "resourceBytes": 996,
+                              "unusedBytes": 996,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/location.ts",
+                              "name": "location.ts?",
+                              "resourceBytes": 1078,
+                              "unusedBytes": 1078,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/api-metadata.ts",
+                              "name": "api-metadata.ts?",
+                              "resourceBytes": 2082,
+                              "unusedBytes": 2082,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/filter-option.ts",
+                              "name": "filter-option.ts?",
+                              "resourceBytes": 1034,
+                              "unusedBytes": 1034,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/filter.ts",
+                              "name": "filter.ts?",
+                              "resourceBytes": 863,
+                              "unusedBytes": 863,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/options-data.ts",
+                              "name": "options-data.ts?",
+                              "resourceBytes": 622,
+                              "unusedBytes": 622,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/core-result-data.ts",
+                              "name": "core-result-data.ts?",
+                              "resourceBytes": 1081,
+                              "unusedBytes": 1081,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/document-data.ts",
+                              "name": "document-data.ts?",
+                              "resourceBytes": 525,
+                              "unusedBytes": 525,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/question-data.ts",
+                              "name": "question-data.ts?",
+                              "resourceBytes": 531,
+                              "unusedBytes": 531,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/course-study-guide-data.ts",
+                              "name": "course-study-guide-data.ts?",
+                              "resourceBytes": 527,
+                              "unusedBytes": 527,
+                            },
+                            Object {
+                              "name": "lit-study-guide-data.ts?",
+                              "resourceBytes": 391,
+                              "unusedBytes": 391,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/course-resource-data.ts",
+                              "name": "course-resource-data.ts?",
+                              "resourceBytes": 1304,
+                              "unusedBytes": 1304,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/course-data.ts",
+                              "name": "course-data.ts?",
+                              "resourceBytes": 1680,
+                              "unusedBytes": 1680,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/dept-data.ts",
+                              "name": "dept-data.ts?",
+                              "resourceBytes": 1342,
+                              "unusedBytes": 1342,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/school-data.ts",
+                              "name": "school-data.ts?",
+                              "resourceBytes": 1366,
+                              "unusedBytes": 1366,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/taxonomy-data.ts",
+                              "name": "taxonomy-data.ts?",
+                              "resourceBytes": 2612,
+                              "unusedBytes": 2612,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/thumbnail-data.ts",
+                              "name": "thumbnail-data.ts?",
+                              "resourceBytes": 522,
+                              "unusedBytes": 522,
+                            },
+                            Object {
+                              "name": "study-guide-video-data.ts?",
+                              "resourceBytes": 371,
+                              "unusedBytes": 371,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-data.ts",
+                              "name": "textbook-data.ts?",
+                              "resourceBytes": 2856,
+                              "unusedBytes": 2856,
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-exercise/chapter-data.ts",
+                                  "name": "chapter-data.ts?",
+                                  "resourceBytes": 728,
+                                  "unusedBytes": 728,
+                                },
+                                Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-exercise/section-data.ts",
+                                  "name": "section-data.ts?",
+                                  "resourceBytes": 1016,
+                                  "unusedBytes": 1016,
+                                },
+                                Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-exercise/heading-data.ts",
+                                  "name": "heading-data.ts?",
+                                  "resourceBytes": 736,
+                                  "unusedBytes": 736,
+                                },
+                              ],
+                              "name": "textbook-exercise",
+                              "resourceBytes": 2480,
+                              "unusedBytes": 2480,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/textbook-exercise-data.ts",
+                              "name": "textbook-exercise-data.ts?",
+                              "resourceBytes": 3470,
+                              "unusedBytes": 3470,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-result.ts",
+                              "name": "search-result.ts?",
+                              "resourceBytes": 2844,
+                              "unusedBytes": 2844,
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "name": "textbook-callout-chapter.ts?",
+                                  "resourceBytes": 506,
+                                  "unusedBytes": 506,
+                                },
+                                Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/model/callout/textbook-callout-data.ts",
+                                  "name": "textbook-callout-data.ts?",
+                                  "resourceBytes": 1721,
+                                  "unusedBytes": 1721,
+                                },
+                              ],
+                              "name": "callout",
+                              "resourceBytes": 2227,
+                              "unusedBytes": 2227,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-callout.ts",
+                              "name": "search-callout.ts?",
+                              "resourceBytes": 568,
+                              "unusedBytes": 568,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/api-response.ts",
+                              "name": "api-response.ts?",
+                              "resourceBytes": 1268,
+                              "unusedBytes": 1268,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-request.ts",
+                              "name": "search-request.ts?",
+                              "resourceBytes": 2885,
+                              "unusedBytes": 2885,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/suggestion-data.ts",
+                              "name": "suggestion-data.ts?",
+                              "resourceBytes": 1052,
+                              "unusedBytes": 1052,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-result-type.ts",
+                              "name": "search-result-type.ts?",
+                              "resourceBytes": 908,
+                              "unusedBytes": 908,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/model/search-store.ts",
+                              "name": "search-store.ts?",
+                              "resourceBytes": 1309,
+                              "unusedBytes": 1309,
+                            },
+                            Object {
+                              "name": "filter-type.ts?",
+                              "resourceBytes": 98,
+                              "unusedBytes": 98,
+                            },
+                          ],
+                          "name": "model",
+                          "resourceBytes": 43941,
+                          "unusedBytes": 43941,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "actions/search-actions.ts?",
+                          "resourceBytes": 108,
+                          "unusedBytes": 108,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/ask-question-callout.tsx",
+                              "name": "ask-question-callout.tsx?",
+                              "resourceBytes": 1185,
+                              "unusedBytes": 1185,
+                            },
+                            Object {
+                              "name": "error-page.tsx?",
+                              "resourceBytes": 274,
+                              "unusedBytes": 274,
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/component/filters/multi-select.tsx",
+                                  "name": "multi-select.tsx?",
+                                  "resourceBytes": 2946,
+                                  "unusedBytes": 2946,
+                                },
+                                Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/component/filters/filter-drop-down.tsx",
+                                  "name": "filter-drop-down.tsx?",
+                                  "resourceBytes": 4546,
+                                  "unusedBytes": 4546,
+                                },
+                                Object {
+                                  "duplicatedNormalizedModuleName": "js/src/search/2018/component/filters/top-filter-controls.tsx",
+                                  "name": "top-filter-controls.tsx?",
+                                  "resourceBytes": 3590,
+                                  "unusedBytes": 3590,
+                                },
+                              ],
+                              "name": "filters",
+                              "resourceBytes": 11082,
+                              "unusedBytes": 11082,
+                            },
+                            Object {
+                              "name": "pill-list.tsx?",
+                              "resourceBytes": 293,
+                              "unusedBytes": 293,
+                            },
+                            Object {
+                              "name": "geo-info.tsx?",
+                              "resourceBytes": 284,
+                              "unusedBytes": 284,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/query-details.tsx",
+                              "name": "query-details.tsx?",
+                              "resourceBytes": 647,
+                              "unusedBytes": 647,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/no-results.tsx",
+                              "name": "no-results.tsx?",
+                              "resourceBytes": 765,
+                              "unusedBytes": 765,
+                            },
+                            Object {
+                              "name": "textbook-copyright.tsx?",
+                              "resourceBytes": 394,
+                              "unusedBytes": 394,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/textbook-callout.tsx",
+                              "name": "textbook-callout.tsx?",
+                              "resourceBytes": 2473,
+                              "unusedBytes": 2473,
+                            },
+                            Object {
+                              "name": "callout.tsx?",
+                              "resourceBytes": 165,
+                              "unusedBytes": 165,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/2018/component/search-result-container.tsx",
+                              "name": "search-result-container.tsx?",
+                              "resourceBytes": 750,
+                              "unusedBytes": 750,
+                            },
+                            Object {
+                              "name": "filter-controls.tsx?",
+                              "resourceBytes": 72,
+                              "unusedBytes": 72,
+                            },
+                          ],
+                          "name": "component",
+                          "resourceBytes": 18384,
+                          "unusedBytes": 18384,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "search-result-title.ts?",
+                              "resourceBytes": 147,
+                              "unusedBytes": 147,
+                            },
+                            Object {
+                              "name": "result-stat-values.ts?",
+                              "resourceBytes": 168,
+                              "unusedBytes": 168,
+                            },
+                            Object {
+                              "name": "search-trigger.ts?",
+                              "resourceBytes": 286,
+                              "unusedBytes": 286,
+                            },
+                            Object {
+                              "name": "search-view.ts?",
+                              "resourceBytes": 108,
+                              "unusedBytes": 108,
+                            },
+                            Object {
+                              "name": "callout-types.ts?",
+                              "resourceBytes": 467,
+                              "unusedBytes": 467,
+                            },
+                          ],
+                          "name": "constant",
+                          "resourceBytes": 1176,
+                          "unusedBytes": 1176,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "service/search-api.ts?",
+                          "resourceBytes": 177,
+                          "unusedBytes": 177,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "app/search-results.tsx?",
+                          "resourceBytes": 11160,
+                          "unusedBytes": 11160,
+                        },
+                      ],
+                      "name": "2018",
+                      "resourceBytes": 74946,
+                      "unusedBytes": 74946,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "events.ts?",
+                              "resourceBytes": 44,
+                              "unusedBytes": 44,
+                            },
+                            Object {
+                              "name": "search-widget-types.ts?",
+                              "resourceBytes": 113,
+                              "unusedBytes": 113,
+                            },
+                          ],
+                          "name": "constants",
+                          "resourceBytes": 157,
+                          "unusedBytes": 157,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "actions/suggestion-actions.ts?",
+                          "resourceBytes": 90,
+                          "unusedBytes": 90,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/model/suggestion.ts",
+                              "name": "suggestion.ts?",
+                              "resourceBytes": 794,
+                              "unusedBytes": 794,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/model/suggestion-store.ts",
+                              "name": "suggestion-store.ts?",
+                              "resourceBytes": 1545,
+                              "unusedBytes": 1545,
+                            },
+                          ],
+                          "name": "model",
+                          "resourceBytes": 2339,
+                          "unusedBytes": 2339,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "service/api/autocomplete-api-service.ts?",
+                          "resourceBytes": 380,
+                          "unusedBytes": 380,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "name": "suggestion-list.tsx?",
+                              "resourceBytes": 402,
+                              "unusedBytes": 402,
+                            },
+                            Object {
+                              "name": "suggestions.tsx?",
+                              "resourceBytes": 247,
+                              "unusedBytes": 247,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/component/search-bar.tsx",
+                              "name": "search-bar.tsx?",
+                              "resourceBytes": 790,
+                              "unusedBytes": 790,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/component/search-widget.tsx",
+                              "name": "search-widget.tsx?",
+                              "resourceBytes": 12166,
+                              "unusedBytes": 12166,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/widget/component/header-search-widget.tsx",
+                              "name": "header-search-widget.tsx?",
+                              "resourceBytes": 2248,
+                              "unusedBytes": 2248,
+                            },
+                          ],
+                          "name": "component",
+                          "resourceBytes": 15853,
+                          "unusedBytes": 15853,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/search/widget/app.tsx",
+                          "name": "app.tsx?",
+                          "resourceBytes": 779,
+                          "unusedBytes": 779,
+                        },
+                      ],
+                      "name": "widget",
+                      "resourceBytes": 19598,
+                      "unusedBytes": 19598,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/store/filter-actions.ts",
+                              "name": "filter-actions.ts?",
+                              "resourceBytes": 946,
+                              "unusedBytes": 946,
+                            },
+                            Object {
+                              "children": undefined,
+                              "name": "item/resource-types.ts?",
+                              "resourceBytes": 783,
+                              "unusedBytes": 783,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/store/filter-store.ts",
+                              "name": "filter-store.ts?",
+                              "resourceBytes": 12717,
+                              "unusedBytes": 12717,
+                            },
+                          ],
+                          "name": "store",
+                          "resourceBytes": 14446,
+                          "unusedBytes": 14446,
+                        },
+                        Object {
+                          "children": Array [
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-list.tsx",
+                              "name": "autocomplete-list.tsx?",
+                              "resourceBytes": 1134,
+                              "unusedBytes": 1134,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-filter.tsx",
+                              "name": "autocomplete-filter.tsx?",
+                              "resourceBytes": 3823,
+                              "unusedBytes": 3823,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-filter-with-icon.tsx",
+                              "name": "autocomplete-filter-with-icon.tsx?",
+                              "resourceBytes": 2696,
+                              "unusedBytes": 2696,
+                            },
+                          ],
+                          "name": "view/filter",
+                          "resourceBytes": 7653,
+                          "unusedBytes": 7653,
+                        },
+                        Object {
+                          "children": undefined,
+                          "name": "service/api/filter-api-service.ts?",
+                          "resourceBytes": 554,
+                          "unusedBytes": 554,
+                        },
+                      ],
+                      "name": "results",
+                      "resourceBytes": 22653,
+                      "unusedBytes": 22653,
+                    },
+                  ],
+                  "name": "search",
+                  "resourceBytes": 117197,
+                  "unusedBytes": 117197,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/utils/service/amplitude-service.ts",
+                          "name": "amplitude-service.ts?",
+                          "resourceBytes": 1348,
+                          "unusedBytes": 1348,
+                        },
+                        Object {
+                          "name": "api-service.ts?",
+                          "resourceBytes": 116,
+                          "unusedBytes": 116,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/utils/service/gsa-inmeta-tags.ts",
+                          "name": "gsa-inmeta-tags.ts?",
+                          "resourceBytes": 591,
+                          "unusedBytes": 591,
+                        },
+                        Object {
+                          "name": "global-service.ts?",
+                          "resourceBytes": 336,
+                          "unusedBytes": 336,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/utils/service/string-service.ts",
+                          "name": "string-service.ts?",
+                          "resourceBytes": 738,
+                          "unusedBytes": 738,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/utils/service/truncation-service.ts",
+                          "name": "truncation-service.ts?",
+                          "resourceBytes": 1453,
+                          "unusedBytes": 1453,
+                        },
+                      ],
+                      "name": "service",
+                      "resourceBytes": 4582,
+                      "unusedBytes": 4582,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "helpers/classname.ts?",
+                      "resourceBytes": 75,
+                      "unusedBytes": 75,
+                    },
+                    Object {
+                      "name": "track.ts?",
+                      "resourceBytes": 138,
+                      "unusedBytes": 138,
+                    },
+                  ],
+                  "name": "utils",
+                  "resourceBytes": 4795,
+                  "unusedBytes": 4795,
+                },
+                Object {
+                  "name": "aged-beef.ts?",
+                  "resourceBytes": 213,
+                  "unusedBytes": 213,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "duplicatedNormalizedModuleName": "js/src/hodor/component/column.tsx",
+                      "name": "column.tsx?",
+                      "resourceBytes": 585,
+                      "unusedBytes": 585,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "js/src/hodor/component/grid.tsx",
+                      "name": "grid.tsx?",
+                      "resourceBytes": 587,
+                      "unusedBytes": 587,
+                    },
+                    Object {
+                      "name": "well.tsx?",
+                      "resourceBytes": 148,
+                      "unusedBytes": 148,
+                    },
+                  ],
+                  "name": "hodor/component",
+                  "resourceBytes": 1320,
+                  "unusedBytes": 1320,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "children": Array [
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/user/store/model/user.ts",
+                              "name": "user.ts?",
+                              "resourceBytes": 1054,
+                              "unusedBytes": 1054,
+                            },
+                            Object {
+                              "duplicatedNormalizedModuleName": "js/src/user/store/model/user-details.ts",
+                              "name": "user-details.ts?",
+                              "resourceBytes": 11402,
+                              "unusedBytes": 11402,
+                            },
+                          ],
+                          "name": "model",
+                          "resourceBytes": 12456,
+                          "unusedBytes": 12456,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/user/store/user-store.ts",
+                          "name": "user-store.ts?",
+                          "resourceBytes": 890,
+                          "unusedBytes": 890,
+                        },
+                      ],
+                      "name": "store",
+                      "resourceBytes": 13346,
+                      "unusedBytes": 13346,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "actions/user-actions.ts?",
+                      "resourceBytes": 306,
+                      "unusedBytes": 306,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "service/api/user-api-service.ts?",
+                      "resourceBytes": 1451,
+                      "unusedBytes": 1451,
+                    },
+                  ],
+                  "name": "user",
+                  "resourceBytes": 15103,
+                  "unusedBytes": 15103,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": undefined,
+                      "name": "constant/upload-statuses.ts?",
+                      "resourceBytes": 3528,
+                      "unusedBytes": 3528,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "service/document-upload-service.ts?",
+                      "resourceBytes": 1356,
+                      "unusedBytes": 1356,
+                    },
+                  ],
+                  "name": "document/common",
+                  "resourceBytes": 4884,
+                  "unusedBytes": 4884,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": undefined,
+                      "name": "utils/amplitudeHelpers.ts?",
+                      "resourceBytes": 723,
+                      "unusedBytes": 723,
+                    },
+                    Object {
+                      "children": undefined,
+                      "name": "constant/course-actions.ts?",
+                      "resourceBytes": 86,
+                      "unusedBytes": 86,
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/dashboard2018/component/nav-menu.tsx",
+                          "name": "nav-menu.tsx?",
+                          "resourceBytes": 6906,
+                          "unusedBytes": 6906,
+                        },
+                        Object {
+                          "duplicatedNormalizedModuleName": "js/src/dashboard2018/component/sitewide-dashboard-navigation.tsx",
+                          "name": "sitewide-dashboard-navigation.tsx?",
+                          "resourceBytes": 1320,
+                          "unusedBytes": 1320,
+                        },
+                      ],
+                      "name": "component",
+                      "resourceBytes": 8226,
+                      "unusedBytes": 8226,
+                    },
+                    Object {
+                      "name": "dashboard-navbar-app.tsx?",
+                      "resourceBytes": 311,
+                      "unusedBytes": 311,
+                    },
+                  ],
+                  "name": "dashboard2018",
+                  "resourceBytes": 9346,
+                  "unusedBytes": 9346,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "taxonomy/service/course-api-service.ts?",
+                  "resourceBytes": 465,
+                  "unusedBytes": 465,
+                },
+              ],
+              "name": "src",
+              "resourceBytes": 218482,
+              "unusedBytes": 218482,
+            },
+            Object {
+              "children": undefined,
+              "name": "vendor/beefjs/dist/beef.js?",
+              "resourceBytes": 11949,
+              "unusedBytes": 11949,
+            },
+            Object {
+              "name": "external \\"window.React\\"?",
+              "resourceBytes": 76,
+              "unusedBytes": 76,
+            },
+            Object {
+              "name": "external \\"window.BeefFlux\\"?",
+              "resourceBytes": 82,
+              "unusedBytes": 82,
+            },
+            Object {
+              "name": "external \\"window.moment\\"?",
+              "resourceBytes": 80,
+              "unusedBytes": 80,
+            },
+            Object {
+              "name": "external \\"window.ReactDOM\\"?",
+              "resourceBytes": 119,
+              "unusedBytes": 119,
+            },
+          ],
+          "name": "js",
+          "resourceBytes": 300653,
+          "unusedBytes": 300653,
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "name": "ResponsiveHeader.js",
+                  "resourceBytes": 466,
+                  "unusedBytes": 466,
+                },
+                Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/LayoutBundle/Resources/assets/js/Utils.js",
+                  "name": "Utils.js",
+                  "resourceBytes": 857,
+                  "unusedBytes": 857,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "vendor/jquery.ba-throttle-debounce.js",
+                  "resourceBytes": 973,
+                  "unusedBytes": 973,
+                },
+              ],
+              "name": "LayoutBundle/Resources/assets/js",
+              "resourceBytes": 2296,
+              "unusedBytes": 2296,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/jquery.iframe-transport.js",
+                  "name": "jquery.iframe-transport.js",
+                  "resourceBytes": 2505,
+                  "unusedBytes": 2505,
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.services.js",
+                      "name": "util.common.services.js",
+                      "resourceBytes": 784,
+                      "unusedBytes": 784,
+                    },
+                    Object {
+                      "name": "util.common.dispatcher.js",
+                      "resourceBytes": 463,
+                      "unusedBytes": 463,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.store.js",
+                      "name": "util.common.store.js",
+                      "resourceBytes": 18595,
+                      "unusedBytes": 18595,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.api.js",
+                      "name": "util.common.api.js",
+                      "resourceBytes": 1306,
+                      "unusedBytes": 1306,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.notifications.js",
+                      "name": "util.common.notifications.js",
+                      "resourceBytes": 4684,
+                      "unusedBytes": 4684,
+                    },
+                    Object {
+                      "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UtilsBundle/Resources/assets/js/Common/util.common.locale.js",
+                      "name": "util.common.locale.js",
+                      "resourceBytes": 9092,
+                      "unusedBytes": 9092,
+                    },
+                  ],
+                  "name": "Common",
+                  "resourceBytes": 34924,
+                  "unusedBytes": 34924,
+                },
+                Object {
+                  "children": undefined,
+                  "name": "Widgets/util.widgets.loader.js",
+                  "resourceBytes": 308,
+                  "unusedBytes": 308,
+                },
+              ],
+              "name": "UtilsBundle/Resources/assets/js",
+              "resourceBytes": 37737,
+              "unusedBytes": 37737,
+            },
+            Object {
+              "children": undefined,
+              "name": "SearchBundle/Resources/assets/js/Smart/search.smart.widget.js",
+              "resourceBytes": 10247,
+              "unusedBytes": 10247,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "productThumbnailStatsService.js",
+                  "resourceBytes": 186,
+                  "unusedBytes": 186,
+                },
+                Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/AnalyticsBundle/Resources/assets/js/productThumbnailStats.js",
+                  "name": "productThumbnailStats.js",
+                  "resourceBytes": 582,
+                  "unusedBytes": 582,
+                },
+              ],
+              "name": "AnalyticsBundle/Resources/assets/js",
+              "resourceBytes": 768,
+              "unusedBytes": 768,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/PaymentBundle/Resources/assets/js/Common/payment.common.services.js",
+                  "name": "payment.common.services.js",
+                  "resourceBytes": 693,
+                  "unusedBytes": 693,
+                },
+                Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/PaymentBundle/Resources/assets/js/Common/payment.common.actions.js",
+                  "name": "payment.common.actions.js",
+                  "resourceBytes": 7165,
+                  "unusedBytes": 7165,
+                },
+                Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/PaymentBundle/Resources/assets/js/Common/payment.common.store.js",
+                  "name": "payment.common.store.js",
+                  "resourceBytes": 3240,
+                  "unusedBytes": 3240,
+                },
+              ],
+              "name": "PaymentBundle/Resources/assets/js/Common",
+              "resourceBytes": 11098,
+              "unusedBytes": 11098,
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "name": "user.common.services.js",
+                  "resourceBytes": 175,
+                  "unusedBytes": 175,
+                },
+                Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UserBundle/Resources/assets/js/Common/user.common.store.js",
+                  "name": "user.common.store.js",
+                  "resourceBytes": 4601,
+                  "unusedBytes": 4601,
+                },
+                Object {
+                  "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/UserBundle/Resources/assets/js/Common/user.common.actions.js",
                   "name": "user.common.actions.js",
                   "resourceBytes": 5561,
                   "unusedBytes": 5561,

--- a/lighthouse-core/test/audits/script-treemap-data-test.js
+++ b/lighthouse-core/test/audits/script-treemap-data-test.js
@@ -82,15 +82,19 @@ describe('ScriptTreemapData audit', () => {
       const {map, content} = loadSourceMapFixture('coursehero-bundle-1');
       expect(map.sourceRoot).toBeTruthy();
       const mainUrl = 'https://courshero.com';
-      const scriptUrl = 'https://courshero.com/script.js';
-      const networkRecords = [generateRecord(scriptUrl, content.length, 'Script')];
+      const scriptUrl1 = 'https://courshero.com/script1.js';
+      const scriptUrl2 = 'https://courshero.com/script2.js';
+      const networkRecords = [
+        generateRecord(scriptUrl1, content.length, 'Script'),
+        generateRecord(scriptUrl2, content.length, 'Script'),
+      ];
 
       const artifacts = {
         URL: {requestedUrl: mainUrl, finalUrl: mainUrl},
         JsUsage: {},
         devtoolsLogs: {defaultPass: networkRecordsToDevtoolsLog(networkRecords)},
-        SourceMaps: [{scriptUrl: scriptUrl, map}],
-        ScriptElements: [{src: scriptUrl, content}],
+        SourceMaps: [{scriptUrl: scriptUrl1, map}, {scriptUrl: scriptUrl2, map}],
+        ScriptElements: [{src: scriptUrl1, content}, {src: scriptUrl2, content}],
       };
       const results = await ScriptTreemapData.audit(artifacts, context);
 
@@ -99,8 +103,19 @@ describe('ScriptTreemapData audit', () => {
     });
 
     it('has root nodes', () => {
-      expect(JSON.stringify(treemapData).length).toMatchInlineSnapshot(`31703`);
+      expect(JSON.stringify(treemapData).length).toMatchInlineSnapshot(`86635`);
       expect(treemapData).toMatchSnapshot();
+    });
+
+    it('finds duplicates', () => {
+      expect(JSON.stringify(treemapData).length).toMatchInlineSnapshot(`86635`);
+      // @ts-ignore all these children exist.
+      const leafNode = treemapData[0].node.
+        children[0].
+        children[0].
+        children[0].
+        children[0].duplicatedNormalizedModuleName;
+      expect(leafNode).toBe('Control/assets/js/vendor/jquery.typeahead.js');
     });
   });
 

--- a/lighthouse-core/test/audits/script-treemap-data-test.js
+++ b/lighthouse-core/test/audits/script-treemap-data-test.js
@@ -91,6 +91,7 @@ describe('ScriptTreemapData audit', () => {
 
       const artifacts = {
         URL: {requestedUrl: mainUrl, finalUrl: mainUrl},
+        // Audit should still work even without usage data.
         JsUsage: {},
         devtoolsLogs: {defaultPass: networkRecordsToDevtoolsLog(networkRecords)},
         SourceMaps: [{scriptUrl: scriptUrl1, map}, {scriptUrl: scriptUrl2, map}],


### PR DESCRIPTION
ref #11254

* `duplicationByPath` expects keys to be modules without a map's `sourceRoot`. 
* While fixing this, I also added a second fixture test using `coursehero-bundle-1`
* `coursehero-bundle-1` doesn't have a `.usage` file, so I removed `JsUsage` from the new test's artifacts. That of course error'd, since it is a required artifact. When I added an empty object instead (`JsUsage: {}`) I noticed a bug where the early bailout code https://github.com/GoogleChrome/lighthouse/blob/a589db542bc1a16baac411837bdbbc99bcd85bf3/lighthouse-core/audits/script-treemap-data.js#L170-L182 bailed out too early ... even though a map was present, it did not create a module tree. The intention was to add as much data to the root node as possible–during the original PR a refactor simplified things but messed up some boolean logic.
* The prior is kinda a moot point, since the `JsUsage` gatherer should always have an array for every entry. Even though it probably doesn't affect anything, the bailout code was slightly wrong so I fixed that here.
