### PR TITLE
RFC: Gatherer and Artifact Dependency API

### DIFF
--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -56,7 +56,7 @@ async function _beforeTimespanPhase(navigationContext, artifacts) {
     if (!gatherer.meta.supportedModes.includes('timespan')) continue;
 
     const artifactPromise = Promise.resolve().then(() =>
-      gatherer.beforeTimespan({driver: navigationContext.driver, gatherMode: 'navigation'})
+      gatherer.beforeTimespan({driver: navigationContext.driver, gatherMode: 'navigation', dependencies: {}})
     );
     artifacts[artifactDefn.id] = artifactPromise;
     await artifactPromise.catch(() => {});
@@ -85,7 +85,7 @@ async function _afterTimespanPhase(navigationContext, artifacts) {
     if (!gatherer.meta.supportedModes.includes('timespan')) continue;
 
     const artifactPromise = (artifacts[artifactDefn.id] || Promise.resolve()).then(() =>
-      gatherer.afterTimespan({driver: navigationContext.driver, gatherMode: 'navigation'})
+      gatherer.afterTimespan({driver: navigationContext.driver, gatherMode: 'navigation', dependencies: /** @type {LH.Artifacts} */ (artifacts)})
     );
     artifacts[artifactDefn.id] = artifactPromise;
     await artifactPromise.catch(() => {});
@@ -102,7 +102,7 @@ async function _snapshotPhase(navigationContext, artifacts) {
     if (!gatherer.meta.supportedModes.includes('snapshot')) continue;
 
     const artifactPromise = Promise.resolve().then(() =>
-      gatherer.snapshot({driver: navigationContext.driver, gatherMode: 'navigation'})
+      gatherer.snapshot({driver: navigationContext.driver, gatherMode: 'navigation', dependencies: /** @type {LH.Artifacts} */ (artifacts)})
     );
     artifacts[artifactDefn.id] = artifactPromise;
     await artifactPromise.catch(() => {});

--- a/lighthouse-core/fraggle-rock/gather/snapshot-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/snapshot-runner.js
@@ -30,7 +30,7 @@ async function snapshot(options) {
       for (const {id, gatherer} of config.artifacts || []) {
         const artifactName = /** @type {keyof LH.GathererArtifacts} */ (id);
         const artifact = await Promise.resolve()
-          .then(() => gatherer.instance.snapshot({gatherMode: 'snapshot', driver}))
+          .then(() => gatherer.instance.snapshot({gatherMode: 'snapshot', driver, dependencies: /** @type {LH.Artifacts} */ (artifacts)}))
           .catch(err => err);
 
         artifacts[artifactName] = artifact;

--- a/lighthouse-core/fraggle-rock/gather/timespan-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/timespan-runner.js
@@ -26,7 +26,7 @@ async function startTimespan(options) {
 
   for (const {id, gatherer} of config.artifacts || []) {
     artifactErrors[id] = await Promise.resolve()
-      .then(() => gatherer.instance.beforeTimespan({gatherMode: 'timespan', driver}))
+      .then(() => gatherer.instance.beforeTimespan({gatherMode: 'timespan', driver, dependencies: {}}))
       .catch(err => err);
   }
 
@@ -47,7 +47,7 @@ async function startTimespan(options) {
             const artifact = artifactErrors[id]
               ? Promise.reject(artifactErrors[id])
               : await Promise.resolve()
-                  .then(() => gatherer.instance.afterTimespan({gatherMode: 'timespan', driver}))
+                  .then(() => gatherer.instance.afterTimespan({gatherMode: 'timespan', driver, dependencies: /** @type {LH.Artifacts} */ (artifacts)}))
                   .catch(err => err);
 
             artifacts[artifactName] = artifact;

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -98,14 +98,16 @@ async function runA11yChecks() {
 }
 /* c8 ignore stop */
 
+/** @implements {LH.Gatherer.FRGathererInstance<'AppCacheManifest'>} */
 class Accessibility extends FRGatherer {
-  /** @type {LH.Gatherer.GathererMeta} */
+  /** @type {LH.Gatherer.GathererMeta<'AppCacheManifest'>} */
   meta = {
+    dependencies: {AppCacheManifest: require('./dobetterweb/appcache.js').GathererSymbol},
     supportedModes: ['snapshot', 'navigation'],
   }
 
   /**
-   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   * @param {LH.Gatherer.FRTransitionalContext<'AppCacheManifest'>} passContext
    * @return {Promise<LH.Artifacts.Accessibility>}
    */
   snapshot(passContext) {

--- a/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
@@ -10,8 +10,11 @@ const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 /* global document */
 
 class AppCacheManifest extends FRGatherer {
+  static GathererSymbol = Symbol('AppCacheManifest');
+
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
+    symbol: AppCacheManifest.GathererSymbol,
     supportedModes: ['snapshot', 'navigation'],
   }
 
@@ -21,6 +24,8 @@ class AppCacheManifest extends FRGatherer {
    */
   snapshot(passContext) {
     const driver = passContext.driver;
+    // This won't typecheck because no dependencies declared.
+    passContext.dependencies.Accessibility;
 
     return driver.evaluate(() => {
       return document.documentElement && document.documentElement.getAttribute('manifest');

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -292,7 +292,7 @@ class TapTargets extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.TapTarget[]>} All visible tap targets with their positions and sizes
    */
-  afterPass(passContext) {
+  snapshot(passContext) {
     return passContext.driver.evaluate(gatherTapTargets, {
       args: [tapTargetsSelector],
       useIsolation: true,

--- a/lighthouse-core/test/fraggle-rock/config/config-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/config-test.js
@@ -135,8 +135,44 @@ describe('Fraggle Rock Config', () => {
 
     const {config} = initializeConfig(configJson, {gatherMode: 'snapshot'});
     expect(config).toMatchObject({
+      artifacts: [{id: 'Accessibility', gatherer: {path: 'accessibility'}}],
+    });
+  });
+
+  it('should support artifact dependencies', () => {
+    const configJson = {
       artifacts: [
-        {id: 'Accessibility', gatherer: {path: 'accessibility'}},
+        {id: 'AppCacheManifest', gatherer: 'appcache'},
+        {id: 'Accessiblity', gatherer: 'accessibility'},
+
+        // Optional extension in a potential future where there is not a static mapping anymore.
+        {
+          id: 'ExtraAppCacheManifest',
+          gatherer: {path: 'appcache', options: {ignoreTheStuff: true}},
+        },
+        {
+          id: 'ExtraAccessibility',
+          gatherer: {
+            path: 'accessibility',
+            dependencies: {AppCacheManifest: 'ExtraAppCacheManifest'},
+          },
+        },
+      ],
+    };
+
+    const {config} = initializeConfig(configJson, {gatherMode: 'snapshot'});
+    expect(config).toMatchObject({
+      artifacts: [
+        {id: 'AppCacheManifest', gatherer: {path: 'appcache'}},
+        {
+          id: 'Accessiblity',
+          gatherer: {
+            path: 'accessibility',
+            dependencies: {
+              AppCacheManifest: {id: 'AppCacheManifest', gatherer: {path: 'appcache'}},
+            },
+          },
+        },
       ],
     });
   });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -161,14 +161,14 @@ declare global {
         artifacts: ArtifactDefn[];
       }
 
-      export interface ArtifactDefn {
+      export interface ArtifactDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
         id: string;
-        gatherer: FRGathererDefn;
+        gatherer: FRGathererDefn<TDependencies>;
       }
 
-      export interface FRGathererDefn {
-        implementation?: ClassOf<Gatherer.FRGathererInstance>;
-        instance: Gatherer.FRGathererInstance;
+      export interface FRGathererDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
+        implementation?: ClassOf<Gatherer.FRGathererInstance<TDependencies>>;
+        instance: Gatherer.FRGathererInstance<TDependencies>;
         path?: string;
       }
 

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -32,9 +32,12 @@ declare global {
     }
 
     /** The limited context interface shared between pre and post Fraggle Rock Lighthouse. */
-    export interface FRTransitionalContext {
+    export interface FRTransitionalContext<TDependencies extends DependencyKey = DefaultDependenciesKey> {
       gatherMode: GatherMode
       driver: FRTransitionalDriver;
+      dependencies: TDependencies extends DefaultDependenciesKey ?
+        {} :
+        Pick<GathererArtifacts, Exclude<TDependencies, DefaultDependenciesKey>>;
     }
 
     export interface PassContext {
@@ -55,14 +58,38 @@ declare global {
       trace?: Trace;
     }
 
-    export type PhaseResultNonPromise = void|LH.GathererArtifacts[keyof LH.GathererArtifacts]
+    export type PhaseArtifact = LH.GathererArtifacts[keyof LH.GathererArtifacts]
+    export type PhaseResultNonPromise = void|PhaseArtifact
     export type PhaseResult = PhaseResultNonPromise | Promise<PhaseResultNonPromise>
 
     export type GatherMode = 'snapshot'|'timespan'|'navigation';
 
-    export interface GathererMeta {
+    export type DefaultDependenciesKey = '__none__'
+    export type DependencyKey = keyof GathererArtifacts | DefaultDependenciesKey
+
+    interface GathererMetaNoDependencies {
+      /**
+       * Used to validate the dependency requirements of gatherers.
+       * If this property is not defined, this gatherer cannot be the dependency of another. */
+      symbol?: Symbol;
+      /** Lists the modes in which this gatherer can run. */
       supportedModes: Array<GatherMode>;
     }
+
+    interface GathererMetaWithDependencies<
+      TDependencies extends DependencyKey = DefaultDependenciesKey
+    > extends GathererMetaNoDependencies {
+      /**
+       * The set of required dependencies that this gatherer needs before it can compute its results.
+       * If
+       */
+      dependencies: Record<TDependencies, Symbol | '*'>;
+    }
+
+    export type GathererMeta<TDependencies extends DependencyKey = DefaultDependenciesKey> =
+      TDependencies extends DefaultDependenciesKey ?
+        GathererMetaNoDependencies :
+        GathererMetaWithDependencies<TDependencies>;
 
     export interface GathererInstance {
       name: keyof LH.GathererArtifacts;
@@ -71,12 +98,12 @@ declare global {
       afterPass(context: LH.Gatherer.PassContext, loadData: LH.Gatherer.LoadData): PhaseResult;
     }
 
-    export interface FRGathererInstance {
+    export interface FRGathererInstance<TDependencies extends DependencyKey = DefaultDependenciesKey> {
       name: keyof LH.GathererArtifacts; // temporary COMPAT measure until artifact config support is available
-      meta: GathererMeta;
-      snapshot(context: FRTransitionalContext): PhaseResult;
-      beforeTimespan(context: FRTransitionalContext): Promise<void>|void;
-      afterTimespan(context: FRTransitionalContext): PhaseResult;
+      meta: GathererMeta<TDependencies>;
+      snapshot(context: FRTransitionalContext<TDependencies>): PhaseResult;
+      beforeTimespan(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
+      afterTimespan(context: FRTransitionalContext<TDependencies>): PhaseResult;
     }
 
     namespace Simulation {


### PR DESCRIPTION
**Summary**
The preliminary RFC was of course the design doc and discussions, but things have firmed up a bit and we've reached the point where we're ready to implement. Before I get too far, I wanted to put up some examples to get everyone's feedback before I harden this. Most of the interesting details are in the typedefs, but essentially all gatherers will be parameterized by their dependency keys. 

Take a look at **appcache.js** for an example of a gatherer that will be used as a dependency.
Take a look at **accessibility.js** for an example of a gatherer that will use another as a dependency.
All gatherers that don't depend on another or will be depended on require no changes.

Some other interesting implications...

- `@implements` is back, muwahaha @connorjclark  ;)
- All initial dependencies still rely on our static artifact key names, but there's room to expand to truly dynamic dependencies should we so desire.
- I think there's room here to take some lessons for audit dependency declarations? or vice versa if I missed an approach from the previous attempt there? 

**Related Issues/PRs**
ref #11313 
[design doc](https://docs.google.com/document/d/1fRCh_NVK82YmIi1Zq8y73_p79d-FdnKsvaxMy0xIpNw/edit)
