### PR TITLE
core(cls): refactor CLS and CLS-AF

### DIFF
--- a/lighthouse-core/computed/layout-shift-variants.js
+++ b/lighthouse-core/computed/layout-shift-variants.js
@@ -8,7 +8,7 @@
 const makeComputedArtifact = require('./computed-artifact.js');
 const TraceOfTab = require('./trace-of-tab.js');
 
-/** @typedef {{ts: number, score: number}} LayoutShiftEvent */
+/** @typedef {{ts: number, score: number, is_main_frame: boolean, weighted_score_delta?: number}} LayoutShiftEvent */
 
 /**
  * @fileoverview An implementation of the Layout Shift variants being considered
@@ -97,11 +97,11 @@ class LayoutShiftVariants {
   }
 
   /**
-   * Returns all main process LayoutShift events.
-   * @param {LH.Artifacts.TraceOfTab} traceOfTab
+   * Returns all LayoutShift events that had no recent input.
+   * @param {LH.TraceEvent[]} traceEvents
    * @return {Array<LayoutShiftEvent>}
    */
-  static getLayoutShiftEvents(traceOfTab) {
+  static getLayoutShiftEvents(traceEvents) {
     const layoutShiftEvents = [];
 
     // Chromium will set `had_recent_input` if there was recent user input, which
@@ -111,10 +111,10 @@ class LayoutShiftVariants {
     // See https://bugs.chromium.org/p/chromium/issues/detail?id=1094974.
     let ignoreHadRecentInput = true;
 
-    for (const event of traceOfTab.mainThreadEvents) {
+    for (const event of traceEvents) {
       if (event.name !== 'LayoutShift' ||
           !event.args.data ||
-          !event.args.data.is_main_frame || // Main frame only for now.
+          event.args.data.is_main_frame === undefined ||
           event.args.data.score === undefined) { // Keep tsc happy, but a score-less event would be useless regardless.
         continue;
       }
@@ -130,6 +130,8 @@ class LayoutShiftVariants {
       layoutShiftEvents.push({
         ts: event.ts,
         score: event.args.data.score,
+        is_main_frame: event.args.data.is_main_frame,
+        weighted_score_delta: event.args.data.weighted_score_delta,
       });
     }
 
@@ -143,7 +145,8 @@ class LayoutShiftVariants {
    */
   static async compute_(trace, context) {
     const traceOfTab = await TraceOfTab.request(trace, context);
-    const layoutShiftEvents = LayoutShiftVariants.getLayoutShiftEvents(traceOfTab);
+    const layoutShiftEvents = LayoutShiftVariants.getLayoutShiftEvents(traceOfTab.mainThreadEvents)
+      .filter(e => e.is_main_frame); // Only main frame for now.
 
     return {
       avgSessionGap5s: LayoutShiftVariants.avgSessionGap5s(layoutShiftEvents),

--- a/lighthouse-core/computed/layout-shift-variants.js
+++ b/lighthouse-core/computed/layout-shift-variants.js
@@ -8,7 +8,7 @@
 const makeComputedArtifact = require('./computed-artifact.js');
 const TraceOfTab = require('./trace-of-tab.js');
 
-/** @typedef {{ts: number, score: number, is_main_frame: boolean, weighted_score_delta?: number}} LayoutShiftEvent */
+/** @typedef {{ts: number, score: number, isMainFrame: boolean, weightedScoreDelta?: number}} LayoutShiftEvent */
 
 /**
  * @fileoverview An implementation of the Layout Shift variants being considered
@@ -130,8 +130,8 @@ class LayoutShiftVariants {
       layoutShiftEvents.push({
         ts: event.ts,
         score: event.args.data.score,
-        is_main_frame: event.args.data.is_main_frame,
-        weighted_score_delta: event.args.data.weighted_score_delta,
+        isMainFrame: event.args.data.is_main_frame,
+        weightedScoreDelta: event.args.data.weighted_score_delta,
       });
     }
 
@@ -146,7 +146,7 @@ class LayoutShiftVariants {
   static async compute_(trace, context) {
     const traceOfTab = await TraceOfTab.request(trace, context);
     const layoutShiftEvents = LayoutShiftVariants.getLayoutShiftEvents(traceOfTab.mainThreadEvents)
-      .filter(e => e.is_main_frame); // Only main frame for now.
+      .filter(e => e.isMainFrame); // Only main frame for now.
 
     return {
       avgSessionGap5s: LayoutShiftVariants.avgSessionGap5s(layoutShiftEvents),

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift-all-frames.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift-all-frames.js
@@ -28,12 +28,12 @@ class CumulativeLayoutShiftAllFrames {
         // COMPAT: remove after m90 hits stable
         // We should replace with a LHError at that point:
         // https://github.com/GoogleChrome/lighthouse/pull/12034#discussion_r568150032
-        if (e.weighted_score_delta === undefined) {
+        if (e.weightedScoreDelta === undefined) {
           traceHasWeightedScore = false;
           return e.score;
         }
 
-        return e.weighted_score_delta;
+        return e.weightedScoreDelta;
       })
       .reduce((sum, score) => sum + score, 0);
 

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift-all-frames.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift-all-frames.js
@@ -10,21 +10,9 @@
 const makeComputedArtifact = require('../computed-artifact.js');
 const TraceOfTab = require('../trace-of-tab.js');
 const log = require('lighthouse-logger');
+const LayoutShiftVariants = require('../layout-shift-variants.js');
 
 class CumulativeLayoutShiftAllFrames {
-  /**
-   * @param {LH.TraceEvent} event
-   * @return {event is LayoutShiftEvent}
-   */
-  static isLayoutShiftEvent(event) {
-    return Boolean(
-      event.name === 'LayoutShift' &&
-      event.args &&
-      event.args.data &&
-      event.args.data.score !== undefined
-    );
-  }
-
   /**
    * @param {LH.Trace} trace
    * @param {LH.Audit.Context} context
@@ -32,22 +20,20 @@ class CumulativeLayoutShiftAllFrames {
    */
   static async compute_(trace, context) {
     const traceOfTab = await TraceOfTab.request(trace, context);
-    const layoutShiftEvents = traceOfTab.frameTreeEvents.filter(this.isLayoutShiftEvent);
+    const layoutShiftEvents = LayoutShiftVariants.getLayoutShiftEvents(traceOfTab.frameTreeEvents);
 
     let traceHasWeightedScore = true;
     const cumulativeShift = layoutShiftEvents
       .map(e => {
-        if (e.args.data.had_recent_input) return 0;
-
         // COMPAT: remove after m90 hits stable
         // We should replace with a LHError at that point:
         // https://github.com/GoogleChrome/lighthouse/pull/12034#discussion_r568150032
-        if (e.args.data.weighted_score_delta !== undefined) {
-          return e.args.data.weighted_score_delta;
+        if (e.weighted_score_delta === undefined) {
+          traceHasWeightedScore = false;
+          return e.score;
         }
 
-        traceHasWeightedScore = false;
-        return e.args.data.score;
+        return e.weighted_score_delta;
       })
       .reduce((sum, score) => sum + score, 0);
 

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift.js
@@ -20,7 +20,7 @@ class CumulativeLayoutShift {
     const layoutShiftEvents = LayoutShiftVariants.getLayoutShiftEvents(traceOfTab.mainThreadEvents);
 
     const cumulativeLayoutShift = layoutShiftEvents
-      .filter(e => e.is_main_frame)
+      .filter(e => e.isMainFrame)
       .reduce((sum, e) => sum += e.score, 0);
 
     return {

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift.js
@@ -7,7 +7,7 @@
 
 const makeComputedArtifact = require('../computed-artifact.js');
 const TraceOfTab = require('../trace-of-tab.js');
-const LHError = require('../../lib/lh-error.js');
+const LayoutShiftVariants = require('../layout-shift-variants.js');
 
 class CumulativeLayoutShift {
   /**
@@ -17,57 +17,16 @@ class CumulativeLayoutShift {
    */
   static async compute_(trace, context) {
     const traceOfTab = await TraceOfTab.request(trace, context);
+    const layoutShiftEvents = LayoutShiftVariants.getLayoutShiftEvents(traceOfTab.mainThreadEvents);
 
-    // Find the last LayoutShift event, if any.
-    let finalLayoutShift;
-    for (let i = traceOfTab.mainThreadEvents.length - 1; i >= 0; i--) {
-      const evt = traceOfTab.mainThreadEvents[i];
-      if (evt.name === 'LayoutShift' && evt.args && evt.args.data && evt.args.data.is_main_frame) {
-        finalLayoutShift = evt;
-        break;
-      }
-    }
-
-    const finalLayoutShiftTraceEventFound = !!finalLayoutShift;
-    // tdresser sez: In about 10% of cases, layout instability is 0, and there will be no trace events.
-    // TODO: Validate that. http://crbug.com/1003459
-    if (!finalLayoutShift) {
-      return {
-        value: 0,
-        debugInfo: {
-          finalLayoutShiftTraceEventFound,
-        },
-      };
-    }
-
-    let cumulativeLayoutShift =
-      finalLayoutShift.args &&
-      finalLayoutShift.args.data &&
-      finalLayoutShift.args.data.cumulative_score;
-
-    if (cumulativeLayoutShift === undefined) {
-      throw new LHError(LHError.errors.LAYOUT_SHIFT_MISSING_DATA);
-    }
-
-    // Chromium will set `had_recent_input` if there was recent user input, which
-    // skips shift events from contributing to CLS. This flag is also set when Lighthouse changes
-    // the emulation size. This consistently results in the first few shift event always being
-    // ignored for CLS. Since we don't expect any user input, we add the score of these
-    // shift events to CLS.
-    // See https://bugs.chromium.org/p/chromium/issues/detail?id=1094974.
-    for (let i = 0; i < traceOfTab.mainThreadEvents.length; i++) {
-      const evt = traceOfTab.mainThreadEvents[i];
-      if (evt.name === 'LayoutShift' && evt.args && evt.args.data && evt.args.data.is_main_frame) {
-        if (!evt.args.data.had_recent_input) break;
-        if (typeof evt.args.data.score !== 'number') continue;
-        cumulativeLayoutShift += evt.args.data.score;
-      }
-    }
+    const cumulativeLayoutShift = layoutShiftEvents
+      .filter(e => e.is_main_frame)
+      .reduce((sum, e) => sum += e.score, 0);
 
     return {
       value: cumulativeLayoutShift,
       debugInfo: {
-        finalLayoutShiftTraceEventFound,
+        finalLayoutShiftTraceEventFound: Boolean(layoutShiftEvents.length),
       },
     };
   }

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -284,11 +284,6 @@ const ERRORS = {
     code: 'UNSUPPORTED_OLD_CHROME',
     message: UIStrings.oldChromeDoesNotSupportFeature,
   },
-  /** Layout Shift trace events are found but without data */
-  LAYOUT_SHIFT_MISSING_DATA: {
-    code: 'LAYOUT_SHIFT_MISSING_DATA',
-    message: UIStrings.badTraceRecording,
-  },
 
   // TTI calculation failures
   FMP_TOO_LATE_FOR_FCPUI: {code: 'FMP_TOO_LATE_FOR_FCPUI', message: UIStrings.pageLoadTookTooLong},

--- a/lighthouse-core/test/computed/metrics/cumulative-layout-shift-all-frames-test.js
+++ b/lighthouse-core/test/computed/metrics/cumulative-layout-shift-all-frames-test.js
@@ -25,6 +25,27 @@ describe('Metrics: CLS All Frames', () => {
     expect(result.value).toBeCloseTo(0.459);
   });
 
+  it('ignores had_recent_input for beginning of trace', async () => {
+    const trace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
+    const mainFrame = trace.traceEvents[0].args.frame;
+    const childFrame = 'CHILDFRAME';
+    const cat = 'loading,rail,devtools.timeline';
+    const context = {computedCache: new Map()};
+    trace.traceEvents.push(
+      /* eslint-disable max-len */
+      {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: mainFrame, url: 'https://example.com'}}},
+      {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: childFrame, parent: mainFrame, url: 'https://frame.com'}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 2, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 3, weighted_score_delta: 1, is_main_frame: false}}}
+      /* eslint-enable max-len */
+    );
+    const result = await CumulativeLayoutShiftAllFrames.request(trace, context);
+    expect(result.value).toBe(4);
+  });
+
   it('uses weighted_score_delta instead of score', async () => {
     const trace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
     const mainFrame = trace.traceEvents[0].args.frame;
@@ -35,9 +56,9 @@ describe('Metrics: CLS All Frames', () => {
       /* eslint-disable max-len */
       {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: mainFrame, url: 'https://example.com'}}},
       {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: childFrame, parent: mainFrame, url: 'https://frame.com'}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 2, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 3, weighted_score_delta: 1}}}
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 2, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 3, weighted_score_delta: 1, is_main_frame: false}}}
       /* eslint-enable max-len */
     );
     const result = await CumulativeLayoutShiftAllFrames.request(trace, context);
@@ -54,9 +75,9 @@ describe('Metrics: CLS All Frames', () => {
       /* eslint-disable max-len */
       {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: mainFrame, url: 'https://example.com'}}},
       {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: childFrame, parent: mainFrame, url: 'https://frame.com'}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 2}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 3}}}
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 2, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 3, is_main_frame: false}}}
       /* eslint-enable max-len */
     );
     const result = await CumulativeLayoutShiftAllFrames.request(trace, context);
@@ -73,11 +94,11 @@ describe('Metrics: CLS All Frames', () => {
       /* eslint-disable max-len */
       {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: mainFrame, url: 'https://example.com'}}},
       {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: childFrame, parent: mainFrame, url: 'https://frame.com'}}},
-      {name: 'LayoutShift', cat, args: {frame: mainFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: mainFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1}}}
+      {name: 'LayoutShift', cat, args: {frame: mainFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: true}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: mainFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: true}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: false}}}
       /* eslint-enable max-len */
     );
     const result = await CumulativeLayoutShiftAllFrames.request(trace, context);
@@ -96,13 +117,13 @@ describe('Metrics: CLS All Frames', () => {
       {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: mainFrame, url: 'https://example.com'}}},
       {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: childFrame, parent: mainFrame, url: 'https://frame.com'}}},
       {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: otherMainFrame, url: 'https://example.com'}}},
-      {name: 'LayoutShift', cat, args: {frame: mainFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: mainFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: otherMainFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1}}},
-      {name: 'LayoutShift', cat, args: {frame: otherMainFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1}}}
+      {name: 'LayoutShift', cat, args: {frame: mainFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: true}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: mainFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: true}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: otherMainFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: otherMainFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}}
       /* eslint-enable max-len */
     );
     const result = await CumulativeLayoutShiftAllFrames.request(trace, context);

--- a/lighthouse-core/test/computed/metrics/cumulative-layout-shift-all-frames-test.js
+++ b/lighthouse-core/test/computed/metrics/cumulative-layout-shift-all-frames-test.js
@@ -25,27 +25,6 @@ describe('Metrics: CLS All Frames', () => {
     expect(result.value).toBeCloseTo(0.459);
   });
 
-  it('ignores had_recent_input for beginning of trace', async () => {
-    const trace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
-    const mainFrame = trace.traceEvents[0].args.frame;
-    const childFrame = 'CHILDFRAME';
-    const cat = 'loading,rail,devtools.timeline';
-    const context = {computedCache: new Map()};
-    trace.traceEvents.push(
-      /* eslint-disable max-len */
-      {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: mainFrame, url: 'https://example.com'}}},
-      {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: childFrame, parent: mainFrame, url: 'https://frame.com'}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 2, weighted_score_delta: 1, is_main_frame: false}}},
-      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 3, weighted_score_delta: 1, is_main_frame: false}}}
-      /* eslint-enable max-len */
-    );
-    const result = await CumulativeLayoutShiftAllFrames.request(trace, context);
-    expect(result.value).toBe(4);
-  });
-
   it('uses weighted_score_delta instead of score', async () => {
     const trace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
     const mainFrame = trace.traceEvents[0].args.frame;
@@ -82,6 +61,27 @@ describe('Metrics: CLS All Frames', () => {
     );
     const result = await CumulativeLayoutShiftAllFrames.request(trace, context);
     expect(result.value).toBe(6);
+  });
+
+  it('ignores had_recent_input for beginning of trace', async () => {
+    const trace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
+    const mainFrame = trace.traceEvents[0].args.frame;
+    const childFrame = 'CHILDFRAME';
+    const cat = 'loading,rail,devtools.timeline';
+    const context = {computedCache: new Map()};
+    trace.traceEvents.push(
+      /* eslint-disable max-len */
+      {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: mainFrame, url: 'https://example.com'}}},
+      {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: childFrame, parent: mainFrame, url: 'https://frame.com'}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: true, score: 2, weighted_score_delta: 1, is_main_frame: false}}},
+      {name: 'LayoutShift', cat, args: {frame: childFrame, data: {had_recent_input: false, score: 3, weighted_score_delta: 1, is_main_frame: false}}}
+      /* eslint-enable max-len */
+    );
+    const result = await CumulativeLayoutShiftAllFrames.request(trace, context);
+    expect(result.value).toBe(4);
   });
 
   it('collects layout shift data from main frame and all child frames', async () => {


### PR DESCRIPTION
Follow up to https://github.com/GoogleChrome/lighthouse/pull/12046#discussion_r569866794 and https://github.com/GoogleChrome/lighthouse/pull/12034.

Removes duplicated code which handles the `had_recent_input` flag in layout shift events.

Plan is to merge after #12046 lands.