### PR TITLE
core(csp-xss): move to default config

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -169,6 +169,9 @@ Object {
       "path": "preload-lcp-image",
     },
     Object {
+      "path": "csp-xss",
+    },
+    Object {
       "path": "full-page-screenshot",
     },
     Object {
@@ -763,6 +766,11 @@ Object {
           "group": "best-practices-trust-safety",
           "id": "no-vulnerable-libraries",
           "weight": 1,
+        },
+        Object {
+          "group": "best-practices-trust-safety",
+          "id": "csp-xss",
+          "weight": 0,
         },
         Object {
           "group": "best-practices-ux",

--- a/lighthouse-core/audits/csp-xss.js
+++ b/lighthouse-core/audits/csp-xss.js
@@ -20,8 +20,8 @@ const UIStrings = {
   title: 'Ensure CSP is effective against XSS attacks',
   /** Description of a Lighthouse audit that evaluates the security of a page's CSP. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. "CSP" stands for "Content Security Policy". "XSS" stands for "Cross Site Scripting". "CSP" and "XSS" do not need to be translated. */
   description: 'A strong Content Security Policy (CSP) significantly ' +
-    'reduces the risk of XSS attacks. ' +
-    '[Learn more](https://csp.withgoogle.com/docs/index.html)',
+    'reduces the risk of cross-site scripting (XSS) attacks. ' +
+    '[Learn more](https://web.dev/strict-csp/)',
   /** Summary text for the results of a Lighthouse audit that evaluates the security of a page's CSP. This is displayed if no CSP is being enforced. "CSP" stands for "Content Security Policy". "CSP" does not need to be translated. */
   noCsp: 'No CSP found in enforcement mode',
   /** Message shown when one or more CSPs are defined in a <meta> tag. Shown in a table with a list of other CSP bypasses and warnings. "CSP" stands for "Content Security Policy". "CSP" and "HTTP" do not need to be translated. */

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -237,6 +237,7 @@ const defaultConfig = {
     'unsized-images',
     'valid-source-maps',
     'preload-lcp-image',
+    'csp-xss',
     'full-page-screenshot',
     'script-treemap-data',
     'manual/pwa-cross-browser',
@@ -561,6 +562,7 @@ const defaultConfig = {
         {id: 'geolocation-on-start', weight: 1, group: 'best-practices-trust-safety'},
         {id: 'notification-on-start', weight: 1, group: 'best-practices-trust-safety'},
         {id: 'no-vulnerable-libraries', weight: 1, group: 'best-practices-trust-safety'},
+        {id: 'csp-xss', weight: 0, group: 'best-practices-trust-safety'},
         // User Experience
         {id: 'password-inputs-can-be-pasted-into', weight: 1, group: 'best-practices-ux'},
         {id: 'image-aspect-ratio', weight: 1, group: 'best-practices-ux'},

--- a/lighthouse-core/config/experimental-config.js
+++ b/lighthouse-core/config/experimental-config.js
@@ -16,7 +16,6 @@ const config = {
   audits: [
     'autocomplete',
     'large-javascript-libraries',
-    'csp-xss',
   ],
   categories: {
     // @ts-ignore: `title` is required in CategoryJson. setting to the same value as the default
@@ -30,7 +29,6 @@ const config = {
     // config is awkward - easier to omit the property here. Will defer to default config.
     'best-practices': {
       auditRefs: [
-        {id: 'csp-xss', weight: 0, group: 'best-practices-trust-safety'},
         {id: 'autocomplete', weight: 0, group: 'best-practices-ux'},
       ],
     },

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -585,7 +585,7 @@
     "message": "Directive"
   },
   "lighthouse-core/audits/csp-xss.js | description": {
-    "message": "A strong Content Security Policy (CSP) significantly reduces the risk of XSS attacks. [Learn more](https://csp.withgoogle.com/docs/index.html)"
+    "message": "A strong Content Security Policy (CSP) significantly reduces the risk of cross-site scripting (XSS) attacks. [Learn more](https://web.dev/strict-csp/)"
   },
   "lighthouse-core/audits/csp-xss.js | metaTagMessage": {
     "message": "The page contains a CSP defined in a <meta> tag. Consider defining the CSP in an HTTP header if you can."

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -585,7 +585,7 @@
     "message": "D̂ír̂éĉt́îv́ê"
   },
   "lighthouse-core/audits/csp-xss.js | description": {
-    "message": "Â śt̂ŕôńĝ Ćôńt̂én̂t́ Ŝéĉúr̂ít̂ý P̂ól̂íĉý (ĈŚP̂) śîǵn̂íf̂íĉán̂t́l̂ý r̂éd̂úĉéŝ t́ĥé r̂íŝḱ ôf́ X̂ŚŜ át̂t́âćk̂ś. [L̂éâŕn̂ ḿôŕê](https://csp.withgoogle.com/docs/index.html)"
+    "message": "Â śt̂ŕôńĝ Ćôńt̂én̂t́ Ŝéĉúr̂ít̂ý P̂ól̂íĉý (ĈŚP̂) śîǵn̂íf̂íĉán̂t́l̂ý r̂éd̂úĉéŝ t́ĥé r̂íŝḱ ôf́ ĉŕôśŝ-śît́ê śĉŕîṕt̂ín̂ǵ (X̂ŚŜ) át̂t́âćk̂ś. [L̂éâŕn̂ ḿôŕê](https://web.dev/strict-csp/)"
   },
   "lighthouse-core/audits/csp-xss.js | metaTagMessage": {
     "message": "T̂h́ê ṕâǵê ćôńt̂áîńŝ á ĈŚP̂ d́êf́îńêd́ îń â <ḿêt́â> t́âǵ. Ĉón̂śîd́êŕ d̂éf̂ín̂ín̂ǵ t̂h́ê ĆŜṔ îń âń ĤT́T̂Ṕ ĥéâd́êŕ îf́ ŷóû ćâń."

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2168,6 +2168,40 @@
         "overallSavingsMs": 0
       }
     },
+    "csp-xss": {
+      "id": "csp-xss",
+      "title": "Ensure CSP is effective against XSS attacks",
+      "description": "A strong Content Security Policy (CSP) significantly reduces the risk of cross-site scripting (XSS) attacks. [Learn more](https://web.dev/strict-csp/)",
+      "score": null,
+      "scoreDisplayMode": "informative",
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "description",
+            "itemType": "text",
+            "subItemsHeading": {
+              "key": "description"
+            },
+            "text": "Description"
+          },
+          {
+            "key": "directive",
+            "itemType": "code",
+            "subItemsHeading": {
+              "key": "directive"
+            },
+            "text": "Directive"
+          }
+        ],
+        "items": [
+          {
+            "severity": "Bypass",
+            "description": "No CSP found in enforcement mode"
+          }
+        ]
+      }
+    },
     "full-page-screenshot": {
       "id": "full-page-screenshot",
       "title": "Full-page screenshot",
@@ -5543,6 +5577,11 @@
           "group": "best-practices-trust-safety"
         },
         {
+          "id": "csp-xss",
+          "weight": 0,
+          "group": "best-practices-trust-safety"
+        },
+        {
           "id": "password-inputs-can-be-pasted-into",
           "weight": 1,
           "group": "best-practices-ux"
@@ -6427,6 +6466,12 @@
       {
         "startTime": 0,
         "name": "lh:computed:LanternFirstContentfulPaint",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:audit:csp-xss",
         "duration": 100,
         "entryType": "measure"
       },
@@ -7334,7 +7379,8 @@
         "audits[font-size].details.headings[0].text"
       ],
       "lighthouse-core/lib/i18n/i18n.js | columnDescription": [
-        "audits[errors-in-console].details.headings[1].text"
+        "audits[errors-in-console].details.headings[1].text",
+        "audits[csp-xss].details.headings[0].text"
       ],
       "lighthouse-core/audits/server-response-time.js | title": [
         "audits[server-response-time].title"
@@ -7826,6 +7872,18 @@
       ],
       "lighthouse-core/audits/preload-lcp-image.js | description": [
         "audits[preload-lcp-image].description"
+      ],
+      "lighthouse-core/audits/csp-xss.js | title": [
+        "audits[csp-xss].title"
+      ],
+      "lighthouse-core/audits/csp-xss.js | description": [
+        "audits[csp-xss].description"
+      ],
+      "lighthouse-core/audits/csp-xss.js | columnDirective": [
+        "audits[csp-xss].details.headings[1].text"
+      ],
+      "lighthouse-core/audits/csp-xss.js | noCsp": [
+        "audits[csp-xss].details.items[0].description"
       ],
       "lighthouse-core/audits/manual/pwa-cross-browser.js | title": [
         "audits[pwa-cross-browser].title"

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-export-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-export-run-expected.txt
@@ -2,11 +2,11 @@ Tests that exporting works.
 
 ++++++++ testExportHtml
 
-# of .lh-audit divs (original): 136
+# of .lh-audit divs (original): 137
 
-# of .lh-audit divs (exported html): 136
+# of .lh-audit divs (exported html): 137
 
 ++++++++ testExportJson
 
-# of audits (json): 155
+# of audits (json): 156
 

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -244,6 +244,7 @@ Auditing: Page has valid source maps
 Auditing: Preload Largest Contentful Paint image
 Computing artifact: LanternLargestContentfulPaint
 Computing artifact: LanternFirstContentfulPaint
+Auditing: Ensure CSP is effective against XSS attacks
 Auditing: Full-page screenshot
 Auditing: Script Treemap Data
 Computing artifact: JSBundles
@@ -433,6 +434,7 @@ color-contrast: pass
 content-width: fail
 crawlable-anchors: pass
 critical-request-chains: informative
+csp-xss: informative
 cumulative-ad-shift: notApplicable
 cumulative-layout-shift: numeric
 custom-controls-labels: manual
@@ -571,7 +573,7 @@ viewport: fail
 viewport-ad-density: notApplicable
 visual-order-follows-dom: manual
 
-# of .lh-audit divs: 156
+# of .lh-audit divs: 157
 
 .lh-audit divs:
 accesskeys
@@ -612,6 +614,7 @@ color-contrast
 content-width
 crawlable-anchors
 critical-request-chains
+csp-xss
 cumulative-ad-shift
 custom-controls-labels
 custom-controls-roles


### PR DESCRIPTION
Updated learn more link to: https://web.dev/strict-csp/

CSP is already enforced on web.dev. Should hold on merging this until [cl/371125171](https://critique-ng.corp.google.com/cl/371125171) lands.