### PR TITLE
core(fr): add artifact dependency support

### DIFF
--- a/lighthouse-core/fraggle-rock/config/config.js
+++ b/lighthouse-core/fraggle-rock/config/config.js
@@ -10,7 +10,13 @@ const log = require('lighthouse-logger');
 const Runner = require('../../runner.js');
 const defaultConfig = require('./default-config.js');
 const {defaultNavigationConfig} = require('../../config/constants.js');
-const {isFRGathererDefn} = require('./validation.js');
+const {
+  isFRGathererDefn,
+  throwInvalidDependencyOrder,
+  isValidArtifactDependency,
+  throwInvalidArtifactDependency,
+  assertArtifactTopologicalOrder,
+} = require('./validation.js');
 const {filterConfigByGatherMode} = require('./filters.js');
 const {
   deepCloneConfigJson,
@@ -48,6 +54,37 @@ function resolveWorkingCopy(configJSON, context) {
 }
 
 /**
+ * Looks up the required artifact IDs for each dependency, throwing if no earlier artifact satisfies the dependency.
+ *
+ * @param {LH.Config.ArtifactJson} artifact
+ * @param {LH.Config.FRGathererDefn} gatherer
+ * @param {Map<Symbol, LH.Config.ArtifactDefn>} artifactDefnsBySymbol
+ * @return {LH.Config.ArtifactDefn['dependencies']}
+ */
+function resolveArtifactDependencies(artifact, gatherer, artifactDefnsBySymbol) {
+  if ('dependencies' in gatherer.instance.meta) {
+    const dependencies = Object.entries(gatherer.instance.meta.dependencies).map(
+      ([dependencyName, artifactSymbol]) => {
+        const dependency = artifactDefnsBySymbol.get(artifactSymbol);
+
+        // Check that dependency was defined before us.
+        if (!dependency) throwInvalidDependencyOrder(artifact.id, dependencyName);
+
+        // Check that the phase relationship is OK too.
+        const validDependency = isValidArtifactDependency(gatherer, dependency.gatherer);
+        if (!validDependency) throwInvalidArtifactDependency(artifact.id, dependencyName);
+
+        return [dependencyName, {id: dependency.id}];
+      }
+    );
+
+    return Object.fromEntries(dependencies);
+  } else {
+    return undefined;
+  }
+}
+
+/**
  *
  * @param {LH.Config.ArtifactJson[]|null|undefined} artifacts
  * @param {string|undefined} configDir
@@ -58,6 +95,9 @@ function resolveArtifactsToDefns(artifacts, configDir) {
 
   const status = {msg: 'Resolve artifact definitions', id: 'lh:config:resolveArtifactsToDefns'};
   log.time(status, 'verbose');
+
+  /** @type {Map<Symbol, LH.Config.ArtifactDefn>} */
+  const artifactDefnsBySymbol = new Map();
 
   const coreGathererList = Runner.getGathererList();
   const artifactDefns = artifacts.map(artifactJson => {
@@ -70,10 +110,16 @@ function resolveArtifactsToDefns(artifacts, configDir) {
       throw new Error(`${gatherer.instance.name} gatherer does not support Fraggle Rock`);
     }
 
-    return {
+    /** @type {LH.Config.ArtifactDefn<LH.Gatherer.DependencyKey>} */
+    const artifact = {
       id: artifactJson.id,
       gatherer,
+      dependencies: resolveArtifactDependencies(artifactJson, gatherer, artifactDefnsBySymbol),
     };
+
+    const symbol = artifact.gatherer.instance.meta.symbol;
+    if (symbol) artifactDefnsBySymbol.set(symbol, artifact);
+    return artifact;
   });
 
   log.timeEnd(status);
@@ -108,6 +154,8 @@ function resolveNavigationsToDefns(navigations, artifactDefns) {
 
     return {...navigationWithDefaults, artifacts};
   });
+
+  assertArtifactTopologicalOrder(navigationDefns);
 
   log.timeEnd(status);
   return navigationDefns;

--- a/lighthouse-core/fraggle-rock/config/config.js
+++ b/lighthouse-core/fraggle-rock/config/config.js
@@ -62,8 +62,9 @@ function resolveWorkingCopy(configJSON, context) {
  * @return {LH.Config.ArtifactDefn['dependencies']}
  */
 function resolveArtifactDependencies(artifact, gatherer, artifactDefnsBySymbol) {
-  if ('dependencies' in gatherer.instance.meta) {
-    const dependencies = Object.entries(gatherer.instance.meta.dependencies).map(
+  if (!('dependencies' in gatherer.instance.meta)) return undefined;
+
+  const dependencies = Object.entries(gatherer.instance.meta.dependencies).map(
       ([dependencyName, artifactSymbol]) => {
         const dependency = artifactDefnsBySymbol.get(artifactSymbol);
 
@@ -76,12 +77,9 @@ function resolveArtifactDependencies(artifact, gatherer, artifactDefnsBySymbol) 
 
         return [dependencyName, {id: dependency.id}];
       }
-    );
+  );
 
-    return Object.fromEntries(dependencies);
-  } else {
-    return undefined;
-  }
+  return Object.fromEntries(dependencies);
 }
 
 /**

--- a/lighthouse-core/fraggle-rock/gather/base-gatherer.js
+++ b/lighthouse-core/fraggle-rock/gather/base-gatherer.js
@@ -55,7 +55,7 @@ class FRGatherer {
    * @return {Promise<LH.Gatherer.PhaseResultNonPromise>}
    */
   async beforePass(passContext) {
-    await this.beforeTimespan(passContext);
+    await this.beforeTimespan({...passContext, dependencies: {}});
   }
 
   /**
@@ -73,10 +73,10 @@ class FRGatherer {
    */
   async afterPass(passContext, loadData) {
     if (this.meta.supportedModes.includes('timespan')) {
-      return this.afterTimespan(passContext);
+      return this.afterTimespan({...passContext, dependencies: {}});
     }
 
-    return this.snapshot(passContext);
+    return this.snapshot({...passContext, dependencies: {}});
   }
 }
 

--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -1,0 +1,36 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * @param {LH.Config.ArtifactDefn} artifact
+ * @param {Record<string, LH.Gatherer.PhaseResult>} artifactsById
+ * @return {Promise<LH.Gatherer.FRTransitionalContext<LH.Gatherer.DependencyKey>['dependencies']>}
+ */
+async function collectArtifactDependencies(artifact, artifactsById) {
+  if (!artifact.dependencies) return {};
+
+  const dependencyPromises = Object.entries(artifact.dependencies).map(
+    async ([dependencyName, dependency]) => {
+      const dependencyArtifact = artifactsById[dependency.id];
+      if (dependencyArtifact === undefined) throw new Error(`"${dependency.id}" did not run`);
+
+      const dependencyPromise = Promise.resolve()
+        .then(() => dependencyArtifact)
+        .catch(err =>
+          Promise.reject(
+            new Error(`Dependency "${dependency.id}" failed with exception: ${err.message}`)
+          )
+        );
+
+      return [dependencyName, await dependencyPromise];
+    }
+  );
+
+  return Object.fromEntries(await Promise.all(dependencyPromises));
+}
+
+module.exports = {collectArtifactDependencies};

--- a/lighthouse-core/fraggle-rock/gather/snapshot-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/snapshot-runner.js
@@ -7,6 +7,7 @@
 
 const Driver = require('./driver.js');
 const Runner = require('../../runner.js');
+const {collectArtifactDependencies} = require('./runner-helpers.js');
 const {initializeConfig} = require('../config/config.js');
 const {getBaseArtifacts} = require('./base-artifacts.js');
 
@@ -27,10 +28,12 @@ async function snapshot(options) {
       /** @type {Partial<LH.GathererArtifacts>} */
       const artifacts = {};
 
-      for (const {id, gatherer} of config.artifacts || []) {
+      for (const artifactDefn of config.artifacts || []) {
+        const {id, gatherer} = artifactDefn;
         const artifactName = /** @type {keyof LH.GathererArtifacts} */ (id);
+        const dependencies = await collectArtifactDependencies(artifactDefn, artifacts);
         const artifact = await Promise.resolve()
-          .then(() => gatherer.instance.snapshot({gatherMode: 'snapshot', driver}))
+          .then(() => gatherer.instance.snapshot({gatherMode: 'snapshot', driver, dependencies}))
           .catch(err => err);
 
         artifacts[artifactName] = artifact;

--- a/lighthouse-core/fraggle-rock/gather/timespan-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/timespan-runner.js
@@ -24,11 +24,10 @@ async function startTimespan(options) {
 
   /** @type {Record<string, Promise<void>>} */
   const artifactErrors = {};
-  const dependencies = {};
 
   for (const {id, gatherer} of config.artifacts || []) {
     artifactErrors[id] = Promise.resolve().then(() =>
-      gatherer.instance.beforeTimespan({gatherMode: 'timespan', driver, dependencies})
+      gatherer.instance.beforeTimespan({gatherMode: 'timespan', driver, dependencies: {}})
     );
 
     // Run each beforeTimespan serially, but handle errors in the next pass.

--- a/lighthouse-core/fraggle-rock/gather/timespan-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/timespan-runner.js
@@ -7,6 +7,7 @@
 
 const Driver = require('./driver.js');
 const Runner = require('../../runner.js');
+const {collectArtifactDependencies} = require('./runner-helpers.js');
 const {initializeConfig} = require('../config/config.js');
 const {getBaseArtifacts} = require('./base-artifacts.js');
 
@@ -21,13 +22,17 @@ async function startTimespan(options) {
 
   const requestedUrl = await options.page.url();
 
-  /** @type {Record<string, Promise<Error|undefined>>} */
+  /** @type {Record<string, Promise<void>>} */
   const artifactErrors = {};
+  const dependencies = {};
 
   for (const {id, gatherer} of config.artifacts || []) {
-    artifactErrors[id] = await Promise.resolve()
-      .then(() => gatherer.instance.beforeTimespan({gatherMode: 'timespan', driver}))
-      .catch(err => err);
+    artifactErrors[id] = Promise.resolve().then(() =>
+      gatherer.instance.beforeTimespan({gatherMode: 'timespan', driver, dependencies})
+    );
+
+    // Run each beforeTimespan serially, but handle errors in the next pass.
+    await artifactErrors[id].catch(() => {});
   }
 
   return {
@@ -42,13 +47,15 @@ async function startTimespan(options) {
           /** @type {Partial<LH.GathererArtifacts>} */
           const artifacts = {};
 
-          for (const {id, gatherer} of config.artifacts || []) {
+          for (const artifactDefn of config.artifacts || []) {
+            const {id, gatherer} = artifactDefn;
             const artifactName = /** @type {keyof LH.GathererArtifacts} */ (id);
-            const artifact = artifactErrors[id]
-              ? Promise.reject(artifactErrors[id])
-              : await Promise.resolve()
-                  .then(() => gatherer.instance.afterTimespan({gatherMode: 'timespan', driver}))
-                  .catch(err => err);
+            const dependencies = await collectArtifactDependencies(artifactDefn, artifacts);
+            const artifact = await artifactErrors[id]
+              .then(() =>
+                gatherer.instance.afterTimespan({gatherMode: 'timespan', driver, dependencies})
+              )
+              .catch(err => err);
 
             artifacts[artifactName] = artifact;
           }

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -292,7 +292,7 @@ class TapTargets extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.TapTarget[]>} All visible tap targets with their positions and sizes
    */
-  afterPass(passContext) {
+  snapshot(passContext) {
     return passContext.driver.evaluate(gatherTapTargets, {
       args: [tapTargetsSelector],
       useIsolation: true,

--- a/lighthouse-core/test/fraggle-rock/config/validation-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/validation-test.js
@@ -11,6 +11,8 @@ const validation = require('../../../fraggle-rock/config/validation.js');
 
 /* eslint-env jest */
 
+/** @typedef {LH.Gatherer.GathererMeta['supportedModes']} SupportedModes */
+
 describe('Fraggle Rock Config Validation', () => {
   describe('isFRGathererDefn', () => {
     it('should identify fraggle rock gatherer definitions', () => {
@@ -20,5 +22,30 @@ describe('Fraggle Rock Config Validation', () => {
     it('should identify legacy gatherer definitions', () => {
       expect(validation.isFRGathererDefn({instance: new BaseLegacyGatherer()})).toBe(false);
     });
+  });
+
+  describe('isValidArtifactDependency', () => {
+    /** @type {Array<{dependent: SupportedModes, dependency: SupportedModes, isValid: boolean}>} */
+    const combinations = [
+      {dependent: ['timespan'], dependency: ['timespan'], isValid: true},
+      {dependent: ['timespan'], dependency: ['snapshot'], isValid: false},
+      {dependent: ['timespan'], dependency: ['navigation'], isValid: false},
+      {dependent: ['snapshot'], dependency: ['timespan'], isValid: true},
+      {dependent: ['snapshot'], dependency: ['snapshot'], isValid: true},
+      {dependent: ['snapshot'], dependency: ['navigation'], isValid: false},
+      {dependent: ['navigation'], dependency: ['timespan'], isValid: true},
+      {dependent: ['navigation'], dependency: ['snapshot'], isValid: true},
+      {dependent: ['navigation'], dependency: ['navigation'], isValid: true},
+    ];
+
+    for (const {dependent, dependency, isValid} of combinations) {
+      it(`should identify ${dependent.join(',')} / ${dependency.join(',')} correctly`, () => {
+        const dependentDefn = {instance: new BaseFRGatherer()};
+        dependentDefn.instance.meta.supportedModes = dependent;
+        const dependencyDefn = {instance: new BaseFRGatherer()};
+        dependencyDefn.instance.meta.supportedModes = dependency;
+        expect(validation.isValidArtifactDependency(dependentDefn, dependencyDefn)).toBe(isValid);
+      });
+    }
   });
 });

--- a/lighthouse-core/test/fraggle-rock/gather/base-gatherer-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/base-gatherer-test.js
@@ -35,7 +35,7 @@ describe('BaseGatherer', () => {
 
       const gatherer = new MyGatherer();
       await gatherer.beforePass(fakeParam);
-      expect(gatherer.beforeTimespan).toHaveBeenCalledWith(fakeParam);
+      expect(gatherer.beforeTimespan).toHaveBeenCalled();
     });
   });
 

--- a/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
+++ b/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
@@ -29,8 +29,27 @@ function createMockSession() {
   };
 }
 
+/**
+ * @param {LH.Gatherer.FRGathererInstance<LH.Gatherer.DependencyKey>['meta']} meta
+ */
+function createMockGathererInstance(meta) {
+  return {
+    meta,
+    beforeTimespan: jest.fn(),
+    afterTimespan: jest.fn(),
+    snapshot: jest.fn(),
+
+    /** @return {LH.Gatherer.FRGathererInstance} */
+    asGatherer() {
+      // @ts-expect-error - We'll rely on the tests passing to know this matches.
+      return this;
+    },
+  };
+}
+
 function createMockPage() {
   return {
+    url: jest.fn().mockReturnValue('https://example.com'),
     goto: jest.fn(),
     target: () => ({createCDPSession: () => createMockSession()}),
 
@@ -68,8 +87,29 @@ function createMockDriver() {
   };
 }
 
+/** @param {() => jest.Mock} runProvider */
+function mockRunnerModule(runProvider) {
+  const runnerModule = {getGathererList: () => []};
+  Object.defineProperty(runnerModule, 'run', {
+    get: runProvider,
+  });
+  return runnerModule;
+}
+
+/** @param {() => Driver} driverProvider */
+function mockDriverModule(driverProvider) {
+  // This must be a regular function becaues Driver is always invoked as a constructor.
+  // Arrow functions cannot be invoked with `new`.
+  return function() {
+    return driverProvider();
+  };
+}
+
 module.exports = {
+  mockRunnerModule,
+  mockDriverModule,
   createMockDriver,
   createMockPage,
   createMockSession,
+  createMockGathererInstance,
 };

--- a/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
@@ -1,0 +1,66 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const helpers = require('../../../fraggle-rock/gather/runner-helpers.js');
+const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+
+/* eslint-env jest */
+
+describe('collectArtifactDependencies', () => {
+  /** @type {LH.Config.ArtifactDefn} */
+  let artifact;
+  /** @type {Record<string, any>} */
+  let artifactsById;
+
+  beforeEach(() => {
+    artifact = {
+      id: 'Artifact',
+      gatherer: {instance: new Gatherer()},
+      dependencies: {ImageElements: {id: 'Dependency'}},
+    };
+    artifactsById = {
+      Dependency: [],
+    };
+  });
+
+  it('should handle no dependencies', async () => {
+    artifact.dependencies = undefined;
+    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    expect(result).toEqual({});
+  });
+
+  it('should handle successful dependencies', async () => {
+    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    expect(result).toEqual({ImageElements: []});
+  });
+
+  it('should handle successful promise dependencies', async () => {
+    artifactsById.Dependency = Promise.resolve([]);
+    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    expect(result).toEqual({ImageElements: []});
+  });
+
+  it('should handle falsy dependencies', async () => {
+    artifactsById.Dependency = null;
+    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    expect(result).toEqual({ImageElements: null});
+  });
+
+  it('should handle missing dependencies', async () => {
+    artifactsById.Dependency = undefined;
+    const result = helpers.collectArtifactDependencies(artifact, artifactsById);
+    await expect(result).rejects.toMatchObject({message: expect.stringContaining('did not run')});
+  });
+
+  it('should handle errored dependencies', async () => {
+    artifactsById.Dependency = Promise.reject(new Error('DEP_FAILURE'));
+    const result = helpers.collectArtifactDependencies(artifact, artifactsById);
+    await expect(result).rejects.toMatchObject({
+      message: expect.stringContaining('"Dependency" failed with exception: DEP_FAILURE'),
+    });
+  });
+});

--- a/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
@@ -33,6 +33,13 @@ describe('collectArtifactDependencies', () => {
     expect(result).toEqual({});
   });
 
+  it('should handle empty dependencies', async () => {
+    // @ts-expect-error - this isn't valid given our set of types, but plugins might do this.
+    artifact.dependencies = {};
+    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    expect(result).toEqual({});
+  });
+
   it('should handle successful dependencies', async () => {
     const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
     expect(result).toEqual({ImageElements: []});

--- a/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
@@ -1,0 +1,112 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const {
+  createMockDriver,
+  createMockPage,
+  createMockGathererInstance,
+  mockDriverModule,
+  mockRunnerModule,
+} = require('./mock-driver.js');
+
+// Establish the mocks before we require our file under test.
+let mockRunnerRun = jest.fn();
+/** @type {ReturnType<typeof createMockDriver>} */
+let mockDriver;
+
+jest.mock('../../../runner.js', () => mockRunnerModule(() => mockRunnerRun));
+jest.mock('../../../fraggle-rock/gather/driver.js', () =>
+  mockDriverModule(() => mockDriver.asDriver())
+);
+
+const {snapshot} = require('../../../fraggle-rock/gather/snapshot-runner.js');
+
+describe('Snapshot Runner', () => {
+  /** @type {ReturnType<typeof createMockPage>} */
+  let mockPage;
+  /** @type {import('puppeteer').Page} */
+  let page;
+  /** @type {ReturnType<typeof createMockGathererInstance>} */
+  let gathererA;
+  /** @type {ReturnType<typeof createMockGathererInstance>} */
+  let gathererB;
+  /** @type {LH.Config.Json} */
+  let config;
+
+  beforeEach(() => {
+    mockPage = createMockPage();
+    mockDriver = createMockDriver();
+    mockRunnerRun = jest.fn();
+    page = mockPage.asPage();
+
+    gathererA = createMockGathererInstance({supportedModes: ['snapshot']});
+    gathererA.snapshot.mockResolvedValue('Artifact A');
+
+    gathererB = createMockGathererInstance({supportedModes: ['snapshot']});
+    gathererB.snapshot.mockResolvedValue('Artifact B');
+
+    config = {
+      artifacts: [
+        {id: 'A', gatherer: {instance: gathererA.asGatherer()}},
+        {id: 'B', gatherer: {instance: gathererB.asGatherer()}},
+      ],
+    };
+  });
+
+  it('should connect to the page and run', async () => {
+    await snapshot({page, config});
+    expect(mockDriver.connect).toHaveBeenCalled();
+    expect(mockRunnerRun).toHaveBeenCalled();
+  });
+
+  it('should collect base artifacts', async () => {
+    mockPage.url.mockResolvedValue('https://lighthouse.example.com/');
+
+    await snapshot({page, config});
+    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    expect(artifacts).toMatchObject({
+      fetchTime: expect.any(String),
+      URL: {finalUrl: 'https://lighthouse.example.com/'},
+    });
+  });
+
+  it('should collect snapshot artifacts', async () => {
+    await snapshot({page, config});
+    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
+    expect(gathererA.snapshot).toHaveBeenCalled();
+    expect(gathererB.snapshot).toHaveBeenCalled();
+  });
+
+  it('should skip timespan artifacts', async () => {
+    gathererB.meta.supportedModes = ['timespan'];
+
+    await snapshot({page, config});
+    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    expect(artifacts).toMatchObject({A: 'Artifact A'});
+    expect(artifacts).not.toHaveProperty('B');
+    expect(gathererB.snapshot).not.toHaveBeenCalled();
+  });
+
+  it('should support artifact dependencies', async () => {
+    const dependencySymbol = Symbol('dep');
+    gathererA.meta.symbol = dependencySymbol;
+    // @ts-expect-error - the default fixture was defined as one without dependencies.
+    gathererB.meta.dependencies = {ImageElements: dependencySymbol};
+
+    await snapshot({page, config});
+    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
+    expect(gathererB.snapshot.mock.calls[0][0]).toMatchObject({
+      dependencies: {
+        ImageElements: 'Artifact A',
+      },
+    });
+  });
+});

--- a/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
@@ -1,0 +1,139 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const {
+  createMockDriver,
+  createMockPage,
+  createMockGathererInstance,
+  mockDriverModule,
+  mockRunnerModule,
+} = require('./mock-driver.js');
+
+// Establish the mocks before we require our file under test.
+let mockRunnerRun = jest.fn();
+/** @type {ReturnType<typeof createMockDriver>} */
+let mockDriver;
+
+jest.mock('../../../runner.js', () => mockRunnerModule(() => mockRunnerRun));
+jest.mock('../../../fraggle-rock/gather/driver.js', () =>
+  mockDriverModule(() => mockDriver.asDriver())
+);
+
+const {startTimespan} = require('../../../fraggle-rock/gather/timespan-runner.js');
+
+describe('Timespan Runner', () => {
+  /** @type {ReturnType<typeof createMockPage>} */
+  let mockPage;
+  /** @type {import('puppeteer').Page} */
+  let page;
+  /** @type {ReturnType<typeof createMockGathererInstance>} */
+  let gathererA;
+  /** @type {ReturnType<typeof createMockGathererInstance>} */
+  let gathererB;
+  /** @type {LH.Config.Json} */
+  let config;
+
+  beforeEach(() => {
+    mockPage = createMockPage();
+    mockDriver = createMockDriver();
+    mockRunnerRun = jest.fn();
+    page = mockPage.asPage();
+
+    gathererA = createMockGathererInstance({supportedModes: ['timespan']});
+    gathererA.afterTimespan.mockResolvedValue('Artifact A');
+
+    gathererB = createMockGathererInstance({supportedModes: ['timespan']});
+    gathererB.afterTimespan.mockResolvedValue('Artifact B');
+
+    config = {
+      artifacts: [
+        {id: 'A', gatherer: {instance: gathererA.asGatherer()}},
+        {id: 'B', gatherer: {instance: gathererB.asGatherer()}},
+      ],
+    };
+  });
+
+  it('should connect to the page and run', async () => {
+    const timespan = await startTimespan({page, config});
+    await timespan.endTimespan();
+    expect(mockDriver.connect).toHaveBeenCalled();
+    expect(mockRunnerRun).toHaveBeenCalled();
+  });
+
+  it('should invoke beforeTimespan', async () => {
+
+  });
+
+  it('should collect base artifacts', async () => {
+    mockPage.url.mockResolvedValue('https://start.example.com/');
+
+    const timespan = await startTimespan({page, config});
+
+    mockPage.url.mockResolvedValue('https://end.example.com/');
+
+    await timespan.endTimespan();
+    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    expect(artifacts).toMatchObject({
+      fetchTime: expect.any(String),
+      URL: {
+        requestedUrl: 'https://start.example.com/',
+        finalUrl: 'https://end.example.com/',
+      },
+    });
+  });
+
+  it('should collect timespan artifacts', async () => {
+    const timespan = await startTimespan({page, config});
+    await timespan.endTimespan();
+    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
+    expect(gathererA.afterTimespan).toHaveBeenCalled();
+    expect(gathererB.afterTimespan).toHaveBeenCalled();
+  });
+
+  it('should carryover failures from beforeTimespan', async () => {
+    const artifactError = new Error('BEFORE_TIMESPAN_ERROR');
+    gathererA.beforeTimespan.mockRejectedValue(artifactError);
+
+    const timespan = await startTimespan({page, config});
+    await timespan.endTimespan();
+    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    expect(artifacts).toMatchObject({A: artifactError, B: 'Artifact B'});
+    expect(gathererA.afterTimespan).not.toHaveBeenCalled();
+    expect(gathererB.afterTimespan).toHaveBeenCalled();
+  });
+
+  it('should skip snapshot artifacts', async () => {
+    gathererB.meta.supportedModes = ['snapshot'];
+
+    const timespan = await startTimespan({page, config});
+    await timespan.endTimespan();
+    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    expect(artifacts).toMatchObject({A: 'Artifact A'});
+    expect(artifacts).not.toHaveProperty('B');
+    expect(gathererB.afterTimespan).not.toHaveBeenCalled();
+  });
+
+  it('should support artifact dependencies', async () => {
+    const dependencySymbol = Symbol('dep');
+    gathererA.meta.symbol = dependencySymbol;
+    // @ts-expect-error - the default fixture was defined as one without dependencies.
+    gathererB.meta.dependencies = {ImageElements: dependencySymbol};
+
+    const timespan = await startTimespan({page, config});
+    await timespan.endTimespan();
+    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
+    expect(gathererB.afterTimespan.mock.calls[0][0]).toMatchObject({
+      dependencies: {
+        ImageElements: 'Artifact A',
+      },
+    });
+  });
+});

--- a/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
@@ -67,7 +67,10 @@ describe('Timespan Runner', () => {
   });
 
   it('should invoke beforeTimespan', async () => {
-
+    const timespan = await startTimespan({page, config});
+    expect(gathererA.beforeTimespan).toHaveBeenCalled();
+    expect(gathererB.beforeTimespan).toHaveBeenCalled();
+    await timespan.endTimespan();
   });
 
   it('should collect base artifacts', async () => {

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -161,14 +161,17 @@ declare global {
         artifacts: ArtifactDefn[];
       }
 
-      export interface ArtifactDefn {
+      export interface ArtifactDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
         id: string;
-        gatherer: FRGathererDefn;
+        gatherer: FRGathererDefn<TDependencies>;
+        dependencies?: TDependencies extends Gatherer.DefaultDependenciesKey ?
+          undefined :
+          Record<Exclude<TDependencies, Gatherer.DefaultDependenciesKey>, {id: string}>;
       }
 
-      export interface FRGathererDefn {
-        implementation?: ClassOf<Gatherer.FRGathererInstance>;
-        instance: Gatherer.FRGathererInstance;
+      export interface FRGathererDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
+        implementation?: ClassOf<Gatherer.FRGathererInstance<TDependencies>>;
+        instance: Gatherer.FRGathererInstance<TDependencies>;
         path?: string;
       }
 


### PR DESCRIPTION
**Summary**
Adds config and runner support for artifact dependencies, see #12017 for expected usage examples and discussion. I know this is a monster PR, but it truly is the minimal set of artifact dependency support that is validated, typechecked, and tested (there isn't even a single gatherer that's upgraded for dependency support in here! 🤯). I do think it's rather helpful to see it all come together rather than jump between different related PRs by potential different reviewers, but we do have few options if we want to reduce the line count.

- Split the config support from runner support and just break some types and/or add temporary meaningless types
- Land the timespan/snapshot runner test updates separately
- Land the config validation pieces separately (everything would typecheck and work but you could create invalid dependency relationships)

**Related Issues/PRs**
ref #11313 
ref #12017
