### PR TITLE
cli: correctly parse screenEmulation boolean flags

### DIFF
--- a/lighthouse-cli/test/cli/cli-flags-test.js
+++ b/lighthouse-cli/test/cli/cli-flags-test.js
@@ -9,7 +9,7 @@
 const assert = require('assert').strict;
 const getFlags = require('../../cli-flags.js').getFlags;
 
-describe('CLI bin', function() {
+describe('CLI flags', function() {
   it('all options should have descriptions', () => {
     getFlags('chrome://version');
     const yargs = require('yargs');
@@ -92,6 +92,115 @@ describe('CLI bin', function() {
       ].join(' '));
 
       expect(flags).toHaveProperty('extraHeaders', require(headersFile));
+    });
+  });
+
+  describe('screenEmulation', () => {
+    const url = 'http://www.example.com';
+
+    describe('width', () => {
+      it('parses a number value', () => {
+        const flags = getFlags(`${url} --screenEmulation.width=500`, {noExitOnFailure: true});
+        expect(flags.screenEmulation).toEqual({width: 500});
+      });
+
+      it('throws on a non-number', () => {
+        expect(() => getFlags(`${url} --screenEmulation.width=yah`, {noExitOnFailure: true}))
+          .toThrow(`Invalid value: 'screenEmulation.width' must be a number`);
+      });
+
+      it('throws with no flag value', () => {
+        expect(() => getFlags(`${url} --screenEmulation.width`, {noExitOnFailure: true}))
+          .toThrow(`Invalid value: 'screenEmulation.width' must be a number`);
+      });
+    });
+
+    describe('height', () => {
+      it('parses a number value', () => {
+        const flags = getFlags(`${url} --screenEmulation.height=123`, {noExitOnFailure: true});
+        expect(flags.screenEmulation).toEqual({height: 123});
+      });
+
+      it('throws on a non-number', () => {
+        expect(() => getFlags(`${url} --screenEmulation.height=false`, {noExitOnFailure: true}))
+          .toThrow(`Invalid value: 'screenEmulation.height' must be a number`);
+      });
+
+      it('throws with no flag value', () => {
+        expect(() => getFlags(`${url} --screenEmulation.height`, {noExitOnFailure: true}))
+          .toThrow(`Invalid value: 'screenEmulation.height' must be a number`);
+      });
+    });
+
+    describe('deviceScaleFactor', () => {
+      it('parses a non-integer numeric value', () => {
+        const flags = getFlags(`${url} --screenEmulation.deviceScaleFactor=1.325`,
+            {noExitOnFailure: true});
+        expect(flags.screenEmulation).toEqual({deviceScaleFactor: 1.325});
+      });
+
+      it('throws on a non-number', () => {
+        expect(() => getFlags(`${url} --screenEmulation.deviceScaleFactor=12px`,
+            {noExitOnFailure: true}))
+          .toThrow(`Invalid value: 'screenEmulation.deviceScaleFactor' must be a number`);
+      });
+
+      it('throws with no flag value', () => {
+        expect(() => getFlags(`${url} --screenEmulation.deviceScaleFactor`,
+            {noExitOnFailure: true}))
+          .toThrow(`Invalid value: 'screenEmulation.deviceScaleFactor' must be a number`);
+      });
+    });
+
+    describe('mobile', () => {
+      it('parses the flag with no value as true', () => {
+        const flags = getFlags(`${url} --screenEmulation.mobile`, {noExitOnFailure: true});
+        expect(flags.screenEmulation).toEqual({mobile: true});
+      });
+
+      it('parses the --no-mobile flag as false', () => {
+        const flags = getFlags(`${url} --no-screenEmulation.mobile`, {noExitOnFailure: true});
+        expect(flags.screenEmulation).toEqual({mobile: false});
+      });
+
+      it('parses the flag with a boolean value', () => {
+        const flagsTrue = getFlags(`${url} --screenEmulation.mobile=true`, {noExitOnFailure: true});
+        expect(flagsTrue.screenEmulation).toEqual({mobile: true});
+        const flagsFalse = getFlags(`${url} --screenEmulation.mobile=false`,
+            {noExitOnFailure: true});
+        expect(flagsFalse.screenEmulation).toEqual({mobile: false});
+      });
+
+      it('throws on a non-boolean value', () => {
+        expect(() => getFlags(`${url} --screenEmulation.mobile=2`, {noExitOnFailure: true}))
+          .toThrow(`Invalid value: 'screenEmulation.mobile' must be a boolean`);
+      });
+    });
+
+    describe('disabled', () => {
+      it('parses the flag with no value as true', () => {
+        const flags = getFlags(`${url} --screenEmulation.disabled`, {noExitOnFailure: true});
+        expect(flags.screenEmulation).toEqual({disabled: true});
+      });
+
+      it('parses the --no-disabled flag as false', () => {
+        const flags = getFlags(`${url} --no-screenEmulation.disabled`, {noExitOnFailure: true});
+        expect(flags.screenEmulation).toEqual({disabled: false});
+      });
+
+      it('parses the flag with a boolean value', () => {
+        const flagsTrue = getFlags(`${url} --screenEmulation.disabled=true`,
+            {noExitOnFailure: true});
+        expect(flagsTrue.screenEmulation).toEqual({disabled: true});
+        const flagsFalse = getFlags(`${url} --screenEmulation.disabled=false`,
+            {noExitOnFailure: true});
+        expect(flagsFalse.screenEmulation).toEqual({disabled: false});
+      });
+
+      it('throws on a non-boolean value', () => {
+        expect(() => getFlags(`${url} --screenEmulation.disabled=str`, {noExitOnFailure: true}))
+          .toThrow(`Invalid value: 'screenEmulation.disabled' must be a boolean`);
+      });
     });
   });
 });


### PR DESCRIPTION
fixes #12246

Unlike [anything that looks like a number](https://github.com/yargs/yargs/blob/b9d6ba32bcce90a24aae38e2cce0e6dc73f44e1b/docs/tricks.md#numbers), things that look like a boolean aren't automatically parsed as one unless set specifically. Setting the `type` on nested properties is [still kind of janky](https://github.com/GoogleChrome/lighthouse/pull/11794/files#r539635508) in yargs, so it's easier to handle in the `coerce` callback.

Also
- adds tests for parsing of all the `screenEmulation` properties
- adds a new option in `cli-flags` so that failure conditions can be tested without yargs logging the errors and calling `process.exit()`. We should have more CLI flag parsing tests, and this should help make that easier.