### PR TITLE
misc(git3po): merge when green for unstable state too

### DIFF
--- a/lighthouse-core/scripts/git3po-rules/land-when-green.yaml
+++ b/lighthouse-core/scripts/git3po-rules/land-when-green.yaml
@@ -5,7 +5,10 @@ filters:
     criteria:
       state: open
       mergeable: true
-      mergeableState: clean
+      mergeableState:
+        $or:
+          - clean
+          - unstable
   - type: label
     label: land-when-ci-is-green
 actions:


### PR DESCRIPTION
Unstable means all required checks passed, but some un required checks failed. For us, that means code cov (not required) can prevent our `land-when-green` label from working.

Only thing documenting `unstable` I could find: https://github.com/octokit/octokit.net/issues/1763