### PR TITLE
deps: update marky to latest

### DIFF
--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -4,6 +4,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^2.6.9",
-    "marky": "^1.2.0"
+    "marky": "^1.2.2"
   }
 }

--- a/lighthouse-logger/yarn.lock
+++ b/lighthouse-logger/yarn.lock
@@ -2,16 +2,17 @@
 # yarn lockfile v1
 
 
-debug@^2.6.8:
+debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
-marky@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.0.tgz#9617ed647bbbea8f45d19526da33dec70606df42"
+marky@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.2.tgz#4456765b4de307a13d263a69b0c79bf226e68323"
+  integrity sha512-k1dB2HNeaNyORco8ulVEhctyEGkKHb2YWAhDsxeFlW2nROIirsctBYzKwwS3Vza+sKTS1zO4Z+n9/+9WbGLIxQ==
 
 ms@2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5516,9 +5516,9 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 marky@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.0.tgz#9617ed647bbbea8f45d19526da33dec70606df42"
-  integrity sha1-lhftZHu76o9F0ZUm2jPexwYG30I=
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.2.tgz#4456765b4de307a13d263a69b0c79bf226e68323"
+  integrity sha512-k1dB2HNeaNyORco8ulVEhctyEGkKHb2YWAhDsxeFlW2nROIirsctBYzKwwS3Vza+sKTS1zO4Z+n9/+9WbGLIxQ==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
fixes #12439 (but really just for contributors)

See https://github.com/nolanlawson/marky/issues/18 for the issue in node 16 (introduced in https://github.com/nodejs/node/pull/37970).

However as noted by @patrickhulce in https://github.com/GoogleChrome/lighthouse-ci/issues/596#issuecomment-832006808, `lighthouse-logger` currently uses `marky@^1.2.0`, so any downstream project just needs to refresh their deps and they'll pick up 1.2.2.

However, contributors (with a git repo checkout) _are_ subject to our `yarn.lock` files for dependencies, so we do need to update those for us.