### PR TITLE
report: convert v6 emulatedFormFactor to v7 formFactor

### DIFF
--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -67,7 +67,7 @@ class Util {
       clone.configSettings.locale = 'en';
     }
     if (!clone.configSettings.formFactor) {
-      //@ts-expect-error fallback handling for emulatedFormFactor
+      // @ts-expect-error fallback handling for emulatedFormFactor
       clone.configSettings.formFactor = clone.configSettings.emulatedFormFactor;
     }
 
@@ -429,9 +429,10 @@ class Util {
     }
 
     // TODO(paulirish): revise Runtime Settings strings: https://github.com/GoogleChrome/lighthouse/pull/11796
-    const deviceEmulation = settings.formFactor === 'mobile'
-      ? Util.i18n.strings.runtimeMobileEmulation
-      : Util.i18n.strings.runtimeDesktopEmulation;
+    const deviceEmulation = {
+      mobile: Util.i18n.strings.runtimeMobileEmulation,
+      desktop: Util.i18n.strings.runtimeDesktopEmulation,
+    }[settings.formFactor] || Util.i18n.strings.runtimeNoEmulation;
 
     return {
       deviceEmulation,

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -424,10 +424,24 @@ class Util {
         networkThrottling = Util.i18n.strings.runtimeUnknown;
     }
 
-    // TODO(paulirish): revise Runtime Settings strings: https://github.com/GoogleChrome/lighthouse/pull/11796
-    const deviceEmulation = settings.formFactor === 'mobile'
-      ? Util.i18n.strings.runtimeMobileEmulation
-      : Util.i18n.strings.runtimeDesktopEmulation;
+
+    let deviceEmulation;
+    // COMPAT: remove this fallback handling at Lighthouse v8
+    // @ts-expect-error fallback handling for emulatedFormFactor
+    if (settings.emulatedFormFactor) {
+      // @ts-expect-error removed setting
+      deviceEmulation = settings.emulatedFormFactor === 'mobile'
+        ? Util.i18n.strings.runtimeMobileEmulation
+        // @ts-expect-error removed setting
+        : settings.emulatedFormFactor === 'desktop'
+          ? Util.i18n.strings.runtimeDesktopEmulation
+          : Util.i18n.strings.runtimeNoEmulation;
+    } else {
+      // TODO(paulirish): revise Runtime Settings strings: https://github.com/GoogleChrome/lighthouse/pull/11796
+      deviceEmulation = settings.formFactor === 'mobile'
+        ? Util.i18n.strings.runtimeMobileEmulation
+        : Util.i18n.strings.runtimeDesktopEmulation;
+    }
 
     return {
       deviceEmulation,

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -66,6 +66,10 @@ class Util {
     if (!clone.configSettings.locale) {
       clone.configSettings.locale = 'en';
     }
+    if (!clone.configSettings.formFactor) {
+      //@ts-expect-error fallback handling for emulatedFormFactor
+      clone.configSettings.formFactor = clone.configSettings.emulatedFormFactor;
+    }
 
     for (const audit of Object.values(clone.audits)) {
       // Turn 'not-applicable' (LHR <4.0) and 'not_applicable' (older proto versions)

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -424,24 +424,10 @@ class Util {
         networkThrottling = Util.i18n.strings.runtimeUnknown;
     }
 
-
-    let deviceEmulation;
-    // COMPAT: remove this fallback handling at Lighthouse v8
-    // @ts-expect-error fallback handling for emulatedFormFactor
-    if (settings.emulatedFormFactor) {
-      // @ts-expect-error removed setting
-      deviceEmulation = settings.emulatedFormFactor === 'mobile'
-        ? Util.i18n.strings.runtimeMobileEmulation
-        // @ts-expect-error removed setting
-        : settings.emulatedFormFactor === 'desktop'
-          ? Util.i18n.strings.runtimeDesktopEmulation
-          : Util.i18n.strings.runtimeNoEmulation;
-    } else {
-      // TODO(paulirish): revise Runtime Settings strings: https://github.com/GoogleChrome/lighthouse/pull/11796
-      deviceEmulation = settings.formFactor === 'mobile'
-        ? Util.i18n.strings.runtimeMobileEmulation
-        : Util.i18n.strings.runtimeDesktopEmulation;
-    }
+    // TODO(paulirish): revise Runtime Settings strings: https://github.com/GoogleChrome/lighthouse/pull/11796
+    const deviceEmulation = settings.formFactor === 'mobile'
+      ? Util.i18n.strings.runtimeMobileEmulation
+      : Util.i18n.strings.runtimeDesktopEmulation;
 
     return {
       deviceEmulation,


### PR DESCRIPTION
fixes #11873 

restored the handling for the report's "Device" string for v6.

![image](https://user-images.githubusercontent.com/39191/102939340-f605ef80-4462-11eb-8010-9c5b69dcf605.png)

I redid the conditionals using ternaries, but that bit has the same logic.