### PR TITLE
misc(sentry): tag protocol method

### DIFF
--- a/lighthouse-core/lib/sentry.js
+++ b/lighthouse-core/lib/sentry.js
@@ -96,11 +96,15 @@ function init(opts) {
       const sampledErrorMatch = SAMPLED_ERRORS.find(sample => sample.pattern.test(err.message));
       if (sampledErrorMatch && sampledErrorMatch.rate <= Math.random()) return;
 
-      // Protocol errors all share same stack trace, so add more to fingerprint
       // @ts-expect-error - properties added to protocol method LHErrors.
       if (err.protocolMethod) {
+        // Protocol errors all share same stack trace, so add more to fingerprint
         // @ts-expect-error - properties added to protocol method LHErrors.
         opts.fingerprint = ['{{ default }}', err.protocolMethod, err.protocolError];
+
+        opts.tags = opts.tags || {};
+        // @ts-expect-error - properties added to protocol method LHErrors.
+        opts.tags.protocolMethod = err.protocolMethod;
       }
 
       return new Promise(resolve => {


### PR DESCRIPTION
tags are cool, they show up like this in Sentry for a given fingerprinted-error: 

![image](https://user-images.githubusercontent.com/4071474/111791808-96688600-8891-11eb-8211-4d36fcc61b82.png)

protocolMethod shows up in individual error reports but since it isn't a tag we can't do aggregate analysis.

helps with #6512 