### PR TITLE
report: flexible viewport for element screenshot overlay

### DIFF
--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -139,17 +139,24 @@ class ElementScreenshotRenderer {
    * @param {LH.Artifacts.FullPageScreenshot} fullPageScreenshot
    */
   static installOverlayFeature(dom, templateContext, fullPageScreenshot) {
-    const reportEl = dom.find('.lh-report', dom.document());
-    const screenshotOverlayClass = 'lh-feature-screenshot-overlay';
-    if (reportEl.classList.contains(screenshotOverlayClass)) return;
-    reportEl.classList.add(screenshotOverlayClass);
+    const topbarEl = dom.find('.lh-topbar', dom.document());
+    const containerEl = topbarEl.parentElement;
+    if (!containerEl) throw new Error('could not find parent element');
 
-    const maxLightboxSize = {
-      width: dom.document().documentElement.clientWidth,
-      height: dom.document().documentElement.clientHeight * 0.75,
-    };
+    const screenshotOverlayClass = 'lh-feature-screenshot-overlay';
+    if (containerEl.classList.contains(screenshotOverlayClass)) return;
+    containerEl.classList.add(screenshotOverlayClass);
 
     dom.document().addEventListener('click', e => {
+      const maxLightboxSize = {
+        width: dom.document().documentElement.clientWidth,
+        height: dom.document().documentElement.clientHeight * 0.75,
+      };
+      if (dom.isDevTools()) {
+        maxLightboxSize.width = containerEl.clientWidth;
+        maxLightboxSize.height = containerEl.clientHeight * 0.75;
+      }
+
       const target = /** @type {?HTMLElement} */ (e.target);
       if (!target) return;
       const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
@@ -175,11 +182,11 @@ class ElementScreenshotRenderer {
       if (!screenshotElement) return;
 
       overlay.appendChild(screenshotElement);
-      overlay.addEventListener('click', () => {
+      containerEl.addEventListener('click', () => {
         overlay.remove();
       });
 
-      reportEl.appendChild(overlay);
+      containerEl.insertBefore(overlay, topbarEl.nextElementSibling);
     });
   }
 

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -148,6 +148,11 @@ class ElementScreenshotRenderer {
     containerEl.classList.add(screenshotOverlayClass);
 
     dom.document().addEventListener('click', e => {
+      const target = /** @type {?HTMLElement} */ (e.target);
+      if (!target) return;
+      const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
+      if (!el) return;
+
       const maxLightboxSize = {
         width: dom.document().documentElement.clientWidth,
         height: dom.document().documentElement.clientHeight * 0.75,
@@ -156,11 +161,6 @@ class ElementScreenshotRenderer {
         maxLightboxSize.width = containerEl.clientWidth;
         maxLightboxSize.height = containerEl.clientHeight * 0.75;
       }
-
-      const target = /** @type {?HTMLElement} */ (e.target);
-      if (!target) return;
-      const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
-      if (!el) return;
 
       const overlay = dom.createElement('div');
       overlay.classList.add('lh-element-screenshot__overlay');

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -186,6 +186,7 @@ class ElementScreenshotRenderer {
         overlay.remove();
       });
 
+      // Must place after the topbar (but before `lh-container`).
       containerEl.insertBefore(overlay, topbarEl.nextElementSibling);
     });
   }

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1549,12 +1549,11 @@
   outline: 2px solid var(--color-lime-400);
 }
 .lh-element-screenshot__overlay {
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
-  width: 100vw;
   height: 100vh;
-  z-index: 1;
+  z-index: 1001;
   background: rgba(0, 0, 0, 0.7);
   display: flex;
   align-items: center;


### PR DESCRIPTION
This resolves a bug where the overlay was not properly sized in CDT. Instead of using the document window is devtools to know how to center the overlay, for CDT we should use the container element size. Also moved the overlay element to be right after the topbar, and had to make it sticky.

To test you need to patch this [CL](https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2596168) to a checkout of devtools frontend, and run:

```
DEVTOOLS_PATH=/Users/cjamcl/src/devtools/devtools-frontend yarn open-devtools
```