### PR TITLE
core(fr): filter configs by gather mode

### DIFF
--- a/lighthouse-core/fraggle-rock/api.js
+++ b/lighthouse-core/fraggle-rock/api.js
@@ -42,9 +42,8 @@ async function snapshot(options) {
       /** @type {Partial<LH.GathererArtifacts>} */
       const artifacts = {};
 
-      for (const {gatherer} of config.artifacts || []) {
-        /** @type {keyof LH.GathererArtifacts} */
-        const artifactName = gatherer.instance.name;
+      for (const {id, gatherer} of config.artifacts || []) {
+        const artifactName = /** @type {keyof LH.GathererArtifacts} */ (id);
         const artifact = await Promise.resolve()
           .then(() => gatherer.instance.snapshot({gatherMode: 'snapshot', driver}))
           .catch(err => err);

--- a/lighthouse-core/fraggle-rock/api.js
+++ b/lighthouse-core/fraggle-rock/api.js
@@ -7,19 +7,11 @@
 
 const Driver = require('./gather/driver.js');
 const Runner = require('../runner.js');
-const Config = require('../config/config.js');
-
-/**
- * @param {LH.Gatherer.GathererInstance|LH.Gatherer.FRGathererInstance} gatherer
- * @return {gatherer is LH.Gatherer.FRGathererInstance}
- */
-function isFRGatherer(gatherer) {
-  return 'meta' in gatherer;
-}
+const {initializeConfig} = require('./config/config.js');
 
 /** @param {{page: import('puppeteer').Page, config?: LH.Config.Json}} options */
 async function snapshot(options) {
-  const config = new Config(options.config);
+  const {config} = initializeConfig(options.config, {gatherMode: 'snapshot'});
   const driver = new Driver(options.page);
   await driver.connect();
 
@@ -47,20 +39,14 @@ async function snapshot(options) {
         PageLoadError: null,
       };
 
-      const gatherers = (config.passes || [])
-        .flatMap(pass => pass.gatherers);
-
       /** @type {Partial<LH.GathererArtifacts>} */
       const artifacts = {};
 
-      for (const {instance} of gatherers) {
-        if (!isFRGatherer(instance)) continue;
-        if (!instance.meta.supportedModes.includes('snapshot')) continue;
-
+      for (const {gatherer} of config.artifacts || []) {
         /** @type {keyof LH.GathererArtifacts} */
-        const artifactName = instance.name;
+        const artifactName = gatherer.instance.name;
         const artifact = await Promise.resolve()
-          .then(() => instance.snapshot({gatherMode: 'snapshot', driver}))
+          .then(() => gatherer.instance.snapshot({gatherMode: 'snapshot', driver}))
           .catch(err => err);
 
         artifacts[artifactName] = artifact;

--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -1,0 +1,81 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ *
+ * @param {LH.Config.FRConfig['artifacts']} artifacts
+ * @param {LH.Gatherer.GatherMode} mode
+ * @return {LH.Config.FRConfig['artifacts']}
+ */
+function filterArtifactsByGatherMode(artifacts, mode) {
+  if (!artifacts) return null;
+  return artifacts.filter(artifact => {
+    return artifact.gatherer.instance.meta.supportedModes.includes(mode);
+  });
+}
+
+/**
+ *
+ * @param {LH.Config.FRConfig['audits']} audits
+ * @param {Array<LH.Config.ArtifactDefn>} availableArtifacts
+ * @return {LH.Config.FRConfig['audits']}
+ */
+function filterAuditsByAvailableArtifacts(audits, availableArtifacts) {
+  if (!audits) return null;
+
+  const availableAritfactIds = new Set(availableArtifacts.map(artifact => artifact.id));
+
+  return audits.filter(audit =>
+    audit.implementation.meta.requiredArtifacts.every(id => availableAritfactIds.has(id))
+  );
+}
+
+/**
+ * @param {LH.Config.Config['categories']} categories
+ * @param {Array<LH.Config.AuditDefn>} availableAudits
+ * @return {LH.Config.Config['categories']}
+ */
+function filterCategoriesByAvailableAudits(categories, availableAudits) {
+  if (!categories) return categories;
+
+  const availableAuditIds = new Set(availableAudits.map(audit => audit.implementation.meta.id));
+
+  return Object.fromEntries(
+    Object.entries(categories).map(([categoryId, category]) => {
+      const filteredCategory = {
+        ...category,
+        auditRefs: category.auditRefs.filter(ref => availableAuditIds.has(ref.id)),
+      };
+      return [categoryId, filteredCategory];
+    })
+  );
+}
+
+/**
+ * @param {LH.Config.FRConfig} config
+ * @param {LH.Gatherer.GatherMode} mode
+ * @return {LH.Config.FRConfig}
+ */
+function filterConfigByGatherMode(config, mode) {
+  const artifacts = filterArtifactsByGatherMode(config.artifacts, mode);
+  const audits = filterAuditsByAvailableArtifacts(config.audits, artifacts || []);
+  const categories = filterCategoriesByAvailableAudits(config.categories, audits || []);
+
+  return {
+    ...config,
+    artifacts,
+    audits,
+    categories,
+  };
+}
+
+module.exports = {
+  filterConfigByGatherMode,
+  filterArtifactsByGatherMode,
+  filterAuditsByAvailableArtifacts,
+  filterCategoriesByAvailableAudits,
+};

--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -6,6 +6,7 @@
 'use strict';
 
 /**
+ * Filters an array of artifacts down to the set that supports the specified gather mode.
  *
  * @param {LH.Config.FRConfig['artifacts']} artifacts
  * @param {LH.Gatherer.GatherMode} mode
@@ -19,6 +20,7 @@ function filterArtifactsByGatherMode(artifacts, mode) {
 }
 
 /**
+ * Filters an array of audits down to the set that can be computed using only the specified artifacts.
  *
  * @param {LH.Config.FRConfig['audits']} audits
  * @param {Array<LH.Config.ArtifactDefn>} availableArtifacts
@@ -35,6 +37,9 @@ function filterAuditsByAvailableArtifacts(audits, availableArtifacts) {
 }
 
 /**
+ * Filters a categories object and their auditRefs down to the set that can be computed using
+ * only the specified audits.
+ *
  * @param {LH.Config.Config['categories']} categories
  * @param {Array<LH.Config.AuditDefn>} availableAudits
  * @return {LH.Config.Config['categories']}
@@ -56,6 +61,8 @@ function filterCategoriesByAvailableAudits(categories, availableAudits) {
 }
 
 /**
+ * Filters a config's artifacts, audits, and categories down to the set that supports the specified gather mode.
+ *
  * @param {LH.Config.FRConfig} config
  * @param {LH.Gatherer.GatherMode} mode
  * @return {LH.Config.FRConfig}

--- a/lighthouse-core/fraggle-rock/config/validation.js
+++ b/lighthouse-core/fraggle-rock/config/validation.js
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * @param {LH.Config.GathererDefn | LH.Config.FRGathererDefn} gathererDefn
+ * @return {gathererDefn is LH.Config.FRGathererDefn}
+ */
+function isFRGathererDefn(gathererDefn) {
+  return 'meta' in gathererDefn.instance;
+}
+
+module.exports = {isFRGathererDefn};

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -26,8 +26,9 @@ const LHError = require('./lib/lh-error.js');
 
 class Runner {
   /**
-   * @param {(runnerData: {requestedUrl: string, config: Config, driverMock?: Driver}) => Promise<LH.Artifacts>} gatherFn
-   * @param {{config: Config, url?: string, driverMock?: Driver}} runOpts
+   * @template {LH.Config.Config | LH.Config.FRConfig} TConfig
+   * @param {(runnerData: {requestedUrl: string, config: TConfig, driverMock?: Driver}) => Promise<LH.Artifacts>} gatherFn
+   * @param {{config: TConfig, url?: string, driverMock?: Driver}} runOpts
    * @return {Promise<LH.RunnerResult|undefined>}
    */
   static async run(gatherFn, runOpts) {

--- a/lighthouse-core/test/fraggle-rock/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/api-test-pptr.js
@@ -66,13 +66,16 @@ describe('Fraggle Rock API', () => {
       const accessibility = lhr.categories.accessibility;
       expect(accessibility.score).toBeLessThan(1);
 
-      const auditResults = accessibility.auditRefs.map(ref => lhr.audits[ref.id]);
-      const irrelevantDisplayModes = new Set(['notApplicable', 'manual']);
-      const applicableAudits = auditResults
-        .filter(audit => !irrelevantDisplayModes.has(audit.scoreDisplayMode));
+      const auditResults = Object.values(lhr.audits);
+      // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
+      expect(auditResults.length).toMatchInlineSnapshot(`58`);
 
-      const erroredAudits = applicableAudits
-        .filter(audit => audit.score === null);
+      const irrelevantDisplayModes = new Set(['notApplicable', 'manual']);
+      const applicableAudits = auditResults.filter(
+        audit => !irrelevantDisplayModes.has(audit.scoreDisplayMode)
+      );
+
+      const erroredAudits = applicableAudits.filter(audit => audit.score === null);
       expect(erroredAudits).toHaveLength(0);
 
       const failedAuditIds = applicableAudits

--- a/lighthouse-core/test/fraggle-rock/config/filters-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/filters-test.js
@@ -1,0 +1,140 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const BaseAudit = require('../../../audits/audit.js');
+const BaseGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const {defaultSettings} = require('../../../config/constants.js');
+const filters = require('../../../fraggle-rock/config/filters.js');
+
+/* eslint-env jest */
+
+describe('Fraggle Rock Config Filtering', () => {
+  const snapshotGatherer = new BaseGatherer();
+  snapshotGatherer.meta = {supportedModes: ['snapshot']};
+  const timespanGatherer = new BaseGatherer();
+  timespanGatherer.meta = {supportedModes: ['timespan']};
+
+  const artifacts = [
+    {id: 'Snapshot', gatherer: {instance: snapshotGatherer}},
+    {id: 'Timespan', gatherer: {instance: timespanGatherer}},
+  ];
+
+  describe('filterArtifactsByGatherMode', () => {
+    it('should handle null', () => {
+      expect(filters.filterArtifactsByGatherMode(null, 'snapshot')).toBe(null);
+    });
+
+    it('should filter to the correct mode', () => {
+      expect(filters.filterArtifactsByGatherMode(artifacts, 'snapshot')).toEqual([
+        {id: 'Snapshot', gatherer: {instance: snapshotGatherer}},
+      ]);
+
+      expect(filters.filterArtifactsByGatherMode(artifacts, 'timespan')).toEqual([
+        {id: 'Timespan', gatherer: {instance: timespanGatherer}},
+      ]);
+    });
+  });
+
+  const auditMeta = {title: '', description: ''};
+  class SnapshotAudit extends BaseAudit {
+    static meta = {
+      id: 'snapshot',
+      requiredArtifacts: /** @type {any} */ (['Snapshot']),
+      ...auditMeta,
+    };
+  }
+  class TimespanAudit extends BaseAudit {
+    static meta = {
+      id: 'timespan',
+      requiredArtifacts: /** @type {any} */ (['Timespan']),
+      ...auditMeta,
+    };
+  }
+  class NavigationAudit extends BaseAudit {
+    static meta = {
+      id: 'navigation',
+      requiredArtifacts: /** @type {any} */ (['Snapshot', 'Timespan']),
+      ...auditMeta,
+    };
+  }
+
+  const audits = [SnapshotAudit, TimespanAudit, NavigationAudit].map(audit => ({
+    implementation: audit,
+    options: {},
+  }));
+
+  describe('filterAuditsByAvailableArtifacts', () => {
+    it('should handle null', () => {
+      expect(filters.filterAuditsByAvailableArtifacts(null, [])).toBe(null);
+    });
+
+    it('should filter when partial artifacts available', () => {
+      const partialArtifacts = [{id: 'Snapshot', gatherer: {instance: snapshotGatherer}}];
+      expect(filters.filterAuditsByAvailableArtifacts(audits, partialArtifacts)).toEqual([
+        {implementation: SnapshotAudit, options: {}},
+      ]);
+    });
+
+    it('should be noop when all artifacts available', () => {
+      expect(filters.filterAuditsByAvailableArtifacts(audits, artifacts)).toEqual(audits);
+    });
+  });
+
+  /** @type {LH.Config.FRConfig['categories']} */
+  const categories = {
+    snapshot: {title: 'Snapshot', auditRefs: [{id: 'snapshot', weight: 0}]},
+    timespan: {title: 'Timespan', auditRefs: [{id: 'timespan', weight: 0}]},
+    navigation: {title: 'Navigation', auditRefs: [{id: 'navigation', weight: 0}]},
+    mixed: {
+      title: 'Mixed',
+      auditRefs: [
+        {id: 'snapshot', weight: 0},
+        {id: 'timespan', weight: 0},
+        {id: 'navigation', weight: 0},
+      ],
+    },
+  };
+
+  describe('filterCategoriesByAvailableAudits', () => {
+    it('should handle null', () => {
+      expect(filters.filterCategoriesByAvailableAudits(null, [])).toBe(null);
+    });
+
+    it('should filter entire categories', () => {
+      const partialAudits = [{implementation: SnapshotAudit, options: {}}];
+      expect(filters.filterCategoriesByAvailableAudits(categories, partialAudits)).toMatchObject({
+        snapshot: {},
+        mixed: {},
+      });
+    });
+
+    it('should filter audits within categories', () => {
+      const partialAudits = [{implementation: SnapshotAudit, options: {}}];
+      const filtered = filters.filterCategoriesByAvailableAudits(categories, partialAudits);
+      if (!filtered) throw new Error(`Failed to produce a categories object`);
+      expect(filtered.mixed).toEqual({
+        title: 'Mixed',
+        auditRefs: [{id: 'snapshot', weight: 0}],
+      });
+    });
+
+    it('should be noop when all audits available', () => {
+      expect(filters.filterCategoriesByAvailableAudits(categories, audits)).toEqual(categories);
+    });
+  });
+
+  describe('filterConfigByGatherMode', () => {
+    it('should filter the entire config', () => {
+      const config = {artifacts, audits, categories, groups: null, settings: defaultSettings};
+      expect(filters.filterConfigByGatherMode(config, 'snapshot')).toMatchObject({
+        artifacts: [{id: 'Snapshot'}],
+        audits: [{implementation: SnapshotAudit}],
+        categories: {snapshot: {}, mixed: {auditRefs: [{id: 'snapshot'}]}},
+      });
+    });
+  });
+});

--- a/lighthouse-core/test/fraggle-rock/config/validation-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/validation-test.js
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const BaseFRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const BaseLegacyGatherer = require('../../../gather/gatherers/gatherer.js');
+const validation = require('../../../fraggle-rock/config/validation.js');
+
+/* eslint-env jest */
+
+describe('Fraggle Rock Config Validation', () => {
+  describe('isFRGathererDefn', () => {
+    it('should identify fraggle rock gatherer definitions', () => {
+      expect(validation.isFRGathererDefn({instance: new BaseFRGatherer()})).toBe(true);
+    });
+
+    it('should identify legacy gatherer definitions', () => {
+      expect(validation.isFRGathererDefn({instance: new BaseLegacyGatherer()})).toBe(false);
+    });
+  });
+});

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -122,7 +122,13 @@ declare global {
 
       export interface ArtifactDefn {
         id: string;
-        gatherer: GathererDefn;
+        gatherer: FRGathererDefn;
+      }
+
+      export interface FRGathererDefn {
+        implementation?: ClassOf<Gatherer.FRGathererInstance>;
+        instance: Gatherer.FRGathererInstance;
+        path?: string;
       }
 
       export interface GathererDefn {


### PR DESCRIPTION
**Summary**
This completes the core snapshot mode support for Fraggle Rock (further gatherer support pending) by filtering out any audits from a config that don't support the gatherer mode being run. This eliminates the huge mess of errors you'd see in the report when previously running in snapshot mode.

I decided against a property in `settings` because our intention is to always have the entrypoint be different for every entry mode (so there is no benefit to duplicate specification in the config) and the same config is shared between many modes which created potential for confusion if the `gatherMode` value was set to a value that didn't match audits/gatherers defined in the config. Contrast this with `onlyAudits`/`onlyCategories` which has no impact on the entrypoint. 

**Related Issues/PRs**
ref #11313 
