### PR TITLE
docs: fixed typo in documentation throttling.md

### DIFF
--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -35,7 +35,7 @@ Starting with Chrome 80, the Audits panel is simplifying the throttling configur
 1. _No throttling_ is removed as it leads to innacurate scoring and misleading metric results.
 1. Within the Audits panel settings, you can uncheck the _Simulated throttling_ checkbox to use _Applied throttling_. For the moment, we are keeping this _Applied throttling_ option available for users of the [`View Trace` button](https://developers.google.com/web/updates/2018/04/devtools#traces). Under applied throttling, the trace matches the metrics values, whereas under Simulated things do not currently match up.
 
-We plan to improve the experience of viewing a trace under simulated throttling. At that point, the _Applied throttling_ option will be removed and _Simulated throttling_ will be the only option within the DevTools Audits panel. Of course, CLI users can still control the exact [configuration](../#cli-options) of throttling.
+We plan to improve the experience of viewing a trace under simulated throttling. At that point, the _Applied throttling_ option will be removed and _Simulated throttling_ will be the only option within the DevTools Audits panel. Of course, CLI users can still control the exact [configuration](../readme.md#cli-options) of throttling.
 
 ## How do I get packet-level throttling?
 


### PR DESCRIPTION
**Summary**

Fixed typo in documentation

https://github.com/GoogleChrome/lighthouse/blob/master/docs/throttling.md#devtools-lighthouse-panel-throttling

**Related Issues/PRs**