### PR TITLE
misc(treemap): unused-bytes view mode

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/unused-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-javascript.js
@@ -20,8 +20,8 @@ const UIStrings = {
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
-const IGNORE_THRESHOLD_IN_BYTES = 20 * 1024;
-const IGNORE_BUNDLE_SOURCE_THRESHOLD_IN_BYTES = 512;
+const UNUSED_BYTES_IGNORE_THRESHOLD = 20 * 1024;
+const UNUSED_BYTES_IGNORE_BUNDLE_SOURCE_THRESHOLD = 512;
 
 /**
  * @param {string[]} strings
@@ -80,8 +80,8 @@ class UnusedJavaScript extends ByteEfficiencyAudit {
   static async audit_(artifacts, networkRecords, context) {
     const bundles = await JsBundles.request(artifacts, context);
     const {
-      unusedThreshold = IGNORE_THRESHOLD_IN_BYTES,
-      bundleSourceUnusedThreshold = IGNORE_BUNDLE_SOURCE_THRESHOLD_IN_BYTES,
+      unusedThreshold = UNUSED_BYTES_IGNORE_THRESHOLD,
+      bundleSourceUnusedThreshold = UNUSED_BYTES_IGNORE_BUNDLE_SOURCE_THRESHOLD,
     } = context.options || {};
 
     const items = [];

--- a/lighthouse-treemap/app/index.html
+++ b/lighthouse-treemap/app/index.html
@@ -71,8 +71,10 @@ Unless required by applicable law or agreed to in writing, software distributed 
           <span class="lh-header--url-and-size">
             <a href="" class="lh-header--url" target="_blank" rel="noopener"></a> • <span class="lh-header--size lh-text-dim"></span></span>
           </span>
-          <div class="lh-modes">
-            <!-- View modes go here -->
+          <div class="lh-mode-wrapper">
+            <div class="lh-modes">
+              <!-- View modes go here -->
+            </div>
           </div>
         </div>
       </header>

--- a/lighthouse-treemap/app/src/main.js
+++ b/lighthouse-treemap/app/src/main.js
@@ -158,7 +158,6 @@ class TreemapViewer {
         id: 'unused-bytes',
         label: 'Unused Bytes',
         subLabel: TreemapUtil.formatBytes(this.currentTreemapRoot.unusedBytes),
-        partitionBy: 'unusedBytes',
         highlightNodePaths,
       });
     }

--- a/lighthouse-treemap/app/src/main.js
+++ b/lighthouse-treemap/app/src/main.js
@@ -142,8 +142,8 @@ class TreemapViewer {
         highlightNodePaths.push(path);
       });
       viewModes.push({
-        id: 'unused-js',
-        label: 'Unused JS',
+        id: 'unused-bytes',
+        label: 'Unused Bytes',
         subLabel: TreemapUtil.formatBytes(this.currentTreemapRoot.unusedBytes),
         partitionBy: 'unusedBytes',
         highlightNodePaths,

--- a/lighthouse-treemap/app/styles/treemap.css
+++ b/lighthouse-treemap/app/styles/treemap.css
@@ -71,6 +71,10 @@ body {
   left: -9999px;
 }
 
+label.view-mode__label {
+  cursor: pointer;
+}
+
 header {
   margin: 5px;
 }

--- a/lighthouse-treemap/app/styles/treemap.css
+++ b/lighthouse-treemap/app/styles/treemap.css
@@ -65,6 +65,12 @@ body {
   background-color: lightblue;
 }
 
+.view-mode__button {
+  /* Hide the default browser UI. */
+  position: absolute;
+  left: -9999px;
+}
+
 header {
   margin: 5px;
 }

--- a/types/treemap.d.ts
+++ b/types/treemap.d.ts
@@ -10,6 +10,16 @@ declare global {
       lhr: LH.Result;
     }
 
+    type NodePath = string[];
+
+    interface ViewMode {
+      id: string;
+      label: string;
+      subLabel: string;
+      partitionBy?: string;
+      highlightNodePaths?: NodePath[];
+    }
+
     interface Node {
       /** Could be a url, a path component from a source map, or an arbitrary string. */
       name: string;

--- a/types/treemap.d.ts
+++ b/types/treemap.d.ts
@@ -13,7 +13,7 @@ declare global {
     type NodePath = string[];
 
     interface ViewMode {
-      id: string;
+      id: 'all' | 'unused-bytes';
       label: string;
       subLabel: string;
       partitionBy?: string;

--- a/types/treemap.d.ts
+++ b/types/treemap.d.ts
@@ -16,7 +16,7 @@ declare global {
       id: 'all' | 'unused-bytes';
       label: string;
       subLabel: string;
-      partitionBy?: string;
+      partitionBy?: 'resourceBytes' | 'unusedBytes';
       highlightNodePaths?: NodePath[];
     }
 


### PR DESCRIPTION
ref #11254

https://lighthouse-1gxbe1yl8-googlechrome.vercel.app/gh-pages/treemap/?debug

This adds a "view modes" data structure, which defines how to interpret the data when walking `currentTreemapRoot`. `unused-bytes` is the first view mode, which highlights nodes with especially large amounts of unused bytes, and partitions the treemap based on percentage of total unused bytes on the page.

This only shows unused bytes based on javascript coverage, but there's no reason in the future that we couldn't determine unused bytes of images, css, etc. and plug them into this view mode.

![image](https://user-images.githubusercontent.com/4071474/109247780-1d9e6e80-77aa-11eb-9755-d93ae6cf9c21.png)
