### PR TITLE
core(navigate): only observe longtasks in PerfObserver

### DIFF
--- a/lighthouse-core/gather/driver/wait-for-condition.js
+++ b/lighthouse-core/gather/driver/wait-for-condition.js
@@ -285,7 +285,7 @@ function registerPerformanceObserverInPage() {
     }
   });
 
-  observer.observe({entryTypes: ['longtask'], buffered: true});
+  observer.observe({type: 'longtask', buffered: true});
 }
 
 /**


### PR DESCRIPTION
**Summary**
Buffered flag only works when you use [`type` not, `entryTypes`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe). It's not really a regression when we turned it on, because we just fell back to the same behavior as before we added it a few weeks ago, but this will make the fix actually work :) (we never *really* needed buffered either, mostly an extra boost of wait condition correctness in ultrarare cases where entries weren't emitted fast enough)

**Related Issues/PRs**
fixes https://github.com/GoogleChrome/lighthouse/issues/12544
