### PR TITLE
core(canonical): add 'not recommended' to relative url string

### DIFF
--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -32,7 +32,7 @@ const UIStrings = {
    * @description Explanatory message stating that there was a failure in an audit caused by a URL being relative instead of absolute.
    * @example {https://example.com/} url
    * */
-  explanationRelative: 'Relative URL ({url})',
+  explanationRelative: 'Relative URL ({url}) (not recommended)',
   /**
    * @description Explanatory message stating that there was a failure in an audit caused by a URL pointing to a different hreflang than the current context.'hreflang' is an HTML attribute and should not be translated.
    * @example {https://example.com/} url


### PR DESCRIPTION

**Summary**
Adds a not recommended flag in relative URLs description.

**Related Issues/PRs**
Ref [#12463](https://github.com/GoogleChrome/lighthouse/issues/12463)
