### PR TITLE
tests(devtools): dynamically fetch chromium version

### DIFF
--- a/third-party/download-content-shell/download-content-shell.js
+++ b/third-party/download-content-shell/download-content-shell.js
@@ -18,6 +18,7 @@ const MAX_CONTENT_SHELLS = 10;
 const PLATFORM = getPlatform();
 const LH_ROOT = `${__dirname}/../..`;
 const CACHE_PATH = path.resolve(LH_ROOT, '.tmp', 'chromium-web-tests', 'content-shells');
+const COMMIT_POSITION_UPDATE_PERIOD = 420;
 
 function main() {
   fs.mkdirSync(CACHE_PATH, {recursive: true});
@@ -67,9 +68,11 @@ function getPlatform() {
 
 async function findMostRecentChromiumCommit() {
   const snapshotUrl = `https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/${PLATFORM}%2FLAST_CHANGE?alt=media`;
-  const commitPosition = await utils.fetch(snapshotUrl);
+  const commitPosition = Number((await utils.fetch(snapshotUrl)).toString());
 
-  return commitPosition.toString();
+  // Only update the content shell roughly once a day.
+  // see https://github.com/GoogleChrome/lighthouse/pull/12232#discussion_r592016416
+  return commitPosition - commitPosition % COMMIT_POSITION_UPDATE_PERIOD;
 }
 
 function deleteOldContentShells() {

--- a/third-party/download-content-shell/download-content-shell.js
+++ b/third-party/download-content-shell/download-content-shell.js
@@ -23,7 +23,8 @@ function main() {
   fs.mkdirSync(CACHE_PATH, {recursive: true});
   deleteOldContentShells();
 
-  findPreviousUploadedPosition(findMostRecentChromiumCommit())
+  findMostRecentChromiumCommit()
+    .then(findPreviousUploadedPosition)
     .then(onUploadedCommitPosition)
     .catch(onError);
 
@@ -64,13 +65,11 @@ function getPlatform() {
   throw new Error(`Unrecognized platform detected: ${process.platform}`);
 }
 
-function findMostRecentChromiumCommit() {
-  // TODO: this code works only if there is a full chromium checkout present.
-  // const commitMessage = shell('git log --max-count=1 --grep="Cr-Commit-Position"').toString().trim();
-  // const commitPosition = commitMessage.match(/Cr-Commit-Position: refs\/heads\/master@\{#([0-9]+)\}/)[1];
-  // return commitPosition;
-  // TODO: make this dynamic.
-  return '856956';
+async function findMostRecentChromiumCommit() {
+  const snapshotUrl = `https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/${PLATFORM}%2FLAST_CHANGE?alt=media`;
+  const commitPosition = await utils.fetch(snapshotUrl);
+
+  return commitPosition.toString();
 }
 
 function deleteOldContentShells() {

--- a/third-party/download-content-shell/utils.js
+++ b/third-party/download-content-shell/utils.js
@@ -31,7 +31,7 @@ function fetch(url) {
 
   function getCallback(resolve, reject, response) {
     if (response.statusCode !== 200) {
-      reject(new Error(`Request error: + ${response.statusCode}`));
+      reject(new Error(`Request error: ${response.statusCode}`));
       return;
     }
     const body = new Stream();


### PR DESCRIPTION
Use the github API to fetch the latest commit message from the Chromium mirror.

There's not really any way to get commit info from a remote git repo without cloning, and the Github API seems more likely to be stable long-term than any feed on `googlesource.com`.

We may have to update the branch name to `main` in the github API url when the `chromium/src` migration occurs: https://groups.google.com/a/chromium.org/g/infra-announce/c/-uMWoep7RNA