### PR TITLE
core(fr): add navigation phase + trace gatherer

### DIFF
--- a/lighthouse-core/fraggle-rock/config/default-config.js
+++ b/lighthouse-core/fraggle-rock/config/default-config.js
@@ -12,6 +12,7 @@ const defaultConfig = {
   artifacts: [
     // Artifacts which can be depended on come first.
     {id: 'DevtoolsLog', gatherer: 'devtools-log'},
+    {id: 'Trace', gatherer: 'trace'},
 
     /* eslint-disable max-len */
     {id: 'Accessibility', gatherer: 'accessibility'},
@@ -34,6 +35,7 @@ const defaultConfig = {
 
     // Artifact copies are renamed for compatibility with legacy artifacts.
     {id: 'devtoolsLogs', gatherer: 'devtools-log-compat'},
+    {id: 'traces', gatherer: 'trace-compat'},
   ],
   navigations: [
     {
@@ -41,6 +43,7 @@ const defaultConfig = {
       artifacts: [
         // Artifacts which can be depended on come first.
         'DevtoolsLog',
+        'Trace',
 
         'Accessibility',
         'Appcache',
@@ -61,6 +64,7 @@ const defaultConfig = {
 
         // Compat artifacts come last.
         'devtoolsLogs',
+        'traces',
       ],
     },
   ],

--- a/lighthouse-core/fraggle-rock/config/validation.js
+++ b/lighthouse-core/fraggle-rock/config/validation.js
@@ -17,7 +17,9 @@ function isFRGathererDefn(gathererDefn) {
  * Determines if the artifact dependency direction is valid.
  * A timespan artifact cannot depend on a snapshot/navigation artifact because snapshot runs after timespan.
  * A snapshot artifact cannot depend on a navigation artifact because it might be run without a navigation.
- * In other words, the dependency's minimum supported mode must be less than or equal to the dependent's.
+ * A navigation artifact also cannot depend on a snapshot artifact because it is collected before snapshot.
+ * In other words, the dependency's minimum supported mode must be less than or equal to the dependent's with
+ * a special exclusion for navigation dependents.
  *
  * @param {LH.Config.FRGathererDefn} dependent The artifact that depends on the other.
  * @param {LH.Config.FRGathererDefn} dependency The artifact that is being depended on by the other.
@@ -27,6 +29,8 @@ function isValidArtifactDependency(dependent, dependency) {
   const levels = {timespan: 0, snapshot: 1, navigation: 2};
   const dependentLevel = Math.min(...dependent.instance.meta.supportedModes.map(l => levels[l]));
   const dependencyLevel = Math.min(...dependency.instance.meta.supportedModes.map(l => levels[l]));
+  // Special case navigation.
+  if (dependentLevel === levels.navigation) return dependencyLevel !== levels.snapshot;
   return dependencyLevel <= dependentLevel;
 }
 
@@ -76,7 +80,7 @@ function throwInvalidArtifactDependency(artifactId, dependencyKey) {
   throw new Error(
     [
       `Dependency "${dependencyKey}" for "${artifactId}" artifact is invalid.`,
-      `A timespan artifact cannot depend on a snapshot artifact.`,
+      `The dependency must be collected before the dependent.`,
     ].join('\n')
   );
 }

--- a/lighthouse-core/fraggle-rock/gather/base-gatherer.js
+++ b/lighthouse-core/fraggle-rock/gather/base-gatherer.js
@@ -20,11 +20,11 @@ class FRGatherer {
   meta = {supportedModes: []}
 
   /**
-   * Method to gather results about a page in a particular state.
+   * Method to start observing a page before a navigation.
    * @param {LH.Gatherer.FRTransitionalContext} passContext
-   * @return {LH.Gatherer.PhaseResult}
+   * @return {Promise<void>|void}
    */
-  snapshot(passContext) { }
+  beforeNavigation(passContext) { }
 
   /**
    * Method to start observing a page for an arbitrary period of time.
@@ -39,6 +39,20 @@ class FRGatherer {
    * @return {LH.Gatherer.PhaseResult}
    */
   afterTimespan(passContext) { }
+
+  /**
+   * Method to end observing a page after a navigation and return the results.
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   * @return {LH.Gatherer.PhaseResult}
+   */
+  afterNavigation(passContext) { }
+
+  /**
+   * Method to gather results about a page in a particular state.
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   * @return {LH.Gatherer.PhaseResult}
+   */
+  snapshot(passContext) { }
 
   /**
    * Legacy property used to define the artifact ID. In Fraggle Rock, the artifact ID lives on the config.

--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -76,6 +76,11 @@ const phaseToPriorPhase = {
 };
 
 /**
+ * Runs the gatherer methods for a particular navigation phase (beforeTimespan/afterNavigation/etc).
+ * All gatherer method return values are stored on the artifact state object, organized by phase.
+ * This method collects required dependencies, runs the applicable gatherer methods, and saves the
+ * result on the artifact state object that was passed as part of `options`.
+ *
  * @param {CollectPhaseArtifactOptions} options
  */
 async function _collectPhaseArtifacts({navigationContext, artifacts, phase}) {

--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -22,6 +22,15 @@ const {getBaseArtifacts} = require('./base-artifacts.js');
 /** @typedef {Record<string, Promise<any>>} IntermediateArtifacts */
 
 /**
+ * @typedef CollectPhaseArtifactOptions
+ * @property {NavigationContext} navigationContext
+ * @property {ArtifactState} artifacts
+ * @property {keyof Omit<LH.Gatherer.FRGathererInstance, 'name'|'meta'>} phase
+ */
+
+/** @typedef {Record<CollectPhaseArtifactOptions['phase'], IntermediateArtifacts>} ArtifactState */
+
+/**
  * @param {{driver: Driver, config: LH.Config.FRConfig, requestedUrl: string}} args
  */
 async function _setup({driver, config, requestedUrl}) {
@@ -47,24 +56,54 @@ async function _setupNavigation({driver, navigation}) {
   // TODO(FR-COMPAT): setup network conditions (throttling & cache state)
 }
 
+/** @type {Set<CollectPhaseArtifactOptions['phase']>} */
+const phasesRequiringDependencies = new Set(['afterTimespan', 'afterNavigation', 'snapshot']);
+/** @type {Record<CollectPhaseArtifactOptions['phase'], LH.Gatherer.GatherMode>} */
+const phaseToGatherMode = {
+  beforeNavigation: 'navigation',
+  beforeTimespan: 'timespan',
+  afterTimespan: 'timespan',
+  afterNavigation: 'navigation',
+  snapshot: 'snapshot',
+};
+/** @type {Record<CollectPhaseArtifactOptions['phase'], CollectPhaseArtifactOptions['phase'] | undefined>} */
+const phaseToPriorPhase = {
+  beforeNavigation: undefined,
+  beforeTimespan: undefined,
+  afterTimespan: 'beforeTimespan',
+  afterNavigation: 'beforeNavigation',
+  snapshot: undefined,
+};
+
 /**
- * @param {NavigationContext} navigationContext
- * @param {IntermediateArtifacts} artifacts
+ * @param {CollectPhaseArtifactOptions} options
  */
-async function _beforeTimespanPhase(navigationContext, artifacts) {
+async function _collectPhaseArtifacts({navigationContext, artifacts, phase}) {
+  const gatherMode = phaseToGatherMode[phase];
+  const priorPhase = phaseToPriorPhase[phase];
+  const priorPhaseArtifacts = (priorPhase && artifacts[priorPhase]) || {};
+
   for (const artifactDefn of navigationContext.navigation.artifacts) {
     const gatherer = artifactDefn.gatherer.instance;
-    if (!gatherer.meta.supportedModes.includes('timespan')) continue;
+    if (!gatherer.meta.supportedModes.includes(gatherMode)) continue;
 
-    const artifactPromise = Promise.resolve().then(() =>
-      gatherer.beforeTimespan({
+    const priorArtifactPromise = priorPhaseArtifacts[artifactDefn.id] || Promise.resolve();
+    const artifactPromise = priorArtifactPromise.then(async () => {
+      const dependencies = phasesRequiringDependencies.has(phase)
+        ? await collectArtifactDependencies(artifactDefn, await _mergeArtifacts(artifacts))
+        : {};
+
+      return gatherer[phase]({
         driver: navigationContext.driver,
         gatherMode: 'navigation',
-        dependencies: {},
-      })
-    );
-    artifacts[artifactDefn.id] = artifactPromise;
-    await artifactPromise.catch(() => {});
+        dependencies,
+      });
+    });
+
+    // Do not set the artifact promise if the result was `undefined`.
+    const result = await artifactPromise.catch(err => err);
+    if (result === undefined) continue;
+    artifacts[phase][artifactDefn.id] = artifactPromise;
   }
 }
 
@@ -81,57 +120,32 @@ async function _navigate(navigationContext) {
 }
 
 /**
- * @param {NavigationContext} navigationContext
- * @param {IntermediateArtifacts} artifacts
- */
-async function _afterTimespanPhase(navigationContext, artifacts) {
-  for (const artifactDefn of navigationContext.navigation.artifacts) {
-    const gatherer = artifactDefn.gatherer.instance;
-    if (!gatherer.meta.supportedModes.includes('timespan')) continue;
-
-    const artifactPromise = (artifacts[artifactDefn.id] || Promise.resolve()).then(async () =>
-      gatherer.afterTimespan({
-        driver: navigationContext.driver,
-        gatherMode: 'navigation',
-        dependencies: await collectArtifactDependencies(artifactDefn, artifacts),
-      })
-    );
-    artifacts[artifactDefn.id] = artifactPromise;
-    await artifactPromise.catch(() => {});
-  }
-}
-
-/**
- * @param {NavigationContext} navigationContext
- * @param {IntermediateArtifacts} artifacts
- */
-async function _snapshotPhase(navigationContext, artifacts) {
-  for (const artifactDefn of navigationContext.navigation.artifacts) {
-    const gatherer = artifactDefn.gatherer.instance;
-    if (!gatherer.meta.supportedModes.includes('snapshot')) continue;
-
-    const artifactPromise = Promise.resolve().then(async () =>
-      gatherer.snapshot({
-        driver: navigationContext.driver,
-        gatherMode: 'navigation',
-        dependencies: await collectArtifactDependencies(artifactDefn, artifacts),
-      })
-    );
-    artifacts[artifactDefn.id] = artifactPromise;
-    await artifactPromise.catch(() => {});
-  }
-}
-
-/**
- * @param {IntermediateArtifacts} timespanArtifacts
- * @param {IntermediateArtifacts} snapshotArtifacts
+ * Merges artifact in Lighthouse order of specificity.
+ * If a gatherer method returns `undefined`, the artifact is skipped for that phase (treated as not set).
+ *
+ *  - Navigation artifacts are the most specific. These win over anything.
+ *  - Snapshot artifacts win out next as they have access to all available information.
+ *  - Timespan artifacts win when nothing else is defined.
+ *
+ * @param {ArtifactState} artifactState
  * @return {Promise<Partial<LH.GathererArtifacts>>}
  */
-async function _mergeArtifacts(timespanArtifacts, snapshotArtifacts) {
+async function _mergeArtifacts(artifactState) {
   /** @type {IntermediateArtifacts} */
   const artifacts = {};
-  for (const [id, promise] of Object.entries({...timespanArtifacts, ...snapshotArtifacts})) {
-    artifacts[id] = await promise.catch(err => err);
+
+  const artifactResultsInIncreasingPriority = [
+    artifactState.afterTimespan,
+    artifactState.snapshot,
+    artifactState.afterNavigation,
+  ];
+
+  for (const artifactResults of artifactResultsInIncreasingPriority) {
+    for (const [id, promise] of Object.entries(artifactResults)) {
+      const artifact = await promise.catch(err => err);
+      if (artifact === undefined) continue;
+      artifacts[id] = artifact;
+    }
   }
 
   return artifacts;
@@ -141,18 +155,26 @@ async function _mergeArtifacts(timespanArtifacts, snapshotArtifacts) {
  * @param {NavigationContext} navigationContext
  */
 async function _navigation(navigationContext) {
-  /** @type {IntermediateArtifacts} */
-  const timespanArtifacts = {};
-  /** @type {IntermediateArtifacts} */
-  const snapshotArtifacts = {};
+  /** @type {ArtifactState} */
+  const artifactState = {
+    beforeNavigation: {},
+    beforeTimespan: {},
+    afterTimespan: {},
+    afterNavigation: {},
+    snapshot: {},
+  };
+
+  const options = {navigationContext, artifacts: artifactState};
 
   await _setupNavigation(navigationContext);
-  await _beforeTimespanPhase(navigationContext, timespanArtifacts);
+  await _collectPhaseArtifacts({phase: 'beforeNavigation', ...options});
+  await _collectPhaseArtifacts({phase: 'beforeTimespan', ...options});
   await _navigate(navigationContext);
-  await _afterTimespanPhase(navigationContext, timespanArtifacts);
-  await _snapshotPhase(navigationContext, snapshotArtifacts);
+  await _collectPhaseArtifacts({phase: 'afterTimespan', ...options});
+  await _collectPhaseArtifacts({phase: 'afterNavigation', ...options});
+  await _collectPhaseArtifacts({phase: 'snapshot', ...options});
 
-  const artifacts = await _mergeArtifacts(timespanArtifacts, snapshotArtifacts);
+  const artifacts = await _mergeArtifacts(artifactState);
   return {artifacts};
 }
 
@@ -214,9 +236,7 @@ module.exports = {
   navigation,
   _setup,
   _setupNavigation,
-  _beforeTimespanPhase,
-  _afterTimespanPhase,
-  _snapshotPhase,
+  _collectPhaseArtifacts,
   _navigate,
   _navigation,
   _navigations,

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -136,6 +136,7 @@ class Driver {
     this.evaluateAsync = this.executionContext.evaluateAsync.bind(this.executionContext);
   }
 
+  /** @deprecated - Not available on Fraggle Rock driver. */
   static get traceCategories() {
     return TraceGatherer.getDefaultTraceCategories();
   }

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -19,6 +19,7 @@ const constants = require('../config/constants.js');
 
 const log = require('lighthouse-logger');
 const DevtoolsLog = require('./devtools-log.js');
+const TraceGatherer = require('./gatherers/trace.js');
 
 const pageFunctions = require('../lib/page-functions.js');
 
@@ -64,9 +65,6 @@ const DEFAULT_PROTOCOL_TIMEOUT = 30000;
  * @implements {LH.Gatherer.FRTransitionalDriver}
  */
 class Driver {
-  /** @private */
-  _traceCategories = Driver.traceCategories;
-
   /**
    * @pri_vate (This should be private, but that makes our tests harder).
    * An event emitter that enforces mapping between Crdp event names and payload types.
@@ -139,43 +137,7 @@ class Driver {
   }
 
   static get traceCategories() {
-    return [
-      // Exclude default categories. We'll be selective to minimize trace size
-      '-*',
-
-      // Used instead of 'toplevel' in Chrome 71+
-      'disabled-by-default-lighthouse',
-
-      // Used for Cumulative Layout Shift metric
-      'loading',
-
-      // All compile/execute events are captured by parent events in devtools.timeline..
-      // But the v8 category provides some nice context for only <0.5% of the trace size
-      'v8',
-      // Same situation here. This category is there for RunMicrotasks only, but with other teams
-      // accidentally excluding microtasks, we don't want to assume a parent event will always exist
-      'v8.execute',
-
-      // For extracting UserTiming marks/measures
-      'blink.user_timing',
-
-      // Not mandatory but not used much
-      'blink.console',
-
-      // Most of the events we need are from these two categories
-      'devtools.timeline',
-      'disabled-by-default-devtools.timeline',
-
-      // Up to 450 (https://goo.gl/rBfhn4) JPGs added to the trace
-      'disabled-by-default-devtools.screenshot',
-
-      // This doesn't add its own events, but adds a `stackTrace` property to devtools.timeline events
-      'disabled-by-default-devtools.timeline.stack',
-
-      // CPU sampling profiler data only enabled for debugging purposes
-      // 'disabled-by-default-v8.cpu_profiler',
-      // 'disabled-by-default-v8.cpu_profiler.hires',
-    ];
+    return TraceGatherer.getDefaultTraceCategories();
   }
 
   /**
@@ -816,15 +778,7 @@ class Driver {
   async beginTrace(settings) {
     const additionalCategories = (settings && settings.additionalTraceCategories &&
         settings.additionalTraceCategories.split(',')) || [];
-    const traceCategories = this._traceCategories.concat(additionalCategories);
-
-    // In Chrome <71, gotta use the chatty 'toplevel' cat instead of our own.
-    // TODO(COMPAT): Once m71 ships to stable, drop this section
-    const milestone = (await this.getBrowserVersion()).milestone;
-    if (milestone < 71) {
-      const toplevelIndex = traceCategories.indexOf('disabled-by-default-lighthouse');
-      traceCategories[toplevelIndex] = 'toplevel';
-    }
+    const traceCategories = TraceGatherer.getDefaultTraceCategories().concat(additionalCategories);
 
     const uniqueCategories = Array.from(new Set(traceCategories));
 
@@ -848,26 +802,7 @@ class Driver {
    * @return {Promise<LH.Trace>}
    */
   endTrace() {
-    /** @type {Array<LH.TraceEvent>} */
-    const traceEvents = [];
-
-    /**
-     * Listener for when dataCollected events fire for each trace chunk
-     * @param {LH.Crdp.Tracing.DataCollectedEvent} data
-     */
-    const dataListener = function(data) {
-      traceEvents.push(...data.value);
-    };
-    this.on('Tracing.dataCollected', dataListener);
-
-    return new Promise((resolve, reject) => {
-      this.once('Tracing.tracingComplete', _ => {
-        this.off('Tracing.dataCollected', dataListener);
-        resolve({traceEvents});
-      });
-
-      this.sendCommand('Tracing.end').catch(reject);
-    });
+    return TraceGatherer.endTraceAndCollectEvents(this.defaultSession);
   }
 
   /**

--- a/lighthouse-core/gather/gatherers/trace-compat.js
+++ b/lighthouse-core/gather/gatherers/trace-compat.js
@@ -1,0 +1,36 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview
+ * This gatherer remaps the result of the Trace gatherer for compatibility with legacy Lighthouse
+ * when devtools logs and traces were special-cased.
+ */
+
+const TraceGatherer = require('./trace.js');
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+
+/** @implements {LH.Gatherer.FRGathererInstance<'Trace'>} */
+class TraceCompat extends FRGatherer {
+  /** @type {LH.Gatherer.GathererMeta<'Trace'>} */
+  meta = {
+    supportedModes: ['navigation'],
+    dependencies: {Trace: TraceGatherer.symbol},
+  };
+
+  /**
+   * @param {LH.Gatherer.FRTransitionalContext<'Trace'>} passContext
+   * @return {Promise<LH.Artifacts['traces']>}
+   */
+  async afterNavigation(passContext) {
+    return {
+      defaultPass: passContext.dependencies.Trace,
+    };
+  }
+}
+
+module.exports = TraceCompat;

--- a/lighthouse-core/gather/gatherers/trace.js
+++ b/lighthouse-core/gather/gatherers/trace.js
@@ -1,0 +1,115 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview
+ * This gatherer collects all network and page devtools protocol traffic during the timespan/navigation.
+ * This protocol log can be used to recreate the network records using lib/network-recorder.js.
+ */
+
+const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
+
+class Trace extends FRGatherer {
+  static getDefaultTraceCategories() {
+    return [
+      // Exclude default categories. We'll be selective to minimize trace size
+      '-*',
+
+      // Used instead of 'toplevel' in Chrome 71+
+      'disabled-by-default-lighthouse',
+
+      // Used for Cumulative Layout Shift metric
+      'loading',
+
+      // All compile/execute events are captured by parent events in devtools.timeline..
+      // But the v8 category provides some nice context for only <0.5% of the trace size
+      'v8',
+      // Same situation here. This category is there for RunMicrotasks only, but with other teams
+      // accidentally excluding microtasks, we don't want to assume a parent event will always exist
+      'v8.execute',
+
+      // For extracting UserTiming marks/measures
+      'blink.user_timing',
+
+      // Not mandatory but not used much
+      'blink.console',
+
+      // Most of the events we need are from these two categories
+      'devtools.timeline',
+      'disabled-by-default-devtools.timeline',
+
+      // Up to 450 (https://goo.gl/rBfhn4) JPGs added to the trace
+      'disabled-by-default-devtools.screenshot',
+
+      // This doesn't add its own events, but adds a `stackTrace` property to devtools.timeline events
+      'disabled-by-default-devtools.timeline.stack',
+
+      // CPU sampling profiler data only enabled for debugging purposes
+      // 'disabled-by-default-v8.cpu_profiler',
+      // 'disabled-by-default-v8.cpu_profiler.hires',
+    ];
+  }
+
+  /**
+   * @param {LH.Gatherer.FRProtocolSession} session
+   * @return {Promise<LH.Trace>}
+   */
+  static async endTraceAndCollectEvents(session) {
+    /** @type {Array<LH.TraceEvent>} */
+    const traceEvents = [];
+
+    /**
+     * Listener for when dataCollected events fire for each trace chunk
+     * @param {LH.Crdp.Tracing.DataCollectedEvent} data
+     */
+    const dataListener = function(data) {
+      traceEvents.push(...data.value);
+    };
+    session.on('Tracing.dataCollected', dataListener);
+
+    return new Promise((resolve, reject) => {
+      session.once('Tracing.tracingComplete', _ => {
+        session.off('Tracing.dataCollected', dataListener);
+        resolve({traceEvents});
+      });
+
+      session.sendCommand('Tracing.end').catch(reject);
+    });
+  }
+
+  static symbol = Symbol('Trace');
+
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    symbol: Trace.symbol,
+    supportedModes: ['timespan', 'navigation'],
+  };
+
+  /**
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   */
+  async beforeTimespan({driver}) {
+    // TODO(FR-COMPAT): read additional trace categories from overall settings?
+    // TODO(FR-COMPAT): check if CSS/DOM domains have been enabled in another session and warn?
+    await driver.defaultSession.sendCommand('Page.enable');
+    await driver.defaultSession.sendCommand('Tracing.start', {
+      categories: Trace.getDefaultTraceCategories().join(','),
+      options: 'sampling-frequency=10000', // 1000 is default and too slow.
+    });
+  }
+
+
+  /**
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   * @return {Promise<LH.Artifacts['Trace']>}
+   */
+  async afterTimespan({driver}) {
+    return Trace.endTraceAndCollectEvents(driver.defaultSession);
+  }
+}
+
+module.exports = Trace;

--- a/lighthouse-core/gather/gatherers/trace.js
+++ b/lighthouse-core/gather/gatherers/trace.js
@@ -102,7 +102,6 @@ class Trace extends FRGatherer {
     });
   }
 
-
   /**
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['Trace']>}

--- a/lighthouse-core/test/fraggle-rock/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/api-test-pptr.js
@@ -165,6 +165,10 @@ describe('Fraggle Rock API', () => {
       const details = lhr.audits['total-byte-weight'].details;
       if (!details || details.type !== 'table') throw new Error('Unexpected byte weight details');
       expect(details.items).toMatchObject([{url: `${serverBaseUrl}/index.html`}]);
+
+      // Check that performance metrics were computed.
+      expect(lhr.audits).toHaveProperty('first-contentful-paint');
+      expect(Number.isFinite(lhr.audits['first-contentful-paint'].numericValue)).toBe(true);
     });
   });
 });

--- a/lighthouse-core/test/fraggle-rock/config/config-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/config-test.js
@@ -230,8 +230,23 @@ describe('Fraggle Rock Config', () => {
         .toThrow(/Failed to find dependency/);
     });
 
-    it('should throw when dependencies are have an invalid phase relationship', () => {
+    it('should throw when timespan needs snapshot', () => {
       dependentGatherer.meta.supportedModes = ['timespan'];
+      dependencyGatherer.meta.supportedModes = ['snapshot'];
+      expect(() => initializeConfig(configJson, {gatherMode: 'navigation'}))
+        .toThrow(/Dependency.*is invalid/);
+    });
+
+    it('should throw when timespan needs navigation', () => {
+      dependentGatherer.meta.supportedModes = ['timespan'];
+      dependencyGatherer.meta.supportedModes = ['navigation'];
+      expect(() => initializeConfig(configJson, {gatherMode: 'navigation'}))
+        .toThrow(/Dependency.*is invalid/);
+    });
+
+    it('should throw when navigation needs snapshot', () => {
+      dependentGatherer.meta.supportedModes = ['navigation'];
+      dependencyGatherer.meta.supportedModes = ['snapshot'];
       expect(() => initializeConfig(configJson, {gatherMode: 'navigation'}))
         .toThrow(/Dependency.*is invalid/);
     });

--- a/lighthouse-core/test/fraggle-rock/config/validation-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/validation-test.js
@@ -34,7 +34,7 @@ describe('Fraggle Rock Config Validation', () => {
       {dependent: ['snapshot'], dependency: ['snapshot'], isValid: true},
       {dependent: ['snapshot'], dependency: ['navigation'], isValid: false},
       {dependent: ['navigation'], dependency: ['timespan'], isValid: true},
-      {dependent: ['navigation'], dependency: ['snapshot'], isValid: true},
+      {dependent: ['navigation'], dependency: ['snapshot'], isValid: false},
       {dependent: ['navigation'], dependency: ['navigation'], isValid: true},
     ];
 

--- a/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
@@ -12,7 +12,7 @@ const {defaultNavigationConfig} = require('../../../config/constants.js');
 
 /* eslint-env jest */
 
-/** @typedef {{snapshot: jest.Mock<any, any>, beforeTimespan:jest.Mock<any, any>, afterTimespan: jest.Mock<any, any>}} MockGatherer */
+/** @typedef {{meta: LH.Gatherer.GathererMeta<'Accessibility'>, snapshot: jest.Mock<any, any>, beforeTimespan:jest.Mock<any, any>, afterTimespan: jest.Mock<any, any>, beforeNavigation:jest.Mock<any, any>, afterNavigation: jest.Mock<any, any>}} MockGatherer */
 
 describe('NavigationRunner', () => {
   let requestedUrl = '';
@@ -33,12 +33,14 @@ describe('NavigationRunner', () => {
         meta: {supportedModes: []},
         beforeTimespan: jest.fn(),
         afterTimespan: jest.fn(),
+        beforeNavigation: jest.fn(),
+        afterNavigation: jest.fn(),
         snapshot: jest.fn(),
       },
     };
   }
 
-  /** @return {{navigation: LH.Config.NavigationDefn, gatherers: {timespan: MockGatherer, snapshot: MockGatherer}}} */
+  /** @return {{navigation: LH.Config.NavigationDefn, gatherers: {timespan: MockGatherer, snapshot: MockGatherer, navigation: MockGatherer}}} */
   function createNavigation() {
     const timespanGatherer = createGathererDefn();
     timespanGatherer.instance.meta.supportedModes = ['timespan', 'navigation'];
@@ -46,12 +48,16 @@ describe('NavigationRunner', () => {
     const snapshotGatherer = createGathererDefn();
     snapshotGatherer.instance.meta.supportedModes = ['snapshot', 'navigation'];
     snapshotGatherer.instance.snapshot = jest.fn().mockResolvedValue({type: 'snapshot'});
+    const navigationGatherer = createGathererDefn();
+    navigationGatherer.instance.meta.supportedModes = ['navigation'];
+    navigationGatherer.instance.afterNavigation = jest.fn().mockResolvedValue({type: 'navigation'});
 
     const navigation = {
       ...defaultNavigationConfig,
       artifacts: [
         {id: 'Timespan', gatherer: timespanGatherer},
         {id: 'Snapshot', gatherer: snapshotGatherer},
+        {id: 'Navigation', gatherer: navigationGatherer},
       ],
     };
 
@@ -60,6 +66,7 @@ describe('NavigationRunner', () => {
       gatherers: {
         timespan: /** @type {any} */ (timespanGatherer.instance),
         snapshot: /** @type {any} */ (snapshotGatherer.instance),
+        navigation: /** @type {any} */ (navigationGatherer.instance),
       },
     };
   }
@@ -143,10 +150,76 @@ describe('NavigationRunner', () => {
       expect(mockDriver._page.goto).toHaveBeenCalled();
     });
 
-    it('collects both timespan and snapshot artifacts', async () => {
+    it('collects timespan, snapshot, and navigation artifacts', async () => {
       const {artifacts} = await runner._navigation({driver, navigation, requestedUrl});
       expect(artifacts).toEqual({
+        Navigation: {type: 'navigation'},
         Timespan: {type: 'timespan'},
+        Snapshot: {type: 'snapshot'},
+      });
+    });
+
+    it('supports dependencies between phases', async () => {
+      const {navigation, gatherers} = createNavigation();
+      navigation.artifacts[1].dependencies = {Accessibility: {id: 'Timespan'}};
+      navigation.artifacts[2].dependencies = {Accessibility: {id: 'Timespan'}};
+
+      const {artifacts} = await runner._navigation({driver, navigation, requestedUrl});
+      expect(artifacts).toEqual({
+        Navigation: {type: 'navigation'},
+        Timespan: {type: 'timespan'},
+        Snapshot: {type: 'snapshot'},
+      });
+
+      expect(gatherers.navigation.afterNavigation).toHaveBeenCalled();
+      const navigationArgs = gatherers.navigation.afterNavigation.mock.calls[0];
+      expect(navigationArgs[0].dependencies).toEqual({Accessibility: {type: 'timespan'}});
+
+      expect(gatherers.snapshot.snapshot).toHaveBeenCalled();
+      const snapshotArgs = gatherers.snapshot.snapshot.mock.calls[0];
+      expect(snapshotArgs[0].dependencies).toEqual({Accessibility: {type: 'timespan'}});
+    });
+
+    it('passes through an error in dependencies', async () => {
+      const {navigation} = createNavigation();
+      const err = new Error('Error in dependency chain');
+      navigation.artifacts[0].gatherer.instance.beforeTimespan = jest.fn().mockRejectedValue(err);
+      navigation.artifacts[1].dependencies = {Accessibility: {id: 'Timespan'}};
+      navigation.artifacts[2].dependencies = {Accessibility: {id: 'Timespan'}};
+
+      const {artifacts} = await runner._navigation({driver, navigation, requestedUrl});
+
+      expect(artifacts).toEqual({
+        Navigation: expect.any(Error),
+        Timespan: err,
+        Snapshot: expect.any(Error),
+      });
+    });
+
+    it('passes through an error in beforeNavigation', async () => {
+      const {navigation, gatherers} = createNavigation();
+      const err = new Error('Error in beforeNavigation');
+      gatherers.navigation.beforeNavigation.mockRejectedValue(err);
+
+      const {artifacts} = await runner._navigation({driver, navigation, requestedUrl});
+
+      expect(artifacts).toEqual({
+        Navigation: err,
+        Timespan: {type: 'timespan'},
+        Snapshot: {type: 'snapshot'},
+      });
+    });
+
+    it('passes through an error in beforeTimespan', async () => {
+      const {navigation, gatherers} = createNavigation();
+      const err = new Error('Error in beforeTimespan');
+      gatherers.timespan.beforeTimespan.mockRejectedValue(err);
+
+      const {artifacts} = await runner._navigation({driver, navigation, requestedUrl});
+
+      expect(artifacts).toEqual({
+        Navigation: {type: 'navigation'},
+        Timespan: err,
         Snapshot: {type: 'snapshot'},
       });
     });
@@ -164,23 +237,6 @@ describe('NavigationRunner', () => {
     it.todo('should skip clear cache when requested');
   });
 
-  describe('_beforeTimespanPhase', () => {
-    /** @type {Record<string, Promise<any>>} */
-    let artifacts;
-
-    beforeEach(() => {
-      artifacts = {};
-    });
-
-    it('should run the beforeTimespan phase of timespan gatherers', async () => {
-      const {navigation, gatherers} = createNavigation();
-      await runner._beforeTimespanPhase({driver, navigation, requestedUrl}, artifacts);
-      expect(artifacts).toEqual({Timespan: expect.any(Promise)});
-      expect(gatherers.timespan.beforeTimespan).toHaveBeenCalled();
-      expect(gatherers.snapshot.beforeTimespan).not.toHaveBeenCalled();
-    });
-  });
-
   describe('_navigate', () => {
     it('should navigate the page', async () => {
       await runner._navigate({driver, navigation, requestedUrl});
@@ -192,90 +248,67 @@ describe('NavigationRunner', () => {
     it.todo('should capture page load errors');
   });
 
-  describe('_afterTimespanPhase', () => {
-    /** @type {Record<string, Promise<any>>} */
+  describe('_collectPhaseArtifacts', () => {
+    /** @type {import('../../../fraggle-rock/gather/navigation-runner').ArtifactState} */
     let artifacts;
 
     beforeEach(() => {
-      artifacts = {};
-    });
-
-    it('should run the afterTimespan phase of timespan gatherers', async () => {
-      const {navigation, gatherers} = createNavigation();
-      await runner._afterTimespanPhase({driver, navigation, requestedUrl}, artifacts);
-      expect(artifacts).toEqual({Timespan: expect.any(Promise)});
-      expect(await artifacts.Timespan).toEqual({type: 'timespan'});
-      expect(gatherers.timespan.afterTimespan).toHaveBeenCalled();
-      expect(gatherers.snapshot.afterTimespan).not.toHaveBeenCalled();
-    });
-
-    it('should pass dependencies to gatherers', async () => {
       artifacts = {
-        Dependency: Promise.resolve([{src: 'https://example.com/image.jpg'}]),
+        beforeNavigation: {},
+        beforeTimespan: {},
+        afterTimespan: {},
+        afterNavigation: {},
+        snapshot: {},
       };
-
-      const {navigation, gatherers} = createNavigation();
-      navigation.artifacts = [
-        {...navigation.artifacts[0], dependencies: {ImageElements: {id: 'Dependency'}}},
-        navigation.artifacts[1],
-      ];
-
-      await runner._afterTimespanPhase({driver, navigation, requestedUrl}, artifacts);
-      expect(artifacts).toEqual({
-        Dependency: expect.any(Promise),
-        Timespan: expect.any(Promise),
-      });
-      expect(gatherers.timespan.afterTimespan).toHaveBeenCalled();
-
-      const receivedDependencies = gatherers.timespan.afterTimespan.mock.calls[0][0].dependencies;
-      expect(receivedDependencies).toEqual({
-        ImageElements: [{src: 'https://example.com/image.jpg'}],
-      });
     });
 
-    it('should combine the previous promises', async () => {
-      artifacts = {Timespan: Promise.reject(new Error('beforeTimespan rejection'))};
-
+    it('should run the navigation phase of navigation gatherers', async () => {
       const {navigation, gatherers} = createNavigation();
-      await runner._afterTimespanPhase({driver, navigation, requestedUrl}, artifacts);
-      expect(artifacts).toEqual({Timespan: expect.any(Promise)});
-      await expect(artifacts.Timespan).rejects.toMatchObject({message: 'beforeTimespan rejection'});
-      expect(gatherers.timespan.afterTimespan).not.toHaveBeenCalled();
-      expect(gatherers.snapshot.afterTimespan).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('_snapshotPhase', () => {
-    /** @type {Record<string, Promise<any>>} */
-    let artifacts;
-
-    beforeEach(() => {
-      artifacts = {};
+      const navigationContext = {driver, navigation, requestedUrl};
+      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'afterNavigation'});
+      expect(artifacts.afterNavigation).toEqual({Navigation: expect.any(Promise)});
+      expect(await artifacts.afterNavigation.Navigation).toEqual({type: 'navigation'});
+      expect(gatherers.navigation.afterNavigation).toHaveBeenCalled();
+      // They were invoked but no artifact was produced.
+      expect(gatherers.timespan.afterNavigation).toHaveBeenCalled();
+      expect(gatherers.snapshot.afterNavigation).toHaveBeenCalled();
     });
 
     it('should run the snapshot phase of snapshot gatherers', async () => {
       const {navigation, gatherers} = createNavigation();
-      await runner._snapshotPhase({driver, navigation, requestedUrl}, artifacts);
-      expect(artifacts).toEqual({Snapshot: expect.any(Promise)});
-      expect(await artifacts.Snapshot).toEqual({type: 'snapshot'});
-      expect(gatherers.timespan.snapshot).not.toHaveBeenCalled();
+      const navigationContext = {driver, navigation, requestedUrl};
+      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'snapshot'});
+      expect(artifacts.snapshot).toEqual({Snapshot: expect.any(Promise)});
+      expect(await artifacts.snapshot.Snapshot).toEqual({type: 'snapshot'});
       expect(gatherers.snapshot.snapshot).toHaveBeenCalled();
+      expect(gatherers.navigation.snapshot).not.toHaveBeenCalled();
+      expect(gatherers.timespan.snapshot).not.toHaveBeenCalled();
     });
 
-    it('should pass dependencies to gatherers', async () => {
-      artifacts = {
+    it('should run the timespan phase of timespan gatherers', async () => {
+      const {navigation, gatherers} = createNavigation();
+      const navigationContext = {driver, navigation, requestedUrl};
+      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'afterTimespan'});
+      expect(artifacts.afterTimespan).toEqual({Timespan: expect.any(Promise)});
+      expect(await artifacts.afterTimespan.Timespan).toEqual({type: 'timespan'});
+      expect(gatherers.timespan.afterTimespan).toHaveBeenCalled();
+      expect(gatherers.snapshot.afterTimespan).not.toHaveBeenCalled();
+      expect(gatherers.navigation.afterTimespan).not.toHaveBeenCalled();
+    });
+
+    it('should pass dependencies from prior phase to gatherers', async () => {
+      artifacts.afterTimespan = {
         Dependency: Promise.resolve([{src: 'https://example.com/image.jpg'}]),
       };
 
       const {navigation, gatherers} = createNavigation();
       navigation.artifacts = [
-        navigation.artifacts[0],
         {...navigation.artifacts[1], dependencies: {ImageElements: {id: 'Dependency'}}},
       ];
 
-      await runner._snapshotPhase({driver, navigation, requestedUrl}, artifacts);
-      expect(artifacts).toEqual({
-        Dependency: expect.any(Promise),
+      const navigationContext = {driver, navigation, requestedUrl};
+      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'snapshot'});
+      expect(artifacts.snapshot).toEqual({
         Snapshot: expect.any(Promise),
       });
       expect(gatherers.snapshot.snapshot).toHaveBeenCalled();
@@ -284,6 +317,47 @@ describe('NavigationRunner', () => {
       expect(receivedDependencies).toEqual({
         ImageElements: [{src: 'https://example.com/image.jpg'}],
       });
+    });
+
+    it('should pass dependencies within same phase to gatherers', async () => {
+      const {navigation, gatherers} = createNavigation();
+      const gatherer = navigation.artifacts[1].gatherer;
+      navigation.artifacts = [
+        {id: 'Dependency', gatherer},
+        {id: 'Snapshot', gatherer, dependencies: {ImageElements: {id: 'Dependency'}}},
+      ];
+
+      const navigationContext = {driver, navigation, requestedUrl};
+      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'snapshot'});
+      expect(artifacts.snapshot).toEqual({
+        Dependency: expect.any(Promise),
+        Snapshot: expect.any(Promise),
+      });
+
+      // Ensure neither threw an exception
+      await artifacts.snapshot.Dependency;
+      await artifacts.snapshot.Snapshot;
+
+      expect(gatherers.snapshot.snapshot).toHaveBeenCalledTimes(2);
+
+      const receivedDependencies = gatherers.snapshot.snapshot.mock.calls[1][0].dependencies;
+      expect(receivedDependencies).toEqual({
+        ImageElements: {type: 'snapshot'},
+      });
+    });
+
+    it('should combine the previous promises', async () => {
+      artifacts.beforeTimespan = {Timespan: Promise.reject(new Error('beforeTimespan rejection'))};
+
+      const {navigation, gatherers} = createNavigation();
+      const navigationContext = {driver, navigation, requestedUrl};
+      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'afterTimespan'});
+      expect(artifacts.afterTimespan).toEqual({Timespan: expect.any(Promise)});
+      await expect(artifacts.afterTimespan.Timespan).rejects.toMatchObject({
+        message: 'beforeTimespan rejection',
+      });
+      expect(gatherers.timespan.afterTimespan).not.toHaveBeenCalled();
+      expect(gatherers.snapshot.afterTimespan).not.toHaveBeenCalled();
     });
   });
 });

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -201,20 +201,6 @@ describe('.beginTrace', () => {
     // Make sure it deduplicates categories too
     expect(tracingStartArgs.categories).not.toMatch(/loading.*loading/);
   });
-
-  it('will adjust traceCategories based on chrome version', async () => {
-    connectionStub.sendCommand = createMockSendCommandFn()
-      .mockResponse('Browser.getVersion', {product: 'Chrome/70.0.3577.0'})
-      .mockResponse('Page.enable')
-      .mockResponse('Tracing.start');
-
-    await driver.beginTrace();
-
-    const tracingStartArgs = connectionStub.sendCommand.findInvocation('Tracing.start');
-    // COMPAT: m70 doesn't have disabled-by-default-lighthouse, so 'toplevel' is used instead.
-    expect(tracingStartArgs.categories).toContain('toplevel');
-    expect(tracingStartArgs.categories).not.toContain('disabled-by-default-lighthouse');
-  });
 });
 
 describe('.setExtraHTTPHeaders', () => {

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -57,7 +57,6 @@ Gathering setup: InspectorIssues
 Gathering setup: SourceMaps
 Gathering setup: FullPageScreenshot
 Beginning devtoolsLog and trace
-Getting browser version
 Loading page & waiting for onload
 Running pass methods
 Gathering in-page: CSSUsage

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -140,6 +140,8 @@ declare global {
       TagsBlockingFirstPaint: Artifacts.TagBlockingFirstPaint[];
       /** Information about tap targets including their position and size. */
       TapTargets: Artifacts.TapTarget[];
+      /** The primary log of devtools protocol activity. Used in Fraggle Rock gathering. */
+      Trace: LH.Trace;
       /** Elements associated with metrics (ie: Largest Contentful Paint element). */
       TraceElements: Artifacts.TraceElement[];
     }

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -100,9 +100,11 @@ declare global {
     export interface FRGathererInstance<TDependencies extends DependencyKey = DefaultDependenciesKey> {
       name: keyof LH.GathererArtifacts; // temporary COMPAT measure until artifact config support is available
       meta: GathererMeta<TDependencies>;
-      snapshot(context: FRTransitionalContext<TDependencies>): PhaseResult;
+      beforeNavigation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
       beforeTimespan(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
       afterTimespan(context: FRTransitionalContext<TDependencies>): PhaseResult;
+      afterNavigation(context: FRTransitionalContext<TDependencies>): PhaseResult;
+      snapshot(context: FRTransitionalContext<TDependencies>): PhaseResult;
     }
 
     namespace Simulation {


### PR DESCRIPTION
**Summary**
The primary goal of this PR is to add the trace gatherer and support performance metrics in Fraggle Rock navigation mode (as well as pave the way for upgrades to support timespan metrics). That change is pretty small, but this triggered a number of other changes.

- Add new `beforeNavigation`/`afterNavigation` methods to distinguish this new category of "navigation-only" gatherers.
- Adjust config validation rules to disallow navigation gatherers from depending on snapshot artifacts.
- Refactor navigation runner to reduce duplication in collection of artifacts of each phase (there are now 5 instead of just 3)
- Refactor default trace categories list to new gatherer, import from legacy driver.
- Add more test coverage for these refactored areas.


**Primary Point of Discussion**

This PR sets the new execution sequence to the following phase order. 

- beforeNavigation
- beforeTimespan
- afterTimespan
- afterNavigation
- snapshot

The primary question IMO is when exactly `beforeNavigation` and `afterNavigation` should take place.

There is an argument for moving `afterNavigation` to happen *after* `snapshot` so it can depend on snapshot artifacts, but that means any timespan style recording would include all of the snapshot gatherer work which seems undesirable. I've kept it before `snapshot` and if anything truly needs the `snapshot` dependency we can think of something like `afterSnapshot` to fill that gap in the future.

**Implications for Gatherer Authoring**

There are 5 potential phases, and this is where that array of supported modes starts enter the territory that concerned me. Really we only have 3 types of valid gatherers. Timespan, Snapshot, or Navigation. We can enforce that fact in config validation if we like. The gatherer of each type should *only* truly implement the set of methods that are related to it *but* all the methods of the supported modes will be invoked. 

Example: A timespan gatherer says it works for both timespans and navigations, but it only implements `beforeTimespan` and `afterTimespan`, leaving the rest as noops. When run in navigation mode, `beforeNavigation` and `afterNavigation` will still be executed.

**Related Issues/PRs**
ref #11313 
