### PR TITLE
core(errors-in-console): properly define default options

### DIFF
--- a/lighthouse-core/audits/errors-in-console.js
+++ b/lighthouse-core/audits/errors-in-console.js
@@ -44,7 +44,7 @@ class ErrorLogs extends Audit {
   }
 
   /** @return {AuditOptions} */
-  static defaultOptions() {
+  static get defaultOptions() {
     // Any failed network requests with error messsage aren't actionable
     return {ignoredPatterns: ['ERR_BLOCKED_BY_CLIENT.Inspector']};
   }

--- a/lighthouse-core/test/audits/errors-in-console-test.js
+++ b/lighthouse-core/test/audits/errors-in-console-test.js
@@ -236,7 +236,7 @@ describe('ConsoleMessages error logs audit', () => {
           'url': 'https://www.facebook.com/tr/',
           'text': 'Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector',
         }],
-      }, {options: ErrorLogsAudit.defaultOptions()});
+      }, {options: ErrorLogsAudit.defaultOptions});
       assert.equal(auditResult.score, 1);
       assert.equal(auditResult.details.items.length, 0);
     });


### PR DESCRIPTION
fixes #10198

#11901 did the real fix, but didn't notice that #9480 had defined the previously empty `defaultOptions` as a static method and not a getter.

Classic case of unit vs integration tests:
- The [upcoming work on overrides and getters/setters](https://github.com/microsoft/TypeScript/issues/42762) might catch this sort of thing in tsc in the future, but I'm not sure
- One way we could tackle this is exposing a way of "properly" running an audit with all the setup and teardown that `audit-runner` does and using that for all unit tests instead of calling `.audit()` directly. That would take care of context being initialized correctly and it would do the `AuditProduct` -> `AuditResult` transformation so tests could run on the real audit output expected in the LHR.