### PR TITLE
clients(lr): enable uses-http2

### DIFF
--- a/lighthouse-core/config/lr-desktop-config.js
+++ b/lighthouse-core/config/lr-desktop-config.js
@@ -17,8 +17,6 @@ const config = {
     throttling: constants.throttling.desktopDense4G,
     screenEmulation: constants.screenEmulationMetrics.desktop,
     emulatedUserAgent: constants.userAgents.desktop,
-    // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
-    skipAudits: ['uses-http2'],
   },
 };
 

--- a/lighthouse-core/config/lr-mobile-config.js
+++ b/lighthouse-core/config/lr-mobile-config.js
@@ -12,8 +12,6 @@ const config = {
     maxWaitForFcp: 15 * 1000,
     maxWaitForLoad: 35 * 1000,
     // lighthouse:default is mobile by default
-    // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
-    skipAudits: ['uses-http2'],
   },
   audits: [
     'metrics/first-contentful-paint-3g',


### PR DESCRIPTION
it's for real this time.


https://developers.google.com/speed/docs/insights/release_notes