### PR TITLE
core(font-size): handle valueless attributes for inline styles

### DIFF
--- a/lighthouse-cli/test/fixtures/seo/seo-tester.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tester.html
@@ -58,7 +58,7 @@
   <p class='small-4'> 4. </p>
   <h6>2</h6>
   <font size="1">3<b>4</b></font>
-  <div style="">
+  <div style=''>
     <p style='font-size:10px'> 5 </p>
   </div>
   <script class='small'>

--- a/lighthouse-cli/test/fixtures/seo/seo-tester.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tester.html
@@ -58,7 +58,9 @@
   <p class='small-4'> 4. </p>
   <h6>2</h6>
   <font size="1">3<b>4</b></font>
-  <p style='font-size:10px'> 5 </p>
+  <div style="">
+    <p style='font-size:10px'> 5 </p>
+  </div>
   <script class='small'>
     // text from SCRIPT tags should be ignored by the font-size audit
   </script>

--- a/lighthouse-cli/test/smokehouse/test-definitions/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/seo/expectations.js
@@ -222,7 +222,7 @@ const expectations = [
                 source: {type: 'url', value: /seo-tester\.html.+$/},
                 selector: {
                   type: 'node',
-                  selector: 'body',
+                  selector: 'div',
                   snippet: '<p style="font-size:10px">',
                 },
                 fontSize: '10px',

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -76,7 +76,7 @@ function getAttributeMap(attributes = []) {
 
   for (let i = 0; i < attributes.length; i += 2) {
     const name = attributes[i].toLowerCase();
-    const value = attributes[i + 1].trim();
+    const value = (attributes[i + 1] || '').trim();
 
     if (value) {
       map.set(name, value);

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -68,18 +68,21 @@ function getUniqueFailingRules(fontSizeArtifact) {
 }
 
 /**
- * @param {Array<string>=} attributes
+ * @param {Array<string|undefined>=} attributes
  * @returns {Map<string, string>}
  */
 function getAttributeMap(attributes = []) {
   const map = new Map();
 
   for (let i = 0; i < attributes.length; i += 2) {
-    const name = attributes[i].toLowerCase();
-    const value = (attributes[i + 1] || '').trim();
+    const name = attributes[i];
+    const value = attributes[i + 1];
+    if (!name || !value) continue;
 
-    if (value) {
-      map.set(name, value);
+    const normalizedValue = value.trim();
+
+    if (normalizedValue) {
+      map.set(name.toLowerCase(), normalizedValue);
     }
   }
 

--- a/lighthouse-core/test/audits/seo/font-size-test.js
+++ b/lighthouse-core/test/audits/seo/font-size-test.js
@@ -227,6 +227,35 @@ describe('SEO: Font size audit', () => {
     expect(auditResult.notApplicable).toBe(true);
   });
 
+  it('handles valueless attributes on grandparent nodes', async () => {
+    const artifacts = {
+      URL,
+      MetaElements: makeMetaElements(validViewport),
+      FontSize: {
+        totalTextLength: 13,
+        failingTextLength: 13,
+        analyzedFailingTextLength: 13,
+        analyzedFailingNodesData: [
+          {
+            nodeId: 1,
+            textLength: 13,
+            fontSize: 10,
+            cssRule: {type: 'Inline'},
+            parentNode: {
+              nodeName: 'p',
+              attributes: ['style', 'font-size: 10px;'],
+              parentNode: {nodeName: 'div', attributes: ['style', undefined]},
+            },
+          },
+        ],
+      },
+    };
+
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
+    assert.equal(auditResult.score, 0);
+    expect(auditResult.displayValue).toBeDisplayString('0% legible text');
+  });
+
   describe('attributes source of style', () => {
     async function runFontSizeAuditWithSingleFailingStyle(style, nodeProperties) {
       const artifacts = {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**

<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

This PR fixes the bug described in #11606. A description of the root cause is in [this comment][1].

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**

Closes https://github.com/GoogleChrome/lighthouse/issues/11606


[1]: https://github.com/GoogleChrome/lighthouse/issues/11606#issuecomment-757362727