### PR TITLE
tests(legacy-javascript): pin to specific versions of core-js

### DIFF
--- a/lighthouse-core/scripts/legacy-javascript/run.js
+++ b/lighthouse-core/scripts/legacy-javascript/run.js
@@ -233,7 +233,8 @@ async function main() {
     });
   }
 
-  for (const coreJsVersion of [2, 3]) {
+  for (const coreJsVersion of ['2.6.12', '3.9.1']) {
+    const major = coreJsVersion.split('.')[0];
     removeCoreJs();
     installCoreJs(coreJsVersion);
 
@@ -245,7 +246,7 @@ async function main() {
     ];
     for (const {esmodules, bugfixes} of moduleOptions) {
       await createVariant({
-        group: `core-js-${coreJsVersion}-preset-env-esmodules`,
+        group: `core-js-${major}-preset-env-esmodules`,
         name: String(esmodules) + (bugfixes ? '_and_bugfixes' : ''),
         code: `require('core-js');\n${mainCode}`,
         babelrc: {
@@ -255,7 +256,7 @@ async function main() {
               {
                 targets: {esmodules},
                 useBuiltIns: 'entry',
-                corejs: coreJsVersion,
+                corejs: major,
                 bugfixes,
               },
             ],
@@ -265,21 +266,21 @@ async function main() {
     }
 
     for (const polyfill of polyfills) {
-      const module = coreJsVersion === 2 ? polyfill.coreJs2Module : polyfill.coreJs3Module;
+      const module = major === '2' ? polyfill.coreJs2Module : polyfill.coreJs3Module;
       await createVariant({
-        group: `core-js-${coreJsVersion}-only-polyfill`,
+        group: `core-js-${major}-only-polyfill`,
         name: module,
         code: makeRequireCodeForPolyfill(module),
       });
     }
 
     const allPolyfillCode = polyfills.map(polyfill => {
-      const module = coreJsVersion === 2 ? polyfill.coreJs2Module : polyfill.coreJs3Module;
+      const module = major === '2' ? polyfill.coreJs2Module : polyfill.coreJs3Module;
       return makeRequireCodeForPolyfill(module);
     }).join('\n');
     await createVariant({
       group: 'all-legacy-polyfills',
-      name: `all-legacy-polyfills-core-js-${coreJsVersion}`,
+      name: `all-legacy-polyfills-core-js-${major}`,
       code: allPolyfillCode,
     });
   }

--- a/lighthouse-core/scripts/legacy-javascript/run.js
+++ b/lighthouse-core/scripts/legacy-javascript/run.js
@@ -40,7 +40,7 @@ function runCommand(command, args) {
 }
 
 /**
- * @param {number} version
+ * @param {string} version
  */
 function installCoreJs(version) {
   runCommand('yarn', [

--- a/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
+++ b/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
@@ -1,5 +1,5 @@
 all-legacy-polyfills
-  86520        all-legacy-polyfills-core-js-3/main.bundle.min.js
+  84149        all-legacy-polyfills-core-js-3/main.bundle.min.js
   55778        all-legacy-polyfills-core-js-2/main.bundle.min.js
 
 core-js-2-only-polyfill
@@ -62,18 +62,18 @@ core-js-2-preset-env-esmodules
    63536       true-and-bugfixes/main.bundle.min.js
 
 core-js-3-only-polyfill
-  29905        es-array-find-index/main.bundle.min.js
-  29833        es-array-find/main.bundle.min.js
-  27930        es-array-from/main.bundle.min.js
-  27225        es-array-filter/main.bundle.min.js
-  27198        es-array-map/main.bundle.min.js
-  26417        es-array-includes/main.bundle.min.js
-  26374        es-array-for-each/main.bundle.min.js
-  26153        es-array-some/main.bundle.min.js
-  26091        es-array-fill/main.bundle.min.js
+  30090        es-array-find-index/main.bundle.min.js
+  30024        es-array-find/main.bundle.min.js
+  29184        es-array-from/main.bundle.min.js
+  27345        es-array-fill/main.bundle.min.js
+  26687        es-array-filter/main.bundle.min.js
+  26663        es-array-map/main.bundle.min.js
+  26579        es-array-includes/main.bundle.min.js
+  26563        es-array-for-each/main.bundle.min.js
+  26342        es-array-some/main.bundle.min.js
   25662        es-reflect-construct/main.bundle.min.js
-  24190        es-array-reduce-right/main.bundle.min.js
-  24152        es-array-reduce/main.bundle.min.js
+  23119        es-array-reduce-right/main.bundle.min.js
+  23081        es-array-reduce/main.bundle.min.js
   22464        es-date-to-iso-string/main.bundle.min.js
   21968        es-object-prevent-extensions/main.bundle.min.js
   21906        es-reflect-get/main.bundle.min.js
@@ -82,7 +82,7 @@ core-js-3-only-polyfill
   21606        es-object-get-prototype-of/main.bundle.min.js
   21456        es-reflect-get-prototype-of/main.bundle.min.js
   21329        es-object-get-own-property-descriptors/main.bundle.min.js
-  21285        es-number-parse-int/main.bundle.min.js
+  21288        es-number-parse-int/main.bundle.min.js
   21214        es-reflect-set-prototype-of/main.bundle.min.js
   21073        es-object-entries/main.bundle.min.js
   21070        es-object-define-properties/main.bundle.min.js
@@ -116,9 +116,9 @@ core-js-3-only-polyfill
    4515        es-function-name/main.bundle.min.js
 
 core-js-3-preset-env-esmodules
-  411807       false/main.bundle.min.js
-  306297       true/main.bundle.min.js
-  305616       true-and-bugfixes/main.bundle.min.js
+  408753       false/main.bundle.min.js
+  304901       true/main.bundle.min.js
+  304220       true-and-bugfixes/main.bundle.min.js
 
 only-plugin
   1787         -babel-plugin-transform-spread/main.bundle.min.js


### PR DESCRIPTION
These test results were changing whenever core-js released a new version. This was overlooked because we don't use yarn.lock to pin these version, but instead manually install the package (since we switch between core-js 2 and 3). Instead, specify what version to install in `run.js`.

I noticed this here: https://github.com/GoogleChrome/lighthouse/pull/12199/checks?check_run_id=2134061233