### PR TITLE
tests(i18n): only accept IcuMessages in toBeDisplayString

### DIFF
--- a/lighthouse-core/test/audits/installable-manifest-test.js
+++ b/lighthouse-core/test/audits/installable-manifest-test.js
@@ -154,7 +154,7 @@ describe('PWA: webapp install banner audit', () => {
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
         assert.strictEqual(result.score, 0);
         const items = result.details.items;
-        expect(items[0].reason).toBeDisplayString(/number of arguments/);
+        expect(items[0].reason).toMatch(/number of arguments/);
       });
     });
 
@@ -167,7 +167,7 @@ describe('PWA: webapp install banner audit', () => {
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
         assert.strictEqual(result.score, 0);
         const items = result.details.items;
-        expect(items[0].reason).toBeDisplayString(/unexpected arguments/);
+        expect(items[0].reason).toMatch(/unexpected arguments/);
       });
     });
 

--- a/lighthouse-core/test/audits/is-on-https-test.js
+++ b/lighthouse-core/test/audits/is-on-https-test.js
@@ -84,7 +84,7 @@ describe('Security: HTTPS audit', () => {
     // Unknown blocked resolution string is used as fallback.
     expect(result.details.items[2]).toMatchObject({
       url: 'http://localhost/image2.jpeg',
-      resolution: expect.toBeDisplayString('MixedContentBlockedLOL'),
+      resolution: 'MixedContentBlockedLOL',
     });
 
     expect(result.score).toBe(0);

--- a/lighthouse-core/test/index-test.js
+++ b/lighthouse-core/test/index-test.js
@@ -92,8 +92,7 @@ describe('Module Tests', function() {
     try {
       await lighthouse('i-am-not-valid', {}, {});
     } catch (err) {
-      expect(err.friendlyMessage)
-          .toBeDisplayString('The URL you have provided appears to be invalid.');
+      expect(err.friendlyMessage).toBe('The URL you have provided appears to be invalid.');
       expect(err.code).toEqual('INVALID_URL');
     }
   });
@@ -103,8 +102,7 @@ describe('Module Tests', function() {
     try {
       await lighthouse('file:///a/fake/index.html', {}, {});
     } catch (err) {
-      expect(err.friendlyMessage)
-          .toBeDisplayString('The URL you have provided appears to be invalid.');
+      expect(err.friendlyMessage).toBe('The URL you have provided appears to be invalid.');
       expect(err.code).toEqual('INVALID_URL');
     }
   });

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -790,7 +790,7 @@ describe('Runner', () => {
 
       // And it bubbled up to the runtimeError.
       expect(lhr.runtimeError.code).toEqual(NO_FCP.code);
-      expect(lhr.runtimeError.message).toBeDisplayString(/did not paint any content.*\(NO_FCP\)/);
+      expect(lhr.runtimeError.message).toMatch(/did not paint any content.*\(NO_FCP\)/);
     });
 
     it('includes a pageLoadError runtimeError over any gatherer runtimeErrors', async () => {
@@ -821,7 +821,7 @@ describe('Runner', () => {
 
       // But top-level runtimeError is the pageLoadError.
       expect(lhr.runtimeError.code).toEqual(LHError.errors.PAGE_HUNG.code);
-      expect(lhr.runtimeError.message).toBeDisplayString(/because the page stopped responding/);
+      expect(lhr.runtimeError.message).toMatch(/because the page stopped responding/);
     });
   });
 

--- a/lighthouse-core/test/test-utils.js
+++ b/lighthouse-core/test/test-utils.js
@@ -14,6 +14,18 @@ const {default: {toBeCloseTo}} = require('expect/build/matchers.js');
 
 expect.extend({
   toBeDisplayString(received, expected) {
+    if (!i18n.isIcuMessage(received)) {
+      const message = () =>
+      [
+        `${this.utils.matcherHint('.toBeDisplayString')}\n`,
+        `Expected object to be an ${this.utils.printExpected('LH.IcuMessage')}`,
+        `Received ${typeof received}`,
+        `  ${this.utils.printReceived(received)}`,
+      ].join('\n');
+
+      return {message, pass: false};
+    }
+
     const actual = i18n.getFormatted(received, 'en-US');
     const pass = expected instanceof RegExp ?
       expected.test(actual) :
@@ -28,7 +40,7 @@ expect.extend({
         `  ${this.utils.printReceived(actual)}`,
       ].join('\n');
 
-    return {actual, message, pass};
+    return {message, pass};
   },
 
   // Expose toBeCloseTo() so it can be used as an asymmetric matcher.


### PR DESCRIPTION
Adds an assertion to `expect.toBeDisplayString` that the passed-in value is an `LH.IcuMessage` and not a matching string.

Originally `expect.toBeDisplayString` was intended to support either `string` or `LH.IcuMessage` since most of the localized LHR properties [end up being a union of the two](https://github.com/GoogleChrome/lighthouse/blob/d236a70daf476f2ffa09b30853cb60b3caac79e0/types/audit.d.ts#L72-L88). However, since then, it's clear that our tests always know if a tested property is going to be localizable or not so it's better to be specific. Doing it this way also avoids the potential to assert that a value is a certain string once localized, but miss the fact that it's just the english string that won't be localized (luckily we don't appear to have that problem anywhere).

Also fixes a few places where these were incorrectly being asserted, mostly on fallbacks that occur specifically when i18n is failing for that audit and on values outside runner, which have usually already been localized.