### PR TITLE
RFC: core(runner): move non-audit code to index and gather-runner

### DIFF
--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -222,20 +222,14 @@ async function navigation(options) {
   const {url: requestedUrl, page} = options;
   const {config} = initializeConfig(options.config, {gatherMode: 'navigation'});
 
-  return Runner.run(
-    async () => {
-      const driver = new Driver(page);
-      const {baseArtifacts} = await _setup({driver, config, requestedUrl});
-      const {artifacts} = await _navigations({driver, config, requestedUrl});
-      await _cleanup({driver});
+  const driver = new Driver(page);
+  const {baseArtifacts} = await _setup({driver, config, requestedUrl});
+  const {artifacts: gathererArtifacts} = await _navigations({driver, config, requestedUrl});
+  await _cleanup({driver});
 
-      return /** @type {LH.Artifacts} */ ({...baseArtifacts, ...artifacts}); // Cast to drop Partial<>
-    },
-    {
-      url: requestedUrl,
-      config,
-    }
-  );
+  const artifacts = /** @type {LH.Artifacts} */ ({...baseArtifacts, ...gathererArtifacts}); // Cast to drop Partial<>
+
+  return Runner.run(artifacts, {config});
 }
 
 module.exports = {

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -11,6 +11,7 @@ const lookupClosestLocale = require('lookup-closest-locale');
 const LOCALES = require('./locales.js');
 const {isObjectOfUnknownValues, isObjectOrArrayOfUnknownValues} = require('../type-verifiers.js');
 
+/** @type {'en'} */
 const DEFAULT_LOCALE = 'en';
 
 /** @typedef {import('intl-messageformat-parser').Element} MessageElement */
@@ -538,6 +539,7 @@ module.exports = {
   collectAllCustomElementsFromICU,
   registerLocaleData,
   isStringOrIcuMessage,
+  DEFAULT_LOCALE,
   // TODO: exported for backwards compatibility. Consider removing on future breaking change.
   createMessageInstanceIdFn: createIcuMessageFn,
 };

--- a/lighthouse-core/test/fixtures/artifacts/alphabet-artifacts/artifacts.json
+++ b/lighthouse-core/test/fixtures/artifacts/alphabet-artifacts/artifacts.json
@@ -1,4 +1,5 @@
 {
+  "LighthouseRunWarnings": [],
   "URL": {
     "requestedUrl": "https://example.com/",
     "finalUrl": "https://example.com/"

--- a/lighthouse-core/test/fixtures/artifacts/empty-artifacts/artifacts.json
+++ b/lighthouse-core/test/fixtures/artifacts/empty-artifacts/artifacts.json
@@ -1,4 +1,5 @@
 {
+  "LighthouseRunWarnings": [],
   "URL": {
     "requestedUrl": "https://example.com/",
     "finalUrl": "https://example.com/"

--- a/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
@@ -74,7 +74,7 @@ describe('Snapshot Runner', () => {
     mockPage.url.mockResolvedValue('https://lighthouse.example.com/');
 
     await snapshot({page, config});
-    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    const artifacts = await mockRunnerRun.mock.calls[0][0];
     expect(artifacts).toMatchObject({
       fetchTime: expect.any(String),
       URL: {finalUrl: 'https://lighthouse.example.com/'},
@@ -83,7 +83,7 @@ describe('Snapshot Runner', () => {
 
   it('should collect snapshot artifacts', async () => {
     await snapshot({page, config});
-    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    const artifacts = await mockRunnerRun.mock.calls[0][0];
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
     expect(gathererA.snapshot).toHaveBeenCalled();
     expect(gathererB.snapshot).toHaveBeenCalled();
@@ -93,7 +93,7 @@ describe('Snapshot Runner', () => {
     gathererB.meta.supportedModes = ['timespan'];
 
     await snapshot({page, config});
-    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    const artifacts = await mockRunnerRun.mock.calls[0][0];
     expect(artifacts).toMatchObject({A: 'Artifact A'});
     expect(artifacts).not.toHaveProperty('B');
     expect(gathererB.snapshot).not.toHaveBeenCalled();
@@ -106,7 +106,7 @@ describe('Snapshot Runner', () => {
     gathererB.meta.dependencies = {ImageElements: dependencySymbol};
 
     await snapshot({page, config});
-    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    const artifacts = await mockRunnerRun.mock.calls[0][0];
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
     expect(gathererB.snapshot.mock.calls[0][0]).toMatchObject({
       dependencies: {

--- a/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
@@ -86,7 +86,7 @@ describe('Timespan Runner', () => {
     mockPage.url.mockResolvedValue('https://end.example.com/');
 
     await timespan.endTimespan();
-    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    const artifacts = await mockRunnerRun.mock.calls[0][0];
     expect(artifacts).toMatchObject({
       fetchTime: expect.any(String),
       URL: {
@@ -99,7 +99,7 @@ describe('Timespan Runner', () => {
   it('should collect timespan artifacts', async () => {
     const timespan = await startTimespan({page, config});
     await timespan.endTimespan();
-    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    const artifacts = await mockRunnerRun.mock.calls[0][0];
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
     expect(gathererA.afterTimespan).toHaveBeenCalled();
     expect(gathererB.afterTimespan).toHaveBeenCalled();
@@ -111,7 +111,7 @@ describe('Timespan Runner', () => {
 
     const timespan = await startTimespan({page, config});
     await timespan.endTimespan();
-    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    const artifacts = await mockRunnerRun.mock.calls[0][0];
     expect(artifacts).toMatchObject({A: artifactError, B: 'Artifact B'});
     expect(gathererA.afterTimespan).not.toHaveBeenCalled();
     expect(gathererB.afterTimespan).toHaveBeenCalled();
@@ -122,7 +122,7 @@ describe('Timespan Runner', () => {
 
     const timespan = await startTimespan({page, config});
     await timespan.endTimespan();
-    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    const artifacts = await mockRunnerRun.mock.calls[0][0];
     expect(artifacts).toMatchObject({A: 'Artifact A'});
     expect(artifacts).not.toHaveProperty('B');
     expect(gathererB.afterTimespan).not.toHaveBeenCalled();
@@ -136,7 +136,7 @@ describe('Timespan Runner', () => {
 
     const timespan = await startTimespan({page, config});
     await timespan.endTimespan();
-    const artifacts = await mockRunnerRun.mock.calls[0][0]();
+    const artifacts = await mockRunnerRun.mock.calls[0][0];
     expect(artifacts).toMatchObject({A: 'Artifact A', B: 'Artifact B'});
     expect(gathererB.afterTimespan.mock.calls[0][0]).toMatchObject({
       dependencies: {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -201,9 +201,9 @@ describe('GatherRunner', function() {
     const requestedUrl = 'https://example.com';
     const driver = fakeDriver;
     const config = makeConfig({passes: []});
-    const options = {requestedUrl, driver, settings: config.settings};
+    const options = {requestedUrl, driver};
 
-    const results = await GatherRunner.run(config.passes, options);
+    const results = await GatherRunner.run(config, options);
     expect(Number.isFinite(results.BenchmarkIndex)).toBeTruthy();
   });
 
@@ -211,9 +211,9 @@ describe('GatherRunner', function() {
     const requestedUrl = 'https://example.com';
     const driver = fakeDriver;
     const config = makeConfig({passes: []});
-    const options = {requestedUrl, driver, settings: config.settings};
+    const options = {requestedUrl, driver};
 
-    const results = await GatherRunner.run(config.passes, options);
+    const results = await GatherRunner.run(config, options);
     expect(results.HostUserAgent).toEqual(fakeDriver.protocolGetVersionResponse.userAgent);
     expect(results.HostUserAgent).toMatch(/Chrome\/\d+/);
   });
@@ -222,9 +222,9 @@ describe('GatherRunner', function() {
     const requestedUrl = 'https://example.com';
     const driver = fakeDriver;
     const config = makeConfig({passes: [{passName: 'defaultPass'}]});
-    const options = {requestedUrl, driver, settings: config.settings};
+    const options = {requestedUrl, driver};
 
-    const results = await GatherRunner.run(config.passes, options);
+    const results = await GatherRunner.run(config, options);
     expect(results.NetworkUserAgent).toContain('Mozilla');
   });
 
@@ -237,9 +237,9 @@ describe('GatherRunner', function() {
       },
     });
     const config = makeConfig({passes: [{passName: 'defaultPass'}]});
-    const options = {requestedUrl, driver, settings: config.settings};
+    const options = {requestedUrl, driver};
 
-    return GatherRunner.run(config.passes, options).then(artifacts => {
+    return GatherRunner.run(config, options).then(artifacts => {
       assert.deepStrictEqual(artifacts.URL, {requestedUrl, finalUrl},
         'did not find expected URL artifact');
     });
@@ -264,9 +264,9 @@ describe('GatherRunner', function() {
           passes: [],
           settings: {},
         });
-        const options = {requestedUrl, driver, settings: config.settings};
+        const options = {requestedUrl, driver};
 
-        const results = await GatherRunner.run(config.passes, options);
+        const results = await GatherRunner.run(config, options);
         expect(results.HostFormFactor).toBe(expectedValue);
       });
     }
@@ -410,10 +410,9 @@ describe('GatherRunner', function() {
     const options = {
       driver,
       requestedUrl,
-      settings: config.settings,
     };
 
-    const artifacts = await GatherRunner.run(config.passes, options);
+    const artifacts = await GatherRunner.run(config, options);
     expect(artifacts.LighthouseRunWarnings).toHaveLength(1);
     expect(artifacts.PageLoadError).toBeInstanceOf(Error);
     expect(artifacts.PageLoadError).toMatchObject({code: 'ERRORED_DOCUMENT_REQUEST'});
@@ -444,10 +443,9 @@ describe('GatherRunner', function() {
     const options = {
       driver,
       requestedUrl,
-      settings: config.settings,
     };
 
-    const artifacts = await GatherRunner.run(config.passes, options);
+    const artifacts = await GatherRunner.run(config, options);
     expect(artifacts.LighthouseRunWarnings).toHaveLength(1);
     expect(artifacts.PageLoadError).toBeInstanceOf(Error);
     expect(artifacts.PageLoadError).toMatchObject({code: 'NO_FCP'});
@@ -484,10 +482,9 @@ describe('GatherRunner', function() {
     const options = {
       driver,
       requestedUrl,
-      settings: config.settings,
     };
 
-    const artifacts = await GatherRunner.run(config.passes, options);
+    const artifacts = await GatherRunner.run(config, options);
     expect(artifacts.LighthouseRunWarnings).toHaveLength(1);
     expect(artifacts.PageLoadError).toEqual(null);
     // @ts-expect-error: Test-only gatherer.
@@ -785,10 +782,9 @@ describe('GatherRunner', function() {
       }],
     });
 
-    return GatherRunner.run(config.passes, {
+    return GatherRunner.run(config, {
       driver: fakeDriver,
       requestedUrl: 'https://example.com',
-      settings: config.settings,
     }).then(_ => {
       assert.ok(t1.called);
       assert.ok(t2.called);
@@ -810,10 +806,9 @@ describe('GatherRunner', function() {
     const options = {
       driver: fakeDriver,
       requestedUrl: 'https://example.com',
-      settings: config.settings,
     };
 
-    return GatherRunner.run(config.passes, options)
+    return GatherRunner.run(config, options)
       .then(artifacts => {
         assert.ok(artifacts.traces.firstPass);
         assert.ok(artifacts.devtoolsLogs.firstPass);
@@ -838,8 +833,8 @@ describe('GatherRunner', function() {
         gatherers: [{instance: new TestGatherer()}],
       }],
     });
-    const options = {driver, requestedUrl, settings: config.settings};
-    const artifacts = await GatherRunner.run(config.passes, options);
+    const options = {driver, requestedUrl};
+    const artifacts = await GatherRunner.run(config, options);
 
     expect(artifacts.PageLoadError).toMatchObject({code: 'NO_DOCUMENT_REQUEST'});
     // @ts-expect-error: Test-only gatherer.
@@ -885,8 +880,8 @@ describe('GatherRunner', function() {
       },
       online: true,
     });
-    const options = {driver, requestedUrl, settings: config.settings};
-    const artifacts = await GatherRunner.run(config.passes, options);
+    const options = {driver, requestedUrl};
+    const artifacts = await GatherRunner.run(config, options);
 
     // t1.pass() and t2.pass() called; t3.pass(), after the error, was not.
     expect(t1.called).toBe(true);
@@ -1373,10 +1368,9 @@ describe('GatherRunner', function() {
       });
 
       /** @type {any} Using Test-only gatherers. */
-      const artifacts = await GatherRunner.run(config.passes, {
+      const artifacts = await GatherRunner.run(config, {
         driver: fakeDriver,
         requestedUrl: 'https://example.com',
-        settings: config.settings,
       });
 
       // Ensure artifacts returned and not errors.
@@ -1429,10 +1423,9 @@ describe('GatherRunner', function() {
         }],
       });
 
-      return GatherRunner.run(config.passes, {
+      return GatherRunner.run(config, {
         driver: fakeDriver,
         requestedUrl: 'https://example.com',
-        settings: config.settings,
       }).then(artifacts => {
         gathererNames.forEach(gathererName => {
           assert.strictEqual(artifacts[gathererName], gathererName);
@@ -1507,10 +1500,9 @@ describe('GatherRunner', function() {
           gatherers: [{instance: new WarningGatherer()}],
         }],
       });
-      const artifacts = await GatherRunner.run(config.passes, {
+      const artifacts = await GatherRunner.run(config, {
         driver: fakeDriver,
         requestedUrl: 'https://example.com',
-        settings: config.settings,
       });
       assert.deepStrictEqual(artifacts.LighthouseRunWarnings, runWarnings);
     });
@@ -1562,10 +1554,9 @@ describe('GatherRunner', function() {
         }],
       });
 
-      return GatherRunner.run(config.passes, {
+      return GatherRunner.run(config, {
         driver: fakeDriver,
         requestedUrl: 'https://example.com',
-        settings: config.settings,
       }).then(artifacts => {
         gathererNames.forEach(gathererName => {
           const errorArtifact = artifacts[gathererName];
@@ -1586,10 +1577,9 @@ describe('GatherRunner', function() {
         }],
       });
 
-      return GatherRunner.run(config.passes, {
+      return GatherRunner.run(config, {
         driver: fakeDriver,
         requestedUrl: 'https://example.com',
-        settings: config.settings,
       }).then(_ => assert.ok(false), _ => assert.ok(true));
     });
 
@@ -1614,10 +1604,9 @@ describe('GatherRunner', function() {
         },
       });
 
-      return GatherRunner.run(config.passes, {
+      return GatherRunner.run(config, {
         driver: unresolvedDriver,
         requestedUrl,
-        settings: config.settings,
       }).then(artifacts => {
         assert.equal(artifacts.LighthouseRunWarnings.length, 1);
         expect(artifacts.LighthouseRunWarnings[0])
@@ -1642,10 +1631,9 @@ describe('GatherRunner', function() {
         },
       });
 
-      return GatherRunner.run(config.passes, {
+      return GatherRunner.run(config, {
         driver: timedoutDriver,
         requestedUrl,
-        settings: config.settings,
       }).then(artifacts => {
         assert.equal(artifacts.LighthouseRunWarnings.length, 1);
         expect(artifacts.LighthouseRunWarnings[0])
@@ -1674,10 +1662,9 @@ describe('GatherRunner', function() {
         },
       });
 
-      return GatherRunner.run(config.passes, {
+      return GatherRunner.run(config, {
         driver: unresolvedDriver,
         requestedUrl,
-        settings: config.settings,
       })
         .then(_ => {
           assert.ok(true);


### PR DESCRIPTION
Externally we've long had a separation between gathering and auditing that's beneficial both conceptually and practically (for things like testing). Internally, though, `runner.js` has mixed things up, being responsible for auditing as well as dealing with loading/saving  `-GA` stages, constructing a `Driver` for the gathering stage, etc.

This PR takes the general "marshalling" code and bumps it up to `lighthouse-core/index.js` and moves the gathering-specific code over to `gather-runner.js`, leaving `runner.js` with auditing and lhr/report generation.

The general move was last discussed in https://github.com/GoogleChrome/lighthouse/pull/11623#pullrequestreview-522000654, and includes uninverting the `gatherFn` callback to instead passing in `artifacts` directly as discussed there.

Because this is internally rearranging things, smoke tests are all passing, and with the changes to the FR runners included here (popping the gathering code out of callbacks and running it in place) all the FR and other unit tests are passing except `runner-test` and `gather-runner-test`, which will need to have some tests moved to different files. I wanted to get feedback before I embarked on that part :)

Easier to review (and significantly shorter) if whitespace is ignored due to the moved `try`/`catch` indentation changes.

Other things that could be good but not currently included:
- rename `runner.js` to `audit-runner.js`
- move html/json/csv report generation to `index.js`. `Runner.run()` would return just an lhr, and `lighthouse()` in `index.js` would be the one to put together the `{lhr, artifacts, report}` `RunnerResult`. This would require a bit more test changes due to the `Runner.run()` return type change.

Other considered ideas that we probably shouldn't do but included in case they jog anyone's thoughts:
- expose an `audit()` method in `index.js`. This would let FR runners use our core entry point instead of calling `Runner` directly. Something like this seems worthwhile but probably better to think about when we start nailing down the FR module API.
- move lhr generation out of `runner`. Doesn't seem worth it because the LHR is the only audit output we ever care about, and there's some internal details (like handling ICU types before `i18n.replaceIcuMessages()` is called) that are currently encapsulated but would have to be exposed
- move `-GA` artifact loading/saving out of `lighthouse-core/` altogether and move them to `lighthouse-cli/`. This would bring `lighthouse-core` closer to the actual core shared between all our clients (and prevent unexpected bundle includes like https://github.com/GoogleChrome/lighthouse/pull/12348#issuecomment-816980557), but it stretches the definition of "CLI" since we'd want node modules to still be able to use it. Our testing also often relies on `auditMode` being available to load artifacts from disk, which would have to be done manually instead. Doesn't seem worth it (for now?).