### PR TITLE
core(config): only allow lighthouse:default extension

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,18 +39,16 @@ lighthouse('https://example.com/', {port: 9222}, config);
 
 | Name | Type |
 | - | - |
-| extends | <code>string&#124;boolean&#124;undefined</code> |
+| extends | <code>string&#124;undefined</code> |
 | settings | <code>Object&#124;undefined</code> |
 | passes | <code>Object[]</code> |
 | audits | <code>string[]</code> |
 | categories | <code>Object&#124;undefined</code> |
 | groups | <code>Object&#124;undefined</code> |
 
-### `extends: "lighthouse:default"|boolean|undefined`
+### `extends: "lighthouse:default"|undefined`
 
 The `extends` property controls if your configuration should inherit from the default Lighthouse configuration. [Learn more.](#config-extension)
-
-Both the values `"lighthouse:default"` and `true` will enable inheritance, while `false` and `undefined` will not.
 
 #### Example
 ```js

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -325,6 +325,9 @@ class Config {
 
     // Extend the default config if specified
     if (configJSON.extends) {
+      if (configJSON.extends !== 'lighthouse:default') {
+        throw new Error('`lighthouse:default` is the only valid extension method.');
+      }
       configJSON = Config.extendConfigJSON(deepCloneConfigJson(defaultConfig), configJSON);
     }
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -620,7 +620,7 @@ describe('Config', () => {
     const saveWarning = evt => warnings.push(evt);
     log.events.addListener('warning', saveWarning);
     const config = new Config({
-      extends: true,
+      extends: 'lighthouse:default',
       settings: {
         onlyCategories: ['accessibility'],
       },
@@ -638,7 +638,7 @@ describe('Config', () => {
     const saveWarning = evt => warnings.push(evt);
     log.events.addListener('warning', saveWarning);
     const config = new Config({
-      extends: true,
+      extends: 'lighthouse:default',
       settings: {
         onlyCategories: ['performance', 'pwa'],
       },
@@ -655,7 +655,7 @@ describe('Config', () => {
 
   it('filters works with extension', () => {
     const config = new Config({
-      extends: true,
+      extends: 'lighthouse:default',
       settings: {
         onlyCategories: ['performance'],
         onlyAudits: ['is-on-https'],
@@ -672,7 +672,7 @@ describe('Config', () => {
     const saveWarning = evt => warnings.push(evt);
     log.events.addListener('warning', saveWarning);
     const config = new Config({
-      extends: true,
+      extends: 'lighthouse:default',
       settings: {
         onlyCategories: ['performance', 'missing-category'],
         onlyAudits: ['first-cpu-idle', 'missing-audit'],
@@ -687,7 +687,7 @@ describe('Config', () => {
   it('throws for invalid use of skipAudits and onlyAudits', () => {
     assert.throws(() => {
       new Config({
-        extends: true,
+        extends: 'lighthouse:default',
         settings: {
           onlyAudits: ['first-meaningful-paint'],
           skipAudits: ['first-meaningful-paint'],
@@ -697,20 +697,15 @@ describe('Config', () => {
   });
 
   it('cleans up flags for settings', () => {
-    const config = new Config({extends: true}, {nonsense: 1, foo: 2, throttlingMethod: 'provided'});
+    const config = new Config({extends: 'lighthouse:default'},
+      {nonsense: 1, foo: 2, throttlingMethod: 'provided'});
     assert.equal(config.settings.throttlingMethod, 'provided');
     assert.ok(config.settings.nonsense === undefined, 'did not cleanup settings');
   });
 
   it('allows overriding of array-typed settings', () => {
-    const config = new Config({extends: true}, {output: ['html']});
+    const config = new Config({extends: 'lighthouse:default'}, {output: ['html']});
     assert.deepStrictEqual(config.settings.output, ['html']);
-  });
-
-  it('does not throw on "lighthouse:full"', () => {
-    const config = new Config({extends: 'lighthouse:full'}, {output: ['html', 'json']});
-    assert.deepStrictEqual(config.settings.throttlingMethod, 'simulate');
-    assert.deepStrictEqual(config.settings.output, ['html', 'json']);
   });
 
   it('extends the config', () => {
@@ -781,6 +776,14 @@ describe('Config', () => {
     assert.equal(config.passes[0].pauseAfterLoadMs, 10001);
     assert.equal(config.passes[0].cpuQuietThresholdMs, 10002);
     assert.equal(config.passes[0].networkQuietThresholdMs, 10003);
+  });
+
+  it('only supports `lighthouse:default` extension', () => {
+    const createConfig = extendsValue => new Config({extends: extendsValue});
+
+    expect(() => createConfig(true)).toThrowError(/default` is the only valid extension/);
+    expect(() => createConfig('lighthouse')).toThrowError(/default` is the only valid/);
+    expect(() => createConfig('lighthouse:full')).toThrowError(/default` is the only valid/);
   });
 
   it('merges settings with correct priority', () => {
@@ -897,9 +900,9 @@ describe('Config', () => {
         devtoolsLogs: {defaultPass: 'path/to/devtools/log'},
       };
       const configA = {};
-      const configB = {extends: true, artifacts};
+      const configB = {extends: 'lighthouse:default', artifacts};
       const merged = Config.extendConfigJSON(configA, configB);
-      assert.equal(merged.extends, true);
+      assert.equal(merged.extends, 'lighthouse:default');
       assert.equal(merged.artifacts, configB.artifacts);
     });
   });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -17,7 +17,7 @@ declare global {
        * The pre-normalization Lighthouse Config format.
        */
       export interface Json {
-        extends?: 'lighthouse:default' | string | boolean;
+        extends?: 'lighthouse:default' | string;
         settings?: SharedFlagsSettings;
         passes?: PassJson[] | null;
         audits?: Config.AuditJson[] | null;


### PR DESCRIPTION
**Summary**
Closes the loop on a few consequences @paulirish and I discussed of #11779. Breaking change to eventually allow extension of `lighthouse:mobile` and `lighthouse:desktop` but make it clearer when your `extends` property is valid.

**Before**
Any truthy value for a config's `extends` property would trigger extension of the default config.

**After**
Any value other than `lighthouse:default` for a config's `extends` property throws a fatal error.

**Related Issues/PRs**
ref #11779
https://github.com/GoogleChrome/lighthouse/issues/10910#issuecomment-644406979