### PR TITLE
misc: move predictive-perf off renderer i18n

### DIFF
--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const Audit = require('./audit.js');
-const I18n = require('../report/html/renderer/i18n.js');
+const i18n = require('../lib/i18n/i18n.js');
 
 const LanternFcp = require('../computed/metrics/lantern-first-contentful-paint.js');
 const LanternFmp = require('../computed/metrics/lantern-first-meaningful-paint.js');
@@ -20,6 +20,8 @@ const LanternLcp = require('../computed/metrics/lantern-largest-contentful-paint
 //   https://www.desmos.com/calculator/bksgkihhj8
 const SCORING_P10 = 3651;
 const SCORING_MEDIAN = 10000;
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, {});
 
 class PredictivePerf extends Audit {
   /**
@@ -91,13 +93,11 @@ class PredictivePerf extends Audit {
       values.roughEstimateOfTTI
     );
 
-    const i18n = new I18n(context.settings.locale);
-
     return {
       score,
       numericValue: values.roughEstimateOfTTI,
       numericUnit: 'millisecond',
-      displayValue: i18n.formatMilliseconds(values.roughEstimateOfTTI),
+      displayValue: str_(i18n.UIStrings.ms, {timeInMs: values.roughEstimateOfTTI}),
       details: {
         type: 'debugdata',
         // TODO: Consider not nesting values under `items`.

--- a/lighthouse-core/report/html/renderer/i18n.js
+++ b/lighthouse-core/report/html/renderer/i18n.js
@@ -18,7 +18,7 @@ const MiB = KiB * KiB;
 class I18n {
   /**
    * @param {LH.Locale} locale
-   * @param {T=} strings
+   * @param {T} strings
    */
   constructor(locale, strings) {
     // When testing, use a locale with more exciting numeric formatting.
@@ -27,7 +27,7 @@ class I18n {
     this._numberDateLocale = locale;
     this._numberFormatter = new Intl.NumberFormat(locale);
     this._percentFormatter = new Intl.NumberFormat(locale, {style: 'percent'});
-    this._strings = /** @type {T} */ (strings || {});
+    this._strings = strings;
   }
 
   get strings() {

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -12,7 +12,7 @@ const acceptableDevToolsLog = require('../fixtures/traces/lcp-m78.devtools.log.j
 
 /* eslint-env jest */
 describe('Performance: predictive performance audit', () => {
-  it('should compute the predicted values', () => {
+  it('should compute the predicted values', async () => {
     const artifacts = {
       traces: {
         [PredictivePerf.DEFAULT_PASS]: acceptableTrace,
@@ -23,13 +23,12 @@ describe('Performance: predictive performance audit', () => {
     };
     const context = {computedCache: new Map(), settings: {locale: 'en'}};
 
-    return PredictivePerf.audit(artifacts, context).then(output => {
-      const metrics = output.details.items[0];
-      for (const [key, value] of Object.entries(metrics)) {
-        metrics[key] = Math.round(value);
-      }
-
-      expect(metrics).toMatchSnapshot();
-    });
+    const output = await PredictivePerf.audit(artifacts, context);
+    expect(output.displayValue).toBeDisplayString('4,670 ms');
+    const metrics = output.details.items[0];
+    for (const [key, value] of Object.entries(metrics)) {
+      metrics[key] = Math.round(value);
+    }
+    expect(metrics).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Due to the kind of weird legacy of the renderer's `i18n.js` (coming from a `util` shared between the report and core), `predictive-perf` ended up using the renderer `i18n` class to do a simple milliseconds format rather than using the i18n pipeline (albeit for a string that no human will see or probably ever needs).

Now, whether or not `predictive-perf` _needs_ a properly localized and formatted milliseconds (instead of just doing rounding and adding `ms` itself locally) is another question, but this is basically free, so I don't think it matters. Either way it allows the renderer `i18n` to not have optional `strings`, which was my original goal with the change, so happy to change if someone feels strongly :)