### PR TITLE
misc(ci): increase fetch-depth for codecov SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
     steps:
     - name: git clone
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
 
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
@@ -120,7 +122,6 @@ jobs:
       with:
         flags: unit
         file: ./unit-coverage.lcov
-        override_commit: $GITHUB_SHA
 
     # For windows, just test the potentially platform-specific code.
     - name: yarn unit-cli
@@ -151,6 +152,8 @@ jobs:
     steps:
     - name: git clone
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
 
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
@@ -179,7 +182,6 @@ jobs:
       with:
         flags: smoke
         file: ./smoke-coverage.lcov
-        override_commit: $GITHUB_SHA
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
       with:
         flags: unit
         file: ./unit-coverage.lcov
+        override_commit: $GITHUB_SHA
 
     # For windows, just test the potentially platform-specific code.
     - name: yarn unit-cli
@@ -178,6 +179,7 @@ jobs:
       with:
         flags: smoke
         file: ./smoke-coverage.lcov
+        override_commit: $GITHUB_SHA
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code


### PR DESCRIPTION
Possible fix for [codecov issues](https://github.com/GoogleChrome/lighthouse/pull/12076/checks?check_run_id=1875137032#step:11:24). It seems to have some problem with the checkout `fetch-depth`, but `100` seems to fit what it's asking for and https://github.com/codecov/codecov-action/issues/190 has been closed for over a month now.

No reason it needs to go rooting around though, we already know the commit hash.

<details>

<summary>codecov issue screenshot</summary>

![image](https://user-images.githubusercontent.com/39191/107581694-508f1280-6bad-11eb-9f29-e27e5aa33221.png)

</details>
