### PR TITLE
report: fix element screenshot position, lifecycle, styles

### DIFF
--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -141,7 +141,8 @@ class ElementScreenshotRenderer {
   static installOverlayFeature(dom, templateContext, fullPageScreenshot) {
     const rootEl = dom.find('.lh-root', dom.document());
     if (!rootEl) {
-      return console.warn('No lh-root. Overlay install failed.'); // eslint-disable-line no-console
+      console.warn('No lh-root. Overlay install failed.'); // eslint-disable-line no-console
+      return;
     }
 
     const screenshotOverlayClass = 'lh-screenshot-overlay--enabled';
@@ -185,7 +186,8 @@ class ElementScreenshotRenderer {
       // This would be unexpected here. 
       // When `screenshotElement` is `null`, there is also no thumbnail element for the user to have clicked to make it this far. 
       if (!screenshotElement) {
-        return overlay.remove();
+        overlay.remove();
+        return;
       }
       overlay.appendChild(screenshotElement);
       overlay.addEventListener('click', () => overlay.remove());

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -144,13 +144,12 @@ class ElementScreenshotRenderer {
       return console.warn('No lh-root. Overlay install failed.'); // eslint-disable-line no-console
     }
 
-
     const screenshotOverlayClass = 'lh-screenshot-overlay--enabled';
     // Don't install the feature more than once.
     if (rootEl.classList.contains(screenshotOverlayClass)) return;
     rootEl.classList.add(screenshotOverlayClass);
 
-    // Add a single listener to the top container to handle all clicks within (event delegation)
+    // Add a single listener to the root element to handle all clicks within (event delegation).
     rootEl.addEventListener('click', e => {
       const target = /** @type {?HTMLElement} */ (e.target);
       if (!target) return;
@@ -161,7 +160,7 @@ class ElementScreenshotRenderer {
       const overlay = dom.createElement('div', 'lh-element-screenshot__overlay');
       rootEl.append(overlay);
 
-      // The newly-added overlay has the bounding rect we need
+      // The newly-added overlay has the dimensions we need.
       const maxLightboxSize = {
         width: overlay.clientWidth * 0.95,
         height: overlay.clientHeight * 0.80,
@@ -183,7 +182,8 @@ class ElementScreenshotRenderer {
         maxLightboxSize
       );
 
-      // This would be unexpected here. The null return is used to not create a thumbnail in details-renderer
+      // This would be unexpected here. 
+      // When `screenshotElement` is `null`, there is also no thumbnail element for the user to have clicked to make it this far. 
       if (!screenshotElement) {
         return overlay.remove();
       }

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -183,8 +183,8 @@ class ElementScreenshotRenderer {
         maxLightboxSize
       );
 
-      // This would be unexpected here. 
-      // When `screenshotElement` is `null`, there is also no thumbnail element for the user to have clicked to make it this far. 
+      // This would be unexpected here.
+      // When `screenshotElement` is `null`, there is also no thumbnail element for the user to have clicked to make it this far.
       if (!screenshotElement) {
         overlay.remove();
         return;

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -139,23 +139,25 @@ class ElementScreenshotRenderer {
    * @param {LH.Artifacts.FullPageScreenshot} fullPageScreenshot
    */
   static installOverlayFeature(dom, templateContext, fullPageScreenshot) {
-    const topbarEl = dom.find('.lh-topbar', dom.document());
-    const containerEl = topbarEl.parentElement;
-    if (!containerEl) throw new Error('could not find parent element');
+    const rootEl = dom.find('.lh-root', dom.document());
+    if (!rootEl) {
+      return console.warn('No lh-root. Overlay install failed.');
+    }
+
 
     const screenshotOverlayClass = 'lh-feature-screenshot-overlay';
     // Don't install the feature more than once.
-    if (containerEl.classList.contains(screenshotOverlayClass)) return;
-    containerEl.classList.add(screenshotOverlayClass);
+    if (rootEl.classList.contains(screenshotOverlayClass)) return;
+    rootEl.classList.add(screenshotOverlayClass);
 
-    containerEl.addEventListener('click', e => {
+    rootEl.addEventListener('click', e => {
       const target = /** @type {?HTMLElement} */ (e.target);
       if (!target) return;
       const el = /** @type {?HTMLElement} */ (target.closest('.lh-node > .lh-element-screenshot'));
       if (!el) return;
 
       const overlay = dom.createElement('div', 'lh-element-screenshot__overlay');
-      containerEl.insertBefore(overlay, topbarEl.nextElementSibling);
+      rootEl.append(overlay);
 
       // The newly-added overlay has the bounding rect we need
       const maxLightboxSize = {

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -144,15 +144,15 @@ class ElementScreenshotRenderer {
     if (!containerEl) throw new Error('could not find parent element');
 
     const screenshotOverlayClass = 'lh-feature-screenshot-overlay';
+    // Don't install the feature more than once.
     if (containerEl.classList.contains(screenshotOverlayClass)) return;
     containerEl.classList.add(screenshotOverlayClass);
 
-    dom.document().addEventListener('click', e => {
+    containerEl.addEventListener('click', e => {
       const target = /** @type {?HTMLElement} */ (e.target);
       if (!target) return;
       const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
       if (!el) return;
-
       // Don't create a lightbox if the click is within in a lightbox
       if (el.closest('.lh-element-screenshot__overlay')) return;
 
@@ -186,11 +186,7 @@ class ElementScreenshotRenderer {
         return overlay.remove();
       }
       overlay.appendChild(screenshotElement);
-      containerEl.addEventListener('click', () => {
-        overlay.remove();
-      });
-
-      containerEl.insertBefore(overlay, topbarEl.nextElementSibling);
+      overlay.addEventListener('click', () => overlay.remove());
     });
   }
 

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -151,10 +151,8 @@ class ElementScreenshotRenderer {
     containerEl.addEventListener('click', e => {
       const target = /** @type {?HTMLElement} */ (e.target);
       if (!target) return;
-      const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
+      const el = /** @type {?HTMLElement} */ (target.closest('.lh-node > .lh-element-screenshot'));
       if (!el) return;
-      // Don't create a lightbox if the click is within in a lightbox
-      if (el.closest('.lh-element-screenshot__overlay')) return;
 
       const overlay = dom.createElement('div', 'lh-element-screenshot__overlay');
       containerEl.insertBefore(overlay, topbarEl.nextElementSibling);

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -150,6 +150,7 @@ class ElementScreenshotRenderer {
     if (rootEl.classList.contains(screenshotOverlayClass)) return;
     rootEl.classList.add(screenshotOverlayClass);
 
+    // Add a single listener to the top container to handle all clicks within (event delegation)
     rootEl.addEventListener('click', e => {
       const target = /** @type {?HTMLElement} */ (e.target);
       if (!target) return;

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -145,7 +145,7 @@ class ElementScreenshotRenderer {
     }
 
 
-    const screenshotOverlayClass = 'lh-feature-screenshot-overlay';
+    const screenshotOverlayClass = 'lh-screenshot-overlay--enabled';
     // Don't install the feature more than once.
     if (rootEl.classList.contains(screenshotOverlayClass)) return;
     rootEl.classList.add(screenshotOverlayClass);

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -153,6 +153,7 @@ class ElementScreenshotRenderer {
     rootEl.addEventListener('click', e => {
       const target = /** @type {?HTMLElement} */ (e.target);
       if (!target) return;
+      // Only activate the overlay for clicks on the screenshot *preview* of an element, not the full-size too.
       const el = /** @type {?HTMLElement} */ (target.closest('.lh-node > .lh-element-screenshot'));
       if (!el) return;
 

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -141,7 +141,7 @@ class ElementScreenshotRenderer {
   static installOverlayFeature(dom, templateContext, fullPageScreenshot) {
     const rootEl = dom.find('.lh-root', dom.document());
     if (!rootEl) {
-      return console.warn('No lh-root. Overlay install failed.');
+      return console.warn('No lh-root. Overlay install failed.'); // eslint-disable-line no-console
     }
 
 

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -153,17 +153,18 @@ class ElementScreenshotRenderer {
       const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
       if (!el) return;
 
-      const maxLightboxSize = {
-        width: dom.document().documentElement.clientWidth,
-        height: dom.document().documentElement.clientHeight * 0.75,
-      };
-      if (dom.isDevTools()) {
-        maxLightboxSize.width = containerEl.clientWidth;
-        maxLightboxSize.height = containerEl.clientHeight * 0.75;
-      }
+      // Don't create a lightbox if the click is within in a lightbox
+      if (el.closest('.lh-element-screenshot__overlay')) return;
 
-      const overlay = dom.createElement('div');
-      overlay.classList.add('lh-element-screenshot__overlay');
+      const overlay = dom.createElement('div', 'lh-element-screenshot__overlay');
+      containerEl.insertBefore(overlay, topbarEl.nextElementSibling);
+
+      // The newly-added overlay has the bounding rect we need
+      const maxLightboxSize = {
+        width: overlay.clientWidth * 0.95,
+        height: overlay.clientHeight * 0.80,
+      };
+
       const elementRectSC = {
         width: Number(el.dataset['rectWidth']),
         height: Number(el.dataset['rectHeight']),
@@ -179,8 +180,11 @@ class ElementScreenshotRenderer {
         elementRectSC,
         maxLightboxSize
       );
-      if (!screenshotElement) return;
 
+      // This would be unexpected here. The null return is used to not create a thumbnail in details-renderer
+      if (!screenshotElement) {
+        return overlay.remove();
+      }
       overlay.appendChild(screenshotElement);
       containerEl.addEventListener('click', () => {
         overlay.remove();

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -139,17 +139,24 @@ class ElementScreenshotRenderer {
    * @param {LH.Artifacts.FullPageScreenshot} fullPageScreenshot
    */
   static installOverlayFeature(dom, templateContext, fullPageScreenshot) {
-    const reportEl = dom.find('.lh-report', dom.document());
-    const screenshotOverlayClass = 'lh-feature-screenshot-overlay';
-    if (reportEl.classList.contains(screenshotOverlayClass)) return;
-    reportEl.classList.add(screenshotOverlayClass);
+    const topbarEl = dom.find('.lh-topbar', dom.document());
+    const containerEl = topbarEl.parentElement;
+    if (!containerEl) throw new Error('could not find parent element');
 
-    const maxLightboxSize = {
-      width: dom.document().documentElement.clientWidth,
-      height: dom.document().documentElement.clientHeight * 0.75,
-    };
+    const screenshotOverlayClass = 'lh-feature-screenshot-overlay';
+    if (containerEl.classList.contains(screenshotOverlayClass)) return;
+    containerEl.classList.add(screenshotOverlayClass);
 
     dom.document().addEventListener('click', e => {
+      const maxLightboxSize = {
+        width: dom.document().documentElement.clientWidth,
+        height: dom.document().documentElement.clientHeight * 0.75,
+      };
+      if (dom.isDevTools()) {
+        maxLightboxSize.width = containerEl.clientWidth;
+        maxLightboxSize.height = containerEl.clientHeight * 0.75;
+      }
+
       const target = /** @type {?HTMLElement} */ (e.target);
       if (!target) return;
       const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
@@ -175,11 +182,11 @@ class ElementScreenshotRenderer {
       if (!screenshotElement) return;
 
       overlay.appendChild(screenshotElement);
-      overlay.addEventListener('click', () => {
+      containerEl.addEventListener('click', () => {
         overlay.remove();
       });
 
-      reportEl.appendChild(overlay);
+      containerEl.insertBefore(overlay, topbarEl.nextElementSibling);
     });
   }
 

--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -148,6 +148,11 @@ class ElementScreenshotRenderer {
     containerEl.classList.add(screenshotOverlayClass);
 
     dom.document().addEventListener('click', e => {
+      const target = /** @type {?HTMLElement} */ (e.target);
+      if (!target) return;
+      const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
+      if (!el) return;
+
       const maxLightboxSize = {
         width: dom.document().documentElement.clientWidth,
         height: dom.document().documentElement.clientHeight * 0.75,
@@ -156,11 +161,6 @@ class ElementScreenshotRenderer {
         maxLightboxSize.width = containerEl.clientWidth;
         maxLightboxSize.height = containerEl.clientHeight * 0.75;
       }
-
-      const target = /** @type {?HTMLElement} */ (e.target);
-      if (!target) return;
-      const el = /** @type {?HTMLElement} */ (target.closest('.lh-element-screenshot'));
-      if (!el) return;
 
       const overlay = dom.createElement('div');
       overlay.classList.add('lh-element-screenshot__overlay');

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -104,7 +104,7 @@
   --image-preview-size: 48px;
   --metric-toggle-lines-fill: #7F7F7F;
   --metrics-toggle-background-color: var(--color-gray-200);
-  --modal-overlay-background: rgba(0, 0, 0, 0.3);
+  --screenshot-overlay-background: rgba(0, 0, 0, 0.3);
   --plugin-badge-background-color: var(--color-white);
   --plugin-badge-size-big: calc(var(--gauge-circle-size-big) / 2.7);
   --plugin-badge-size: calc(var(--gauge-circle-size) / 2.7);
@@ -257,7 +257,7 @@
   --gauge-wrapper-width: 97px;
   --header-line-height: 20px;
   --header-padding: 16px 0 16px 0;
-  --modal-overlay-background: transparent;
+  --screenshot-overlay-background: transparent;
   --plugin-icon-size: 75%;
   --pwa-icon-margin: 0 7px 0 -3px;
   --report-font-family-monospace: 'Menlo', 'dejavu sans mono', 'Consolas', 'Lucida Console', monospace;
@@ -1557,7 +1557,7 @@
   right: 0;
   bottom: 0;
   z-index: 2000; /* .lh-topbar is 1000 */
-  background: var(--modal-overlay-background);
+  background: var(--screenshot-overlay-background);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1569,10 +1569,10 @@
   outline: 1px solid var(--color-gray-700);
 }
 
-.lh-feature-screenshot-overlay .lh-element-screenshot {
+.lh-screenshot-overlay--enabled .lh-element-screenshot {
   cursor: zoom-out;
 }
-.lh-feature-screenshot-overlay .lh-node .lh-element-screenshot {
+.lh-screenshot-overlay--enabled .lh-node .lh-element-screenshot {
   cursor: zoom-in;
 }
 

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -104,6 +104,7 @@
   --image-preview-size: 48px;
   --metric-toggle-lines-fill: #7F7F7F;
   --metrics-toggle-background-color: var(--color-gray-200);
+  --modal-overlay-background: rgba(0, 0, 0, 0.3);
   --plugin-badge-background-color: var(--color-white);
   --plugin-badge-size-big: calc(var(--gauge-circle-size-big) / 2.7);
   --plugin-badge-size: calc(var(--gauge-circle-size) / 2.7);
@@ -256,6 +257,7 @@
   --gauge-wrapper-width: 97px;
   --header-line-height: 20px;
   --header-padding: 16px 0 16px 0;
+  --modal-overlay-background: transparent;
   --plugin-icon-size: 75%;
   --pwa-icon-margin: 0 7px 0 -3px;
   --report-font-family-monospace: 'Menlo', 'dejavu sans mono', 'Consolas', 'Lucida Console', monospace;
@@ -1555,7 +1557,7 @@
   right: 0;
   bottom: 0;
   z-index: 2000; /* .lh-topbar is 1000 */
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--modal-overlay-background);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1562,6 +1562,11 @@
   cursor: zoom-out;
 }
 
+.lh-element-screenshot__overlay .lh-element-screenshot {
+  margin-right: 0; /* clearing margin used in thumbnail case */
+  outline: 1px solid var(--color-gray-700);
+}
+
 .lh-feature-screenshot-overlay .lh-element-screenshot {
   cursor: zoom-out;
 }

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1549,12 +1549,13 @@
   outline: 2px solid var(--color-lime-400);
 }
 .lh-element-screenshot__overlay {
-  position: sticky;
+  position: fixed;
   top: 0;
   left: 0;
-  height: 100vh;
-  z-index: 1001;
-  background: rgba(0, 0, 0, 0.7);
+  right: 0;
+  bottom: 0;
+  z-index: 2000; /* .lh-topbar is 1000 */
+  background: rgba(0, 0, 0, 0.3);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -1549,12 +1549,11 @@
   outline: 2px solid var(--color-lime-400);
 }
 .lh-element-screenshot__overlay {
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
-  width: 100vw;
   height: 100vh;
-  z-index: 1;
+  z-index: 1001;
   background: rgba(0, 0, 0, 0.7);
   display: flex;
   align-items: center;


### PR DESCRIPTION
this is an alternative to #11843  and #11844

(and here's the diff against #11843, which may be useful: https://github.com/GoogleChrome/lighthouse/compare/fps-tweak-viewport...fps-tweak-partytime )

okay a few things..

### use fixed positioning to keep the overlay on top of the report content

if our overlay element was placed higher up in the devtools DOM, `pos:abs` would work. (That's what it used there for [their equivalent "glassPane" component](https://source.chromium.org/chromium/chromium/src/+/master:third_party/devtools-frontend/src/front_end/ui/glassPane.css;l=7-16;bpv=1;bpt=0)).  

i don't see a good way to use `pos:sticky` without a nasty hack like `margin-bottom: -100vh;` to fix it [pushing down the report content](https://github.com/GoogleChrome/lighthouse/pull/11843/files#r544688266). 

`fixed` works well. DOM-wise the position of the overlay doesn't matter since it rolls up to its containing block. It can remain a child of `.lh-report` so there's no diff, but I slightly prefer it's a child of `lh-root` so it has more visibility.



#### overlay positioning aside

There are options but it gets interesting when considering our report within another page/webapp. (eg DevTools). 

1. does overlay go on top of topbar? I think yes, cuz otherwise you can toggle the topbar menu and it displays _under_ the overlay
2. does overlay go on top of devtools toolbar?  I wasn't sure but I checked the DevTools glasspane and it goes on top. Here's an example modal & glasspane in Network panel: rightclick table headers > response headers > manage header columns. (Also their glasspane is transparent, so I've done that too.) Anyway, this all convinced me that the overlay should sit on top of everything. 

### size the lightbox screenshot relative to the overlay

with the overlay the size we want, we can use its dimensions as input for the `maxLightboxSize` which goes into the amazing sizing algorithm. that thing is too sweet and handles landscape/portrait viewports so so well.

this means we add the overlay to the dom first and then measure it, but i think that's OK!


### small style tweaks on lightbox overlay.

it had 20px margin that it wanted for the thumbnail but was being applied in the lightbox too:
![image](https://user-images.githubusercontent.com/39191/102433807-8c9c6180-3fc8-11eb-8fb4-e061e8dcf83d.png)

also i added a 1px `outline` around it, just for visual contrast. (yay for outline not affecting dimensions)

and I lessened the overlay's gray bgcolor a tad. more opacity ~= less dark. and in devtools, it's transparent to match the glasspane.

(obv these are not critical and i can defer till later if desired)

### fix lightbox click lifecycle

basically the same thing that #11845 was getting at.  The core problem is that we use the `.lh-element-screenshot` class for both thumbnails and lightbox images. 

I kept @connorjclark's "moved the listener to the rootEl, instead of the document". 👍 

And after starting with adding an extra `if elem.closest(am-i-in-the-lightbox) return;` I realized [the existing selector could be tweaked](880fee527e5620b4818a91bab8abfb2170c5ed37).



