### PR TITLE
tests: add simple repro for oopif

### DIFF
--- a/lighthouse-cli/test/fixtures/oopif.html
+++ b/lighthouse-cli/test/fixtures/oopif.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <body>
-    <h1>Hello frames</h1>
-    <iframe id="oopif" name="oopif" src="https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/" style="width: 100vw; height: 110vh;"></iframe>
-    <iframe id="outer-iframe" src="http://localhost:10200/online-only.html" style="position: fixed"></iframe>
-  </body>
-</html>

--- a/lighthouse-cli/test/fixtures/oopif/oopif-inner.html
+++ b/lighthouse-cli/test/fixtures/oopif/oopif-inner.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>I'm iframed</title>
+
+<aside hidden>
+  <h2 style="color:red">this iframe isn't an oopif.</h2>
+  <h3>we saw that <code>navigator.deviceMemory</code> is the _same_ indicating they share a process</h3>
+  <h4>please ensure chrome was run with this:</h4>
+  <code>--host-rules="MAP oopifdomain 127.0.0.1" --isolate-origins="http://oopifdomain:10503"</code>
+</aside>
+
+<h3>Hello there, I'm a page in an out of process iframe.</h3>
+
+<script>
+  // See comment in oopif-outer.html
+  const isOopif = location.hash !== `#${navigator.deviceMemory}GB`;
+  if (!isOopif) {
+    document.querySelector('aside').hidden = false;
+  }
+</script>

--- a/lighthouse-cli/test/fixtures/oopif/oopif-outer.html
+++ b/lighthouse-cli/test/fixtures/oopif/oopif-outer.html
@@ -1,12 +1,17 @@
 <!DOCTYPE html>
 
 <h1>Hello oopif</h1>
-<iframe id="oopif" src="http://oopifdomain:10503/oopif/oopif-inner.html"  style="width: 90vw; height: 40vh;"></iframe>
-<br>
-<small>If the above iframe doesn't load, run chrome with <code>--host-rules="MAP oopifdomain 127.0.0.1" --isolate-origins="http://oopifdomain:10503"</code></small>
 <script>
+  // We construct the iframe in JS only to synchronously set the location hash
+  const iframe = document.createElement('iframe');
+  iframe.id='oopif';
   // Experimental hack to detect we're OOPIF clientside.
   // The deviceMemory API seems to not work for OOPIF, so we match values between outer/inner frames
   // See script in oopif-inner.html
-  window.oopif.src += `#${navigator.deviceMemory}GB`;
+  iframe.src=`http://oopifdomain:10503/oopif/oopif-inner.html#${navigator.deviceMemory}GB`;
+  iframe.style='width: 90vw; height: 40vh';
+  document.body.append(iframe);
 </script>
+
+<br>
+<small>If the above iframe doesn't load, run chrome with <code>--host-rules="MAP oopifdomain 127.0.0.1" --isolate-origins="http://oopifdomain:10503"</code></small>

--- a/lighthouse-cli/test/fixtures/oopif/oopif-outer.html
+++ b/lighthouse-cli/test/fixtures/oopif/oopif-outer.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+
+<h1>Hello oopif</h1>
+<iframe id="oopif" src="http://oopifdomain:10503/oopif/oopif-inner.html"  style="width: 90vw; height: 40vh;"></iframe>
+<br>
+<small>If the above iframe doesn't load, run chrome with <code>--host-rules="MAP oopifdomain 127.0.0.1" --isolate-origins="http://oopifdomain:10503"</code></small>
+<script>
+  // Experimental hack to detect we're OOPIF clientside.
+  // The deviceMemory API seems to not work for OOPIF, so we match values between outer/inner frames
+  // See script in oopif-inner.html
+  window.oopif.src += `#${navigator.deviceMemory}GB`;
+</script>

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
@@ -59,6 +59,7 @@ async function internalRun(url, tmpPath, configJson, isDebug) {
     `${url}`,
     `--output-path=${outputPath}`,
     '--output=json',
+    `--chrome-flags='--host-rules="MAP oopifdomain 127.0.0.1" --isolate-origins="http://oopifdomain:10503"'`,
     `-G=${artifactsDirectory}`,
     `-A=${artifactsDirectory}`,
     '--quiet',

--- a/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-config.js
@@ -11,12 +11,6 @@
  */
 module.exports = {
   extends: 'lighthouse:default',
-  settings: {
-    // This test runs in CI and hits the outside network of a live site.
-    // Be a little more forgiving on how long it takes all network requests of several nested iframes
-    // to complete.
-    maxWaitForLoad: 180000,
-  },
   passes: [
     // CI machines are pretty weak which lead to many more long tasks than normal.
     // Reduce our requirement for CPU quiet.

--- a/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-expectations.js
@@ -12,18 +12,18 @@
 module.exports = [
   {
     lhr: {
-      requestedUrl: 'http://localhost:10200/oopif.html',
-      finalUrl: 'http://localhost:10200/oopif.html',
+      requestedUrl: 'http://localhost:10200/oopif/oopif-outer.html',
+      finalUrl: 'http://localhost:10200/oopif/oopif-outer.html',
       audits: {
         'network-requests': {
           details: {
-            items: {
-            // We want to make sure we are finding the iframe's requests (paulirish.com) *AND*
-            // the iframe's iframe's iframe's requests (youtube.com/doubleclick/etc).
-            // - paulirish.com ~40-60 requests
-            // - paulirish.com + all descendant iframes ~80-90 requests
-              length: '>70',
-            },
+            items: [
+              {'url': 'http://localhost:10200/oopif/oopif-outer.html'},
+              {'url': 'http://oopifdomain:10503/oopif/oopif-inner.html'},
+              // This is a BUG. There should not be a second network request the oopif document
+              {'url': 'http://oopifdomain:10503/oopif/oopif-inner.html'},
+              {'url': 'http://localhost:10200/favicon.ico'},
+            ],
           },
         },
       },
@@ -32,21 +32,12 @@ module.exports = [
       IFrameElements: [
         {
           id: 'oopif',
-          src: 'https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/',
+          src: /^http:\/\/oopifdomain:10503\/oopif\/oopif-inner\.html/,
           clientRect: {
             width: '>0',
             height: '>0',
           },
           isPositionFixed: false,
-        },
-        {
-          id: 'outer-iframe',
-          src: 'http://localhost:10200/online-only.html',
-          clientRect: {
-            width: '>0',
-            height: '>0',
-          },
-          isPositionFixed: true,
         },
       ],
     },

--- a/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-expectations.js
@@ -20,8 +20,6 @@ module.exports = [
             items: [
               {'url': 'http://localhost:10200/oopif/oopif-outer.html'},
               {'url': 'http://oopifdomain:10503/oopif/oopif-inner.html'},
-              // This is a BUG. There should not be a second network request the oopif document
-              {'url': 'http://oopifdomain:10503/oopif/oopif-inner.html'},
               {'url': 'http://localhost:10200/favicon.ico'},
             ],
           },


### PR DESCRIPTION
a few of us have been working with iframes recently and I mostly wanted a nice simple repro for them.


### basic approach

run chrome with `--host-rules="MAP oopifdomain 127.0.0.1" --isolate-origins="http://oopifdomain:10503"` and then open an iframe to `"http://oopifdomain:10503"...`.


```html
<iframe id="oopif" src="http://oopifdomain:10503/online-only.html"  style="width: 90vw; height: 120px;"></iframe>
```




### pr 

i coulda just documented it but I figured why not replace the existing `oopif.html` smoketest, which relies on paulirish.com and youtube. 

![image](https://user-images.githubusercontent.com/39191/103703604-ab08d380-4f5c-11eb-9030-6ce2c04432e5.png)

i also added a "feature detect" that detects the iframe is isolated using `navigator.deviceMemory`. it isn't necessary, but maybe its worth it.

the downside is these chrome flags need to be set on the browser, and so i'm currently injecting them into the smokehouse CLI runner. this isn't great. (and means the bundle smoketest runner wont load this correctly)

**options**

- A: use this approach and somehow skip the test where we can't set CLI flags.
- B: don't use `isolate-origins` and instead just make a simpler demo where we always have oopif.  eg localhost iframing https://paulirish.github.io/tiny-demos-on-https/simple.html gives me an oopif, though i don't know if this is 100% reproducible.