### PR TITLE
clients(lr): should skip uses-http2 audit for mobile

### DIFF
--- a/lighthouse-core/config/lr-mobile-config.js
+++ b/lighthouse-core/config/lr-mobile-config.js
@@ -12,19 +12,19 @@ const config = {
     maxWaitForFcp: 15 * 1000,
     maxWaitForLoad: 35 * 1000,
     // lighthouse:default is mobile by default
+    // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
+    skipAudits: ['uses-http2'],
   },
-  // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
-  skipAudits: ['uses-http2'],
   audits: [
     'metrics/first-contentful-paint-3g',
   ],
   categories: {
-    // @ts-expect-error TODO(bckenny): type extended Config where e.g. category.title isn't required
-    performance: {
+    // TODO(bckenny): type extended Config where e.g. category.title isn't required
+    performance: /** @type {LH.Config.CategoryJson} */({
       auditRefs: [
         {id: 'first-contentful-paint-3g', weight: 0},
       ],
-    },
+    }),
   },
 };
 


### PR DESCRIPTION
Root cause was [this PR](https://github.com/GoogleChrome/lighthouse/pull/11777) combined with this [TS bug](https://github.com/microsoft/TypeScript/issues/42893).


fixes #12113