### PR TITLE
core(network): do not consider cross frame requests critical

### DIFF
--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -66,11 +66,10 @@ class NetworkRecorder extends EventEmitter {
   isCriticalIdle() {
     const rootFrameRequest = this._records.find(r => r.resourceType === 'Document');
     const rootFrameId = rootFrameRequest && rootFrameRequest.frameId;
-    const rootFrameRequests = new Set(this._records.filter(r => r.frameId === rootFrameId));
 
     return this._isActiveIdlePeriod(
       0,
-      request => rootFrameRequests.has(request) &&
+      request => request.frameId === rootFrameId &&
         (request.priority === 'VeryHigh' || request.priority === 'High')
     );
   }

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -57,6 +57,12 @@ class NetworkRecorder extends EventEmitter {
     return this._isActiveIdlePeriod(0);
   }
 
+  /**
+   * Returns whether any important resources for the page are in progress.
+   * Above-the-fold images and XHRs should be included.
+   * Tracking pixels, low priority images, and cross frame requests should be excluded.
+   * @return {boolean}
+   */
   isCriticalIdle() {
     const rootFrameRequest = this._records.find(r => r.resourceType === 'Document');
     const rootFrameId = rootFrameRequest && rootFrameRequest.frameId;

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -58,9 +58,14 @@ class NetworkRecorder extends EventEmitter {
   }
 
   isCriticalIdle() {
+    const rootFrameRequest = this._records.find(r => r.resourceType === 'Document');
+    const rootFrameId = rootFrameRequest && rootFrameRequest.frameId;
+    const rootFrameRequests = new Set(this._records.filter(r => r.frameId === rootFrameId));
+
     return this._isActiveIdlePeriod(
       0,
-      request => request.priority === 'VeryHigh' || request.priority === 'High'
+      request => rootFrameRequests.has(request) &&
+        (request.priority === 'VeryHigh' || request.priority === 'High')
     );
   }
 

--- a/lighthouse-core/test/lib/network-recorder-test.js
+++ b/lighthouse-core/test/lib/network-recorder-test.js
@@ -291,6 +291,23 @@ describe('network recorder', function() {
       expect(recorder.isCriticalIdle()).toBe(false);
     });
 
+    it('should not consider cross frame requests critical', () => {
+      for (const message of devtoolsLog) recorder.dispatch(message);
+      expect(recorder.isIdle()).toBe(true);
+      expect(recorder.is2Idle()).toBe(true);
+      expect(recorder.isCriticalIdle()).toBe(true);
+
+      const crossFrameLog = networkRecordsToDevtoolsLog([
+        {requestId: '5', url: 'http://3p.example.com', priority: 'VeryHigh', frameId: 'OOPIF'},
+      ]);
+      const startMessage = crossFrameLog.find(e => e.method === 'Network.requestWillBeSent');
+      recorder.dispatch(startMessage);
+
+      expect(recorder.isIdle()).toBe(false);
+      expect(recorder.is2Idle()).toBe(true);
+      expect(recorder.isCriticalIdle()).toBe(true);
+    });
+
     it('should capture single low-pri request state in getters', () => {
       const startMessage = devtoolsLog.find(event => event.method === 'Network.requestWillBeSent');
       startMessage.params.request.initialPriority = 'Low';


### PR DESCRIPTION
**Summary**
Ignores child frame requests for the new `isCriticalIdle` check. Solves the most important consequence of https://github.com/GoogleChrome/lighthouse/issues/11850 that will be introduced with 7.0

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/issues/11850
