### PR TITLE
core(fr): add session.onAnyProtocolMessage listener

### DIFF
--- a/lighthouse-core/fraggle-rock/gather/driver.js
+++ b/lighthouse-core/fraggle-rock/gather/driver.js
@@ -19,7 +19,7 @@ const defaultSession = {
   setNextProtocolTimeout: throwNotConnectedFn,
   on: throwNotConnectedFn,
   once: throwNotConnectedFn,
-  onAny: throwNotConnectedFn,
+  onAnyProtocolMessage: throwNotConnectedFn,
   off: throwNotConnectedFn,
   sendCommand: throwNotConnectedFn,
 };

--- a/lighthouse-core/fraggle-rock/gather/driver.js
+++ b/lighthouse-core/fraggle-rock/gather/driver.js
@@ -19,6 +19,7 @@ const defaultSession = {
   setNextProtocolTimeout: throwNotConnectedFn,
   on: throwNotConnectedFn,
   once: throwNotConnectedFn,
+  onAny: throwNotConnectedFn,
   off: throwNotConnectedFn,
   sendCommand: throwNotConnectedFn,
 };

--- a/lighthouse-core/fraggle-rock/gather/driver.js
+++ b/lighthouse-core/fraggle-rock/gather/driver.js
@@ -19,6 +19,7 @@ const defaultSession = {
   setNextProtocolTimeout: throwNotConnectedFn,
   on: throwNotConnectedFn,
   once: throwNotConnectedFn,
+  onAnyProtocolMessage: throwNotConnectedFn,
   off: throwNotConnectedFn,
   sendCommand: throwNotConnectedFn,
 };

--- a/lighthouse-core/fraggle-rock/gather/driver.js
+++ b/lighthouse-core/fraggle-rock/gather/driver.js
@@ -19,7 +19,6 @@ const defaultSession = {
   setNextProtocolTimeout: throwNotConnectedFn,
   on: throwNotConnectedFn,
   once: throwNotConnectedFn,
-  onAnyProtocolMessage: throwNotConnectedFn,
   off: throwNotConnectedFn,
   sendCommand: throwNotConnectedFn,
 };

--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -73,7 +73,7 @@ class ProtocolSession {
    * Bind to our custom event that fires for *any* protocol event.
    * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
    */
-  onAny(callback) {
+  onAnyProtocolMessage(callback) {
     this._session.on('*', /** @type {*} */ (callback));
   }
 

--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -71,8 +71,7 @@ class ProtocolSession {
 
   /**
    * Bind to our custom event that fires for *any* protocol event.
-   * @template {keyof LH.CrdpEvents} E
-   * @param {(payload: {method: E, params: LH.CrdpEvents[E]}) => void} callback
+   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
    */
   onAny(callback) {
     this._session.on('*', /** @type {*} */ (callback));

--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const MONKEYPATCHED_EMIT = Symbol('monkeypatch');
+const SessionEmitMonkeypatch = Symbol('monkeypatch');
 
 /** @implements {LH.Gatherer.FRProtocolSession} */
 class ProtocolSession {
@@ -19,13 +19,13 @@ class ProtocolSession {
     // This patched method will now emit a copy of every event on `*`.
     const originalEmit = session.emit;
     // @ts-expect-error - Test for the monkeypatch.
-    if (originalEmit[MONKEYPATCHED_EMIT]) return;
+    if (originalEmit[SessionEmitMonkeypatch]) return;
     session.emit = (method, ...params) => {
       originalEmit.call(session, '*', {method, params});
       return originalEmit.call(session, method, ...params);
     };
     // @ts-expect-error - It's monkeypatching 🤷‍♂️.
-    session.emit[MONKEYPATCHED_EMIT] = true;
+    session.emit[SessionEmitMonkeypatch] = true;
   }
 
   /**

--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -26,21 +26,6 @@ class ProtocolSession {
     };
     // @ts-expect-error - It's monkeypatching 🤷‍♂️.
     session.emit[SessionEmitMonkeypatch] = true;
-
-    /** @type {LH.Gatherer.FRProtocolSession['on']} @param {Array<*>} args */
-    this.on = (...args) => args.length === 1 ?
-      session.on('*', args[0]) :
-      session.on(args[0], args[1]);
-
-    /** @type {LH.Gatherer.FRProtocolSession['once']} */
-    this.once = (event, callback) => {
-      session.once(event, callback);
-    };
-
-    /** @type {LH.Gatherer.FRProtocolSession['off']} @param {Array<*>} args */
-    this.off = (...args) => args.length === 1 ?
-      session.off('*', args[0]) :
-      session.off(args[0], args[1]);
   }
 
   /**
@@ -62,6 +47,44 @@ class ProtocolSession {
    */
   setNextProtocolTimeout(ms) { // eslint-disable-line no-unused-vars
     // TODO(FR-COMPAT): support protocol timeout
+  }
+
+  /**
+   * Bind listeners for protocol events.
+   * @template {keyof LH.CrdpEvents} E
+   * @param {E} eventName
+   * @param {(...args: LH.CrdpEvents[E]) => void} callback
+   */
+  on(eventName, callback) {
+    this._session.on(eventName, /** @type {*} */ (callback));
+  }
+
+  /**
+   * Bind listeners for protocol events.
+   * @template {keyof LH.CrdpEvents} E
+   * @param {E} eventName
+   * @param {(...args: LH.CrdpEvents[E]) => void} callback
+   */
+  once(eventName, callback) {
+    this._session.once(eventName, /** @type {*} */ (callback));
+  }
+
+  /**
+   * Bind to our custom event that fires for *any* protocol event.
+   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
+   */
+  onAnyProtocolMessage(callback) {
+    this._session.on('*', /** @type {*} */ (callback));
+  }
+
+  /**
+   * Bind listeners for protocol events.
+   * @template {keyof LH.CrdpEvents} E
+   * @param {E} eventName
+   * @param {(...args: LH.CrdpEvents[E]) => void} callback
+   */
+  off(eventName, callback) {
+    this._session.off(eventName, /** @type {*} */ (callback));
   }
 
   /**

--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -26,6 +26,21 @@ class ProtocolSession {
     };
     // @ts-expect-error - It's monkeypatching 🤷‍♂️.
     session.emit[SessionEmitMonkeypatch] = true;
+
+    /** @type {LH.Gatherer.FRProtocolSession['on']} @param {Array<*>} args */
+    this.on = (...args) => args.length === 1 ?
+      session.on('*', args[0]) :
+      session.on(args[0], args[1]);
+
+    /** @type {LH.Gatherer.FRProtocolSession['once']} */
+    this.once = (event, callback) => {
+      session.once(event, callback);
+    };
+
+    /** @type {LH.Gatherer.FRProtocolSession['off']} @param {Array<*>} args */
+    this.off = (...args) => args.length === 1 ?
+      session.off('*', args[0]) :
+      session.off(args[0], args[1]);
   }
 
   /**
@@ -47,44 +62,6 @@ class ProtocolSession {
    */
   setNextProtocolTimeout(ms) { // eslint-disable-line no-unused-vars
     // TODO(FR-COMPAT): support protocol timeout
-  }
-
-  /**
-   * Bind listeners for protocol events.
-   * @template {keyof LH.CrdpEvents} E
-   * @param {E} eventName
-   * @param {(...args: LH.CrdpEvents[E]) => void} callback
-   */
-  on(eventName, callback) {
-    this._session.on(eventName, /** @type {*} */ (callback));
-  }
-
-  /**
-   * Bind listeners for protocol events.
-   * @template {keyof LH.CrdpEvents} E
-   * @param {E} eventName
-   * @param {(...args: LH.CrdpEvents[E]) => void} callback
-   */
-  once(eventName, callback) {
-    this._session.once(eventName, /** @type {*} */ (callback));
-  }
-
-  /**
-   * Bind to our custom event that fires for *any* protocol event.
-   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
-   */
-  onAnyProtocolMessage(callback) {
-    this._session.on('*', /** @type {*} */ (callback));
-  }
-
-  /**
-   * Bind listeners for protocol events.
-   * @template {keyof LH.CrdpEvents} E
-   * @param {E} eventName
-   * @param {(...args: LH.CrdpEvents[E]) => void} callback
-   */
-  off(eventName, callback) {
-    this._session.off(eventName, /** @type {*} */ (callback));
   }
 
   /**

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -86,6 +86,22 @@ class Connection {
     this._eventEmitter.on(eventName, cb);
   }
 
+  /**
+   * Unbind listeners for connection events.
+   * @param {'protocolevent'} eventName
+   * @param {function(LH.Protocol.RawEventMessage): void} cb
+   */
+  off(eventName, cb) {
+    if (eventName !== 'protocolevent') {
+      throw new Error('Only supports "protocolevent" events');
+    }
+
+    if (!this._eventEmitter) {
+      throw new Error('Attempted to add event listener after connection disposed.');
+    }
+    this._eventEmitter.removeListener(eventName, cb);
+  }
+
   /* eslint-disable no-unused-vars */
 
   /**

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -86,22 +86,6 @@ class Connection {
     this._eventEmitter.on(eventName, cb);
   }
 
-  /**
-   * Unbind listeners for connection events.
-   * @param {'protocolevent'} eventName
-   * @param {function(LH.Protocol.RawEventMessage): void} cb
-   */
-  off(eventName, cb) {
-    if (eventName !== 'protocolevent') {
-      throw new Error('Only supports "protocolevent" events');
-    }
-
-    if (!this._eventEmitter) {
-      throw new Error('Attempted to add event listener after connection disposed.');
-    }
-    this._eventEmitter.removeListener(eventName, cb);
-  }
-
   /* eslint-disable no-unused-vars */
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -277,6 +277,14 @@ class Driver {
   }
 
   /**
+   * Bind to *any* protocol event.
+   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
+   */
+  onAny(callback) {
+    this._connection.on('protocolevent', callback);
+  }
+
+  /**
    * Debounce enabling or disabling domains to prevent driver users from
    * stomping on each other. Maintains an internal count of the times a domain
    * has been enabled. Returns false if the command would have no effect (domain

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -280,7 +280,7 @@ class Driver {
    * Bind to *any* protocol event.
    * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
    */
-  onAny(callback) {
+  onAnyProtocolMessage(callback) {
     this._connection.on('protocolevent', callback);
   }
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -129,6 +129,16 @@ class Driver {
   constructor(connection) {
     this._connection = connection;
 
+    /** @type {LH.Gatherer.FRProtocolSession['on']} @param {Array<*>} args */
+    this.on = (...args) => args.length === 1 ?
+      this._connection.on('protocolevent', args[0]) :
+      this._on(args[0], args[1]);
+
+    /** @type {LH.Gatherer.FRProtocolSession['off']} @param {Array<*>} args */
+    this.off = (...args) => args.length === 1 ?
+      this._connection.off('protocolevent', args[0]) :
+      this._off(args[0], args[1]);
+
     this.on('Target.attachedToTarget', event => {
       this._handleTargetAttached(event).catch(this._handleEventError);
     });
@@ -236,7 +246,7 @@ class Driver {
    * @param {E} eventName
    * @param {(...args: LH.CrdpEvents[E]) => void} cb
    */
-  on(eventName, cb) {
+  _on(eventName, cb) {
     if (this._eventEmitter === null) {
       throw new Error('connect() must be called before attempting to listen to events.');
     }
@@ -268,20 +278,12 @@ class Driver {
    * @param {E} eventName
    * @param {Function} cb
    */
-  off(eventName, cb) {
+  _off(eventName, cb) {
     if (this._eventEmitter === null) {
       throw new Error('connect() must be called before attempting to remove an event listener.');
     }
 
     this._eventEmitter.removeListener(eventName, cb);
-  }
-
-  /**
-   * Bind to *any* protocol event.
-   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
-   */
-  onAnyProtocolMessage(callback) {
-    this._connection.on('protocolevent', callback);
   }
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -129,16 +129,6 @@ class Driver {
   constructor(connection) {
     this._connection = connection;
 
-    /** @type {LH.Gatherer.FRProtocolSession['on']} @param {Array<*>} args */
-    this.on = (...args) => args.length === 1 ?
-      this._connection.on('protocolevent', args[0]) :
-      this._on(args[0], args[1]);
-
-    /** @type {LH.Gatherer.FRProtocolSession['off']} @param {Array<*>} args */
-    this.off = (...args) => args.length === 1 ?
-      this._connection.off('protocolevent', args[0]) :
-      this._off(args[0], args[1]);
-
     this.on('Target.attachedToTarget', event => {
       this._handleTargetAttached(event).catch(this._handleEventError);
     });
@@ -246,7 +236,7 @@ class Driver {
    * @param {E} eventName
    * @param {(...args: LH.CrdpEvents[E]) => void} cb
    */
-  _on(eventName, cb) {
+  on(eventName, cb) {
     if (this._eventEmitter === null) {
       throw new Error('connect() must be called before attempting to listen to events.');
     }
@@ -278,12 +268,20 @@ class Driver {
    * @param {E} eventName
    * @param {Function} cb
    */
-  _off(eventName, cb) {
+  off(eventName, cb) {
     if (this._eventEmitter === null) {
       throw new Error('connect() must be called before attempting to remove an event listener.');
     }
 
     this._eventEmitter.removeListener(eventName, cb);
+  }
+
+  /**
+   * Bind to *any* protocol event.
+   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
+   */
+  onAnyProtocolMessage(callback) {
+    this._connection.on('protocolevent', callback);
   }
 
   /**

--- a/lighthouse-core/test/fraggle-rock/gather/driver-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/driver-test.js
@@ -34,7 +34,7 @@ beforeEach(() => {
   // @ts-expect-error - Individual mock functions are applied as necessary.
   pageTarget = {createCDPSession: () => puppeteerSession};
   // @ts-expect-error - Individual mock functions are applied as necessary.
-  puppeteerSession = {on: jest.fn(), off: jest.fn(), send: jest.fn()};
+  puppeteerSession = {on: jest.fn(), off: jest.fn(), send: jest.fn(), emit: jest.fn()};
   driver = new Driver(page);
 });
 

--- a/lighthouse-core/test/fraggle-rock/gather/session-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/session-test.js
@@ -66,7 +66,7 @@ describe('ProtocolSession', () => {
   for (const method of delegateMethods) {
     describe(`.${method}`, () => {
       it('delegates to puppeteer', async () => {
-        const puppeteerFn = (puppeteerSession[method] = jest.fn());
+        const puppeteerFn = puppeteerSession[method] = jest.fn();
         const callback = () => undefined;
 
         session[method]('Page.frameNavigated', callback);
@@ -103,7 +103,7 @@ describe('ProtocolSession', () => {
 
   describe('.sendCommand', () => {
     it('delegates to puppeteer', async () => {
-      const send = (puppeteerSession.send = jest.fn().mockResolvedValue(123));
+      const send = puppeteerSession.send = jest.fn().mockResolvedValue(123);
 
       const result = await session.sendCommand('Page.navigate', {url: 'foo'});
       expect(result).toEqual(123);

--- a/lighthouse-core/test/fraggle-rock/gather/session-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/session-test.js
@@ -5,6 +5,7 @@
  */
 'use strict';
 
+const {EventEmitter} = require('events');
 const ProtocolSession = require('../../../fraggle-rock/gather/session.js');
 
 /* eslint-env jest */
@@ -17,8 +18,47 @@ describe('ProtocolSession', () => {
 
   beforeEach(() => {
     // @ts-expect-error - Individual mock functions are applied as necessary.
-    puppeteerSession = {};
+    puppeteerSession = {emit: jest.fn()};
     session = new ProtocolSession(puppeteerSession);
+  });
+
+  describe('ProtocolSession', () => {
+    it('should emit a copy of events on "*"', () => {
+      // @ts-expect-error - we want to use a more limited test of a real event emitter.
+      puppeteerSession = new EventEmitter();
+      session = new ProtocolSession(puppeteerSession);
+
+      const regularListener = jest.fn();
+      const allListener = jest.fn();
+
+      puppeteerSession.on('Foo', regularListener);
+      puppeteerSession.on('*', allListener);
+      puppeteerSession.emit('Foo', 1, 2, 3);
+      puppeteerSession.emit('Bar', 1, 2, 3);
+
+      expect(regularListener).toHaveBeenCalledTimes(1);
+      expect(allListener).toHaveBeenCalledTimes(2);
+      expect(allListener).toHaveBeenCalledWith({method: 'Foo', params: [1, 2, 3]});
+      expect(allListener).toHaveBeenCalledWith({method: 'Bar', params: [1, 2, 3]});
+    });
+
+    it('should not fire duplicate events', () => {
+      // @ts-expect-error - we want to use a more limited test of a real event emitter.
+      puppeteerSession = new EventEmitter();
+      session = new ProtocolSession(puppeteerSession);
+      session = new ProtocolSession(puppeteerSession);
+
+      const regularListener = jest.fn();
+      const allListener = jest.fn();
+
+      puppeteerSession.on('Foo', regularListener);
+      puppeteerSession.on('*', allListener);
+      puppeteerSession.emit('Foo', 1, 2, 3);
+      puppeteerSession.emit('Bar', 1, 2, 3);
+
+      expect(regularListener).toHaveBeenCalledTimes(1);
+      expect(allListener).toHaveBeenCalledTimes(2);
+    });
   });
 
   /** @type {Array<'on'|'off'|'once'>} */
@@ -26,7 +66,7 @@ describe('ProtocolSession', () => {
   for (const method of delegateMethods) {
     describe(`.${method}`, () => {
       it('delegates to puppeteer', async () => {
-        const puppeteerFn = puppeteerSession[method] = jest.fn();
+        const puppeteerFn = (puppeteerSession[method] = jest.fn());
         const callback = () => undefined;
 
         session[method]('Page.frameNavigated', callback);
@@ -35,9 +75,35 @@ describe('ProtocolSession', () => {
     });
   }
 
+  describe('.onAny', () => {
+    it('should listen for any event', () => {
+      // @ts-expect-error - we want to use a more limited test of a real event emitter.
+      puppeteerSession = new EventEmitter();
+      session = new ProtocolSession(puppeteerSession);
+
+      const regularListener = jest.fn();
+      const allListener = jest.fn();
+
+      session.on('Page.frameNavigated', regularListener);
+      session.onAny(allListener);
+
+      puppeteerSession.emit('Page.frameNavigated');
+      puppeteerSession.emit('Debugger.scriptParsed', {script: 'details'});
+
+      expect(regularListener).toHaveBeenCalledTimes(1);
+      expect(regularListener).toHaveBeenCalledWith();
+      expect(allListener).toHaveBeenCalledTimes(2);
+      expect(allListener).toHaveBeenCalledWith({method: 'Page.frameNavigated', params: []});
+      expect(allListener).toHaveBeenCalledWith({
+        method: 'Debugger.scriptParsed',
+        params: [{script: 'details'}],
+      });
+    });
+  });
+
   describe('.sendCommand', () => {
     it('delegates to puppeteer', async () => {
-      const send = puppeteerSession.send = jest.fn().mockResolvedValue(123);
+      const send = (puppeteerSession.send = jest.fn().mockResolvedValue(123));
 
       const result = await session.sendCommand('Page.navigate', {url: 'foo'});
       expect(result).toEqual(123);

--- a/lighthouse-core/test/fraggle-rock/gather/session-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/session-test.js
@@ -75,7 +75,7 @@ describe('ProtocolSession', () => {
     });
   }
 
-  describe('.onAny', () => {
+  describe('.onAnyProtocolMessage', () => {
     it('should listen for any event', () => {
       // @ts-expect-error - we want to use a more limited test of a real event emitter.
       puppeteerSession = new EventEmitter();
@@ -85,7 +85,7 @@ describe('ProtocolSession', () => {
       const allListener = jest.fn();
 
       session.on('Page.frameNavigated', regularListener);
-      session.onAny(allListener);
+      session.onAnyProtocolMessage(allListener);
 
       puppeteerSession.emit('Page.frameNavigated');
       puppeteerSession.emit('Debugger.scriptParsed', {script: 'details'});

--- a/lighthouse-core/test/fraggle-rock/gather/session-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/session-test.js
@@ -75,7 +75,7 @@ describe('ProtocolSession', () => {
     });
   }
 
-  describe('.on(callback)', () => {
+  describe('.onAnyProtocolMessage', () => {
     it('should listen for any event', () => {
       // @ts-expect-error - we want to use a more limited test of a real event emitter.
       puppeteerSession = new EventEmitter();
@@ -85,7 +85,7 @@ describe('ProtocolSession', () => {
       const allListener = jest.fn();
 
       session.on('Page.frameNavigated', regularListener);
-      session.on(allListener);
+      session.onAnyProtocolMessage(allListener);
 
       puppeteerSession.emit('Page.frameNavigated');
       puppeteerSession.emit('Debugger.scriptParsed', {script: 'details'});

--- a/lighthouse-core/test/fraggle-rock/gather/session-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/session-test.js
@@ -75,7 +75,7 @@ describe('ProtocolSession', () => {
     });
   }
 
-  describe('.onAnyProtocolMessage', () => {
+  describe('.on(callback)', () => {
     it('should listen for any event', () => {
       // @ts-expect-error - we want to use a more limited test of a real event emitter.
       puppeteerSession = new EventEmitter();
@@ -85,7 +85,7 @@ describe('ProtocolSession', () => {
       const allListener = jest.fn();
 
       session.on('Page.frameNavigated', regularListener);
-      session.onAnyProtocolMessage(allListener);
+      session.on(allListener);
 
       puppeteerSession.emit('Page.frameNavigated');
       puppeteerSession.emit('Debugger.scriptParsed', {script: 'details'});

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -18,7 +18,7 @@ declare global {
       setNextProtocolTimeout(ms: number): void;
       on<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
       once<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
-      onAny(callback: (payload: LH.Protocol.RawEventMessage) => void): void
+      onAnyProtocolMessage(callback: (payload: LH.Protocol.RawEventMessage) => void): void
       off<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
       sendCommand<TMethod extends keyof LH.CrdpCommands>(method: TMethod, ...params: LH.CrdpCommands[TMethod]['paramsType']): Promise<LH.CrdpCommands[TMethod]['returnType']>;
     }

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -18,6 +18,7 @@ declare global {
       setNextProtocolTimeout(ms: number): void;
       on<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
       once<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
+      onAny(callback: (payload: LH.Protocol.RawEventMessage) => void): void
       off<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
       sendCommand<TMethod extends keyof LH.CrdpCommands>(method: TMethod, ...params: LH.CrdpCommands[TMethod]['paramsType']): Promise<LH.CrdpCommands[TMethod]['returnType']>;
     }

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -18,8 +18,9 @@ declare global {
       setNextProtocolTimeout(ms: number): void;
       on<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
       once<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
-      onAnyProtocolMessage(callback: (payload: LH.Protocol.RawEventMessage) => void): void
       off<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
+      on(callback: (args: LH.Protocol.RawEventMessage) => void): void;
+      off(callback: (args: LH.Protocol.RawEventMessage) => void): void;
       sendCommand<TMethod extends keyof LH.CrdpCommands>(method: TMethod, ...params: LH.CrdpCommands[TMethod]['paramsType']): Promise<LH.CrdpCommands[TMethod]['returnType']>;
     }
 

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -18,9 +18,8 @@ declare global {
       setNextProtocolTimeout(ms: number): void;
       on<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
       once<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
+      onAnyProtocolMessage(callback: (payload: LH.Protocol.RawEventMessage) => void): void
       off<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
-      on(callback: (args: LH.Protocol.RawEventMessage) => void): void;
-      off(callback: (args: LH.Protocol.RawEventMessage) => void): void;
       sendCommand<TMethod extends keyof LH.CrdpCommands>(method: TMethod, ...params: LH.CrdpCommands[TMethod]['paramsType']): Promise<LH.CrdpCommands[TMethod]['returnType']>;
     }
 


### PR DESCRIPTION
**Summary**
Paves the way for devtools log artifact on the new FR driver/session system. This monkeypatches our puppeteer session so we can listen for any protocol event. It's on the agenda to discuss at next sync with their team if they'd be open a PR for an official API, but it's relatively lightweight (and enables backcompat) in the meantime.


**Related Issues/PRs**
ref #11313 
