### PR TITLE
misc(proto): backport proto formatting fixes

### DIFF
--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -55,7 +55,7 @@ enum LighthouseError {
   DNS_FAILURE = 19;
   // A timeout in the initial connection to the debugger protocol.
   CRI_TIMEOUT = 20;
-  // The page requested was not HTML. 
+  // The page requested was not HTML.
   NOT_HTML = 21;
   // The trace did not contain a ResourceSendRequest event.
   NO_RESOURCE_REQUEST = 22;
@@ -88,7 +88,8 @@ message LighthouseResult {
     // The benchmark index that indicates rough device class
     google.protobuf.DoubleValue benchmark_index = 3;
 
-    // The version of libraries with which these results were generated. Ex: axe-core.
+    // The version of libraries with which these results were generated. Ex:
+    // axe-core.
     map<string, string> credits = 4;
   }
 
@@ -131,7 +132,8 @@ message LighthouseResult {
     // This enum served the emulated_form_factor field, but in v7, that field
     // was deprecated. Meanwhile in v7, the form_factor field was added and has
     // a mobile/desktop enum, so we simplify reuse, minus the `none` option.
-    // See https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md#changes-made-in-v7
+    // See
+    // https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md#changes-made-in-v7
     enum EmulatedFormFactor {
       UNKNOWN_FORM_FACTOR = 0;
       mobile = 1;
@@ -305,7 +307,8 @@ message AuditResult {
   // information can be found in the audit details, if present.
   google.protobuf.DoubleValue numeric_value = 11;
 
-  // The unit of the numeric_value field. Used to format the numeric value for display.
+  // The unit of the numeric_value field. Used to format the numeric value for
+  // display.
   string numeric_unit = 12;
 }
 
@@ -376,79 +379,108 @@ message I18n {
     // This label is for a filter checkbox above a table of items
     string third_party_resources_label = 20;
 
-    // Descriptive explanation for emulation setting when emulating a generic desktop form factor, as opposed to a mobile-device like form factor.
+    // Descriptive explanation for emulation setting when emulating a generic
+    // desktop form factor, as opposed to a mobile-device like form factor.
     string runtime_desktop_emulation = 21;
-    
-    // Descriptive explanation for emulation setting when emulating a Nexus 5X mobile device.
+
+    // Descriptive explanation for emulation setting when emulating a Nexus 5X
+    // mobile device.
     string runtime_mobile_emulation = 22;
-    
-    // Descriptive explanation for emulation setting when no device emulation is set.
+
+    // Descriptive explanation for emulation setting when no device emulation is
+    // set.
     string runtime_no_emulation = 23;
-    
-    // Label for a row in a table that shows the estimated CPU power of the machine running Lighthouse. Example row values: 532, 1492, 783.
+
+    // Label for a row in a table that shows the estimated CPU power of the
+    // machine running Lighthouse. Example row values: 532, 1492, 783.
     string runtime_settings_benchmark = 24;
-    
-    // Label for a row in a table that describes the CPU throttling conditions that were used during a Lighthouse run, if any.
+
+    // Label for a row in a table that describes the CPU throttling conditions
+    // that were used during a Lighthouse run, if any.
     string runtime_settings_CPU_throttling = 25;
-    
-    // Label for a row in a table that describes the kind of device that was emulated for the Lighthouse run.  Example values for row elements: 'No Emulation', 'Emulated Desktop', etc.
+
+    // Label for a row in a table that describes the kind of device that was
+    // emulated for the Lighthouse run.  Example values for row elements: 'No
+    // Emulation', 'Emulated Desktop', etc.
     string runtime_settings_device = 26;
-    
-    // Label for a row in a table that shows the time at which a Lighthouse run was conducted; formatted as a timestamp, e.g. Jan 1, 1970 12:00 AM UTC.
+
+    // Label for a row in a table that shows the time at which a Lighthouse run
+    // was conducted; formatted as a timestamp, e.g. Jan 1, 1970 12:00 AM UTC.
     string runtime_settings_fetch_time = 27;
-    
-    // Label for a row in a table that describes the network throttling conditions that were used during a Lighthouse run, if any.
+
+    // Label for a row in a table that describes the network throttling
+    // conditions that were used during a Lighthouse run, if any.
     string runtime_settings_network_throttling = 28;
-    
-    // Title of the Runtime settings table in a Lighthouse report.  Runtime settings are the environment configurations that a specific report used at auditing time.
+
+    // Title of the Runtime settings table in a Lighthouse report.  Runtime
+    // settings are the environment configurations that a specific report used
+    // at auditing time.
     string runtime_settings_title = 29;
-    
-    // Label for a row in a table that shows the User Agent that was detected on the Host machine that ran Lighthouse.
+
+    // Label for a row in a table that shows the User Agent that was detected on
+    // the Host machine that ran Lighthouse.
     string runtime_settings_UA = 30;
-    
-    // Label for a row in a table that shows the User Agent that was used to send out all network requests during the Lighthouse run.
+
+    // Label for a row in a table that shows the User Agent that was used to
+    // send out all network requests during the Lighthouse run.
     string runtime_settings_UA_network = 31;
-    
-    // Label for a row in a table that shows the URL that was audited during a Lighthouse run.
+
+    // Label for a row in a table that shows the URL that was audited during a
+    // Lighthouse run.
     string runtime_settings_Url = 32;
-    
-    // Descriptive explanation for a runtime setting that is set to an unknown value.
+
+    // Descriptive explanation for a runtime setting that is set to an unknown
+    // value.
     string runtime_unknown = 33;
-    
-    // Option in a dropdown menu that copies the Lighthouse JSON object to the system clipboard.
+
+    // Option in a dropdown menu that copies the Lighthouse JSON object to the
+    // system clipboard.
     string dropdown_copy_JSON = 34;
-    
-    // Option in a dropdown menu that toggles the themeing of the report between Light(default) and Dark themes.
+
+    // Option in a dropdown menu that toggles the themeing of the report between
+    // Light(default) and Dark themes.
     string dropdown_dark_theme = 35;
-    
-    // Option in a dropdown menu that opens a full Lighthouse report in a print dialog. 
+
+    // Option in a dropdown menu that opens a full Lighthouse report in a print
+    // dialog.
     string dropdown_print_expanded = 36;
-    
-    // Option in a dropdown menu that opens a small, summary report in a print dialog. 
+
+    // Option in a dropdown menu that opens a small, summary report in a print
+    // dialog.
     string dropdown_print_summary = 37;
-    
-    // Option in a dropdown menu that saves the current report as a new Github Gist.
+
+    // Option in a dropdown menu that saves the current report as a new Github
+    // Gist.
     string dropdown_save_gist = 38;
-    
-    // Option in a dropdown menu that saves the Lighthouse report HTML locally to the system as a '.html' file.
+
+    // Option in a dropdown menu that saves the Lighthouse report HTML locally
+    // to the system as a '.html' file.
     string dropdown_save_HTML = 39;
-    
-    // Option in a dropdown menu that saves the Lighthouse JSON object to the local system as a '.json' file.
+
+    // Option in a dropdown menu that saves the Lighthouse JSON object to the
+    // local system as a '.json' file.
     string dropdown_save_JSON = 40;
-    
-    // Option in a dropdown menu that opens the current report in the Lighthouse Viewer Application.
+
+    // Option in a dropdown menu that opens the current report in the Lighthouse
+    // Viewer Application.
     string dropdown_viewer = 41;
-    
-    // Label for button to create an issue against the Lighthouse Github project.
+
+    // Label for button to create an issue against the Lighthouse Github
+    // project.
     string footer_issue = 42;
-    
-    // Descriptive explanation for environment throttling that was provided by the runtime environment instead of provided by Lighthouse throttling.
+
+    // Descriptive explanation for environment throttling that was provided by
+    // the runtime environment instead of provided by Lighthouse throttling.
     string throttling_provided = 43;
 
-    // Label for a row in a table that shows in what tool Lighthouse is being run (e.g. The lighthouse CLI, Chrome DevTools, Lightrider, WebPageTest, etc).
+    // Label for a row in a table that shows in what tool Lighthouse is being
+    // run (e.g. The lighthouse CLI, Chrome DevTools, Lightrider, WebPageTest,
+    // etc).
     string runtime_settings_channel = 44;
 
-    // Text link pointing to the Lighthouse scoring calculator. This link immediately follows a sentence stating the performance score is calculated from the perf metrics.
+    // Text link pointing to the Lighthouse scoring calculator. This link
+    // immediately follows a sentence stating the performance score is
+    // calculated from the perf metrics.
     string calculator_link = 45;
 
     // Label for a row in a table that shows the version of the Axe library used


### PR DESCRIPTION
In LR, the linter often complains about the formatting of this file. I'm backporting the automatic formatting changes that satisfy the linter.

Technically the linter didn't like the 5 instances of trailing whitespace, and the format checker didn't like the non-wrapping text.

So anyway.. both fixed.

-------

and no i don't see a simple way we can compatibly format out here in GH when landing  changes to the file. :/