### PR TITLE
tests(legacy-javascript): sync results

### DIFF
--- a/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
+++ b/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
@@ -116,9 +116,9 @@ core-js-3-only-polyfill
    4515        es-function-name/main.bundle.min.js
 
 core-js-3-preset-env-esmodules
-  410517       false/main.bundle.min.js
-  305001       true/main.bundle.min.js
-  304320       true-and-bugfixes/main.bundle.min.js
+  411807       false/main.bundle.min.js
+  306297       true/main.bundle.min.js
+  305616       true-and-bugfixes/main.bundle.min.js
 
 only-plugin
   1787         -babel-plugin-transform-spread/main.bundle.min.js

--- a/lighthouse-core/scripts/test-legacy-javascript.sh
+++ b/lighthouse-core/scripts/test-legacy-javascript.sh
@@ -17,7 +17,7 @@ fi
 
 printf "Determined the following files have been touched:\n\n$CHANGED_FILES\n\n"
 
-if ! echo $CHANGED_FILES | grep -E 'legacy-javascript' > /dev/null; then
+if ! echo $CHANGED_FILES | grep -E 'legacy-javascript|js-bundles|source-map|SourceMap' > /dev/null; then
   echo "No legacy-javascript files affected, skipping test."
   exit 0
 fi


### PR DESCRIPTION
I couldn't determine the revision that caused this to change, every revision I checked out ended up resulting in different results for `core-js-3-preset-env-esmodules` than what was checked in for that revision.