### PR TITLE
core(unsized-images): skip images that are zero-sized

### DIFF
--- a/lighthouse-core/audits/unsized-images.js
+++ b/lighthouse-core/audits/unsized-images.js
@@ -46,11 +46,11 @@ class UnsizedImages extends Audit {
    * @return {boolean}
    */
   static isValidAttr(attrValue) {
-    // First, superweird edge case of using the positive-sign. The the spec _sorta_ says it's valid...
+    // First, superweird edge case of using the positive-sign. The spec _sorta_ says it's valid...
     // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-integers
     //   > Otherwise, if the character is … (+): Advance position to the next character.
     //   > (The "+" is ignored, but it is not conforming.)
-    // lol.  Chrome (at least) doesn't ignore but rejects this as a non-conforming value.
+    // lol.  Irrelevant though b/c Chrome (at least) doesn't ignore. It rejects this as a non-conforming value.
     if (attrValue.startsWith('+')) return false;
 
     // parseInt isn't exactly the same as the html's spec for parsing integers, but it's close enough

--- a/lighthouse-core/audits/unsized-images.js
+++ b/lighthouse-core/audits/unsized-images.js
@@ -91,15 +91,15 @@ class UnsizedImages extends Audit {
     const unsizedImages = [];
 
     for (const image of images) {
+      // Fixed images are out of document flow and won't cause layout shifts
       const isFixedImage =
         image.cssComputedPosition === 'fixed' || image.cssComputedPosition === 'absolute';
-      // Fixed images are out of document flow and won't cause layout shifts
       if (isFixedImage) continue;
 
+      // Zero-sized images won't cause layout shift. We approve!
       const boundingRect = image.node.boundingRect;
       // Either the image was set to 0,0 size or a parent is not displayed.
       const isNotDisplayed = boundingRect.width === 0 && boundingRect.height === 0;
-      // Zero-sized images won't cause layout shift. We approve!
       if (isNotDisplayed) continue;
 
       // The image was sized with HTML or CSS. Good job.

--- a/lighthouse-core/test/audits/unsized-images-test.js
+++ b/lighthouse-core/test/audits/unsized-images-test.js
@@ -10,7 +10,7 @@ const UnsizedImagesAudit = require('../../audits/unsized-images.js');
 /* eslint-env jest */
 
 function generateImage(props, src = 'https://google.com/logo.png', isCss = false,
-  isInShadowDOM = false, cssComputedPosition = 'static', node = {boundingRect:{}}) {
+  isInShadowDOM = false, cssComputedPosition = 'static', node = {boundingRect: {}}) {
   const image = {src, isCss, isInShadowDOM, cssComputedPosition, node};
   Object.assign(image, props);
   return image;
@@ -244,13 +244,28 @@ describe('Sized images audit', () => {
         node: {
           boundingRect: {
             width: 0,
-            height: 0
-          }
-        }
+            height: 0,
+          },
+        },
       });
       expect(result.score).toEqual(1);
     });
 
+    it('passes when an image has is unsized, but its parent is not displayed..', async () => {
+      const result = await runAudit({
+        attributeWidth: '',
+        attributeHeight: '',
+        cssWidth: '',
+        cssHeight: '',
+        node: {
+          boundingRect: {
+            width: 0,
+            height: 0,
+          },
+        },
+      });
+      expect(result.score).toEqual(1);
+    });
   });
 
   describe('has invalid width', () => {
@@ -418,19 +433,19 @@ describe('Size attribute validity check', () => {
     expect(UnsizedImagesAudit.isValidAttr('')).toEqual(false);
   });
 
-  it('fails on non-numeric characters', () => {
+  it('handles non-numeric edgecases', () => {
     expect(UnsizedImagesAudit.isValidAttr('zero')).toEqual(false);
-    expect(UnsizedImagesAudit.isValidAttr('1002$')).toEqual(false);
+    expect(UnsizedImagesAudit.isValidAttr('1002$')).toEqual(true); // interpretted as 1002
     expect(UnsizedImagesAudit.isValidAttr('s-5')).toEqual(false);
-    expect(UnsizedImagesAudit.isValidAttr('3,000')).toEqual(false);
-    expect(UnsizedImagesAudit.isValidAttr('100.0')).toEqual(false);
-    expect(UnsizedImagesAudit.isValidAttr('2/3')).toEqual(false);
+    expect(UnsizedImagesAudit.isValidAttr('3,000')).toEqual(true); // interpretted as 3
+    expect(UnsizedImagesAudit.isValidAttr('100.0')).toEqual(true); // interpretted as 100
+    expect(UnsizedImagesAudit.isValidAttr('2/3')).toEqual(true); // interpretted as 2
     expect(UnsizedImagesAudit.isValidAttr('-2020')).toEqual(false);
-    expect(UnsizedImagesAudit.isValidAttr('+2020')).toEqual(false);
+    expect(UnsizedImagesAudit.isValidAttr('+2020')).toEqual(false); // see isValidAttr comments about positive-sign
   });
 
-  it('fails on zero input', () => {
-    expect(UnsizedImagesAudit.isValidAttr('0')).toEqual(false);
+  it('passes on zero input', () => {
+    expect(UnsizedImagesAudit.isValidAttr('0')).toEqual(true);
   });
 
   it('passes on non-zero non-negative integer input', () => {

--- a/lighthouse-core/test/audits/unsized-images-test.js
+++ b/lighthouse-core/test/audits/unsized-images-test.js
@@ -10,7 +10,7 @@ const UnsizedImagesAudit = require('../../audits/unsized-images.js');
 /* eslint-env jest */
 
 function generateImage(props, src = 'https://google.com/logo.png', isCss = false,
-  isInShadowDOM = false, cssComputedPosition = 'static', node = {}) {
+  isInShadowDOM = false, cssComputedPosition = 'static', node = {boundingRect:{}}) {
   const image = {src, isCss, isInShadowDOM, cssComputedPosition, node};
   Object.assign(image, props);
   return image;
@@ -234,6 +234,23 @@ describe('Sized images audit', () => {
       });
       expect(result.score).toEqual(1);
     });
+
+    it('passes when an image has attribute width/height of zero', async () => {
+      const result = await runAudit({
+        attributeWidth: '0',
+        attributeHeight: '0',
+        cssWidth: '',
+        cssHeight: '',
+        node: {
+          boundingRect: {
+            width: 0,
+            height: 0
+          }
+        }
+      });
+      expect(result.score).toEqual(1);
+    });
+
   });
 
   describe('has invalid width', () => {

--- a/lighthouse-core/test/audits/unsized-images-test.js
+++ b/lighthouse-core/test/audits/unsized-images-test.js
@@ -251,7 +251,7 @@ describe('Sized images audit', () => {
       expect(result.score).toEqual(1);
     });
 
-    it('passes when an image has is unsized, but its parent is not displayed..', async () => {
+    it('passes when an image is unsized, but its parent is not displayed', async () => {
       const result = await runAudit({
         attributeWidth: '',
         attributeHeight: '',


### PR DESCRIPTION
running kohls i saw these in the unsized-images results..

![image](https://user-images.githubusercontent.com/39191/107068953-1b8e5480-6796-11eb-9c11-2a75439ef005.png)


of course anything that's zero width & height isn't part of the layout (equivalent to display:none) but we hadn't really been checking that.

the boundingRect we have ends up being ideal for this calculation and includes if a parent is hidden or w/e.

sweet.
