### PR TITLE
core(fr): add base gatherer class

### DIFF
--- a/lighthouse-core/fraggle-rock/api.js
+++ b/lighthouse-core/fraggle-rock/api.js
@@ -10,12 +10,11 @@ const Runner = require('../runner.js');
 const Config = require('../config/config.js');
 
 /**
- * @param {LH.Gatherer.GathererInstance} gatherer
+ * @param {LH.Gatherer.GathererInstance|LH.Gatherer.FRGathererInstance} gatherer
  * @return {gatherer is LH.Gatherer.FRGathererInstance}
  */
 function isFRGatherer(gatherer) {
-  // TODO(FR-COMPAT): use configuration on gatherer.meta to detect interface compatibility
-  return gatherer.name === 'Accessibility';
+  return 'meta' in gatherer;
 }
 
 /** @param {{page: import('puppeteer').Page, config?: LH.Config.Json}} options */
@@ -55,13 +54,13 @@ async function snapshot(options) {
       const artifacts = {};
 
       for (const {instance} of gatherers) {
-        // TODO(FR-COMPAT): use configuration on gatherer.meta to detect snapshot support
         if (!isFRGatherer(instance)) continue;
+        if (!instance.meta.supportedModes.includes('snapshot')) continue;
 
         /** @type {keyof LH.GathererArtifacts} */
         const artifactName = instance.name;
         const artifact = await Promise.resolve()
-          .then(() => instance.afterPass({driver}))
+          .then(() => instance.snapshot({gatherMode: 'snapshot', driver}))
           .catch(err => err);
 
         artifacts[artifactName] = artifact;

--- a/lighthouse-core/fraggle-rock/gather/base-gatherer.js
+++ b/lighthouse-core/fraggle-rock/gather/base-gatherer.js
@@ -1,0 +1,63 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-disable no-unused-vars */
+
+/**
+ * Base class for all gatherers supporting both Fraggle Rock and the legacy flow.
+ * Most extending classes should implement the Fraggle Rock API and let this class handle translation.
+ * See lighthouse-core/gather/gatherers/gatherer.js for legacy method explanations.
+ *
+ * @implements {LH.Gatherer.GathererInstance}
+ * @implements {LH.Gatherer.FRGathererInstance}
+ */
+class FRGatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {supportedModes: []}
+
+  /**
+   * Method to gather results about a page in a particular state.
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   * @return {LH.Gatherer.PhaseResult}
+   */
+  snapshot(passContext) { }
+
+  /**
+   * Legacy property used to define the artifact ID. In Fraggle Rock, the artifact ID lives on the config.
+   * @return {keyof LH.GathererArtifacts}
+   */
+  get name() {
+    // @ts-expect-error - assume that class name has been added to LH.GathererArtifacts.
+    return this.constructor.name;
+  }
+
+  /**
+   * Legacy method. Called before navigation to target url, roughly corresponds to `beforeTimespan`.
+   * @param {LH.Gatherer.PassContext} passContext
+   * @return {LH.Gatherer.PhaseResult}
+   */
+  beforePass(passContext) { }
+
+  /**
+   * Legacy method. Should never be used by a Fraggle Rock gatherer, here for compat only.
+   * @param {LH.Gatherer.PassContext} passContext
+   * @return {LH.Gatherer.PhaseResult}
+   */
+  pass(passContext) { }
+
+  /**
+   * Legacy method. Roughly corresponds to `afterTimespan` or `snapshot` depending on type of gatherer.
+   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.LoadData} loadData
+   * @return {LH.Gatherer.PhaseResult}
+   */
+  afterPass(passContext, loadData) {
+    return this.snapshot(passContext);
+  }
+}
+
+module.exports = FRGatherer;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -703,6 +703,7 @@ class GatherRunner {
       for (const passConfig of passConfigs) {
         /** @type {LH.Gatherer.PassContext} */
         const passContext = {
+          gatherMode: 'navigation',
           driver,
           url: options.requestedUrl,
           settings: options.settings,

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -7,7 +7,7 @@
 
 /* global window, document, getNodeDetails */
 
-const Gatherer = require('./gatherer.js');
+const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const axeLibSource = require('../../lib/axe.js').source;
 const pageFunctions = require('../../lib/page-functions.js');
 
@@ -98,14 +98,20 @@ async function runA11yChecks() {
 }
 
 /**
+ * @implements {LH.Gatherer.GathererInstance}
  * @implements {LH.Gatherer.FRGathererInstance}
  */
 class Accessibility extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.Accessibility>}
    */
-  afterPass(passContext) {
+  snapshot(passContext) {
     const driver = passContext.driver;
 
     return driver.evaluate(runA11yChecks, {

--- a/lighthouse-core/test/fraggle-rock/gather/base-gatherer-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/base-gatherer-test.js
@@ -13,7 +13,7 @@ const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const fakeParam = {};
 
 describe('BaseGatherer', () => {
-  it('should fullfill the contract of of both interfaces', () => {
+  it('should fullfill the contract of both interfaces', () => {
     const gatherer = new Gatherer();
 
     // Fraggle Rock Gatherer contract

--- a/lighthouse-core/test/fraggle-rock/gather/base-gatherer-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/base-gatherer-test.js
@@ -1,0 +1,44 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+
+/* eslint-env jest */
+
+/** @type {any} */
+const fakeParam = {};
+
+describe('BaseGatherer', () => {
+  it('should fullfill the contract of of both interfaces', () => {
+    const gatherer = new Gatherer();
+
+    // Fraggle Rock Gatherer contract
+    expect(typeof gatherer.meta).toBe('object');
+    expect(gatherer.snapshot(fakeParam)).toBe(undefined);
+
+    // Legacy Gatherer contract
+    expect(typeof gatherer.name).toBe('string');
+    expect(gatherer.beforePass(fakeParam)).toBe(undefined);
+    expect(gatherer.pass(fakeParam)).toBe(undefined);
+    expect(gatherer.afterPass(fakeParam, fakeParam)).toBe(undefined);
+  });
+
+  describe('.afterPass', () => {
+    it('delegates to snapshot', () => {
+      class MyGatherer extends Gatherer {
+        /** @param {*} _ */
+        snapshot(_) {
+          return 'Hello, Fraggle!';
+        }
+      }
+
+      const gatherer = new MyGatherer();
+      expect(gatherer.snapshot(fakeParam)).toEqual('Hello, Fraggle!');
+      expect(gatherer.afterPass(fakeParam, fakeParam)).toEqual('Hello, Fraggle!');
+    });
+  });
+});

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -31,10 +31,12 @@ declare global {
 
     /** The limited context interface shared between pre and post Fraggle Rock Lighthouse. */
     export interface FRTransitionalContext {
+      gatherMode: GatherMode
       driver: FRTransitionalDriver;
     }
 
     export interface PassContext {
+      gatherMode: 'navigation';
       /** The url of the currently loaded page. If the main document redirects, this will be updated to keep track. */
       url: string;
       driver: Driver;
@@ -54,6 +56,12 @@ declare global {
     type PhaseResult_ = void|LH.GathererArtifacts[keyof LH.GathererArtifacts]
     export type PhaseResult = PhaseResult_ | Promise<PhaseResult_>
 
+    export type GatherMode = 'snapshot'|'timespan'|'navigation';
+
+    export interface GathererMeta {
+      supportedModes: Array<GatherMode>;
+    }
+
     export interface GathererInstance {
       name: keyof LH.GathererArtifacts;
       beforePass(context: LH.Gatherer.PassContext): PhaseResult;
@@ -62,8 +70,9 @@ declare global {
     }
 
     export interface FRGathererInstance {
-      name: keyof LH.GathererArtifacts;
-      afterPass(context: FRTransitionalContext): PhaseResult;
+      name: keyof LH.GathererArtifacts; // temporary COMPAT measure until artifact config support is available
+      meta: GathererMeta;
+      snapshot(context: FRTransitionalContext): PhaseResult;
     }
 
     namespace Simulation {


### PR DESCRIPTION
**Summary**
Adds the base Fraggle Rock gatherer class that allows transition of gatherers to implement both APIs.

Why a new class instead of the augmenting the old class? Clarity. This approach allows anyone reading a gatherer file to immediately see whether it supports the new modes or not. We'll also be able to know from a type perspective that a gatherer doesn't support the new method, forcing a one-by-one examination of each gatherer as we upgrade them for FR.

**Related Issues/PRs**
ref #11313 
[Design Doc](https://docs.google.com/document/d/1fRCh_NVK82YmIi1Zq8y73_p79d-FdnKsvaxMy0xIpNw/edit#)
