### PR TITLE
core: fix main session OOPIF checks for devtools

### DIFF
--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -207,6 +207,13 @@ class NetworkRecorder extends EventEmitter {
    * @return {NetworkRequest|undefined}
    */
   _findRealRequestAndSetSession(requestId, sessionId) {
+    // The very first sessionId processed is always the main sessionId. In all but DevTools,
+    // this sessionId is undefined. However, in DevTools the main Lighthouse protocol connection
+    // does send events with sessionId set to a string, because of how DevTools routes the protocol
+    // to Lighthouse.
+    // Many places in Lighthouse use `record.sessionId === undefined` to mean that the session is not
+    // an OOPIF. To maintain this property, we intercept sessionId here and set it to undefined if
+    // itt matches the first value seen.
     if (this._mainSessionId === null) {
       this._mainSessionId = sessionId;
     }

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -21,6 +21,8 @@ class NetworkRecorder extends EventEmitter {
     this._records = [];
     /** @type {Map<string, NetworkRequest>} */
     this._recordsById = new Map();
+    /** @type {string|null|undefined} */
+    this._mainSessionId = null;
   }
 
   /**
@@ -205,6 +207,13 @@ class NetworkRecorder extends EventEmitter {
    * @return {NetworkRequest|undefined}
    */
   _findRealRequestAndSetSession(requestId, sessionId) {
+    if (this._mainSessionId === null) {
+      this._mainSessionId = sessionId;
+    }
+    if (this._mainSessionId === sessionId) {
+      sessionId = undefined;
+    }
+
     let request = this._recordsById.get(requestId);
     if (!request || !request.isValid) return undefined;
 

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -213,7 +213,7 @@ class NetworkRecorder extends EventEmitter {
     // to Lighthouse.
     // Many places in Lighthouse use `record.sessionId === undefined` to mean that the session is not
     // an OOPIF. To maintain this property, we intercept sessionId here and set it to undefined if
-    // itt matches the first value seen.
+    // it matches the first value seen.
     if (this._mainSessionId === null) {
       this._mainSessionId = sessionId;
     }


### PR DESCRIPTION
I noticed in DevTools that no source map contents were being used: so no subRows in unused-javascript with module-level coverage, and no bundle in script-treemap-data.

JSBundles had errored `sizes` because `scriptElement.content` was null:

![image](https://user-images.githubusercontent.com/4071474/119182216-7be49180-ba27-11eb-89ce-7eb872e121c3.png)

This property is set for external scripts in a post-processing step in ScriptElements:

![image](https://user-images.githubusercontent.com/4071474/119182273-8d2d9e00-ba27-11eb-87d4-a21cbc1d3ee8.png)

In DevTools, the OOPIF check filtered out all records because `sessionId` is set even for the main protocol connection. This is due to a complication introduced while adding multi-client support. See https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2607769 for more. I failed to followup on that, and we have no tests touching OOPIF checks in devtools tests, so it went unnoticed.

This PR is a possible workaround/bandaid. I manually verified with `yarn open-devtools` that JSBundles `sizes` property is set correctly, and all the audits are correctly processing module information. I'll look into adding tests too.