### PR TITLE
core(proto): clarify deprecated state of EmulatedFormFactor enum

### DIFF
--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -130,8 +130,8 @@ message LighthouseResult {
     // The possible form factors an audit can be run in.
     // This enum served the emulated_form_factor field, but in v7, that field
     // was deprecated. Meanwhile in v7, the form_factor field was added and has
-    // a mobile/desktop enum, so this "legacy-ish" enum gets reused.
-    // https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md#changes-made-in-v7
+    // a mobile/desktop enum, so we simplify reuse, minus the `none` option.
+    // See https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md#changes-made-in-v7
     enum EmulatedFormFactor {
       UNKNOWN_FORM_FACTOR = 0;
       mobile = 1;

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -127,8 +127,12 @@ message LighthouseResult {
   // Message containing the configuration settings for the LH run
   message ConfigSettings {
 
-    // The possible form factors an audit can be run in
-    enum EmulatedFormFactor { // Deprecated
+    // The possible form factors an audit can be run in.
+    // This enum was added for the emulated_form_factor field, but in v7, that field was deprecated.
+    // Meanwhile, the form_factor field was added and has a mobile/desktop enum, so this
+    // "legacy-ish" enum gets reused.
+    // https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md#changes-made-in-v7
+    enum EmulatedFormFactor {
       UNKNOWN_FORM_FACTOR = 0;
       mobile = 1;
       desktop = 2;

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -125,6 +125,7 @@ message LighthouseResult {
   map<string, CategoryGroup> category_groups = 11;
 
   // Message containing the configuration settings for the LH run
+  // Next tag: 6
   message ConfigSettings {
 
     // The possible form factors an audit can be run in.
@@ -139,8 +140,13 @@ message LighthouseResult {
       none = 3  [deprecated = true];
     }
 
-    // The form factor emulation to apply. Do not use.
+    // Removed in v7. Do not use.
     EmulatedFormFactor emulated_form_factor = 1 [deprecated = true];
+
+    // How Lighthouse should interpret this run in regards to scoring performance metrics and skipping mobile-only tests in desktop.
+    // Also see the comment above the EmulatedFormFactor enum
+    EmulatedFormFactor form_factor = 5;
+    
 
     // The locale that was active during the audit
     string locale = 2;
@@ -152,9 +158,6 @@ message LighthouseResult {
     // How Lighthouse was run, e.g. from the Chrome extension or from the npm
     // module
     string channel = 4;
-
-    // How Lighthouse should interpret this run in regards to scoring performance metrics and skipping mobile-only tests in desktop.
-    EmulatedFormFactor form_factor = 5;
   }
 
   // The settings that were used to run this audit

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -128,8 +128,8 @@ message LighthouseResult {
   message ConfigSettings {
 
     // The possible form factors an audit can be run in.
-    // This enum was added for the emulated_form_factor field, but in v7, that field was deprecated.
-    // Meanwhile, the form_factor field was added and has a mobile/desktop enum, so this
+    // This enum served the emulated_form_factor field, but in v7, that field was deprecated.
+    // Meanwhile in v7, the form_factor field was added and has a mobile/desktop enum, so this
     // "legacy-ish" enum gets reused.
     // https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md#changes-made-in-v7
     enum EmulatedFormFactor {
@@ -138,7 +138,6 @@ message LighthouseResult {
       desktop = 2;
       none = 3  [deprecated = true];
     }
-
 
     // The form factor emulation to apply. Do not use.
     EmulatedFormFactor emulated_form_factor = 1 [deprecated = true];

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -125,28 +125,26 @@ message LighthouseResult {
   map<string, CategoryGroup> category_groups = 11;
 
   // Message containing the configuration settings for the LH run
-  // Next tag: 6
+  // Next field number: 6
   message ConfigSettings {
-
     // The possible form factors an audit can be run in.
-    // This enum served the emulated_form_factor field, but in v7, that field was deprecated.
-    // Meanwhile in v7, the form_factor field was added and has a mobile/desktop enum, so this
-    // "legacy-ish" enum gets reused.
+    // This enum served the emulated_form_factor field, but in v7, that field
+    // was deprecated. Meanwhile in v7, the form_factor field was added and has
+    // a mobile/desktop enum, so this "legacy-ish" enum gets reused.
     // https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md#changes-made-in-v7
     enum EmulatedFormFactor {
       UNKNOWN_FORM_FACTOR = 0;
       mobile = 1;
       desktop = 2;
-      none = 3  [deprecated = true];
+      none = 3 [deprecated = true];
     }
 
     // Removed in v7. Do not use.
     EmulatedFormFactor emulated_form_factor = 1 [deprecated = true];
 
-    // How Lighthouse should interpret this run in regards to scoring performance metrics and skipping mobile-only tests in desktop.
-    // Also see the comment above the EmulatedFormFactor enum
+    // How Lighthouse should interpret this run in regards to scoring
+    // performance metrics and skipping mobile-only tests in desktop.
     EmulatedFormFactor form_factor = 5;
-    
 
     // The locale that was active during the audit
     string locale = 2;


### PR DESCRIPTION
small tweak to the proto changes from #11779


the enum isn't actually deprecated..

I would have made two separate Enums, as semantically they're _somewhat_ different.. but, you can't have two enum values that aren't unique.  example:

![image](https://user-images.githubusercontent.com/39191/104383213-56c59c80-54e4-11eb-98cd-492367cfeb91.png)

So sharing the same enum made sense.

Anyway, lots of comments.