### PR TITLE
clients(viewer): exclude html-report-assets.js from viewer bundle

### DIFF
--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -20,7 +20,7 @@ async function run() {
   const generatorBrowserify = browserify(generatorFilename, {standalone: 'ReportGenerator'})
     .transform('@wardpeet/brfs', {
       readFileSyncTransform: minifyFileTransform,
-    });
+    }).ignore(require.resolve('../lighthouse-core/report/html/html-report-assets.js'));
 
   /** @type {Promise<string>} */
   const generatorJsPromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
this is dead code, because the report assets are already here.

this PR takes viewer's bundled.js from 355k to 82k.

TBH I don't totally follow the path that these report assets take in the viewer case. But they are added to the output very explicitly in build-viewer. And however `html-report-assets.js` is pulled in... it's they are not needed there.