### PR TITLE
tests: increase treemap pptr timeouts

### DIFF
--- a/lighthouse-treemap/test/treemap-test-pptr.js
+++ b/lighthouse-treemap/test/treemap-test-pptr.js
@@ -15,6 +15,10 @@ const portNumber = 10200;
 const treemapUrl = `http://localhost:${portNumber}/dist/gh-pages/treemap/index.html`;
 const debugOptions = require('../app/debug.json');
 
+// These tests run in Chromium and have their own timeouts.
+// Make sure we get the more helpful test-specific timeout error instead of jest's generic one.
+jest.setTimeout(35_000);
+
 describe('Lighthouse Treemap', () => {
   // eslint-disable-next-line no-console
   console.log('\n✨ Be sure to have recently run this: yarn build-treemap');

--- a/lighthouse-viewer/test/viewer-test-pptr.js
+++ b/lighthouse-viewer/test/viewer-test-pptr.js
@@ -22,6 +22,10 @@ const defaultConfig =
 const lighthouseCategories = Object.keys(defaultConfig.categories);
 const getAuditsOfCategory = category => defaultConfig.categories[category].auditRefs;
 
+// These tests run in Chromium and have their own timeouts.
+// Make sure we get the more helpful test-specific timeout error instead of jest's generic one.
+jest.setTimeout(35_000);
+
 // TODO: should be combined in some way with clients/test/extension/extension-test.js
 describe('Lighthouse Viewer', () => {
   // eslint-disable-next-line no-console


### PR DESCRIPTION

**Summary**
Increases the test timeout on our pptr tests that don't have an explicit one. I've only personally ran into it for treemap but conceptually same thing applies to viewer.

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/pull/11915/checks?check_run_id=1650996600#step:11:21
