### PR TITLE
tests(fr): update test artifact

### DIFF
--- a/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
@@ -133,16 +133,18 @@ describe('NavigationRunner', () => {
         {
           ...config,
           navigations: [
-            {id: 'default', artifacts: ['Accessibility']},
+            {id: 'default', artifacts: ['FontSize']},
             {id: 'second', artifacts: ['ConsoleMessages']},
           ],
         },
         {gatherMode: 'navigation'}
       ).config;
 
+      // Both gatherers will error in these test conditions, but artifact errors
+      // will be merged into single `artifacts` object.
       const {artifacts} = await runner._navigations({driver, config, requestedUrl});
       const artifactIds = Object.keys(artifacts);
-      expect(artifactIds).toContain('Accessibility');
+      expect(artifactIds).toContain('FontSize');
       expect(artifactIds).toContain('ConsoleMessages');
     });
   });


### PR DESCRIPTION
fixes #12160

There's a better fix that could be had here, but in the interest of time this change maintains the status quo by picking a different gatherer that does throw an error in the test run. Also adds a comment for the next person debugging a problem here.