### PR TITLE
tests(smoke): restore dbw_tester exception assertions

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -1454,6 +1454,7 @@ Object {
     Object {
       "blankPage": "about:blank",
       "blockedUrlPatterns": Array [
+        "*.css",
         "*.jpg",
         "*.jpeg",
         "*.png",

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -211,53 +211,43 @@ const expectations = [
         'errors-in-console': {
           score: 0,
           details: {
-            items: {
-              length: '7 +/- 1',
-              // COMPAT: In 89.0.4351.0 we observed one additional runtime error and it's origin is currently unknown
-              // TODO: Investigate and resolve it's presence. https://github.com/GoogleChrome/lighthouse/issues/11803
-              //     {
-              //       source: 'exception',
-              //       description: 'TypeError: the given value is not a Promise',
-              //       url: 'http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js',
-              //     },
-            },
-            // items: [
-            //   {
-            //     source: 'other',
-            //     description: 'Application Cache Error event: Manifest fetch failed (404) http://localhost:10200/dobetterweb/clock.appcache',
-            //     url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-            //   },
-            //   {
-            //     source: 'exception',
-            //     description: /^Error: A distinctive error\s+at http:\/\/localhost:10200\/dobetterweb\/dbw_tester.html:\d+:\d+$/,
-            //     url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-            //   },
-            //   {
-            //     source: 'network',
-            //     description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-            //     url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-            //   },
-            //   {
-            //     source: 'network',
-            //     description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-            //     url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
-            //   },
-            //   {
-            //     source: 'network',
-            //     description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-            //     url: 'http://localhost:10200/favicon.ico',
-            //   },
-            //   {
-            //     source: 'network',
-            //     description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-            //     url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-            //   },
-            //   {
-            //     source: 'console.error',
-            //     description: 'Error! Error!',
-            //     url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-            //   },
-            // ],
+            items: [
+              {
+                source: 'other',
+                description: 'Application Cache Error event: Manifest fetch failed (404) http://localhost:10200/dobetterweb/clock.appcache',
+                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+              },
+              {
+                source: 'exception',
+                description: /^Error: A distinctive error\s+at http:\/\/localhost:10200\/dobetterweb\/dbw_tester.html:\d+:\d+$/,
+                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+              },
+              {
+                source: 'console.error',
+                description: 'Error! Error!',
+                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+              },
+              {
+                source: 'network',
+                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+                url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
+              },
+              {
+                source: 'network',
+                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+                url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
+              },
+              {
+                source: 'network',
+                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+                url: 'http://localhost:10200/favicon.ico',
+              },
+              {
+                source: 'network',
+                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+                url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
+              },
+            ],
           },
         },
         'is-on-https': {

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -175,8 +175,7 @@ const defaultConfig = {
     passName: 'redirectPass',
     loadFailureMode: 'warn',
     // Speed up the redirect pass by blocking stylesheets, fonts, and images
-    // TODO: restore blocked *.css when https://github.com/GoogleChrome/lighthouse/issues/11803 is resolved.
-    blockedUrlPatterns: ['*.jpg', '*.jpeg', '*.png', '*.gif', '*.svg', '*.ttf', '*.woff', '*.woff2'],
+    blockedUrlPatterns: ['*.css', '*.jpg', '*.jpeg', '*.png', '*.gif', '*.svg', '*.ttf', '*.woff', '*.woff2'],
     gatherers: [
       'http-redirect',
     ],


### PR DESCRIPTION
closes #11800 now that the top-level-await chromium bug is fixed.

reverts much of #11799 but also takes into account the consoleMessages changes in #11663

also reverts #11813

