### PR TITLE
core(fr): initial gatherer migration for snapshot, navigation

### DIFF
--- a/lighthouse-core/gather/driver/execution-context.js
+++ b/lighthouse-core/gather/driver/execution-context.js
@@ -167,8 +167,7 @@ class ExecutionContext {
     const depsSerialized = options.deps ? options.deps.join('\n') : '';
     const expression = `(() => {
       ${depsSerialized}
-      ${mainFn}
-      return ${mainFn.name}(${argsSerialized});
+      return (${mainFn})(${argsSerialized});
     })()`;
     return this.evaluateAsync(expression, options);
   }

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -7,7 +7,7 @@
 
 /* global window, document, getNodeDetails */
 
-const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const axeLibSource = require('../../lib/axe.js').source;
 const pageFunctions = require('../../lib/page-functions.js');
 
@@ -98,7 +98,7 @@ async function runA11yChecks() {
 }
 /* c8 ignore stop */
 
-class Accessibility extends Gatherer {
+class Accessibility extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -98,10 +98,6 @@ async function runA11yChecks() {
 }
 /* c8 ignore stop */
 
-/**
- * @implements {LH.Gatherer.GathererInstance}
- * @implements {LH.Gatherer.FRGathererInstance}
- */
 class Accessibility extends Gatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {

--- a/lighthouse-core/gather/gatherers/cache-contents.js
+++ b/lighthouse-core/gather/gatherers/cache-contents.js
@@ -7,7 +7,7 @@
 
 /* global caches */
 
-const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 
 /**
  * @return {Promise<Array<string>>}
@@ -37,7 +37,7 @@ function getCacheContents() {
 }
 /* c8 ignore stop */
 
-class CacheContents extends Gatherer {
+class CacheContents extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/cache-contents.js
+++ b/lighthouse-core/gather/gatherers/cache-contents.js
@@ -7,10 +7,9 @@
 
 /* global caches */
 
-const Gatherer = require('./gatherer.js');
+const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 
 /**
- * This is run in the page, not Lighthouse itself.
  * @return {Promise<Array<string>>}
  */
 /* c8 ignore start */
@@ -39,12 +38,17 @@ function getCacheContents() {
 /* c8 ignore stop */
 
 class CacheContents extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
    * Creates an array of cached URLs.
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['CacheContents']>}
    */
-  async afterPass(passContext) {
+  async snapshot(passContext) {
     const driver = passContext.driver;
 
     const cacheUrls = await driver.evaluate(getCacheContents, {args: []});

--- a/lighthouse-core/gather/gatherers/console-messages.js
+++ b/lighthouse-core/gather/gatherers/console-messages.js
@@ -30,10 +30,6 @@ function remoteObjectToString(obj) {
   return `[${type} ${className}]`;
 }
 
-/**
- * @implements {LH.Gatherer.GathererInstance}
- * @implements {LH.Gatherer.FRGathererInstance}
- */
 class ConsoleMessages extends Gatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {

--- a/lighthouse-core/gather/gatherers/console-messages.js
+++ b/lighthouse-core/gather/gatherers/console-messages.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 
 /**
  * @param {LH.Crdp.Runtime.RemoteObject} obj
@@ -30,7 +30,7 @@ function remoteObjectToString(obj) {
   return `[${type} ${className}]`;
 }
 
-class ConsoleMessages extends Gatherer {
+class ConsoleMessages extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['timespan', 'navigation'],

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -5,35 +5,40 @@
  */
 'use strict';
 
-const Gatherer = require('./gatherer.js');
+const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 
 /**
  * @fileoverview Tracks unused CSS rules.
  */
 class CSSUsage extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['CSSUsage']>}
    */
-  async afterPass(passContext) {
-    const driver = passContext.driver;
+  async snapshot(passContext) {
+    const session = passContext.driver.defaultSession;
 
     /** @type {Array<LH.Crdp.CSS.StyleSheetAddedEvent>} */
     const stylesheets = [];
     /** @param {LH.Crdp.CSS.StyleSheetAddedEvent} sheet */
     const onStylesheetAdded = sheet => stylesheets.push(sheet);
-    driver.on('CSS.styleSheetAdded', onStylesheetAdded);
+    session.on('CSS.styleSheetAdded', onStylesheetAdded);
 
-    await driver.sendCommand('DOM.enable');
-    await driver.sendCommand('CSS.enable');
-    await driver.sendCommand('CSS.startRuleUsageTracking');
-    await driver.evaluateAsync('getComputedStyle(document.body)');
-    driver.off('CSS.styleSheetAdded', onStylesheetAdded);
+    await session.sendCommand('DOM.enable');
+    await session.sendCommand('CSS.enable');
+    await session.sendCommand('CSS.startRuleUsageTracking');
+    await passContext.driver.evaluateAsync('getComputedStyle(document.body)');
+    session.off('CSS.styleSheetAdded', onStylesheetAdded);
 
     // Fetch style sheet content in parallel.
     const promises = stylesheets.map(sheet => {
       const styleSheetId = sheet.header.styleSheetId;
-      return driver.sendCommand('CSS.getStyleSheetText', {styleSheetId}).then(content => {
+      return session.sendCommand('CSS.getStyleSheetText', {styleSheetId}).then(content => {
         return {
           header: sheet.header,
           content: content.text,
@@ -42,9 +47,9 @@ class CSSUsage extends Gatherer {
     });
     const styleSheetInfo = await Promise.all(promises);
 
-    const ruleUsageResponse = await driver.sendCommand('CSS.stopRuleUsageTracking');
-    await driver.sendCommand('CSS.disable');
-    await driver.sendCommand('DOM.disable');
+    const ruleUsageResponse = await session.sendCommand('CSS.stopRuleUsageTracking');
+    await session.sendCommand('CSS.disable');
+    await session.sendCommand('DOM.disable');
 
     const dedupedStylesheets = new Map(styleSheetInfo.map(sheet => {
       return [sheet.content, sheet];

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -5,40 +5,35 @@
  */
 'use strict';
 
-const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+const Gatherer = require('./gatherer.js');
 
 /**
  * @fileoverview Tracks unused CSS rules.
  */
 class CSSUsage extends Gatherer {
-  /** @type {LH.Gatherer.GathererMeta} */
-  meta = {
-    supportedModes: ['snapshot', 'navigation'],
-  }
-
   /**
-   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   * @param {LH.Gatherer.PassContext} passContext
    * @return {Promise<LH.Artifacts['CSSUsage']>}
    */
-  async snapshot(passContext) {
-    const session = passContext.driver.defaultSession;
+  async afterPass(passContext) {
+    const driver = passContext.driver;
 
     /** @type {Array<LH.Crdp.CSS.StyleSheetAddedEvent>} */
     const stylesheets = [];
     /** @param {LH.Crdp.CSS.StyleSheetAddedEvent} sheet */
     const onStylesheetAdded = sheet => stylesheets.push(sheet);
-    session.on('CSS.styleSheetAdded', onStylesheetAdded);
+    driver.on('CSS.styleSheetAdded', onStylesheetAdded);
 
-    await session.sendCommand('DOM.enable');
-    await session.sendCommand('CSS.enable');
-    await session.sendCommand('CSS.startRuleUsageTracking');
-    await passContext.driver.evaluateAsync('getComputedStyle(document.body)');
-    session.off('CSS.styleSheetAdded', onStylesheetAdded);
+    await driver.sendCommand('DOM.enable');
+    await driver.sendCommand('CSS.enable');
+    await driver.sendCommand('CSS.startRuleUsageTracking');
+    await driver.evaluateAsync('getComputedStyle(document.body)');
+    driver.off('CSS.styleSheetAdded', onStylesheetAdded);
 
     // Fetch style sheet content in parallel.
     const promises = stylesheets.map(sheet => {
       const styleSheetId = sheet.header.styleSheetId;
-      return session.sendCommand('CSS.getStyleSheetText', {styleSheetId}).then(content => {
+      return driver.sendCommand('CSS.getStyleSheetText', {styleSheetId}).then(content => {
         return {
           header: sheet.header,
           content: content.text,
@@ -47,9 +42,9 @@ class CSSUsage extends Gatherer {
     });
     const styleSheetInfo = await Promise.all(promises);
 
-    const ruleUsageResponse = await session.sendCommand('CSS.stopRuleUsageTracking');
-    await session.sendCommand('CSS.disable');
-    await session.sendCommand('DOM.disable');
+    const ruleUsageResponse = await driver.sendCommand('CSS.stopRuleUsageTracking');
+    await driver.sendCommand('CSS.disable');
+    await driver.sendCommand('DOM.disable');
 
     const dedupedStylesheets = new Map(styleSheetInfo.map(sheet => {
       return [sheet.content, sheet];

--- a/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
@@ -5,11 +5,11 @@
  */
 'use strict';
 
-const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 
 /* global document */
 
-class AppCacheManifest extends Gatherer {
+class AppCacheManifest extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
@@ -5,20 +5,29 @@
  */
 'use strict';
 
-const Gatherer = require('../gatherer.js');
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+
+/* global document */
 
 class AppCacheManifest extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * Returns the value of the html element's manifest attribute or null if it
-   * is not defined.
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['AppCacheManifest']>}
    */
-  afterPass(passContext) {
+  snapshot(passContext) {
     const driver = passContext.driver;
 
-    return driver.querySelector('html')
-      .then(node => node && node.getAttribute('manifest'));
+    return driver.evaluate(() => {
+      return document.documentElement && document.documentElement.getAttribute('manifest');
+    }, {
+      args: [],
+      useIsolation: true,
+    });
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/doctype.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/doctype.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 
 /* global document */
 
@@ -24,7 +24,7 @@ function getDoctype() {
   return {name, publicId, systemId};
 }
 
-class Doctype extends Gatherer {
+class Doctype extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/dobetterweb/doctype.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/doctype.js
@@ -5,7 +5,9 @@
  */
 'use strict';
 
-const Gatherer = require('../gatherer.js');
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+
+/* global document */
 
 /**
  * Get and return `name`, `publicId`, `systemId` from
@@ -14,22 +16,30 @@ const Gatherer = require('../gatherer.js');
  */
 function getDoctype() {
   // An example of this is warnerbros.com/archive/spacejam/movie/jam.htm
-  if (!document.doctype) { // eslint-disable-line no-undef
+  if (!document.doctype) {
     return null;
   }
 
-  const {name, publicId, systemId} = document.doctype; // eslint-disable-line no-undef
+  const {name, publicId, systemId} = document.doctype;
   return {name, publicId, systemId};
 }
 
 class Doctype extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['Doctype']>}
    */
-  afterPass(passContext) {
+  snapshot(passContext) {
     const driver = passContext.driver;
-    return driver.evaluate(getDoctype, {args: []});
+    return driver.evaluate(getDoctype, {
+      args: [],
+      useIsolation: true,
+    });
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../../lib/page-functions.js');
 
 /**
@@ -76,7 +76,7 @@ function getDOMStats(element = document.body, deep = true) {
 }
 /* c8 ignore stop */
 
-class DOMStats extends Gatherer {
+class DOMStats extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const Gatherer = require('../gatherer.js');
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../../lib/page-functions.js');
 
 /**
@@ -77,20 +77,25 @@ function getDOMStats(element = document.body, deep = true) {
 /* c8 ignore stop */
 
 class DOMStats extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['DOMStats']>}
    */
-  async afterPass(passContext) {
+  async snapshot(passContext) {
     const driver = passContext.driver;
 
-    await driver.sendCommand('DOM.enable');
+    await driver.defaultSession.sendCommand('DOM.enable');
     const results = await driver.evaluate(getDOMStats, {
       args: [],
       useIsolation: true,
       deps: [pageFunctions.getNodeDetailsString],
     });
-    await driver.sendCommand('DOM.disable');
+    await driver.defaultSession.sendCommand('DOM.disable');
     return results;
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
@@ -7,10 +7,9 @@
 
 /* global document ClipboardEvent getNodeDetails */
 
-const Gatherer = require('../gatherer.js');
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../../lib/page-functions.js');
 
-// This is run in the page, not Lighthouse itself.
 /**
  * @return {LH.Artifacts['PasswordInputsWithPreventedPaste']}
  */
@@ -30,11 +29,16 @@ function findPasswordInputsWithPreventedPaste() {
 /* c8 ignore stop */
 
 class PasswordInputsWithPreventedPaste extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['PasswordInputsWithPreventedPaste']>}
    */
-  afterPass(passContext) {
+  snapshot(passContext) {
     return passContext.driver.evaluate(findPasswordInputsWithPreventedPaste, {
       args: [],
       deps: [pageFunctions.getNodeDetailsString],

--- a/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
@@ -7,7 +7,7 @@
 
 /* global document ClipboardEvent getNodeDetails */
 
-const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../../lib/page-functions.js');
 
 /**
@@ -28,7 +28,7 @@ function findPasswordInputsWithPreventedPaste() {
 }
 /* c8 ignore stop */
 
-class PasswordInputsWithPreventedPaste extends Gatherer {
+class PasswordInputsWithPreventedPaste extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/form-elements.js
+++ b/lighthouse-core/gather/gatherers/form-elements.js
@@ -7,7 +7,7 @@
 
 /* global getNodeDetails */
 
-const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../lib/page-functions.js');
 
 /* eslint-env browser, node */
@@ -84,7 +84,7 @@ function collectFormElements() {
 }
 /* c8 ignore stop */
 
-class FormElements extends Gatherer {
+class FormElements extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],
@@ -94,10 +94,10 @@ class FormElements extends Gatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['FormElements']>}
    */
-  snapshot(passContext) {
+  async snapshot(passContext) {
     const driver = passContext.driver;
 
-    return driver.evaluate(collectFormElements, {
+    const formElements = await driver.evaluate(collectFormElements, {
       args: [],
       useIsolation: true,
       deps: [
@@ -105,6 +105,7 @@ class FormElements extends Gatherer {
         pageFunctions.getNodeDetailsString,
       ],
     });
+    return formElements;
   }
 }
 

--- a/lighthouse-core/gather/gatherers/form-elements.js
+++ b/lighthouse-core/gather/gatherers/form-elements.js
@@ -7,7 +7,7 @@
 
 /* global getNodeDetails */
 
-const Gatherer = require('./gatherer.js');
+const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../lib/page-functions.js');
 
 /* eslint-env browser, node */
@@ -85,14 +85,19 @@ function collectFormElements() {
 /* c8 ignore stop */
 
 class FormElements extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['FormElements']>}
    */
-  async afterPass(passContext) {
+  snapshot(passContext) {
     const driver = passContext.driver;
 
-    const formElements = await driver.evaluate(collectFormElements, {
+    return driver.evaluate(collectFormElements, {
       args: [],
       useIsolation: true,
       deps: [
@@ -100,7 +105,6 @@ class FormElements extends Gatherer {
         pageFunctions.getNodeDetailsString,
       ],
     });
-    return formElements;
   }
 }
 

--- a/lighthouse-core/gather/gatherers/global-listeners.js
+++ b/lighthouse-core/gather/gatherers/global-listeners.js
@@ -12,9 +12,14 @@
  * around page unload, but this can be expanded in the future.
  */
 
-const Gatherer = require('./gatherer.js');
+const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 
 class GlobalListeners extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
    * @param {LH.Crdp.DOMDebugger.EventListener} listener
    * @return {listener is {type: 'pagehide'|'unload'|'visibilitychange'} & LH.Crdp.DOMDebugger.EventListener}
@@ -51,14 +56,14 @@ class GlobalListeners extends Gatherer {
   }
 
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['GlobalListeners']>}
    */
-  async afterPass(passContext) {
-    const driver = passContext.driver;
+  async snapshot(passContext) {
+    const session = passContext.driver.defaultSession;
 
     // Get a RemoteObject handle to `window`.
-    const {result: {objectId}} = await driver.sendCommand('Runtime.evaluate', {
+    const {result: {objectId}} = await session.sendCommand('Runtime.evaluate', {
       expression: 'window',
       returnByValue: false,
     });
@@ -67,7 +72,7 @@ class GlobalListeners extends Gatherer {
     }
 
     // And get all its listeners of interest.
-    const {listeners} = await driver.sendCommand('DOMDebugger.getEventListeners', {objectId});
+    const {listeners} = await session.sendCommand('DOMDebugger.getEventListeners', {objectId});
     const filteredListeners = listeners.filter(GlobalListeners._filterForAllowlistedTypes)
     .map(listener => {
       const {type, scriptId, lineNumber, columnNumber} = listener;

--- a/lighthouse-core/gather/gatherers/global-listeners.js
+++ b/lighthouse-core/gather/gatherers/global-listeners.js
@@ -12,9 +12,9 @@
  * around page unload, but this can be expanded in the future.
  */
 
-const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 
-class GlobalListeners extends Gatherer {
+class GlobalListeners extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/iframe-elements.js
+++ b/lighthouse-core/gather/gatherers/iframe-elements.js
@@ -7,7 +7,7 @@
 
 /* global getNodeDetails */
 
-const Gatherer = require('./gatherer.js');
+const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../lib/page-functions.js');
 
 /* eslint-env browser, node */
@@ -36,12 +36,17 @@ function collectIFrameElements() {
 /* c8 ignore stop */
 
 class IFrameElements extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['IFrameElements']>}
    * @override
    */
-  async afterPass(passContext) {
+  async snapshot(passContext) {
     const driver = passContext.driver;
 
     const iframeElements = await driver.evaluate(collectIFrameElements, {

--- a/lighthouse-core/gather/gatherers/iframe-elements.js
+++ b/lighthouse-core/gather/gatherers/iframe-elements.js
@@ -7,7 +7,7 @@
 
 /* global getNodeDetails */
 
-const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../lib/page-functions.js');
 
 /* eslint-env browser, node */
@@ -35,7 +35,7 @@ function collectIFrameElements() {
 }
 /* c8 ignore stop */
 
-class IFrameElements extends Gatherer {
+class IFrameElements extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/meta-elements.js
+++ b/lighthouse-core/gather/gatherers/meta-elements.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../lib/page-functions.js');
 
 /* globals getElementsInDocument */
@@ -32,7 +32,7 @@ function collectMetaElements() {
 }
 /* c8 ignore stop */
 
-class MetaElements extends Gatherer {
+class MetaElements extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/meta-elements.js
+++ b/lighthouse-core/gather/gatherers/meta-elements.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Gatherer = require('./gatherer.js');
+const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../lib/page-functions.js');
 
 /* globals getElementsInDocument */
@@ -33,11 +33,16 @@ function collectMetaElements() {
 /* c8 ignore stop */
 
 class MetaElements extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['MetaElements']>}
    */
-  async afterPass(passContext) {
+  snapshot(passContext) {
     const driver = passContext.driver;
 
     // We'll use evaluateAsync because the `node.getAttribute` method doesn't actually normalize

--- a/lighthouse-core/gather/gatherers/seo/embedded-content.js
+++ b/lighthouse-core/gather/gatherers/seo/embedded-content.js
@@ -7,7 +7,7 @@
 
 /* globals getElementsInDocument getNodeDetails */
 
-const Gatherer = require('../gatherer.js');
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../../lib/page-functions.js');
 
 /**
@@ -41,11 +41,16 @@ function getEmbeddedContent() {
 }
 
 class EmbeddedContent extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['EmbeddedContent']>}
    */
-  afterPass(passContext) {
+  snapshot(passContext) {
     return passContext.driver.evaluate(getEmbeddedContent, {
       args: [],
       deps: [

--- a/lighthouse-core/gather/gatherers/seo/embedded-content.js
+++ b/lighthouse-core/gather/gatherers/seo/embedded-content.js
@@ -7,7 +7,7 @@
 
 /* globals getElementsInDocument getNodeDetails */
 
-const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../../lib/page-functions.js');
 
 /**
@@ -40,7 +40,7 @@ function getEmbeddedContent() {
     }));
 }
 
-class EmbeddedContent extends Gatherer {
+class EmbeddedContent extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -16,7 +16,7 @@
  * This gatherer collects stylesheet metadata by itself, instead of relying on the styles gatherer which is slow (because it parses the stylesheet content).
  */
 
-const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const FONT_SIZE_PROPERTY_NAME = 'font-size';
 const MINIMAL_LEGIBLE_FONT_SIZE_PX = 12;
 // limit number of protocol calls to make sure that gatherer doesn't take more than 1-2s
@@ -178,7 +178,7 @@ async function fetchSourceRule(session, nodeId) {
   };
 }
 
-class FontSize extends Gatherer {
+class FontSize extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -16,7 +16,7 @@
  * This gatherer collects stylesheet metadata by itself, instead of relying on the styles gatherer which is slow (because it parses the stylesheet content).
  */
 
-const Gatherer = require('../gatherer.js');
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const FONT_SIZE_PROPERTY_NAME = 'font-size';
 const MINIMAL_LEGIBLE_FONT_SIZE_PX = 12;
 // limit number of protocol calls to make sure that gatherer doesn't take more than 1-2s
@@ -156,12 +156,12 @@ function getTextLength(text) {
 }
 
 /**
- * @param {Driver} driver
+ * @param {LH.Gatherer.FRProtocolSession} session
  * @param {number} nodeId text node
  * @returns {Promise<NodeFontData['cssRule']|undefined>}
  */
-async function fetchSourceRule(driver, nodeId) {
-  const matchedRules = await driver.sendCommand('CSS.getMatchedStylesForNode', {
+async function fetchSourceRule(session, nodeId) {
+  const matchedRules = await session.sendCommand('CSS.getMatchedStylesForNode', {
     nodeId,
   });
   const sourceRule = getEffectiveFontRule(matchedRules);
@@ -179,19 +179,24 @@ async function fetchSourceRule(driver, nodeId) {
 }
 
 class FontSize extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext['driver']} driver
+   * @param {LH.Gatherer.FRProtocolSession} session
    * @param {Array<NodeFontData>} failingNodes
    */
-  static async fetchFailingNodeSourceRules(driver, failingNodes) {
+  static async fetchFailingNodeSourceRules(session, failingNodes) {
     const nodesToAnalyze = failingNodes
       .sort((a, b) => b.textLength - a.textLength)
       .slice(0, MAX_NODES_SOURCE_RULE_FETCHED);
 
     // DOM.getDocument is necessary for pushNodesByBackendIdsToFrontend to properly retrieve nodeIds if the `DOM` domain was enabled before this gatherer, invoke it to be safe.
-    await driver.sendCommand('DOM.getDocument', {depth: -1, pierce: true});
+    await session.sendCommand('DOM.getDocument', {depth: -1, pierce: true});
 
-    const {nodeIds} = await driver.sendCommand('DOM.pushNodesByBackendIdsToFrontend', {
+    const {nodeIds} = await session.sendCommand('DOM.pushNodesByBackendIdsToFrontend', {
       backendNodeIds: nodesToAnalyze.map(node => node.parentNode.backendNodeId),
     });
 
@@ -199,7 +204,7 @@ class FontSize extends Gatherer {
       .map(async (failingNode, i) => {
         failingNode.nodeId = nodeIds[i];
         try {
-          const cssRule = await fetchSourceRule(driver, nodeIds[i]);
+          const cssRule = await fetchSourceRule(session, nodeIds[i]);
           failingNode.cssRule = cssRule;
         } catch (err) {
           // The node was deleted. We don't need to distinguish between lack-of-rule
@@ -309,24 +314,26 @@ class FontSize extends Gatherer {
   }
 
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.FontSize>} font-size analysis
    */
-  async afterPass(passContext) {
+  async snapshot(passContext) {
+    const session = passContext.driver.defaultSession;
+
     /** @type {Map<string, LH.Crdp.CSS.CSSStyleSheetHeader>} */
     const stylesheets = new Map();
     /** @param {LH.Crdp.CSS.StyleSheetAddedEvent} sheet */
     const onStylesheetAdded = sheet => stylesheets.set(sheet.header.styleSheetId, sheet.header);
-    passContext.driver.on('CSS.styleSheetAdded', onStylesheetAdded);
+    session.on('CSS.styleSheetAdded', onStylesheetAdded);
 
     await Promise.all([
-      passContext.driver.sendCommand('DOMSnapshot.enable'),
-      passContext.driver.sendCommand('DOM.enable'),
-      passContext.driver.sendCommand('CSS.enable'),
+      session.sendCommand('DOMSnapshot.enable'),
+      session.sendCommand('DOM.enable'),
+      session.sendCommand('CSS.enable'),
     ]);
 
     // Get the computed font-size style of every node.
-    const snapshot = await passContext.driver.sendCommand('DOMSnapshot.captureSnapshot', {
+    const snapshot = await session.sendCommand('DOMSnapshot.captureSnapshot', {
       computedStyles: ['font-size'],
     });
 
@@ -338,9 +345,9 @@ class FontSize extends Gatherer {
     const {
       analyzedFailingNodesData,
       analyzedFailingTextLength,
-    } = await FontSize.fetchFailingNodeSourceRules(passContext.driver, failingNodes);
+    } = await FontSize.fetchFailingNodeSourceRules(session, failingNodes);
 
-    passContext.driver.off('CSS.styleSheetAdded', onStylesheetAdded);
+    session.off('CSS.styleSheetAdded', onStylesheetAdded);
 
     // For the nodes whose computed style we could attribute to a stylesheet, assign
     // the stylsheet to the data.
@@ -350,9 +357,9 @@ class FontSize extends Gatherer {
       .forEach(data => (data.cssRule.stylesheet = stylesheets.get(data.cssRule.styleSheetId)));
 
     await Promise.all([
-      passContext.driver.sendCommand('DOMSnapshot.disable'),
-      passContext.driver.sendCommand('DOM.disable'),
-      passContext.driver.sendCommand('CSS.disable'),
+      session.sendCommand('DOMSnapshot.disable'),
+      session.sendCommand('DOM.disable'),
+      session.sendCommand('CSS.disable'),
     ]);
 
     return {

--- a/lighthouse-core/gather/gatherers/seo/robots-txt.js
+++ b/lighthouse-core/gather/gatherers/seo/robots-txt.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Gatherer = require('../gatherer.js');
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 
 /* global fetch, URL, location */
 
@@ -26,13 +26,17 @@ async function getRobotsTxtContent() {
 }
 /* c8 ignore stop */
 
-
 class RobotsTxt extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['RobotsTxt']>}
    */
-  afterPass(passContext) {
+  snapshot(passContext) {
     return passContext.driver.evaluate(getRobotsTxtContent, {
       args: [],
       useIsolation: true,

--- a/lighthouse-core/gather/gatherers/seo/robots-txt.js
+++ b/lighthouse-core/gather/gatherers/seo/robots-txt.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 
 /* global fetch, URL, location */
 
@@ -26,7 +26,7 @@ async function getRobotsTxtContent() {
 }
 /* c8 ignore stop */
 
-class RobotsTxt extends Gatherer {
+class RobotsTxt extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -7,7 +7,7 @@
 
 /* global document, window, getComputedStyle, getElementsInDocument, Node, getNodeDetails, getRectCenterPoint */
 
-const Gatherer = require('../gatherer.js');
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../../lib/page-functions.js');
 const RectHelpers = require('../../../lib/rect-helpers.js');
 
@@ -289,7 +289,7 @@ function gatherTapTargets(tapTargetsSelector) {
 
 class TapTargets extends Gatherer {
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.TapTarget[]>} All visible tap targets with their positions and sizes
    */
   afterPass(passContext) {

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -7,7 +7,7 @@
 
 /* global document, window, getComputedStyle, getElementsInDocument, Node, getNodeDetails, getRectCenterPoint */
 
-const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const pageFunctions = require('../../../lib/page-functions.js');
 const RectHelpers = require('../../../lib/rect-helpers.js');
 
@@ -287,7 +287,7 @@ function gatherTapTargets(tapTargetsSelector) {
 }
 /* c8 ignore stop */
 
-class TapTargets extends Gatherer {
+class TapTargets extends FRGatherer {
   /**
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.TapTarget[]>} All visible tap targets with their positions and sizes

--- a/lighthouse-core/gather/gatherers/viewport-dimensions.js
+++ b/lighthouse-core/gather/gatherers/viewport-dimensions.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 
 /* global window */
 
@@ -27,7 +27,7 @@ function getViewportDimensions() {
 }
 /* c8 ignore stop */
 
-class ViewportDimensions extends Gatherer {
+class ViewportDimensions extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],

--- a/lighthouse-core/gather/gatherers/viewport-dimensions.js
+++ b/lighthouse-core/gather/gatherers/viewport-dimensions.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Gatherer = require('./gatherer.js');
+const Gatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 
 /* global window */
 
@@ -28,11 +28,16 @@ function getViewportDimensions() {
 /* c8 ignore stop */
 
 class ViewportDimensions extends Gatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['snapshot', 'navigation'],
+  }
+
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.ViewportDimensions>}
    */
-  async afterPass(passContext) {
+  async snapshot(passContext) {
     const driver = passContext.driver;
 
     const dimensions = await driver.evaluate(getViewportDimensions, {

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -1291,8 +1291,13 @@ describe('Config', () => {
       // Round-trip through JSON to drop live 'instance'/'implementation' props.
       const mergedJson = JSON.parse(JSON.stringify(merged));
 
+      const expectedInstance = {
+        meta: {
+          supportedModes: ['snapshot', 'navigation'],
+        },
+      };
       assert.deepEqual(mergedJson[0].gatherers,
-        [{path: 'viewport-dimensions', instance: {}}]);
+        [{path: 'viewport-dimensions', instance: expectedInstance}]);
     });
 
     function loadGatherer(gathererEntry) {

--- a/lighthouse-core/test/gather/driver/execution-context-test.js
+++ b/lighthouse-core/test/gather/driver/execution-context-test.js
@@ -206,10 +206,9 @@ describe('.evaluate', () => {
           return __nativePromise.resolve()
             .then(_ => (() => {
       
-      function main(value) {
+      return (function main(value) {
       return value;
-    }
-      return main(1);
+    })(1);
     })())
             .catch(function wrapRuntimeEvalErrorInBrowser(err) {
   if (!err || typeof err === 'string') {
@@ -246,10 +245,32 @@ describe('.evaluate', () => {
     const code = mockFn.mock.calls[0][0];
     expect(code).toBe(`(() => {
       
-      function mainFn(value) {
+      return (function mainFn(value) {
       return value;
-    }
-      return mainFn(1);
+    })(1);
+    })()`);
+    expect(eval(code)).toEqual(1);
+  });
+
+  it('transforms parameters into an expression (arrows)', async () => {
+    // Mock so the argument can be intercepted, and the generated code
+    // can be evaluated without the error catching code.
+    const mockFn = executionContext._evaluateInContext = jest.fn()
+      .mockImplementation(() => Promise.resolve());
+
+    /** @param {number} value */
+    const mainFn = (value) => {
+      return value;
+    };
+    /** @type {number} */
+    const value = await executionContext.evaluate(mainFn, {args: [1]}); // eslint-disable-line no-unused-vars
+
+    const code = mockFn.mock.calls[0][0];
+    expect(code).toBe(`(() => {
+      
+      return ((value) => {
+      return value;
+    })(1);
     })()`);
     expect(eval(code)).toEqual(1);
   });
@@ -294,10 +315,9 @@ describe('.evaluate', () => {
 function square(val) {
       return val * val;
     }
-      function mainFn({a, b}, passThru) {
+      return (function mainFn({a, b}, passThru) {
       return {a: abs(a), b: square(b), passThru};
-    }
-      return mainFn({"a":-5,"b":10},"hello");
+    })({"a":-5,"b":10},"hello");
     })()`);
     expect(eval(code)).toEqual({a: 5, b: 100, passThru: 'hello'});
   });

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -121,7 +121,7 @@ describe('Font size gatherer', () => {
   });
 
   it('returns information about font sizes used on page', async () => {
-    const driver = {
+    const session = {
       on() {},
       off() {},
       async sendCommand(command, args) {
@@ -143,6 +143,7 @@ describe('Font size gatherer', () => {
         }
       },
     };
+    const driver = {defaultSession: session};
 
     const artifact = await fontSizeGather.afterPass({driver});
     const expectedFailingTextLength = Array.from(smallText.trim()).length;


### PR DESCRIPTION
This migrates the gatherers (14) that only use `afterPass`, the interface already supported by `FRTransitionalContext`, and no `loadData`.

```
CacheContents
Appcache
Doctype
Domstats
PasswordInputsWithPreventedPaste
FormElements
GlobalListeners
IframeElements
MetaElements
EmbeddedContent
FontSize
RobotsTxt
TapTargets
ViewportDimensions
```

ref #11313
