### PR TITLE
clients(psi): support element screenshots

### DIFF
--- a/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
+++ b/lighthouse-core/report/html/renderer/element-screenshot-renderer.js
@@ -20,7 +20,8 @@
 /**
  * @typedef InstallOverlayFeatureParams
  * @property {DOM} dom
- * @property {Element} el
+ * @property {Element} reportEl
+ * @property {Element} overlayContainerEl
  * @property {ParentNode} templateContext
  * @property {LH.Artifacts.FullPageScreenshot} fullPageScreenshot
  */
@@ -139,16 +140,17 @@ class ElementScreenshotRenderer {
 
   /**
    * Installs the lightbox elements and wires up click listeners to all .lh-element-screenshot elements.
-   * @param {InstallOverlayFeatureParams} _
+   * @param {InstallOverlayFeatureParams} opts
    */
-  static installOverlayFeature({dom, el, templateContext, fullPageScreenshot}) {
+  static installOverlayFeature(opts) {
+    const {dom, reportEl, overlayContainerEl, templateContext, fullPageScreenshot} = opts;
     const screenshotOverlayClass = 'lh-screenshot-overlay--enabled';
     // Don't install the feature more than once.
-    if (el.classList.contains(screenshotOverlayClass)) return;
-    el.classList.add(screenshotOverlayClass);
+    if (reportEl.classList.contains(screenshotOverlayClass)) return;
+    reportEl.classList.add(screenshotOverlayClass);
 
     // Add a single listener to the provided element to handle all clicks within (event delegation).
-    el.addEventListener('click', e => {
+    reportEl.addEventListener('click', e => {
       const target = /** @type {?HTMLElement} */ (e.target);
       if (!target) return;
       // Only activate the overlay for clicks on the screenshot *preview* of an element, not the full-size too.
@@ -156,7 +158,7 @@ class ElementScreenshotRenderer {
       if (!el) return;
 
       const overlay = dom.createElement('div', 'lh-element-screenshot__overlay');
-      el.append(overlay);
+      overlayContainerEl.append(overlay);
 
       // The newly-added overlay has the dimensions we need.
       const maxLightboxSize = {

--- a/lighthouse-core/report/html/renderer/psi.js
+++ b/lighthouse-core/report/html/renderer/psi.js
@@ -16,7 +16,7 @@
  */
 'use strict';
 
-/* globals self DOM PerformanceCategoryRenderer Util I18n DetailsRenderer */
+/* globals self DOM PerformanceCategoryRenderer Util I18n DetailsRenderer ElementScreenshotRenderer */
 
 
 /**
@@ -31,7 +31,7 @@
  *
  * @param {LH.Result | string} LHResult The stringified version of {LH.Result}
  * @param {Document} document The host page's window.document
- * @return {{scoreGaugeEl: Element, perfCategoryEl: Element, finalScreenshotDataUri: string|null, scoreScaleEl: Element}}
+ * @return {{scoreGaugeEl: Element, perfCategoryEl: Element, finalScreenshotDataUri: string|null, scoreScaleEl: Element, installFeatures: Function}}
  */
 function prepareLabData(LHResult, document) {
   const lhResult = (typeof LHResult === 'string') ?
@@ -59,7 +59,13 @@ function prepareLabData(LHResult, document) {
   reportLHR.categoryGroups.metrics.description =
       Util.i18n.strings.lsPerformanceCategoryDescription;
 
-  const perfRenderer = new PerformanceCategoryRenderer(dom, new DetailsRenderer(dom));
+  const fullPageScreenshot =
+    reportLHR.audits['full-page-screenshot'] && reportLHR.audits['full-page-screenshot'].details &&
+    reportLHR.audits['full-page-screenshot'].details.type === 'full-page-screenshot' ?
+    reportLHR.audits['full-page-screenshot'].details : undefined;
+
+  const detailsRenderer = new DetailsRenderer(dom, {fullPageScreenshot});
+  const perfRenderer = new PerformanceCategoryRenderer(dom, detailsRenderer);
   // PSI environment string will ensure the categoryHeader and permalink elements are excluded
   const perfCategoryEl = perfRenderer.render(perfCategory, reportLHR.categoryGroups, 'PSI');
 
@@ -75,7 +81,37 @@ function prepareLabData(LHResult, document) {
   const clonedScoreTemplate = dom.cloneTemplate('#tmpl-lh-scorescale', dom.document());
   const scoreScaleEl = dom.find('.lh-scorescale', clonedScoreTemplate);
 
-  return {scoreGaugeEl, perfCategoryEl, finalScreenshotDataUri, scoreScaleEl};
+  /** @param {HTMLElement} reportEl */
+  const installFeatures = (reportEl) => {
+    if (fullPageScreenshot) {
+      ElementScreenshotRenderer.installFullPageScreenshot(
+        reportEl, fullPageScreenshot.screenshot);
+
+      // Append the overlay element to a specific part of the DOM so that
+      // the sticky tab group element renders correctly. If put in the reportEl
+      // like normal, then the sticky header would bleed through the overlay
+      // element.
+      const screenshotsContainer = document.querySelector('.element-screenshots-container');
+      if (!screenshotsContainer) {
+        throw new Error('missing .element-screenshots-container');
+      }
+
+      const screenshotEl = document.createElement('div');
+      screenshotsContainer.append(screenshotEl);
+      ElementScreenshotRenderer.installOverlayFeature({
+        dom,
+        reportEl,
+        overlayContainerEl: screenshotEl,
+        templateContext: document,
+        fullPageScreenshot,
+      });
+      // Not part of the reportEl, so have to install the feature here too.
+      ElementScreenshotRenderer.installFullPageScreenshot(
+        screenshotEl, fullPageScreenshot.screenshot);
+    }
+  };
+
+  return {scoreGaugeEl, perfCategoryEl, finalScreenshotDataUri, scoreScaleEl, installFeatures};
 }
 
 /**

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -320,7 +320,8 @@ class ReportUIFeatures {
 
     ElementScreenshotRenderer.installOverlayFeature({
       dom: this._dom,
-      el,
+      reportEl: el,
+      overlayContainerEl: el,
       templateContext: this._templateContext,
       fullPageScreenshot,
     });

--- a/lighthouse-core/test/report/html/renderer/psi-test.js
+++ b/lighthouse-core/test/report/html/renderer/psi-test.js
@@ -19,6 +19,8 @@ const CategoryRenderer = require('../../../../report/html/renderer/category-rend
 const DetailsRenderer = require('../../../../report/html/renderer/details-renderer.js');
 const CriticalRequestChainRenderer =
     require('../../../../report/html/renderer/crc-details-renderer.js');
+const ElementScreenshotRenderer =
+    require('../../../../report/html/renderer/element-screenshot-renderer.js');
 
 const {itIfProtoExists, sampleResultsRoundtripStr} = testUtils.getProtoRoundTrip();
 const sampleResultsStr = fs.readFileSync(__dirname + '/../../../results/sample_v2.json', 'utf-8');
@@ -45,6 +47,7 @@ describe('DOM', () => {
         require('../../../../report/html/renderer/performance-category-renderer.js');
     global.PerformanceCategoryRenderer = PerformanceCategoryRenderer;
     global.CriticalRequestChainRenderer = CriticalRequestChainRenderer;
+    global.ElementScreenshotRenderer = ElementScreenshotRenderer;
 
     const {window} = new jsdom.JSDOM(TEMPLATE_FILE);
     document = window.document;
@@ -58,6 +61,7 @@ describe('DOM', () => {
     global.DetailsRenderer = undefined;
     global.PerformanceCategoryRenderer = undefined;
     global.CriticalRequestChainRenderer = undefined;
+    global.ElementScreenshotRenderer = undefined;
   });
 
   describe('psi prepareLabData helpers', () => {


### PR DESCRIPTION
Introduces a new `installFeatures` return in `psi.js`, which takes care of installing element screenshots in PSI.