### PR TITLE
tests: add smokehouse to bin for downstream use

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -24,9 +24,9 @@ lighthouse-logger/
 
 # Exclude the CLI smoketests but keep the smoketest runner that is used
 # by downstream projects (e.g. publisher ads).
-lighthouse-cli/test/cli
-lighthouse-cli/test/fixtures
-lighthouse-cli/test/smokehouse/test-definitions
+lighthouse-cli/test/*
+!lighthouse-cli/test/smokehouse/
+lighthouse-cli/test/smokehouse/test-definitions/
 
 results/
 lantern-data/

--- a/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
+++ b/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
@@ -90,7 +90,7 @@ function pruneExpectedNetworkRequests(testDefns, takeNetworkRequestUrls) {
         const msg = `'networkRequests' cannot be asserted in test '${id}'. They should only be asserted on tests from an in-process server`;
         if (process.env.CI) {
           // If we're in CI, we require any networkRequests expectations to be asserted.
-          throw new Error();
+          throw new Error(msg);
         }
 
         console.warn(log.redify('Warning:'),

--- a/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
+++ b/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license Copyright 2019 The Lighthouse Authors. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -13,13 +14,12 @@
 /* eslint-disable no-console */
 
 const path = require('path');
+const cloneDeep = require('lodash.clonedeep');
 const yargs = require('yargs');
 const log = require('lighthouse-logger');
-
 const {runSmokehouse} = require('../smokehouse.js');
-const {server, serverForOffline} = require('../../fixtures/static-server.js');
 
-const coreTestDefnsPath = `${__dirname}/../test-definitions/core-tests.js`;
+const coreTestDefnsPath = path.join(__dirname, '../test-definitions/core-tests.js');
 
 /**
  * Possible Lighthouse runners. Loaded dynamically so e.g. a CLI run isn't
@@ -63,6 +63,44 @@ function getDefinitionsToRun(allTestDefns, requestedIds, {invertMatch}) {
   }
 
   return smokes;
+}
+
+/**
+ * Prune the `networkRequests` from the test expectations when `takeNetworkRequestUrls`
+ * is not defined. Custom servers may not have this method available in-process.
+ * Also asserts that any expectation with `networkRequests` is run serially. For core
+ * tests, we don't currently have a good way to map requests to test definitions if
+ * the tests are run in parallel.
+ * @param {Array<Smokehouse.TestDfn>} testDefns
+ * @param {Function|undefined} takeNetworkRequestUrls
+ * @return {Array<Smokehouse.TestDfn>}
+ */
+function pruneExpectedNetworkRequests(testDefns, takeNetworkRequestUrls) {
+  const pruneNetworkRequests = !takeNetworkRequestUrls;
+
+  const clonedDefns = cloneDeep(testDefns);
+  for (const {id, expectations, runSerially} of clonedDefns) {
+    for (const expectation of expectations) {
+      if (!runSerially && expectation.networkRequests) {
+        throw new Error(`'${id}' must be set to 'runSerially: true' to assert 'networkRequests'`);
+      }
+
+      if (pruneNetworkRequests && expectation.networkRequests) {
+        // eslint-disable-next-line max-len
+        const msg = `'networkRequests' cannot be asserted in test '${id}'. They should only be asserted on tests from an in-process server`;
+        if (process.env.CI) {
+          // If we're in CI, we require any networkRequests expectations to be asserted.
+          throw new Error();
+        }
+
+        console.warn(log.redify('Warning:'),
+            `${msg}. Pruning expectation: ${JSON.stringify(expectation.networkRequests)}`);
+        expectation.networkRequests = undefined;
+      }
+    }
+  }
+
+  return clonedDefns;
 }
 
 /**
@@ -132,20 +170,27 @@ async function begin() {
   const invertMatch = argv.invertMatch;
   const testDefns = getDefinitionsToRun(allTestDefns, requestedTestIds, {invertMatch});
 
-  const takeNetworkRequestUrls = () => {
-    return server.takeRequestUrls();
-  };
-
-  const options = {jobs, retries, isDebug: argv.debug, lighthouseRunner, takeNetworkRequestUrls};
-
   let isPassing;
+  let server;
+  let serverForOffline;
+  let takeNetworkRequestUrls = undefined;
+
   try {
-    server.listen(10200, 'localhost');
-    serverForOffline.listen(10503, 'localhost');
-    isPassing = (await runSmokehouse(testDefns, options)).success;
+    // If running the core tests, spin up the test server.
+    if (testDefnPath === coreTestDefnsPath) {
+      ({server, serverForOffline} = require('../../fixtures/static-server.js'));
+      server.listen(10200, 'localhost');
+      serverForOffline.listen(10503, 'localhost');
+      takeNetworkRequestUrls = server.takeRequestUrls.bind(server);
+    }
+
+    const prunedTestDefns = pruneExpectedNetworkRequests(testDefns, takeNetworkRequestUrls);
+    const options = {jobs, retries, isDebug: argv.debug, lighthouseRunner, takeNetworkRequestUrls};
+
+    isPassing = (await runSmokehouse(prunedTestDefns, options)).success;
   } finally {
-    await server.close();
-    await serverForOffline.close();
+    if (server) await server.close();
+    if (serverForOffline) await serverForOffline.close();
   }
 
   const exitCode = isPassing ? 0 : 1;

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
@@ -54,7 +54,7 @@ async function internalRun(url, tmpPath, configJson, isDebug) {
   const artifactsDirectory = `${tmpPath}/artifacts/`;
 
   const args = [
-    'lighthouse-cli/index.js',
+    `${__dirname}/../../../index.js`, // 'lighthouse-cli/index.js'
     `${url}`,
     `--output-path=${outputPath}`,
     '--output=json',

--- a/lighthouse-cli/test/smokehouse/readme.md
+++ b/lighthouse-cli/test/smokehouse/readme.md
@@ -174,6 +174,10 @@ Smokehouse comes with a core set of test definitions, but it can run any set of 
   };
   module.exports = expectations;
   ```
-- run smokehouse
+- with `lighthouse` installed as a dependency/peer dependency, run
 
-  `yarn smoke --tests-path plugin-tests.js`
+  `yarn smokehouse --tests-path plugin-tests.js`
+
+  or
+
+  `npx --no-install smokehouse --tests-path plugin-tests.js`

--- a/lighthouse-cli/test/smokehouse/report-assert.js
+++ b/lighthouse-cli/test/smokehouse/report-assert.js
@@ -157,9 +157,8 @@ function makeComparison(name, actualResult, expectedResult) {
  * @param {LocalConsole} localConsole
  * @param {LH.Result} lhr
  * @param {Smokehouse.ExpectedRunnerResult} expected
- * @param {boolean|undefined} isSync
  */
-function pruneExpectations(localConsole, lhr, expected, isSync) {
+function pruneExpectations(localConsole, lhr, expected) {
   const userAgent = lhr.environment.hostUserAgent;
   const userAgentMatch = /Chrome\/(\d+)/.exec(userAgent); // Chrome/85.0.4174.0
   if (!userAgentMatch) throw new Error('Could not get chrome version.');
@@ -200,18 +199,6 @@ function pruneExpectations(localConsole, lhr, expected, isSync) {
 
   const cloned = cloneDeep(expected);
 
-  // Tests must be run synchronously so we can clear the request list between tests.
-  // We do not have a good way to map requests to test definitions if the tests are run in parallel.
-  if (!isSync && expected.networkRequests) {
-    const msg = 'Network requests should only be asserted on tests run synchronously';
-    if (process.env.CI) {
-      throw new Error(msg);
-    } else {
-      localConsole.log(`${msg}, pruning expectation: ${JSON.stringify(expected.networkRequests)}`);
-      delete cloned.networkRequests;
-    }
-  }
-
   pruneNewerChromeExpectations(cloned);
   return cloned;
 }
@@ -219,7 +206,7 @@ function pruneExpectations(localConsole, lhr, expected, isSync) {
 /**
  * Collate results into comparisons of actual and expected scores on each audit/artifact.
  * @param {LocalConsole} localConsole
- * @param {{lhr: LH.Result, artifacts: LH.Artifacts, networkRequests: string[]}} actual
+ * @param {{lhr: LH.Result, artifacts: LH.Artifacts, networkRequests?: string[]}} actual
  * @param {Smokehouse.ExpectedRunnerResult} expected
  * @return {Comparison[]}
  */
@@ -358,15 +345,15 @@ function assertLogString(count) {
 /**
  * Log all the comparisons between actual and expected test results, then print
  * summary. Returns count of passed and failed tests.
- * @param {{lhr: LH.Result, artifacts: LH.Artifacts, networkRequests: string[]}} actual
+ * @param {{lhr: LH.Result, artifacts: LH.Artifacts, networkRequests?: string[]}} actual
  * @param {Smokehouse.ExpectedRunnerResult} expected
- * @param {{isDebug?: boolean, isSync?: boolean}=} reportOptions
+ * @param {{isDebug?: boolean}=} reportOptions
  * @return {{passed: number, failed: number, log: string}}
  */
 function report(actual, expected, reportOptions = {}) {
   const localConsole = new LocalConsole();
 
-  expected = pruneExpectations(localConsole, actual.lhr, expected, reportOptions.isSync);
+  expected = pruneExpectations(localConsole, actual.lhr, expected);
   const comparisons = collateResults(localConsole, actual, expected);
 
   let correctCount = 0;

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -111,7 +111,7 @@ function assertNonNegativeInteger(loggableName, value) {
  * once all are finished.
  * @param {ConcurrentMapper} concurrentMapper
  * @param {Smokehouse.TestDfn} smokeTestDefn
- * @param {{concurrency: number, retries: number, lighthouseRunner: Smokehouse.LighthouseRunner, isDebug?: boolean, takeNetworkRequestUrls: () => string[]}} defnOptions
+ * @param {{concurrency: number, retries: number, lighthouseRunner: Smokehouse.LighthouseRunner, isDebug?: boolean, takeNetworkRequestUrls?: () => string[]}} defnOptions
  * @return {Promise<SmokehouseResult>}
  */
 async function runSmokeTestDefn(concurrentMapper, smokeTestDefn, defnOptions) {
@@ -126,7 +126,6 @@ async function runSmokeTestDefn(concurrentMapper, smokeTestDefn, defnOptions) {
       lighthouseRunner,
       retries,
       isDebug,
-      isSync: concurrency === 1,
       takeNetworkRequestUrls,
     };
   });
@@ -176,7 +175,7 @@ function purpleify(str) {
 /**
  * Run Lighthouse in the selected runner. Returns `log`` for logging once
  * all tests in a defn are complete.
- * @param {{requestedUrl: string, configJson?: LH.Config.Json, expectation: Smokehouse.ExpectedRunnerResult, lighthouseRunner: Smokehouse.LighthouseRunner, retries: number, isDebug?: boolean, isSync?: boolean, takeNetworkRequestUrls: () => string[]}} testOptions
+ * @param {{requestedUrl: string, configJson?: LH.Config.Json, expectation: Smokehouse.ExpectedRunnerResult, lighthouseRunner: Smokehouse.LighthouseRunner, retries: number, isDebug?: boolean, takeNetworkRequestUrls?: () => string[]}} testOptions
  * @return {Promise<{passed: number, failed: number, log: string}>}
  */
 async function runSmokeTest(testOptions) {
@@ -190,7 +189,6 @@ async function runSmokeTest(testOptions) {
     lighthouseRunner,
     retries,
     isDebug,
-    isSync,
     takeNetworkRequestUrls,
   } = testOptions;
 
@@ -208,7 +206,7 @@ async function runSmokeTest(testOptions) {
     try {
       result = {
         ...await lighthouseRunner(requestedUrl, configJson, {isDebug}),
-        networkRequests: takeNetworkRequestUrls(),
+        networkRequests: takeNetworkRequestUrls ? takeNetworkRequestUrls() : undefined,
       };
     } catch (e) {
       logChildProcessError(localConsole, e);
@@ -216,7 +214,7 @@ async function runSmokeTest(testOptions) {
     }
 
     // Assert result.
-    report = getAssertionReport(result, expectation, {isDebug, isSync});
+    report = getAssertionReport(result, expectation, {isDebug});
     if (report.failed) {
       localConsole.log(`${report.failed} assertion(s) failed.`);
       continue; // Retry, if possible.

--- a/lighthouse-core/scripts/release/test.sh
+++ b/lighthouse-core/scripts/release/test.sh
@@ -30,6 +30,10 @@ echo "Testing a fresh local install..."
 VERSION=$(node -e "console.log(require('./package.json').version)")
 npm pack
 
+# Start pristine's static-server (and kill it on exit) for smokehouse run below.
+yarn static-server &
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
 rm -rf /tmp/lighthouse-local-test || true
 mkdir -p /tmp/lighthouse-local-test
 cd /tmp/lighthouse-local-test
@@ -38,9 +42,6 @@ npm init -y
 npm install "$LH_PRISTINE_ROOT/lighthouse-$VERSION.tgz"
 npm explore lighthouse -- npm run fast -- http://example.com
 
-# Start up pristine's static-server (and kill it on exit).
-node "$LH_PRISTINE_ROOT/lighthouse-cli/test/fixtures/static-server.js" &
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 # Packaged smokehouse/lighthouse using pristine's static-server and test fixtures.
 yarn smokehouse --tests-path="$LH_PRISTINE_ROOT/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js" --retries=2
 

--- a/lighthouse-core/scripts/release/test.sh
+++ b/lighthouse-core/scripts/release/test.sh
@@ -30,8 +30,9 @@ echo "Testing a fresh local install..."
 VERSION=$(node -e "console.log(require('./package.json').version)")
 npm pack
 
-# Start pristine's static-server (and kill it on exit) for smokehouse run below.
+# Start pristine's static-server for smokehouse run below.
 yarn static-server &
+# Kill static-server on exit (see https://github.com/GoogleChrome/lighthouse/pull/12446#discussion_r627589729).
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
 rm -rf /tmp/lighthouse-local-test || true

--- a/lighthouse-core/scripts/release/test.sh
+++ b/lighthouse-core/scripts/release/test.sh
@@ -36,11 +36,13 @@ cd /tmp/lighthouse-local-test
 
 npm init -y
 npm install "$LH_PRISTINE_ROOT/lighthouse-$VERSION.tgz"
-npx add-dependencies package.json mime-types lodash.clonedeep
-npm install --only=prod
-cp -r "$LH_PRISTINE_ROOT/lighthouse-cli/test/fixtures" node_modules/lighthouse/lighthouse-cli/test
-npm explore lighthouse -- npm run smoke -- --tests-path "$LH_PRISTINE_ROOT/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js" --retries=3
 npm explore lighthouse -- npm run fast -- http://example.com
+
+# Start up pristine's static-server (and kill it on exit).
+node "$LH_PRISTINE_ROOT/lighthouse-cli/test/fixtures/static-server.js" &
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+# Packaged smokehouse/lighthouse using pristine's static-server and test fixtures.
+yarn smokehouse --tests-path="$LH_PRISTINE_ROOT/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js" --retries=2
 
 cd "$LH_PRISTINE_ROOT"
 rm -rf /tmp/lighthouse-local-test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./lighthouse-core/index.js",
   "bin": {
     "lighthouse": "./lighthouse-cli/index.js",
-    "chrome-debug": "./lighthouse-core/scripts/manual-chrome-launcher.js"
+    "chrome-debug": "./lighthouse-core/scripts/manual-chrome-launcher.js",
+    "smokehouse": "./lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js"
   },
   "engines": {
     "node": ">=12.13.0"
@@ -141,7 +142,7 @@
     "jest": "^26.6.1",
     "jsdom": "^12.2.0",
     "lighthouse-plugin-publisher-ads": "^1.3.0",
-    "lodash.clonedeep": "^4.5.0",
+    "mime-types": "^2.1.30",
     "node-fetch": "^2.6.1",
     "npm-run-posix-or-windows": "^2.0.2",
     "package-json-versionify": "^1.0.4",
@@ -171,6 +172,7 @@
     "jsonlint-mod": "^1.7.6",
     "lighthouse-logger": "^1.2.0",
     "lighthouse-stack-packs": "^1.4.0",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "lodash.set": "^4.3.2",

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -43,7 +43,7 @@
     /** A function that runs Lighthouse with the given options. Defaults to running Lighthouse via the CLI. */
     lighthouseRunner?: LighthouseRunner;
     /** A function that gets a list of URLs requested to the server since the last fetch. */
-    takeNetworkRequestUrls: () => string[];
+    takeNetworkRequestUrls?: () => string[];
   }
 
   export interface SmokehouseLibOptions extends SmokehouseOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5607,17 +5607,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@~1.37.0:
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
-  integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
+mime-db@1.47.0:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
+  integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
 
-mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.21"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
-  integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
+mime-types@^2.1.12, mime-types@^2.1.30, mime-types@~2.1.19:
+  version "2.1.30"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
+  integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
   dependencies:
-    mime-db "~1.37.0"
+    mime-db "1.47.0"
 
 mime@^2.0.3:
   version "2.4.4"


### PR DESCRIPTION
follow up to #12415 and #12325

Relatively unimportant improvement given the lack of users of this, but makes the experience of running smoke tests for downstream projects (publisher-ads only?) a lot better. This lets us do our release testing of a pristine packed lighthouse more cleanly too, though (which also acts as a test that we're not breaking testing for downstream projects...).

The changes end up a little tangled to accomplish this, but starting at the entry point:
- expose a `smokehouse` bin script so downstream doesn't have to [reach in to find it](https://github.com/googleads/publisher-ads-lighthouse-plugin/blob/2df6b33bcecda4ef5f4948be3d906511c29ca0ae/lighthouse-plugin-publisher-ads/test/smoke/run-smoke.js#L50). Packages with `lighthouse` as a dep can run it with `yarn smokehouse` or `npx --no-install smokehouse`
- since this becomes part of our public interface, move `lodash.clonedeep` to deps
- since `static-server` can only serve the core smoke tests by design, dynamically require and start it only if running the core tests (and officially add `mime-types` ([used](https://github.com/GoogleChrome/lighthouse/blob/8b41c549f00488e6856a9c3992fe7ee92eb3e5d8/lighthouse-cli/test/fixtures/static-server.js#L16) by `static-server`) to our devDeps)
- move `release/test.sh` to use this entry point with the pristine checkout's static-server and tests
- make `takeNetworkRequestUrls` optional after all (see [original discussion](https://github.com/GoogleChrome/lighthouse/pull/12325#discussion_r612601472) to make it required). For users of `smokehouse-bin` that aren't using the core tests (like publisher-ads and us during release time), they can't pass in that function (since it's a CLI run), and it turns out we're not interested in implementing network request collection for smokerider at the current time anyways :)
- since we have two bits to pipe through for deciding whether or not to assert `networkRequests` now, and `smokehouse-bin` is the only place that really knows about everything going on, move the pruning of those out to `smokehouse-bin` so the assertions on expectations can go back to being a little simpler. I went back and forth about the location of this last one...happy to discuss.