### PR TITLE
report: close element screenshot overlay when clicking on image

### DIFF
--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -147,7 +147,20 @@ class ElementScreenshotRenderer {
     if (containerEl.classList.contains(screenshotOverlayClass)) return;
     containerEl.classList.add(screenshotOverlayClass);
 
+    /** @type {HTMLElement|null} */
+    let overlay = null;
     dom.document().addEventListener('click', e => {
+      if (overlay) {
+        overlay.remove();
+        overlay = null;
+        return;
+      }
+
+      const target = /** @type {?HTMLElement} */ (e.target);
+      if (!target) return;
+      const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
+      if (!el) return;
+
       const maxLightboxSize = {
         width: dom.document().documentElement.clientWidth,
         height: dom.document().documentElement.clientHeight * 0.75,
@@ -157,13 +170,6 @@ class ElementScreenshotRenderer {
         maxLightboxSize.height = containerEl.clientHeight * 0.75;
       }
 
-      const target = /** @type {?HTMLElement} */ (e.target);
-      if (!target) return;
-      const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
-      if (!el) return;
-
-      const overlay = dom.createElement('div');
-      overlay.classList.add('lh-element-screenshot__overlay');
       const elementRectSC = {
         width: Number(el.dataset['rectWidth']),
         height: Number(el.dataset['rectHeight']),
@@ -181,11 +187,9 @@ class ElementScreenshotRenderer {
       );
       if (!screenshotElement) return;
 
+      overlay = dom.createElement('div');
+      overlay.classList.add('lh-element-screenshot__overlay');
       overlay.appendChild(screenshotElement);
-      containerEl.addEventListener('click', () => {
-        overlay.remove();
-      });
-
       containerEl.insertBefore(overlay, topbarEl.nextElementSibling);
     });
   }

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -149,7 +149,7 @@ class ElementScreenshotRenderer {
 
     /** @type {HTMLElement|null} */
     let overlay = null;
-    dom.document().addEventListener('click', e => {
+    containerEl.addEventListener('click', e => {
       if (overlay) {
         overlay.remove();
         overlay = null;


### PR DESCRIPTION
before, clicking on the overlay image would close it... only to immediately reopen. This is a major problem on mobile, because the entire screen could be the overlay, and would be impossible to close.

Modified the overlay code to use a single click event listener and toggle between opening/closing. Also moved the listener to the rootEl, instead of the document (for example, so that changing tabs in DevTools doesn't close the overlay).

(#11843  should land first)
