### PR TITLE
docs(readme): add plugin: lighthouse-plugin-crux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -366,6 +366,8 @@ This section details services that have integrated Lighthouse data. If you're wo
 
 * **[lighthouse-plugin-publisher-ads](https://github.com/googleads/publisher-ads-lighthouse-plugin)** - a tool to improve ad speed and overall quality through a series of automated audits. At the moment, this is primarily targeted at sites using Google Ad Manager. This tool will aid in resolving discovered problems, providing a tool to be used to evaluate effectiveness of iterative changes while suggesting actionable feedback.
 
+* **[lighthouse-plugin-crux](https://github.com/dvelasquez/lighthouse-plugin-crux)** - a plugin that quickly gathers real-user-metrics data from the [Chrome UX Report API](https://developers.google.com/web/tools/chrome-user-experience-report/api/reference).
+
 ## Related Projects
 Other awesome open source projects that use Lighthouse.
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
This PR updates the README.md adding a lighthouse plugin that I'm maintaining: [lighthouse-plugin-crux](https://github.com/dvelasquez/lighthouse-plugin-crux)

The main difference with the already added `lighthouse-plugin-field-performance` is that this plugin uses the CrUX API instead of the PageSpeed Insights API. The CrUX API is faster since it doesn't need to run a full Lighthouse run to return the results.