### PR TITLE
misc(ci): update GH actions commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         node-version: 12.x
 
     - name: Set up protoc
-      uses: arduino/setup-protoc@64c0c85
+      uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3
       with:
         version: '3.7.1'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - name: Upload test coverage to Codecov
       if: matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@6004246
+      uses: codecov/codecov-action@6004246f47ab62d32be025ce173b241cd84ac58e
       with:
         flags: unit
         file: ./unit-coverage.lcov
@@ -178,7 +178,7 @@ jobs:
 
     - name: Upload test coverage to Codecov
       if: matrix.chrome-channel == 'ToT'
-      uses: codecov/codecov-action@6004246
+      uses: codecov/codecov-action@6004246f47ab62d32be025ce173b241cd84ac58e
       with:
         flags: smoke
         file: ./smoke-coverage.lcov

--- a/.github/workflows/issue-assigner.yml
+++ b/.github/workflows/issue-assigner.yml
@@ -6,7 +6,7 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
-      - uses: patrickhulce/issue-assigner@eeec7a1
+      - uses: patrickhulce/issue-assigner@eeec7a10bd3c02f02d2284fc82a8adabdc001869
         with:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           maintainers: 'patrickhulce,paulirish,connorjclark,adamraine,brendankenny'


### PR DESCRIPTION
seems like github actions stopped supporting the short shas 😞 https://github.com/GoogleChrome/lighthouse/runs/1920862528#step:1:26


![image](https://user-images.githubusercontent.com/2301202/108271841-0969ca00-7137-11eb-9311-a981254a016f.png)
