### PR TITLE
core(fr): add navigations to config

### DIFF
--- a/lighthouse-core/config/constants.js
+++ b/lighthouse-core/config/constants.js
@@ -136,6 +136,21 @@ const defaultPassConfig = {
   gatherers: [],
 };
 
+/** @type {Required<LH.Config.NavigationJson>} */
+const defaultNavigationConfig = {
+  id: 'default',
+  loadFailureMode: 'fatal',
+  disableThrottling: false,
+  disableStorageReset: false,
+  pauseAfterFcpMs: 0,
+  pauseAfterLoadMs: 0,
+  networkQuietThresholdMs: 0,
+  cpuQuietThresholdMs: 0,
+  blockedUrlPatterns: [],
+  blankPage: 'about:blank',
+  artifacts: [],
+};
+
 const nonSimulatedPassConfigOverrides = {
   pauseAfterFcpMs: 5250,
   pauseAfterLoadMs: 5250,
@@ -149,5 +164,6 @@ module.exports = {
   userAgents,
   defaultSettings,
   defaultPassConfig,
+  defaultNavigationConfig,
   nonSimulatedPassConfigOverrides,
 };

--- a/lighthouse-core/fraggle-rock/config/default-config.js
+++ b/lighthouse-core/fraggle-rock/config/default-config.js
@@ -13,6 +13,12 @@ const defaultConfig = {
     {id: 'Accessibility', gatherer: 'accessibility'},
     {id: 'ConsoleMessages', gatherer: 'console-messages'},
   ],
+  navigations: [
+    {
+      id: 'default',
+      artifacts: ['Accessibility', 'ConsoleMessages'],
+    },
+  ],
   settings: legacyDefaultConfig.settings,
   audits: legacyDefaultConfig.audits,
   categories: legacyDefaultConfig.categories,

--- a/lighthouse-core/test/fraggle-rock/config/filters-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/filters-test.js
@@ -129,7 +129,14 @@ describe('Fraggle Rock Config Filtering', () => {
 
   describe('filterConfigByGatherMode', () => {
     it('should filter the entire config', () => {
-      const config = {artifacts, audits, categories, groups: null, settings: defaultSettings};
+      const config = {
+        artifacts,
+        navigations: null,
+        audits,
+        categories,
+        groups: null,
+        settings: defaultSettings,
+      };
       expect(filters.filterConfigByGatherMode(config, 'snapshot')).toMatchObject({
         artifacts: [{id: 'Snapshot'}],
         audits: [{implementation: SnapshotAudit}],

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -20,12 +20,17 @@ declare global {
       export interface Json {
         extends?: 'lighthouse:default' | string;
         settings?: SharedFlagsSettings;
-        artifacts?: ArtifactJson[] | null;
-        passes?: PassJson[] | null;
         audits?: Config.AuditJson[] | null;
         categories?: Record<string, CategoryJson> | null;
         groups?: Record<string, Config.GroupJson> | null;
-        plugins?: Array<string>,
+        plugins?: Array<string>;
+
+        // Fraggle Rock Only
+        artifacts?: ArtifactJson[] | null;
+        navigations?: NavigationJson[] | null;
+
+        // Legacy Only
+        passes?: PassJson[] | null;
       }
 
       /**
@@ -45,23 +50,54 @@ declare global {
       export interface FRConfig {
         settings: Settings;
         artifacts: ArtifactDefn[] | null;
+        navigations: NavigationDefn[] | null;
         audits: AuditDefn[] | null;
         categories: Record<string, Category> | null;
         groups: Record<string, Group> | null;
       }
 
-      export interface PassJson {
-        passName: string;
+      interface SharedPassNavigationJson {
+        /**
+         * Controls the behavior when the navigation fails to complete (due to server error, no FCP, etc).
+         * Fatal means Lighthouse will exit immediately and return a runtimeError / non-zero exit code.
+         * Warn means a toplevel warning will appear in the report, but the run will complete with success.
+         * Ignore means a failure is expected and no action should be taken.
+         */
         loadFailureMode?: 'fatal'|'warn'|'ignore';
-        recordTrace?: boolean;
-        useThrottling?: boolean;
+        /** The number of milliseconds to wait after FCP until the page should be considered loaded. */
         pauseAfterFcpMs?: number;
+        /** The number of milliseconds to wait after the load event until the page should be considered loaded. */
         pauseAfterLoadMs?: number;
+        /** The number of milliseconds to wait between high priority network requests or 3 simulataneous requests before the page should be considered loaded. */
         networkQuietThresholdMs?: number;
+        /** The number of milliseconds to wait between long tasks until the page should be considered loaded. */
         cpuQuietThresholdMs?: number;
+        /** Substring patterns of network resources to block during this navigation, '*' wildcards supported though unnecessary as prefix or suffix (due to substring matching). */
         blockedUrlPatterns?: string[];
+        /** The URL to use for the "blank" neutral page in between navigations. Defaults to `about:blank`. */
         blankPage?: string;
+      }
+
+      export interface PassJson extends SharedPassNavigationJson {
+        /** The identifier for the pass. Config extension will deduplicate passes with the same passName. */
+        passName: string;
+        /** Whether a trace and devtoolsLog should be recorded for the pass. */
+        recordTrace?: boolean;
+        /** Whether throttling settings should be used for the pass. */
+        useThrottling?: boolean;
+        /** The array of gatherers to run during the pass. */
         gatherers?: GathererJson[];
+      }
+
+      export interface NavigationJson extends SharedPassNavigationJson {
+        /** The identifier for the navigation. Config extension will deduplicate navigations with the same id. */
+        id: string;
+        /** Whether throttling settings should be skipped for the pass. */
+        disableThrottling?: boolean;
+        /** Whether storage clearing (service workers, cache storage) should be skipped for the pass. A run-wide setting of `true` takes precedence over this value. */
+        disableStorageReset?: boolean;
+        /** The array of artifacts to collect during the navigation. */
+        artifacts?: Array<string>;
       }
 
       export interface ArtifactJson {
@@ -118,6 +154,10 @@ declare global {
 
       export interface Pass extends Required<PassJson> {
         gatherers: GathererDefn[];
+      }
+
+      export interface NavigationDefn extends Omit<Required<NavigationJson>, 'artifacts'> {
+        artifacts: ArtifactDefn[];
       }
 
       export interface ArtifactDefn {


### PR DESCRIPTION
**Summary**
Adds basic navigations to the fraggle rock config. I decided to go ahead and document the complete navigation config object so everyone can see where it's headed and what replaces what even if the properties aren't supported in the navigation prototype yet (see config.d.ts).

**Fraggle Rock Config**
```js
const configJson = {
    artifacts: [{id: 'Accessibility', gatherer: 'accessibility'}],
    navigations: [{id: 'default', artifacts: ['Accessibility']}],
};
```

**Legacy Config**
```js
const configJson = {
    passes: [{passName: 'defaultPass', gatherers: ['accessibility']}],
};
```

**Related Issues/PRs**
ref #11313 
[design doc](https://docs.google.com/document/d/1fRCh_NVK82YmIi1Zq8y73_p79d-FdnKsvaxMy0xIpNw/edit)