### PR TITLE
i18n: prevent strings with identical message and description

### DIFF
--- a/lighthouse-core/audits/accessibility/aria-command-name.js
+++ b/lighthouse-core/audits/accessibility/aria-command-name.js
@@ -18,7 +18,7 @@ const UIStrings = {
   title: '`button`, `link`, and `menuitem` elements have accessible names',
   /** Title of an accessibility audit that evaluates if important HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: '`button`, `link`, and `menuitem` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for command elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more](https://web.dev/aria-name/).',
 };
 

--- a/lighthouse-core/audits/accessibility/aria-meter-name.js
+++ b/lighthouse-core/audits/accessibility/aria-meter-name.js
@@ -14,11 +14,11 @@ const AxeAudit = require('./axe-audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if important HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if meter HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
   title: 'ARIA `meter` elements have accessible names',
-  /** Title of an accessibility audit that evaluates if important HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if meter HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'ARIA `meter` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for meter elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more](https://web.dev/aria-name/).',
 };
 

--- a/lighthouse-core/audits/accessibility/aria-progressbar-name.js
+++ b/lighthouse-core/audits/accessibility/aria-progressbar-name.js
@@ -14,9 +14,9 @@ const AxeAudit = require('./axe-audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if important HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if progressbar HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
   title: 'ARIA `progressbar` elements have accessible names',
-  /** Title of an accessibility audit that evaluates if important HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if progressbar HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'ARIA `progressbar` elements do not have accessible names.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more](https://web.dev/aria-name/).',

--- a/lighthouse-core/audits/accessibility/aria-tooltip-name.js
+++ b/lighthouse-core/audits/accessibility/aria-tooltip-name.js
@@ -14,11 +14,11 @@ const AxeAudit = require('./axe-audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if important HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if tooltip HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
   title: 'ARIA `tooltip` elements have accessible names',
-  /** Title of an accessibility audit that evaluates if important HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if tooltip HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'ARIA `tooltip` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for tooltips. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more](https://web.dev/aria-name/).',
 };
 

--- a/lighthouse-core/audits/accessibility/aria-treeitem-name.js
+++ b/lighthouse-core/audits/accessibility/aria-treeitem-name.js
@@ -14,9 +14,9 @@ const AxeAudit = require('./axe-audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if important HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if treeitem HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
   title: 'ARIA `treeitem` elements have accessible names',
-  /** Title of an accessibility audit that evaluates if important HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if treeitem HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'ARIA `treeitem` elements do not have accessible names.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more](https://web.dev/aria-name/).',

--- a/lighthouse-core/audits/installable-manifest.js
+++ b/lighthouse-core/audits/installable-manifest.js
@@ -61,8 +61,8 @@ const UIStrings = {
   */
   'no-acceptable-icon': `No supplied icon is at least {value0}\xa0px square in PNG, SVG or WebP format`,
 
-  /** Error message explaining that the downloaded icon was empty or corrupt. */
-  'cannot-download-icon': `Downloaded icon was empty or corrupted`,
+  /** Error message explaining that an icon was unable to be downloaded. */
+  'cannot-download-icon': `Icon was unable to be downloaded`,
   /** Error message explaining that the downloaded icon was empty or corrupt. */
   'no-icon-available': `Downloaded icon was empty or corrupted`,
   /** Error message explaining that the specified application platform is not supported on Android. */

--- a/lighthouse-core/audits/installable-manifest.js
+++ b/lighthouse-core/audits/installable-manifest.js
@@ -61,8 +61,8 @@ const UIStrings = {
   */
   'no-acceptable-icon': `No supplied icon is at least {value0}\xa0px square in PNG, SVG or WebP format`,
 
-  /** Error message explaining that an icon was unable to be downloaded. */
-  'cannot-download-icon': `Icon was unable to be downloaded`,
+  /** Error message explaining that the icon could not be downloaded. */
+  'cannot-download-icon': `Could not download a required icon from the manifest`,
   /** Error message explaining that the downloaded icon was empty or corrupt. */
   'no-icon-available': `Downloaded icon was empty or corrupted`,
   /** Error message explaining that the specified application platform is not supported on Android. */

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -855,7 +855,7 @@
     "message": "The app is already installed"
   },
   "lighthouse-core/audits/installable-manifest.js | cannot-download-icon": {
-    "message": "Downloaded icon was empty or corrupted"
+    "message": "Icon was unable to be downloaded"
   },
   "lighthouse-core/audits/installable-manifest.js | columnValue": {
     "message": "Failure reason"

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -855,7 +855,7 @@
     "message": "The app is already installed"
   },
   "lighthouse-core/audits/installable-manifest.js | cannot-download-icon": {
-    "message": "Icon was unable to be downloaded"
+    "message": "Could not download a required icon from the manifest"
   },
   "lighthouse-core/audits/installable-manifest.js | columnValue": {
     "message": "Failure reason"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -855,7 +855,7 @@
     "message": "T̂h́ê áp̂ṕ îś âĺr̂éâd́ŷ ín̂śt̂ál̂ĺêd́"
   },
   "lighthouse-core/audits/installable-manifest.js | cannot-download-icon": {
-    "message": "D̂óŵńl̂óâd́êd́ îćôń ŵáŝ ém̂ṕt̂ý ôŕ ĉór̂ŕûṕt̂éd̂"
+    "message": "Îćôń ŵáŝ ún̂áb̂ĺê t́ô b́ê d́ôẃn̂ĺôád̂éd̂"
   },
   "lighthouse-core/audits/installable-manifest.js | columnValue": {
     "message": "F̂áîĺûŕê ŕêáŝón̂"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -855,7 +855,7 @@
     "message": "T̂h́ê áp̂ṕ îś âĺr̂éâd́ŷ ín̂śt̂ál̂ĺêd́"
   },
   "lighthouse-core/audits/installable-manifest.js | cannot-download-icon": {
-    "message": "Îćôń ŵáŝ ún̂áb̂ĺê t́ô b́ê d́ôẃn̂ĺôád̂éd̂"
+    "message": "Ĉóûĺd̂ ńôt́ d̂óŵńl̂óâd́ â ŕêq́ûír̂éd̂ íĉón̂ f́r̂óm̂ t́ĥé m̂án̂íf̂éŝt́"
   },
   "lighthouse-core/audits/installable-manifest.js | columnValue": {
     "message": "F̂áîĺûŕê ŕêáŝón̂"

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -591,6 +591,11 @@ function collectAllStringsInDir(dir) {
             strings[seenId].meaning = strings[seenId].description;
             collisions++;
           }
+
+          if (ctc.meaning === strings[seenId].meaning) {
+            throw new Error(`'${messageKey}' is an exact duplicate of '${seenId}' when placeholders are removed. Each strings' \`message\` or \`description\` must be different for the translation pipeline`);
+          }
+
           collisionStrings.push(ctc.message);
           collisions++;
         }
@@ -631,7 +636,7 @@ if (require.main === module) {
 
   if (collisions > 0) {
     console.log(`MEANING COLLISION: ${collisions} string(s) have the same content.`);
-    assert.equal(collisions, 32, `The number of duplicate strings have changed, update this assertion if that is expected, or reword strings. Collisions: ${collisionStrings.join('\n')}`);
+    assert.equal(collisions, 30, `The number of duplicate strings have changed, update this assertion if that is expected, or reword strings. Collisions: ${collisionStrings.join('\n')}`);
   }
 
   writeStringsToCtcFiles('en-US', strings);

--- a/lighthouse-core/test/audits/installable-manifest-test.js
+++ b/lighthouse-core/test/audits/installable-manifest-test.js
@@ -139,7 +139,7 @@ describe('PWA: webapp install banner audit', () => {
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
         assert.strictEqual(result.score, 0);
         const items = result.details.items;
-        expect(items[0].reason).toBeDisplayString(/icon was empty or corrupted/);
+        expect(items[0].reason).toBeDisplayString('Icon was unable to be downloaded');
       });
     });
   });

--- a/lighthouse-core/test/audits/installable-manifest-test.js
+++ b/lighthouse-core/test/audits/installable-manifest-test.js
@@ -139,7 +139,7 @@ describe('PWA: webapp install banner audit', () => {
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
         assert.strictEqual(result.score, 0);
         const items = result.details.items;
-        expect(items[0].reason).toBeDisplayString('Icon was unable to be downloaded');
+        expect(items[0].reason).toBeDisplayString(/Could not download a required icon from/);
       });
     });
   });


### PR DESCRIPTION
Our translation pipeline requires each string to be unique after placeholders are removed, or, if there are colliding strings, to have a different `@description` than the duplicates (the unique description is [passed on as the internal `meaning` property](https://github.com/GoogleChrome/lighthouse/blob/9514723a3a77f37f02b57b04e05eb47cf9f4ee7b/lighthouse-core/scripts/i18n/collect-strings.js#L585-L599)).

In the run up to 7.0, we added a few strings that don't follow this rule and so the translation process failed. e.g.

```js
/** Title of an accessibility audit that evaluates if important HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
title: 'ARIA `meter` elements have accessible names',
```

and

```js
/** Title of an accessibility audit that evaluates if important HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
title: 'ARIA `progressbar` elements have accessible names',
```

While the two strings are different in the source and as they appear in the report, when the placeholders are removed (in this case, the \`meter\` and \`progressbar\` [inline code blocks](https://github.com/GoogleChrome/lighthouse/blob/9514723a3a77f37f02b57b04e05eb47cf9f4ee7b/lighthouse-core/lib/i18n/README.md#markdown)), the strings are identical as far as the translation pipeline is concerned.

This PR:
- de-dupes the strings currently causing issues with the translation pipeline
- adds a check to `collect-strings` for fatal string collisions  so this will be caught automatically in the future

This takes the somewhat lazy route of (mostly) making the descriptions unique while leaving the strings the same, but we could be more radical and move some of these to `i18n.js` if it seems worth it.

The error output looks something like:

```
$ node lighthouse-core/scripts/i18n/collect-strings.js

====
Collecting strings from lighthouse//lighthouse-core
====
Collecting from lighthouse-core/audits/accessibility/accesskeys.js
Collecting from lighthouse-core/audits/accessibility/aria-allowed-attr.js
Collecting from lighthouse-core/audits/accessibility/aria-command-name.js
Collecting from lighthouse-core/audits/accessibility/aria-tooltip-name.js
Collecting from lighthouse-core/audits/accessibility/aria-treeitem-name.js
lighthouse/lighthouse-core/scripts/i18n/collect-strings.js:596
            throw new Error(`...`);
            ^

Error: 'lighthouse-core/audits/accessibility/aria-treeitem-name.js | title' is an exact duplicate of 'lighthouse-core/audits/accessibility/aria-tooltip-name.js | title' when placeholders are removed. Each strings' `message` or `description` must be different for the translation pipeline
    at collectAllStringsInDir (lighthouse/lighthouse-core/scripts/i18n/collect-strings.js:596:19)
    at Object.<anonymous> (lighthouse/lighthouse-core/scripts/i18n/collect-strings.js:633:25)

error Command failed with exit code 1.
```