### PR TITLE
report: make metric filter tab accessible

### DIFF
--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -311,17 +311,17 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     ]);
     for (const metric of filterChoices) {
       const elemId = `metric-${metric.acronym}`;
+      const radioEl = this.dom.createChildOf(metricFilterEl, 'input', 'lh-metricfilter__radio', {
+        type: 'radio',
+        name: 'metricsfilter',
+        id: elemId,
+      });
+
       const labelEl = this.dom.createChildOf(metricFilterEl, 'label', 'lh-metricfilter__label', {
         for: elemId,
         title: metric.result && metric.result.title,
       });
       labelEl.textContent = metric.acronym || metric.id;
-      const radioEl = this.dom.createChildOf(labelEl, 'input', 'lh-metricfilter__radio', {
-        type: 'radio',
-        name: 'metricsfilter',
-        id: elemId,
-        hidden: 'true',
-      });
 
       if (metric.acronym === 'All') {
         radioEl.checked = true;

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -589,6 +589,14 @@
   margin-top: var(--default-padding);
 }
 
+.lh-metricfilter__radio {
+  position: absolute;
+  left: -9999px;
+}
+.lh-metricfilter input[type='radio']:focus-visible + label {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
 .lh-metricfilter__label {
   border: solid 1px var(--color-gray-400);
   align-items: center;


### PR DESCRIPTION
fixes #12501

I did the same thing as here: https://github.com/GoogleChrome/lighthouse/pull/12495