### PR TITLE
tests(smoke): remove max chrome for lantern script attribution

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/lantern/lantern-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/lantern/lantern-expectations.js
@@ -88,8 +88,6 @@ module.exports = [
           details: {
             items: {
               0: {
-                // TODO: Remove when attribution is resolved.
-                _maxChromiumMilestone: 90,
                 url: /main-thread-consumer/,
                 scripting: '>9000',
               },


### PR DESCRIPTION
Patch recently landed: https://crrev.com/c/2773125

ToT should be fixed.

Closes https://github.com/GoogleChrome/lighthouse/issues/12262
