### PR TITLE
tests: smoke request count assertion

### DIFF
--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -19,6 +19,7 @@
   export type ExpectedRunnerResult = {
     lhr: ExpectedLHR,
     artifacts?: Partial<Record<keyof LH.Artifacts, any>>
+    networkRequests?: any;
   }
 
   export interface TestDfn {


### PR DESCRIPTION
Verifies `networkRequests` alongside `lhr` and `artifacts`.

Groups requests by socket and then remaps based on the first URL to get the requested URLs for each smoke test. Only surfaces requests made to the smoke server at `localhost:10200`.

Closes https://github.com/GoogleChrome/lighthouse/issues/11506