### PR TITLE
docs(throttling): retitle devtools panel h2

### DIFF
--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -25,7 +25,7 @@ Within web performance testing, there are four typical styles of network throttl
 
 Lighthouse, by default, uses simulated throttling as it provides both quick evaluation and minimized variance. However, some may want to experiment with more accurate throttling... [Learn more about these throttling types and how they behave in in different scenarios](https://www.debugbear.com/blog/network-throttling-methods).
 
-## DevTools' Audits Panel Throttling
+## DevTools' Lighthouse Panel Throttling
 
 In Chrome 79 and earlier, you could choose between [the throttling types](#types-of-throttling) of Simulated, Applied, and none.
 


### PR DESCRIPTION
the link from devtools actually was relinked assuming we rename the docs. (to be correct)


![image](https://user-images.githubusercontent.com/39191/108889067-c7baa280-75c0-11eb-980e-b1ccf72dfba6.png)

so this part is easy.
