### PR TITLE
misc(scripts): fix unbound variable in open-devtools

### DIFF
--- a/lighthouse-core/scripts/open-devtools.sh
+++ b/lighthouse-core/scripts/open-devtools.sh
@@ -44,4 +44,4 @@ gn gen out/Default
 gclient sync
 autoninja -C out/Default
 
-"$CHROME_PATH" --custom-devtools-frontend=file://"$DEVTOOLS_PATH"/out/Default/resources/inspector --user-data-dir=/tmp/chromeprofile-open-devtools
+"$CHROME_PATH" --custom-devtools-frontend=file://"$DEVTOOLS_PATH"/out/Default/resources/inspector $*

--- a/lighthouse-core/scripts/open-devtools.sh
+++ b/lighthouse-core/scripts/open-devtools.sh
@@ -14,7 +14,7 @@ TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
 DEFAULT_DEVTOOLS_PATH="$TEST_DIR/devtools/devtools-frontend"
 DEVTOOLS_PATH=${DEVTOOLS_PATH:-"$DEFAULT_DEVTOOLS_PATH"}
 
-if [[ -z $CHROME_PATH ]]; then
+if [ -z "${CHROME_PATH:-}" ]; then
   echo 'Must set $CHROME_PATH'
   exit 1
 fi
@@ -22,7 +22,7 @@ fi
 echo "CHROME_PATH: $CHROME_PATH"
 echo "DEVTOOLS_PATH: $DEVTOOLS_PATH"
 
-if [ ! -d $DEVTOOLS_PATH ]; then
+if [ ! -d "$DEVTOOLS_PATH" ]; then
   echo "No devtools found at $DEVTOOLS_PATH. Have you run 'yarn test-devtools' yet?"
   exit 1
 fi
@@ -43,4 +43,5 @@ cd "$DEVTOOLS_PATH"
 gn gen out/Default
 gclient sync
 autoninja -C out/Default
-"$CHROME_PATH" --custom-devtools-frontend=file://$DEVTOOLS_PATH/out/Default/resources/inspector
+
+"$CHROME_PATH" --custom-devtools-frontend=file://"$DEVTOOLS_PATH"/out/Default/resources/inspector --user-data-dir=/tmp/chromeprofile-open-devtools


### PR DESCRIPTION
(low priority) 

without the change on L17, the script errors our for me.

L25 is just making shellcheck happy

L47 i just wanted to reuse the same temporary chrome profile in these situations. @connorjclark @adamraine if the user-data-dir thang doesnt work for your workflows, no big deal. happy to add on my own. :) 