### PR TITLE
v7.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,25 +12,30 @@ Thanks to our new contributors 👽🐷🐰🐯🐻!
 
 ## Core
 
-* fr: add navigation runner ([#11975](https://github.com/GoogleChrome/lighthouse/pull/11975))
 * handle timer throttling in DevTools to avoid timeouts ([#11987](https://github.com/GoogleChrome/lighthouse/pull/11987))
 * config: refactor config cloning for fraggle rock ([#11759](https://github.com/GoogleChrome/lighthouse/pull/11759))
 * console-messages: use source-location ([#11899](https://github.com/GoogleChrome/lighthouse/pull/11899))
 * errors-in-console: ignore BLOCKED_BY_CLIENT.Inspector errors ([#11901](https://github.com/GoogleChrome/lighthouse/pull/11901))
 * font-size: handle valueless attributes for inline styles ([#11934](https://github.com/GoogleChrome/lighthouse/pull/11934))
-* fr: add navigations to config ([#11957](https://github.com/GoogleChrome/lighthouse/pull/11957))
-* fr: add timespan runner ([#11944](https://github.com/GoogleChrome/lighthouse/pull/11944))
-* fr: filter configs by gather mode ([#11941](https://github.com/GoogleChrome/lighthouse/pull/11941))
 * full-page-screenshot: get the MAX_TEXTURE_SIZE from the browser ([#11847](https://github.com/GoogleChrome/lighthouse/pull/11847))
 * metrics: support FCP for all frames with devtools throttling ([#11874](https://github.com/GoogleChrome/lighthouse/pull/11874))
 * add type checking to page functions ([#11958](https://github.com/GoogleChrome/lighthouse/pull/11958))
 * normalize creation of NodeValue ([#11877](https://github.com/GoogleChrome/lighthouse/pull/11877))
-* fr: add base config ([#11915](https://github.com/GoogleChrome/lighthouse/pull/11915))
-* fr: add base gatherer class ([#11917](https://github.com/GoogleChrome/lighthouse/pull/11917))
 * full-page-screenshot: do not render zero size rects ([#11853](https://github.com/GoogleChrome/lighthouse/pull/11853))
 * proto: clarify deprecated state of EmulatedFormFactor enum ([#11946](https://github.com/GoogleChrome/lighthouse/pull/11946))
 * replace most usages of evaluateAsync with structured evaluate ([#11754](https://github.com/GoogleChrome/lighthouse/pull/11754))
 * trace: compute trace for main frame and any child frames ([#11760](https://github.com/GoogleChrome/lighthouse/pull/11760))
+
+## Fraggle Rock
+
+Support for auditing user flows ([#11313](https://github.com/GoogleChrome/lighthouse/issues/11313))
+
+* add navigation runner ([#11975](https://github.com/GoogleChrome/lighthouse/pull/11975))
+* add navigations to config ([#11957](https://github.com/GoogleChrome/lighthouse/pull/11957))
+* add timespan runner ([#11944](https://github.com/GoogleChrome/lighthouse/pull/11944))
+* filter configs by gather mode ([#11941](https://github.com/GoogleChrome/lighthouse/pull/11941))
+* add base config ([#11915](https://github.com/GoogleChrome/lighthouse/pull/11915))
+* add base gatherer class ([#11917](https://github.com/GoogleChrome/lighthouse/pull/11917))
 
 ## Report
 
@@ -40,8 +45,7 @@ Thanks to our new contributors 👽🐷🐰🐯🐻!
 
 ## Deps
 
-* snyk: update snyk snapshot ([#11979](https://github.com/GoogleChrome/lighthouse/pull/11979))
-* snyk: update snyk snapshot ([#11952](https://github.com/GoogleChrome/lighthouse/pull/11952))
+* snyk: update snyk snapshot ([#11979](https://github.com/GoogleChrome/lighthouse/pull/11979), [#11952](https://github.com/GoogleChrome/lighthouse/pull/11952))
 
 ## I18n
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,10 +18,8 @@ Thanks to our new contributors 👽🐷🐰🐯🐻!
 * font-size: handle valueless attributes for inline styles ([#11934](https://github.com/GoogleChrome/lighthouse/pull/11934))
 * full-page-screenshot: get the MAX_TEXTURE_SIZE from the browser ([#11847](https://github.com/GoogleChrome/lighthouse/pull/11847))
 * metrics: support FCP for all frames with devtools throttling ([#11874](https://github.com/GoogleChrome/lighthouse/pull/11874))
-* add type checking to page functions ([#11958](https://github.com/GoogleChrome/lighthouse/pull/11958))
 * normalize creation of NodeValue ([#11877](https://github.com/GoogleChrome/lighthouse/pull/11877))
 * full-page-screenshot: do not render zero size rects ([#11853](https://github.com/GoogleChrome/lighthouse/pull/11853))
-* proto: clarify deprecated state of EmulatedFormFactor enum ([#11946](https://github.com/GoogleChrome/lighthouse/pull/11946))
 * replace most usages of evaluateAsync with structured evaluate ([#11754](https://github.com/GoogleChrome/lighthouse/pull/11754))
 * trace: compute trace for main frame and any child frames ([#11760](https://github.com/GoogleChrome/lighthouse/pull/11760))
 
@@ -71,6 +69,8 @@ Support for auditing user flows ([#11313](https://github.com/GoogleChrome/lighth
 
 ## Misc
 
+* add type checking to page functions ([#11958](https://github.com/GoogleChrome/lighthouse/pull/11958))
+* proto: clarify deprecated state of EmulatedFormFactor enum ([#11946](https://github.com/GoogleChrome/lighthouse/pull/11946))
 * fix "fast" npm script ([#11997](https://github.com/GoogleChrome/lighthouse/pull/11997))
 * use typed-query-selector for native querySelector ([#11990](https://github.com/GoogleChrome/lighthouse/pull/11990))
 * return specific html element type for dom.find ([#11526](https://github.com/GoogleChrome/lighthouse/pull/11526))

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,83 @@
+Thanks to our new contributors 👽🐷🐰🐯🐻! 
+Paul Irish @paulirish
+Tyler Kindy @tkindy
+ <a name="7.0.1"></a>
+# 7.0.1 (2021-01-26)
+[Full Changelog](https://github.com/GoogleChrome/lighthouse/compare/v7.0.0...v7.0.1)
+
+~~ TODO: https://chromiumdash.appspot.com/schedule ~~
+We expect this release to ship in the DevTools of [Chrome XX](https://chromiumdash.appspot.com/schedule), and to PageSpeed Insights within 2 weeks.
+
+## Notable Changes
+~~ TODO: Move notable changes here ~~
+
+
+## Core
+
+* fr: add navigation runner ([#11975](https://github.com/GoogleChrome/lighthouse/pull/11975))
+* handle timer throttling in DevTools to avoid timeouts ([#11987](https://github.com/GoogleChrome/lighthouse/pull/11987))
+* config: refactor config cloning for fraggle rock ([#11759](https://github.com/GoogleChrome/lighthouse/pull/11759))
+* console-messages: use source-location ([#11899](https://github.com/GoogleChrome/lighthouse/pull/11899))
+* errors-in-console: ignore BLOCKED_BY_CLIENT.Inspector errors ([#11901](https://github.com/GoogleChrome/lighthouse/pull/11901))
+* font-size: handle valueless attributes for inline styles ([#11934](https://github.com/GoogleChrome/lighthouse/pull/11934))
+* fr: add navigations to config ([#11957](https://github.com/GoogleChrome/lighthouse/pull/11957))
+* fr: add timespan runner ([#11944](https://github.com/GoogleChrome/lighthouse/pull/11944))
+* fr: filter configs by gather mode ([#11941](https://github.com/GoogleChrome/lighthouse/pull/11941))
+* full-page-screenshot: get the MAX_TEXTURE_SIZE from the browser ([#11847](https://github.com/GoogleChrome/lighthouse/pull/11847))
+* metrics: support FCP for all frames with devtools throttling ([#11874](https://github.com/GoogleChrome/lighthouse/pull/11874))
+* add type checking to page functions ([#11958](https://github.com/GoogleChrome/lighthouse/pull/11958))
+* normalize creation of NodeValue ([#11877](https://github.com/GoogleChrome/lighthouse/pull/11877))
+* fr: add base config ([#11915](https://github.com/GoogleChrome/lighthouse/pull/11915))
+* fr: add base gatherer class ([#11917](https://github.com/GoogleChrome/lighthouse/pull/11917))
+* full-page-screenshot: do not render zero size rects ([#11853](https://github.com/GoogleChrome/lighthouse/pull/11853))
+* proto: clarify deprecated state of EmulatedFormFactor enum ([#11946](https://github.com/GoogleChrome/lighthouse/pull/11946))
+* replace most usages of evaluateAsync with structured evaluate ([#11754](https://github.com/GoogleChrome/lighthouse/pull/11754))
+* trace: compute trace for main frame and any child frames ([#11760](https://github.com/GoogleChrome/lighthouse/pull/11760))
+
+## Report
+
+* remove title from audit clump expand ([#11989](https://github.com/GoogleChrome/lighthouse/pull/11989))
+* use source maps to show original file name ([#10930](https://github.com/GoogleChrome/lighthouse/pull/10930))
+* convert v6 emulatedFormFactor to v7 formFactor ([#11876](https://github.com/GoogleChrome/lighthouse/pull/11876))
+
+## Deps
+
+* snyk: update snyk snapshot ([#11979](https://github.com/GoogleChrome/lighthouse/pull/11979))
+* snyk: update snyk snapshot ([#11952](https://github.com/GoogleChrome/lighthouse/pull/11952))
+
+## I18n
+
+* prevent strings with identical message and description ([#11976](https://github.com/GoogleChrome/lighthouse/pull/11976))
+* import ([#11947](https://github.com/GoogleChrome/lighthouse/pull/11947))
+
+## Docs
+
+* chromium-web-tests: add debugging tips ([#11684](https://github.com/GoogleChrome/lighthouse/pull/11684))
+* readme: add plugin: lighthouse-plugin-crux ([#11868](https://github.com/GoogleChrome/lighthouse/pull/11868))
+
+## Tests
+
+* legacy-javascript: sync results ([#11980](https://github.com/GoogleChrome/lighthouse/pull/11980))
+* smoke: add category to run some perf tests in parallel ([#11932](https://github.com/GoogleChrome/lighthouse/pull/11932))
+* revert mistaken change to yarn unit-core ([#11955](https://github.com/GoogleChrome/lighthouse/pull/11955))
+* run code coverage in github actions ([#11770](https://github.com/GoogleChrome/lighthouse/pull/11770))
+* remove travis ([#11902](https://github.com/GoogleChrome/lighthouse/pull/11902))
+* increase treemap pptr timeouts ([#11916](https://github.com/GoogleChrome/lighthouse/pull/11916))
+* add missing arrays to InspectorIssues sample artifact ([#11871](https://github.com/GoogleChrome/lighthouse/pull/11871))
+* add more files in lighthouse-core/tests to tsconfig ([#11728](https://github.com/GoogleChrome/lighthouse/pull/11728))
+* add warn-not-offline-capable smoketest ([#11842](https://github.com/GoogleChrome/lighthouse/pull/11842))
+
+## Misc
+
+* fix "fast" npm script ([#11997](https://github.com/GoogleChrome/lighthouse/pull/11997))
+* use typed-query-selector for native querySelector ([#11990](https://github.com/GoogleChrome/lighthouse/pull/11990))
+* return specific html element type for dom.find ([#11526](https://github.com/GoogleChrome/lighthouse/pull/11526))
+* build: extract 'yarn link…' rigamarole to own npm script ([#11977](https://github.com/GoogleChrome/lighthouse/pull/11977))
+* proto: backport proto formatting fixes ([#11978](https://github.com/GoogleChrome/lighthouse/pull/11978))
+* scripts: fix unbound variable in open-devtools ([#11845](https://github.com/GoogleChrome/lighthouse/pull/11845))
+* update-report-fixtures: use a consistent server port ([#11848](https://github.com/GoogleChrome/lighthouse/pull/11848))
+* add type checking to TagsBlockingFirstPaint ([#11841](https://github.com/GoogleChrome/lighthouse/pull/11841))
+
 <a name="7.0.0"></a>
 # 7.0.0 (2020-12-16)
 [Full Changelog](https://github.com/GoogleChrome/lighthouse/compare/v6.5.0...v7.0.0)

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,6 @@ Thanks to our new contributors 👽🐷🐰🐯🐻!
 ## Core
 
 * handle timer throttling in DevTools to avoid timeouts ([#11987](https://github.com/GoogleChrome/lighthouse/pull/11987))
-* config: refactor config cloning for fraggle rock ([#11759](https://github.com/GoogleChrome/lighthouse/pull/11759))
 * console-messages: use source-location ([#11899](https://github.com/GoogleChrome/lighthouse/pull/11899))
 * errors-in-console: ignore BLOCKED_BY_CLIENT.Inspector errors ([#11901](https://github.com/GoogleChrome/lighthouse/pull/11901))
 * font-size: handle valueless attributes for inline styles ([#11934](https://github.com/GoogleChrome/lighthouse/pull/11934))
@@ -31,6 +30,7 @@ Thanks to our new contributors 👽🐷🐰🐯🐻!
 Support for auditing user flows ([#11313](https://github.com/GoogleChrome/lighthouse/issues/11313))
 
 * add navigation runner ([#11975](https://github.com/GoogleChrome/lighthouse/pull/11975))
+* config: refactor config cloning for fraggle rock ([#11759](https://github.com/GoogleChrome/lighthouse/pull/11759))
 * add navigations to config ([#11957](https://github.com/GoogleChrome/lighthouse/pull/11957))
 * add timespan runner ([#11944](https://github.com/GoogleChrome/lighthouse/pull/11944))
 * filter configs by gather mode ([#11941](https://github.com/GoogleChrome/lighthouse/pull/11941))

--- a/changelog.md
+++ b/changelog.md
@@ -1,16 +1,14 @@
-Thanks to our new contributors 👽🐷🐰🐯🐻! 
-Paul Irish @paulirish
-Tyler Kindy @tkindy
- <a name="7.0.1"></a>
+<a name="7.0.1"></a>
 # 7.0.1 (2021-01-26)
 [Full Changelog](https://github.com/GoogleChrome/lighthouse/compare/v7.0.0...v7.0.1)
 
-~~ TODO: https://chromiumdash.appspot.com/schedule ~~
-We expect this release to ship in the DevTools of [Chrome XX](https://chromiumdash.appspot.com/schedule), and to PageSpeed Insights within 2 weeks.
+We expect this release to ship in the DevTools of [Chrome 90](https://chromiumdash.appspot.com/schedule), and to PageSpeed Insights within 2 weeks.
 
-## Notable Changes
-~~ TODO: Move notable changes here ~~
+## New contributors
 
+Thanks to our new contributors 👽🐷🐰🐯🐻!
+
+- Tyler Kindy @tkindy
 
 ## Core
 
@@ -290,7 +288,7 @@ This is a minor release to fix an issue in the npm package where v6.4.0 was publ
 
 ## New Contributors
 
-Thanks to our new contributor 👽🐷🐰🐯🐻! 
+Thanks to our new contributor 👽🐷🐰🐯🐻!
 
 - Csaba Palfi @csabapalfi
 
@@ -315,7 +313,7 @@ We expect this release to ship in the DevTools of [Chrome 88](https://chromiumda
 
 ## New Contributors
 
-Thanks to our new contributors 👽🐷🐰🐯🐻! 
+Thanks to our new contributors 👽🐷🐰🐯🐻!
 
 - Denis Seleznev @hcodes
 - Irfan Maulana @mazipan
@@ -518,9 +516,9 @@ Insights within 2 weeks.
 
 ## New Contributors
 
-Thanks to our new contributors 👽🐷🐰🐯🐻! 
+Thanks to our new contributors 👽🐷🐰🐯🐻!
 
-* Adam Raine @adamraine 
+* Adam Raine @adamraine
 * Saavan Nanavati @saavannanavati
 * lemcardenas @lemcardenas
 * George Makunde Martin @gMakunde

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -60,10 +60,10 @@ A Lighthouse plugin is just a node module with a name that starts with `lighthou
   "name": "lighthouse-plugin-cats",
   "main": "plugin.js",
   "peerDependencies": {
-    "lighthouse": "^7.0.0"
+    "lighthouse": "^7.0.1"
   },
   "devDependencies": {
-    "lighthouse": "^7.0.0"
+    "lighthouse": "^7.0.1"
   }
 }
 ```

--- a/docs/recipes/custom-audit/package.json
+++ b/docs/recipes/custom-audit/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "lighthouse": "^7.0.0"
+    "lighthouse": "^7.0.1"
   }
 }

--- a/docs/recipes/gulp/package.json
+++ b/docs/recipes/gulp/package.json
@@ -7,6 +7,6 @@
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-connect": "^5.0.0",
-    "lighthouse": "^7.0.0"
+    "lighthouse": "^7.0.1"
   }
 }

--- a/docs/recipes/lighthouse-plugin-example/package.json
+++ b/docs/recipes/lighthouse-plugin-example/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "main": "./plugin.js",
   "peerDependencies": {
-    "lighthouse": "^7.0.0"
+    "lighthouse": "^7.0.1"
   },
   "devDependencies": {
-    "lighthouse": "^7.0.0"
+    "lighthouse": "^7.0.1"
   }
 }

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -8,7 +8,7 @@
       "axe-core": "3.5.5"
     }
   },
-  "lighthouseVersion": "7.0.0",
+  "lighthouseVersion": "7.0.1",
   "fetchTime": "2018-03-13T00:55:45.840Z",
   "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
   "finalUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Automated auditing, performance metrics, and best practices for the web.",
   "main": "./lighthouse-core/index.js",
   "bin": {

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-emulate-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-emulate-run-expected.txt
@@ -14,7 +14,7 @@ Generate report: enabled visible
 
 =============== Lighthouse Results ===============
 URL: http://127.0.0.1:8000/devtools/lighthouse/resources/lighthouse-emulate-pass.html
-Version: 7.0.0
+Version: 7.0.1
 formFactor: mobile
 screenEmulation: {
   "mobile": true,

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -380,7 +380,7 @@ Generating results...
 
 =============== Lighthouse Results ===============
 URL: http://127.0.0.1:8000/devtools/lighthouse/resources/lighthouse-basic.html
-Version: 7.0.0
+Version: 7.0.1
 ViewportDimensions: {
   "innerWidth": 980,
   "innerHeight": 1743,


### PR DESCRIPTION
Some of these were sprinkled in the web test output on my machine:
```
error: Request Overlay.setShowFlexOverlays failed. {"code":-32601,"message":"'Overlay.setShowFlexOverlays' wasn't found"}
```
I removed them, should be good in CI.