### PR TITLE
core(trace-elements): use currentSrc in node snippet for lcp element

### DIFF
--- a/lighthouse-core/gather/gatherers/trace-elements.js
+++ b/lighthouse-core/gather/gatherers/trace-elements.js
@@ -32,7 +32,7 @@ function getNodeDetailsData(traceEventType) {
 
   /** @type {import('../../lib/page-functions.js').NodeDetailsOptions=} */
   let options;
-  if (traceEventType === 'largest-contentful-paint') {
+  if (elem.tagName === 'img' && traceEventType === 'largest-contentful-paint') {
     options = {
       snippet: {
         attrMapper(name, value) {


### PR DESCRIPTION
Fixes #11895

Adds an `options` parameter to `getNodeDetails`, allowing callers to customize functions called inside the page for collecting `NodeDetails`.

Tweaks `getOuterHTMLSnippet` to take a mapper function (instead of an ignore list, which isn't actually used anywhere).