### PR TITLE
tests: remove flaky Chrome launch from unit-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
 
     # For windows, just test the potentially platform-specific code.
     - name: yarn unit-cli
-      run: yarn unit-cli || yarn unit-cli --onlyFailures
+      run: yarn unit-cli
       if: matrix.os == 'windows-latest'
     - run: yarn diff:sample-json
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
In the spirit of improving flaky tests, `unit-cli` has loooong had a flake based on a Chrome launch sometimes timing out. You know the one:

```
●  process.exit called with "1"

      84 | function printConnectionErrorAndExit() {
      85 |   console.error('Unable to connect to Chrome');
    > 86 |   return process.exit(_RUNTIME_ERROR_CODE);
         |                  ^
      87 | }
      88 | 
      89 | /** @return {never} */

      at printConnectionErrorAndExit (lighthouse-cli/run.js:86:18)
```

(for example: https://github.com/GoogleChrome/lighthouse/runs/2249363555?check_suite_focus=true)

The issue is that this is more or less a smoke test without any of the functionality we've built into smokehouse to handle dealing with launching and testing with Chrome in a CI environment.

Looking way back, the original point of the test (from #2602) was to make sure that Lighthouse can run when `lighthouse-cli` is accessed directly as a node module, since our smoke tests load Lighthouse via CLI. Very similar to the smoke tests, but we have no other test ensuring we don't break this particular use case. Since then, the assertions have grown to check a few other aspects of the run.

However the overlap between this and smokehouse's execution path is almost total (they both pass through `runLighthouse` in `run.js`), so it seems sufficient for this test to run lighthouse with `--auditMode` and the sample artifacts to make sure it's runnable, and trust smokehouse to verify `run.js` is exercising the gathering steps.

After this I believe there's no other Chrome launch in `unit-cli`, so it should be stable going forward.