### PR TITLE
core(deprecations): ignore warning for ::-webkit-details-marker

### DIFF
--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -57,7 +57,8 @@ class Deprecations extends Audit {
     const entries = artifacts.ConsoleMessages;
 
     const deprecations = entries.filter(log => log.source === 'deprecation')
-    /** Temporary ignore until Chrome M91 became stable version that doesn't throw deprecation on ::-webkit-details-marker. */ 
+    // Temporary ignore until Chrome M91 became stable version.
+    // M91 doesn't throw deprecation on ::-webkit-details-marker.
     .filter(log => !log.text.includes('::-webkit-details-marker'))
     .map(log => {
       return {

--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -56,7 +56,10 @@ class Deprecations extends Audit {
   static audit(artifacts) {
     const entries = artifacts.ConsoleMessages;
 
-    const deprecations = entries.filter(log => log.source === 'deprecation').map(log => {
+    const deprecations = entries.filter(log => log.source === 'deprecation')
+    /** Temporary ignore until Chrome M91 became stable version that doesn't throw deprecation on ::-webkit-details-marker. */ 
+    .filter(log => !log.text.includes('::-webkit-details-marker'))
+    .map(log => {
       return {
         value: log.text,
         source: Audit.makeSourceLocationFromConsoleMessage(log),

--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -57,7 +57,7 @@ class Deprecations extends Audit {
     const entries = artifacts.ConsoleMessages;
 
     const deprecations = entries.filter(log => log.source === 'deprecation')
-    // Temporary ignore until Chrome M91 became stable version.
+    // TODO(M91): Temporary ignore until Chrome M91 became stable version.
     // M91 doesn't throw deprecation on ::-webkit-details-marker.
     .filter(log => !log.text.includes('::-webkit-details-marker'))
     .map(log => {


### PR DESCRIPTION
Temporary fix for #12089 


see also [report: use ::marker by connorjclark · #12267](https://github.com/GoogleChrome/lighthouse/pull/12267)