### PR TITLE
core(fr): separate phase from gatherMode

### DIFF
--- a/lighthouse-core/fraggle-rock/config/validation.js
+++ b/lighthouse-core/fraggle-rock/config/validation.js
@@ -14,12 +14,8 @@ function isFRGathererDefn(gathererDefn) {
 }
 
 /**
- * Determines if the artifact dependency direction is valid.
- * A timespan artifact cannot depend on a snapshot/navigation artifact because snapshot runs after timespan.
- * A snapshot artifact cannot depend on a navigation artifact because it might be run without a navigation.
- * A navigation artifact also cannot depend on a snapshot artifact because it is collected before snapshot.
- * In other words, the dependency's minimum supported mode must be less than or equal to the dependent's with
- * a special exclusion for navigation dependents.
+ * Determines if the artifact dependency direction is valid. The dependency's minimum supported mode
+ * must be less than or equal to the dependent's.
  *
  * @param {LH.Config.FRGathererDefn} dependent The artifact that depends on the other.
  * @param {LH.Config.FRGathererDefn} dependency The artifact that is being depended on by the other.
@@ -29,9 +25,13 @@ function isValidArtifactDependency(dependent, dependency) {
   const levels = {timespan: 0, snapshot: 1, navigation: 2};
   const dependentLevel = Math.min(...dependent.instance.meta.supportedModes.map(l => levels[l]));
   const dependencyLevel = Math.min(...dependency.instance.meta.supportedModes.map(l => levels[l]));
-  // Special case navigation.
-  if (dependentLevel === levels.navigation) return dependencyLevel !== levels.snapshot;
-  return dependencyLevel <= dependentLevel;
+
+  // A timespan artifact cannot depend on a snapshot/navigation artifact because it might run without a snapshot.
+  if (dependentLevel === levels.timespan) return dependencyLevel === levels.timespan;
+  // A snapshot artifact cannot depend on a timespan/navigation artifact because it might run without a timespan.
+  if (dependentLevel === levels.snapshot) return dependencyLevel === levels.snapshot;
+  // A navigation artifact can depend on anything.
+  return true;
 }
 
 /**

--- a/lighthouse-core/fraggle-rock/gather/base-gatherer.js
+++ b/lighthouse-core/fraggle-rock/gather/base-gatherer.js
@@ -20,39 +20,42 @@ class FRGatherer {
   meta = {supportedModes: []}
 
   /**
-   * Method to start observing a page before a navigation.
-   * @param {LH.Gatherer.FRTransitionalContext} passContext
-   * @return {Promise<void>|void}
-   */
-  beforeNavigation(passContext) { }
-
-  /**
    * Method to start observing a page for an arbitrary period of time.
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<void>|void}
    */
-  beforeTimespan(passContext) { }
+  startInstrumentation(passContext) { }
 
   /**
-   * Method to end observing a page after an arbitrary period of time and return the results.
+   * Method to start observing a page when the measurements are very sensitive and
+   * should observe as little Lighthouse-induced work as possible.
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   * @return {Promise<void>|void}
+   */
+  startSensitiveInstrumentation(passContext) { }
+
+  /**
+   * Method to stop observing a page when the measurements are very sensitive and
+   * should observe as little Lighthouse-induced work as possible.
+   *
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   * @return {Promise<void>|void}
+   */
+  stopSensitiveInstrumentation(passContext) { }
+
+  /**
+   * Method to end observing a page after an arbitrary period of time.
+   * @param {LH.Gatherer.FRTransitionalContext} passContext
+   * @return {Promise<void>|void}
+   */
+  stopInstrumentation(passContext) { }
+
+  /**
+   * Method to gather results about a page.
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {LH.Gatherer.PhaseResult}
    */
-  afterTimespan(passContext) { }
-
-  /**
-   * Method to end observing a page after a navigation and return the results.
-   * @param {LH.Gatherer.FRTransitionalContext} passContext
-   * @return {LH.Gatherer.PhaseResult}
-   */
-  afterNavigation(passContext) { }
-
-  /**
-   * Method to gather results about a page in a particular state.
-   * @param {LH.Gatherer.FRTransitionalContext} passContext
-   * @return {LH.Gatherer.PhaseResult}
-   */
-  snapshot(passContext) { }
+  getArtifact(passContext) { }
 
   /**
    * Legacy property used to define the artifact ID. In Fraggle Rock, the artifact ID lives on the config.
@@ -64,12 +67,13 @@ class FRGatherer {
   }
 
   /**
-   * Legacy method. Called before navigation to target url, roughly corresponds to `beforeTimespan`.
+   * Legacy method. Called before navigation to target url, roughly corresponds to `startInstrumentation`.
    * @param {LH.Gatherer.PassContext} passContext
    * @return {Promise<LH.Gatherer.PhaseResultNonPromise>}
    */
   async beforePass(passContext) {
-    await this.beforeTimespan({...passContext, dependencies: {}});
+    await this.startInstrumentation({...passContext, dependencies: {}});
+    await this.startSensitiveInstrumentation({...passContext, dependencies: {}});
   }
 
   /**
@@ -80,17 +84,15 @@ class FRGatherer {
   pass(passContext) { }
 
   /**
-   * Legacy method. Roughly corresponds to `afterTimespan` or `snapshot` depending on type of gatherer.
+   * Legacy method. Roughly corresponds to `stopInstrumentation` or `getArtifact` depending on type of gatherer.
    * @param {LH.Gatherer.PassContext} passContext
    * @param {LH.Gatherer.LoadData} loadData
    * @return {Promise<LH.Gatherer.PhaseResultNonPromise>}
    */
   async afterPass(passContext, loadData) {
-    if (this.meta.supportedModes.includes('timespan')) {
-      return this.afterTimespan({...passContext, dependencies: {}});
-    }
-
-    return this.snapshot({...passContext, dependencies: {}});
+    await this.stopSensitiveInstrumentation({...passContext, dependencies: {}});
+    await this.stopInstrumentation({...passContext, dependencies: {}});
+    return this.getArtifact({...passContext, dependencies: {}});
   }
 }
 

--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -79,9 +79,7 @@ async function collectPhaseArtifacts(options) {
       });
     });
 
-    // Do not set the artifact promise if the result was `undefined`.
-    const result = await artifactPromise.catch(err => err);
-    if (result === undefined) continue;
+    await artifactPromise.catch(() => {});
     artifactState[phase][artifactDefn.id] = artifactPromise;
   }
 }

--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -6,12 +6,84 @@
 'use strict';
 
 /**
+ * @typedef CollectPhaseArtifactOptions
+ * @property {import('./driver.js')} driver
+ * @property {Array<LH.Config.ArtifactDefn>} artifactDefinitions
+ * @property {ArtifactState} artifactState
+ * @property {LH.Gatherer.FRGatherPhase} phase
+ * @property {LH.Gatherer.GatherMode} gatherMode
+ */
+
+/** @typedef {Record<string, Promise<any>>} IntermediateArtifacts */
+
+/** @typedef {Record<CollectPhaseArtifactOptions['phase'], IntermediateArtifacts>} ArtifactState */
+
+/**
  *
  * @param {{id: string}} dependency
  * @param {Error} error
  */
 function createDependencyError(dependency, error) {
   return new Error(`Dependency "${dependency.id}" failed with exception: ${error.message}`);
+}
+
+/** @return {ArtifactState} */
+function getEmptyArtifactState() {
+  return {
+    startInstrumentation: {},
+    startSensitiveInstrumentation: {},
+    stopSensitiveInstrumentation: {},
+    stopInstrumentation: {},
+    getArtifact: {},
+  };
+}
+
+
+// We make this an explicit record instead of array, so it's easily type checked.
+/** @type {Record<CollectPhaseArtifactOptions['phase'], CollectPhaseArtifactOptions['phase'] | undefined>} */
+const phaseToPriorPhase = {
+  startInstrumentation: undefined,
+  startSensitiveInstrumentation: 'startInstrumentation',
+  stopSensitiveInstrumentation: 'startSensitiveInstrumentation',
+  stopInstrumentation: 'stopSensitiveInstrumentation',
+  getArtifact: 'stopInstrumentation',
+};
+
+/**
+ * Runs the gatherer methods for a particular navigation phase (startInstrumentation/getArtifact/etc).
+ * All gatherer method return values are stored on the artifact state object, organized by phase.
+ * This method collects required dependencies, runs the applicable gatherer methods, and saves the
+ * result on the artifact state object that was passed as part of `options`.
+ *
+ * @param {CollectPhaseArtifactOptions} options
+ */
+async function collectPhaseArtifacts(options) {
+  const {driver, artifactDefinitions, artifactState, phase, gatherMode} = options;
+  const priorPhase = phaseToPriorPhase[phase];
+  const priorPhaseArtifacts = (priorPhase && artifactState[priorPhase]) || {};
+
+  for (const artifactDefn of artifactDefinitions) {
+    const gatherer = artifactDefn.gatherer.instance;
+
+    const priorArtifactPromise = priorPhaseArtifacts[artifactDefn.id] || Promise.resolve();
+    const artifactPromise = priorArtifactPromise.then(async () => {
+      const dependencies = phase === 'getArtifact'
+        ? await collectArtifactDependencies(artifactDefn, artifactState.getArtifact)
+        : {};
+
+      return gatherer[phase]({
+        url: await driver.url(),
+        gatherMode,
+        driver,
+        dependencies,
+      });
+    });
+
+    // Do not set the artifact promise if the result was `undefined`.
+    const result = await artifactPromise.catch(err => err);
+    if (result === undefined) continue;
+    artifactState[phase][artifactDefn.id] = artifactPromise;
+  }
 }
 
 /**
@@ -41,4 +113,28 @@ async function collectArtifactDependencies(artifact, artifactsById) {
   return Object.fromEntries(await Promise.all(dependencyPromises));
 }
 
-module.exports = {collectArtifactDependencies};
+/**
+ * Awaits the result of artifact, catching errors to set the artifact to an error instead.
+ *
+ * @param {ArtifactState} artifactState
+ * @return {Promise<Partial<LH.GathererArtifacts>>}
+ */
+async function awaitArtifacts(artifactState) {
+  /** @type {IntermediateArtifacts} */
+  const artifacts = {};
+
+  for (const [id, promise] of Object.entries(artifactState.getArtifact)) {
+    const artifact = await promise.catch(err => err);
+    if (artifact === undefined) continue;
+    artifacts[id] = artifact;
+  }
+
+  return artifacts;
+}
+
+module.exports = {
+  getEmptyArtifactState,
+  awaitArtifacts,
+  collectPhaseArtifacts,
+  collectArtifactDependencies,
+};

--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -123,8 +123,7 @@ async function awaitArtifacts(artifactState) {
 
   for (const [id, promise] of Object.entries(artifactState.getArtifact)) {
     const artifact = await promise.catch(err => err);
-    if (artifact === undefined) continue;
-    artifacts[id] = artifact;
+    if (artifact !== undefined) artifacts[id] = artifact;
   }
 
   return artifacts;

--- a/lighthouse-core/fraggle-rock/gather/timespan-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/timespan-runner.js
@@ -7,7 +7,11 @@
 
 const Driver = require('./driver.js');
 const Runner = require('../../runner.js');
-const {collectArtifactDependencies} = require('./runner-helpers.js');
+const {
+  getEmptyArtifactState,
+  collectPhaseArtifacts,
+  awaitArtifacts,
+} = require('./runner-helpers.js');
 const {initializeConfig} = require('../config/config.js');
 const {getBaseArtifacts} = require('./base-artifacts.js');
 
@@ -20,24 +24,13 @@ async function startTimespan(options) {
   const driver = new Driver(options.page);
   await driver.connect();
 
+  const artifactDefinitions = config.artifacts || [];
   const requestedUrl = await options.page.url();
-
-  /** @type {Record<string, Promise<void>>} */
-  const artifactErrors = {};
-
-  for (const {id, gatherer} of config.artifacts || []) {
-    artifactErrors[id] = Promise.resolve().then(() =>
-      gatherer.instance.beforeTimespan({
-        gatherMode: 'timespan',
-        url: requestedUrl,
-        driver,
-        dependencies: {},
-      })
-    );
-
-    // Run each beforeTimespan serially, but handle errors in the next pass.
-    await artifactErrors[id].catch(() => {});
-  }
+  const artifactState = getEmptyArtifactState();
+  /** @type {Omit<import('./runner-helpers.js').CollectPhaseArtifactOptions, 'phase'>} */
+  const phaseOptions = {driver, artifactDefinitions, artifactState, gatherMode: 'timespan'};
+  await collectPhaseArtifacts({phase: 'startInstrumentation', ...phaseOptions});
+  await collectPhaseArtifacts({phase: 'startSensitiveInstrumentation', ...phaseOptions});
 
   return {
     async endTimespan() {
@@ -48,29 +41,11 @@ async function startTimespan(options) {
           baseArtifacts.URL.requestedUrl = requestedUrl;
           baseArtifacts.URL.finalUrl = finalUrl;
 
-          /** @type {Partial<LH.GathererArtifacts>} */
-          const artifacts = {};
+          await collectPhaseArtifacts({phase: 'stopSensitiveInstrumentation', ...phaseOptions});
+          await collectPhaseArtifacts({phase: 'stopInstrumentation', ...phaseOptions});
+          await collectPhaseArtifacts({phase: 'getArtifact', ...phaseOptions});
 
-          for (const artifactDefn of config.artifacts || []) {
-            const {id, gatherer} = artifactDefn;
-            const artifactName = /** @type {keyof LH.GathererArtifacts} */ (id);
-            const dependencies = await collectArtifactDependencies(artifactDefn, artifacts);
-            /** @type {LH.Gatherer.FRTransitionalContext} */
-            const context = {
-              gatherMode: 'timespan',
-              url: finalUrl,
-              driver,
-              dependencies,
-            };
-            const artifact = await artifactErrors[id]
-              .then(() =>
-                gatherer.instance.afterTimespan(context)
-              )
-              .catch(err => err);
-
-            artifacts[artifactName] = artifact;
-          }
-
+          const artifacts = await awaitArtifacts(artifactState);
           return /** @type {LH.Artifacts} */ ({...baseArtifacts, ...artifacts}); // Cast to drop Partial<>
         },
         {

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -124,7 +124,7 @@ class Accessibility extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.Accessibility>}
    */
-  snapshot(passContext) {
+  getArtifact(passContext) {
     const driver = passContext.driver;
 
     return driver.executionContext.evaluate(runA11yChecks, {

--- a/lighthouse-core/gather/gatherers/cache-contents.js
+++ b/lighthouse-core/gather/gatherers/cache-contents.js
@@ -48,7 +48,7 @@ class CacheContents extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['CacheContents']>}
    */
-  async snapshot(passContext) {
+  async getArtifact(passContext) {
     const driver = passContext.driver;
 
     const cacheUrls = await driver.executionContext.evaluate(getCacheContents, {args: []});

--- a/lighthouse-core/gather/gatherers/console-messages.js
+++ b/lighthouse-core/gather/gatherers/console-messages.js
@@ -135,7 +135,7 @@ class ConsoleMessages extends FRGatherer {
   /**
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    */
-  async beforeTimespan(passContext) {
+  async startInstrumentation(passContext) {
     const session = passContext.driver.defaultSession;
 
     session.on('Log.entryAdded', this._onLogEntryAdded);
@@ -151,15 +151,21 @@ class ConsoleMessages extends FRGatherer {
 
   /**
    * @param {LH.Gatherer.FRTransitionalContext} passContext
-   * @return {Promise<LH.Artifacts['ConsoleMessages']>}
+   * @return {Promise<void>}
    */
-  async afterTimespan({driver}) {
+  async stopInstrumentation({driver}) {
     await driver.defaultSession.sendCommand('Log.stopViolationsReport');
     await driver.defaultSession.off('Log.entryAdded', this._onLogEntryAdded);
     await driver.defaultSession.sendCommand('Log.disable');
     await driver.defaultSession.off('Runtime.consoleAPICalled', this._onConsoleAPICalled);
     await driver.defaultSession.off('Runtime.exceptionThrown', this._onExceptionThrown);
     await driver.defaultSession.sendCommand('Runtime.disable');
+  }
+
+  /**
+   * @return {Promise<LH.Artifacts['ConsoleMessages']>}
+   */
+  async getArtifact() {
     return this._logEntries;
   }
 }

--- a/lighthouse-core/gather/gatherers/devtools-log-compat.js
+++ b/lighthouse-core/gather/gatherers/devtools-log-compat.js
@@ -26,7 +26,7 @@ class DevtoolsLogCompat extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext<'DevtoolsLog'>} passContext
    * @return {Promise<LH.Artifacts['devtoolsLogs']>}
    */
-  async afterTimespan(passContext) {
+  async getArtifact(passContext) {
     return {
       defaultPass: passContext.dependencies.DevtoolsLog,
     };

--- a/lighthouse-core/gather/gatherers/devtools-log.js
+++ b/lighthouse-core/gather/gatherers/devtools-log.js
@@ -35,7 +35,7 @@ class DevtoolsLog extends FRGatherer {
   /**
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    */
-  async beforeTimespan({driver}) {
+  async startSensitiveInstrumentation({driver}) {
     this._messageLog.reset();
     this._messageLog.beginRecording();
     driver.defaultSession.addProtocolMessageListener(this._onProtocolMessage);
@@ -47,13 +47,17 @@ class DevtoolsLog extends FRGatherer {
 
   /**
    * @param {LH.Gatherer.FRTransitionalContext} passContext
-   * @return {Promise<LH.Artifacts['DevtoolsLog']>}
    */
-  async afterTimespan({driver}) {
-    const messages = this._messageLog.messages;
+  async stopSensitiveInstrumentation({driver}) {
     this._messageLog.endRecording();
     driver.defaultSession.removeProtocolMessageListener(this._onProtocolMessage);
-    return messages;
+  }
+
+  /**
+   * @return {Promise<LH.Artifacts['DevtoolsLog']>}
+   */
+  async getArtifact() {
+    return this._messageLog.messages;
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
@@ -19,7 +19,7 @@ class AppCacheManifest extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['AppCacheManifest']>}
    */
-  snapshot(passContext) {
+  getArtifact(passContext) {
     const driver = passContext.driver;
 
     return driver.executionContext.evaluate(() => {

--- a/lighthouse-core/gather/gatherers/dobetterweb/doctype.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/doctype.js
@@ -34,7 +34,7 @@ class Doctype extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['Doctype']>}
    */
-  snapshot(passContext) {
+  getArtifact(passContext) {
     const driver = passContext.driver;
     return driver.executionContext.evaluate(getDoctype, {
       args: [],

--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -86,7 +86,7 @@ class DOMStats extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['DOMStats']>}
    */
-  async snapshot(passContext) {
+  async getArtifact(passContext) {
     const driver = passContext.driver;
 
     await driver.defaultSession.sendCommand('DOM.enable');

--- a/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
@@ -38,7 +38,7 @@ class PasswordInputsWithPreventedPaste extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['PasswordInputsWithPreventedPaste']>}
    */
-  snapshot(passContext) {
+  getArtifact(passContext) {
     return passContext.driver.executionContext.evaluate(findPasswordInputsWithPreventedPaste, {
       args: [],
       deps: [pageFunctions.getNodeDetailsString],

--- a/lighthouse-core/gather/gatherers/form-elements.js
+++ b/lighthouse-core/gather/gatherers/form-elements.js
@@ -95,7 +95,7 @@ class FormElements extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['FormElements']>}
    */
-  async snapshot(passContext) {
+  async getArtifact(passContext) {
     const driver = passContext.driver;
 
     const formElements = await driver.executionContext.evaluate(collectFormElements, {

--- a/lighthouse-core/gather/gatherers/global-listeners.js
+++ b/lighthouse-core/gather/gatherers/global-listeners.js
@@ -59,7 +59,7 @@ class GlobalListeners extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['GlobalListeners']>}
    */
-  async snapshot(passContext) {
+  async getArtifact(passContext) {
     const session = passContext.driver.defaultSession;
 
     // Get a RemoteObject handle to `window`.

--- a/lighthouse-core/gather/gatherers/iframe-elements.js
+++ b/lighthouse-core/gather/gatherers/iframe-elements.js
@@ -46,7 +46,7 @@ class IFrameElements extends FRGatherer {
    * @return {Promise<LH.Artifacts['IFrameElements']>}
    * @override
    */
-  async snapshot(passContext) {
+  async getArtifact(passContext) {
     const driver = passContext.driver;
 
     const iframeElements = await driver.executionContext.evaluate(collectIFrameElements, {

--- a/lighthouse-core/gather/gatherers/installability-errors.js
+++ b/lighthouse-core/gather/gatherers/installability-errors.js
@@ -38,7 +38,7 @@ class InstallabilityErrors extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} context
    * @return {Promise<LH.Artifacts['InstallabilityErrors']>}
    */
-  snapshot(context) {
+  getArtifact(context) {
     const driver = context.driver;
 
     return InstallabilityErrors.getInstallabilityErrors(driver.defaultSession);

--- a/lighthouse-core/gather/gatherers/meta-elements.js
+++ b/lighthouse-core/gather/gatherers/meta-elements.js
@@ -49,7 +49,7 @@ class MetaElements extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['MetaElements']>}
    */
-  snapshot(passContext) {
+  getArtifact(passContext) {
     const driver = passContext.driver;
 
     // We'll use evaluateAsync because the `node.getAttribute` method doesn't actually normalize

--- a/lighthouse-core/gather/gatherers/network-user-agent.js
+++ b/lighthouse-core/gather/gatherers/network-user-agent.js
@@ -34,7 +34,7 @@ class NetworkUserAgent extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext<'DevtoolsLog'>} context
    * @return {Promise<LH.Artifacts['NetworkUserAgent']>}
    */
-  async afterTimespan(context) {
+  async getArtifact(context) {
     return NetworkUserAgent.getNetworkUserAgent(context.dependencies.DevtoolsLog);
   }
 }

--- a/lighthouse-core/gather/gatherers/seo/embedded-content.js
+++ b/lighthouse-core/gather/gatherers/seo/embedded-content.js
@@ -50,7 +50,7 @@ class EmbeddedContent extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['EmbeddedContent']>}
    */
-  snapshot(passContext) {
+  getArtifact(passContext) {
     return passContext.driver.executionContext.evaluate(getEmbeddedContent, {
       args: [],
       deps: [

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -317,7 +317,7 @@ class FontSize extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.FontSize>} font-size analysis
    */
-  async snapshot(passContext) {
+  async getArtifact(passContext) {
     const session = passContext.driver.defaultSession;
 
     /** @type {Map<string, LH.Crdp.CSS.CSSStyleSheetHeader>} */

--- a/lighthouse-core/gather/gatherers/seo/robots-txt.js
+++ b/lighthouse-core/gather/gatherers/seo/robots-txt.js
@@ -36,7 +36,7 @@ class RobotsTxt extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts['RobotsTxt']>}
    */
-  snapshot(passContext) {
+  getArtifact(passContext) {
     return passContext.driver.executionContext.evaluate(getRobotsTxtContent, {
       args: [],
       useIsolation: true,

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -292,7 +292,7 @@ class TapTargets extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.TapTarget[]>} All visible tap targets with their positions and sizes
    */
-  snapshot(passContext) {
+  getArtifact(passContext) {
     return passContext.driver.executionContext.evaluate(gatherTapTargets, {
       args: [tapTargetsSelector],
       useIsolation: true,

--- a/lighthouse-core/gather/gatherers/trace-compat.js
+++ b/lighthouse-core/gather/gatherers/trace-compat.js
@@ -26,7 +26,7 @@ class TraceCompat extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext<'Trace'>} passContext
    * @return {Promise<LH.Artifacts['traces']>}
    */
-  async afterNavigation(passContext) {
+  async getArtifact(passContext) {
     return {
       defaultPass: passContext.dependencies.Trace,
     };

--- a/lighthouse-core/gather/gatherers/trace.js
+++ b/lighthouse-core/gather/gatherers/trace.js
@@ -14,6 +14,9 @@
 const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 
 class Trace extends FRGatherer {
+  /** @type {LH.Trace} */
+  _trace = {traceEvents: []};
+
   static getDefaultTraceCategories() {
     return [
       // Exclude default categories. We'll be selective to minimize trace size
@@ -92,7 +95,7 @@ class Trace extends FRGatherer {
   /**
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    */
-  async beforeTimespan({driver}) {
+  async startSensitiveInstrumentation({driver}) {
     // TODO(FR-COMPAT): read additional trace categories from overall settings?
     // TODO(FR-COMPAT): check if CSS/DOM domains have been enabled in another session and warn?
     await driver.defaultSession.sendCommand('Page.enable');
@@ -104,10 +107,13 @@ class Trace extends FRGatherer {
 
   /**
    * @param {LH.Gatherer.FRTransitionalContext} passContext
-   * @return {Promise<LH.Artifacts['Trace']>}
    */
-  async afterTimespan({driver}) {
-    return Trace.endTraceAndCollectEvents(driver.defaultSession);
+  async stopSensitiveInstrumentation({driver}) {
+    this._trace = await Trace.endTraceAndCollectEvents(driver.defaultSession);
+  }
+
+  getArtifact() {
+    return this._trace;
   }
 }
 

--- a/lighthouse-core/gather/gatherers/viewport-dimensions.js
+++ b/lighthouse-core/gather/gatherers/viewport-dimensions.js
@@ -37,7 +37,7 @@ class ViewportDimensions extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.ViewportDimensions>}
    */
-  async snapshot(passContext) {
+  async getArtifact(passContext) {
     const driver = passContext.driver;
 
     const dimensions = await driver.executionContext.evaluate(getViewportDimensions, {

--- a/lighthouse-core/gather/gatherers/web-app-manifest.js
+++ b/lighthouse-core/gather/gatherers/web-app-manifest.js
@@ -92,7 +92,7 @@ class WebAppManifest extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} context
    * @return {Promise<LH.Artifacts['WebAppManifest']>}
    */
-  snapshot(context) {
+  getArtifact(context) {
     const driver = context.driver;
 
     return WebAppManifest.getWebAppManifest(driver.defaultSession, context.url);

--- a/lighthouse-core/test/fraggle-rock/config/config-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/config-test.js
@@ -243,13 +243,6 @@ describe('Fraggle Rock Config', () => {
       expect(() => initializeConfig(configJson, {gatherMode: 'navigation'}))
         .toThrow(/Dependency.*is invalid/);
     });
-
-    it('should throw when navigation needs snapshot', () => {
-      dependentGatherer.meta.supportedModes = ['navigation'];
-      dependencyGatherer.meta.supportedModes = ['snapshot'];
-      expect(() => initializeConfig(configJson, {gatherMode: 'navigation'}))
-        .toThrow(/Dependency.*is invalid/);
-    });
   });
 
   it.todo('should support extension');

--- a/lighthouse-core/test/fraggle-rock/config/validation-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/validation-test.js
@@ -30,11 +30,11 @@ describe('Fraggle Rock Config Validation', () => {
       {dependent: ['timespan'], dependency: ['timespan'], isValid: true},
       {dependent: ['timespan'], dependency: ['snapshot'], isValid: false},
       {dependent: ['timespan'], dependency: ['navigation'], isValid: false},
-      {dependent: ['snapshot'], dependency: ['timespan'], isValid: true},
+      {dependent: ['snapshot'], dependency: ['timespan'], isValid: false},
       {dependent: ['snapshot'], dependency: ['snapshot'], isValid: true},
       {dependent: ['snapshot'], dependency: ['navigation'], isValid: false},
       {dependent: ['navigation'], dependency: ['timespan'], isValid: true},
-      {dependent: ['navigation'], dependency: ['snapshot'], isValid: false},
+      {dependent: ['navigation'], dependency: ['snapshot'], isValid: true},
       {dependent: ['navigation'], dependency: ['navigation'], isValid: true},
     ];
 

--- a/lighthouse-core/test/fraggle-rock/gather/base-gatherer-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/base-gatherer-test.js
@@ -18,7 +18,7 @@ describe('BaseGatherer', () => {
 
     // Fraggle Rock Gatherer contract
     expect(typeof gatherer.meta).toBe('object');
-    expect(gatherer.snapshot(fakeParam)).toBe(undefined);
+    expect(gatherer.getArtifact(fakeParam)).toBe(undefined);
 
     // Legacy Gatherer contract
     expect(typeof gatherer.name).toBe('string');
@@ -28,49 +28,45 @@ describe('BaseGatherer', () => {
   });
 
   describe('.beforePass', () => {
-    it('delegates to beforeTimespan by default', async () => {
+    it('delegates to startInstrumentation by default', async () => {
       class MyGatherer extends Gatherer {
-        beforeTimespan = jest.fn()
+        startInstrumentation = jest.fn();
+        startSensitiveInstrumentation = jest.fn();
       }
 
       const gatherer = new MyGatherer();
       await gatherer.beforePass(fakeParam);
-      expect(gatherer.beforeTimespan).toHaveBeenCalled();
+      expect(gatherer.startInstrumentation).toHaveBeenCalled();
+      expect(gatherer.startSensitiveInstrumentation).toHaveBeenCalled();
     });
   });
 
   describe('.afterPass', () => {
-    it('delegates to snapshot by default', async () => {
+    it('delegates to getArtifact by default', async () => {
       class MyGatherer extends Gatherer {
         /** @param {*} _ */
-        snapshot(_) {
+        getArtifact(_) {
           return 'Hello, Fraggle!';
         }
       }
 
       const gatherer = new MyGatherer();
-      expect(gatherer.snapshot(fakeParam)).toEqual('Hello, Fraggle!');
+      expect(gatherer.getArtifact(fakeParam)).toEqual('Hello, Fraggle!');
       expect(await gatherer.afterPass(fakeParam, fakeParam)).toEqual('Hello, Fraggle!');
     });
 
-    it('delegates to afterTimespan when supported', async () => {
+    it('invokes stopInstrumentation when supported', async () => {
       class MyGatherer extends Gatherer {
         /** @type {LH.Gatherer.GathererMeta} */
         meta = {supportedModes: ['timespan']};
-
-        /** @param {*} _ */
-        snapshot(_) {
-          return 'Oops, wrong method!';
-        }
-
-        /** @param {*} _ */
-        afterTimespan(_) {
-          return 'Hello, Fraggle!';
-        }
+        stopInstrumentation = jest.fn();
+        stopSensitiveInstrumentation = jest.fn();
       }
 
       const gatherer = new MyGatherer();
-      expect(await gatherer.afterPass(fakeParam, fakeParam)).toEqual('Hello, Fraggle!');
+      await gatherer.afterPass(fakeParam, fakeParam);
+      expect(gatherer.stopInstrumentation).toHaveBeenCalled();
+      expect(gatherer.stopSensitiveInstrumentation).toHaveBeenCalled();
     });
   });
 });

--- a/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
+++ b/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
@@ -44,6 +44,8 @@ function createMockGathererInstance(meta) {
     meta,
     startInstrumentation: jest.fn(),
     stopInstrumentation: jest.fn(),
+    startSensitiveInstrumentation: jest.fn(),
+    stopSensitiveInstrumentation: jest.fn(),
     getArtifact: jest.fn(),
 
     /** @return {LH.Gatherer.FRGathererInstance} */

--- a/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
+++ b/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
@@ -42,9 +42,9 @@ function createMockSession() {
 function createMockGathererInstance(meta) {
   return {
     meta,
-    beforeTimespan: jest.fn(),
-    afterTimespan: jest.fn(),
-    snapshot: jest.fn(),
+    startInstrumentation: jest.fn(),
+    stopInstrumentation: jest.fn(),
+    getArtifact: jest.fn(),
 
     /** @return {LH.Gatherer.FRGathererInstance} */
     asGatherer() {

--- a/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
@@ -12,7 +12,7 @@ const {defaultNavigationConfig} = require('../../../config/constants.js');
 
 /* eslint-env jest */
 
-/** @typedef {{meta: LH.Gatherer.GathererMeta<'Accessibility'>, snapshot: jest.Mock<any, any>, beforeTimespan:jest.Mock<any, any>, afterTimespan: jest.Mock<any, any>, beforeNavigation:jest.Mock<any, any>, afterNavigation: jest.Mock<any, any>}} MockGatherer */
+/** @typedef {{meta: LH.Gatherer.GathererMeta<'Accessibility'>, getArtifact: jest.Mock<any, any>, startInstrumentation:jest.Mock<any, any>, stopInstrumentation: jest.Mock<any, any>, startSensitiveInstrumentation:jest.Mock<any, any>, stopSensitiveInstrumentation: jest.Mock<any, any>}} MockGatherer */
 
 describe('NavigationRunner', () => {
   let requestedUrl = '';
@@ -31,11 +31,11 @@ describe('NavigationRunner', () => {
       instance: {
         name: 'Accessibility',
         meta: {supportedModes: []},
-        beforeTimespan: jest.fn(),
-        afterTimespan: jest.fn(),
-        beforeNavigation: jest.fn(),
-        afterNavigation: jest.fn(),
-        snapshot: jest.fn(),
+        startInstrumentation: jest.fn(),
+        stopInstrumentation: jest.fn(),
+        startSensitiveInstrumentation: jest.fn(),
+        stopSensitiveInstrumentation: jest.fn(),
+        getArtifact: jest.fn(),
       },
     };
   }
@@ -44,13 +44,15 @@ describe('NavigationRunner', () => {
   function createNavigation() {
     const timespanGatherer = createGathererDefn();
     timespanGatherer.instance.meta.supportedModes = ['timespan', 'navigation'];
-    timespanGatherer.instance.afterTimespan = jest.fn().mockResolvedValue({type: 'timespan'});
+    timespanGatherer.instance.stopInstrumentation = jest.fn().mockResolvedValue({type: 'timespan'});
     const snapshotGatherer = createGathererDefn();
     snapshotGatherer.instance.meta.supportedModes = ['snapshot', 'navigation'];
-    snapshotGatherer.instance.snapshot = jest.fn().mockResolvedValue({type: 'snapshot'});
+    snapshotGatherer.instance.getArtifact = jest.fn().mockResolvedValue({type: 'snapshot'});
     const navigationGatherer = createGathererDefn();
     navigationGatherer.instance.meta.supportedModes = ['navigation'];
-    navigationGatherer.instance.afterNavigation = jest.fn().mockResolvedValue({type: 'navigation'});
+    navigationGatherer.instance.stopSensitiveInstrumentation = jest
+      .fn()
+      .mockResolvedValue({type: 'navigation'});
 
     const navigation = {
       ...defaultNavigationConfig,
@@ -180,19 +182,21 @@ describe('NavigationRunner', () => {
         Snapshot: {type: 'snapshot'},
       });
 
-      expect(gatherers.navigation.afterNavigation).toHaveBeenCalled();
-      const navigationArgs = gatherers.navigation.afterNavigation.mock.calls[0];
+      expect(gatherers.navigation.stopSensitiveInstrumentation).toHaveBeenCalled();
+      const navigationArgs = gatherers.navigation.stopSensitiveInstrumentation.mock.calls[0];
       expect(navigationArgs[0].dependencies).toEqual({Accessibility: {type: 'timespan'}});
 
-      expect(gatherers.snapshot.snapshot).toHaveBeenCalled();
-      const snapshotArgs = gatherers.snapshot.snapshot.mock.calls[0];
+      expect(gatherers.snapshot.getArtifact).toHaveBeenCalled();
+      const snapshotArgs = gatherers.snapshot.getArtifact.mock.calls[0];
       expect(snapshotArgs[0].dependencies).toEqual({Accessibility: {type: 'timespan'}});
     });
 
     it('passes through an error in dependencies', async () => {
       const {navigation} = createNavigation();
       const err = new Error('Error in dependency chain');
-      navigation.artifacts[0].gatherer.instance.beforeTimespan = jest.fn().mockRejectedValue(err);
+      navigation.artifacts[0].gatherer.instance.startInstrumentation = jest
+        .fn()
+        .mockRejectedValue(err);
       navigation.artifacts[1].dependencies = {Accessibility: {id: 'Timespan'}};
       navigation.artifacts[2].dependencies = {Accessibility: {id: 'Timespan'}};
 
@@ -205,10 +209,10 @@ describe('NavigationRunner', () => {
       });
     });
 
-    it('passes through an error in beforeNavigation', async () => {
+    it('passes through an error in startSensitiveInstrumentation', async () => {
       const {navigation, gatherers} = createNavigation();
-      const err = new Error('Error in beforeNavigation');
-      gatherers.navigation.beforeNavigation.mockRejectedValue(err);
+      const err = new Error('Error in startSensitiveInstrumentation');
+      gatherers.navigation.startSensitiveInstrumentation.mockRejectedValue(err);
 
       const {artifacts} = await runner._navigation({driver, navigation, requestedUrl});
 
@@ -219,10 +223,10 @@ describe('NavigationRunner', () => {
       });
     });
 
-    it('passes through an error in beforeTimespan', async () => {
+    it('passes through an error in startInstrumentation', async () => {
       const {navigation, gatherers} = createNavigation();
-      const err = new Error('Error in beforeTimespan');
-      gatherers.timespan.beforeTimespan.mockRejectedValue(err);
+      const err = new Error('Error in startInstrumentation');
+      gatherers.timespan.startInstrumentation.mockRejectedValue(err);
 
       const {artifacts} = await runner._navigation({driver, navigation, requestedUrl});
 
@@ -263,50 +267,58 @@ describe('NavigationRunner', () => {
 
     beforeEach(() => {
       artifacts = {
-        beforeNavigation: {},
-        beforeTimespan: {},
-        afterTimespan: {},
-        afterNavigation: {},
-        snapshot: {},
+        startSensitiveInstrumentation: {},
+        startInstrumentation: {},
+        stopInstrumentation: {},
+        stopSensitiveInstrumentation: {},
+        getArtifact: {},
       };
     });
 
     it('should run the navigation phase of navigation gatherers', async () => {
       const {navigation, gatherers} = createNavigation();
       const navigationContext = {driver, navigation, requestedUrl};
-      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'afterNavigation'});
-      expect(artifacts.afterNavigation).toEqual({Navigation: expect.any(Promise)});
-      expect(await artifacts.afterNavigation.Navigation).toEqual({type: 'navigation'});
-      expect(gatherers.navigation.afterNavigation).toHaveBeenCalled();
+      await runner._collectPhaseArtifacts({
+        navigationContext,
+        artifacts,
+        phase: 'stopSensitiveInstrumentation',
+      });
+      expect(artifacts.stopSensitiveInstrumentation).toEqual({Navigation: expect.any(Promise)});
+      expect(await artifacts.stopSensitiveInstrumentation.Navigation).toEqual({type: 'navigation'});
+      expect(gatherers.navigation.stopSensitiveInstrumentation).toHaveBeenCalled();
       // They were invoked but no artifact was produced.
-      expect(gatherers.timespan.afterNavigation).toHaveBeenCalled();
-      expect(gatherers.snapshot.afterNavigation).toHaveBeenCalled();
+      expect(gatherers.timespan.stopSensitiveInstrumentation).toHaveBeenCalled();
+      expect(gatherers.snapshot.stopSensitiveInstrumentation).toHaveBeenCalled();
     });
 
     it('should run the snapshot phase of snapshot gatherers', async () => {
       const {navigation, gatherers} = createNavigation();
       const navigationContext = {driver, navigation, requestedUrl};
-      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'snapshot'});
-      expect(artifacts.snapshot).toEqual({Snapshot: expect.any(Promise)});
-      expect(await artifacts.snapshot.Snapshot).toEqual({type: 'snapshot'});
-      expect(gatherers.snapshot.snapshot).toHaveBeenCalled();
-      expect(gatherers.navigation.snapshot).not.toHaveBeenCalled();
-      expect(gatherers.timespan.snapshot).not.toHaveBeenCalled();
+      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'getArtifact'});
+      expect(artifacts.getArtifact).toEqual({Snapshot: expect.any(Promise)});
+      expect(await artifacts.getArtifact.Snapshot).toEqual({type: 'snapshot'});
+      expect(gatherers.snapshot.getArtifact).toHaveBeenCalled();
+      expect(gatherers.navigation.getArtifact).not.toHaveBeenCalled();
+      expect(gatherers.timespan.getArtifact).not.toHaveBeenCalled();
     });
 
     it('should run the timespan phase of timespan gatherers', async () => {
       const {navigation, gatherers} = createNavigation();
       const navigationContext = {driver, navigation, requestedUrl};
-      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'afterTimespan'});
-      expect(artifacts.afterTimespan).toEqual({Timespan: expect.any(Promise)});
-      expect(await artifacts.afterTimespan.Timespan).toEqual({type: 'timespan'});
-      expect(gatherers.timespan.afterTimespan).toHaveBeenCalled();
-      expect(gatherers.snapshot.afterTimespan).not.toHaveBeenCalled();
-      expect(gatherers.navigation.afterTimespan).not.toHaveBeenCalled();
+      await runner._collectPhaseArtifacts({
+        navigationContext,
+        artifacts,
+        phase: 'stopInstrumentation',
+      });
+      expect(artifacts.stopInstrumentation).toEqual({Timespan: expect.any(Promise)});
+      expect(await artifacts.stopInstrumentation.Timespan).toEqual({type: 'timespan'});
+      expect(gatherers.timespan.stopInstrumentation).toHaveBeenCalled();
+      expect(gatherers.snapshot.stopInstrumentation).not.toHaveBeenCalled();
+      expect(gatherers.navigation.stopInstrumentation).not.toHaveBeenCalled();
     });
 
     it('should pass dependencies from prior phase to gatherers', async () => {
-      artifacts.afterTimespan = {
+      artifacts.stopInstrumentation = {
         Dependency: Promise.resolve([{src: 'https://example.com/image.jpg'}]),
       };
 
@@ -316,13 +328,13 @@ describe('NavigationRunner', () => {
       ];
 
       const navigationContext = {driver, navigation, requestedUrl};
-      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'snapshot'});
-      expect(artifacts.snapshot).toEqual({
+      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'getArtifact'});
+      expect(artifacts.getArtifact).toEqual({
         Snapshot: expect.any(Promise),
       });
-      expect(gatherers.snapshot.snapshot).toHaveBeenCalled();
+      expect(gatherers.snapshot.getArtifact).toHaveBeenCalled();
 
-      const receivedDependencies = gatherers.snapshot.snapshot.mock.calls[0][0].dependencies;
+      const receivedDependencies = gatherers.snapshot.getArtifact.mock.calls[0][0].dependencies;
       expect(receivedDependencies).toEqual({
         ImageElements: [{src: 'https://example.com/image.jpg'}],
       });
@@ -337,36 +349,42 @@ describe('NavigationRunner', () => {
       ];
 
       const navigationContext = {driver, navigation, requestedUrl};
-      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'snapshot'});
-      expect(artifacts.snapshot).toEqual({
+      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'getArtifact'});
+      expect(artifacts.getArtifact).toEqual({
         Dependency: expect.any(Promise),
         Snapshot: expect.any(Promise),
       });
 
       // Ensure neither threw an exception
-      await artifacts.snapshot.Dependency;
-      await artifacts.snapshot.Snapshot;
+      await artifacts.getArtifact.Dependency;
+      await artifacts.getArtifact.Snapshot;
 
-      expect(gatherers.snapshot.snapshot).toHaveBeenCalledTimes(2);
+      expect(gatherers.snapshot.getArtifact).toHaveBeenCalledTimes(2);
 
-      const receivedDependencies = gatherers.snapshot.snapshot.mock.calls[1][0].dependencies;
+      const receivedDependencies = gatherers.snapshot.getArtifact.mock.calls[1][0].dependencies;
       expect(receivedDependencies).toEqual({
         ImageElements: {type: 'snapshot'},
       });
     });
 
     it('should combine the previous promises', async () => {
-      artifacts.beforeTimespan = {Timespan: Promise.reject(new Error('beforeTimespan rejection'))};
+      artifacts.startInstrumentation = {
+        Timespan: Promise.reject(new Error('startInstrumentation rejection')),
+      };
 
       const {navigation, gatherers} = createNavigation();
       const navigationContext = {driver, navigation, requestedUrl};
-      await runner._collectPhaseArtifacts({navigationContext, artifacts, phase: 'afterTimespan'});
-      expect(artifacts.afterTimespan).toEqual({Timespan: expect.any(Promise)});
-      await expect(artifacts.afterTimespan.Timespan).rejects.toMatchObject({
-        message: 'beforeTimespan rejection',
+      await runner._collectPhaseArtifacts({
+        navigationContext,
+        artifacts,
+        phase: 'stopInstrumentation',
       });
-      expect(gatherers.timespan.afterTimespan).not.toHaveBeenCalled();
-      expect(gatherers.snapshot.afterTimespan).not.toHaveBeenCalled();
+      expect(artifacts.stopInstrumentation).toEqual({Timespan: expect.any(Promise)});
+      await expect(artifacts.stopInstrumentation.Timespan).rejects.toMatchObject({
+        message: 'startInstrumentation rejection',
+      });
+      expect(gatherers.timespan.stopInstrumentation).not.toHaveBeenCalled();
+      expect(gatherers.snapshot.stopInstrumentation).not.toHaveBeenCalled();
     });
   });
 });

--- a/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
@@ -7,6 +7,7 @@
 
 const helpers = require('../../../fraggle-rock/gather/runner-helpers.js');
 const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
+const {createMockDriver, createMockGathererInstance} = require('./mock-driver.js');
 
 /* eslint-env jest */
 
@@ -14,7 +15,7 @@ describe('collectArtifactDependencies', () => {
   /** @type {LH.Config.ArtifactDefn} */
   let artifact;
   /** @type {Record<string, any>} */
-  let artifactsById;
+  let artifactStateById;
 
   beforeEach(() => {
     artifact = {
@@ -22,52 +23,197 @@ describe('collectArtifactDependencies', () => {
       gatherer: {instance: new Gatherer()},
       dependencies: {ImageElements: {id: 'Dependency'}},
     };
-    artifactsById = {
+    artifactStateById = {
       Dependency: [],
     };
   });
 
   it('should handle no dependencies', async () => {
     artifact.dependencies = undefined;
-    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    const result = await helpers.collectArtifactDependencies(artifact, artifactStateById);
     expect(result).toEqual({});
   });
 
   it('should handle empty dependencies', async () => {
     // @ts-expect-error - this isn't valid given our set of types, but plugins might do this.
     artifact.dependencies = {};
-    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    const result = await helpers.collectArtifactDependencies(artifact, artifactStateById);
     expect(result).toEqual({});
   });
 
   it('should handle successful dependencies', async () => {
-    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    const result = await helpers.collectArtifactDependencies(artifact, artifactStateById);
     expect(result).toEqual({ImageElements: []});
   });
 
   it('should handle successful promise dependencies', async () => {
-    artifactsById.Dependency = Promise.resolve([]);
-    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    artifactStateById.Dependency = Promise.resolve([]);
+    const result = await helpers.collectArtifactDependencies(artifact, artifactStateById);
     expect(result).toEqual({ImageElements: []});
   });
 
   it('should handle falsy dependencies', async () => {
-    artifactsById.Dependency = null;
-    const result = await helpers.collectArtifactDependencies(artifact, artifactsById);
+    artifactStateById.Dependency = null;
+    const result = await helpers.collectArtifactDependencies(artifact, artifactStateById);
     expect(result).toEqual({ImageElements: null});
   });
 
   it('should handle missing dependencies', async () => {
-    artifactsById.Dependency = undefined;
-    const result = helpers.collectArtifactDependencies(artifact, artifactsById);
+    artifactStateById.Dependency = undefined;
+    const result = helpers.collectArtifactDependencies(artifact, artifactStateById);
     await expect(result).rejects.toMatchObject({message: expect.stringContaining('did not run')});
   });
 
   it('should handle errored dependencies', async () => {
-    artifactsById.Dependency = Promise.reject(new Error('DEP_FAILURE'));
-    const result = helpers.collectArtifactDependencies(artifact, artifactsById);
+    artifactStateById.Dependency = Promise.reject(new Error('DEP_FAILURE'));
+    const result = helpers.collectArtifactDependencies(artifact, artifactStateById);
     await expect(result).rejects.toMatchObject({
       message: expect.stringContaining('"Dependency" failed with exception: DEP_FAILURE'),
     });
+  });
+});
+
+describe('collectPhaseArtifacts', () => {
+  /** @type {import('../../../fraggle-rock/gather/runner-helpers').ArtifactState} */
+  let artifactState = {
+    startInstrumentation: {},
+    startSensitiveInstrumentation: {},
+    stopSensitiveInstrumentation: {},
+    stopInstrumentation: {},
+    getArtifact: {},
+  };
+
+  /** @type {ReturnType<ReturnType<typeof createMockDriver>['asDriver']>} */
+  let driver;
+  /** @type {ReturnType<typeof createMockDriver>} */
+  let mockDriver;
+
+  function createGathererSet() {
+    const timespan = createMockGathererInstance({supportedModes: ['timespan', 'navigation']});
+    timespan.getArtifact.mockResolvedValue({type: 'timespan'});
+    const snapshot = createMockGathererInstance({supportedModes: ['snapshot', 'navigation']});
+    snapshot.getArtifact.mockResolvedValue({type: 'snapshot'});
+    const navigation = createMockGathererInstance({supportedModes: ['navigation']});
+    navigation.getArtifact.mockResolvedValue({type: 'navigation'});
+
+    return {
+      artifactDefinitions: [
+        {id: 'Timespan', gatherer: {instance: timespan.asGatherer()}},
+        {id: 'Snapshot', gatherer: {instance: snapshot.asGatherer()}},
+        {id: 'Navigation', gatherer: {instance: navigation.asGatherer()}},
+      ],
+      gatherers: {timespan, snapshot, navigation},
+    };
+  }
+
+  beforeEach(() => {
+    mockDriver = createMockDriver();
+    driver = mockDriver.asDriver();
+    artifactState = {
+      startInstrumentation: {},
+      startSensitiveInstrumentation: {},
+      stopSensitiveInstrumentation: {},
+      stopInstrumentation: {},
+      getArtifact: {},
+    };
+  });
+
+  for (const phase_ of Object.keys(artifactState)) {
+    const phase = /** @type {keyof typeof artifactState} */ (phase_);
+    for (const gatherMode of ['navigation', 'timespan', 'snapshot']) {
+      it(`should run the ${phase} phase of gatherers in ${gatherMode} mode`, async () => {
+        const {artifactDefinitions, gatherers} = createGathererSet();
+        await helpers.collectPhaseArtifacts({
+          driver,
+          artifactDefinitions,
+          artifactState,
+          phase,
+          gatherMode: /** @type {any} */ (gatherMode),
+        });
+        expect(artifactState[phase]).toEqual({
+          Timespan: expect.any(Promise),
+          Snapshot: expect.any(Promise),
+          Navigation: expect.any(Promise),
+        });
+        expect(gatherers.navigation[phase]).toHaveBeenCalled();
+        expect(gatherers.timespan[phase]).toHaveBeenCalled();
+        expect(gatherers.snapshot[phase]).toHaveBeenCalled();
+      });
+    }
+  }
+
+  it('should gather the artifacts', async () => {
+    const {artifactDefinitions} = createGathererSet();
+    await helpers.collectPhaseArtifacts({
+      driver,
+      artifactDefinitions,
+      artifactState,
+      gatherMode: 'navigation',
+      phase: 'getArtifact',
+    });
+    expect(await artifactState.getArtifact.Snapshot).toEqual({type: 'snapshot'});
+    expect(await artifactState.getArtifact.Timespan).toEqual({type: 'timespan'});
+    expect(await artifactState.getArtifact.Navigation).toEqual({type: 'navigation'});
+  });
+
+  it('should pass dependencies to gatherers', async () => {
+    const {artifactDefinitions: artifacts_, gatherers} = createGathererSet();
+    const gatherer = artifacts_[1].gatherer;
+    const artifactDefinitions = [
+      {id: 'Dependency', gatherer},
+      {id: 'Snapshot', gatherer, dependencies: {ImageElements: {id: 'Dependency'}}},
+    ];
+
+    await helpers.collectPhaseArtifacts({
+      driver,
+      artifactDefinitions,
+      artifactState,
+      gatherMode: 'navigation',
+      phase: 'getArtifact',
+    });
+    expect(artifactState.getArtifact).toEqual({
+      Dependency: expect.any(Promise),
+      Snapshot: expect.any(Promise),
+    });
+
+    // Ensure neither threw an exception
+    await artifactState.getArtifact.Dependency;
+    await artifactState.getArtifact.Snapshot;
+
+    expect(gatherers.snapshot.getArtifact).toHaveBeenCalledTimes(2);
+
+    const receivedDependencies = gatherers.snapshot.getArtifact.mock.calls[1][0].dependencies;
+    expect(receivedDependencies).toEqual({
+      ImageElements: {type: 'snapshot'},
+    });
+  });
+
+  it('should combine the previous promises', async () => {
+    artifactState.stopInstrumentation = {
+      Timespan: Promise.reject(new Error('stopInstrumentation rejection')),
+    };
+
+    const {artifactDefinitions, gatherers} = createGathererSet();
+    await helpers.collectPhaseArtifacts({
+      driver,
+      artifactDefinitions,
+      artifactState,
+      gatherMode: 'navigation',
+      phase: 'getArtifact',
+    });
+    expect(artifactState.getArtifact).toEqual({
+      Snapshot: expect.any(Promise),
+      Timespan: expect.any(Promise),
+      Navigation: expect.any(Promise),
+    });
+
+    // Ensure the others didn't reject.
+    await artifactState.getArtifact.Snapshot;
+    await artifactState.getArtifact.Navigation;
+
+    await expect(artifactState.getArtifact.Timespan).rejects.toMatchObject({
+      message: 'stopInstrumentation rejection',
+    });
+    expect(gatherers.timespan.getArtifact).not.toHaveBeenCalled();
   });
 });

--- a/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
@@ -89,6 +89,15 @@ describe('Snapshot Runner', () => {
     expect(gathererB.getArtifact).toHaveBeenCalled();
   });
 
+  it('should not invoke instrumentation methods', async () => {
+    await snapshot({page, config});
+    await mockRunnerRun.mock.calls[0][0]();
+    expect(gathererA.startInstrumentation).not.toHaveBeenCalled();
+    expect(gathererA.startSensitiveInstrumentation).not.toHaveBeenCalled();
+    expect(gathererA.stopSensitiveInstrumentation).not.toHaveBeenCalled();
+    expect(gathererA.stopInstrumentation).not.toHaveBeenCalled();
+  });
+
   it('should skip timespan artifacts', async () => {
     gathererB.meta.supportedModes = ['timespan'];
 

--- a/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
@@ -51,10 +51,10 @@ describe('Snapshot Runner', () => {
     });
 
     gathererA = createMockGathererInstance({supportedModes: ['snapshot']});
-    gathererA.snapshot.mockResolvedValue('Artifact A');
+    gathererA.getArtifact.mockResolvedValue('Artifact A');
 
     gathererB = createMockGathererInstance({supportedModes: ['snapshot']});
-    gathererB.snapshot.mockResolvedValue('Artifact B');
+    gathererB.getArtifact.mockResolvedValue('Artifact B');
 
     config = {
       artifacts: [
@@ -85,8 +85,8 @@ describe('Snapshot Runner', () => {
     await snapshot({page, config});
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
-    expect(gathererA.snapshot).toHaveBeenCalled();
-    expect(gathererB.snapshot).toHaveBeenCalled();
+    expect(gathererA.getArtifact).toHaveBeenCalled();
+    expect(gathererB.getArtifact).toHaveBeenCalled();
   });
 
   it('should skip timespan artifacts', async () => {
@@ -96,7 +96,7 @@ describe('Snapshot Runner', () => {
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: 'Artifact A'});
     expect(artifacts).not.toHaveProperty('B');
-    expect(gathererB.snapshot).not.toHaveBeenCalled();
+    expect(gathererB.getArtifact).not.toHaveBeenCalled();
   });
 
   it('should support artifact dependencies', async () => {
@@ -108,7 +108,7 @@ describe('Snapshot Runner', () => {
     await snapshot({page, config});
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
-    expect(gathererB.snapshot.mock.calls[0][0]).toMatchObject({
+    expect(gathererB.getArtifact.mock.calls[0][0]).toMatchObject({
       dependencies: {
         ImageElements: 'Artifact A',
       },

--- a/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
@@ -51,10 +51,10 @@ describe('Timespan Runner', () => {
     });
 
     gathererA = createMockGathererInstance({supportedModes: ['timespan']});
-    gathererA.stopInstrumentation.mockResolvedValue('Artifact A');
+    gathererA.getArtifact.mockResolvedValue('Artifact A');
 
     gathererB = createMockGathererInstance({supportedModes: ['timespan']});
-    gathererB.stopInstrumentation.mockResolvedValue('Artifact B');
+    gathererB.getArtifact.mockResolvedValue('Artifact B');
 
     config = {
       artifacts: [
@@ -75,6 +75,8 @@ describe('Timespan Runner', () => {
     const timespan = await startTimespan({page, config});
     expect(gathererA.startInstrumentation).toHaveBeenCalled();
     expect(gathererB.startInstrumentation).toHaveBeenCalled();
+    expect(gathererA.startSensitiveInstrumentation).toHaveBeenCalled();
+    expect(gathererB.startSensitiveInstrumentation).toHaveBeenCalled();
     await timespan.endTimespan();
   });
 
@@ -96,13 +98,21 @@ describe('Timespan Runner', () => {
     });
   });
 
+  it('should invoke stop instrumentation', async () => {
+    const timespan = await startTimespan({page, config});
+    await timespan.endTimespan();
+    await mockRunnerRun.mock.calls[0][0]();
+    expect(gathererA.stopSensitiveInstrumentation).toHaveBeenCalled();
+    expect(gathererB.stopSensitiveInstrumentation).toHaveBeenCalled();
+    expect(gathererA.stopInstrumentation).toHaveBeenCalled();
+    expect(gathererB.stopInstrumentation).toHaveBeenCalled();
+  });
+
   it('should collect timespan artifacts', async () => {
     const timespan = await startTimespan({page, config});
     await timespan.endTimespan();
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
-    expect(gathererA.stopInstrumentation).toHaveBeenCalled();
-    expect(gathererB.stopInstrumentation).toHaveBeenCalled();
   });
 
   it('should carryover failures from startInstrumentation', async () => {
@@ -125,7 +135,8 @@ describe('Timespan Runner', () => {
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: 'Artifact A'});
     expect(artifacts).not.toHaveProperty('B');
-    expect(gathererB.stopInstrumentation).not.toHaveBeenCalled();
+    expect(gathererB.startInstrumentation).not.toHaveBeenCalled();
+    expect(gathererB.getArtifact).not.toHaveBeenCalled();
   });
 
   it('should support artifact dependencies', async () => {
@@ -138,7 +149,7 @@ describe('Timespan Runner', () => {
     await timespan.endTimespan();
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
-    expect(gathererB.stopInstrumentation.mock.calls[0][0]).toMatchObject({
+    expect(gathererB.getArtifact.mock.calls[0][0]).toMatchObject({
       dependencies: {
         ImageElements: 'Artifact A',
       },

--- a/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
@@ -51,10 +51,10 @@ describe('Timespan Runner', () => {
     });
 
     gathererA = createMockGathererInstance({supportedModes: ['timespan']});
-    gathererA.afterTimespan.mockResolvedValue('Artifact A');
+    gathererA.stopInstrumentation.mockResolvedValue('Artifact A');
 
     gathererB = createMockGathererInstance({supportedModes: ['timespan']});
-    gathererB.afterTimespan.mockResolvedValue('Artifact B');
+    gathererB.stopInstrumentation.mockResolvedValue('Artifact B');
 
     config = {
       artifacts: [
@@ -71,10 +71,10 @@ describe('Timespan Runner', () => {
     expect(mockRunnerRun).toHaveBeenCalled();
   });
 
-  it('should invoke beforeTimespan', async () => {
+  it('should invoke startInstrumentation', async () => {
     const timespan = await startTimespan({page, config});
-    expect(gathererA.beforeTimespan).toHaveBeenCalled();
-    expect(gathererB.beforeTimespan).toHaveBeenCalled();
+    expect(gathererA.startInstrumentation).toHaveBeenCalled();
+    expect(gathererB.startInstrumentation).toHaveBeenCalled();
     await timespan.endTimespan();
   });
 
@@ -101,20 +101,20 @@ describe('Timespan Runner', () => {
     await timespan.endTimespan();
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
-    expect(gathererA.afterTimespan).toHaveBeenCalled();
-    expect(gathererB.afterTimespan).toHaveBeenCalled();
+    expect(gathererA.stopInstrumentation).toHaveBeenCalled();
+    expect(gathererB.stopInstrumentation).toHaveBeenCalled();
   });
 
-  it('should carryover failures from beforeTimespan', async () => {
+  it('should carryover failures from startInstrumentation', async () => {
     const artifactError = new Error('BEFORE_TIMESPAN_ERROR');
-    gathererA.beforeTimespan.mockRejectedValue(artifactError);
+    gathererA.startInstrumentation.mockRejectedValue(artifactError);
 
     const timespan = await startTimespan({page, config});
     await timespan.endTimespan();
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: artifactError, B: 'Artifact B'});
-    expect(gathererA.afterTimespan).not.toHaveBeenCalled();
-    expect(gathererB.afterTimespan).toHaveBeenCalled();
+    expect(gathererA.stopInstrumentation).not.toHaveBeenCalled();
+    expect(gathererB.stopInstrumentation).toHaveBeenCalled();
   });
 
   it('should skip snapshot artifacts', async () => {
@@ -125,7 +125,7 @@ describe('Timespan Runner', () => {
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: 'Artifact A'});
     expect(artifacts).not.toHaveProperty('B');
-    expect(gathererB.afterTimespan).not.toHaveBeenCalled();
+    expect(gathererB.stopInstrumentation).not.toHaveBeenCalled();
   });
 
   it('should support artifact dependencies', async () => {
@@ -138,7 +138,7 @@ describe('Timespan Runner', () => {
     await timespan.endTimespan();
     const artifacts = await mockRunnerRun.mock.calls[0][0]();
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
-    expect(gathererB.afterTimespan.mock.calls[0][0]).toMatchObject({
+    expect(gathererB.stopInstrumentation.mock.calls[0][0]).toMatchObject({
       dependencies: {
         ImageElements: 'Artifact A',
       },

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -117,7 +117,7 @@ declare global {
       startSensitiveInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
       stopSensitiveInstrumentation(context: FRTransitionalContext<TDependencies>): Promise<void>|void;
       stopInstrumentation(context: FRTransitionalContext<TDependencies>): Promise<void>|void;
-      collectArtifact(context: FRTransitionalContext<TDependencies>): PhaseResult;
+      getArtifact(context: FRTransitionalContext<TDependencies>): PhaseResult;
     }
 
     namespace Simulation {

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -108,14 +108,16 @@ declare global {
       afterPass(context: LH.Gatherer.PassContext, loadData: LH.Gatherer.LoadData): PhaseResult;
     }
 
+    export type FRGatherPhase = keyof Omit<LH.Gatherer.FRGathererInstance, 'name'|'meta'>
+
     export interface FRGathererInstance<TDependencies extends DependencyKey = DefaultDependenciesKey> {
       name: keyof LH.GathererArtifacts; // temporary COMPAT measure until artifact config support is available
       meta: GathererMeta<TDependencies>;
-      beforeNavigation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
-      beforeTimespan(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
-      afterTimespan(context: FRTransitionalContext<TDependencies>): PhaseResult;
-      afterNavigation(context: FRTransitionalContext<TDependencies>): PhaseResult;
-      snapshot(context: FRTransitionalContext<TDependencies>): PhaseResult;
+      startInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
+      startSensitiveInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
+      stopSensitiveInstrumentation(context: FRTransitionalContext<TDependencies>): Promise<void>|void;
+      stopInstrumentation(context: FRTransitionalContext<TDependencies>): Promise<void>|void;
+      collectArtifact(context: FRTransitionalContext<TDependencies>): PhaseResult;
     }
 
     namespace Simulation {


### PR DESCRIPTION
**Summary**
After trying to prototype out a few of the tougher gatherers we'll eventually want to convert, they required some hacky maneuvering to fit into the current phase structure of Fraggle Rock. After talking with @paulirish we came to the conclusion it'd be better if the concept of `phase` and `gatherMode` **weren't** so tied to together. It was convenient to understand and reason about when it all worked seamlessly, but just made things really confusing when gatherers became more complex (where do you need to write gatherer functionality to get it to run? I want this to run in timespan and navigation modes will `beforeTimespan` be called if I also use `beforeNavigation`?) .

This PR...

- Severs the name relationship between phases and gather modes by renaming the phases.
  - `beforeTimespan` -> `startInstrumentation`
  - `afterTimespan` -> `stopInstrumentation`
  - `startSensitiveInstrumentation`/`stopSensitiveInstrumentation` -> better separates the performance sensitive observations that should capture as little of Lighthouse overhead as possible (i.e. tracing, network logs, debugger, etc)
  - `beforeNavigation`/`afterNavigation` no longer needed, instrumentation methods are invoked for both timespan and navigation gatherModes and gatherers can decide if they want to alter their behavior or not.
  - `snapshot` -> `getArtifact`
- Refactors the 3 FR runners to share all of this phase collection logic so it's not repeated.
- Forces all gatherers to return their results in `getArtifact`. This might feel reminiscent of the ancient times when every gatherer had to store information on `this` before returning it in a "collect" method *but* it's a little different because every snapshot gatherer still won't have to touch `this` and `timespan` gatherers mostly already have to store their data on `this` during observations anyway, so we still get many of the benefits. This is technically an optional change, but I think it further reinforces the idea that in `stop*` methods the ONLY thing that should be done is to stop observing, and all heavier logic should happen in `getArtifact`. The fact that it's optional means if we regret this decision in the future we could always undo it later, but if we start with allowing `stop*` to return artifacts we can't really go back on it.
  - This also removes the ability to depend on other artifacts in `stopInstrumentation` phase (because the artifact is only computed in `getArtifact`)

**Feedback I'm Looking For**
- Does the above make sense? 
    - Missing any phases?
    - Do we want to preserve the returning of the artifact in `stopInstrumentation` for ease and more dependency opportunities?
    - Anything I'm missing :)
- Any strong preferences on other phase names?



**Alternative Phase Names**

If you'd like to 🚲 🏠  the new phase names, here were some others thrown around...

- `startObservations` / `endObservations`
- `startHeavyInstrumentation`
- `beginDelicateInstrumentation`
- `collectArtifact`
- `gather`
- `collect`
- `analyze`


**TODO**

- ~~Validate names with the team~~
- ~~Update all the FR runner tests for the new model of execution~~
- ~~Do final searches for any occurrences of the old names~~

**Related Issues/PRs**
ref #11313 
