### PR TITLE
misc: fix "fast" npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "coveralls": "cat unit-coverage.lcov | coveralls",
     "devtools": "bash lighthouse-core/scripts/roll-to-devtools.sh",
     "chrome": "node lighthouse-core/scripts/manual-chrome-launcher.js",
-    "fast": "yarn start --screenEmulation.disabled --no-emulated-user-agent --throttlingMethod=provided",
+    "fast": "yarn start --preset=desktop --throttlingMethod=provided",
     "deploy-treemap": "yarn build-treemap --deploy",
     "deploy-viewer": "yarn build-viewer --deploy",
     "now-build": "node lighthouse-core/scripts/build-report-for-autodeployment.js && yarn build-viewer && yarn build-treemap && cp -r dist/gh-pages dist/now/gh-pages",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "coveralls": "cat unit-coverage.lcov | coveralls",
     "devtools": "bash lighthouse-core/scripts/roll-to-devtools.sh",
     "chrome": "node lighthouse-core/scripts/manual-chrome-launcher.js",
-    "fast": "yarn start --throttlingMethod=provided",
+    "fast": "yarn start --screenEmulation.disabled --no-emulated-user-agent --throttlingMethod=provided",
     "deploy-treemap": "yarn build-treemap --deploy",
     "deploy-viewer": "yarn build-viewer --deploy",
     "now-build": "node lighthouse-core/scripts/build-report-for-autodeployment.js && yarn build-viewer && yarn build-treemap && cp -r dist/gh-pages dist/now/gh-pages",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "coveralls": "cat unit-coverage.lcov | coveralls",
     "devtools": "bash lighthouse-core/scripts/roll-to-devtools.sh",
     "chrome": "node lighthouse-core/scripts/manual-chrome-launcher.js",
-    "fast": "yarn start --emulated-form-factor=none --throttlingMethod=provided",
+    "fast": "yarn start --throttlingMethod=provided",
     "deploy-treemap": "yarn build-treemap --deploy",
     "deploy-viewer": "yarn build-viewer --deploy",
     "now-build": "node lighthouse-core/scripts/build-report-for-autodeployment.js && yarn build-viewer && yarn build-treemap && cp -r dist/gh-pages dist/now/gh-pages",


### PR DESCRIPTION
Release test was failing on this step:
https://github.com/GoogleChrome/lighthouse/blob/85331168e3c52ff389f7053386f95556cc03049d/lighthouse-core/scripts/release/test.sh#L41

npm fast:
https://github.com/GoogleChrome/lighthouse/blob/85331168e3c52ff389f7053386f95556cc03049d/package.json#L59

`--emulated-form-factor` is removed as of https://github.com/GoogleChrome/lighthouse/pull/11779