### PR TITLE
core(unsized-images): ignore non-network SVGs

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -195,6 +195,14 @@ setTimeout(() => {
   <!-- PASS(webp): image is vector -->
   <!-- PASS(responsive): image is vector -->
   <!-- PASS(responsive-inverse): is vector -->
+  <!-- PASS(offscreen): image is too small -->
+  <!-- PASS(unsized-images): is non-network SVG -->
+  <img src="data:image/svg+xml;charset=utf-8,<svg width=&quot;180&quot; height=&quot;60&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+
+  <!-- PASS(optimized): image is vector -->
+  <!-- PASS(webp): image is vector -->
+  <!-- PASS(responsive): image is vector -->
+  <!-- PASS(responsive-inverse): is vector -->
   <!-- PASS(offscreen): image is offscreen and loads before TTI, but loads lazily -->
   <!-- PASS(unsized-images): has CSS sizing -->
   <img style="width: 100px; height: 100px;" src="large.svg?nativeLazyLoad" loading="lazy">

--- a/lighthouse-core/audits/unsized-images.js
+++ b/lighthouse-core/audits/unsized-images.js
@@ -96,6 +96,16 @@ class UnsizedImages extends Audit {
   }
 
   /**
+   * @param {LH.Artifacts.ImageElement} image
+   * @return {boolean}
+   */
+  static isNonNetworkSvg(image) {
+    const isSvg = image.mimeType === 'image/svg+xml';
+    const isNonNetwork = URL.NON_NETWORK_PROTOCOLS.some(protocol => image.src.startsWith(protocol));
+    return isSvg && isNonNetwork;
+  }
+
+  /**
    * @param {LH.Artifacts} artifacts
    * @return {Promise<LH.Audit.Product>}
    */
@@ -109,6 +119,10 @@ class UnsizedImages extends Audit {
       const isFixedImage =
         image.cssComputedPosition === 'fixed' || image.cssComputedPosition === 'absolute';
       if (isFixedImage) continue;
+
+      // Non-network SVGs with dimensions don't cause layout shifts in practice, skip them.
+      // See https://github.com/GoogleChrome/lighthouse/issues/11631
+      if (UnsizedImages.isNonNetworkSvg(image)) continue;
 
       // The image was sized with HTML or CSS. Good job.
       if (UnsizedImages.isSizedImage(image)) continue;

--- a/lighthouse-core/test/audits/unsized-images-test.js
+++ b/lighthouse-core/test/audits/unsized-images-test.js
@@ -78,6 +78,21 @@ describe('Sized images audit', () => {
     expect(result.score).toEqual(1);
   });
 
+  it('passes when an image is a non-network SVG', async () => {
+    const result = await runAudit({
+      cssComputedPosition: '',
+      attributeWidth: '',
+      attributeHeight: '',
+      _privateCssSizing: {
+        width: null,
+        height: null,
+      },
+      mimeType: 'image/svg+xml',
+      src: 'data:image/svg+xml;base64,foo',
+    });
+    expect(result.score).toEqual(1);
+  });
+
   describe('has empty width', () => {
     it('fails when an image only has attribute height', async () => {
       const result = await runAudit({
@@ -111,6 +126,19 @@ describe('Sized images audit', () => {
           width: null,
           height: '100',
         },
+      });
+      expect(result.score).toEqual(0);
+    });
+
+    it('fails a network svg', async () => {
+      const result = await runAudit({
+        attributeWidth: '',
+        attributeHeight: '100',
+        _privateCssSizing: {
+          width: null,
+          height: '100',
+        },
+        mimeType: 'image/svg+xml',
       });
       expect(result.score).toEqual(0);
     });


### PR DESCRIPTION
**Summary**
Fixes a rather long-standing incompat with next.js method of image placeholders. See #11631, #12116 for details.

**Related Issues/PRs**
fixes https://github.com/GoogleChrome/lighthouse/issues/11631
ref #12116
