### PR TITLE
docs: Remove AMP Plugin example from plugins.md

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -368,7 +368,6 @@ Most artifacts will try to represent as truthfully as possible what was observed
 - [YouTube Embed](https://github.com/connorjclark/lighthouse-plugin-yt) - Identifies YouTube embeds
 - [Lighthouse Plugin Recipe](./recipes/lighthouse-plugin-example)
 - [Field Performance](https://github.com/treosh/lighthouse-plugin-field-performance) - A plugin to gather and display Chrome UX Report field data
-- [AMP Plugin](https://github.com/ampproject/amp-toolbox/tree/main/packages/lighthouse-plugin-amp) - Runs pages through the AMP validator.
 - [Publisher Ads Audits](https://github.com/googleads/pub-ads-lighthouse-plugin) - a well-written, but complex, plugin
 - [Green Web Foundation](https://github.com/thegreenwebfoundation/lighthouse-plugin-greenhouse) - A plugin to see which domains run on renewable power.
 - [requests-content-md5](https://www.npmjs.com/package/lighthouse-plugin-md5) - Generates MD5 hashes from the content of network requests..


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
I removed the "AMP Plugin" link from the plugins.md pointing to the lighthouse-plugin-amp plugin which seems to not be available anymore (points to a 404, the plugin seems to not be available anymore at the destination project).

**Related Issues/PRs**
- I didn't found a related issue