### PR TITLE
core(preload): do not warn for cache loads

### DIFF
--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -86,13 +86,17 @@ class UsesRelPreloadAudit extends Audit {
     }
 
     // A failed preload attempt will manifest as a URL that was requested twice within the same frame.
-    // Once with `isLinkPreload` AND again without `isLinkPreload`.
+    // Once with `isLinkPreload` AND again without `isLinkPreload` but not hitting the cache.
     const duplicateRequestsAfterPreload = requests.filter(request => {
       const preloadURLsForFrame = preloadURLsByFrame.get(request.frameId);
       if (!preloadURLsForFrame) return false;
       if (!preloadURLsForFrame.has(request.url)) return false;
-      return !request.isLinkPreload;
+      const fromCache = request.fromDiskCache ||
+        request.fromMemoryCache ||
+        request.fromPrefetchCache;
+      return !fromCache && !request.isLinkPreload;
     });
+
     return new Set(duplicateRequestsAfterPreload.map(req => req.url));
   }
 

--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -94,6 +94,7 @@ class NetworkRequest {
     this.resourceSize = 0;
     this.fromDiskCache = false;
     this.fromMemoryCache = false;
+    this.fromPrefetchCache = false;
 
     /** @type {LightriderStatistics|undefined} Extra timing information available only when run in Lightrider. */
     this.lrStatistics = undefined;
@@ -292,6 +293,9 @@ class NetworkRequest {
 
     this.transferSize = response.encodedDataLength;
     if (typeof response.fromDiskCache === 'boolean') this.fromDiskCache = response.fromDiskCache;
+    if (typeof response.fromPrefetchCache === 'boolean') {
+      this.fromPrefetchCache = response.fromPrefetchCache;
+    }
 
     this.statusCode = response.status;
 

--- a/lighthouse-core/test/audits/uses-rel-preload-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preload-test.js
@@ -244,6 +244,21 @@ describe('Performance: uses-rel-preload audit', () => {
     expect(result.warnings).toBeUndefined();
   });
 
+  it(`should not warn for records served from cache`, async () => {
+    const networkRecords = getMockNetworkRecords();
+    networkRecords[2].isLinkPreload = true;
+    networkRecords.push({
+      url: networkRecords[2].url,
+      isLinkPreload: false,
+      fromDiskCache: true,
+    });
+
+    const artifacts = mockArtifacts(networkRecords, defaultMainResourceUrl);
+    const context = {settings: {}, computedCache: new Map()};
+    const result = await UsesRelPreload.audit(artifacts, context);
+    expect(result.warnings).toBeUndefined();
+  });
+
   it(`shouldn't suggest preload for already preloaded records`, () => {
     const networkRecords = getMockNetworkRecords();
     networkRecords[2].isLinkPreload = true;


### PR DESCRIPTION
**Summary**
At some point there was a Chromium change where used preload requests now appear as duplicate requests but with one of the `from*Cache` flags set. This updates Lighthouse logic to be inline with that new pattern.

**Related Issues/PRs**
fixes https://github.com/GoogleChrome/lighthouse/issues/11933
