### PR TITLE
tests(smoke): temporarily disable offline-warning check

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -176,19 +176,22 @@ module.exports = [
   {
     lhr: {
       requestedUrl: 'http://localhost:10503/offline-ready.html?broken',
+      // This page's SW has a `fetch` handler that doesn't provide a 200 response.
       finalUrl: 'http://localhost:10503/offline-ready.html?broken',
       audits: {
         'installable-manifest': {
           score: 0,
           details: {items: {length: 1}},
-          // COMPAT: 'warn-not-offline-capable' was disabled in m91 until
-          // performance issues can be addressed: https://crbug.com/1187668#c22
+          // TODO: 'warn-not-offline-capable' was disabled in m91. Turn back on once
+          // issues are addressed and check is re-enabled: https://crbug.com/1187668#c22
           // warnings: {length: 1},
         },
       },
     },
     artifacts: {
       InstallabilityErrors: {
+        // COMPAT: `warn-not-offline-capable` occurs in m89 but may be cherry-picked out of m90.
+        _minChromiumMilestone: 91,
         errors: {
           length: 1,
           // 0: {

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -179,24 +179,22 @@ module.exports = [
       finalUrl: 'http://localhost:10503/offline-ready.html?broken',
       audits: {
         'installable-manifest': {
-          // Only starting in m89 do we get 'warn-not-offline-capable'.
-          // This only happens when a populated `fetch` handler that doesn't provide a 200 response
-          _minChromiumMilestone: 89,
           score: 0,
           details: {items: {length: 1}},
-          warnings: {length: 1},
+          // COMPAT: 'warn-not-offline-capable' was disabled in m91 until
+          // performance issues can be addressed: https://crbug.com/1187668#c22
+          // warnings: {length: 1},
         },
       },
     },
     artifacts: {
       InstallabilityErrors: {
-        _minChromiumMilestone: 89,
         errors: {
-          length: 2,
+          length: 1,
+          // 0: {
+          //   errorId: /warn-not-offline-capable/,
+          // },
           0: {
-            errorId: /warn-not-offline-capable/,
-          },
-          1: {
             errorId: /no-icon-available/,
           },
         },


### PR DESCRIPTION
work around #12311 in the smoke tests to fix CI.

Chrome 89 is stable now and `warn-not-offline-capable` may be removed from Chrome 90 in addition to Chrome 91 where it's already removed, so there didn't seem to be any point in gating this behind a `_minChromiumMilestone`.

Leaving the actual `installable-manifest` audit unchanged for now, since if the offline check is turned back on we should get automatically notified when this smoke test fails again :)