### PR TITLE
core(csp-xss): add severity text column to report

### DIFF
--- a/lighthouse-core/audits/csp-xss.js
+++ b/lighthouse-core/audits/csp-xss.js
@@ -100,7 +100,7 @@ class CspXss extends Audit {
       const items = syntaxFindings[i].map(f => this.findingToTableItem(f));
       if (!items.length) continue;
       results.push({
-        severity: str_(i18n.UIStrings.rowSeverityHigh),
+        severity: str_(i18n.UIStrings.itemSeverityHigh),
         description: {
           type: 'code',
           value: rawCsps[i],
@@ -126,7 +126,7 @@ class CspXss extends Audit {
       return {
         score: 0,
         results: [{
-          severity: str_(i18n.UIStrings.rowSeverityHigh),
+          severity: str_(i18n.UIStrings.itemSeverityHigh),
           description: str_(UIStrings.noCsp),
           directive: undefined,
         }],
@@ -137,14 +137,14 @@ class CspXss extends Audit {
 
     const results = [
       ...this.constructSyntaxResults(syntax, rawCsps),
-      ...bypasses.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.rowSeverityHigh))),
-      ...warnings.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.rowSeverityMedium))),
+      ...bypasses.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.itemSeverityHigh))),
+      ...warnings.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.itemSeverityMedium))),
     ];
 
     // Add extra warning for a CSP defined in a meta tag.
     if (cspMetaTags.length) {
       results.push({
-        severity: str_(i18n.UIStrings.rowSeverityMedium),
+        severity: str_(i18n.UIStrings.itemSeverityMedium),
         description: str_(UIStrings.metaTagMessage),
         directive: undefined,
       });

--- a/lighthouse-core/audits/csp-xss.js
+++ b/lighthouse-core/audits/csp-xss.js
@@ -31,6 +31,8 @@ const UIStrings = {
   columnDirective: 'Directive',
   /** Label for a column in a data table; entries will be the severity of an issue with the CSP. "CSP" stands for "Content Security Policy". */
   columnSeverity: 'Severity',
+  /** Table item value calling out the presence of a syntax error. */
+  itemSeveritySyntax: 'Syntax',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -100,7 +102,7 @@ class CspXss extends Audit {
       const items = syntaxFindings[i].map(f => this.findingToTableItem(f));
       if (!items.length) continue;
       results.push({
-        severity: str_(i18n.UIStrings.itemSeverityHigh),
+        severity: str_(UIStrings.itemSeveritySyntax),
         description: {
           type: 'code',
           value: rawCsps[i],

--- a/lighthouse-core/audits/csp-xss.js
+++ b/lighthouse-core/audits/csp-xss.js
@@ -29,6 +29,8 @@ const UIStrings = {
     'Consider defining the CSP in an HTTP header if you can.',
   /** Label for a column in a data table; entries will be a directive of a CSP. "CSP" stands for "Content Security Policy". */
   columnDirective: 'Directive',
+  /** Label for a column in a data table; entries will be the severity of an issue with the CSP. "CSP" stands for "Content Security Policy". */
+  columnSeverity: 'Severity',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -74,14 +76,14 @@ class CspXss extends Audit {
 
   /**
    * @param {Finding} finding
-   * @param {string=} icon
+   * @param {(string|LH.IcuMessage)=} severity
    * @return {LH.Audit.Details.TableItem}
    */
-  static findingToTableItem(finding, icon) {
+  static findingToTableItem(finding, severity) {
     return {
       directive: finding.directive,
       description: getTranslatedDescription(finding),
-      severity: icon,
+      severity,
     };
   }
 
@@ -98,7 +100,7 @@ class CspXss extends Audit {
       const items = syntaxFindings[i].map(f => this.findingToTableItem(f));
       if (!items.length) continue;
       results.push({
-        severity: 'Syntax',
+        severity: str_(i18n.UIStrings.rowSeverityHigh),
         description: {
           type: 'code',
           value: rawCsps[i],
@@ -124,7 +126,7 @@ class CspXss extends Audit {
       return {
         score: 0,
         results: [{
-          severity: 'Bypass',
+          severity: str_(i18n.UIStrings.rowSeverityHigh),
           description: str_(UIStrings.noCsp),
           directive: undefined,
         }],
@@ -135,14 +137,14 @@ class CspXss extends Audit {
 
     const results = [
       ...this.constructSyntaxResults(syntax, rawCsps),
-      ...bypasses.map(f => this.findingToTableItem(f, 'Bypass')),
-      ...warnings.map(f => this.findingToTableItem(f, 'Warning')),
+      ...bypasses.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.rowSeverityHigh))),
+      ...warnings.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.rowSeverityHigh))),
     ];
 
     // Add extra warning for a CSP defined in a meta tag.
     if (cspMetaTags.length) {
       results.push({
-        severity: 'Warning',
+        severity: str_(i18n.UIStrings.rowSeverityHigh),
         description: str_(UIStrings.metaTagMessage),
         directive: undefined,
       });
@@ -165,6 +167,7 @@ class CspXss extends Audit {
       /* eslint-disable max-len */
       {key: 'description', itemType: 'text', subItemsHeading: {key: 'description'}, text: str_(i18n.UIStrings.columnDescription)},
       {key: 'directive', itemType: 'code', subItemsHeading: {key: 'directive'}, text: str_(UIStrings.columnDirective)},
+      {key: 'severity', itemType: 'text', subItemsHeading: {key: 'severity'}, text: str_(UIStrings.columnSeverity)},
       /* eslint-enable max-len */
     ];
     const details = Audit.makeTableDetails(headings, results);

--- a/lighthouse-core/audits/csp-xss.js
+++ b/lighthouse-core/audits/csp-xss.js
@@ -78,7 +78,7 @@ class CspXss extends Audit {
 
   /**
    * @param {Finding} finding
-   * @param {(string|LH.IcuMessage)=} severity
+   * @param {LH.IcuMessage=} severity
    * @return {LH.Audit.Details.TableItem}
    */
   static findingToTableItem(finding, severity) {

--- a/lighthouse-core/audits/csp-xss.js
+++ b/lighthouse-core/audits/csp-xss.js
@@ -138,13 +138,13 @@ class CspXss extends Audit {
     const results = [
       ...this.constructSyntaxResults(syntax, rawCsps),
       ...bypasses.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.rowSeverityHigh))),
-      ...warnings.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.rowSeverityHigh))),
+      ...warnings.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.rowSeverityMedium))),
     ];
 
     // Add extra warning for a CSP defined in a meta tag.
     if (cspMetaTags.length) {
       results.push({
-        severity: str_(i18n.UIStrings.rowSeverityHigh),
+        severity: str_(i18n.UIStrings.rowSeverityMedium),
         description: str_(UIStrings.metaTagMessage),
         directive: undefined,
       });

--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -47,7 +47,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 const SEMVER_REGEX = /^(\d+\.\d+\.\d+)[^-0-9]+/;
 
 /** @type {Record<string, LH.IcuMessage>} */
-const rowMap = {
+const severityStringsMap = {
   'low': str_(i18n.UIStrings.rowSeverityLow),
   'medium': str_(i18n.UIStrings.rowSeverityMedium),
   'high': str_(i18n.UIStrings.rowSeverityHigh),
@@ -140,7 +140,7 @@ class NoVulnerableLibrariesAudit extends Audit {
 
     const vulns = matchingVulns.map(vuln => {
       return {
-        severity: rowMap[vuln.severity],
+        severity: severityStringsMap[vuln.severity],
         numericSeverity: this.severityMap[vuln.severity],
         library: `${lib.name}@${normalizedVersion}`,
         url: 'https://snyk.io/vuln/' + vuln.id,

--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -40,12 +40,6 @@ const UIStrings = {
   columnVuln: 'Vulnerability Count',
   /** Label for a column in a data table; entries will be the severity of the vulnerabilities found within a Javascript library. */
   columnSeverity: 'Highest Severity',
-  /** Table row value for the severity of a small, or low impact Javascript vulnerability.  Part of a ranking scale in the form: low, medium, high. */
-  rowSeverityLow: 'Low',
-  /** Table row value for the severity of a Javascript vulnerability.  Part of a ranking scale in the form: low, medium, high. */
-  rowSeverityMedium: 'Medium',
-  /** Table row value for the severity of a high impact, or dangerous Javascript vulnerability.  Part of a ranking scale in the form: low, medium, high. */
-  rowSeverityHigh: 'High',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -54,9 +48,9 @@ const SEMVER_REGEX = /^(\d+\.\d+\.\d+)[^-0-9]+/;
 
 /** @type {Record<string, LH.IcuMessage>} */
 const rowMap = {
-  'low': str_(UIStrings.rowSeverityLow),
-  'medium': str_(UIStrings.rowSeverityMedium),
-  'high': str_(UIStrings.rowSeverityHigh),
+  'low': str_(i18n.UIStrings.rowSeverityLow),
+  'medium': str_(i18n.UIStrings.rowSeverityMedium),
+  'high': str_(i18n.UIStrings.rowSeverityHigh),
 };
 
 /** @typedef {{npm: Object<string, Array<{id: string, severity: string, semver: {vulnerable: Array<string>}}>>}} SnykDB */

--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -48,9 +48,9 @@ const SEMVER_REGEX = /^(\d+\.\d+\.\d+)[^-0-9]+/;
 
 /** @type {Record<string, LH.IcuMessage>} */
 const severityStringsMap = {
-  'low': str_(i18n.UIStrings.rowSeverityLow),
-  'medium': str_(i18n.UIStrings.rowSeverityMedium),
-  'high': str_(i18n.UIStrings.rowSeverityHigh),
+  'low': str_(i18n.UIStrings.itemSeverityLow),
+  'medium': str_(i18n.UIStrings.itemSeverityMedium),
+  'high': str_(i18n.UIStrings.itemSeverityHigh),
 };
 
 /** @typedef {{npm: Object<string, Array<{id: string, severity: string, semver: {vulnerable: Array<string>}}>>}} SnykDB */

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -140,6 +140,12 @@ const UIStrings = {
   largestContentfulPaintMetric: 'Largest Contentful Paint',
   /** The name of the metric "Cumulative Layout Shift" that indicates how much the page changes its layout while it loads. If big segments of the page shift their location during load, the Cumulative Layout Shift will be higher. Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit. */
   cumulativeLayoutShiftMetric: 'Cumulative Layout Shift',
+  /** Table row value for the severity of a small, or low impact vulnerability. Part of a ranking scale in the form: low, medium, high. */
+  rowSeverityLow: 'Low',
+  /** Table row value for the severity of a vulnerability. Part of a ranking scale in the form: low, medium, high. */
+  rowSeverityMedium: 'Medium',
+  /** Table row value for the severity of a high impact, or dangerous vulnerability. Part of a ranking scale in the form: low, medium, high. */
+  rowSeverityHigh: 'High',
 };
 
 const formats = {

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -140,12 +140,12 @@ const UIStrings = {
   largestContentfulPaintMetric: 'Largest Contentful Paint',
   /** The name of the metric "Cumulative Layout Shift" that indicates how much the page changes its layout while it loads. If big segments of the page shift their location during load, the Cumulative Layout Shift will be higher. Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit. */
   cumulativeLayoutShiftMetric: 'Cumulative Layout Shift',
-  /** Table row value for the severity of a small, or low impact vulnerability. Part of a ranking scale in the form: low, medium, high. */
-  rowSeverityLow: 'Low',
-  /** Table row value for the severity of a vulnerability. Part of a ranking scale in the form: low, medium, high. */
-  rowSeverityMedium: 'Medium',
-  /** Table row value for the severity of a high impact, or dangerous vulnerability. Part of a ranking scale in the form: low, medium, high. */
-  rowSeverityHigh: 'High',
+  /** Table item value for the severity of a small, or low impact vulnerability. Part of a ranking scale in the form: low, medium, high. */
+  itemSeverityLow: 'Low',
+  /** Table item value for the severity of a vulnerability. Part of a ranking scale in the form: low, medium, high. */
+  itemSeverityMedium: 'Medium',
+  /** Table item value for the severity of a high impact, or dangerous vulnerability. Part of a ranking scale in the form: low, medium, high. */
+  itemSeverityHigh: 'High',
 };
 
 const formats = {

--- a/lighthouse-core/lib/i18n/locales/ar-XB.json
+++ b/lighthouse-core/lib/i18n/locales/ar-XB.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "‏‮Includes‬‏ ‏‮front‬‏-‏‮end‬‏ ‏‮JavaScript‬‏ ‏‮libraries‬‏ ‏‮with‬‏ ‏‮known‬‏ ‏‮security‬‏ ‏‮vulnerabilities‬‏"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "‏‮High‬‏"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "‏‮Low‬‏"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "‏‮Medium‬‏"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "‏‮Avoids‬‏ ‏‮front‬‏-‏‮end‬‏ ‏‮JavaScript‬‏ ‏‮libraries‬‏ ‏‮with‬‏ ‏‮known‬‏ ‏‮security‬‏ ‏‮vulnerabilities‬‏"
   },

--- a/lighthouse-core/lib/i18n/locales/ar.json
+++ b/lighthouse-core/lib/i18n/locales/ar.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "يتم تضمين مكتبات الواجهة الأمامية JavaScript ذات الثغرات الأمنية المعروفة"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "مرتفع"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "منخفض"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "متوسط"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "يتم تجنُب مكتبات الواجهة الأمامية JavaScript ذات الثغرات الأمنية المعروفة"
   },

--- a/lighthouse-core/lib/i18n/locales/bg.json
+++ b/lighthouse-core/lib/i18n/locales/bg.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Включва библиотеки на JavaScript за предния слой, съдържащи известни уязвимости в сигурността"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Високо"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Ниско"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Средно"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Избягва библиотеки на JavaScript за предния слой, съдържащи известни уязвимости в сигурността"
   },

--- a/lighthouse-core/lib/i18n/locales/ca.json
+++ b/lighthouse-core/lib/i18n/locales/ca.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Inclou biblioteques de JavaScript d'interfície amb vulnerabilitats de seguretat conegudes"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Alta"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Baixa"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Mitjana"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Evita les biblioteques de JavaScript d'interfície amb vulnerabilitats de seguretat conegudes"
   },

--- a/lighthouse-core/lib/i18n/locales/cs.json
+++ b/lighthouse-core/lib/i18n/locales/cs.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Zahrnuje frontendové javascriptové knihovny se známými chybami zabezpečení"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Vysoká"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Nízká"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Střední"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Nepoužívá frontendové javascriptové knihovny se známými chybami zabezpečení"
   },

--- a/lighthouse-core/lib/i18n/locales/da.json
+++ b/lighthouse-core/lib/i18n/locales/da.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Indeholder JavaScript-biblioteker i frontend med kendte sikkerhedssårbarheder"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Høj"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Lavt"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Middel"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Undgår frontend JavaScript-biblioteker med kendte sikkerhedssårbarheder"
   },

--- a/lighthouse-core/lib/i18n/locales/de.json
+++ b/lighthouse-core/lib/i18n/locales/de.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Enthält Front-End-JavaScript-Bibliotheken mit bekannten Sicherheitslücken"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Hoch"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Niedrig"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Mittel"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Vermeidet Front-End-JavaScript-Bibliotheken mit bekannten Sicherheitslücken"
   },

--- a/lighthouse-core/lib/i18n/locales/el.json
+++ b/lighthouse-core/lib/i18n/locales/el.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Συμπερίληψη βιβλιοθηκών JavaScript διεπαφής με γνωστές ευπάθειες ασφάλειας"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Υψηλή"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Χαμηλή"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Μέτρια"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Αποφυγή όλων των βιβλιοθηκών JavaScript διεπαφής με γνωστές ευπάθειες ασφάλειας"
   },

--- a/lighthouse-core/lib/i18n/locales/en-GB.json
+++ b/lighthouse-core/lib/i18n/locales/en-GB.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Includes front-end JavaScript libraries with known security vulnerabilities"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "High"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Low"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Medium"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Avoids front-end JavaScript libraries with known security vulnerabilities"
   },

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -584,6 +584,9 @@
   "lighthouse-core/audits/csp-xss.js | columnDirective": {
     "message": "Directive"
   },
+  "lighthouse-core/audits/csp-xss.js | columnSeverity": {
+    "message": "Severity"
+  },
   "lighthouse-core/audits/csp-xss.js | description": {
     "message": "A strong Content Security Policy (CSP) significantly reduces the risk of cross-site scripting (XSS) attacks. [Learn more](https://web.dev/strict-csp/)"
   },
@@ -760,15 +763,6 @@
   },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Includes front-end JavaScript libraries with known security vulnerabilities"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "High"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Low"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Medium"
   },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Avoids front-end JavaScript libraries with known security vulnerabilities"
@@ -1879,6 +1873,15 @@
   },
   "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
     "message": "Other"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | rowSeverityHigh": {
+    "message": "High"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | rowSeverityLow": {
+    "message": "Low"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | rowSeverityMedium": {
+    "message": "Medium"
   },
   "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
     "message": "Script"

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -1856,6 +1856,15 @@
   "lighthouse-core/lib/i18n/i18n.js | interactiveMetric": {
     "message": "Time to Interactive"
   },
+  "lighthouse-core/lib/i18n/i18n.js | itemSeverityHigh": {
+    "message": "High"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | itemSeverityLow": {
+    "message": "Low"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | itemSeverityMedium": {
+    "message": "Medium"
+  },
   "lighthouse-core/lib/i18n/i18n.js | largestContentfulPaintMetric": {
     "message": "Largest Contentful Paint"
   },
@@ -1873,15 +1882,6 @@
   },
   "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
     "message": "Other"
-  },
-  "lighthouse-core/lib/i18n/i18n.js | rowSeverityHigh": {
-    "message": "High"
-  },
-  "lighthouse-core/lib/i18n/i18n.js | rowSeverityLow": {
-    "message": "Low"
-  },
-  "lighthouse-core/lib/i18n/i18n.js | rowSeverityMedium": {
-    "message": "Medium"
   },
   "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
     "message": "Script"

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -590,6 +590,9 @@
   "lighthouse-core/audits/csp-xss.js | description": {
     "message": "A strong Content Security Policy (CSP) significantly reduces the risk of cross-site scripting (XSS) attacks. [Learn more](https://web.dev/strict-csp/)"
   },
+  "lighthouse-core/audits/csp-xss.js | itemSeveritySyntax": {
+    "message": "Syntax"
+  },
   "lighthouse-core/audits/csp-xss.js | metaTagMessage": {
     "message": "The page contains a CSP defined in a <meta> tag. Consider defining the CSP in an HTTP header if you can."
   },

--- a/lighthouse-core/lib/i18n/locales/en-XA.json
+++ b/lighthouse-core/lib/i18n/locales/en-XA.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "[Îñçļûðéš ƒŕöñţ-éñð ĴåvåŠçŕîþţ ļîбŕåŕîéš ŵîţĥ ķñöŵñ šéçûŕîţý vûļñéŕåбîļîţîéš one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "[Ĥîĝĥ one]"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "[Ļöŵ one]"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "[Méðîûm one]"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "[Åvöîðš ƒŕöñţ-éñð ĴåvåŠçŕîþţ ļîбŕåŕîéš ŵîţĥ ķñöŵñ šéçûŕîţý vûļñéŕåбîļîţîéš one two three four five six seven eight nine ten eleven twelve thirteen fourteen]"
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -1856,6 +1856,15 @@
   "lighthouse-core/lib/i18n/i18n.js | interactiveMetric": {
     "message": "T̂ím̂é t̂ó Îńt̂ér̂áĉt́îv́ê"
   },
+  "lighthouse-core/lib/i18n/i18n.js | itemSeverityHigh": {
+    "message": "Ĥíĝh́"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | itemSeverityLow": {
+    "message": "L̂óŵ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | itemSeverityMedium": {
+    "message": "M̂éd̂íûḿ"
+  },
   "lighthouse-core/lib/i18n/i18n.js | largestContentfulPaintMetric": {
     "message": "L̂ár̂ǵêśt̂ Ćôńt̂én̂t́f̂úl̂ Ṕâín̂t́"
   },
@@ -1873,15 +1882,6 @@
   },
   "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
     "message": "Ôt́ĥér̂"
-  },
-  "lighthouse-core/lib/i18n/i18n.js | rowSeverityHigh": {
-    "message": "Ĥíĝh́"
-  },
-  "lighthouse-core/lib/i18n/i18n.js | rowSeverityLow": {
-    "message": "L̂óŵ"
-  },
-  "lighthouse-core/lib/i18n/i18n.js | rowSeverityMedium": {
-    "message": "M̂éd̂íûḿ"
   },
   "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
     "message": "Ŝćr̂íp̂t́"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -590,6 +590,9 @@
   "lighthouse-core/audits/csp-xss.js | description": {
     "message": "Â śt̂ŕôńĝ Ćôńt̂én̂t́ Ŝéĉúr̂ít̂ý P̂ól̂íĉý (ĈŚP̂) śîǵn̂íf̂íĉán̂t́l̂ý r̂éd̂úĉéŝ t́ĥé r̂íŝḱ ôf́ ĉŕôśŝ-śît́ê śĉŕîṕt̂ín̂ǵ (X̂ŚŜ) át̂t́âćk̂ś. [L̂éâŕn̂ ḿôŕê](https://web.dev/strict-csp/)"
   },
+  "lighthouse-core/audits/csp-xss.js | itemSeveritySyntax": {
+    "message": "Ŝýn̂t́âx́"
+  },
   "lighthouse-core/audits/csp-xss.js | metaTagMessage": {
     "message": "T̂h́ê ṕâǵê ćôńt̂áîńŝ á ĈŚP̂ d́êf́îńêd́ îń â <ḿêt́â> t́âǵ. Ĉón̂śîd́êŕ d̂éf̂ín̂ín̂ǵ t̂h́ê ĆŜṔ îń âń ĤT́T̂Ṕ ĥéâd́êŕ îf́ ŷóû ćâń."
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -584,6 +584,9 @@
   "lighthouse-core/audits/csp-xss.js | columnDirective": {
     "message": "D̂ír̂éĉt́îv́ê"
   },
+  "lighthouse-core/audits/csp-xss.js | columnSeverity": {
+    "message": "Ŝév̂ér̂ít̂ý"
+  },
   "lighthouse-core/audits/csp-xss.js | description": {
     "message": "Â śt̂ŕôńĝ Ćôńt̂én̂t́ Ŝéĉúr̂ít̂ý P̂ól̂íĉý (ĈŚP̂) śîǵn̂íf̂íĉán̂t́l̂ý r̂éd̂úĉéŝ t́ĥé r̂íŝḱ ôf́ ĉŕôśŝ-śît́ê śĉŕîṕt̂ín̂ǵ (X̂ŚŜ) át̂t́âćk̂ś. [L̂éâŕn̂ ḿôŕê](https://web.dev/strict-csp/)"
   },
@@ -760,15 +763,6 @@
   },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Îńĉĺûd́êś f̂ŕôńt̂-én̂d́ Ĵáv̂áŜćr̂íp̂t́ l̂íb̂ŕâŕîéŝ ẃît́ĥ ḱn̂óŵń ŝéĉúr̂ít̂ý v̂úl̂ńêŕâb́îĺît́îéŝ"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Ĥíĝh́"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "L̂óŵ"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "M̂éd̂íûḿ"
   },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Âv́ôíd̂ś f̂ŕôńt̂-én̂d́ Ĵáv̂áŜćr̂íp̂t́ l̂íb̂ŕâŕîéŝ ẃît́ĥ ḱn̂óŵń ŝéĉúr̂ít̂ý v̂úl̂ńêŕâb́îĺît́îéŝ"
@@ -1879,6 +1873,15 @@
   },
   "lighthouse-core/lib/i18n/i18n.js | otherResourceType": {
     "message": "Ôt́ĥér̂"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | rowSeverityHigh": {
+    "message": "Ĥíĝh́"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | rowSeverityLow": {
+    "message": "L̂óŵ"
+  },
+  "lighthouse-core/lib/i18n/i18n.js | rowSeverityMedium": {
+    "message": "M̂éd̂íûḿ"
   },
   "lighthouse-core/lib/i18n/i18n.js | scriptResourceType": {
     "message": "Ŝćr̂íp̂t́"

--- a/lighthouse-core/lib/i18n/locales/es-419.json
+++ b/lighthouse-core/lib/i18n/locales/es-419.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Incluye bibliotecas JavaScript de frontend con vulnerabilidades de seguridad conocidas"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Alta"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Baja"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Media"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Evita las bibliotecas JavaScript de frontend con vulnerabilidades de seguridad conocidas"
   },

--- a/lighthouse-core/lib/i18n/locales/es.json
+++ b/lighthouse-core/lib/i18n/locales/es.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Incluye bibliotecas en el frontend de JavaScript con vulnerabilidades de seguridad conocidas"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Alta"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Baja"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Media"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Evita en el frontend las bibliotecas de JavaScript con vulnerabilidades de seguridad conocidas"
   },

--- a/lighthouse-core/lib/i18n/locales/fi.json
+++ b/lighthouse-core/lib/i18n/locales/fi.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Sisältää käyttöliittymän JavaScript-kirjastot, joissa on tunnettuja tietoturvahaavoittuvuuksia"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Vakava"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Vähäinen"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Kohtalainen"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Välttää käyttöliittymän JavaScript-kirjastoja, joissa on tunnettuja tietoturvahaavoittuvuuksia"
   },

--- a/lighthouse-core/lib/i18n/locales/fil.json
+++ b/lighthouse-core/lib/i18n/locales/fil.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "May mga kasamang front-end na library ng JavaScript na may mga kilalang kahinaan sa seguridad"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Mataas"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Mababa"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Katamtaman"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Umiiwas sa mga front-end na library ng JavaScript na may mga kilalang kahinaan sa seguridad"
   },

--- a/lighthouse-core/lib/i18n/locales/fr.json
+++ b/lighthouse-core/lib/i18n/locales/fr.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "La page utilise des bibliothèques JavaScript frontales présentant des failles de sécurité connues"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Élevée"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Faible"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Moyenne"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Les bibliothèques JavaScript frontales ne présentent aucune faille de sécurité connue"
   },

--- a/lighthouse-core/lib/i18n/locales/he.json
+++ b/lighthouse-core/lib/i18n/locales/he.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "הדף מכיל ספריות JavaScript חזיתיות בעלות פגיעויות ידועות באבטחה"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "גבוהה"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "נמוכה"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "בינונית"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "הדף לא מכיל ספריות JavaScript חזיתיות בעלות פגיעויות ידועות באבטחה"
   },

--- a/lighthouse-core/lib/i18n/locales/hi.json
+++ b/lighthouse-core/lib/i18n/locales/hi.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "ऐसी फ़्रंट-एंड JavaScript लाइब्रेरी का इस्तेमाल करता है जिनमें शामिल सुरक्षा जोखिमों के बारे में सबको पता होता है."
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "ज़्यादा"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "कम"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "मीडियम"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "ऐसी फ़्रंट-एंड JavaScript लाइब्रेरी का इस्तेमाल नहीं करता जिनमें शामिल सुरक्षा जोखिमों के बारे में सबको पता होता है."
   },

--- a/lighthouse-core/lib/i18n/locales/hr.json
+++ b/lighthouse-core/lib/i18n/locales/hr.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Uključuje pristupne JavaScript biblioteke s poznatim sigurnosnim propustima"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Visok"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Nisko"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Srednje"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Izbjegava pristupne JavaScript biblioteke s poznatim sigurnosnim propustima"
   },

--- a/lighthouse-core/lib/i18n/locales/hu.json
+++ b/lighthouse-core/lib/i18n/locales/hu.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Ismert sebezhetőségeket tartalmazó front-end JavaScript-függvénytárakat használ"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Magas"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Alacsony"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Közepes"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Kerüli az ismert sebezhetőségeket tartalmazó front-end JavaScript-függvénytárakat"
   },

--- a/lighthouse-core/lib/i18n/locales/id.json
+++ b/lighthouse-core/lib/i18n/locales/id.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Menyertakan library JavaScript front-end yang memiliki kerentanan keamanan umum"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Tinggi"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Rendah"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Sedang"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Menghindari library JavaScript front-end yang memiliki kerentanan keamanan umum"
   },

--- a/lighthouse-core/lib/i18n/locales/it.json
+++ b/lighthouse-core/lib/i18n/locales/it.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Include librerie JavaScript front-end con vulnerabilità di sicurezza note"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Alta"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Bassa"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Media"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Evita librerie JavaScript front-end con vulnerabilità di sicurezza note"
   },

--- a/lighthouse-core/lib/i18n/locales/ja.json
+++ b/lighthouse-core/lib/i18n/locales/ja.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "既知のセキュリティの脆弱性を含んだフロントエンドの JavaScript ライブラリが含まれています"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "高"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "低"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "中"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "既知のセキュリティの脆弱性を含んだフロントエンドの JavaScript ライブラリは除外されています"
   },

--- a/lighthouse-core/lib/i18n/locales/ko.json
+++ b/lighthouse-core/lib/i18n/locales/ko.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "알려진 보안 취약점이 있는 프런트 엔드 JavaScript 라이브러리가 포함됨"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "높음"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "낮음"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "보통"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "알려진 보안 취약점이 있는 프런트 엔드 JavaScript 라이브러리를 사용하지 않음"
   },

--- a/lighthouse-core/lib/i18n/locales/lt.json
+++ b/lighthouse-core/lib/i18n/locales/lt.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Puslapyje yra „JavaScript“ sąsajos bibliotekų, kuriose yra žinomų saugos pažeidimų"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Didelis"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Mažas"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Vidutinis"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Vengiama „JavaScript“ sąsajos bibliotekų, kuriose yra žinomų saugos pažeidimų"
   },

--- a/lighthouse-core/lib/i18n/locales/lv.json
+++ b/lighthouse-core/lib/i18n/locales/lv.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Ietver JavaScript priekšgalsistēmas bibliotēkas ar zināmu drošības ievainojamību"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Augsts"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Zems"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Vidējs"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Nepieļauj JavaScript priekšgalsistēmas bibliotēkas ar zināmām drošības ievainojamībām"
   },

--- a/lighthouse-core/lib/i18n/locales/nl.json
+++ b/lighthouse-core/lib/i18n/locales/nl.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Omvat front end JavaScript-bibliotheken met bekende beveiligingskwetsbaarheden"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Hoog"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Laag"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Normaal"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Vermijdt front end JavaScript-bibliotheken met bekende beveiligingskwetsbaarheden"
   },

--- a/lighthouse-core/lib/i18n/locales/no.json
+++ b/lighthouse-core/lib/i18n/locales/no.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Inkluderer JavaScript-grensesnittsbiblioteker med kjente sikkerhetssårbarheter"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Høy"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Lav"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Middels"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Unngår JavaScript-grensesnittsbiblioteker med kjente sikkerhetssårbarheter"
   },

--- a/lighthouse-core/lib/i18n/locales/pl.json
+++ b/lighthouse-core/lib/i18n/locales/pl.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Używa bibliotek JavaScript interfejsu użytkownika, które mają znane luki w zabezpieczeniach"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Wysoki"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Niski"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Średni"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Nie używa bibliotek JavaScript interfejsu użytkownika, które mają znane luki w zabezpieczeniach"
   },

--- a/lighthouse-core/lib/i18n/locales/pt-PT.json
+++ b/lighthouse-core/lib/i18n/locales/pt-PT.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Inclui bibliotecas de interface JavaScript com vulnerabilidades de segurança conhecidas"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Alto"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Baixo"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Médio"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Evita bibliotecas de interface JavaScript com vulnerabilidades de segurança conhecidas"
   },

--- a/lighthouse-core/lib/i18n/locales/pt.json
+++ b/lighthouse-core/lib/i18n/locales/pt.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Inclui bibliotecas JavaScript de front-end com vulnerabilidades de segurança conhecidas"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Alto"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Baixo"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Médio"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Evita bibliotecas JavaScript de front-end com vulnerabilidades de segurança conhecidas"
   },

--- a/lighthouse-core/lib/i18n/locales/ro.json
+++ b/lighthouse-core/lib/i18n/locales/ro.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Include bibliotecile JavaScript front-end cu vulnerabilități de securitate cunoscute"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Înaltă"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Redusă"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Medie"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Evită bibliotecile JavaScript front-end cu vulnerabilități de securitate cunoscute"
   },

--- a/lighthouse-core/lib/i18n/locales/ru.json
+++ b/lighthouse-core/lib/i18n/locales/ru.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Содержит клиентские библиотеки JavaScript с известными уязвимостями"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Высокая"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Низкая"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Средняя"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Не содержит клиентские библиотеки JavaScript с известными уязвимостями"
   },

--- a/lighthouse-core/lib/i18n/locales/sk.json
+++ b/lighthouse-core/lib/i18n/locales/sk.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Zahrnuje JavaScriptové knižnice v klientskom rozhraní so známymi chybami zabezpečenia"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Vysoká"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Nízka"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Stredné"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Nepoužíva v klientskom rozhraní knižnice JavaScriptov so známymi chybami zabezpečenia"
   },

--- a/lighthouse-core/lib/i18n/locales/sl.json
+++ b/lighthouse-core/lib/i18n/locales/sl.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Vključuje knjižniceJavaScript vmesnikov z znanimi varnostnimi ranljivostmi"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Visoka"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Nizka"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Srednja"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Izogiba se knjižnicam JavaScript vmesnikov z znanimi varnostnimi ranljivostmi"
   },

--- a/lighthouse-core/lib/i18n/locales/sr-Latn.json
+++ b/lighthouse-core/lib/i18n/locales/sr-Latn.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Obuhvata korisničke JavaScript datoteke sa poznatim bezbednosnim propustima"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Visoka"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Niska"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Srednja"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Izbegava korisničke JavaScript datoteke sa poznatim bezbednosnim propustima"
   },

--- a/lighthouse-core/lib/i18n/locales/sr.json
+++ b/lighthouse-core/lib/i18n/locales/sr.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Обухвата корисничке JavaScript датотеке са познатим безбедносним пропустима"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Висока"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Ниска"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Средња"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Избегава корисничке JavaScript датотеке са познатим безбедносним пропустима"
   },

--- a/lighthouse-core/lib/i18n/locales/sv.json
+++ b/lighthouse-core/lib/i18n/locales/sv.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Innehåller JavaScript-bibliotek på klientsidan med kända säkerhetsbrister"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Hög"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Låg"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Medelstor"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Undviker JavaScript-bibliotek med kända säkerhetsproblem på klientsidan"
   },

--- a/lighthouse-core/lib/i18n/locales/ta.json
+++ b/lighthouse-core/lib/i18n/locales/ta.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "தெரிந்த பாதுகாப்புக் குறைபாடுகளுள்ள ஃபிரண்ட் எண்டு JavaScript லைப்ரரிகள் இதில் அடங்கும்"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "அதிகம்"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "குறைவானது"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "நடுத்தரமானது"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "தெரிந்த பாதுகாப்புக் குறைபாடுகளுடைய ஃபிரண்ட் எண்ட் JavaScript லைப்ரரிகளைத் தவிர்க்கிறது"
   },

--- a/lighthouse-core/lib/i18n/locales/te.json
+++ b/lighthouse-core/lib/i18n/locales/te.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "తెలిసిన భద్రతా ప్రమాదాలను కలిగి ఉండే ఫ్రంట్-ఎండ్ JavaScript లైబ్రరీలను జోడిస్తుంది"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "అధికం"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "తక్కువ"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "మధ్యస్థం"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "తెలిసిన భద్రతా ప్రమాదాలను కలిగి ఉండే ఫ్రంట్-ఎండ్ JavaScript లైబ్రరీలను నివారిస్తుంది"
   },

--- a/lighthouse-core/lib/i18n/locales/th.json
+++ b/lighthouse-core/lib/i18n/locales/th.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "มีไลบรารี JavaScript ส่วนหน้าที่มีช่องโหว่ด้านความปลอดภัย"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "สูง"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "ต่ำ"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "ปานกลาง"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "หลีกเลี่ยงการใช้ไลบรารี JavaScript ส่วนหน้าที่มีช่องโหว่ด้านความปลอดภัย"
   },

--- a/lighthouse-core/lib/i18n/locales/tr.json
+++ b/lighthouse-core/lib/i18n/locales/tr.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Bilinen güvenlik açıklarına sahip JavaScript kitaplıkları kullanıcı arabirimi içeriyor"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Yüksek"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Düşük"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Orta"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Bilinen güvenlik açıklarına sahip JavaScript kitaplıkları kullanıcı arabirimini önlüyor"
   },

--- a/lighthouse-core/lib/i18n/locales/uk.json
+++ b/lighthouse-core/lib/i18n/locales/uk.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Включає бібліотеки JavaScript зовнішнього інтерфейсу з відомими прогалинами системи безпеки"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Високий"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Низький"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Середній"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Уникає бібліотек JavaScript зовнішнього інтерфейсу з відомими прогалинами в системі безпеки"
   },

--- a/lighthouse-core/lib/i18n/locales/vi.json
+++ b/lighthouse-core/lib/i18n/locales/vi.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "Bao gồm các thư viện giao diện người dùng JavaScript có những lỗ hổng bảo mật đã biết"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "Cao"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "Thấp"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "Trung bình"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "Tránh các thư viện giao diện người dùng JavaScript có lỗ hổng bảo mật đã biết"
   },

--- a/lighthouse-core/lib/i18n/locales/zh-HK.json
+++ b/lighthouse-core/lib/i18n/locales/zh-HK.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "包括前端 JavaScript 程式庫具有已知安全漏洞"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "高"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "低"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "中"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "避免使用包含已知安全漏洞的前端 JavaScript 程式庫"
   },

--- a/lighthouse-core/lib/i18n/locales/zh-TW.json
+++ b/lighthouse-core/lib/i18n/locales/zh-TW.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "包含的前端 JavaScript 程式庫具有已知安全漏洞"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "高"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "低"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "中"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "避免使用包含已知安全漏洞的前端 JavaScript 程式庫"
   },

--- a/lighthouse-core/lib/i18n/locales/zh.json
+++ b/lighthouse-core/lib/i18n/locales/zh.json
@@ -761,15 +761,6 @@
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | failureTitle": {
     "message": "包含有已知安全漏洞的前端 JavaScript 库"
   },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityHigh": {
-    "message": "高"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityLow": {
-    "message": "低"
-  },
-  "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": {
-    "message": "中"
-  },
   "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": {
     "message": "避免使用含已知安全漏洞的前端 JavaScript 库"
   },

--- a/lighthouse-core/test/audits/csp-xss-test.js
+++ b/lighthouse-core/test/audits/csp-xss-test.js
@@ -11,16 +11,18 @@ const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.
 
 /* eslint-env jest */
 
-/** Using tooltips while severity icons are just for testing. */
-const ICONS = {
-  bypass: 'Bypass',
-  warning: 'Warning',
-  syntax: 'Syntax',
+const SEVERITY = {
+  high: {
+    formattedDefault: 'High',
+  },
+  medium: {
+    formattedDefault: 'Medium',
+  },
 };
 
 const STATIC_RESULTS = {
   noObjectSrc: {
-    severity: ICONS.bypass,
+    severity: SEVERITY.high,
     description: {
       formattedDefault:
         'Elements controlled by object-src are considered legacy features. ' +
@@ -30,7 +32,7 @@ const STATIC_RESULTS = {
     directive: 'object-src',
   },
   noBaseUri: {
-    severity: ICONS.bypass,
+    severity: SEVERITY.high,
     description: {
       formattedDefault:
         'Missing base-uri allows injected <base> tags to set the base URL for all ' +
@@ -40,7 +42,7 @@ const STATIC_RESULTS = {
     directive: 'base-uri',
   },
   noReportingDestination: {
-    severity: ICONS.warning,
+    severity: SEVERITY.medium,
     description: {
       formattedDefault:
         'No CSP configures a reporting destination. ' +
@@ -49,7 +51,7 @@ const STATIC_RESULTS = {
     directive: 'report-uri',
   },
   metaTag: {
-    severity: ICONS.warning,
+    severity: SEVERITY.medium,
     description: {
       formattedDefault:
         'The page contains a CSP defined in a <meta> tag. ' +
@@ -58,7 +60,7 @@ const STATIC_RESULTS = {
     directive: undefined,
   },
   unsafeInlineFallback: {
-    severity: ICONS.warning,
+    severity: SEVERITY.medium,
     description: {
       formattedDefault:
         'Consider adding \'unsafe-inline\' (ignored by browsers supporting ' +
@@ -87,7 +89,7 @@ it('audit basic header', async () => {
   expect(results.details.items).toMatchObject(
     [
       {
-        severity: ICONS.syntax,
+        severity: SEVERITY.high,
         description: {
           value:
             'script-src \'nonce-12345678\'; foo-bar \'none\'',
@@ -250,7 +252,7 @@ describe('constructResults', () => {
     expect(score).toEqual(0);
     expect(results).toMatchObject([
       {
-        severity: ICONS.syntax,
+        severity: SEVERITY.high,
         description: {
           value: 'script-src \'none\'; foo-bar \'none\'',
         },
@@ -292,7 +294,7 @@ describe('constructResults', () => {
     expect(score).toEqual(0);
     expect(results).toMatchObject([
       {
-        severity: ICONS.bypass,
+        severity: SEVERITY.high,
         description: {
           formattedDefault: 'No CSP found in enforcement mode',
         },
@@ -311,7 +313,7 @@ describe('constructSyntaxResults', () => {
     const results = CspXss.constructSyntaxResults(syntaxFindings, rawCsps);
     expect(results).toMatchObject([
       {
-        severity: ICONS.syntax,
+        severity: SEVERITY.high,
         description: {
           value: 'foo-bar \'none\'',
         },
@@ -351,7 +353,7 @@ describe('constructSyntaxResults', () => {
     const results = CspXss.constructSyntaxResults(syntaxFindings, rawCsps);
     expect(results).toMatchObject([
       {
-        severity: ICONS.syntax,
+        severity: SEVERITY.high,
         description: {
           value: 'foo-bar \'asdf\'',
         },
@@ -389,7 +391,7 @@ describe('constructSyntaxResults', () => {
     const results = CspXss.constructSyntaxResults(syntaxFindings, rawCsps);
     expect(results).toMatchObject([
       {
-        severity: ICONS.syntax,
+        severity: SEVERITY.high,
         description: {
           value: 'foo-bar \'none\'',
         },
@@ -406,7 +408,7 @@ describe('constructSyntaxResults', () => {
         },
       },
       {
-        severity: ICONS.syntax,
+        severity: SEVERITY.high,
         description: {
           value: 'object-src \'asdf\'',
         },

--- a/lighthouse-core/test/audits/csp-xss-test.js
+++ b/lighthouse-core/test/audits/csp-xss-test.js
@@ -12,6 +12,9 @@ const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.
 /* eslint-env jest */
 
 const SEVERITY = {
+  syntax: {
+    formattedDefault: 'Syntax',
+  },
   high: {
     formattedDefault: 'High',
   },
@@ -89,7 +92,7 @@ it('audit basic header', async () => {
   expect(results.details.items).toMatchObject(
     [
       {
-        severity: SEVERITY.high,
+        severity: SEVERITY.syntax,
         description: {
           value:
             'script-src \'nonce-12345678\'; foo-bar \'none\'',
@@ -252,7 +255,7 @@ describe('constructResults', () => {
     expect(score).toEqual(0);
     expect(results).toMatchObject([
       {
-        severity: SEVERITY.high,
+        severity: SEVERITY.syntax,
         description: {
           value: 'script-src \'none\'; foo-bar \'none\'',
         },
@@ -313,7 +316,7 @@ describe('constructSyntaxResults', () => {
     const results = CspXss.constructSyntaxResults(syntaxFindings, rawCsps);
     expect(results).toMatchObject([
       {
-        severity: SEVERITY.high,
+        severity: SEVERITY.syntax,
         description: {
           value: 'foo-bar \'none\'',
         },
@@ -353,7 +356,7 @@ describe('constructSyntaxResults', () => {
     const results = CspXss.constructSyntaxResults(syntaxFindings, rawCsps);
     expect(results).toMatchObject([
       {
-        severity: SEVERITY.high,
+        severity: SEVERITY.syntax,
         description: {
           value: 'foo-bar \'asdf\'',
         },
@@ -391,7 +394,7 @@ describe('constructSyntaxResults', () => {
     const results = CspXss.constructSyntaxResults(syntaxFindings, rawCsps);
     expect(results).toMatchObject([
       {
-        severity: SEVERITY.high,
+        severity: SEVERITY.syntax,
         description: {
           value: 'foo-bar \'none\'',
         },
@@ -408,7 +411,7 @@ describe('constructSyntaxResults', () => {
         },
       },
       {
-        severity: SEVERITY.high,
+        severity: SEVERITY.syntax,
         description: {
           value: 'object-src \'asdf\'',
         },

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -7893,7 +7893,7 @@
       "lighthouse-core/audits/csp-xss.js | columnSeverity": [
         "audits[csp-xss].details.headings[2].text"
       ],
-      "lighthouse-core/lib/i18n/i18n.js | rowSeverityHigh": [
+      "lighthouse-core/lib/i18n/i18n.js | itemSeverityHigh": [
         "audits[csp-xss].details.items[0].severity"
       ],
       "lighthouse-core/audits/csp-xss.js | noCsp": [
@@ -8447,7 +8447,7 @@
       "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": [
         "audits[no-vulnerable-libraries].details.headings[2].text"
       ],
-      "lighthouse-core/lib/i18n/i18n.js | rowSeverityMedium": [
+      "lighthouse-core/lib/i18n/i18n.js | itemSeverityMedium": [
         "audits[no-vulnerable-libraries].details.items[0].highestSeverity"
       ],
       "lighthouse-core/audits/dobetterweb/js-libraries.js | title": [

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2192,11 +2192,19 @@
               "key": "directive"
             },
             "text": "Directive"
+          },
+          {
+            "key": "severity",
+            "itemType": "text",
+            "subItemsHeading": {
+              "key": "severity"
+            },
+            "text": "Severity"
           }
         ],
         "items": [
           {
-            "severity": "Bypass",
+            "severity": "High",
             "description": "No CSP found in enforcement mode"
           }
         ]
@@ -7882,6 +7890,12 @@
       "lighthouse-core/audits/csp-xss.js | columnDirective": [
         "audits[csp-xss].details.headings[1].text"
       ],
+      "lighthouse-core/audits/csp-xss.js | columnSeverity": [
+        "audits[csp-xss].details.headings[2].text"
+      ],
+      "lighthouse-core/lib/i18n/i18n.js | rowSeverityHigh": [
+        "audits[csp-xss].details.items[0].severity"
+      ],
       "lighthouse-core/audits/csp-xss.js | noCsp": [
         "audits[csp-xss].details.items[0].description"
       ],
@@ -8433,7 +8447,7 @@
       "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | columnSeverity": [
         "audits[no-vulnerable-libraries].details.headings[2].text"
       ],
-      "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | rowSeverityMedium": [
+      "lighthouse-core/lib/i18n/i18n.js | rowSeverityMedium": [
         "audits[no-vulnerable-libraries].details.items[0].highestSeverity"
       ],
       "lighthouse-core/audits/dobetterweb/js-libraries.js | title": [


### PR DESCRIPTION
While working on the [web.dev documentation](https://docs.google.com/document/d/19uk3g09Ma6QPUHXwVtu158_Fw2BD5HpuxfowNDW_Pg4/edit?resourcekey=0-vEBR30OzQpRMRrdDkodX9w#), I thought it would be useful to map the section headers to severity indicators in the report. Our last discussion on this ruled out using icons, but I would like to gauge interest in a simple text value. Documentation elaborates on the meaning of "High" and "Medium".

<img width="907" alt="Screen Shot 2021-05-24 at 3 40 11 PM" src="https://user-images.githubusercontent.com/6752989/119399015-5c0ed100-bca6-11eb-9a75-c8f23c8eda7f.png">
