### PR TITLE
misc: tighten querySelector types

### DIFF
--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -113,8 +113,10 @@ function getElementsInDocument(selector) {
   const _findAllElements = nodes => {
     for (let i = 0, el; el = nodes[i]; ++i) {
       if (!selector || realMatchesFn.call(el, selector)) {
+        /** @type {ParseSelector<T>} */
         // @ts-expect-error - el is verified as matching above, tsc just can't verify it through the .call().
-        results.push(el);
+        const matchedEl = el;
+        results.push(matchedEl);
       }
 
       // If the element has a shadow root, dig deeper.

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -19,7 +19,11 @@
  * Otherwise, minification will mangle the variable names and break usage.
  */
 
-/** @typedef {HTMLElementTagNameMap & {[id: string]: HTMLElement}} HTMLElementByTagName */
+/**
+ * `typed-query-selector`'s CSS selector parser.
+ * @template {string} T
+ * @typedef {import('typed-query-selector/parser').ParseSelector<T>} ParseSelector
+ */
 
 /* global window document Node ShadowRoot HTMLElement */
 
@@ -98,19 +102,21 @@ function checkTimeSinceLastLongTask() {
  * @template {string} T
  * @param {T} selector Optional simple CSS selector to filter nodes on.
  *     Combinators are not supported.
- * @return {Array<HTMLElementByTagName[T]>}
+ * @return {Array<ParseSelector<T>>}
  */
 function getElementsInDocument(selector) {
   const realMatchesFn = window.__ElementMatches || window.Element.prototype.matches;
-  /** @type {Array<HTMLElement>} */
+  /** @type {Array<ParseSelector<T>>} */
   const results = [];
 
-  /** @param {NodeListOf<HTMLElement>} nodes */
+  /** @param {NodeListOf<Element>} nodes */
   const _findAllElements = nodes => {
     for (let i = 0, el; el = nodes[i]; ++i) {
       if (!selector || realMatchesFn.call(el, selector)) {
+        // @ts-expect-error - el is verified as matching above, tsc just can't verify it through the .call().
         results.push(el);
       }
+
       // If the element has a shadow root, dig deeper.
       if (el.shadowRoot) {
         _findAllElements(el.shadowRoot.querySelectorAll('*'));

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -5,9 +5,7 @@
  */
 
 import _Crdp from 'devtools-protocol/types/protocol';
-import _CrdpMappings from 'devtools-protocol/types/protocol-mapping'
-
-// Import for side effects improving types of querySelector/querySelectorAll.
+import _CrdpMappings from 'devtools-protocol/types/protocol-mapping';
 import {ParseSelector} from 'typed-query-selector/parser';
 
 declare global {

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -8,7 +8,7 @@ import _Crdp from 'devtools-protocol/types/protocol';
 import _CrdpMappings from 'devtools-protocol/types/protocol-mapping'
 
 // Import for side effects improving types of querySelector/querySelectorAll.
-import 'typed-query-selector';
+import {ParseSelector} from 'typed-query-selector/parser';
 
 declare global {
   // Augment Intl to include
@@ -391,5 +391,11 @@ declare global {
 
     // Not defined in tsc yet: https://github.com/microsoft/TypeScript/issues/40807
     requestIdleCallback(callback: (deadline: {didTimeout: boolean, timeRemaining: () => DOMHighResTimeStamp}) => void, options?: {timeout: number}): number;
+  }
+
+  // Stricter querySelector/querySelectorAll using typed-query-selector.
+  interface ParentNode {
+    querySelector<S extends string>(selector: S): ParseSelector<S> | null;
+    querySelectorAll<S extends string>(selector: S): NodeListOf<ParseSelector<S>>;
   }
 }


### PR DESCRIPTION
Fixes an issue with the new typed `querySelector` (just this and #12011, I promise :).

The problem is that the [`typed-query-selector` shim](https://github.com/g-plane/typed-query-selector/blob/823e4b850280dab7192cd0468b8e97c196e9e8ec/shim.d.ts) that adds stricter types to `querySelector`/`querySelectorAll` has a type parameter that's only used in the return type. This is usually recommended against in TypeScript because it means that the contextual type can more often than not _become_ the return type as long as it fits the parameter bounds, rather than the compiler complaining that the return type and the contextual type don't match.

I put more details in https://github.com/g-plane/typed-query-selector/issues/12, but as an example, on master you could currently do

```js
/** @type {HTMLAnchorElement|null} */
const el = document.querySelector('div');
```

or

```js
/** @type {NodeListOf<HTMLAnchorElement>} */
const els = document.querySelectorAll('div');
```

without error.

As mentioned in the upstream bug, it's not clear that they'll want to fix the problem as it also adds a feature (explicit type overrides), but using the `ParseSelector` directly is an [intended and documented part of the library](https://github.com/g-plane/typed-query-selector/tree/823e4b850280dab7192cd0468b8e97c196e9e8ec#use-the-parser), so it seems ok to use our own `querySelector`/`querySelectorAll` shims.

This PR also updates `pageFunctions.getElementsInDocument` to use the better typed returns, because that's what I was doing when I noticed this and #12011 :)