### PR TITLE
misc(treemap): esc to zoom out

### DIFF
--- a/lighthouse-treemap/app/src/main.js
+++ b/lighthouse-treemap/app/src/main.js
@@ -161,10 +161,14 @@ class TreemapViewer {
       this.updateColors();
     });
 
-    treemapEl.addEventListener('keypress', (e) => {
+    treemapEl.addEventListener('keyup', (e) => {
       if (!(e instanceof KeyboardEvent)) return;
 
       if (e.key === 'Enter') this.updateColors();
+
+      if (e.key === 'Escape' && this.treemap) {
+        this.treemap.zoom([]); // zoom out to root
+      }
     });
 
     treemapEl.addEventListener('mouseover', (e) => {

--- a/lighthouse-treemap/types/treemap.d.ts
+++ b/lighthouse-treemap/types/treemap.d.ts
@@ -7,6 +7,7 @@ declare global {
     constructor(data: any, options: WebTreeMapOptions);
     render(el: HTMLElement): void;
     layout(data: any, el: HTMLElement): void;
+    zoom(address: number[]): void
   }
 
   interface WebTreeMapOptions {


### PR DESCRIPTION
as suggested by brendan

(keypress doesn't catch Escape, but keyup does.)

ref #11254