### PR TITLE
tests(ci): run test-treemap twice to deflake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     - name: yarn test-viewer
       run: xvfb-run --auto-servernum yarn test-viewer
     - name: yarn test-treemap
-      run: xvfb-run --auto-servernum yarn test-treemap
+      run: xvfb-run --auto-servernum yarn test-treemap || yarn test-treemap
 
     - run: yarn diff:sample-json
     - run: yarn type-check


### PR DESCRIPTION
I just ran into this flake, but remember seeing it a bit over the past ~month.

example: https://github.com/GoogleChrome/lighthouse/pull/11847/checks?check_run_id=1691814542

![image](https://user-images.githubusercontent.com/39191/104390999-cabb7100-54f3-11eb-980b-6a2a2d235307.png)


i doublechecked the syntax and this does work. :) 