### PR TITLE
core(fr): extract driver preparation methods

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -462,39 +462,6 @@ class Driver {
     this._devtoolsLog.endRecording();
     return this._devtoolsLog.messages;
   }
-
-  /**
-   * Use a RequestIdleCallback shim for tests run with simulated throttling, so that the deadline can be used without
-   * a penalty
-   * @param {LH.Config.Settings} settings
-   * @return {Promise<void>}
-   */
-  async registerRequestIdleCallbackWrap(settings) {
-    if (settings.throttlingMethod === 'simulate') {
-      await this.executionContext.evaluateOnNewDocument(
-        pageFunctions.wrapRequestIdleCallback,
-        {args: [settings.throttling.cpuSlowdownMultiplier]}
-      );
-    }
-  }
-
-  /**
-   * Dismiss JavaScript dialogs (alert, confirm, prompt), providing a
-   * generic promptText in case the dialog is a prompt.
-   * @return {Promise<void>}
-   */
-  async dismissJavaScriptDialogs() {
-    this.on('Page.javascriptDialogOpening', data => {
-      log.warn('Driver', `${data.type} dialog opened by the page automatically suppressed.`);
-
-      this.sendCommand('Page.handleJavaScriptDialog', {
-        accept: true,
-        promptText: 'Lighthouse prompt response',
-      }).catch(err => log.warn('Driver', err));
-    });
-
-    await this.sendCommand('Page.enable');
-  }
 }
 
 module.exports = Driver;

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -15,8 +15,6 @@ const log = require('lighthouse-logger');
 const DevtoolsLog = require('./devtools-log.js');
 const TraceGatherer = require('./gatherers/trace.js');
 
-const pageFunctions = require('../lib/page-functions.js');
-
 // Pulled in for Connection type checking.
 // eslint-disable-next-line no-unused-vars
 const Connection = require('./connections/connection.js');

--- a/lighthouse-core/gather/driver/prepare.js
+++ b/lighthouse-core/gather/driver/prepare.js
@@ -1,0 +1,174 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const log = require('lighthouse-logger');
+const storage = require('./storage.js');
+const emulation = require('../../lib/emulation.js');
+const pageFunctions = require('../../lib/page-functions.js');
+
+/**
+ * Enables `Debugger` domain to receive async stacktrace information on network request initiators.
+ * This is critical for tracking attribution of tasks and performance simulation accuracy.
+ * @param {LH.Gatherer.FRProtocolSession} session
+ */
+async function enableAsyncStacks(session) {
+  const enable = async () => {
+    await session.sendCommand('Debugger.enable');
+    await session.sendCommand('Debugger.setSkipAllPauses', {skip: true});
+    await session.sendCommand('Debugger.setAsyncCallStackDepth', {maxDepth: 8});
+  };
+
+  // Resume any pauses that make it through `setSkipAllPauses`
+  session.on('Debugger.paused', () => session.sendCommand('Debugger.resume'));
+
+  // `Debugger.setSkipAllPauses` is reset after every navigation, so retrigger it.
+  // See https://bugs.chromium.org/p/chromium/issues/detail?id=990945&q=setSkipAllPauses&can=2
+  session.on('Page.frameNavigated', event => {
+    if (event.frame.parentId) return;
+    enable().catch(err => log.error('Driver', err));
+  });
+
+  await enable();
+}
+
+/**
+ * Use a RequestIdleCallback shim for tests run with simulated throttling, so that the deadline can be used without
+ * a penalty.
+ * @param {LH.Gatherer.FRTransitionalDriver} driver
+ * @param {LH.Config.Settings} settings
+ * @return {Promise<void>}
+ */
+async function shimRequestIdleCallbackOnNewDocument(driver, settings) {
+  await driver.executionContext.evaluateOnNewDocument(pageFunctions.wrapRequestIdleCallback, {
+    args: [settings.throttling.cpuSlowdownMultiplier],
+  });
+}
+
+
+/**
+   * Dismiss JavaScript dialogs (alert, confirm, prompt), providing a
+   * generic promptText in case the dialog is a prompt.
+  * @param {LH.Gatherer.FRProtocolSession} session
+   * @return {Promise<void>}
+   */
+async function dismissJavaScriptDialogs(session) {
+  session.on('Page.javascriptDialogOpening', data => {
+    log.warn('Driver', `${data.type} dialog opened by the page automatically suppressed.`);
+
+    session.sendCommand('Page.handleJavaScriptDialog', {
+      accept: true,
+      promptText: 'Lighthouse prompt response',
+    }).catch(err => log.warn('Driver', err));
+  });
+
+  await session.sendCommand('Page.enable');
+}
+
+/**
+ * @param {LH.Gatherer.FRProtocolSession} session
+ * @param {{url: string}} navigation
+ * @return {Promise<{warnings: Array<LH.IcuMessage>}>}
+ */
+async function resetStorageForNavigation(session, navigation) {
+  /** @type {Array<LH.IcuMessage>} */
+  const warnings = [];
+
+  // Reset the storage and warn if there appears to be other important data.
+  const warning = await storage.getImportantStorageWarning(session, navigation.url);
+  if (warning) warnings.push(warning);
+  await storage.clearDataForOrigin(session, navigation.url);
+  await storage.clearBrowserCaches(session);
+
+  return {warnings};
+}
+
+/**
+ * Prepares a target for a particular navigation by resetting storage and setting throttling.
+ *
+ * This method assumes `prepareTargetForNavigationMode` has already been invoked.
+ *
+ * @param {LH.Gatherer.FRProtocolSession} session
+ * @param {LH.Config.Settings} settings
+ * @param {Pick<LH.Config.NavigationDefn, 'disableThrottling'|'disableStorageReset'|'blockedUrlPatterns'> & {url: string}} navigation
+ */
+async function prepareNetworkForNavigation(session, settings, navigation) {
+  const status = {msg: 'Preparing network conditions', id: `lh:gather:prepareNetworkForNavigation`};
+  log.time(status);
+
+  if (navigation.disableThrottling) await emulation.clearThrottling(session);
+  else await emulation.throttle(session, settings);
+
+  // Set request blocking before any network activity.
+  // No "clearing" is done at the end of the navigation since Network.setBlockedURLs([]) will unset all if
+  // neccessary at the beginning of the next navigation.
+  const blockedUrls = (navigation.blockedUrlPatterns || [])
+    .concat(settings.blockedUrlPatterns || []);
+  await session.sendCommand('Network.setBlockedURLs', {urls: blockedUrls});
+
+  const headers = settings.extraHeaders;
+  if (headers) await session.sendCommand('Network.setExtraHTTPHeaders', {headers});
+
+  log.timeEnd(status);
+}
+
+/**
+ * Prepares a target to be analyzed in navigation mode by enabling protocol domains, emulation, and new document
+ * handlers for global APIs or error handling.
+ *
+ * This method should be used in combination with `prepareTargetForIndividualNavigation` before a specific navigation occurs.
+ *
+ * @param {LH.Gatherer.FRTransitionalDriver} driver
+ * @param {LH.Config.Settings} settings
+ */
+async function prepareTargetForNavigationMode(driver, settings) {
+  // Emulate our target device screen and user agent.
+  await emulation.emulate(driver.defaultSession, settings);
+
+  // Enable better stacks on network requests.
+  await enableAsyncStacks(driver.defaultSession);
+
+  // Automatically handle any JavaScript dialogs to prevent a hung renderer.
+  await dismissJavaScriptDialogs(driver.defaultSession);
+
+  // Inject our snippet to cache important web platform APIs before they're (possibly) ponyfilled by the page.
+  await driver.executionContext.cacheNativesOnNewDocument();
+
+  // Wrap requestIdleCallback so pages under simulation receive the correct rIC deadlines.
+  if (settings.throttlingMethod === 'simulate') {
+    await shimRequestIdleCallbackOnNewDocument(driver, settings);
+  }
+}
+
+/**
+ * Prepares a target for a particular navigation by resetting storage and setting network.
+ *
+ * This method assumes `prepareTargetForNavigationMode` has already been invoked.
+ *
+ * @param {LH.Gatherer.FRProtocolSession} session
+ * @param {LH.Config.Settings} settings
+ * @param {Pick<LH.Config.NavigationDefn, 'disableThrottling'|'disableStorageReset'|'blockedUrlPatterns'> & {url: string}} navigation
+ * @return {Promise<{warnings: Array<LH.IcuMessage>}>}
+ */
+async function prepareTargetForIndividualNavigation(session, settings, navigation) {
+  /** @type {Array<LH.IcuMessage>} */
+  const warnings = [];
+
+  const shouldResetStorage = !settings.disableStorageReset && !navigation.disableStorageReset;
+  if (shouldResetStorage) {
+    const {warnings: storageWarnings} = await resetStorageForNavigation(session, navigation);
+    warnings.push(...storageWarnings);
+  }
+
+  await prepareNetworkForNavigation(session, settings, navigation);
+
+  return {warnings};
+}
+
+module.exports = {
+  prepareTargetForNavigationMode,
+  prepareTargetForIndividualNavigation,
+};

--- a/lighthouse-core/gather/driver/storage.js
+++ b/lighthouse-core/gather/driver/storage.js
@@ -100,8 +100,8 @@ async function getImportantStorageWarning(session, url) {
  * @param {LH.Gatherer.FRProtocolSession} session
  * @return {Promise<void>}
  */
-async function cleanBrowserCaches(session) {
-  const status = {msg: 'Cleaning browser cache', id: 'lh:storage:cleanBrowserCaches'};
+async function clearBrowserCaches(session) {
+  const status = {msg: 'Cleaning browser cache', id: 'lh:storage:clearBrowserCaches'};
   log.time(status);
 
   // Wipe entire disk cache
@@ -115,7 +115,7 @@ async function cleanBrowserCaches(session) {
 
 module.exports = {
   clearDataForOrigin,
-  cleanBrowserCaches,
+  clearBrowserCaches,
   getImportantStorageWarning,
   UIStrings,
 };

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -755,7 +755,7 @@ class GatherRunner {
       passContext.settings,
       {
         url: passContext.url,
-        disableStorageReset: false, // Legacy LH has no concept of storage reset per-pass
+        disableStorageReset: !passConfig.useThrottling,
         disableThrottling: !passConfig.useThrottling,
         blockedUrlPatterns: passConfig.blockedUrlPatterns,
       }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -14,6 +14,7 @@ const constants = require('../config/constants.js');
 const i18n = require('../lib/i18n/i18n.js');
 const URL = require('../lib/url-shim.js');
 const {getBenchmarkIndex} = require('./driver/environment.js');
+const prepare = require('./driver/prepare.js');
 const storage = require('./driver/storage.js');
 const navigation = require('./driver/navigation.js');
 const serviceWorkers = require('./driver/service-workers.js');
@@ -174,46 +175,19 @@ class GatherRunner {
   /**
    * @param {Driver} driver
    * @param {{requestedUrl: string, settings: LH.Config.Settings}} options
-   * @param {(string | LH.IcuMessage)[]} LighthouseRunWarnings
    * @return {Promise<void>}
    */
-  static async setupDriver(driver, options, LighthouseRunWarnings) {
+  static async setupDriver(driver, options) {
     const status = {msg: 'Initializing…', id: 'lh:gather:setupDriver'};
     log.time(status);
-    const resetStorage = !options.settings.disableStorageReset;
     const session = driver.defaultSession;
 
     // Assert no service workers are still installed, so we test that they would actually be installed for a new user.
     // TODO(FR-COMPAT): re-evaluate the necessity of this check
     await GatherRunner.assertNoSameOriginServiceWorkerClients(session, options.requestedUrl);
 
-    // Emulate our target device screen and user agent.
-    await emulation.emulate(driver.defaultSession, options.settings);
+    await prepare.prepareTargetForNavigationMode(driver, options.settings);
 
-    // Enable `Debugger` domain to receive async stacktrace information on network request initiators.
-    // This is critical for tracing certain performance simulation situations.
-    session.on('Debugger.paused', () => session.sendCommand('Debugger.resume'));
-    await session.sendCommand('Debugger.enable');
-    await session.sendCommand('Debugger.setSkipAllPauses', {skip: true});
-    await session.sendCommand('Debugger.setAsyncCallStackDepth', {maxDepth: 8});
-
-    // Inject our snippet to cache important web platform APIs before they're (possibly) ponyfilled by the page.
-    await driver.executionContext.cacheNativesOnNewDocument();
-
-    // Automatically handle any JavaScript dialogs to prevent a hung renderer.
-    await driver.dismissJavaScriptDialogs();
-
-    // Wrap requestIdleCallback so pages under simulation receive the correct rIC deadlines.
-    await driver.registerRequestIdleCallbackWrap(options.settings);
-
-    // Reset the storage and warn if there appears to be other important data.
-    if (resetStorage) {
-      const warning = await storage.getImportantStorageWarning(session, options.requestedUrl);
-      if (warning) {
-        LighthouseRunWarnings.push(warning);
-      }
-      await storage.clearDataForOrigin(session, options.requestedUrl);
-    }
     log.timeEnd(status);
   }
 
@@ -405,35 +379,6 @@ class GatherRunner {
     if (baseArtifacts.BenchmarkIndex > SLOW_CPU_BENCHMARK_INDEX_THRESHOLD) return;
 
     return str_(UIStrings.warningSlowHostCpu);
-  }
-
-  /**
-   * Initialize network settings for the pass, e.g. throttling, blocked URLs,
-   * and manual request headers.
-   * @param {LH.Gatherer.PassContext} passContext
-   * @return {Promise<void>}
-   */
-  static async setupPassNetwork(passContext) {
-    const status = {msg: 'Setting up network for the pass trace', id: `lh:gather:setupPassNetwork`};
-    log.time(status);
-
-    const session = passContext.driver.defaultSession;
-    const passConfig = passContext.passConfig;
-    if (passConfig.useThrottling) await emulation.throttle(session, passContext.settings);
-    else await emulation.clearThrottling(session);
-
-    const blockedUrls = (passContext.passConfig.blockedUrlPatterns || [])
-      .concat(passContext.settings.blockedUrlPatterns || []);
-
-    // Set request blocking before any network activity
-    // No "clearing" is done at the end of the pass since Network.setBlockedURLs([]) will unset all if
-    // neccessary at the beginning of the next pass.
-    await session.sendCommand('Network.setBlockedURLs', {urls: blockedUrls});
-
-    const headers = passContext.settings.extraHeaders;
-    if (headers) await session.sendCommand('Network.setExtraHTTPHeaders', {headers});
-
-    log.timeEnd(status);
   }
 
   /**
@@ -728,7 +673,7 @@ class GatherRunner {
       const baseArtifacts = await GatherRunner.initializeBaseArtifacts(options);
       baseArtifacts.BenchmarkIndex = await getBenchmarkIndex(driver.executionContext);
 
-      await GatherRunner.setupDriver(driver, options, baseArtifacts.LighthouseRunWarnings);
+      await GatherRunner.setupDriver(driver, options);
 
       let isFirstPass = true;
       for (const passConfig of passConfigs) {
@@ -775,17 +720,6 @@ class GatherRunner {
   }
 
   /**
-   * Returns whether this pass should clear the caches.
-   * Only if it is a performance run and the settings don't disable it.
-   * @param {LH.Gatherer.PassContext} passContext
-   * @return {boolean}
-   */
-  static shouldClearCaches(passContext) {
-    const {settings, passConfig} = passContext;
-    return !settings.disableStorageReset && passConfig.recordTrace && passConfig.useThrottling;
-  }
-
-  /**
    * Save the devtoolsLog and trace (if applicable) to baseArtifacts.
    * @param {LH.Gatherer.PassContext} passContext
    * @param {LH.Gatherer.LoadData} loadData
@@ -816,10 +750,17 @@ class GatherRunner {
 
     // Go to about:blank, set up, and run `beforePass()` on gatherers.
     await GatherRunner.loadBlank(driver, passConfig.blankPage);
-    await GatherRunner.setupPassNetwork(passContext);
-    if (GatherRunner.shouldClearCaches(passContext)) {
-      await storage.cleanBrowserCaches(driver.defaultSession); // Clear disk & memory cache if it's a perf run
-    }
+    const {warnings} = await prepare.prepareTargetForIndividualNavigation(
+      driver.defaultSession,
+      passContext.settings,
+      {
+        url: passContext.url,
+        disableStorageReset: false, // Legacy LH has no concept of storage reset per-pass
+        disableThrottling: !passConfig.useThrottling,
+        blockedUrlPatterns: passConfig.blockedUrlPatterns,
+      }
+    );
+    passContext.LighthouseRunWarnings.push(...warnings);
     await GatherRunner.beforePass(passContext, gathererResults);
 
     // Navigate, start recording, and run `pass()` on gatherers.

--- a/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
+++ b/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
@@ -73,8 +73,18 @@ function createMockPage() {
 }
 
 function createMockExecutionContext() {
-  const context = /** @type {ExecutionContext} */ ({});
-  return {...context, evaluate: jest.fn(), evaluateAsync: jest.fn()};
+  return {
+    evaluate: jest.fn(),
+    evaluateAsync: jest.fn(),
+    evaluateOnNewDocument: jest.fn(),
+    cacheNativesOnNewDocument: jest.fn(),
+
+    /** @return {ExecutionContext} */
+    asExecutionContext() {
+      // @ts-expect-error - We'll rely on the tests passing to know this matches.
+      return this;
+    },
+  };
 }
 
 function createMockDriver() {
@@ -89,7 +99,7 @@ function createMockDriver() {
     url: () => page.url(),
     defaultSession: session,
     connect: jest.fn(),
-    executionContext: context,
+    executionContext: context.asExecutionContext(),
 
     /** @return {Driver} */
     asDriver() {

--- a/lighthouse-core/test/gather/driver/prepare-test.js
+++ b/lighthouse-core/test/gather/driver/prepare-test.js
@@ -1,0 +1,340 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const storageMock = {
+  clearDataForOrigin: jest.fn(),
+  clearBrowserCaches: jest.fn(),
+  getImportantStorageWarning: jest.fn(),
+};
+jest.mock('../../../gather/driver/storage.js', () => storageMock);
+
+const {createMockSession, createMockDriver} = require('../../fraggle-rock/gather/mock-driver.js');
+const {flushAllTimersAndMicrotasks} = require('../../test-utils.js');
+const prepare = require('../../../gather/driver/prepare.js');
+const constants = require('../../../config/constants.js');
+
+const url = 'https://example.com';
+let sessionMock = createMockSession();
+
+beforeEach(() => {
+  sessionMock = createMockSession();
+  sessionMock.sendCommand
+    .mockResponse('Network.emulateNetworkConditions')
+    .mockResponse('Emulation.setCPUThrottlingRate')
+    .mockResponse('Network.setBlockedURLs')
+    .mockResponse('Network.setExtraHTTPHeaders');
+  storageMock.clearBrowserCaches = jest.fn();
+  storageMock.clearDataForOrigin = jest.fn();
+  storageMock.getImportantStorageWarning = jest.fn();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('.prepareNetworkForNavigation()', () => {
+  it('sets throttling appropriately', async () => {
+    await prepare.prepareNetworkForNavigation(
+      sessionMock.asSession(),
+      {
+        ...constants.defaultSettings,
+        throttlingMethod: 'devtools',
+        throttling: {
+          ...constants.defaultSettings.throttling,
+          requestLatencyMs: 100,
+          downloadThroughputKbps: 8,
+          uploadThroughputKbps: 8,
+          cpuSlowdownMultiplier: 2,
+        },
+      },
+      {
+        ...constants.defaultNavigationConfig,
+        url,
+      }
+    );
+
+    expect(sessionMock.sendCommand.findInvocation('Network.emulateNetworkConditions')).toEqual({
+      latency: 100,
+      downloadThroughput: 1024,
+      uploadThroughput: 1024,
+      offline: false,
+    });
+    expect(sessionMock.sendCommand.findInvocation('Emulation.setCPUThrottlingRate')).toEqual({
+      rate: 2,
+    });
+  });
+
+  it('disables throttling', async () => {
+    await prepare.prepareNetworkForNavigation(
+      sessionMock.asSession(),
+      {
+        ...constants.defaultSettings,
+        throttlingMethod: 'devtools',
+        throttling: {
+          ...constants.defaultSettings.throttling,
+          requestLatencyMs: 100,
+          downloadThroughputKbps: 8,
+          uploadThroughputKbps: 8,
+          cpuSlowdownMultiplier: 2,
+        },
+      },
+      {
+        ...constants.defaultNavigationConfig,
+        url,
+        disableThrottling: true,
+      }
+    );
+
+    expect(sessionMock.sendCommand.findInvocation('Network.emulateNetworkConditions')).toEqual({
+      latency: 0,
+      downloadThroughput: 0,
+      uploadThroughput: 0,
+      offline: false,
+    });
+    expect(sessionMock.sendCommand.findInvocation('Emulation.setCPUThrottlingRate')).toEqual({
+      rate: 1,
+    });
+  });
+
+  it('unsets url patterns when empty', async () => {
+    await prepare.prepareNetworkForNavigation(
+      sessionMock.asSession(),
+      {
+        ...constants.defaultSettings,
+        blockedUrlPatterns: null,
+      },
+      {
+        ...constants.defaultNavigationConfig,
+        blockedUrlPatterns: [],
+        url,
+      }
+    );
+
+    expect(sessionMock.sendCommand.findInvocation('Network.setBlockedURLs')).toEqual({
+      urls: [],
+    });
+  });
+
+  it('blocks url patterns', async () => {
+    await prepare.prepareNetworkForNavigation(
+      sessionMock.asSession(),
+      {
+        ...constants.defaultSettings,
+        blockedUrlPatterns: ['https://a.example.com'],
+      },
+      {
+        ...constants.defaultNavigationConfig,
+        blockedUrlPatterns: ['https://b.example.com'],
+        url,
+      }
+    );
+
+    expect(sessionMock.sendCommand.findInvocation('Network.setBlockedURLs')).toEqual({
+      urls: ['https://b.example.com', 'https://a.example.com'],
+    });
+  });
+
+  it('sets extraHeaders', async () => {
+    await prepare.prepareNetworkForNavigation(
+      sessionMock.asSession(),
+      {...constants.defaultSettings, extraHeaders: {'Cookie': 'monster', 'x-men': 'wolverine'}},
+      {...constants.defaultNavigationConfig, url}
+    );
+
+    expect(sessionMock.sendCommand.findInvocation('Network.setExtraHTTPHeaders')).toEqual({
+      headers: {
+        'Cookie': 'monster',
+        'x-men': 'wolverine',
+      },
+    });
+  });
+});
+
+describe('.prepareTargetForIndividualNavigation()', () => {
+  it('clears storage when not disabled', async () => {
+    await prepare.prepareTargetForIndividualNavigation(
+      sessionMock.asSession(),
+      {...constants.defaultSettings, disableStorageReset: false},
+      {...constants.defaultNavigationConfig, disableStorageReset: false, url}
+    );
+
+    expect(storageMock.clearDataForOrigin).toHaveBeenCalled();
+    expect(storageMock.clearBrowserCaches).toHaveBeenCalled();
+  });
+
+  it('does not clear storage when globally disabled', async () => {
+    await prepare.prepareTargetForIndividualNavigation(
+      sessionMock.asSession(),
+      {...constants.defaultSettings, disableStorageReset: true},
+      {...constants.defaultNavigationConfig, disableStorageReset: false, url}
+    );
+
+    expect(storageMock.clearDataForOrigin).not.toHaveBeenCalled();
+    expect(storageMock.clearBrowserCaches).not.toHaveBeenCalled();
+  });
+
+  it('does not clear storage when disabled per navigation', async () => {
+    await prepare.prepareTargetForIndividualNavigation(
+      sessionMock.asSession(),
+      {...constants.defaultSettings, disableStorageReset: false},
+      {...constants.defaultNavigationConfig, disableStorageReset: true, url}
+    );
+
+    expect(storageMock.clearDataForOrigin).not.toHaveBeenCalled();
+    expect(storageMock.clearBrowserCaches).not.toHaveBeenCalled();
+  });
+
+  it('collects storage warnings', async () => {
+    storageMock.getImportantStorageWarning.mockResolvedValue({message: 'This is a warning'});
+    const {warnings} = await prepare.prepareTargetForIndividualNavigation(
+      sessionMock.asSession(),
+      {...constants.defaultSettings, disableStorageReset: false},
+      {...constants.defaultNavigationConfig, disableStorageReset: false, url}
+    );
+
+    expect(warnings).toEqual([{message: 'This is a warning'}]);
+  });
+});
+
+describe('.prepareTargetForNavigationMode()', () => {
+  let driverMock = createMockDriver();
+
+  beforeEach(() => {
+    driverMock = createMockDriver();
+    sessionMock = driverMock._session;
+
+    sessionMock.sendCommand
+      .mockResponse('Network.enable')
+      .mockResponse('Network.setUserAgentOverride')
+      .mockResponse('Emulation.setDeviceMetricsOverride')
+      .mockResponse('Emulation.setTouchEmulationEnabled')
+      .mockResponse('Debugger.enable')
+      .mockResponse('Debugger.setSkipAllPauses')
+      .mockResponse('Debugger.setAsyncCallStackDepth')
+      .mockResponse('Page.enable');
+  });
+
+  it('emulates the target device', async () => {
+    await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+      screenEmulation: {
+        disabled: false,
+        mobile: true,
+        deviceScaleFactor: 2,
+        width: 200,
+        height: 300,
+      },
+    });
+
+    expect(sessionMock.sendCommand.findInvocation('Emulation.setDeviceMetricsOverride')).toEqual({
+      mobile: true,
+      deviceScaleFactor: 2,
+      width: 200,
+      height: 300,
+    });
+  });
+
+  it('enables async stacks', async () => {
+    await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+    });
+
+    const invocations = sessionMock.sendCommand.mock.calls;
+    const debuggerInvocations = invocations.filter(call => call[0].startsWith('Debugger.'));
+    expect(debuggerInvocations.map(argList => argList[0])).toEqual([
+      'Debugger.enable',
+      'Debugger.setSkipAllPauses',
+      'Debugger.setAsyncCallStackDepth',
+    ]);
+  });
+
+  it('enables async stacks on every main frame navigation', async () => {
+    jest.useFakeTimers();
+
+    sessionMock.sendCommand
+      .mockResponse('Debugger.enable')
+      .mockResponse('Debugger.setSkipAllPauses')
+      .mockResponse('Debugger.setAsyncCallStackDepth');
+
+    sessionMock.on.mockEvent('Page.frameNavigated', {frame: {}});
+    sessionMock.on.mockEvent('Page.frameNavigated', {frame: {parentId: '1'}});
+    sessionMock.on.mockEvent('Page.frameNavigated', {frame: {parentId: '2'}});
+    sessionMock.on.mockEvent('Page.frameNavigated', {frame: {parentId: '3'}});
+
+    await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+    });
+
+    await flushAllTimersAndMicrotasks();
+
+    const invocations = sessionMock.sendCommand.mock.calls;
+    const debuggerInvocations = invocations.filter(call => call[0].startsWith('Debugger.'));
+    expect(debuggerInvocations.map(argList => argList[0])).toEqual([
+      'Debugger.enable',
+      'Debugger.setSkipAllPauses',
+      'Debugger.setAsyncCallStackDepth',
+      'Debugger.enable',
+      'Debugger.setSkipAllPauses',
+      'Debugger.setAsyncCallStackDepth',
+    ]);
+  });
+
+  it('cache natives on new document', async () => {
+    await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+    });
+
+    expect(driverMock._executionContext.cacheNativesOnNewDocument).toHaveBeenCalled();
+  });
+
+  it('install rIC shim on simulated throttling', async () => {
+    await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+      throttlingMethod: 'simulate',
+    });
+
+    const invocations = driverMock._executionContext.evaluateOnNewDocument.mock.calls;
+    if (!invocations.length) expect(invocations).toHaveLength(1);
+    const matchingInvocations = invocations.filter(argList =>
+      argList[0].toString().includes('requestIdleCallback')
+    );
+    if (!matchingInvocations.length) expect(invocations).toContain('An item shimming rIC');
+  });
+
+  it('not install rIC shim on devtools throttling', async () => {
+    await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+      throttlingMethod: 'devtools',
+    });
+
+    const invocations = driverMock._executionContext.evaluateOnNewDocument.mock.calls;
+    const matchingInvocations = invocations.filter(argList =>
+      argList[0].toString().includes('requestIdleCallback')
+    );
+    expect(matchingInvocations).toHaveLength(0);
+  });
+
+  it('handle javascript dialogs automatically', async () => {
+    jest.useFakeTimers();
+
+    sessionMock.sendCommand.mockResponse('Page.handleJavaScriptDialog');
+    sessionMock.on.mockEvent('Page.javascriptDialogOpening', {type: 'confirm'});
+
+    await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+    });
+
+    await flushAllTimersAndMicrotasks();
+
+    expect(sessionMock.sendCommand).toHaveBeenCalledWith('Page.handleJavaScriptDialog', {
+      accept: true,
+      promptText: 'Lighthouse prompt response',
+    });
+  });
+});

--- a/lighthouse-core/test/test-utils.js
+++ b/lighthouse-core/test/test-utils.js
@@ -241,6 +241,10 @@ function makeMocksForGatherRunner() {
     throttle: jest.fn(),
     clearThrottling: jest.fn(),
   }));
+  jest.mock('../gather/driver/prepare.js', () => ({
+    prepareTargetForNavigationMode: jest.fn(),
+    prepareTargetForIndividualNavigation: jest.fn().mockResolvedValue({warnings: []}),
+  }));
   jest.mock('../gather/driver/storage.js', () => ({
     clearDataForOrigin: jest.fn(),
     cleanBrowserCaches: jest.fn(),


### PR DESCRIPTION
**Summary**
Starts to extract pieces from gather-runner for shared FR usage. 

This creates a `driver/prepare.js` whose goal is to prepare a target for gathering (setup global protocol domains, hung usage handling, throttling, emulation, etc). This one is a little murkier where it should belong. I can see an argument for `runner-helpers.js` instead, and I can see an argument for a completely new place that previously didn't exist. I chose `driver/prepare` because it is aligned with this logic previously living in the driver monolith, felt weird to put it in the `fraggle-rock` folder and have legacy gather-runner reaching into it. If there are strong opinions about another place, it's just a filename/path, so speak up :)


**Related Issues/PRs**
ref #11313 

