### PR TITLE
misc: include SVG elements by default in typed querySelector

### DIFF
--- a/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
@@ -20,7 +20,7 @@
 
 const Gatherer = require('../gatherer.js');
 
-/* global document, window, HTMLLinkElement */
+/* global document, window, HTMLLinkElement, SVGScriptElement */
 
 /** @typedef {{href: string, media: string, msSinceHTMLEnd: number, matches: boolean}} MediaChange */
 /** @typedef {{tagName: 'LINK', url: string, href: string, rel: string, media: string, disabled: boolean, mediaChanges: Array<MediaChange>}} LinkTag */
@@ -84,7 +84,11 @@ async function collectTagsThatBlockFirstPaint() {
 
     /** @type {Array<ScriptTag>} */
     const scriptTags = [...document.querySelectorAll('head script[src]')]
-      .filter(scriptTag => {
+      .filter(/** @return {scriptTag is HTMLScriptElement} */ scriptTag => {
+        // SVGScriptElement can't appear in <head> (it'll be kicked to <body>), but keep tsc happy.
+        // https://html.spec.whatwg.org/multipage/semantics.html#the-head-element
+        if (scriptTag instanceof SVGScriptElement) return false;
+
         return (
           !scriptTag.hasAttribute('async') &&
           !scriptTag.hasAttribute('defer') &&

--- a/lighthouse-core/report/html/renderer/dom.js
+++ b/lighthouse-core/report/html/renderer/dom.js
@@ -19,6 +19,7 @@
 /* globals URL self Util */
 
 /** @typedef {HTMLElementTagNameMap & {[id: string]: HTMLElement}} HTMLElementByTagName */
+/** @template {string} T @typedef {import('typed-query-selector/parser').ParseSelector<T, Element>} ParseSelector */
 
 class DOM {
   /**
@@ -216,13 +217,18 @@ class DOM {
    * @template {string} T
    * @param {T} query
    * @param {ParentNode} context
+   * @return {ParseSelector<T>}
    */
   find(query, context) {
     const result = context.querySelector(query);
     if (result === null) {
       throw new Error(`query ${query} not found`);
     }
-    return result;
+
+    // Because we control the report layout and templates, use the simpler
+    // `typed-query-selector` types that don't require differentiating between
+    // e.g. HTMLAnchorElement and SVGAElement. See https://github.com/GoogleChrome/lighthouse/issues/12011.
+    return /** @type {ParseSelector<T>} */ (result);
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/dom.js
+++ b/lighthouse-core/report/html/renderer/dom.js
@@ -227,7 +227,7 @@ class DOM {
 
     // Because we control the report layout and templates, use the simpler
     // `typed-query-selector` types that don't require differentiating between
-    // e.g. HTMLAnchorElement and SVGAElement. See https://github.com/GoogleChrome/lighthouse/issues/12011.
+    // e.g. HTMLAnchorElement and SVGAElement. See https://github.com/GoogleChrome/lighthouse/issues/12011
     return /** @type {ParseSelector<T>} */ (result);
   }
 

--- a/lighthouse-treemap/app/src/util.js
+++ b/lighthouse-treemap/app/src/util.js
@@ -8,6 +8,7 @@
 /* eslint-env browser */
 
 /** @typedef {HTMLElementTagNameMap & {[id: string]: HTMLElement}} HTMLElementByTagName */
+/** @template {string} T @typedef {import('typed-query-selector/parser').ParseSelector<T, Element>} ParseSelector */
 
 const KiB = 1024;
 const MiB = KiB * KiB;
@@ -108,13 +109,17 @@ class TreemapUtil {
    * @template {string} T
    * @param {T} query
    * @param {ParentNode=} context
+   * @return {ParseSelector<T>}
    */
   static find(query, context = document) {
     const result = context.querySelector(query);
     if (result === null) {
       throw new Error(`query ${query} not found`);
     }
-    return result;
+    // Because we control the treemap layout and templates, use the simpler
+    // `typed-query-selector` types that don't require differentiating between
+    // e.g. HTMLAnchorElement and SVGAElement. See https://github.com/GoogleChrome/lighthouse/issues/12011.
+    return /** @type {ParseSelector<T>} */ (result);
   }
 
   /**

--- a/lighthouse-treemap/app/src/util.js
+++ b/lighthouse-treemap/app/src/util.js
@@ -118,7 +118,7 @@ class TreemapUtil {
     }
     // Because we control the treemap layout and templates, use the simpler
     // `typed-query-selector` types that don't require differentiating between
-    // e.g. HTMLAnchorElement and SVGAElement. See https://github.com/GoogleChrome/lighthouse/issues/12011.
+    // e.g. HTMLAnchorElement and SVGAElement. See https://github.com/GoogleChrome/lighthouse/issues/12011
     return /** @type {ParseSelector<T>} */ (result);
   }
 

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -6,7 +6,25 @@
 
 import _Crdp from 'devtools-protocol/types/protocol';
 import _CrdpMappings from 'devtools-protocol/types/protocol-mapping';
-import {ParseSelector} from 'typed-query-selector/parser';
+import {ParseSelectorToTagNames} from 'typed-query-selector/parser';
+
+/** Merge properties of the types in union `T`. Where properties overlap, property types becomes the union of the two (or more) possible types. */
+type MergeTypes<T> = {
+  [K in (T extends unknown ? keyof T : never)]: T extends Record<K, infer U> ? U : never;
+};
+
+// Helper types for strict querySelector/querySelectorAll that includes the overlap
+// between HTML and SVG node names (<a>, <script>, etc).
+// see https://github.com/GoogleChrome/lighthouse/issues/12011
+type HtmlAndSvgElementTagNameMap = MergeTypes<HTMLElementTagNameMap|SVGElementTagNameMap> & {
+  // Fall back to Element (base of HTMLElement and SVGElement) if no specific tag name matches.
+  [id: string]: Element;
+};
+type QuerySelectorParse<I extends string> = ParseSelectorToTagNames<I> extends infer TagNames ?
+  TagNames extends Array<string> ?
+    HtmlAndSvgElementTagNameMap[TagNames[number]] :
+    Element: // Fall back for queries typed-query-selector fails to parse, e.g. `'[alt], [aria-label]'`.
+  never;
 
 declare global {
   // Augment Intl to include
@@ -394,7 +412,7 @@ declare global {
 
   // Stricter querySelector/querySelectorAll using typed-query-selector.
   interface ParentNode {
-    querySelector<S extends string>(selector: S): ParseSelector<S> | null;
-    querySelectorAll<S extends string>(selector: S): NodeListOf<ParseSelector<S>>;
+    querySelector<S extends string>(selector: S): QuerySelectorParse<S>;
+    querySelectorAll<S extends string>(selector: S): NodeListOf<QuerySelectorParse<S>>;
   }
 }


### PR DESCRIPTION
fixes #12011

To recap: we need gatherers to deal with svg elements where they overlap in tag names with HTML elements (at least `<a>`, `<script>`, `<style>`, and `<title>`) since real pages contain those elements and those svg elements have different attributes and behavior than their HTML counterparts (causing bugs like #6481). This PR makes `querySelector` include those svg elements by default instead of only including them if no matching HTML element was found.

So now `document.querySelector('a')` returns a value of type `HTMLAnchorElement | SVGAElement` instead of just `HTMLAnchorElement`, and the subsequent code has to identify which of the two it's dealing with before proceeding.

_However_, we also use `querySelector` a lot in the report (usually via `dom.find()`), and it's annoying to have to do that extra work when we were also the ones that just wrote the template being queried and it only includes an `HTMLAnchorElement`. This PR maintains the current behavior of `dom.find()` to make report authoring easier.

This wasn't quite the idea laid out in https://github.com/GoogleChrome/lighthouse/issues/12011#issuecomment-768529482 ("make `dom.find()` only return HTMLElements (the same way it already filters out `null`)") because it turns out we already query into svg at least twice in the report (for chevrons and clipping the full-page screenshot), there may be more (e.g. queries without a tag name in them), and there's no strong reason for us to prevent doing _any_ svg querying in the future.

As a result, for `dom.find()` this PR maintains the old behavior of pretending there's no such thing as an `SVGStyleElement` (only in the world of the report), assuming that there's no reason we'd ever want an `SVGStyleElement` in there (you can just style svg from html-level css). If that ever changes, we can always make `dom.find()` stricter.