### PR TITLE
test: add warn-not-offline-capable smoketest

### DIFF
--- a/lighthouse-cli/test/fixtures/offline-ready-sw.js
+++ b/lighthouse-cli/test/fixtures/offline-ready-sw.js
@@ -59,6 +59,9 @@ self.addEventListener('fetch', event => {
     return;
   }
 
+  // no real offline capability in the ?broken case
+  if (self.location.search.includes('broken')) return;
+
   event.respondWith(
     caches.match(event.request).then(cachedResponse => {
       if (cachedResponse) {

--- a/lighthouse-cli/test/fixtures/offline-ready.html
+++ b/lighthouse-cli/test/fixtures/offline-ready.html
@@ -43,7 +43,7 @@
   if (window.location.search.includes('slow')) {
     window.addEventListener('load', () => registerServiceWorker('?delay=5000&slow'));
   } else {
-    registerServiceWorker();
+    registerServiceWorker(window.location.search);
   }
 
 </script>

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -172,14 +172,14 @@ module.exports = [
   },
 
   {
-    // Only starting in m89 do we get 'warn-not-offline-capable'.
-    // This only happens when a populated `fetch` handler that doesn't provide a 200 response
-    _minChromiumMilestone: 89,
     lhr: {
       requestedUrl: 'http://localhost:10503/offline-ready.html?broken',
       finalUrl: 'http://localhost:10503/offline-ready.html?broken',
       audits: {
         'installable-manifest': {
+          // Only starting in m89 do we get 'warn-not-offline-capable'.
+          // This only happens when a populated `fetch` handler that doesn't provide a 200 response
+          _minChromiumMilestone: 89,
           score: 0,
           details: {items: {length: 1}},
           warnings: {length: 1},
@@ -188,6 +188,7 @@ module.exports = [
     },
     artifacts: {
       InstallabilityErrors: {
+        _minChromiumMilestone: 89,
         errors: {
           length: 2,
           0: {

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -172,6 +172,9 @@ module.exports = [
   },
 
   {
+    // Only starting in m89 do we get 'warn-not-offline-capable'.
+    // This only happens when a populated `fetch` handler that doesn't provide a 200 response
+    _minChromiumMilestone: 89,
     lhr: {
       requestedUrl: 'http://localhost:10503/offline-ready.html?broken',
       finalUrl: 'http://localhost:10503/offline-ready.html?broken',
@@ -186,9 +189,6 @@ module.exports = [
     artifacts: {
       InstallabilityErrors: {
         errors: {
-          // Only starting in m89 do we get 'warn-not-offline-capable'.
-          // This only happens when a populated `fetch` handler that doesn't provide a 200 response
-          '_minChromiumMilestone': 89,
           length: 2,
           0: {
             errorId: /warn-not-offline-capable/,

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -181,21 +181,24 @@ module.exports = [
           details: {items: {length: 1}},
           warnings: {length: 1},
         },
-      }
+      },
     },
     artifacts: {
       InstallabilityErrors: {
         errors: {
+          // Only starting in m89 do we get 'warn-not-offline-capable'.
+          // This only happens when a populated `fetch` handler that doesn't provide a 200 response
+          '_minChromiumMilestone': 89,
           length: 2,
           0: {
             errorId: /warn-not-offline-capable/,
           },
           1: {
             errorId: /no-icon-available/,
-          }
+          },
         },
       },
-    }
+    },
   },
 
   {

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -101,13 +101,11 @@ module.exports = [
       },
       InstallabilityErrors: {
         errors: {
-          length: '>= 1',
+          length: 1,
           0: {
-            // COMPAT: In m89 the `warn-not-offline-capable` error was added.
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=965802#c46
-            // We've seen this errorId pop up there: https://github.com/GoogleChrome/lighthouse/issues/11800
-            // Our length and errorId assertions allows for just the no-icon-available error or both
-            errorId: /(no-icon-available)|(warn-not-offline-capable)/,
+            // For a few days in m89, the warn-not-offline-capable error also showed up here.
+            // https://github.com/GoogleChrome/lighthouse/issues/11800
+            errorId: /no-icon-available/,
           },
         },
       },
@@ -171,6 +169,33 @@ module.exports = [
         },
       },
     },
+  },
+
+  {
+    lhr: {
+      requestedUrl: 'http://localhost:10503/offline-ready.html?broken',
+      finalUrl: 'http://localhost:10503/offline-ready.html?broken',
+      audits: {
+        'installable-manifest': {
+          score: 0,
+          details: {items: {length: 1}},
+          warnings: {length: 1},
+        },
+      }
+    },
+    artifacts: {
+      InstallabilityErrors: {
+        errors: {
+          length: 2,
+          0: {
+            errorId: /warn-not-offline-capable/,
+          },
+          1: {
+            errorId: /no-icon-available/,
+          }
+        },
+      },
+    }
   },
 
   {


### PR DESCRIPTION




in `offline-expectations.js` i revert back to the expectations we had previous to the false-positive hitting our offline-ready page ➡️  fixes #11800  

and then I add a new smoketest to make sure we reliably get the errorId if the serviceworker isn't doing offline right.➡️  fixes #11826 