### PR TITLE
misc: fix PhaseArtifact type to include Stacks

### DIFF
--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -68,7 +68,8 @@ declare global {
       LH.Artifacts['devtoolsLogs'] |
       LH.Artifacts['traces'] |
       LH.Artifacts['WebAppManifest'] |
-      LH.Artifacts['InstallabilityErrors'];
+      LH.Artifacts['InstallabilityErrors'] |
+      LH.Artifacts['Stacks'];
     export type PhaseResultNonPromise = void|PhaseArtifact
     export type PhaseResult = PhaseResultNonPromise | Promise<PhaseResultNonPromise>
 


### PR DESCRIPTION
fix for the problem in https://github.com/GoogleChrome/lighthouse/pull/12274#discussion_r597988531 We could also merge into #12274 instead of master if that's better for anyone.

The problem wasn't detected because the elements of `MetaElements` have all optional properties, so in theory could match any object (like a `DetectedStack`) so long as there weren't any conflicting types (e.g. if somehow there was `content?: string` in `MetaElement` but `content: number` in `DetectedStack`), which there aren't.

Typescript throws in one additional check for protection against accidental cases like this by ensuring that the source and target types have to [have at least one property in common](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-4.html#weak-type-detection) when one of the two types is all optional, but `MetaElement` has `name?: string` and `DetectedStack` has `name: string`, so there's no problem there.

The error in #12274 occurs when adding a new required property to `MetaElement`, so `DetectedStack` can no longer be mistaken for an element of `MetaElements` (same thing happens if you make any MetaElement property except `name` required).