### PR TITLE
docs(config): add remote debugging port example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,7 @@ The `extends` property controls if your configuration should inherit from the de
 
 ### `settings: Object|undefined`
 
-The settings property controls various aspects of running Lighthouse such as CPU/network throttling and which audits should run.
+The settings property controls various aspects of running Lighthouse such as CPU/network throttling and which audits should run. You can also specify to run lighthouse against a remote browser by passing tbe chrome debugging port.
 
 #### Example
 ```js
@@ -67,6 +67,7 @@ The settings property controls various aspects of running Lighthouse such as CPU
   settings: {
     onlyCategories: ['performance'],
     onlyAudits: ['works-offline'],
+    port: 9222,
   }
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,7 @@ The `extends` property controls if your configuration should inherit from the de
 
 ### `settings: Object|undefined`
 
-The settings property controls various aspects of running Lighthouse such as CPU/network throttling and which audits should run. You can also specify to run lighthouse against a remote browser by passing tbe chrome debugging port.
+The settings property controls various aspects of running Lighthouse such as CPU/network throttling and which audits should run.
 
 #### Example
 ```js
@@ -67,6 +67,16 @@ The settings property controls various aspects of running Lighthouse such as CPU
   settings: {
     onlyCategories: ['performance'],
     onlyAudits: ['works-offline'],
+  }
+}
+```
+
+If you are looking to run lighthouse against a remote browser you can pass the chrome debugging port in the settings object.
+
+#### Example
+```js
+{
+  settings: {
     port: 9222,
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
Making it more clear for how you can connect lighthouse to an existing browser.

<!-- Describe the need for this change -->
This Setting isn't obvious and this should help make things clearer for the next person. Wanting to run lighthouse to a remote browser.
<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
https://github.com/GoogleChrome/lighthouse-ci/issues/559
