### PR TITLE
core(fr): fix usage of distributed conditional type

### DIFF
--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -72,13 +72,13 @@ async function collectPhaseArtifacts(options) {
     const artifactPromise = priorArtifactPromise.then(async () => {
       const dependencies = phase === 'getArtifact'
         ? await collectArtifactDependencies(artifactDefn, artifactState.getArtifact)
-        : {};
+        : /** @type {Dependencies} */ ({});
 
       return gatherer[phase]({
         url: await driver.url(),
         gatherMode,
         driver,
-        dependencies: /** @type {Dependencies} */ (dependencies),
+        dependencies,
         computedCache,
       });
     });

--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -19,6 +19,8 @@
 
 /** @typedef {Record<CollectPhaseArtifactOptions['phase'], IntermediateArtifacts>} ArtifactState */
 
+/** @typedef {LH.Gatherer.FRTransitionalContext<LH.Gatherer.DependencyKey>['dependencies']} Dependencies */
+
 /**
  *
  * @param {{id: string}} dependency
@@ -76,7 +78,7 @@ async function collectPhaseArtifacts(options) {
         url: await driver.url(),
         gatherMode,
         driver,
-        dependencies,
+        dependencies: /** @type {Dependencies} */ (dependencies), // eslint-disable-line max-len
         computedCache,
       });
     });
@@ -89,10 +91,10 @@ async function collectPhaseArtifacts(options) {
 /**
  * @param {LH.Config.ArtifactDefn} artifact
  * @param {Record<string, LH.Gatherer.PhaseResult>} artifactsById
- * @return {Promise<LH.Gatherer.FRTransitionalContext<LH.Gatherer.DependencyKey>['dependencies']>}
+ * @return {Promise<Dependencies>}
  */
 async function collectArtifactDependencies(artifact, artifactsById) {
-  if (!artifact.dependencies) return {};
+  if (!artifact.dependencies) return /** @type {Dependencies} */ ({});
 
   const dependencyPromises = Object.entries(artifact.dependencies).map(
     async ([dependencyName, dependency]) => {

--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -78,7 +78,7 @@ async function collectPhaseArtifacts(options) {
         url: await driver.url(),
         gatherMode,
         driver,
-        dependencies: /** @type {Dependencies} */ (dependencies), // eslint-disable-line max-len
+        dependencies: /** @type {Dependencies} */ (dependencies),
         computedCache,
       });
     });

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -45,7 +45,7 @@ declare global {
       /** The cached results of computed artifacts. */
       computedCache: Map<string, ArbitraryEqualityMap>;
       /** The set of available dependencies requested by the current gatherer. */
-      dependencies: TDependencies extends DefaultDependenciesKey ?
+      dependencies: [TDependencies] extends [DefaultDependenciesKey] ?
         {} :
         Pick<GathererArtifacts, Exclude<TDependencies, DefaultDependenciesKey>>;
     }

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -45,9 +45,7 @@ declare global {
       /** The cached results of computed artifacts. */
       computedCache: Map<string, ArbitraryEqualityMap>;
       /** The set of available dependencies requested by the current gatherer. */
-      dependencies: [TDependencies] extends [DefaultDependenciesKey] ?
-        {} :
-        Pick<GathererArtifacts, Exclude<TDependencies, DefaultDependenciesKey>>;
+      dependencies: Pick<GathererArtifacts, Exclude<TDependencies, DefaultDependenciesKey>>;
     }
 
     export interface PassContext {


### PR DESCRIPTION
Incorrect behavior when defining multiple dependencies in `FRTransitionalContext`. This was caused by [distributed conditional types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types).