### PR TITLE
misc: reorganize accessibility gatherer

### DIFF
--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -33,7 +33,7 @@ class AxeAudit extends Audit {
     // Indicate if a test is not applicable.
     // This means aXe did not find any nodes which matched these checks.
     // Note in Lighthouse we use the phrasing "Not Applicable" (aXe uses "inapplicable", which sounds weird).
-    const notApplicables = artifacts.Accessibility.notApplicable;
+    const notApplicables = artifacts.Accessibility.notApplicable || [];
     const isNotApplicable = notApplicables.find(result => result.id === this.meta.id);
     if (isNotApplicable) {
       return {
@@ -45,7 +45,7 @@ class AxeAudit extends Audit {
     // Detect errors reported within aXe 'incomplete' results
     // aXe uses this result type to indicate errors, or rules which require manual investigation
     // If aXe reports an error, then bubble it up to the caller
-    const incomplete = artifacts.Accessibility.incomplete;
+    const incomplete = artifacts.Accessibility.incomplete || [];
     const incompleteResult = incomplete.find(result => result.id === this.meta.id);
     if (incompleteResult && incompleteResult.error) {
       return {
@@ -55,7 +55,7 @@ class AxeAudit extends Audit {
     }
 
     const isInformative = this.meta.scoreDisplayMode === Audit.SCORING_MODES.INFORMATIVE;
-    const violations = artifacts.Accessibility.violations;
+    const violations = artifacts.Accessibility.violations || [];
     const failureCases = isInformative ? violations.concat(incomplete) : violations;
     const rule = failureCases.find(result => result.id === this.meta.id);
     const impact = rule && rule.impact;

--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -33,11 +33,11 @@ class AxeAudit extends Audit {
     // Indicate if a test is not applicable.
     // This means aXe did not find any nodes which matched these checks.
     // Note in Lighthouse we use the phrasing "Not Applicable" (aXe uses "inapplicable", which sounds weird).
-    const notApplicables = artifacts.Accessibility.notApplicable || [];
+    const notApplicables = artifacts.Accessibility.notApplicable;
     const isNotApplicable = notApplicables.find(result => result.id === this.meta.id);
     if (isNotApplicable) {
       return {
-        score: 1,
+        score: null,
         notApplicable: true,
       };
     }
@@ -45,7 +45,7 @@ class AxeAudit extends Audit {
     // Detect errors reported within aXe 'incomplete' results
     // aXe uses this result type to indicate errors, or rules which require manual investigation
     // If aXe reports an error, then bubble it up to the caller
-    const incomplete = artifacts.Accessibility.incomplete || [];
+    const incomplete = artifacts.Accessibility.incomplete;
     const incompleteResult = incomplete.find(result => result.id === this.meta.id);
     if (incompleteResult && incompleteResult.error) {
       return {
@@ -55,7 +55,7 @@ class AxeAudit extends Audit {
     }
 
     const isInformative = this.meta.scoreDisplayMode === Audit.SCORING_MODES.INFORMATIVE;
-    const violations = artifacts.Accessibility.violations || [];
+    const violations = artifacts.Accessibility.violations;
     const failureCases = isInformative ? violations.concat(incomplete) : violations;
     const rule = failureCases.find(result => result.id === this.meta.id);
     const impact = rule && rule.impact;
@@ -66,7 +66,7 @@ class AxeAudit extends Audit {
     // Since there is no score impact from informative rules, display the rule as not applicable
     if (isInformative && !rule) {
       return {
-        score: 1,
+        score: null,
         notApplicable: true,
       };
     }

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -20,7 +20,7 @@ const pageFunctions = require('../../lib/page-functions.js');
 /* c8 ignore start */
 async function runA11yChecks() {
   /** @type {import('axe-core/axe')} */
-  // @ts-expect-error axe defined by axeLibSource
+  // @ts-expect-error - axe defined by axeLibSource
   const axe = window.axe;
   const application = `lighthouse-${Math.random()}`;
   axe.configure({
@@ -65,47 +65,52 @@ async function runA11yChecks() {
   // are relative to the top of the page
   document.documentElement.scrollTop = 0;
 
-  /** @param {import('axe-core/axe').Result} result */
-  const augmentAxeNodes = result => {
-    result.helpUrl = result.helpUrl.replace(application, 'lighthouse');
-    if (axeResults.inapplicable.includes(result)) return;
-
-    result.nodes.forEach(node => {
-      // @ts-expect-error - getNodeDetails put into scope via stringification
-      node.node = getNodeDetails(node.element);
-      // @ts-expect-error - avoid circular JSON concerns
-      node.element = node.any = node.all = node.none = node.html = undefined;
-    });
-
-    // Ensure errors can be serialized over the protocol
-    /** @type {(Error & {message: string, errorNode: any}) | undefined} */
-    // @ts-expect-error - when rules error axe sets these properties
-    // see https://github.com/dequelabs/axe-core/blob/eeff122c2de11dd690fbad0e50ba2fdb244b50e8/lib/core/base/audit.js#L684-L693
-    const error = result.error;
-    if (error instanceof Error) {
-      // @ts-expect-error
-      result.error = {
-        name: error.name,
-        message: error.message,
-        stack: error.stack,
-        errorNode: error.errorNode,
-      };
-    }
-  };
-
-  // Augment the node objects with outerHTML snippet & custom path string
-  axeResults.violations.forEach(augmentAxeNodes);
-  axeResults.incomplete.forEach(augmentAxeNodes);
-  axeResults.inapplicable.forEach(augmentAxeNodes);
-
-  // We only need violations, and circular references are possible outside of violations
   return {
-    // @ts-expect-error value is augmented above.
-    violations: axeResults.violations,
-    notApplicable: axeResults.inapplicable,
-    // @ts-expect-error value is augmented above.
-    incomplete: axeResults.incomplete,
+    violations: axeResults.violations.map(createAxeRuleResultArtifact),
+    incomplete: axeResults.incomplete.map(createAxeRuleResultArtifact),
+    notApplicable: axeResults.inapplicable.map(result => ({id: result.id})),
     version: axeResults.testEngine.version,
+  };
+}
+
+/**
+ * @param {import('axe-core/axe').Result} result
+ * @return {LH.Artifacts.AxeRuleResult}
+ */
+function createAxeRuleResultArtifact(result) {
+  // Simplify `nodes` and collect nodeDetails for each.
+  const nodes = result.nodes.map(node => {
+    const {target, failureSummary, element} = node;
+    // TODO: with `elementRef: true`, `element` _should_ always be defined, but need to verify.
+    // @ts-expect-error - getNodeDetails put into scope via stringification
+    const nodeDetails = getNodeDetails(/** @type {HTMLElement} */ (element));
+
+    return {
+      target,
+      failureSummary,
+      node: nodeDetails,
+    };
+  });
+
+  // Ensure errors can be serialized over the protocol.
+  /** @type {Error | undefined} */
+  // @ts-expect-error - when rules throw an error, axe saves it here.
+  // see https://github.com/dequelabs/axe-core/blob/eeff122c2de11dd690fbad0e50ba2fdb244b50e8/lib/core/base/audit.js#L684-L693
+  const resultError = result.error;
+  let error;
+  if (resultError instanceof Error) {
+    error = {
+      name: resultError.name,
+      message: resultError.message,
+    };
+  }
+
+  return {
+    id: result.id,
+    impact: result.impact || undefined,
+    tags: result.tags,
+    nodes,
+    error,
   };
 }
 /* c8 ignore stop */
@@ -129,15 +134,8 @@ class Accessibility extends FRGatherer {
       deps: [
         axeLibSource,
         pageFunctions.getNodeDetailsString,
+        createAxeRuleResultArtifact,
       ],
-    }).then(returnedValue => {
-      if (!returnedValue) {
-        throw new Error('No axe-core results returned');
-      }
-      if (!Array.isArray(returnedValue.violations)) {
-        throw new Error('Unable to parse axe results' + returnedValue);
-      }
-      return returnedValue;
     });
   }
 }

--- a/lighthouse-core/test/audits/accessibility/axe-audit-test.js
+++ b/lighthouse-core/test/audits/accessibility/axe-audit-test.js
@@ -102,10 +102,9 @@ describe('Accessibility: axe-audit', () => {
       }
       const artifacts = {
         Accessibility: {
-          passes: [{
-            id: 'fake-axe-pass',
-            help: 'http://example.com/',
-          }],
+          violations: [],
+          notApplicable: [],
+          incomplete: [],
         },
       };
 
@@ -134,15 +133,7 @@ describe('Accessibility: axe-audit', () => {
             }],
             help: 'http://example.com/',
           }],
-          // TODO: remove: axe-core v3.3.0 backwards-compatibility test
-          violations: [{
-            id: 'fake-axe-failure-case',
-            nodes: [{
-              html: '<input id="multi-label-form-element" />',
-              node: {},
-            }],
-            help: 'http://example.com/',
-          }],
+          violations: [],
         },
       };
 

--- a/lighthouse-core/test/gather/gatherers/accessibility-test.js
+++ b/lighthouse-core/test/gather/gatherers/accessibility-test.js
@@ -17,34 +17,6 @@ describe('Accessibility gatherer', () => {
     accessibilityGather = new AccessibilityGather();
   });
 
-  it('fails if nothing is returned', () => {
-    return accessibilityGather.afterPass({
-      driver: {
-        executionContext: {
-          async evaluate() {},
-        },
-      },
-    }).then(
-      _ => assert.ok(false),
-      _ => assert.ok(true));
-  });
-
-  it('fails if result has no violations array', () => {
-    return accessibilityGather.afterPass({
-      driver: {
-        executionContext: {
-          async evaluate() {
-            return {
-              url: 'https://example.com',
-            };
-          },
-        },
-      },
-    }).then(
-      _ => assert.ok(false),
-      _ => assert.ok(true));
-  });
-
   it('propagates error retrieving the results', () => {
     const error = 'There was an error.';
     return accessibilityGather.afterPass({

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -1587,12 +1587,8 @@
           "wcag311",
           "ACT"
         ],
-        "description": "Ensures every HTML document has a lang attribute",
-        "help": "<html> element must have a lang attribute",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/html-has-lang?application=lighthouse",
         "nodes": [
           {
-            "impact": "serious",
             "target": [
               "html"
             ],
@@ -1626,12 +1622,8 @@
           "section508.22.a",
           "ACT"
         ],
-        "description": "Ensures <img> elements have alternate text or a role of none or presentation",
-        "help": "Images must have alternate text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/image-alt?application=lighthouse",
         "nodes": [
           {
-            "impact": "critical",
             "target": [
               "img[src=\"lighthouse-480x318\\.jpg\\?iar1\"]"
             ],
@@ -1653,7 +1645,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "img[src=\"lighthouse-480x318\\.jpg\\?iar2\"]"
             ],
@@ -1675,7 +1666,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "img[src=\"lighthouse-480x318\\.jpg\\?isr1\"]"
             ],
@@ -1697,7 +1687,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "img[src=\"lighthouse-480x318\\.jpg\\?isr2\"]"
             ],
@@ -1719,7 +1708,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "img[src=\"lighthouse-480x318\\.jpg\\?isr3\"]"
             ],
@@ -1741,7 +1729,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "img[src=\"lighthouse-480x318\\.jpg\\?isr4\"]"
             ],
@@ -1763,7 +1750,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "img[src$=\"lighthouse-rotating\\.gif\"]"
             ],
@@ -1785,7 +1771,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "img:nth-child(37)"
             ],
@@ -1807,7 +1792,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "img:nth-child(43)"
             ],
@@ -1842,12 +1826,8 @@
           "section508.22.n",
           "ACT"
         ],
-        "description": "Ensures every form element has a label",
-        "help": "Form elements must have labels",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/label?application=lighthouse",
         "nodes": [
           {
-            "impact": "critical",
             "target": [
               "input[onpaste=\"event\\.preventDefault\\(\\)\\;\"]"
             ],
@@ -1869,7 +1849,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "input:nth-child(35)"
             ],
@@ -1891,7 +1870,6 @@
             }
           },
           {
-            "impact": "critical",
             "target": [
               "input[onpaste=\"return\\ false\\;\"]"
             ],
@@ -1926,12 +1904,8 @@
           "section508.22.a",
           "ACT"
         ],
-        "description": "Ensures links have discernible text",
-        "help": "Links must have discernible text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/link-name?application=lighthouse",
         "nodes": [
           {
-            "impact": "serious",
             "target": [
               "a[href=\"javascript\\:void\\(0\\)\"]"
             ],
@@ -1953,7 +1927,6 @@
             }
           },
           {
-            "impact": "serious",
             "target": [
               "a[href$=\"mailto\\:inbox\\@email\\.com\"]"
             ],
@@ -1986,12 +1959,8 @@
           "section508",
           "section508.22.a"
         ],
-        "description": "Ensures <object> elements have alternate text",
-        "help": "<object> elements must have alternate text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/object-alt?application=lighthouse",
         "nodes": [
           {
-            "impact": "serious",
             "target": [
               "#\\35 934a"
             ],
@@ -2013,7 +1982,6 @@
             }
           },
           {
-            "impact": "serious",
             "target": [
               "#\\35 934b"
             ],
@@ -2037,397 +2005,6 @@
         ]
       }
     ],
-    "notApplicable": [
-      {
-        "id": "accesskeys",
-        "impact": null,
-        "tags": [
-          "cat.keyboard",
-          "best-practice"
-        ],
-        "description": "Ensures every accesskey attribute value is unique",
-        "help": "accesskey attribute value must be unique",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/accesskeys?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "aria-command-name",
-        "impact": null,
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag412"
-        ],
-        "description": "Ensures every ARIA button, link and menuitem has an accessible name",
-        "help": "ARIA commands must have an accessible name",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/aria-command-name?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "aria-hidden-focus",
-        "impact": null,
-        "tags": [
-          "cat.name-role-value",
-          "wcag2a",
-          "wcag412",
-          "wcag131"
-        ],
-        "description": "Ensures aria-hidden elements do not contain focusable elements",
-        "help": "ARIA hidden element must not contain focusable elements",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/aria-hidden-focus?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "aria-input-field-name",
-        "impact": null,
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag412",
-          "ACT"
-        ],
-        "description": "Ensures every ARIA input field has an accessible name",
-        "help": "ARIA input fields must have an accessible name",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/aria-input-field-name?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "aria-meter-name",
-        "impact": null,
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag111"
-        ],
-        "description": "Ensures every ARIA meter node has an accessible name",
-        "help": "ARIA meter nodes must have an accessible name",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/aria-meter-name?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "aria-progressbar-name",
-        "impact": null,
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag111"
-        ],
-        "description": "Ensures every ARIA progressbar node has an accessible name",
-        "help": "ARIA progressbar nodes must have an accessible name",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/aria-progressbar-name?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "aria-roledescription",
-        "impact": null,
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag412"
-        ],
-        "description": "Ensure aria-roledescription is only used on elements with an implicit or explicit role",
-        "help": "Use aria-roledescription on elements with a semantic role",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/aria-roledescription?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "aria-toggle-field-name",
-        "impact": null,
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag412",
-          "ACT"
-        ],
-        "description": "Ensures every ARIA toggle field has an accessible name",
-        "help": "ARIA toggle fields have an accessible name",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/aria-toggle-field-name?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "aria-tooltip-name",
-        "impact": null,
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag412"
-        ],
-        "description": "Ensures every ARIA tooltip node has an accessible name",
-        "help": "ARIA tooltip nodes must have an accessible name",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/aria-tooltip-name?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "aria-treeitem-name",
-        "impact": null,
-        "tags": [
-          "cat.aria",
-          "best-practice"
-        ],
-        "description": "Ensures every ARIA treeitem node has an accessible name",
-        "help": "ARIA treeitem nodes must have an accessible name",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/aria-treeitem-name?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "definition-list",
-        "impact": null,
-        "tags": [
-          "cat.structure",
-          "wcag2a",
-          "wcag131"
-        ],
-        "description": "Ensures <dl> elements are structured correctly",
-        "help": "<dl> elements must only directly contain properly-ordered <dt> and <dd> groups, <script>, <template> or <div> elements",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/definition-list?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "dlitem",
-        "impact": null,
-        "tags": [
-          "cat.structure",
-          "wcag2a",
-          "wcag131"
-        ],
-        "description": "Ensures <dt> and <dd> elements are contained by a <dl>",
-        "help": "<dt> and <dd> elements must be contained by a <dl>",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/dlitem?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "duplicate-id-active",
-        "impact": null,
-        "tags": [
-          "cat.parsing",
-          "wcag2a",
-          "wcag411"
-        ],
-        "description": "Ensures every id attribute value of active elements is unique",
-        "help": "IDs of active elements must be unique",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/duplicate-id-active?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "frame-title",
-        "impact": null,
-        "tags": [
-          "cat.text-alternatives",
-          "wcag2a",
-          "wcag241",
-          "wcag412",
-          "section508",
-          "section508.22.i"
-        ],
-        "description": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
-        "help": "Frames must have title attribute",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/frame-title?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "html-lang-valid",
-        "impact": null,
-        "tags": [
-          "cat.language",
-          "wcag2a",
-          "wcag311",
-          "ACT"
-        ],
-        "description": "Ensures the lang attribute of the <html> element has a valid value",
-        "help": "<html> element must have a valid value for the lang attribute",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/html-lang-valid?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "input-button-name",
-        "impact": null,
-        "tags": [
-          "cat.name-role-value",
-          "wcag2a",
-          "wcag412",
-          "section508",
-          "section508.22.a"
-        ],
-        "description": "Ensures input buttons have discernible text",
-        "help": "Input buttons must have discernible text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/input-button-name?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "input-image-alt",
-        "impact": null,
-        "tags": [
-          "cat.text-alternatives",
-          "wcag2a",
-          "wcag111",
-          "section508",
-          "section508.22.a",
-          "ACT"
-        ],
-        "description": "Ensures <input type=\"image\"> elements have alternate text",
-        "help": "Image buttons must have alternate text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/input-image-alt?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "list",
-        "impact": null,
-        "tags": [
-          "cat.structure",
-          "wcag2a",
-          "wcag131"
-        ],
-        "description": "Ensures that lists are structured correctly",
-        "help": "<ul> and <ol> must only directly contain <li>, <script> or <template> elements",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/list?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "listitem",
-        "impact": null,
-        "tags": [
-          "cat.structure",
-          "wcag2a",
-          "wcag131"
-        ],
-        "description": "Ensures <li> elements are used semantically",
-        "help": "<li> elements must be contained in a <ul> or <ol>",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/listitem?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "meta-refresh",
-        "impact": null,
-        "tags": [
-          "cat.time-and-media",
-          "wcag2a",
-          "wcag2aaa",
-          "wcag221",
-          "wcag224",
-          "wcag325"
-        ],
-        "description": "Ensures <meta http-equiv=\"refresh\"> is not used",
-        "help": "Timed refresh must not exist",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/meta-refresh?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "role-img-alt",
-        "impact": null,
-        "tags": [
-          "cat.text-alternatives",
-          "wcag2a",
-          "wcag111",
-          "section508",
-          "section508.22.a",
-          "ACT"
-        ],
-        "description": "Ensures [role='img'] elements have alternate text",
-        "help": "[role='img'] elements have an alternative text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/role-img-alt?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "scrollable-region-focusable",
-        "impact": null,
-        "tags": [
-          "cat.keyboard",
-          "wcag2a",
-          "wcag211"
-        ],
-        "description": "Elements that have scrollable content should be accessible by keyboard",
-        "help": "Ensure that scrollable region has keyboard access",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/scrollable-region-focusable?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "select-name",
-        "impact": null,
-        "tags": [
-          "cat.forms",
-          "wcag2a",
-          "wcag412",
-          "wcag131",
-          "section508",
-          "section508.22.n",
-          "ACT"
-        ],
-        "description": "Ensures select element has an accessible name",
-        "help": "Select element must have and accessible name",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/select-name?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "tabindex",
-        "impact": null,
-        "tags": [
-          "cat.keyboard",
-          "best-practice"
-        ],
-        "description": "Ensures tabindex attribute values are not greater than 0",
-        "help": "Elements should not have tabindex greater than zero",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/tabindex?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "td-headers-attr",
-        "impact": null,
-        "tags": [
-          "cat.tables",
-          "wcag2a",
-          "wcag131",
-          "section508",
-          "section508.22.g"
-        ],
-        "description": "Ensure that each cell in a table using the headers refers to another cell in that table",
-        "help": "All cells in a table element that use the headers attribute must only refer to other cells of that same table",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/td-headers-attr?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "th-has-data-cells",
-        "impact": null,
-        "tags": [
-          "cat.tables",
-          "wcag2a",
-          "wcag131",
-          "section508",
-          "section508.22.g"
-        ],
-        "description": "Ensure that each table header in a data table refers to data cells",
-        "help": "All th elements and elements with role=columnheader/rowheader must have data cells they describe",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/th-has-data-cells?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "valid-lang",
-        "impact": null,
-        "tags": [
-          "cat.language",
-          "wcag2aa",
-          "wcag312"
-        ],
-        "description": "Ensures lang attributes have valid values",
-        "help": "lang attribute must have a valid value",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/valid-lang?application=lighthouse",
-        "nodes": []
-      },
-      {
-        "id": "video-caption",
-        "impact": null,
-        "tags": [
-          "cat.text-alternatives",
-          "wcag2a",
-          "wcag122",
-          "section508",
-          "section508.22.a"
-        ],
-        "description": "Ensures <video> elements have captions",
-        "help": "<video> elements must have captions",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/video-caption?application=lighthouse",
-        "nodes": []
-      }
-    ],
     "incomplete": [
       {
         "id": "color-contrast",
@@ -2437,12 +2014,8 @@
           "wcag2aa",
           "wcag143"
         ],
-        "description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds",
-        "help": "Elements must have sufficient color contrast",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/4.1/color-contrast?application=lighthouse",
         "nodes": [
           {
-            "impact": "serious",
             "target": [
               "a[rel=\"noopener\"]"
             ],
@@ -2464,6 +2037,92 @@
             }
           }
         ]
+      }
+    ],
+    "notApplicable": [
+      {
+        "id": "accesskeys"
+      },
+      {
+        "id": "aria-command-name"
+      },
+      {
+        "id": "aria-hidden-focus"
+      },
+      {
+        "id": "aria-input-field-name"
+      },
+      {
+        "id": "aria-meter-name"
+      },
+      {
+        "id": "aria-progressbar-name"
+      },
+      {
+        "id": "aria-roledescription"
+      },
+      {
+        "id": "aria-toggle-field-name"
+      },
+      {
+        "id": "aria-tooltip-name"
+      },
+      {
+        "id": "aria-treeitem-name"
+      },
+      {
+        "id": "definition-list"
+      },
+      {
+        "id": "dlitem"
+      },
+      {
+        "id": "duplicate-id-active"
+      },
+      {
+        "id": "frame-title"
+      },
+      {
+        "id": "html-lang-valid"
+      },
+      {
+        "id": "input-button-name"
+      },
+      {
+        "id": "input-image-alt"
+      },
+      {
+        "id": "list"
+      },
+      {
+        "id": "listitem"
+      },
+      {
+        "id": "meta-refresh"
+      },
+      {
+        "id": "role-img-alt"
+      },
+      {
+        "id": "scrollable-region-focusable"
+      },
+      {
+        "id": "select-name"
+      },
+      {
+        "id": "tabindex"
+      },
+      {
+        "id": "td-headers-attr"
+      },
+      {
+        "id": "th-has-data-cells"
+      },
+      {
+        "id": "valid-lang"
+      },
+      {
+        "id": "video-caption"
       }
     ],
     "version": "4.1.2"


### PR DESCRIPTION
with the recent talk about the `accessibility` gatherer, I thought I would bring out this change which I had in another branch but is probably worth it on its own. This gatherer was written in ancient times so does some odd things, and it returns a bunch more stuff than [we have in `artifacts.d.ts`](https://github.com/GoogleChrome/lighthouse/blob/86a5f08a2d2ab08d40e3243ac32b68f39d77bfac/types/artifacts.d.ts#L159-L182), which means it's not usable by audits and so is wasted. `axe-core` also ships with types now, so we should use them :)

The goal is that it should be easier to follow and clearer where every part of the artifact comes from. No smoke test changes.

Can update after #12075 lands.