### PR TITLE
core(errors-in-console): ignore BLOCKED_BY_CLIENT.Inspector errors

### DIFF
--- a/lighthouse-core/audits/errors-in-console.js
+++ b/lighthouse-core/audits/errors-in-console.js
@@ -45,6 +45,7 @@ class ErrorLogs extends Audit {
 
   /** @return {AuditOptions} */
   static defaultOptions() {
+    // Any failed network requests with error messsage aren't actionable
     return {ignoredPatterns: ['ERR_BLOCKED_BY_CLIENT.Inspector']};
   }
 

--- a/lighthouse-core/audits/errors-in-console.js
+++ b/lighthouse-core/audits/errors-in-console.js
@@ -45,9 +45,8 @@ class ErrorLogs extends Audit {
 
   /** @return {AuditOptions} */
   static defaultOptions() {
-    return {};
+    return {ignoredPatterns: ['ERR_BLOCKED_BY_CLIENT.Inspector']};
   }
-
 
   /**
    * @template {{description: string | undefined}} T

--- a/lighthouse-core/test/audits/errors-in-console-test.js
+++ b/lighthouse-core/test/audits/errors-in-console-test.js
@@ -124,22 +124,6 @@ describe('ConsoleMessages error logs audit', () => {
       'TypeError: Cannot read property \'msie\' of undefined');
   });
 
-  // https://github.com/GoogleChrome/lighthouse/issues/10198
-  it('filters out blocked_by_client.inspector messages', () => {
-    const auditResult = ErrorLogsAudit.audit({
-      ConsoleMessages: [{
-        'source': 'exception',
-        'level': 'error',
-        'timestamp': 1506535813608.003,
-        'url': 'https://www.facebook.com/tr/',
-        'text': 'Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector',
-      }],
-    }, {options: ErrorLogsAudit.defaultOptions()});
-    assert.equal(auditResult.score, 1);
-    assert.equal(auditResult.details.items.length, 0);
-  });
-
-
   describe('options', () => {
     it('does nothing with an empty pattern', () => {
       const options = {ignoredPatterns: ''};
@@ -238,6 +222,23 @@ describe('ConsoleMessages error logs audit', () => {
 
       expect(result.score).toBe(1);
       expect(result.details.items).toHaveLength(0);
+    });
+  });
+
+  describe('defaultOptions', () => {
+    // See https://github.com/GoogleChrome/lighthouse/issues/10198
+    it('filters out blocked_by_client.inspector messages by default', () => {
+      const auditResult = ErrorLogsAudit.audit({
+        ConsoleMessages: [{
+          'source': 'exception',
+          'level': 'error',
+          'timestamp': 1506535813608.003,
+          'url': 'https://www.facebook.com/tr/',
+          'text': 'Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector',
+        }],
+      }, {options: ErrorLogsAudit.defaultOptions()});
+      assert.equal(auditResult.score, 1);
+      assert.equal(auditResult.details.items.length, 0);
     });
   });
 });

--- a/lighthouse-core/test/audits/errors-in-console-test.js
+++ b/lighthouse-core/test/audits/errors-in-console-test.js
@@ -124,6 +124,22 @@ describe('ConsoleMessages error logs audit', () => {
       'TypeError: Cannot read property \'msie\' of undefined');
   });
 
+  // Checks bug #10198
+  it('filters out blocked_by_client.inspector messages', () => {
+    const auditResult = ErrorLogsAudit.audit({
+      ConsoleMessages: [{
+        'source': 'exception',
+        'level': 'error',
+        'timestamp': 1506535813608.003,
+        'url': 'https://www.facebook.com/tr/',
+        'text': 'Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector',
+      }],
+    }, {options: ErrorLogsAudit.defaultOptions()});
+    assert.equal(auditResult.score, 1);
+    assert.equal(auditResult.details.items.length, 0);
+  });
+
+
   describe('options', () => {
     it('does nothing with an empty pattern', () => {
       const options = {ignoredPatterns: ''};

--- a/lighthouse-core/test/audits/errors-in-console-test.js
+++ b/lighthouse-core/test/audits/errors-in-console-test.js
@@ -124,7 +124,7 @@ describe('ConsoleMessages error logs audit', () => {
       'TypeError: Cannot read property \'msie\' of undefined');
   });
 
-  // Checks bug #10198
+  // https://github.com/GoogleChrome/lighthouse/issues/10198
   it('filters out blocked_by_client.inspector messages', () => {
     const auditResult = ErrorLogsAudit.audit({
       ConsoleMessages: [{


### PR DESCRIPTION
the `.Inspector` [`Network.BlockedReason`](https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-BlockedReason) indicates it's devtools instrumentation itself that's blocking.  And we see cases where this crops up and is just noise.

fixes https://github.com/GoogleChrome/lighthouse/issues/10198