### PR TITLE
core(fr): add base config

### DIFF
--- a/lighthouse-core/config/config-helpers.js
+++ b/lighthouse-core/config/config-helpers.js
@@ -6,9 +6,15 @@
 'use strict';
 
 const path = require('path');
+const isDeepEqual = require('lodash.isequal');
+const constants = require('./constants.js');
+const Budget = require('./budget.js');
 const Audit = require('../audits/audit.js');
 const Runner = require('../runner.js');
 const i18n = require('../lib/i18n/i18n.js');
+
+/** @typedef {typeof import('../gather/gatherers/gatherer.js')} GathererConstructor */
+/** @typedef {InstanceType<GathererConstructor>} Gatherer */
 
 /**
  * If any items with identical `path` properties are found in the input array,
@@ -34,6 +40,77 @@ const mergeOptionsOfItems = function(items) {
 
   return mergedItems;
 };
+
+/**
+ * Recursively merges config fragment objects in a somewhat Lighthouse-specific way.
+ *
+ *    - `null` is treated similarly to `undefined` for whether a value should be overridden.
+ *    - `overwriteArrays` controls array extension behavior:
+ *        - true: Arrays are overwritten without any merging or concatenation.
+ *        - false: Arrays are concatenated and de-duped by isDeepEqual.
+ *    - Objects are recursively merged.
+ *    - If the `settings` key is encountered while traversing an object, its arrays are *always*
+ *      overridden, not concatenated. (`overwriteArrays` is flipped to `true`)
+ *
+ * More widely typed than exposed merge() function, below.
+ * @param {Object<string, any>|Array<any>|undefined|null} base
+ * @param {Object<string, any>|Array<any>} extension
+ * @param {boolean=} overwriteArrays
+ */
+function _mergeConfigFragment(base, extension, overwriteArrays = false) {
+  // If the default value doesn't exist or is explicitly null, defer to the extending value
+  if (typeof base === 'undefined' || base === null) {
+    return extension;
+  } else if (typeof extension === 'undefined') {
+    return base;
+  } else if (Array.isArray(extension)) {
+    if (overwriteArrays) return extension;
+    if (!Array.isArray(base)) throw new TypeError(`Expected array but got ${typeof base}`);
+    const merged = base.slice();
+    extension.forEach(item => {
+      if (!merged.some(candidate => isDeepEqual(candidate, item))) merged.push(item);
+    });
+
+    return merged;
+  } else if (typeof extension === 'object') {
+    if (typeof base !== 'object') throw new TypeError(`Expected object but got ${typeof base}`);
+    if (Array.isArray(base)) throw new TypeError('Expected object but got Array');
+    Object.keys(extension).forEach(key => {
+      const localOverwriteArrays = overwriteArrays ||
+        (key === 'settings' && typeof base[key] === 'object');
+      base[key] = _mergeConfigFragment(base[key], extension[key], localOverwriteArrays);
+    });
+    return base;
+  }
+
+  return extension;
+}
+
+/**
+ * Until support of jsdoc templates with constraints, type in config.d.ts.
+ * See https://github.com/Microsoft/TypeScript/issues/24283
+ * @type {LH.Config.Merge}
+ */
+const mergeConfigFragment = _mergeConfigFragment;
+
+/**
+ * Validate the settings after they've been built
+ * @param {LH.Config.Settings} settings
+ */
+function assertValidSettings(settings) {
+  if (!settings.formFactor) {
+    throw new Error(`\`settings.formFactor\` must be defined as 'mobile' or 'desktop'. See https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md`);
+  }
+
+  if (!settings.screenEmulation.disabled) {
+    // formFactor doesn't control emulation. So we don't want a mismatch:
+    //   Bad mismatch A: user wants mobile emulation but scoring is configured for desktop
+    //   Bad mismtach B: user wants everything desktop and set formFactor, but accidentally not screenEmulation
+    if (settings.screenEmulation.mobile !== (settings.formFactor === 'mobile')) {
+      throw new Error(`Screen emulation mobile setting (${settings.screenEmulation.mobile}) does not match formFactor setting (${settings.formFactor}). See https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md`);
+    }
+  }
+}
 
 /**
  * Throws an error if the provided object does not implement the required properties of an audit
@@ -84,34 +161,205 @@ function assertValidAudit(auditDefinition) {
 }
 
 /**
- * Expands the audits from user-specified JSON to an internal audit definition format.
- * @param {LH.Config.Json['audits']} audits
- * @return {?Array<{id?: string, path: string, options?: {}} | {id?: string, implementation: typeof Audit, path?: string, options?: {}}>}
+ * Expands a gatherer from user-specified to an internal gatherer definition format.
+ *
+ * Input Examples:
+ *  - 'my-gatherer'
+ *  - class MyGatherer extends Gatherer { }
+ *  - {instance: myGathererInstance}
+ *
+ * @param {LH.Config.GathererJson} gatherer
+ * @return {{instance?: Gatherer, implementation?: GathererConstructor, path?: string}} passes
  */
-function expandAuditShorthand(audits) {
-  if (!audits) {
-    return null;
+function expandGathererShorthand(gatherer) {
+  if (typeof gatherer === 'string') {
+    // just 'path/to/gatherer'
+    return {path: gatherer};
+  } else if ('implementation' in gatherer || 'instance' in gatherer) {
+    // {implementation: GathererConstructor, ...} or {instance: GathererInstance, ...}
+    return gatherer;
+  } else if ('path' in gatherer) {
+    // {path: 'path/to/gatherer', ...}
+    if (typeof gatherer.path !== 'string') {
+      throw new Error('Invalid Gatherer type ' + JSON.stringify(gatherer));
+    }
+    return gatherer;
+  } else if (typeof gatherer === 'function') {
+    // just GathererConstructor
+    return {implementation: gatherer};
+  } else if (gatherer && typeof gatherer.beforePass === 'function') {
+    // just GathererInstance
+    return {instance: gatherer};
+  } else {
+    throw new Error('Invalid Gatherer type ' + JSON.stringify(gatherer));
+  }
+}
+
+/**
+ * Expands the audits from user-specified JSON to an internal audit definition format.
+ * @param {LH.Config.AuditJson} audit
+ * @return {{id?: string, path: string, options?: {}} | {id?: string, implementation: typeof Audit, path?: string, options?: {}}}
+ */
+function expandAuditShorthand(audit) {
+  if (typeof audit === 'string') {
+    // just 'path/to/audit'
+    return {path: audit, options: {}};
+  } else if ('implementation' in audit && typeof audit.implementation.audit === 'function') {
+    // {implementation: AuditClass, ...}
+    return audit;
+  } else if ('path' in audit && typeof audit.path === 'string') {
+    // {path: 'path/to/audit', ...}
+    return audit;
+  } else if ('audit' in audit && typeof audit.audit === 'function') {
+    // just AuditClass
+    return {implementation: audit, options: {}};
+  } else {
+    throw new Error('Invalid Audit type ' + JSON.stringify(audit));
+  }
+}
+
+/**
+ * @param {string} gathererPath
+ * @param {Array<string>} coreGathererList
+ * @param {string=} configDir
+ * @return {LH.Config.GathererDefn}
+ */
+function requireGatherer(gathererPath, coreGathererList, configDir) {
+  const coreGatherer = coreGathererList.find(a => a === `${gathererPath}.js`);
+
+  let requirePath = `../gather/gatherers/${gathererPath}`;
+  if (!coreGatherer) {
+    // Otherwise, attempt to find it elsewhere. This throws if not found.
+    requirePath = resolveModulePath(gathererPath, configDir, 'gatherer');
   }
 
-  const newAudits = audits.map(audit => {
-    if (typeof audit === 'string') {
-      // just 'path/to/audit'
-      return {path: audit, options: {}};
-    } else if ('implementation' in audit && typeof audit.implementation.audit === 'function') {
-      // {implementation: AuditClass, ...}
-      return audit;
-    } else if ('path' in audit && typeof audit.path === 'string') {
-      // {path: 'path/to/audit', ...}
-      return audit;
-    } else if ('audit' in audit && typeof audit.audit === 'function') {
-      // just AuditClass
-      return {implementation: audit, options: {}};
-    } else {
-      throw new Error('Invalid Audit type ' + JSON.stringify(audit));
-    }
-  });
+  const GathererClass = /** @type {GathererConstructor} */ (require(requirePath));
 
-  return newAudits;
+  return {
+    instance: new GathererClass(),
+    implementation: GathererClass,
+    path: gathererPath,
+  };
+}
+
+/**
+ *
+ * @param {string} auditPath
+ * @param {Array<string>} coreAuditList
+ * @param {string=} configDir
+ * @return {LH.Config.AuditDefn['implementation']}
+ */
+function requireAudit(auditPath, coreAuditList, configDir) {
+// See if the audit is a Lighthouse core audit.
+  const auditPathJs = `${auditPath}.js`;
+  const coreAudit = coreAuditList.find(a => a === auditPathJs);
+  let requirePath = `../audits/${auditPath}`;
+  if (!coreAudit) {
+  // TODO: refactor and delete `global.isDevtools`.
+    if (global.isDevtools || global.isLightrider) {
+    // This is for pubads bundling.
+      requirePath = auditPath;
+    } else {
+    // Otherwise, attempt to find it elsewhere. This throws if not found.
+      const absolutePath = resolveModulePath(auditPath, configDir, 'audit');
+      // Use a relative path so bundler can easily expose it.
+      requirePath = path.relative(__dirname, absolutePath);
+    }
+  }
+
+  return require(requirePath);
+}
+
+/**
+ * Creates a settings object from potential flags object by dropping all the properties
+ * that don't exist on Config.Settings.
+ * @param {Partial<LH.Flags>=} flags
+ * @return {RecursivePartial<LH.Config.Settings>}
+*/
+function cleanFlagsForSettings(flags = {}) {
+  /** @type {RecursivePartial<LH.Config.Settings>} */
+  const settings = {};
+
+  for (const key of Object.keys(flags)) {
+    if (key in constants.defaultSettings) {
+      // @ts-expect-error tsc can't yet express that key is only a single type in each iteration, not a union of types.
+      settings[key] = flags[key];
+    }
+  }
+
+  return settings;
+}
+
+/**
+ * @param {LH.SharedFlagsSettings} settingsJson
+ * @param {LH.Flags|undefined} overrides
+ * @return {LH.Config.Settings}
+ */
+function resolveSettings(settingsJson = {}, overrides = undefined) {
+  // If a locale is requested in flags or settings, use it. A typical CLI run will not have one,
+  // however `lookupLocale` will always determine which of our supported locales to use (falling
+  // back if necessary).
+  const locale = i18n.lookupLocale((overrides && overrides.locale) || settingsJson.locale);
+
+  // Fill in missing settings with defaults
+  const {defaultSettings} = constants;
+  const settingWithDefaults = mergeConfigFragment(deepClone(defaultSettings), settingsJson, true);
+
+  // Override any applicable settings with CLI flags
+  const settingsWithFlags = mergeConfigFragment(
+    settingWithDefaults,
+    cleanFlagsForSettings(overrides),
+    true
+  );
+
+  if (settingsWithFlags.budgets) {
+    settingsWithFlags.budgets = Budget.initializeBudget(settingsWithFlags.budgets);
+  }
+  // Locale is special and comes only from flags/settings/lookupLocale.
+  settingsWithFlags.locale = locale;
+
+  // Default constants uses the mobile UA. Explicitly stating to true asks LH to use the associated UA.
+  // It's a little awkward, but the alternatives are not allowing `true` or a dedicated `disableUAEmulation` setting.
+  if (settingsWithFlags.emulatedUserAgent === true) {
+    settingsWithFlags.emulatedUserAgent = constants.userAgents[settingsWithFlags.formFactor];
+  }
+
+  assertValidSettings(settingsWithFlags);
+  return settingsWithFlags;
+}
+
+
+/**
+ * Turns a GathererJson into a GathererDefn which involves a few main steps:
+ *    - Expanding the JSON shorthand the full definition format.
+ *    - `require`ing in the implementation.
+ *    - Creating a gatherer instance from the implementation.
+ * @param {LH.Config.GathererJson} gathererJson
+ * @param {Array<string>} coreGathererList
+ * @param {string=} configDir
+ * @return {LH.Config.GathererDefn}
+ */
+function resolveGathererToDefn(gathererJson, coreGathererList, configDir) {
+  const gathererDefn = expandGathererShorthand(gathererJson);
+  if (gathererDefn.instance) {
+    return {
+      instance: gathererDefn.instance,
+      implementation: gathererDefn.implementation,
+      path: gathererDefn.path,
+    };
+  } else if (gathererDefn.implementation) {
+    const GathererClass = gathererDefn.implementation;
+    return {
+      instance: new GathererClass(),
+      implementation: gathererDefn.implementation,
+      path: gathererDefn.path,
+    };
+  } else if (gathererDefn.path) {
+    const path = gathererDefn.path;
+    return requireGatherer(path, coreGathererList, configDir);
+  } else {
+    throw new Error('Invalid expanded Gatherer: ' + JSON.stringify(gathererDefn));
+  }
 }
 
 /**
@@ -122,41 +370,25 @@ function expandAuditShorthand(audits) {
  * @param {string=} configDir
  * @return {Array<LH.Config.AuditDefn>|null}
  */
-function requireAudits(audits, configDir) {
-  const expandedAudits = expandAuditShorthand(audits);
-  if (!expandedAudits) {
+function resolveAuditsToDefns(audits, configDir) {
+  if (!audits) {
     return null;
   }
 
   const coreList = Runner.getAuditList();
-  const auditDefns = expandedAudits.map(audit => {
+  const auditDefns = audits.map(auditJson => {
+    const auditDefn = expandAuditShorthand(auditJson);
     let implementation;
-    if ('implementation' in audit) {
-      implementation = audit.implementation;
+    if ('implementation' in auditDefn) {
+      implementation = auditDefn.implementation;
     } else {
-      // See if the audit is a Lighthouse core audit.
-      const auditPathJs = `${audit.path}.js`;
-      const coreAudit = coreList.find(a => a === auditPathJs);
-      let requirePath = `../audits/${audit.path}`;
-      if (!coreAudit) {
-        // TODO: refactor and delete `global.isDevtools`.
-        if (global.isDevtools || global.isLightrider) {
-          // This is for pubads bundling.
-          requirePath = audit.path;
-        } else {
-          // Otherwise, attempt to find it elsewhere. This throws if not found.
-          const absolutePath = resolveModule(audit.path, configDir, 'audit');
-          // Use a relative path so bundler can easily expose it.
-          requirePath = path.relative(__dirname, absolutePath);
-        }
-      }
-      implementation = /** @type {typeof Audit} */ (require(requirePath));
+      implementation = requireAudit(auditDefn.path, coreList, configDir);
     }
 
     return {
       implementation,
-      path: audit.path,
-      options: audit.options || {},
+      path: auditDefn.path,
+      options: auditDefn.options || {},
     };
   });
 
@@ -175,7 +407,7 @@ function requireAudits(audits, configDir) {
  * @return {string}
  * @throws {Error}
  */
-function resolveModule(moduleIdentifier, configDir, category) {
+function resolveModulePath(moduleIdentifier, configDir, category) {
   // module in a node_modules/ that is...
   // |                                | Lighthouse globally installed | Lighthouse locally installed |
   // |--------------------------------|-------------------------------|------------------------------|
@@ -325,6 +557,9 @@ module.exports = {
   deepClone,
   deepCloneConfigJson,
   mergeOptionsOfItems,
-  requireAudits,
-  resolveModule,
+  mergeConfigFragment,
+  resolveSettings,
+  resolveGathererToDefn,
+  resolveAuditsToDefns,
+  resolveModulePath,
 };

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -10,15 +10,16 @@ const defaultConfig = require('./default-config.js');
 const constants = require('./constants.js');
 const i18n = require('./../lib/i18n/i18n.js');
 
-const isDeepEqual = require('lodash.isequal');
 const log = require('lighthouse-logger');
 const path = require('path');
 const Runner = require('../runner.js');
 const ConfigPlugin = require('./config-plugin.js');
-const Budget = require('./budget.js');
 const {
-  requireAudits,
-  resolveModule,
+  mergeConfigFragment,
+  resolveSettings,
+  resolveAuditsToDefns,
+  resolveGathererToDefn,
+  resolveModulePath,
   deepClone,
   deepCloneConfigJson,
 } = require('./config-helpers.js');
@@ -190,25 +191,6 @@ function assertValidFlags(flags) {
 }
 
 /**
- * Validate the settings after they've been built
- * @param {LH.Config.Settings} settings
- */
-function assertValidSettings(settings) {
-  if (!settings.formFactor) {
-    throw new Error(`\`settings.formFactor\` must be defined as 'mobile' or 'desktop'. See https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md`);
-  }
-
-  if (!settings.screenEmulation.disabled) {
-    // formFactor doesn't control emulation. So we don't want a mismatch:
-    //   Bad mismatch A: user wants mobile emulation but scoring is configured for desktop
-    //   Bad mismtach B: user wants everything desktop and set formFactor, but accidentally not screenEmulation
-    if (settings.screenEmulation.mobile !== (settings.formFactor === 'mobile')) {
-      throw new Error(`Screen emulation mobile setting (${settings.screenEmulation.mobile}) does not match formFactor setting (${settings.formFactor}). See https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md`);
-    }
-  }
-}
-
-/**
  * Throws if pluginName is invalid or (somehow) collides with a category in the
  * configJSON being added to.
  * @param {LH.Config.Json} configJSON
@@ -224,67 +206,6 @@ function assertValidPluginName(configJSON, pluginName) {
   }
 }
 
-/**
- * Creates a settings object from potential flags object by dropping all the properties
- * that don't exist on Config.Settings.
- * @param {Partial<LH.Flags>=} flags
- * @return {RecursivePartial<LH.Config.Settings>}
-*/
-function cleanFlagsForSettings(flags = {}) {
-  /** @type {RecursivePartial<LH.Config.Settings>} */
-  const settings = {};
-
-  for (const key of Object.keys(flags)) {
-    if (key in constants.defaultSettings) {
-      // @ts-expect-error tsc can't yet express that key is only a single type in each iteration, not a union of types.
-      settings[key] = flags[key];
-    }
-  }
-
-  return settings;
-}
-
-/**
- * More widely typed than exposed merge() function, below.
- * @param {Object<string, any>|Array<any>|undefined|null} base
- * @param {Object<string, any>|Array<any>} extension
- * @param {boolean=} overwriteArrays
- */
-function _merge(base, extension, overwriteArrays = false) {
-  // If the default value doesn't exist or is explicitly null, defer to the extending value
-  if (typeof base === 'undefined' || base === null) {
-    return extension;
-  } else if (typeof extension === 'undefined') {
-    return base;
-  } else if (Array.isArray(extension)) {
-    if (overwriteArrays) return extension;
-    if (!Array.isArray(base)) throw new TypeError(`Expected array but got ${typeof base}`);
-    const merged = base.slice();
-    extension.forEach(item => {
-      if (!merged.some(candidate => isDeepEqual(candidate, item))) merged.push(item);
-    });
-
-    return merged;
-  } else if (typeof extension === 'object') {
-    if (typeof base !== 'object') throw new TypeError(`Expected object but got ${typeof base}`);
-    if (Array.isArray(base)) throw new TypeError('Expected object but got Array');
-    Object.keys(extension).forEach(key => {
-      const localOverwriteArrays = overwriteArrays ||
-        (key === 'settings' && typeof base[key] === 'object');
-      base[key] = _merge(base[key], extension[key], localOverwriteArrays);
-    });
-    return base;
-  }
-
-  return extension;
-}
-
-/**
- * Until support of jsdoc templates with constraints, type in config.d.ts.
- * See https://github.com/Microsoft/TypeScript/issues/24283
- * @type {LH.Config.Merge}
- */
-const merge = _merge;
 
 /**
  * @implements {LH.Config.Config}
@@ -329,7 +250,7 @@ class Config {
     if (flags) {
       assertValidFlags(flags);
     }
-    const settings = Config.initSettings(configJSON.settings, flags);
+    const settings = resolveSettings(configJSON.settings || {}, flags);
 
     // Augment passes with necessary defaults and require gatherers.
     const passesWithDefaults = Config.augmentPassesWithDefaults(configJSON.passes);
@@ -349,7 +270,6 @@ class Config {
 
     Config.filterConfigIfNeeded(this);
 
-    assertValidSettings(this.settings);
     assertValidPasses(this.passes, this.audits);
     assertValidCategories(this.categories, this.audits, this.groups);
 
@@ -406,14 +326,14 @@ class Config {
         if (!basePass) {
           baseJSON.passes.push(pass);
         } else {
-          merge(basePass, pass);
+          mergeConfigFragment(basePass, pass);
         }
       }
 
       delete extendJSON.passes;
     }
 
-    return merge(baseJSON, extendJSON);
+    return mergeConfigFragment(baseJSON, extendJSON);
   }
 
   /**
@@ -433,7 +353,7 @@ class Config {
       // TODO: refactor and delete `global.isDevtools`.
       const pluginPath = global.isDevtools || global.isLightrider ?
         pluginName :
-        resolveModule(pluginName, configDir, 'plugin');
+        resolveModulePath(pluginName, configDir, 'plugin');
       const rawPluginJson = require(pluginPath);
       const pluginJson = ConfigPlugin.parsePlugin(rawPluginJson, pluginName);
 
@@ -453,79 +373,7 @@ class Config {
     }
 
     const {defaultPassConfig} = constants;
-    return passes.map(pass => merge(deepClone(defaultPassConfig), pass));
-  }
-
-  /**
-   * @param {LH.SharedFlagsSettings=} settingsJson
-   * @param {LH.Flags=} flags
-   * @return {LH.Config.Settings}
-   */
-  static initSettings(settingsJson = {}, flags) {
-    // If a locale is requested in flags or settings, use it. A typical CLI run will not have one,
-    // however `lookupLocale` will always determine which of our supported locales to use (falling
-    // back if necessary).
-    const locale = i18n.lookupLocale((flags && flags.locale) || settingsJson.locale);
-
-    // Fill in missing settings with defaults
-    const {defaultSettings} = constants;
-    const settingWithDefaults = merge(deepClone(defaultSettings), settingsJson, true);
-
-    // Override any applicable settings with CLI flags
-    const settingsWithFlags = merge(settingWithDefaults || {}, cleanFlagsForSettings(flags), true);
-
-    if (settingsWithFlags.budgets) {
-      settingsWithFlags.budgets = Budget.initializeBudget(settingsWithFlags.budgets);
-    }
-    // Locale is special and comes only from flags/settings/lookupLocale.
-    settingsWithFlags.locale = locale;
-
-    // Default constants uses the mobile UA. Explicitly stating to true asks LH to use the associated UA.
-    // It's a little awkward, but the alternatives are not allowing `true` or a dedicated `disableUAEmulation` setting.
-    if (settingsWithFlags.emulatedUserAgent === true) {
-      settingsWithFlags.emulatedUserAgent = constants.userAgents[settingsWithFlags.formFactor];
-    }
-
-    return settingsWithFlags;
-  }
-
-  /**
-   * Expands the gatherers from user-specified to an internal gatherer definition format.
-   *
-   * Input Examples:
-   *  - 'my-gatherer'
-   *  - class MyGatherer extends Gatherer { }
-   *  - {instance: myGathererInstance}
-   *
-   * @param {Array<LH.Config.GathererJson>} gatherers
-   * @return {Array<{instance?: Gatherer, implementation?: GathererConstructor, path?: string, options?: {}}>} passes
-   */
-  static expandGathererShorthand(gatherers) {
-    const expanded = gatherers.map(gatherer => {
-      if (typeof gatherer === 'string') {
-        // just 'path/to/gatherer'
-        return {path: gatherer, options: {}};
-      } else if ('implementation' in gatherer || 'instance' in gatherer) {
-        // {implementation: GathererConstructor, ...} or {instance: GathererInstance, ...}
-        return gatherer;
-      } else if ('path' in gatherer) {
-        // {path: 'path/to/gatherer', ...}
-        if (typeof gatherer.path !== 'string') {
-          throw new Error('Invalid Gatherer type ' + JSON.stringify(gatherer));
-        }
-        return gatherer;
-      } else if (typeof gatherer === 'function') {
-        // just GathererConstructor
-        return {implementation: gatherer, options: {}};
-      } else if (gatherer && typeof gatherer.beforePass === 'function') {
-        // just GathererInstance
-        return {instance: gatherer, options: {}};
-      } else {
-        throw new Error('Invalid Gatherer type ' + JSON.stringify(gatherer));
-      }
-    });
-
-    return expanded;
+    return passes.map(pass => mergeConfigFragment(deepClone(defaultPassConfig), pass));
   }
 
   /**
@@ -733,7 +581,7 @@ class Config {
 
   /**
    * Take an array of audits and audit paths and require any paths (possibly
-   * relative to the optional `configDir`) using `resolveModule`,
+   * relative to the optional `configDir`) using `resolveModulePath`,
    * leaving only an array of AuditDefns.
    * @param {LH.Config.Json['audits']} audits
    * @param {string=} configDir
@@ -742,39 +590,15 @@ class Config {
   static requireAudits(audits, configDir) {
     const status = {msg: 'Requiring audits', id: 'lh:config:requireAudits'};
     log.time(status, 'verbose');
-    const auditDefns = requireAudits(audits, configDir);
+    const auditDefns = resolveAuditsToDefns(audits, configDir);
     log.timeEnd(status);
     return auditDefns;
   }
 
   /**
-   * @param {string} path
-   * @param {Array<string>} coreAuditList
-   * @param {string=} configDir
-   * @return {LH.Config.GathererDefn}
-   */
-  static requireGathererFromPath(path, coreAuditList, configDir) {
-    const coreGatherer = coreAuditList.find(a => a === `${path}.js`);
-
-    let requirePath = `../gather/gatherers/${path}`;
-    if (!coreGatherer) {
-      // Otherwise, attempt to find it elsewhere. This throws if not found.
-      requirePath = resolveModule(path, configDir, 'gatherer');
-    }
-
-    const GathererClass = /** @type {GathererConstructor} */ (require(requirePath));
-
-    return {
-      instance: new GathererClass(),
-      implementation: GathererClass,
-      path,
-    };
-  }
-
-  /**
    * Takes an array of passes with every property now initialized except the
    * gatherers and requires them, (relative to the optional `configDir` if
-   * provided) using `resolveModule`, returning an array of full Passes.
+   * provided) using `resolveModulePath`, returning an array of full Passes.
    * @param {?Array<Required<LH.Config.PassJson>>} passes
    * @param {string=} configDir
    * @return {Config['passes']}
@@ -788,27 +612,8 @@ class Config {
 
     const coreList = Runner.getGathererList();
     const fullPasses = passes.map(pass => {
-      const gathererDefns = Config.expandGathererShorthand(pass.gatherers).map(gathererDefn => {
-        if (gathererDefn.instance) {
-          return {
-            instance: gathererDefn.instance,
-            implementation: gathererDefn.implementation,
-            path: gathererDefn.path,
-          };
-        } else if (gathererDefn.implementation) {
-          const GathererClass = gathererDefn.implementation;
-          return {
-            instance: new GathererClass(),
-            implementation: gathererDefn.implementation,
-            path: gathererDefn.path,
-          };
-        } else if (gathererDefn.path) {
-          const path = gathererDefn.path;
-          return Config.requireGathererFromPath(path, coreList, configDir);
-        } else {
-          throw new Error('Invalid expanded Gatherer: ' + JSON.stringify(gathererDefn));
-        }
-      });
+      const gathererDefns = pass.gatherers
+        .map(gatherer => resolveGathererToDefn(gatherer, coreList, configDir));
 
       // De-dupe gatherers by artifact name because artifact IDs must be unique at runtime.
       const uniqueDefns = Array.from(

--- a/lighthouse-core/fraggle-rock/config/config.js
+++ b/lighthouse-core/fraggle-rock/config/config.js
@@ -1,0 +1,107 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const path = require('path');
+const log = require('lighthouse-logger');
+const Runner = require('../../runner.js');
+const defaultConfig = require('./default-config.js');
+const {
+  deepCloneConfigJson,
+  resolveSettings,
+  resolveAuditsToDefns,
+  resolveGathererToDefn,
+} = require('../../config/config-helpers.js');
+const defaultConfigPath = path.join(__dirname, './default-config.js');
+
+/**
+ * @param {LH.Config.Json|undefined} configJSON
+ * @param {{configPath?: string}} context
+ * @return {{configWorkingCopy: LH.Config.Json, configDir?: string, configPath?: string}}
+ */
+function resolveWorkingCopy(configJSON, context) {
+  let {configPath} = context;
+
+  if (configPath && !path.isAbsolute(configPath)) {
+    throw new Error('configPath must be an absolute path');
+  }
+
+  if (!configJSON) {
+    configJSON = defaultConfig;
+    configPath = defaultConfigPath;
+  }
+
+  // The directory of the config path, if one was provided.
+  const configDir = configPath ? path.dirname(configPath) : undefined;
+
+  return {
+    configWorkingCopy: deepCloneConfigJson(configJSON),
+    configPath,
+    configDir,
+  };
+}
+
+/**
+ *
+ * @param {LH.Config.ArtifactJson[]|null|undefined} artifacts
+ * @param {string|undefined} configDir
+ * @return {LH.Config.ArtifactDefn[] | null}
+ */
+function resolveArtifactsToDefns(artifacts, configDir) {
+  if (!artifacts) return null;
+
+  const status = {msg: 'Resolve artifact definitions', id: 'lh:config:resolveArtifactsToDefns'};
+  log.time(status, 'verbose');
+
+  const coreGathererList = Runner.getGathererList();
+  const artifactDefns = artifacts.map(artifactJson => {
+    return {
+      id: artifactJson.id,
+      gatherer: resolveGathererToDefn(artifactJson.gatherer, coreGathererList, configDir),
+    };
+  });
+
+  log.timeEnd(status);
+  return artifactDefns;
+}
+
+/**
+ * @param {LH.Config.Json|undefined} configJSON
+ * @param {{configPath?: string, settingsOverrides?: LH.SharedFlagsSettings}} context
+ * @return {{config: LH.Config.FRConfig, warnings: string[]}}
+ */
+function initializeConfig(configJSON, context) {
+  const status = {msg: 'Initialize config', id: 'lh:config'};
+  log.time(status, 'verbose');
+
+  const {configWorkingCopy, configDir} = resolveWorkingCopy(configJSON, context);
+
+  // TODO(FR-COMPAT): handle config extension
+  // TODO(FR-COMPAT): handle config plugins
+  // TODO(FR-COMPAT): enforce navigation invariants
+
+  const settings = resolveSettings(configWorkingCopy.settings || {}, context.settingsOverrides);
+  const artifacts = resolveArtifactsToDefns(configWorkingCopy.artifacts, configDir);
+
+  /** @type {LH.Config.FRConfig} */
+  const config = {
+    artifacts,
+    audits: resolveAuditsToDefns(configWorkingCopy.audits, configDir),
+    categories: configWorkingCopy.categories || null,
+    groups: configWorkingCopy.groups || null,
+    settings,
+  };
+
+  // TODO(FR-COMPAT): filter config
+  // TODO(FR-COMPAT): validate navigations
+  // TODO(FR-COMPAT): validate audits
+  // TODO(FR-COMPAT): validate categories
+
+  log.timeEnd(status);
+  return {config, warnings: []};
+}
+
+module.exports = {resolveWorkingCopy, initializeConfig};

--- a/lighthouse-core/fraggle-rock/config/default-config.js
+++ b/lighthouse-core/fraggle-rock/config/default-config.js
@@ -1,0 +1,21 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const legacyDefaultConfig = require('../../config/default-config.js');
+
+/** @type {LH.Config.Json} */
+const defaultConfig = {
+  artifacts: [
+    {id: 'Accessibility', gatherer: 'accessibility'},
+  ],
+  settings: legacyDefaultConfig.settings,
+  audits: legacyDefaultConfig.audits,
+  categories: legacyDefaultConfig.categories,
+  groups: legacyDefaultConfig.groups,
+};
+
+module.exports = defaultConfig;

--- a/lighthouse-core/test/config/config-helpers-test.js
+++ b/lighthouse-core/test/config/config-helpers-test.js
@@ -8,14 +8,79 @@
 /* eslint-env jest */
 
 const path = require('path');
-const {deepClone, deepCloneConfigJson, requireAudits, resolveModule} =
-  require('../../config/config-helpers.js');
+const {
+  deepClone,
+  deepCloneConfigJson,
+  resolveSettings,
+  resolveGathererToDefn,
+  resolveAuditsToDefns,
+  resolveModulePath,
+  mergeConfigFragment,
+} = require('../../config/config-helpers.js');
+const Runner = require('../../runner.js');
 const Gatherer = require('../../gather/gatherers/gatherer.js');
+const ImageElementsGatherer = require('../../gather/gatherers/image-elements.js');
 const UserTimingsAudit = require('../../audits/user-timings.js');
 
 jest.mock('process', () => ({
   cwd: () => jest.fn(),
 }));
+
+describe('.mergeConfigFragment', () => {
+  it('should merge properties in like Object.assign', () => {
+    const base = {a: 1, b: 'yes', c: true};
+    const extension = {a: 2, c: false, d: 123};
+    const merged = mergeConfigFragment(base, extension);
+    expect(merged).toBe(base);
+    expect(merged).toEqual({a: 2, b: 'yes', c: false, d: 123});
+  });
+
+  it('should merge recursively', () => {
+    const base = {foo: {bar: 1}};
+    const extension = {foo: {baz: 2, bam: 3}};
+    const merged = mergeConfigFragment(base, extension);
+    expect(merged).toEqual({foo: {bar: 1, baz: 2, bam: 3}});
+  });
+
+  it('should not preserve null', () => {
+    // It is unclear how important this behavior is, but the `null` issue has had subtle
+    // importance in the config for many years at this point.
+    const base = {foo: null};
+    const extension = {foo: undefined};
+    const merged = mergeConfigFragment(base, extension);
+    expect(merged).toEqual({foo: undefined});
+  });
+
+  it('should concat arrays with deduplication', () => {
+    const base = {arr: [{x: 1}, {y: 2}]};
+    const extension = {arr: [{z: 3}, {x: 1}]};
+    const merged = mergeConfigFragment(base, extension);
+    expect(merged).toEqual({arr: [{x: 1}, {y: 2}, {z: 3}]});
+  });
+
+  it('should overwrite arrays when `overwriteArrays=true`', () => {
+    const base = {arr: [{x: 1}, {y: 2}]};
+    const extension = {arr: [{z: 3}, {x: 1}]};
+    const merged = mergeConfigFragment(base, extension, true);
+    expect(merged).toEqual({arr: [{z: 3}, {x: 1}]});
+  });
+
+  it('should special-case the `settings` key to enable `overwriteArrays`', () => {
+    const base = {settings: {onlyAudits: ['none']}};
+    const extension = {settings: {onlyAudits: ['user-timings']}};
+    const merged = mergeConfigFragment(base, extension);
+    expect(merged).toEqual({settings: {onlyAudits: ['user-timings']}});
+  });
+
+  it('should throw when merging incompatible types', () => {
+    expect(() => mergeConfigFragment(123, {})).toThrow();
+    expect(() => mergeConfigFragment('foo', {})).toThrow();
+    expect(() => mergeConfigFragment(123, [])).toThrow();
+    expect(() => mergeConfigFragment('foo', [])).toThrow();
+    expect(() => mergeConfigFragment({}, [])).toThrow();
+    expect(() => mergeConfigFragment([], {})).toThrow();
+  });
+});
 
 describe('.deepClone', () => {
   it('should clone things deeply', () => {
@@ -81,16 +146,145 @@ describe('.deepCloneConfigJson', () => {
   });
 });
 
+describe('.resolveSettings', () => {
+  it('resolves the locale', () => {
+    const settings = resolveSettings({locale: 'zh-CN'});
+    expect(settings.locale).toEqual('zh');
+  });
 
-describe('.requireAudits', () => {
+  it('fills with defaults', () => {
+    const settings = resolveSettings({});
+    expect(settings.formFactor).toEqual('mobile');
+  });
+
+  it('preserves array settings when merging', () => {
+    const settings = resolveSettings({output: ['html']});
+    expect(settings.output).toEqual(['html']);
+  });
+
+  it('cleans unrecognized properties from overrides', () => {
+    const settings = resolveSettings({}, {nonsense: 1, output: 'html'});
+    expect(settings.output).toEqual('html');
+    expect(settings).not.toHaveProperty('nonsense');
+  });
+
+  describe('budgets', () => {
+    it('initializes budgets', () => {
+      const settings = resolveSettings({
+        budgets: [
+          {
+            path: '/',
+            resourceCounts: [{resourceType: 'image', budget: 500}],
+          },
+        ],
+      });
+
+      expect(settings).toMatchObject({
+        budgets: [
+          {
+            path: '/',
+            resourceCounts: [{resourceType: 'image', budget: 500}],
+          },
+        ],
+      });
+    });
+
+    it('validates budgets', () => {
+      expect(() => resolveSettings({budgets: ['invalid']})).toThrow(/Budget file is not/);
+    });
+  });
+
+  describe('validation', () => {
+    it('formFactor', () => {
+      const desktopSettings = {formFactor: 'desktop', screenEmulation: {mobile: false}};
+      expect(() => resolveSettings(desktopSettings)).not.toThrow();
+      expect(() => resolveSettings({formFactor: 'mobile'})).not.toThrow();
+      expect(() => resolveSettings({formFactor: 'tablet'})).toThrow();
+      expect(() => resolveSettings({formFactor: 'thing-a-ma-bob'})).toThrow();
+    });
+
+    it('screenEmulation', () => {
+      expect(() =>
+        resolveSettings({
+          formFactor: 'mobile',
+          screenEmulation: {mobile: false},
+        })
+      ).toThrow();
+      expect(() =>
+        resolveSettings({
+          formFactor: 'desktop',
+          screenEmulation: {mobile: true},
+        })
+      ).toThrow();
+      expect(() =>
+        resolveSettings({
+          formFactor: 'mobile',
+          screenEmulation: {mobile: false, disabled: true},
+        })
+      ).not.toThrow();
+      expect(() =>
+        resolveSettings({
+          formFactor: 'desktop',
+          screenEmulation: {mobile: true, disabled: true},
+        })
+      ).not.toThrow();
+    });
+  });
+});
+
+describe('.resolveGathererToDefn', () => {
+  const coreList = Runner.getGathererList();
+
+  it('should expand gatherer path short-hand', () => {
+    const result = resolveGathererToDefn('image-elements', coreList);
+    expect(result).toEqual({
+      path: 'image-elements',
+      implementation: ImageElementsGatherer,
+      instance: expect.any(ImageElementsGatherer),
+    });
+  });
+
+  it('should find relative to configDir', () => {
+    const configDir = path.resolve(__dirname, '../../gather/');
+    const result = resolveGathererToDefn('gatherers/image-elements', [], configDir);
+    expect(result).toEqual({
+      path: 'gatherers/image-elements',
+      implementation: ImageElementsGatherer,
+      instance: expect.any(ImageElementsGatherer),
+    });
+  });
+
+  it('should expand gatherer impl short-hand', () => {
+    const result = resolveGathererToDefn({implementation: ImageElementsGatherer}, coreList);
+    expect(result).toEqual({
+      implementation: ImageElementsGatherer,
+      instance: expect.any(ImageElementsGatherer),
+    });
+  });
+
+  it('throws for invalid gathererDefn', () => {
+    expect(() => resolveGathererToDefn({})).toThrow(/Invalid Gatherer type/);
+  });
+});
+
+describe('.resolveAuditsToDefns', () => {
   it('should expand audit short-hand', () => {
-    const result = requireAudits(['user-timings']);
+    const result = resolveAuditsToDefns(['user-timings']);
 
     expect(result).toEqual([{path: 'user-timings', options: {}, implementation: UserTimingsAudit}]);
   });
 
+  it('should find relative to configDir', () => {
+    const configDir = path.resolve(__dirname, '../../');
+    const result = resolveAuditsToDefns(['audits/user-timings'], configDir);
+
+    expect(result).toEqual([
+      {path: 'audits/user-timings', options: {}, implementation: UserTimingsAudit},
+    ]);
+  });
+
   it('should handle multiple audit definition styles', () => {
-    const result = requireAudits(['user-timings', {implementation: UserTimingsAudit}]);
+    const result = resolveAuditsToDefns(['user-timings', {implementation: UserTimingsAudit}]);
 
     expect(result).toMatchObject([{path: 'user-timings'}, {implementation: UserTimingsAudit}]);
   });
@@ -101,7 +295,7 @@ describe('.requireAudits', () => {
       {path: 'is-on-https', options: {x: 1, y: 1}},
       {path: 'is-on-https', options: {x: 2}},
     ];
-    const merged = requireAudits(audits);
+    const merged = resolveAuditsToDefns(audits);
     expect(merged).toMatchObject([
       {path: 'user-timings', options: {}},
       {path: 'is-on-https', options: {x: 2, y: 1}},
@@ -109,11 +303,11 @@ describe('.requireAudits', () => {
   });
 
   it('throws for invalid auditDefns', () => {
-    expect(() => requireAudits([new Gatherer()])).toThrow(/Invalid Audit type/);
+    expect(() => resolveAuditsToDefns([new Gatherer()])).toThrow(/Invalid Audit type/);
   });
 });
 
-describe('resolveModule', () => {
+describe('.resolveModulePath', () => {
   const configFixturePath = path.resolve(__dirname, '../fixtures/config');
 
   beforeEach(() => {
@@ -122,21 +316,21 @@ describe('resolveModule', () => {
 
   it('lighthouse and plugins are installed in the same path', () => {
     const pluginName = 'chrome-launcher';
-    const pathToPlugin = resolveModule(pluginName, null, 'plugin');
+    const pathToPlugin = resolveModulePath(pluginName, null, 'plugin');
     expect(pathToPlugin).toEqual(require.resolve(pluginName));
   });
 
   describe('plugin paths to a file', () => {
     it('relative to the current working directory', () => {
       const pluginName = 'lighthouse-plugin-config-helper';
-      const pathToPlugin = resolveModule(pluginName, null, 'plugin');
+      const pathToPlugin = resolveModulePath(pluginName, null, 'plugin');
       expect(pathToPlugin).toEqual(require.resolve(path.resolve(configFixturePath, pluginName)));
     });
 
     it('relative to the config path', () => {
       process.cwd = jest.fn(() => path.resolve(configFixturePath, '../'));
       const pluginName = 'lighthouse-plugin-config-helper';
-      const pathToPlugin = resolveModule(pluginName, configFixturePath, 'plugin');
+      const pathToPlugin = resolveModulePath(pluginName, configFixturePath, 'plugin');
       expect(pathToPlugin).toEqual(require.resolve(path.resolve(configFixturePath, pluginName)));
     });
   });
@@ -152,7 +346,7 @@ describe('resolveModule', () => {
       const pluginDir = `${pluginsDirectory}/node_modules/plugin-in-working-directory`;
       process.cwd = jest.fn(() => pluginsDirectory);
 
-      const pathToPlugin = resolveModule(pluginName, null, 'plugin');
+      const pathToPlugin = resolveModulePath(pluginName, null, 'plugin');
 
       expect(pathToPlugin).toEqual(require.resolve(pluginName, {paths: [pluginDir]}));
     });
@@ -167,7 +361,7 @@ describe('resolveModule', () => {
       const configDirectory = `${pluginsDirectory}/config`;
       process.cwd = jest.fn(() => '/usr/bin/node');
 
-      const pathToPlugin = resolveModule(pluginName, configDirectory, 'plugin');
+      const pathToPlugin = resolveModulePath(pluginName, configDirectory, 'plugin');
 
       expect(pathToPlugin).toEqual(require.resolve(pluginName, {paths: [configDirectory]}));
     });

--- a/lighthouse-core/test/fraggle-rock/config/config-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/config-test.js
@@ -1,0 +1,64 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const {initializeConfig} = require('../../../fraggle-rock/config/config.js');
+
+/* eslint-env jest */
+
+describe('Fraggle Rock Config', () => {
+  it('should throw if the config path is not absolute', () => {
+    const configFn = () => initializeConfig(undefined, {configPath: '../relative/path'});
+    expect(configFn).toThrow(/must be an absolute path/);
+  });
+
+  it('should not mutate the original input', () => {
+    const configJson = {artifacts: [{id: 'ImageElements', gatherer: 'image-elements'}]};
+    const {config} = initializeConfig(configJson, {});
+    expect(configJson).toEqual({artifacts: [{id: 'ImageElements', gatherer: 'image-elements'}]});
+    expect(config).not.toBe(configJson);
+    expect(config).not.toEqual(configJson);
+    expect(config.artifacts).toMatchObject([{gatherer: {path: 'image-elements'}}]);
+  });
+
+  it('should use default config when none passed in', () => {
+    const {config} = initializeConfig(undefined, {});
+    expect(config.settings).toMatchObject({formFactor: 'mobile'});
+    if (!config.audits) throw new Error('Did not define audits');
+    expect(config.audits.length).toBeGreaterThan(0);
+  });
+
+  it('should resolve settings with defaults', () => {
+    const {config} = initializeConfig(
+      {settings: {output: 'csv', maxWaitForFcp: 1234}},
+      {settingsOverrides: {maxWaitForFcp: 12345}}
+    );
+
+    expect(config.settings).toMatchObject({
+      formFactor: 'mobile', // inherit from default
+      output: 'csv', // config-specific overrides
+      maxWaitForFcp: 12345, // explicit overrides
+    });
+  });
+
+  it('should resolve artifact definitions', () => {
+    const configJson = {artifacts: [{id: 'ImageElements', gatherer: 'image-elements'}]};
+    const {config} = initializeConfig(configJson, {});
+
+    expect(config).toMatchObject({
+      artifacts: [{id: 'ImageElements', gatherer: {path: 'image-elements'}}],
+    });
+  });
+
+  it.todo('should support extension');
+  it.todo('should support plugins');
+  it.todo('should set default properties on navigations');
+  it.todo('should adjust default pass options for throttling method');
+  it.todo('should normalize gatherer inputs');
+  it.todo('should require gatherers from their paths');
+  it.todo('should filter configuration');
+  it.todo('should validate audit/gatherer interdependencies');
+});


### PR DESCRIPTION
**Summary**
Base config logic for the new Fraggle Rock config. It's lots of lines, but mostly a move + adding missing tests. 

- Moves shared logic from `config.js` to `config-helpers.js`
    - merge logic
    - settings resolution and validation
    - gatherer resolution and validation
- Unites some naming and structural discrepancies between the two configs and gatherers/audits
    - `merge` was fairly generic when it has some highly specific config logic it it, renamed to `mergeConfigFragment` 
    - `resolveThing` is the new nomenclature used for converting from config input to config output (i.e. `thingJson` to `thingDefn`). This was previously some mixture of `requireThing`/`initializeThing`
    - `requireThing` is now just the logic to actually require an individual `Thing`
    - 
- Creates a new `fraggle-rock/config/config.js` to contain new config logic.
    - The barebones artifact flow for now. Remaining logic is stubbed out in tests and comments.
- Adds tests for previously untested config helpers.

**Related Issues/PRs**
ref #11313 
[Design Doc](https://docs.google.com/document/d/1fRCh_NVK82YmIi1Zq8y73_p79d-FdnKsvaxMy0xIpNw/edit#)