### PR TITLE
core(script-treemap-data): do not create nodes with blank names

### DIFF
--- a/lighthouse-core/audits/script-treemap-data.js
+++ b/lighthouse-core/audits/script-treemap-data.js
@@ -79,6 +79,8 @@ class ScriptTreemapDataAudit extends Audit {
       // Strip off the shared root.
       const sourcePathSegments = source.replace(sourceRoot, '').split(/\/+/);
       sourcePathSegments.forEach((sourcePathSegment, i) => {
+        if (sourcePathSegment.length === 0) return;
+
         const isLeaf = i === sourcePathSegments.length - 1;
 
         let child = node.children && node.children.find(child => child.name === sourcePathSegment);
@@ -123,6 +125,17 @@ class ScriptTreemapDataAudit extends Audit {
       }
     }
     collapseAll(sourceRootNode);
+
+    // If sourceRootNode.name is falsy (no defined sourceRoot + no collapsed common prefix),
+    // collapse the sourceRootNode children into the scriptNode.
+    // Otherwise, we add another node.
+    if (!sourceRootNode.name) {
+      return {
+        ...sourceRootNode,
+        name: src,
+        children: sourceRootNode.children,
+      };
+    }
 
     // Script node should be just the script src.
     const scriptNode = {...sourceRootNode};

--- a/lighthouse-core/test/audits/__snapshots__/script-treemap-data-test.js.snap
+++ b/lighthouse-core/test/audits/__snapshots__/script-treemap-data-test.js.snap
@@ -5216,584 +5216,577 @@ Array [
               Object {
                 "children": Array [
                   Object {
-                    "children": Array [
-                      Object {
-                        "name": "util.ts",
-                        "resourceBytes": 4043,
-                        "unusedBytes": 500,
-                      },
-                      Object {
-                        "name": "icons.tsx",
-                        "resourceBytes": 2531,
-                        "unusedBytes": 24,
-                      },
-                      Object {
-                        "name": "clean-modify.ts",
-                        "resourceBytes": 331,
-                      },
-                    ],
-                    "name": "lib",
-                    "resourceBytes": 6905,
-                    "unusedBytes": 524,
+                    "name": "util.ts",
+                    "resourceBytes": 4043,
+                    "unusedBytes": 500,
                   },
                   Object {
-                    "children": Array [
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "style.scss",
-                            "resourceBytes": 410,
-                          },
-                          Object {
-                            "name": "index.tsx",
-                            "resourceBytes": 2176,
-                            "unusedBytes": 37,
-                          },
-                        ],
-                        "name": "Options",
-                        "resourceBytes": 2586,
-                        "unusedBytes": 37,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "name": "styles.css",
-                                    "resourceBytes": 75,
-                                  },
-                                  Object {
-                                    "name": "index.ts",
-                                    "resourceBytes": 2088,
-                                    "unusedBytes": 42,
-                                  },
-                                ],
-                                "name": "TwoUp",
-                                "resourceBytes": 2163,
-                                "unusedBytes": 42,
-                              },
-                              Object {
-                                "children": undefined,
-                                "name": "PinchZoom/index.ts",
-                                "resourceBytes": 3653,
-                                "unusedBytes": 73,
-                              },
-                            ],
-                            "name": "custom-els",
-                            "resourceBytes": 5816,
-                            "unusedBytes": 115,
-                          },
-                          Object {
-                            "name": "style.scss",
-                            "resourceBytes": 447,
-                          },
-                          Object {
-                            "name": "index.tsx",
-                            "resourceBytes": 5199,
-                            "unusedBytes": 73,
-                          },
-                        ],
-                        "name": "Output",
-                        "resourceBytes": 11462,
-                        "unusedBytes": 188,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "style.scss",
-                            "resourceBytes": 780,
-                          },
-                          Object {
-                            "name": "FileSize.tsx",
-                            "resourceBytes": 445,
-                            "unusedBytes": 21,
-                          },
-                          Object {
-                            "name": "index.tsx",
-                            "resourceBytes": 1538,
-                            "unusedBytes": 19,
-                          },
-                        ],
-                        "name": "results",
-                        "resourceBytes": 2763,
-                        "unusedBytes": 40,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "style.scss",
-                            "resourceBytes": 132,
-                          },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "name": "styles.css",
-                                "resourceBytes": 105,
-                              },
-                              Object {
-                                "name": "index.ts",
-                                "resourceBytes": 3461,
-                                "unusedBytes": 28,
-                              },
-                            ],
-                            "name": "custom-els/MultiPanel",
-                            "resourceBytes": 3566,
-                            "unusedBytes": 28,
-                          },
-                          Object {
-                            "name": "result-cache.ts",
-                            "resourceBytes": 611,
-                            "unusedBytes": 20,
-                          },
-                          Object {
-                            "name": "index.tsx",
-                            "resourceBytes": 8782,
-                            "unusedBytes": 28,
-                          },
-                        ],
-                        "name": "compress",
-                        "resourceBytes": 13091,
-                        "unusedBytes": 76,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "style.scss",
-                            "resourceBytes": 200,
-                          },
-                          Object {
-                            "name": "index.tsx",
-                            "resourceBytes": 566,
-                            "unusedBytes": 9,
-                          },
-                        ],
-                        "name": "range",
-                        "resourceBytes": 766,
-                        "unusedBytes": 9,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "style.scss",
-                            "resourceBytes": 106,
-                          },
-                          Object {
-                            "name": "index.tsx",
-                            "resourceBytes": 247,
-                            "unusedBytes": 1,
-                          },
-                        ],
-                        "name": "checkbox",
-                        "resourceBytes": 353,
-                        "unusedBytes": 1,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "style.scss",
-                            "resourceBytes": 66,
-                          },
-                          Object {
-                            "name": "index.tsx",
-                            "resourceBytes": 901,
-                            "unusedBytes": 21,
-                          },
-                        ],
-                        "name": "expander",
-                        "resourceBytes": 967,
-                        "unusedBytes": 21,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "style.scss",
-                            "resourceBytes": 103,
-                          },
-                          Object {
-                            "name": "index.tsx",
-                            "resourceBytes": 291,
-                            "unusedBytes": 21,
-                          },
-                        ],
-                        "name": "select",
-                        "resourceBytes": 394,
-                        "unusedBytes": 21,
-                      },
-                    ],
-                    "name": "components",
-                    "resourceBytes": 32382,
-                    "unusedBytes": 393,
+                    "name": "icons.tsx",
+                    "resourceBytes": 2531,
+                    "unusedBytes": 24,
                   },
                   Object {
-                    "children": Array [
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "util.ts",
-                            "resourceBytes": 159,
-                          },
-                          Object {
-                            "name": "quality-option.tsx",
-                            "resourceBytes": 398,
-                            "unusedBytes": 19,
-                          },
-                        ],
-                        "name": "generic",
-                        "resourceBytes": 557,
-                        "unusedBytes": 19,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 268,
-                            "unusedBytes": 44,
-                          },
-                          Object {
-                            "name": "encoder.tsx",
-                            "resourceBytes": 101,
-                            "unusedBytes": 22,
-                          },
-                        ],
-                        "name": "browser-png",
-                        "resourceBytes": 369,
-                        "unusedBytes": 66,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 282,
-                            "unusedBytes": 44,
-                          },
-                          Object {
-                            "name": "encoder.ts",
-                            "resourceBytes": 115,
-                            "unusedBytes": 22,
-                          },
-                          Object {
-                            "name": "options.ts",
-                            "resourceBytes": 35,
-                            "unusedBytes": 35,
-                          },
-                        ],
-                        "name": "browser-jpeg",
-                        "resourceBytes": 432,
-                        "unusedBytes": 101,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 358,
-                            "unusedBytes": 44,
-                          },
-                          Object {
-                            "name": "encoder.ts",
-                            "resourceBytes": 115,
-                            "unusedBytes": 22,
-                          },
-                          Object {
-                            "name": "options.ts",
-                            "resourceBytes": 34,
-                            "unusedBytes": 34,
-                          },
-                        ],
-                        "name": "browser-webp",
-                        "resourceBytes": 507,
-                        "unusedBytes": 100,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 343,
-                            "unusedBytes": 44,
-                          },
-                          Object {
-                            "name": "encoder.ts",
-                            "resourceBytes": 101,
-                            "unusedBytes": 22,
-                          },
-                        ],
-                        "name": "browser-gif",
-                        "resourceBytes": 444,
-                        "unusedBytes": 66,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 347,
-                            "unusedBytes": 44,
-                          },
-                          Object {
-                            "name": "encoder.ts",
-                            "resourceBytes": 101,
-                            "unusedBytes": 22,
-                          },
-                        ],
-                        "name": "browser-tiff",
-                        "resourceBytes": 448,
-                        "unusedBytes": 66,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 349,
-                            "unusedBytes": 44,
-                          },
-                          Object {
-                            "name": "encoder.ts",
-                            "resourceBytes": 101,
-                            "unusedBytes": 22,
-                          },
-                        ],
-                        "name": "browser-jp2",
-                        "resourceBytes": 450,
-                        "unusedBytes": 66,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 343,
-                            "unusedBytes": 44,
-                          },
-                          Object {
-                            "name": "encoder.ts",
-                            "resourceBytes": 101,
-                            "unusedBytes": 22,
-                          },
-                        ],
-                        "name": "browser-bmp",
-                        "resourceBytes": 444,
-                        "unusedBytes": 66,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 349,
-                            "unusedBytes": 44,
-                          },
-                          Object {
-                            "name": "encoder.ts",
-                            "resourceBytes": 101,
-                            "unusedBytes": 22,
-                          },
-                        ],
-                        "name": "browser-pdf",
-                        "resourceBytes": 450,
-                        "unusedBytes": 66,
-                      },
-                      Object {
-                        "name": "tiny.webp",
-                        "resourceBytes": 89,
-                      },
-                      Object {
-                        "name": "processor.ts",
-                        "resourceBytes": 2380,
-                        "unusedBytes": 22,
-                      },
-                      Object {
-                        "children": undefined,
-                        "name": "processor-worker/index.ts",
-                        "resourceBytes": 50,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "util.ts",
-                            "resourceBytes": 134,
-                          },
-                          Object {
-                            "name": "processor-sync.ts",
-                            "resourceBytes": 462,
-                            "unusedBytes": 13,
-                          },
-                          Object {
-                            "name": "processor-meta.ts",
-                            "resourceBytes": 225,
-                          },
-                          Object {
-                            "name": "options.tsx",
-                            "resourceBytes": 3970,
-                            "unusedBytes": 53,
-                          },
-                        ],
-                        "name": "resize",
-                        "resourceBytes": 4791,
-                        "unusedBytes": 66,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 436,
-                            "unusedBytes": 3,
-                          },
-                          Object {
-                            "name": "options.tsx",
-                            "resourceBytes": 4416,
-                            "unusedBytes": 21,
-                          },
-                        ],
-                        "name": "mozjpeg",
-                        "resourceBytes": 4852,
-                        "unusedBytes": 24,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "options.tsx",
-                            "resourceBytes": 366,
-                            "unusedBytes": 21,
-                          },
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 59,
-                          },
-                        ],
-                        "name": "optipng",
-                        "resourceBytes": 425,
-                        "unusedBytes": 21,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "encoder-meta.ts",
-                            "resourceBytes": 660,
-                            "unusedBytes": 660,
-                          },
-                          Object {
-                            "name": "options.tsx",
-                            "resourceBytes": 5114,
-                            "unusedBytes": 93,
-                          },
-                        ],
-                        "name": "webp",
-                        "resourceBytes": 5774,
-                        "unusedBytes": 753,
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "name": "options.tsx",
-                            "resourceBytes": 1052,
-                            "unusedBytes": 44,
-                          },
-                          Object {
-                            "name": "processor-meta.ts",
-                            "resourceBytes": 40,
-                          },
-                        ],
-                        "name": "imagequant",
-                        "resourceBytes": 1092,
-                        "unusedBytes": 44,
-                      },
-                      Object {
-                        "children": undefined,
-                        "name": "identity/encoder-meta.ts",
-                        "resourceBytes": 46,
-                      },
-                      Object {
-                        "name": "encoders.ts",
-                        "resourceBytes": 336,
-                      },
-                      Object {
-                        "name": "preprocessors.ts",
-                        "resourceBytes": 75,
-                      },
-                      Object {
-                        "name": "decoders.ts",
-                        "resourceBytes": 206,
-                      },
-                      Object {
-                        "children": undefined,
-                        "name": "rotate/processor-meta.ts",
-                        "resourceBytes": 18,
-                        "unusedBytes": 18,
-                      },
-                      Object {
-                        "name": "input-processors.ts",
-                        "resourceBytes": 11,
-                        "unusedBytes": 11,
-                      },
-                    ],
-                    "name": "codecs",
-                    "resourceBytes": 24246,
-                    "unusedBytes": 1575,
-                  },
-                  Object {
-                    "children": Array [
-                      Object {
-                        "name": "styles.css",
-                        "resourceBytes": 180,
-                      },
-                      Object {
-                        "name": "index.ts",
-                        "resourceBytes": 2138,
-                        "unusedBytes": 293,
-                      },
-                    ],
-                    "name": "custom-els/RangeInput",
-                    "resourceBytes": 2318,
-                    "unusedBytes": 293,
+                    "name": "clean-modify.ts",
+                    "resourceBytes": 331,
                   },
                 ],
-                "name": "src",
-                "resourceBytes": 65851,
-                "unusedBytes": 2785,
+                "name": "lib",
+                "resourceBytes": 6905,
+                "unusedBytes": 524,
               },
               Object {
                 "children": Array [
                   Object {
-                    "children": undefined,
-                    "name": "comlink/comlink.js",
-                    "resourceBytes": 4117,
-                    "unusedBytes": 256,
+                    "children": Array [
+                      Object {
+                        "name": "style.scss",
+                        "resourceBytes": 410,
+                      },
+                      Object {
+                        "name": "index.tsx",
+                        "resourceBytes": 2176,
+                        "unusedBytes": 37,
+                      },
+                    ],
+                    "name": "Options",
+                    "resourceBytes": 2586,
+                    "unusedBytes": 37,
                   },
                   Object {
-                    "children": undefined,
-                    "name": "pretty-bytes/index.js",
-                    "resourceBytes": 635,
-                    "unusedBytes": 11,
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "children": Array [
+                              Object {
+                                "name": "styles.css",
+                                "resourceBytes": 75,
+                              },
+                              Object {
+                                "name": "index.ts",
+                                "resourceBytes": 2088,
+                                "unusedBytes": 42,
+                              },
+                            ],
+                            "name": "TwoUp",
+                            "resourceBytes": 2163,
+                            "unusedBytes": 42,
+                          },
+                          Object {
+                            "children": undefined,
+                            "name": "PinchZoom/index.ts",
+                            "resourceBytes": 3653,
+                            "unusedBytes": 73,
+                          },
+                        ],
+                        "name": "custom-els",
+                        "resourceBytes": 5816,
+                        "unusedBytes": 115,
+                      },
+                      Object {
+                        "name": "style.scss",
+                        "resourceBytes": 447,
+                      },
+                      Object {
+                        "name": "index.tsx",
+                        "resourceBytes": 5199,
+                        "unusedBytes": 73,
+                      },
+                    ],
+                    "name": "Output",
+                    "resourceBytes": 11462,
+                    "unusedBytes": 188,
                   },
                   Object {
-                    "children": undefined,
-                    "name": "pointer-tracker/dist/PointerTracker.mjs",
-                    "resourceBytes": 2672,
-                    "unusedBytes": 13,
+                    "children": Array [
+                      Object {
+                        "name": "style.scss",
+                        "resourceBytes": 780,
+                      },
+                      Object {
+                        "name": "FileSize.tsx",
+                        "resourceBytes": 445,
+                        "unusedBytes": 21,
+                      },
+                      Object {
+                        "name": "index.tsx",
+                        "resourceBytes": 1538,
+                        "unusedBytes": 19,
+                      },
+                    ],
+                    "name": "results",
+                    "resourceBytes": 2763,
+                    "unusedBytes": 40,
                   },
                   Object {
-                    "children": undefined,
-                    "name": "linkstate/dist/linkstate.es.js",
-                    "resourceBytes": 412,
+                    "children": Array [
+                      Object {
+                        "name": "style.scss",
+                        "resourceBytes": 132,
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "name": "styles.css",
+                            "resourceBytes": 105,
+                          },
+                          Object {
+                            "name": "index.ts",
+                            "resourceBytes": 3461,
+                            "unusedBytes": 28,
+                          },
+                        ],
+                        "name": "custom-els/MultiPanel",
+                        "resourceBytes": 3566,
+                        "unusedBytes": 28,
+                      },
+                      Object {
+                        "name": "result-cache.ts",
+                        "resourceBytes": 611,
+                        "unusedBytes": 20,
+                      },
+                      Object {
+                        "name": "index.tsx",
+                        "resourceBytes": 8782,
+                        "unusedBytes": 28,
+                      },
+                    ],
+                    "name": "compress",
+                    "resourceBytes": 13091,
+                    "unusedBytes": 76,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "style.scss",
+                        "resourceBytes": 200,
+                      },
+                      Object {
+                        "name": "index.tsx",
+                        "resourceBytes": 566,
+                        "unusedBytes": 9,
+                      },
+                    ],
+                    "name": "range",
+                    "resourceBytes": 766,
+                    "unusedBytes": 9,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "style.scss",
+                        "resourceBytes": 106,
+                      },
+                      Object {
+                        "name": "index.tsx",
+                        "resourceBytes": 247,
+                        "unusedBytes": 1,
+                      },
+                    ],
+                    "name": "checkbox",
+                    "resourceBytes": 353,
                     "unusedBytes": 1,
                   },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "style.scss",
+                        "resourceBytes": 66,
+                      },
+                      Object {
+                        "name": "index.tsx",
+                        "resourceBytes": 901,
+                        "unusedBytes": 21,
+                      },
+                    ],
+                    "name": "expander",
+                    "resourceBytes": 967,
+                    "unusedBytes": 21,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "style.scss",
+                        "resourceBytes": 103,
+                      },
+                      Object {
+                        "name": "index.tsx",
+                        "resourceBytes": 291,
+                        "unusedBytes": 21,
+                      },
+                    ],
+                    "name": "select",
+                    "resourceBytes": 394,
+                    "unusedBytes": 21,
+                  },
                 ],
-                "name": "node_modules",
-                "resourceBytes": 7836,
-                "unusedBytes": 281,
+                "name": "components",
+                "resourceBytes": 32382,
+                "unusedBytes": 393,
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "util.ts",
+                        "resourceBytes": 159,
+                      },
+                      Object {
+                        "name": "quality-option.tsx",
+                        "resourceBytes": 398,
+                        "unusedBytes": 19,
+                      },
+                    ],
+                    "name": "generic",
+                    "resourceBytes": 557,
+                    "unusedBytes": 19,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 268,
+                        "unusedBytes": 44,
+                      },
+                      Object {
+                        "name": "encoder.tsx",
+                        "resourceBytes": 101,
+                        "unusedBytes": 22,
+                      },
+                    ],
+                    "name": "browser-png",
+                    "resourceBytes": 369,
+                    "unusedBytes": 66,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 282,
+                        "unusedBytes": 44,
+                      },
+                      Object {
+                        "name": "encoder.ts",
+                        "resourceBytes": 115,
+                        "unusedBytes": 22,
+                      },
+                      Object {
+                        "name": "options.ts",
+                        "resourceBytes": 35,
+                        "unusedBytes": 35,
+                      },
+                    ],
+                    "name": "browser-jpeg",
+                    "resourceBytes": 432,
+                    "unusedBytes": 101,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 358,
+                        "unusedBytes": 44,
+                      },
+                      Object {
+                        "name": "encoder.ts",
+                        "resourceBytes": 115,
+                        "unusedBytes": 22,
+                      },
+                      Object {
+                        "name": "options.ts",
+                        "resourceBytes": 34,
+                        "unusedBytes": 34,
+                      },
+                    ],
+                    "name": "browser-webp",
+                    "resourceBytes": 507,
+                    "unusedBytes": 100,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 343,
+                        "unusedBytes": 44,
+                      },
+                      Object {
+                        "name": "encoder.ts",
+                        "resourceBytes": 101,
+                        "unusedBytes": 22,
+                      },
+                    ],
+                    "name": "browser-gif",
+                    "resourceBytes": 444,
+                    "unusedBytes": 66,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 347,
+                        "unusedBytes": 44,
+                      },
+                      Object {
+                        "name": "encoder.ts",
+                        "resourceBytes": 101,
+                        "unusedBytes": 22,
+                      },
+                    ],
+                    "name": "browser-tiff",
+                    "resourceBytes": 448,
+                    "unusedBytes": 66,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 349,
+                        "unusedBytes": 44,
+                      },
+                      Object {
+                        "name": "encoder.ts",
+                        "resourceBytes": 101,
+                        "unusedBytes": 22,
+                      },
+                    ],
+                    "name": "browser-jp2",
+                    "resourceBytes": 450,
+                    "unusedBytes": 66,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 343,
+                        "unusedBytes": 44,
+                      },
+                      Object {
+                        "name": "encoder.ts",
+                        "resourceBytes": 101,
+                        "unusedBytes": 22,
+                      },
+                    ],
+                    "name": "browser-bmp",
+                    "resourceBytes": 444,
+                    "unusedBytes": 66,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 349,
+                        "unusedBytes": 44,
+                      },
+                      Object {
+                        "name": "encoder.ts",
+                        "resourceBytes": 101,
+                        "unusedBytes": 22,
+                      },
+                    ],
+                    "name": "browser-pdf",
+                    "resourceBytes": 450,
+                    "unusedBytes": 66,
+                  },
+                  Object {
+                    "name": "tiny.webp",
+                    "resourceBytes": 89,
+                  },
+                  Object {
+                    "name": "processor.ts",
+                    "resourceBytes": 2380,
+                    "unusedBytes": 22,
+                  },
+                  Object {
+                    "children": undefined,
+                    "name": "processor-worker/index.ts",
+                    "resourceBytes": 50,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "util.ts",
+                        "resourceBytes": 134,
+                      },
+                      Object {
+                        "name": "processor-sync.ts",
+                        "resourceBytes": 462,
+                        "unusedBytes": 13,
+                      },
+                      Object {
+                        "name": "processor-meta.ts",
+                        "resourceBytes": 225,
+                      },
+                      Object {
+                        "name": "options.tsx",
+                        "resourceBytes": 3970,
+                        "unusedBytes": 53,
+                      },
+                    ],
+                    "name": "resize",
+                    "resourceBytes": 4791,
+                    "unusedBytes": 66,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 436,
+                        "unusedBytes": 3,
+                      },
+                      Object {
+                        "name": "options.tsx",
+                        "resourceBytes": 4416,
+                        "unusedBytes": 21,
+                      },
+                    ],
+                    "name": "mozjpeg",
+                    "resourceBytes": 4852,
+                    "unusedBytes": 24,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "options.tsx",
+                        "resourceBytes": 366,
+                        "unusedBytes": 21,
+                      },
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 59,
+                      },
+                    ],
+                    "name": "optipng",
+                    "resourceBytes": 425,
+                    "unusedBytes": 21,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "encoder-meta.ts",
+                        "resourceBytes": 660,
+                        "unusedBytes": 660,
+                      },
+                      Object {
+                        "name": "options.tsx",
+                        "resourceBytes": 5114,
+                        "unusedBytes": 93,
+                      },
+                    ],
+                    "name": "webp",
+                    "resourceBytes": 5774,
+                    "unusedBytes": 753,
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "name": "options.tsx",
+                        "resourceBytes": 1052,
+                        "unusedBytes": 44,
+                      },
+                      Object {
+                        "name": "processor-meta.ts",
+                        "resourceBytes": 40,
+                      },
+                    ],
+                    "name": "imagequant",
+                    "resourceBytes": 1092,
+                    "unusedBytes": 44,
+                  },
+                  Object {
+                    "children": undefined,
+                    "name": "identity/encoder-meta.ts",
+                    "resourceBytes": 46,
+                  },
+                  Object {
+                    "name": "encoders.ts",
+                    "resourceBytes": 336,
+                  },
+                  Object {
+                    "name": "preprocessors.ts",
+                    "resourceBytes": 75,
+                  },
+                  Object {
+                    "name": "decoders.ts",
+                    "resourceBytes": 206,
+                  },
+                  Object {
+                    "children": undefined,
+                    "name": "rotate/processor-meta.ts",
+                    "resourceBytes": 18,
+                    "unusedBytes": 18,
+                  },
+                  Object {
+                    "name": "input-processors.ts",
+                    "resourceBytes": 11,
+                    "unusedBytes": 11,
+                  },
+                ],
+                "name": "codecs",
+                "resourceBytes": 24246,
+                "unusedBytes": 1575,
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "name": "styles.css",
+                    "resourceBytes": 180,
+                  },
+                  Object {
+                    "name": "index.ts",
+                    "resourceBytes": 2138,
+                    "unusedBytes": 293,
+                  },
+                ],
+                "name": "custom-els/RangeInput",
+                "resourceBytes": 2318,
+                "unusedBytes": 293,
               },
             ],
-            "name": "webpack:/.",
-            "resourceBytes": 73687,
-            "unusedBytes": 3066,
+            "name": "src",
+            "resourceBytes": 65851,
+            "unusedBytes": 2785,
           },
           Object {
-            "name": "(unmapped)",
-            "resourceBytes": 10061,
-            "unusedBytes": 3760,
+            "children": Array [
+              Object {
+                "children": undefined,
+                "name": "comlink/comlink.js",
+                "resourceBytes": 4117,
+                "unusedBytes": 256,
+              },
+              Object {
+                "children": undefined,
+                "name": "pretty-bytes/index.js",
+                "resourceBytes": 635,
+                "unusedBytes": 11,
+              },
+              Object {
+                "children": undefined,
+                "name": "pointer-tracker/dist/PointerTracker.mjs",
+                "resourceBytes": 2672,
+                "unusedBytes": 13,
+              },
+              Object {
+                "children": undefined,
+                "name": "linkstate/dist/linkstate.es.js",
+                "resourceBytes": 412,
+                "unusedBytes": 1,
+              },
+            ],
+            "name": "node_modules",
+            "resourceBytes": 7836,
+            "unusedBytes": 281,
           },
         ],
-        "name": "",
-        "resourceBytes": 83748,
-        "unusedBytes": 6826,
+        "name": "webpack:/.",
+        "resourceBytes": 73687,
+        "unusedBytes": 3066,
+      },
+      Object {
+        "name": "(unmapped)",
+        "resourceBytes": 10061,
+        "unusedBytes": 3760,
       },
     ],
     "name": "https://squoosh.app/main-app.js",

--- a/lighthouse-treemap/app/debug.json
+++ b/lighthouse-treemap/app/debug.json
@@ -16,20 +16,20 @@
           "nodes": [
             {
               "name": "https://www.coursehero.com/",
-              "resourceBytes": 69863
+              "resourceBytes": 70365
             },
             {
-              "name": "https://bam-cell.nr-data.net/1/404bf9505f?a=136461810,151089887&v=1208.49599aa&to=NVFbZUFUC0RTAEcLXQwbekRAQQpaHQtcD1cSVV5U&rst=4357&ck=1&ref=https://www.coursehero.com/&ap=173&be=478&fe=4230&dc=1201&af=err,xhr,stn,ins,spa&perf=%7B%22timing%22:%7B%22of%22:1620365366024,%22n%22:0,%22f%22:2,%22dn%22:3,%22dne%22:56,%22c%22:56,%22s%22:71,%22ce%22:101,%22rq%22:101,%22rp%22:441,%22rpe%22:459,%22dl%22:450,%22di%22:1201,%22ds%22:1201,%22de%22:1365,%22dc%22:4230,%22l%22:4230,%22le%22:4242%7D,%22navigation%22:%7B%7D%7D&fp=841&fcp=902&at=GRZMEwlOGBsQAhFYSR9J&jsonp=NREUM.setToken",
-              "resourceBytes": 57,
+              "name": "https://bam-cell.nr-data.net/1/404bf9505f?a=136461810,1502219757&v=1209.f04e2b9&to=NVFbZUFUC0RTAEcLXQwbekRAQQpaHQtcD1cSVV5U&rst=3363&ck=1&ref=https://www.coursehero.com/&ap=148&be=372&fe=3276&dc=939&af=err,xhr,stn,ins,spa&perf=%7B%22timing%22:%7B%22of%22:1622071185896,%22n%22:0,%22f%22:2,%22dn%22:4,%22dne%22:20,%22c%22:20,%22s%22:34,%22ce%22:63,%22rq%22:63,%22rp%22:332,%22rpe%22:345,%22dl%22:343,%22di%22:939,%22ds%22:939,%22de%22:1120,%22dc%22:3276,%22l%22:3276,%22le%22:3289%7D,%22navigation%22:%7B%7D%7D&fp=727&fcp=727&at=GRZMEwlOGBsQAhFYSR9J&jsonp=NREUM.setToken",
+              "resourceBytes": 49,
               "unusedBytes": 0
             },
             {
-              "name": "https://js-agent.newrelic.com/nr-spa-1208.min.js",
-              "resourceBytes": 42861,
-              "unusedBytes": 12191
+              "name": "https://js-agent.newrelic.com/nr-spa-1209.min.js",
+              "resourceBytes": 42826,
+              "unusedBytes": 12352
             },
             {
-              "name": "https://track.adform.net/Serving/TrackPoint/?pm=364845&ADFPageName=CourseHero%7CHomepage&ADFdivider=%7C&ord=869686766831&Set1=en-US%7Cen-US%7C360x640%7C30&ADFtpmode=2&loc=https%3A%2F%2Fwww.coursehero.com%2F",
+              "name": "https://track.adform.net/Serving/TrackPoint/?pm=364845&ADFPageName=CourseHero%7CHomepage&ADFdivider=%7C&ord=387208348173&Set1=en-US%7Cen-US%7C360x640%7C30&ADFtpmode=2&loc=https%3A%2F%2Fwww.coursehero.com%2F",
               "resourceBytes": 334,
               "unusedBytes": 0
             },
@@ -44,29 +44,29 @@
               "unusedBytes": 0
             },
             {
-              "name": "https://www.gstatic.com/recaptcha/releases/npGaewopg1UaB8CNtYfx-y1j/recaptcha__en.js",
-              "resourceBytes": 342789,
-              "unusedBytes": 270447
+              "name": "https://connect.facebook.net/en_US/sdk.js?hash=e6ed24b6a8546d507f9965fe561c2243&ua=modern_es6",
+              "resourceBytes": 222185,
+              "unusedBytes": 159434
             },
             {
-              "name": "https://connect.facebook.net/en_US/sdk.js?hash=e3d4ea5a529970bf687878589673fb2e&ua=modern_es6",
-              "resourceBytes": 215794,
-              "unusedBytes": 153411
+              "name": "https://www.gstatic.com/recaptcha/releases/sG0iO6gHcGdWJzjJjW9AY49S/recaptcha__en.js",
+              "resourceBytes": 350180,
+              "unusedBytes": 258981
             },
             {
-              "name": "https://www.youtube.com/s/player/838cc154/www-widgetapi.vflset/www-widgetapi.js",
-              "resourceBytes": 122872,
-              "unusedBytes": 101767
+              "name": "https://www.youtube.com/s/player/e467278e/www-widgetapi.vflset/www-widgetapi.js",
+              "resourceBytes": 123855,
+              "unusedBytes": 102544
             },
             {
               "name": "https://bat.bing.com/bat.js",
-              "resourceBytes": 30235,
+              "resourceBytes": 30236,
               "unusedBytes": 4787
             },
             {
               "name": "https://client.px-cloud.net/PXiz9CgRRu/main.min.js",
-              "resourceBytes": 109339,
-              "unusedBytes": 53272
+              "resourceBytes": 121120,
+              "unusedBytes": 55705
             },
             {
               "name": "https://sc-static.net/scevent.min.js",
@@ -75,7 +75,7 @@
             },
             {
               "name": "https://secure.quantserve.com/quant.js",
-              "resourceBytes": 24047,
+              "resourceBytes": 24067,
               "unusedBytes": 6993
             },
             {
@@ -85,7 +85,7 @@
             },
             {
               "name": "https://bruxvw2g.micpn.com/p/js/1.js",
-              "resourceBytes": 43000,
+              "resourceBytes": 43049,
               "unusedBytes": 23413
             },
             {
@@ -95,8 +95,8 @@
             },
             {
               "name": "https://track.adform.net/serving/scripts/trackpoint/async/",
-              "resourceBytes": 81728,
-              "unusedBytes": 57137
+              "resourceBytes": 81451,
+              "unusedBytes": 57136
             },
             {
               "name": "https://snap.licdn.com/li.lms-analytics/insight.min.js",
@@ -110,7 +110,7 @@
             },
             {
               "name": "https://www.googleadservices.com/pagead/conversion_async.js",
-              "resourceBytes": 36666,
+              "resourceBytes": 36885,
               "unusedBytes": 16985
             },
             {
@@ -120,13 +120,13 @@
             },
             {
               "name": "https://www.googletagmanager.com/gtm.js?id=GTM-DK9F",
-              "resourceBytes": 251110,
-              "unusedBytes": 64473
+              "resourceBytes": 252926,
+              "unusedBytes": 65819
             },
             {
               "name": "https://www.coursehero.com/Babout-at-I-daressentlesse-a-crue-an-endone-to-N",
-              "resourceBytes": 129316,
-              "unusedBytes": 33088
+              "resourceBytes": 129807,
+              "unusedBytes": 33028
             },
             {
               "name": "https://cdn.speedcurve.com/js/lux.js?id=471255868",
@@ -134,146 +134,153 @@
               "unusedBytes": 14716
             },
             {
-              "name": "https://www.coursehero.com/sym-assets/js/bundle-e43017e-999b4da.js",
-              "resourceBytes": 712480,
-              "unusedBytes": 491531,
+              "name": "https://www.coursehero.com/sym-assets/js/bundle-e43017e-1b36cba.js",
+              "resourceBytes": 713442,
+              "unusedBytes": 491539,
               "children": [
                 {
                   "name": "coursehero:///",
-                  "resourceBytes": 712480,
-                  "unusedBytes": 491531,
+                  "resourceBytes": 713442,
+                  "unusedBytes": 491539,
                   "children": [
                     {
-                      "name": "Control",
-                      "resourceBytes": 686936,
-                      "unusedBytes": 485960,
+                      "name": "run/monolith-build/src",
+                      "resourceBytes": 690415,
+                      "unusedBytes": 488800,
                       "children": [
                         {
-                          "name": "javascript",
-                          "resourceBytes": 512149,
-                          "unusedBytes": 357660,
+                          "name": "Control",
+                          "resourceBytes": 686936,
+                          "unusedBytes": 485960,
                           "children": [
                             {
-                              "name": "jquery/2.2.4/jquery.min.js",
-                              "resourceBytes": 85500,
-                              "unusedBytes": 35751
-                            },
-                            {
-                              "name": "angular.js/1.3.20",
-                              "resourceBytes": 278332,
-                              "unusedBytes": 257133,
+                              "name": "javascript",
+                              "resourceBytes": 512149,
+                              "unusedBytes": 357660,
                               "children": [
                                 {
-                                  "name": "angular.js",
-                                  "resourceBytes": 247998,
-                                  "unusedBytes": 227031
+                                  "name": "jquery/2.2.4/jquery.min.js",
+                                  "resourceBytes": 85500,
+                                  "unusedBytes": 35751
                                 },
                                 {
-                                  "name": "angular-animate.js",
-                                  "resourceBytes": 30334,
-                                  "unusedBytes": 30102
+                                  "name": "angular.js/1.3.20",
+                                  "resourceBytes": 278332,
+                                  "unusedBytes": 257133,
+                                  "children": [
+                                    {
+                                      "name": "angular.js",
+                                      "resourceBytes": 247998,
+                                      "unusedBytes": 227031
+                                    },
+                                    {
+                                      "name": "angular-animate.js",
+                                      "resourceBytes": 30334,
+                                      "unusedBytes": 30102
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "error_logging.js",
+                                  "resourceBytes": 865,
+                                  "unusedBytes": 802
+                                },
+                                {
+                                  "name": "common/modules/angular-ui/angular-ui.min.js",
+                                  "resourceBytes": 17321,
+                                  "unusedBytes": 14391
+                                },
+                                {
+                                  "name": "react/16.13.1/umd/react.production.min.js",
+                                  "resourceBytes": 12191,
+                                  "unusedBytes": 5082
+                                },
+                                {
+                                  "name": "react-dom/16.13.1/umd/react-dom.production.min.js",
+                                  "resourceBytes": 117940,
+                                  "unusedBytes": 44501
                                 }
                               ]
                             },
                             {
-                              "name": "error_logging.js",
-                              "resourceBytes": 865,
-                              "unusedBytes": 802
-                            },
-                            {
-                              "name": "common/modules/angular-ui/angular-ui.min.js",
-                              "resourceBytes": 17321,
-                              "unusedBytes": 14391
-                            },
-                            {
-                              "name": "react/16.13.1/umd/react.production.min.js",
-                              "resourceBytes": 12191,
-                              "unusedBytes": 5082
-                            },
-                            {
-                              "name": "react-dom/16.13.1/umd/react-dom.production.min.js",
-                              "resourceBytes": 117940,
-                              "unusedBytes": 44501
-                            }
-                          ]
-                        },
-                        {
-                          "name": "assets/js",
-                          "resourceBytes": 174787,
-                          "unusedBytes": 128300,
-                          "children": [
-                            {
-                              "name": "vendor",
-                              "resourceBytes": 131887,
-                              "unusedBytes": 104498,
+                              "name": "assets/js",
+                              "resourceBytes": 174787,
+                              "unusedBytes": 128300,
                               "children": [
                                 {
-                                  "name": "jquery.magnific.popup.js",
-                                  "resourceBytes": 29039,
-                                  "unusedBytes": 24128
+                                  "name": "vendor",
+                                  "resourceBytes": 131887,
+                                  "unusedBytes": 104498,
+                                  "children": [
+                                    {
+                                      "name": "jquery.magnific.popup.js",
+                                      "resourceBytes": 29039,
+                                      "unusedBytes": 24128
+                                    },
+                                    {
+                                      "name": "jquery.owl.carousel.js",
+                                      "resourceBytes": 30009,
+                                      "unusedBytes": 28067
+                                    },
+                                    {
+                                      "name": "jquery.select.js",
+                                      "resourceBytes": 59038,
+                                      "unusedBytes": 49562
+                                    },
+                                    {
+                                      "name": "jquery.lazyload.js",
+                                      "resourceBytes": 5179,
+                                      "unusedBytes": 714
+                                    },
+                                    {
+                                      "name": "jquery.waypoint.js",
+                                      "resourceBytes": 8622,
+                                      "unusedBytes": 2027
+                                    }
+                                  ]
                                 },
                                 {
-                                  "name": "jquery.owl.carousel.js",
-                                  "resourceBytes": 30009,
-                                  "unusedBytes": 28067
+                                  "name": "utils/ch-analytics-workaround.js",
+                                  "resourceBytes": 862,
+                                  "unusedBytes": 849
                                 },
                                 {
-                                  "name": "jquery.select.js",
-                                  "resourceBytes": 59038,
-                                  "unusedBytes": 49562
+                                  "name": "analytics/UserBehaviorEventTracking.js",
+                                  "resourceBytes": 7722,
+                                  "unusedBytes": 7256
                                 },
                                 {
-                                  "name": "jquery.lazyload.js",
-                                  "resourceBytes": 5179,
-                                  "unusedBytes": 714
-                                },
-                                {
-                                  "name": "jquery.waypoint.js",
-                                  "resourceBytes": 8622,
-                                  "unusedBytes": 2027
+                                  "name": "ch-analytics.js",
+                                  "resourceBytes": 34316,
+                                  "unusedBytes": 15697
                                 }
                               ]
-                            },
-                            {
-                              "name": "utils/ch-analytics-workaround.js",
-                              "resourceBytes": 862,
-                              "unusedBytes": 849
-                            },
-                            {
-                              "name": "analytics/UserBehaviorEventTracking.js",
-                              "resourceBytes": 7722,
-                              "unusedBytes": 7256
-                            },
-                            {
-                              "name": "ch-analytics.js",
-                              "resourceBytes": 34316,
-                              "unusedBytes": 15697
                             }
                           ]
-                        }
-                      ]
-                    },
-                    {
-                      "name": "Symfony/src/CourseHero",
-                      "resourceBytes": 3479,
-                      "unusedBytes": 2840,
-                      "children": [
-                        {
-                          "name": "UtilsBundle/Resources/assets/js/jquery.iframe-transport.js",
-                          "resourceBytes": 2505,
-                          "unusedBytes": 2414
                         },
                         {
-                          "name": "LayoutBundle/Resources/assets/js/vendor/jquery.ba-throttle-debounce.js",
-                          "resourceBytes": 974,
-                          "unusedBytes": 426
+                          "name": "Symfony/src/CourseHero",
+                          "resourceBytes": 3479,
+                          "unusedBytes": 2840,
+                          "children": [
+                            {
+                              "name": "UtilsBundle/Resources/assets/js/jquery.iframe-transport.js",
+                              "resourceBytes": 2505,
+                              "unusedBytes": 2414
+                            },
+                            {
+                              "name": "LayoutBundle/Resources/assets/js/vendor/jquery.ba-throttle-debounce.js",
+                              "resourceBytes": 974,
+                              "unusedBytes": 426
+                            }
+                          ]
                         }
                       ]
                     },
                     {
                       "name": "js",
-                      "resourceBytes": 21973,
-                      "unusedBytes": 2731,
+                      "resourceBytes": 22935,
+                      "unusedBytes": 2739,
                       "children": [
                         {
                           "name": "webpack/bootstrap?",
@@ -282,7 +289,7 @@
                         },
                         {
                           "name": "node_modules",
-                          "resourceBytes": 17076,
+                          "resourceBytes": 18038,
                           "children": [
                             {
                               "name": "@babel/runtime/helpers",
@@ -325,11 +332,11 @@
                             },
                             {
                               "name": "ua-parser-js/src/ua-parser.js?",
-                              "resourceBytes": 15509,
-                              "unusedBytes": 638
+                              "resourceBytes": 16471,
+                              "unusedBytes": 646
                             }
                           ],
-                          "unusedBytes": 1496
+                          "unusedBytes": 1504
                         },
                         {
                           "name": "src/supported-browsers",
@@ -368,7 +375,7 @@
               "unusedBytes": 16415
             },
             {
-              "name": "https://googleads.g.doubleclick.net/pagead/viewthroughconversion/1029779469/?random=1620365367855&cv=9&fst=1620365367855&num=1&guid=ON&resp=GooglemKTybQhCsO&eid=2505059650&u_h=640&u_w=360&u_ah=640&u_aw=360&u_cd=30&u_his=2&u_tz=-360&u_java=false&u_nplug=0&u_nmime=0&gtm=2wg4s0&sendb=1&ig=1&frm=0&url=https%3A%2F%2Fwww.coursehero.com%2F&tiba=Course%20Hero%20%7C%20Make%20every%20study%20hour%20count&hn=www.googleadservices.com&async=1&rfmt=3&fmt=4",
+              "name": "https://googleads.g.doubleclick.net/pagead/viewthroughconversion/1029779469/?random=1622071187382&cv=9&fst=1622071187382&num=1&guid=ON&resp=GooglemKTybQhCsO&eid=2505059650&u_h=640&u_w=360&u_ah=640&u_aw=360&u_cd=30&u_his=2&u_tz=-420&u_java=false&u_nplug=0&u_nmime=0&gtm=2wg5j0&sendb=1&ig=1&frm=0&url=https%3A%2F%2Fwww.coursehero.com%2F&tiba=Course%20Hero%20%7C%20Make%20every%20study%20hour%20count&hn=www.googleadservices.com&async=1&rfmt=3&fmt=4",
               "resourceBytes": 1624,
               "unusedBytes": 0
             },
@@ -378,8 +385,8 @@
             },
             {
               "name": "https://d2oh4tlt9mrke9.cloudfront.net/Record/js/sessioncam.recorder.js",
-              "resourceBytes": 273281,
-              "unusedBytes": 227199
+              "resourceBytes": 274163,
+              "unusedBytes": 227827
             },
             {
               "name": "https://cdn.polyfill.io/v3/polyfill.min.js?flags=gated&features=default%2CArray.prototype.includes%2CArray.prototype.find%2CArray.prototype.findIndex%2Cfetch%2CObject.assign%2CObject.entries%2CObject.values%2CObject.entries%2CNodeList.prototype.forEach%2CIntersectionObserver%2CIntersectionObserverEntry%2CAbortController",
@@ -387,178 +394,322 @@
               "unusedBytes": 0
             },
             {
-              "name": "https://www.coursehero.com/sym-assets/js/bundle-8ed4419-3cfb752.js",
-              "resourceBytes": 1111780,
-              "unusedBytes": 685723,
+              "name": "https://www.coursehero.com/sym-assets/js/bundle-8ed4419-0ae34c0.js",
+              "resourceBytes": 1115365,
+              "unusedBytes": 687348,
               "children": [
                 {
                   "name": "coursehero:///",
-                  "resourceBytes": 1111780,
-                  "unusedBytes": 685723,
+                  "resourceBytes": 1115365,
+                  "unusedBytes": 687348,
                   "children": [
                     {
-                      "name": "Control",
-                      "resourceBytes": 472043,
-                      "unusedBytes": 293522,
+                      "name": "run/monolith-build/src",
+                      "resourceBytes": 539401,
+                      "unusedBytes": 356931,
                       "children": [
                         {
-                          "name": "assets/js",
-                          "resourceBytes": 457930,
-                          "unusedBytes": 290721,
+                          "name": "Control",
+                          "resourceBytes": 472043,
+                          "unusedBytes": 293522,
                           "children": [
                             {
-                              "name": "vendor",
-                              "resourceBytes": 450086,
-                              "unusedBytes": 285692,
+                              "name": "assets/js",
+                              "resourceBytes": 467930,
+                              "unusedBytes": 290721,
                               "children": [
                                 {
-                                  "name": "jquery.typeahead.js",
-                                  "resourceBytes": 39282,
-                                  "unusedBytes": 33714
-                                },
-                                {
-                                  "name": "media-match.js",
-                                  "resourceBytes": 4673,
-                                  "unusedBytes": 4624
-                                },
-                                {
-                                  "name": "enquire.min.js",
-                                  "resourceBytes": 2025,
-                                  "unusedBytes": 1500
-                                },
-                                {
-                                  "name": "lab.js",
-                                  "resourceBytes": 5369,
-                                  "unusedBytes": 4482
-                                },
-                                {
-                                  "name": "moment.min.js",
-                                  "resourceBytes": 34603,
-                                  "unusedBytes": 26363
-                                },
-                                {
-                                  "name": "angular-moment.min.js",
-                                  "resourceBytes": 3968,
-                                  "unusedBytes": 2944
-                                },
-                                {
-                                  "name": "ng-infinite-scroll.min.js",
-                                  "resourceBytes": 814,
-                                  "unusedBytes": 695
-                                },
-                                {
-                                  "name": "angular.ng-modules.js",
-                                  "resourceBytes": 1499
-                                },
-                                {
-                                  "name": "ng",
-                                  "resourceBytes": 73246,
-                                  "unusedBytes": 65776,
+                                  "name": "vendor",
+                                  "resourceBytes": 460086,
+                                  "unusedBytes": 285692,
                                   "children": [
                                     {
-                                      "name": "select",
-                                      "resourceBytes": 57648,
-                                      "unusedBytes": 51214,
+                                      "name": "jquery.typeahead.js",
+                                      "resourceBytes": 39282,
+                                      "unusedBytes": 33714
+                                    },
+                                    {
+                                      "name": "media-match.js",
+                                      "resourceBytes": 4673,
+                                      "unusedBytes": 4624
+                                    },
+                                    {
+                                      "name": "enquire.min.js",
+                                      "resourceBytes": 2025,
+                                      "unusedBytes": 1500
+                                    },
+                                    {
+                                      "name": "lab.js",
+                                      "resourceBytes": 5369,
+                                      "unusedBytes": 4482
+                                    },
+                                    {
+                                      "name": "moment.min.js",
+                                      "resourceBytes": 34603,
+                                      "unusedBytes": 26363
+                                    },
+                                    {
+                                      "name": "angular-moment.min.js",
+                                      "resourceBytes": 3968,
+                                      "unusedBytes": 2944
+                                    },
+                                    {
+                                      "name": "ng-infinite-scroll.min.js",
+                                      "resourceBytes": 814,
+                                      "unusedBytes": 695
+                                    },
+                                    {
+                                      "name": "angular.ng-modules.js",
+                                      "resourceBytes": 1499
+                                    },
+                                    {
+                                      "name": "ng",
+                                      "resourceBytes": 73246,
+                                      "unusedBytes": 65776,
                                       "children": [
                                         {
-                                          "name": "select.js",
-                                          "resourceBytes": 48513,
-                                          "unusedBytes": 46095,
-                                          "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/select/select.js"
+                                          "name": "select",
+                                          "resourceBytes": 57648,
+                                          "unusedBytes": 51214,
+                                          "children": [
+                                            {
+                                              "name": "select.js",
+                                              "resourceBytes": 48513,
+                                              "unusedBytes": 46095,
+                                              "duplicatedNormalizedModuleName": "run/monolith-build/src/Control/assets/js/vendor/ng/select/select.js"
+                                            },
+                                            {
+                                              "name": "angular-sanitize.js",
+                                              "resourceBytes": 9135,
+                                              "unusedBytes": 5119,
+                                              "duplicatedNormalizedModuleName": "run/monolith-build/src/Control/assets/js/vendor/ng/select/angular-sanitize.js"
+                                            }
+                                          ]
                                         },
                                         {
-                                          "name": "angular-sanitize.js",
-                                          "resourceBytes": 9135,
-                                          "unusedBytes": 5119,
-                                          "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/select/angular-sanitize.js"
+                                          "name": "angular-smooth-scroll.min.js",
+                                          "resourceBytes": 2237,
+                                          "unusedBytes": 2051
+                                        },
+                                        {
+                                          "name": "ng-file-upload.js",
+                                          "resourceBytes": 13361,
+                                          "unusedBytes": 12511
                                         }
                                       ]
                                     },
                                     {
-                                      "name": "angular-smooth-scroll.min.js",
-                                      "resourceBytes": 2237,
-                                      "unusedBytes": 2051
+                                      "name": "phoneparser.js",
+                                      "resourceBytes": 22883,
+                                      "unusedBytes": 14631
                                     },
                                     {
-                                      "name": "ng-file-upload.js",
-                                      "resourceBytes": 13361,
-                                      "unusedBytes": 12511
+                                      "name": "sweetalert.js",
+                                      "resourceBytes": 16857,
+                                      "unusedBytes": 15567
+                                    },
+                                    {
+                                      "name": "katex.min.js",
+                                      "resourceBytes": 254867,
+                                      "unusedBytes": 115396,
+                                      "duplicatedNormalizedModuleName": "run/monolith-build/src/Control/assets/js/vendor/katex.min.js"
                                     }
                                   ]
                                 },
                                 {
-                                  "name": "phoneparser.js",
-                                  "resourceBytes": 22883,
-                                  "unusedBytes": 14631
+                                  "name": "ch.global.js",
+                                  "resourceBytes": 1150,
+                                  "unusedBytes": 488
                                 },
                                 {
-                                  "name": "sweetalert.js",
-                                  "resourceBytes": 16857,
-                                  "unusedBytes": 15567
+                                  "name": "course_hero_mq",
+                                  "resourceBytes": 4422,
+                                  "unusedBytes": 3768,
+                                  "children": [
+                                    {
+                                      "name": "course-hero-mq.js",
+                                      "resourceBytes": 4186,
+                                      "unusedBytes": 3669
+                                    },
+                                    {
+                                      "name": "course-hero-mq-transport.js",
+                                      "resourceBytes": 236,
+                                      "unusedBytes": 99
+                                    }
+                                  ]
                                 },
                                 {
-                                  "name": "katex.min.js",
-                                  "resourceBytes": 254867,
-                                  "unusedBytes": 115396,
-                                  "duplicatedNormalizedModuleName": "Control/assets/js/vendor/katex.min.js"
+                                  "name": "workForUs.js",
+                                  "resourceBytes": 727
+                                },
+                                {
+                                  "name": "analytics/global_tracking.js",
+                                  "resourceBytes": 1545,
+                                  "unusedBytes": 773
                                 }
                               ]
                             },
                             {
-                              "name": "ch.global.js",
-                              "resourceBytes": 1150,
-                              "unusedBytes": 488
-                            },
-                            {
-                              "name": "course_hero_mq",
-                              "resourceBytes": 4422,
-                              "unusedBytes": 3768,
+                              "name": "javascript",
+                              "resourceBytes": 4113,
                               "children": [
                                 {
-                                  "name": "course-hero-mq.js",
-                                  "resourceBytes": 4186,
-                                  "unusedBytes": 3669
+                                  "name": "tracker_pageview.js",
+                                  "resourceBytes": 341
                                 },
                                 {
-                                  "name": "course-hero-mq-transport.js",
-                                  "resourceBytes": 236,
-                                  "unusedBytes": 99
+                                  "name": "widgets/product-thumbnail-stats.js",
+                                  "resourceBytes": 3772,
+                                  "unusedBytes": 2801
                                 }
-                              ]
-                            },
-                            {
-                              "name": "workForUs.js",
-                              "resourceBytes": 727
-                            },
-                            {
-                              "name": "analytics/global_tracking.js",
-                              "resourceBytes": 1545,
-                              "unusedBytes": 773
+                              ],
+                              "unusedBytes": 2801
                             }
                           ]
                         },
                         {
-                          "name": "javascript",
-                          "resourceBytes": 4113,
+                          "name": "Symfony/src/CourseHero",
+                          "resourceBytes": 67358,
+                          "unusedBytes": 63409,
                           "children": [
                             {
-                              "name": "tracker_pageview.js",
-                              "resourceBytes": 341
+                              "name": "LayoutBundle/Resources/assets/js",
+                              "resourceBytes": 1324,
+                              "unusedBytes": 1170,
+                              "children": [
+                                {
+                                  "name": "ResponsiveHeader.js",
+                                  "resourceBytes": 466,
+                                  "unusedBytes": 466
+                                },
+                                {
+                                  "name": "Utils.js",
+                                  "resourceBytes": 858,
+                                  "unusedBytes": 704
+                                }
+                              ]
                             },
                             {
-                              "name": "widgets/product-thumbnail-stats.js",
-                              "resourceBytes": 3772,
-                              "unusedBytes": 2801
+                              "name": "SearchBundle/Resources/assets/js/Smart/search.smart.widget.js",
+                              "resourceBytes": 8415,
+                              "unusedBytes": 8174
+                            },
+                            {
+                              "name": "UtilsBundle/Resources/assets/js",
+                              "resourceBytes": 35240,
+                              "unusedBytes": 33202,
+                              "children": [
+                                {
+                                  "name": "Common",
+                                  "resourceBytes": 34932,
+                                  "unusedBytes": 33045,
+                                  "children": [
+                                    {
+                                      "name": "util.common.services.js",
+                                      "resourceBytes": 784,
+                                      "unusedBytes": 533
+                                    },
+                                    {
+                                      "name": "util.common.dispatcher.js",
+                                      "resourceBytes": 463,
+                                      "unusedBytes": 323
+                                    },
+                                    {
+                                      "name": "util.common.store.js",
+                                      "resourceBytes": 18603,
+                                      "unusedBytes": 17597
+                                    },
+                                    {
+                                      "name": "util.common.api.js",
+                                      "resourceBytes": 1306,
+                                      "unusedBytes": 1165
+                                    },
+                                    {
+                                      "name": "util.common.notifications.js",
+                                      "resourceBytes": 4684,
+                                      "unusedBytes": 4481
+                                    },
+                                    {
+                                      "name": "util.common.locale.js",
+                                      "resourceBytes": 9092,
+                                      "unusedBytes": 8946
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "Widgets/util.widgets.loader.js",
+                                  "resourceBytes": 308,
+                                  "unusedBytes": 157
+                                }
+                              ]
+                            },
+                            {
+                              "name": "AnalyticsBundle/Resources/assets/js",
+                              "resourceBytes": 768,
+                              "children": [
+                                {
+                                  "name": "productThumbnailStatsService.js",
+                                  "resourceBytes": 186
+                                },
+                                {
+                                  "name": "productThumbnailStats.js",
+                                  "resourceBytes": 582,
+                                  "unusedBytes": 344
+                                }
+                              ],
+                              "unusedBytes": 344
+                            },
+                            {
+                              "name": "PaymentBundle/Resources/assets/js/Common",
+                              "resourceBytes": 11142,
+                              "unusedBytes": 10471,
+                              "children": [
+                                {
+                                  "name": "payment.common.services.js",
+                                  "resourceBytes": 693,
+                                  "unusedBytes": 454
+                                },
+                                {
+                                  "name": "payment.common.actions.js",
+                                  "resourceBytes": 7165,
+                                  "unusedBytes": 6948
+                                },
+                                {
+                                  "name": "payment.common.store.js",
+                                  "resourceBytes": 3284,
+                                  "unusedBytes": 3069
+                                }
+                              ]
+                            },
+                            {
+                              "name": "UserBundle/Resources/assets/js/Common",
+                              "resourceBytes": 10469,
+                              "children": [
+                                {
+                                  "name": "user.common.services.js",
+                                  "resourceBytes": 175
+                                },
+                                {
+                                  "name": "user.common.store.js",
+                                  "resourceBytes": 4733,
+                                  "unusedBytes": 4537
+                                },
+                                {
+                                  "name": "user.common.actions.js",
+                                  "resourceBytes": 5561,
+                                  "unusedBytes": 5511
+                                }
+                              ],
+                              "unusedBytes": 10048
                             }
-                          ],
-                          "unusedBytes": 2801
+                          ]
                         }
                       ]
                     },
                     {
                       "name": "js",
-                      "resourceBytes": 547237,
-                      "unusedBytes": 306022,
+                      "resourceBytes": 550822,
+                      "unusedBytes": 307647,
                       "children": [
                         {
                           "name": "webpack/bootstrap?",
@@ -567,7 +718,7 @@
                         },
                         {
                           "name": "node_modules",
-                          "resourceBytes": 198268,
+                          "resourceBytes": 198600,
                           "children": [
                             {
                               "name": "lodash",
@@ -1272,13 +1423,13 @@
                             },
                             {
                               "name": "@babel/runtime",
-                              "resourceBytes": 11071,
-                              "unusedBytes": 5664,
+                              "resourceBytes": 11183,
+                              "unusedBytes": 5644,
                               "children": [
                                 {
                                   "name": "helpers",
-                                  "resourceBytes": 11040,
-                                  "unusedBytes": 5664,
+                                  "resourceBytes": 11152,
+                                  "unusedBytes": 5644,
                                   "children": [
                                     {
                                       "name": "classCallCheck.js?",
@@ -1287,8 +1438,12 @@
                                     },
                                     {
                                       "name": "createClass.js?",
-                                      "resourceBytes": 1696,
+                                      "resourceBytes": 1637,
                                       "unusedBytes": 751
+                                    },
+                                    {
+                                      "name": "defineProperty.js?",
+                                      "resourceBytes": 490
                                     },
                                     {
                                       "name": "assertThisInitialized.js?",
@@ -1320,10 +1475,6 @@
                                       "unusedBytes": 69
                                     },
                                     {
-                                      "name": "defineProperty.js?",
-                                      "resourceBytes": 288
-                                    },
-                                    {
                                       "name": "initializerWarningHelper.js?",
                                       "resourceBytes": 1698,
                                       "unusedBytes": 1088
@@ -1335,8 +1486,8 @@
                                     },
                                     {
                                       "name": "slicedToArray.js?",
-                                      "resourceBytes": 156,
-                                      "unusedBytes": 67
+                                      "resourceBytes": 124,
+                                      "unusedBytes": 47
                                     },
                                     {
                                       "name": "extends.js?",
@@ -1410,7 +1561,7 @@
                                     },
                                     {
                                       "name": "esm",
-                                      "resourceBytes": 586,
+                                      "resourceBytes": 587,
                                       "unusedBytes": 468,
                                       "children": [
                                         {
@@ -1425,7 +1576,7 @@
                                         },
                                         {
                                           "name": "assertThisInitialized.js?",
-                                          "resourceBytes": 153,
+                                          "resourceBytes": 154,
                                           "unusedBytes": 124
                                         },
                                         {
@@ -1448,105 +1599,15 @@
                               "unusedBytes": 620
                             },
                             {
+                              "name": "tslib/tslib.es6.js?",
+                              "resourceBytes": 790,
+                              "unusedBytes": 683
+                            },
+                            {
                               "name": "react-granite",
-                              "resourceBytes": 35284,
-                              "unusedBytes": 25635,
+                              "resourceBytes": 34567,
+                              "unusedBytes": 25008,
                               "children": [
-                                {
-                                  "name": "node_modules",
-                                  "resourceBytes": 20558,
-                                  "unusedBytes": 12730,
-                                  "children": [
-                                    {
-                                      "name": "tslib/tslib.es6.js?",
-                                      "resourceBytes": 758,
-                                      "unusedBytes": 663
-                                    },
-                                    {
-                                      "name": "react-modal/lib",
-                                      "resourceBytes": 19800,
-                                      "children": [
-                                        {
-                                          "name": "helpers",
-                                          "resourceBytes": 5648,
-                                          "children": [
-                                            {
-                                              "name": "safeHTMLElement.js?",
-                                              "resourceBytes": 235
-                                            },
-                                            {
-                                              "name": "tabbable.js?",
-                                              "resourceBytes": 766,
-                                              "unusedBytes": 612,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/tabbable.js"
-                                            },
-                                            {
-                                              "name": "ariaAppHider.js?",
-                                              "resourceBytes": 998,
-                                              "unusedBytes": 487,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/ariaAppHider.js"
-                                            },
-                                            {
-                                              "name": "portalOpenInstances.js?",
-                                              "resourceBytes": 648,
-                                              "unusedBytes": 278,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/portalOpenInstances.js"
-                                            },
-                                            {
-                                              "name": "focusManager.js?",
-                                              "resourceBytes": 1055,
-                                              "unusedBytes": 775,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/focusManager.js"
-                                            },
-                                            {
-                                              "name": "scopeTab.js?",
-                                              "resourceBytes": 749,
-                                              "unusedBytes": 602,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/scopeTab.js"
-                                            },
-                                            {
-                                              "name": "classList.js?",
-                                              "resourceBytes": 497,
-                                              "unusedBytes": 369
-                                            },
-                                            {
-                                              "name": "bodyTrap.js?",
-                                              "resourceBytes": 700,
-                                              "unusedBytes": 571,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/bodyTrap.js"
-                                            }
-                                          ],
-                                          "unusedBytes": 3694
-                                        },
-                                        {
-                                          "name": "index.js?",
-                                          "resourceBytes": 1255,
-                                          "unusedBytes": 1037
-                                        },
-                                        {
-                                          "name": "components",
-                                          "resourceBytes": 12897,
-                                          "unusedBytes": 7336,
-                                          "children": [
-                                            {
-                                              "name": "Modal.js?",
-                                              "resourceBytes": 5554,
-                                              "unusedBytes": 2365,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/components/Modal.js"
-                                            },
-                                            {
-                                              "name": "ModalPortal.js?",
-                                              "resourceBytes": 7343,
-                                              "unusedBytes": 4971,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/components/ModalPortal.js"
-                                            }
-                                          ]
-                                        }
-                                      ],
-                                      "unusedBytes": 12067
-                                    }
-                                  ]
-                                },
                                 {
                                   "name": "Box/index.js?",
                                   "resourceBytes": 885,
@@ -1554,13 +1615,96 @@
                                 },
                                 {
                                   "name": "Icon/index.js?",
-                                  "resourceBytes": 1848,
-                                  "unusedBytes": 1564
+                                  "resourceBytes": 1849,
+                                  "unusedBytes": 1565
+                                },
+                                {
+                                  "name": "node_modules/react-modal/lib",
+                                  "resourceBytes": 19801,
+                                  "children": [
+                                    {
+                                      "name": "helpers",
+                                      "resourceBytes": 5648,
+                                      "children": [
+                                        {
+                                          "name": "safeHTMLElement.js?",
+                                          "resourceBytes": 235
+                                        },
+                                        {
+                                          "name": "tabbable.js?",
+                                          "resourceBytes": 766,
+                                          "unusedBytes": 612,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/tabbable.js"
+                                        },
+                                        {
+                                          "name": "ariaAppHider.js?",
+                                          "resourceBytes": 998,
+                                          "unusedBytes": 487,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/ariaAppHider.js"
+                                        },
+                                        {
+                                          "name": "portalOpenInstances.js?",
+                                          "resourceBytes": 648,
+                                          "unusedBytes": 278,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/portalOpenInstances.js"
+                                        },
+                                        {
+                                          "name": "focusManager.js?",
+                                          "resourceBytes": 1055,
+                                          "unusedBytes": 775,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/focusManager.js"
+                                        },
+                                        {
+                                          "name": "scopeTab.js?",
+                                          "resourceBytes": 749,
+                                          "unusedBytes": 602,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/scopeTab.js"
+                                        },
+                                        {
+                                          "name": "classList.js?",
+                                          "resourceBytes": 497,
+                                          "unusedBytes": 369
+                                        },
+                                        {
+                                          "name": "bodyTrap.js?",
+                                          "resourceBytes": 700,
+                                          "unusedBytes": 571,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/bodyTrap.js"
+                                        }
+                                      ],
+                                      "unusedBytes": 3694
+                                    },
+                                    {
+                                      "name": "index.js?",
+                                      "resourceBytes": 1256,
+                                      "unusedBytes": 1038
+                                    },
+                                    {
+                                      "name": "components",
+                                      "resourceBytes": 12897,
+                                      "unusedBytes": 7336,
+                                      "children": [
+                                        {
+                                          "name": "Modal.js?",
+                                          "resourceBytes": 5554,
+                                          "unusedBytes": 2365,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/components/Modal.js"
+                                        },
+                                        {
+                                          "name": "ModalPortal.js?",
+                                          "resourceBytes": 7343,
+                                          "unusedBytes": 4971,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/components/ModalPortal.js"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "unusedBytes": 12068
                                 },
                                 {
                                   "name": "common/index.js?",
-                                  "resourceBytes": 2646,
-                                  "unusedBytes": 2551
+                                  "resourceBytes": 2652,
+                                  "unusedBytes": 2557
                                 },
                                 {
                                   "name": "Card/index.js?",
@@ -1569,8 +1713,8 @@
                                 },
                                 {
                                   "name": "Modal/index.js?",
-                                  "resourceBytes": 1237,
-                                  "unusedBytes": 1204
+                                  "resourceBytes": 1265,
+                                  "unusedBytes": 1232
                                 },
                                 {
                                   "name": "Button/index.js?",
@@ -1589,7 +1733,7 @@
                                 },
                                 {
                                   "name": "Tooltip/index.js?",
-                                  "resourceBytes": 1410,
+                                  "resourceBytes": 1415,
                                   "unusedBytes": 1126
                                 }
                               ]
@@ -1846,7 +1990,7 @@
                             },
                             {
                               "name": "react-transition-group",
-                              "resourceBytes": 10772,
+                              "resourceBytes": 10773,
                               "unusedBytes": 7293,
                               "children": [
                                 {
@@ -1876,7 +2020,7 @@
                                 },
                                 {
                                   "name": "TransitionGroup.js?",
-                                  "resourceBytes": 4022,
+                                  "resourceBytes": 4023,
                                   "unusedBytes": 3172,
                                   "duplicatedNormalizedModuleName": "node_modules/react-transition-group/TransitionGroup.js"
                                 },
@@ -1919,7 +2063,7 @@
                             },
                             {
                               "name": "react-lifecycles-compat/react-lifecycles-compat.es.js?",
-                              "resourceBytes": 2929,
+                              "resourceBytes": 2950,
                               "unusedBytes": 565
                             },
                             {
@@ -1992,7 +2136,7 @@
                             },
                             {
                               "name": "create-react-context/lib",
-                              "resourceBytes": 2843,
+                              "resourceBytes": 2844,
                               "children": [
                                 {
                                   "name": "index.js?",
@@ -2000,7 +2144,7 @@
                                 },
                                 {
                                   "name": "implementation.js?",
-                                  "resourceBytes": 2643,
+                                  "resourceBytes": 2644,
                                   "unusedBytes": 2440,
                                   "duplicatedNormalizedModuleName": "node_modules/create-react-context/lib/implementation.js"
                                 }
@@ -2031,34 +2175,101 @@
                               ]
                             },
                             {
-                              "name": "regexp.prototype.flags",
-                              "resourceBytes": 1257,
-                              "unusedBytes": 760,
+                              "name": "react-popper",
+                              "resourceBytes": 14875,
+                              "unusedBytes": 6869,
                               "children": [
                                 {
-                                  "name": "implementation.js?",
-                                  "resourceBytes": 331,
-                                  "unusedBytes": 265
+                                  "name": "node_modules",
+                                  "resourceBytes": 9217,
+                                  "unusedBytes": 1831,
+                                  "children": [
+                                    {
+                                      "name": "regexp.prototype.flags",
+                                      "resourceBytes": 1257,
+                                      "unusedBytes": 760,
+                                      "children": [
+                                        {
+                                          "name": "implementation.js?",
+                                          "resourceBytes": 331,
+                                          "unusedBytes": 265
+                                        },
+                                        {
+                                          "name": "polyfill.js?",
+                                          "resourceBytes": 375,
+                                          "unusedBytes": 263
+                                        },
+                                        {
+                                          "name": "index.js?",
+                                          "resourceBytes": 138
+                                        },
+                                        {
+                                          "name": "shim.js?",
+                                          "resourceBytes": 413,
+                                          "unusedBytes": 232
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "name": "deep-equal/index.js?",
+                                      "resourceBytes": 1085,
+                                      "unusedBytes": 978
+                                    },
+                                    {
+                                      "name": "es-abstract",
+                                      "resourceBytes": 6875,
+                                      "unusedBytes": 93,
+                                      "children": [
+                                        {
+                                          "name": "helpers/callBind.js?",
+                                          "resourceBytes": 189,
+                                          "unusedBytes": 39
+                                        },
+                                        {
+                                          "name": "GetIntrinsic.js?",
+                                          "resourceBytes": 6686,
+                                          "unusedBytes": 54,
+                                          "duplicatedNormalizedModuleName": "node_modules/es-abstract/GetIntrinsic.js"
+                                        }
+                                      ]
+                                    }
+                                  ]
                                 },
                                 {
-                                  "name": "polyfill.js?",
-                                  "resourceBytes": 375,
-                                  "unusedBytes": 263
-                                },
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 138
-                                },
-                                {
-                                  "name": "shim.js?",
-                                  "resourceBytes": 413,
-                                  "unusedBytes": 232
+                                  "name": "lib/esm",
+                                  "resourceBytes": 5658,
+                                  "unusedBytes": 5038,
+                                  "children": [
+                                    {
+                                      "name": "Manager.js?",
+                                      "resourceBytes": 604,
+                                      "unusedBytes": 464,
+                                      "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Manager.js"
+                                    },
+                                    {
+                                      "name": "utils.js?",
+                                      "resourceBytes": 276,
+                                      "unusedBytes": 264
+                                    },
+                                    {
+                                      "name": "Reference.js?",
+                                      "resourceBytes": 721,
+                                      "unusedBytes": 568,
+                                      "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Reference.js"
+                                    },
+                                    {
+                                      "name": "Popper.js?",
+                                      "resourceBytes": 4057,
+                                      "unusedBytes": 3742,
+                                      "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Popper.js"
+                                    }
+                                  ]
                                 }
                               ]
                             },
                             {
                               "name": "lodash-es",
-                              "resourceBytes": 1909,
+                              "resourceBytes": 2045,
                               "children": [
                                 {
                                   "name": "_freeGlobal.js?",
@@ -2117,19 +2328,29 @@
                                   "unusedBytes": 140
                                 },
                                 {
+                                  "name": "_trimmedEndIndex.js?",
+                                  "resourceBytes": 81,
+                                  "unusedBytes": 67
+                                },
+                                {
+                                  "name": "_baseTrim.js?",
+                                  "resourceBytes": 71,
+                                  "unusedBytes": 55
+                                },
+                                {
                                   "name": "isObject.js?",
                                   "resourceBytes": 79,
                                   "unusedBytes": 72
                                 },
                                 {
                                   "name": "toNumber.js?",
-                                  "resourceBytes": 354,
-                                  "unusedBytes": 261
+                                  "resourceBytes": 337,
+                                  "unusedBytes": 254
                                 },
                                 {
                                   "name": "toFinite.js?",
-                                  "resourceBytes": 117,
-                                  "unusedBytes": 77
+                                  "resourceBytes": 118,
+                                  "unusedBytes": 78
                                 },
                                 {
                                   "name": "toInteger.js?",
@@ -2147,49 +2368,7 @@
                                   "unusedBytes": 95
                                 }
                               ],
-                              "unusedBytes": 1228
-                            },
-                            {
-                              "name": "react-popper",
-                              "resourceBytes": 6761,
-                              "unusedBytes": 6033,
-                              "children": [
-                                {
-                                  "name": "node_modules/deep-equal/index.js?",
-                                  "resourceBytes": 1085,
-                                  "unusedBytes": 978
-                                },
-                                {
-                                  "name": "lib/esm",
-                                  "resourceBytes": 5676,
-                                  "unusedBytes": 5055,
-                                  "children": [
-                                    {
-                                      "name": "Manager.js?",
-                                      "resourceBytes": 606,
-                                      "unusedBytes": 466,
-                                      "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Manager.js"
-                                    },
-                                    {
-                                      "name": "utils.js?",
-                                      "resourceBytes": 276,
-                                      "unusedBytes": 264
-                                    },
-                                    {
-                                      "name": "Reference.js?",
-                                      "resourceBytes": 722,
-                                      "unusedBytes": 569,
-                                      "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Reference.js"
-                                    },
-                                    {
-                                      "name": "Popper.js?",
-                                      "resourceBytes": 4072,
-                                      "unusedBytes": 3756,
-                                      "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Popper.js"
-                                    }
-                                  ]
-                                }
-                              ]
+                              "unusedBytes": 1344
                             },
                             {
                               "name": "gud/index.js?",
@@ -2223,24 +2402,6 @@
                               ]
                             },
                             {
-                              "name": "es-abstract",
-                              "resourceBytes": 6875,
-                              "unusedBytes": 93,
-                              "children": [
-                                {
-                                  "name": "helpers/callBind.js?",
-                                  "resourceBytes": 189,
-                                  "unusedBytes": 39
-                                },
-                                {
-                                  "name": "GetIntrinsic.js?",
-                                  "resourceBytes": 6686,
-                                  "unusedBytes": 54,
-                                  "duplicatedNormalizedModuleName": "node_modules/es-abstract/GetIntrinsic.js"
-                                }
-                              ]
-                            },
-                            {
                               "name": "has-symbols",
                               "resourceBytes": 1089,
                               "children": [
@@ -2257,7 +2418,7 @@
                             },
                             {
                               "name": "is-date-object/index.js?",
-                              "resourceBytes": 846,
+                              "resourceBytes": 851,
                               "unusedBytes": 296
                             },
                             {
@@ -2267,11 +2428,11 @@
                             },
                             {
                               "name": "downshift/dist/downshift.esm.js?",
-                              "resourceBytes": 17908,
-                              "unusedBytes": 16185
+                              "resourceBytes": 17909,
+                              "unusedBytes": 16186
                             }
                           ],
-                          "unusedBytes": 126305
+                          "unusedBytes": 126441
                         },
                         {
                           "name": "(webpack)/buildin",
@@ -2291,7 +2452,7 @@
                         },
                         {
                           "name": "src",
-                          "resourceBytes": 341927,
+                          "resourceBytes": 345180,
                           "children": [
                             {
                               "name": "shims",
@@ -2309,17 +2470,17 @@
                             },
                             {
                               "name": "layout/header",
-                              "resourceBytes": 5882,
+                              "resourceBytes": 5905,
                               "unusedBytes": 3734,
                               "children": [
                                 {
                                   "name": "dashboard-bridge.ts?",
-                                  "resourceBytes": 1647,
+                                  "resourceBytes": 1663,
                                   "unusedBytes": 1121
                                 },
                                 {
                                   "name": "library.ts?",
-                                  "resourceBytes": 869,
+                                  "resourceBytes": 876,
                                   "unusedBytes": 350
                                 },
                                 {
@@ -2335,13 +2496,13 @@
                             },
                             {
                               "name": "utils",
-                              "resourceBytes": 7652,
-                              "unusedBytes": 3978,
+                              "resourceBytes": 7638,
+                              "unusedBytes": 3894,
                               "children": [
                                 {
                                   "name": "service",
-                                  "resourceBytes": 7481,
-                                  "unusedBytes": 3978,
+                                  "resourceBytes": 7452,
+                                  "unusedBytes": 3894,
                                   "children": [
                                     {
                                       "name": "local-storage-service.ts?",
@@ -2350,13 +2511,13 @@
                                     },
                                     {
                                       "name": "amplitude-service.ts?",
-                                      "resourceBytes": 4013,
-                                      "unusedBytes": 2851,
+                                      "resourceBytes": 3957,
+                                      "unusedBytes": 2767,
                                       "duplicatedNormalizedModuleName": "js/src/utils/service/amplitude-service.ts"
                                     },
                                     {
                                       "name": "string-service.ts?",
-                                      "resourceBytes": 1480,
+                                      "resourceBytes": 1502,
                                       "unusedBytes": 785
                                     },
                                     {
@@ -2366,7 +2527,7 @@
                                     },
                                     {
                                       "name": "global-service.ts?",
-                                      "resourceBytes": 769,
+                                      "resourceBytes": 774,
                                       "unusedBytes": 62,
                                       "duplicatedNormalizedModuleName": "js/src/utils/service/global-service.ts"
                                     },
@@ -2379,46 +2540,46 @@
                                 },
                                 {
                                   "name": "track.ts?",
-                                  "resourceBytes": 171
+                                  "resourceBytes": 186
                                 }
                               ]
                             },
                             {
                               "name": "common",
-                              "resourceBytes": 53303,
-                              "unusedBytes": 35460,
+                              "resourceBytes": 54282,
+                              "unusedBytes": 36065,
                               "children": [
                                 {
                                   "name": "helper",
-                                  "resourceBytes": 1219,
-                                  "unusedBytes": 1073,
+                                  "resourceBytes": 1247,
+                                  "unusedBytes": 1087,
                                   "children": [
                                     {
                                       "name": "scroll-helper.ts?",
-                                      "resourceBytes": 510,
+                                      "resourceBytes": 524,
                                       "unusedBytes": 368
                                     },
                                     {
                                       "name": "html-images-loaded.ts?",
-                                      "resourceBytes": 709,
-                                      "unusedBytes": 705
+                                      "resourceBytes": 723,
+                                      "unusedBytes": 719
                                     }
                                   ]
                                 },
                                 {
                                   "name": "base-model.ts?",
-                                  "resourceBytes": 723,
+                                  "resourceBytes": 728,
                                   "unusedBytes": 379
                                 },
                                 {
                                   "name": "component",
-                                  "resourceBytes": 16661,
-                                  "unusedBytes": 13256,
+                                  "resourceBytes": 17321,
+                                  "unusedBytes": 13601,
                                   "children": [
                                     {
                                       "name": "school-dropdown/school.ts?",
-                                      "resourceBytes": 662,
-                                      "unusedBytes": 227
+                                      "resourceBytes": 684,
+                                      "unusedBytes": 242
                                     },
                                     {
                                       "name": "content-item-loader.tsx?",
@@ -2432,36 +2593,41 @@
                                     },
                                     {
                                       "name": "school-search.tsx?",
-                                      "resourceBytes": 5317,
-                                      "unusedBytes": 4823,
+                                      "resourceBytes": 5329,
+                                      "unusedBytes": 4835,
                                       "duplicatedNormalizedModuleName": "js/src/common/component/school-search.tsx"
                                     },
                                     {
+                                      "name": "error-boundary/error-page.tsx?",
+                                      "resourceBytes": 706,
+                                      "unusedBytes": 427
+                                    },
+                                    {
                                       "name": "checkbox.tsx?",
-                                      "resourceBytes": 1623,
-                                      "unusedBytes": 1196
+                                      "resourceBytes": 1526,
+                                      "unusedBytes": 1094
                                     },
                                     {
                                       "name": "search",
-                                      "resourceBytes": 5408,
-                                      "unusedBytes": 4016,
+                                      "resourceBytes": 5416,
+                                      "unusedBytes": 4009,
                                       "children": [
                                         {
                                           "name": "abstract-taxonomy-search.tsx?",
-                                          "resourceBytes": 3527,
-                                          "unusedBytes": 2947,
+                                          "resourceBytes": 3499,
+                                          "unusedBytes": 2914,
                                           "duplicatedNormalizedModuleName": "js/src/common/component/search/abstract-taxonomy-search.tsx"
                                         },
                                         {
                                           "name": "course-search.tsx?",
-                                          "resourceBytes": 1013,
-                                          "unusedBytes": 565,
+                                          "resourceBytes": 1031,
+                                          "unusedBytes": 578,
                                           "duplicatedNormalizedModuleName": "js/src/common/component/search/course-search.tsx"
                                         },
                                         {
                                           "name": "subject-search.tsx?",
-                                          "resourceBytes": 868,
-                                          "unusedBytes": 504
+                                          "resourceBytes": 886,
+                                          "unusedBytes": 517
                                         }
                                       ]
                                     },
@@ -2477,7 +2643,7 @@
                                     },
                                     {
                                       "name": "spinner.tsx?",
-                                      "resourceBytes": 290,
+                                      "resourceBytes": 299,
                                       "unusedBytes": 286
                                     }
                                   ]
@@ -2498,7 +2664,7 @@
                                 },
                                 {
                                   "name": "base-component.ts?",
-                                  "resourceBytes": 459,
+                                  "resourceBytes": 475,
                                   "unusedBytes": 180
                                 },
                                 {
@@ -2519,7 +2685,7 @@
                                 },
                                 {
                                   "name": "input/keycode.ts?",
-                                  "resourceBytes": 651,
+                                  "resourceBytes": 656,
                                   "unusedBytes": 157
                                 },
                                 {
@@ -2543,18 +2709,18 @@
                                 },
                                 {
                                   "name": "store",
-                                  "resourceBytes": 29079,
-                                  "unusedBytes": 19862,
+                                  "resourceBytes": 29344,
+                                  "unusedBytes": 20108,
                                   "children": [
                                     {
                                       "name": "model/content.ts?",
-                                      "resourceBytes": 8852,
-                                      "unusedBytes": 2233
+                                      "resourceBytes": 9116,
+                                      "unusedBytes": 2483
                                     },
                                     {
                                       "name": "content-store.ts?",
-                                      "resourceBytes": 20227,
-                                      "unusedBytes": 17629
+                                      "resourceBytes": 20228,
+                                      "unusedBytes": 17625
                                     }
                                   ]
                                 }
@@ -2566,18 +2732,18 @@
                             },
                             {
                               "name": "document",
-                              "resourceBytes": 78503,
-                              "unusedBytes": 26655,
+                              "resourceBytes": 78926,
+                              "unusedBytes": 26931,
                               "children": [
                                 {
                                   "name": "express-unlock",
-                                  "resourceBytes": 73726,
-                                  "unusedBytes": 25705,
+                                  "resourceBytes": 74144,
+                                  "unusedBytes": 25981,
                                   "children": [
                                     {
                                       "name": "constants",
-                                      "resourceBytes": 4996,
-                                      "unusedBytes": 1530,
+                                      "resourceBytes": 5090,
+                                      "unusedBytes": 1574,
                                       "children": [
                                         {
                                           "name": "actions.ts?",
@@ -2586,8 +2752,13 @@
                                         },
                                         {
                                           "name": "steps.ts?",
-                                          "resourceBytes": 3252,
-                                          "unusedBytes": 910
+                                          "resourceBytes": 3209,
+                                          "unusedBytes": 894
+                                        },
+                                        {
+                                          "name": "buckets.ts?",
+                                          "resourceBytes": 137,
+                                          "unusedBytes": 60
                                         }
                                       ]
                                     },
@@ -2608,7 +2779,7 @@
                                     },
                                     {
                                       "name": "assets/express-unlock.scss?",
-                                      "resourceBytes": 42339
+                                      "resourceBytes": 42431
                                     },
                                     {
                                       "name": "utils",
@@ -2634,8 +2805,8 @@
                                     },
                                     {
                                       "name": "component",
-                                      "resourceBytes": 9503,
-                                      "unusedBytes": 8502,
+                                      "resourceBytes": 9546,
+                                      "unusedBytes": 8545,
                                       "children": [
                                         {
                                           "name": "checkout-body.tsx?",
@@ -2649,8 +2820,8 @@
                                         },
                                         {
                                           "name": "checkout-header.tsx?",
-                                          "resourceBytes": 1415,
-                                          "unusedBytes": 1402
+                                          "resourceBytes": 1426,
+                                          "unusedBytes": 1413
                                         },
                                         {
                                           "name": "left-panel/document-in-cart.tsx?",
@@ -2659,8 +2830,8 @@
                                         },
                                         {
                                           "name": "left-panel.tsx?",
-                                          "resourceBytes": 1386,
-                                          "unusedBytes": 1194
+                                          "resourceBytes": 1418,
+                                          "unusedBytes": 1226
                                         },
                                         {
                                           "name": "right-panel.tsx?",
@@ -2671,19 +2842,19 @@
                                     },
                                     {
                                       "name": "express-unlock.tsx?",
-                                      "resourceBytes": 5394,
-                                      "unusedBytes": 5390
+                                      "resourceBytes": 5583,
+                                      "unusedBytes": 5579
                                     }
                                   ]
                                 },
                                 {
                                   "name": "common",
-                                  "resourceBytes": 4508,
+                                  "resourceBytes": 4513,
                                   "unusedBytes": 685,
                                   "children": [
                                     {
                                       "name": "constant/upload-statuses.ts?",
-                                      "resourceBytes": 3693,
+                                      "resourceBytes": 3698,
                                       "unusedBytes": 157
                                     },
                                     {
@@ -2702,19 +2873,19 @@
                             },
                             {
                               "name": "search",
-                              "resourceBytes": 165654,
+                              "resourceBytes": 167376,
                               "children": [
                                 {
                                   "name": "results",
-                                  "resourceBytes": 142562,
+                                  "resourceBytes": 144207,
                                   "children": [
                                     {
                                       "name": "component",
-                                      "resourceBytes": 26887,
+                                      "resourceBytes": 26228,
                                       "children": [
                                         {
                                           "name": "AnswerCard",
-                                          "resourceBytes": 10510,
+                                          "resourceBytes": 10515,
                                           "children": [
                                             {
                                               "name": "AnswerCard.scss?",
@@ -2751,7 +2922,7 @@
                                             },
                                             {
                                               "name": "AnswerCard.tsx?",
-                                              "resourceBytes": 1477,
+                                              "resourceBytes": 1482,
                                               "unusedBytes": 1207
                                             }
                                           ],
@@ -2779,35 +2950,30 @@
                                           "unusedBytes": 1345
                                         },
                                         {
-                                          "name": "error-page.tsx?",
-                                          "resourceBytes": 701,
-                                          "unusedBytes": 427
-                                        },
-                                        {
                                           "name": "filters",
-                                          "resourceBytes": 11555,
-                                          "unusedBytes": 10549,
+                                          "resourceBytes": 11587,
+                                          "unusedBytes": 10576,
                                           "children": [
                                             {
                                               "name": "multi-select.tsx?",
-                                              "resourceBytes": 2953,
-                                              "unusedBytes": 2765
+                                              "resourceBytes": 2977,
+                                              "unusedBytes": 2789
                                             },
                                             {
                                               "name": "filter-drop-down.tsx?",
-                                              "resourceBytes": 4966,
-                                              "unusedBytes": 4517
+                                              "resourceBytes": 4983,
+                                              "unusedBytes": 4529
                                             },
                                             {
                                               "name": "top-filter-controls.tsx?",
-                                              "resourceBytes": 3636,
-                                              "unusedBytes": 3267
+                                              "resourceBytes": 3627,
+                                              "unusedBytes": 3258
                                             }
                                           ]
                                         },
                                         {
                                           "name": "pill-list.tsx?",
-                                          "resourceBytes": 720,
+                                          "resourceBytes": 725,
                                           "unusedBytes": 446
                                         },
                                         {
@@ -2821,27 +2987,27 @@
                                           "unusedBytes": 680
                                         }
                                       ],
-                                      "unusedBytes": 21775
+                                      "unusedBytes": 21375
                                     },
                                     {
                                       "name": "store",
-                                      "resourceBytes": 14855,
+                                      "resourceBytes": 15220,
                                       "unusedBytes": 7411,
                                       "children": [
                                         {
                                           "name": "filter-actions.ts?",
-                                          "resourceBytes": 935,
+                                          "resourceBytes": 1116,
                                           "unusedBytes": 308,
                                           "duplicatedNormalizedModuleName": "js/src/search/results/store/filter-actions.ts"
                                         },
                                         {
                                           "name": "item/resource-types.ts?",
-                                          "resourceBytes": 1206,
+                                          "resourceBytes": 1239,
                                           "unusedBytes": 465
                                         },
                                         {
                                           "name": "filter-store.ts?",
-                                          "resourceBytes": 12714,
+                                          "resourceBytes": 12865,
                                           "unusedBytes": 6638,
                                           "duplicatedNormalizedModuleName": "js/src/search/results/store/filter-store.ts"
                                         }
@@ -2849,18 +3015,18 @@
                                     },
                                     {
                                       "name": "view/filter",
-                                      "resourceBytes": 8527,
+                                      "resourceBytes": 8537,
                                       "unusedBytes": 7420,
                                       "children": [
                                         {
                                           "name": "autocomplete-list.tsx?",
-                                          "resourceBytes": 1558,
+                                          "resourceBytes": 1563,
                                           "unusedBytes": 1198,
                                           "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-list.tsx"
                                         },
                                         {
                                           "name": "autocomplete-filter.tsx?",
-                                          "resourceBytes": 4263,
+                                          "resourceBytes": 4268,
                                           "unusedBytes": 3636,
                                           "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-filter.tsx"
                                         },
@@ -2874,12 +3040,12 @@
                                     },
                                     {
                                       "name": "service",
-                                      "resourceBytes": 3847,
+                                      "resourceBytes": 3852,
                                       "unusedBytes": 2545,
                                       "children": [
                                         {
                                           "name": "filter-api-service.ts?",
-                                          "resourceBytes": 975,
+                                          "resourceBytes": 980,
                                           "unusedBytes": 383,
                                           "duplicatedNormalizedModuleName": "js/src/search/results/service/filter-api-service.ts"
                                         },
@@ -2897,7 +3063,7 @@
                                     },
                                     {
                                       "name": "model",
-                                      "resourceBytes": 71812,
+                                      "resourceBytes": 73873,
                                       "children": [
                                         {
                                           "name": "filter-type.ts?",
@@ -2905,209 +3071,209 @@
                                         },
                                         {
                                           "name": "course-school-combo.ts?",
-                                          "resourceBytes": 1272,
-                                          "unusedBytes": 347
+                                          "resourceBytes": 1314,
+                                          "unusedBytes": 382
                                         },
                                         {
                                           "name": "error.ts?",
-                                          "resourceBytes": 963,
-                                          "unusedBytes": 349
+                                          "resourceBytes": 985,
+                                          "unusedBytes": 359
                                         },
                                         {
                                           "name": "subject-data.ts?",
-                                          "resourceBytes": 1981,
-                                          "unusedBytes": 722
+                                          "resourceBytes": 2025,
+                                          "unusedBytes": 742
                                         },
                                         {
                                           "name": "filter-data.ts?",
-                                          "resourceBytes": 1484,
-                                          "unusedBytes": 499
+                                          "resourceBytes": 1516,
+                                          "unusedBytes": 519
                                         },
                                         {
                                           "name": "location.ts?",
-                                          "resourceBytes": 1518,
-                                          "unusedBytes": 441
+                                          "resourceBytes": 1560,
+                                          "unusedBytes": 471
                                         },
                                         {
                                           "name": "api-metadata.ts?",
-                                          "resourceBytes": 2501,
-                                          "unusedBytes": 734
+                                          "resourceBytes": 2568,
+                                          "unusedBytes": 789
                                         },
                                         {
                                           "name": "filter-option.ts?",
-                                          "resourceBytes": 1465,
-                                          "unusedBytes": 482
+                                          "resourceBytes": 1502,
+                                          "unusedBytes": 507
                                         },
                                         {
                                           "name": "filter.ts?",
-                                          "resourceBytes": 1315,
-                                          "unusedBytes": 429
+                                          "resourceBytes": 1347,
+                                          "unusedBytes": 449
                                         },
                                         {
                                           "name": "options-data.ts?",
-                                          "resourceBytes": 1062,
-                                          "unusedBytes": 405
+                                          "resourceBytes": 1084,
+                                          "unusedBytes": 415
                                         },
                                         {
                                           "name": "core-result-data.ts?",
-                                          "resourceBytes": 1503,
-                                          "unusedBytes": 443
+                                          "resourceBytes": 1545,
+                                          "unusedBytes": 473
                                         },
                                         {
                                           "name": "document-data.ts?",
-                                          "resourceBytes": 1125,
-                                          "unusedBytes": 385
+                                          "resourceBytes": 1152,
+                                          "unusedBytes": 400
                                         },
                                         {
                                           "name": "question-data.ts?",
-                                          "resourceBytes": 983,
-                                          "unusedBytes": 357
+                                          "resourceBytes": 1005,
+                                          "unusedBytes": 367
                                         },
                                         {
                                           "name": "course-study-guide-data.ts?",
-                                          "resourceBytes": 2689,
-                                          "unusedBytes": 836
+                                          "resourceBytes": 2753,
+                                          "unusedBytes": 876
                                         },
                                         {
                                           "name": "lit-study-guide-data.ts?",
-                                          "resourceBytes": 2851,
-                                          "unusedBytes": 901
+                                          "resourceBytes": 2925,
+                                          "unusedBytes": 951
                                         },
                                         {
                                           "name": "course-resource-data.ts?",
-                                          "resourceBytes": 2186,
-                                          "unusedBytes": 745
+                                          "resourceBytes": 2240,
+                                          "unusedBytes": 775
                                         },
                                         {
                                           "name": "course-data.ts?",
-                                          "resourceBytes": 2920,
-                                          "unusedBytes": 927
+                                          "resourceBytes": 2994,
+                                          "unusedBytes": 977
                                         },
                                         {
                                           "name": "dept-data.ts?",
-                                          "resourceBytes": 2248,
-                                          "unusedBytes": 767
+                                          "resourceBytes": 2302,
+                                          "unusedBytes": 797
                                         },
                                         {
                                           "name": "school-data.ts?",
-                                          "resourceBytes": 2227,
-                                          "unusedBytes": 779
+                                          "resourceBytes": 2281,
+                                          "unusedBytes": 809
                                         },
                                         {
                                           "name": "taxonomy-data.ts?",
-                                          "resourceBytes": 3488,
-                                          "unusedBytes": 1618
+                                          "resourceBytes": 3551,
+                                          "unusedBytes": 1657
                                         },
                                         {
                                           "name": "thumbnail-data.ts?",
-                                          "resourceBytes": 998,
-                                          "unusedBytes": 353
+                                          "resourceBytes": 1020,
+                                          "unusedBytes": 363
                                         },
                                         {
                                           "name": "study-guide-video-data.ts?",
-                                          "resourceBytes": 2260,
-                                          "unusedBytes": 779
+                                          "resourceBytes": 2314,
+                                          "unusedBytes": 809
                                         },
                                         {
                                           "name": "textbook-data.ts?",
-                                          "resourceBytes": 3717,
-                                          "unusedBytes": 1062
+                                          "resourceBytes": 3821,
+                                          "unusedBytes": 1142
                                         },
                                         {
                                           "name": "textbook-exercise",
-                                          "resourceBytes": 5315,
-                                          "unusedBytes": 1984,
+                                          "resourceBytes": 5427,
+                                          "unusedBytes": 2024,
                                           "children": [
                                             {
                                               "name": "chapter-data.ts?",
-                                              "resourceBytes": 1646,
-                                              "unusedBytes": 643
+                                              "resourceBytes": 1680,
+                                              "unusedBytes": 653
                                             },
                                             {
                                               "name": "section-data.ts?",
-                                              "resourceBytes": 1985,
-                                              "unusedBytes": 694
+                                              "resourceBytes": 2029,
+                                              "unusedBytes": 714
                                             },
                                             {
                                               "name": "heading-data.ts?",
-                                              "resourceBytes": 1684,
-                                              "unusedBytes": 647
+                                              "resourceBytes": 1718,
+                                              "unusedBytes": 657
                                             }
                                           ]
                                         },
                                         {
                                           "name": "textbook-exercise-data.ts?",
-                                          "resourceBytes": 4646,
-                                          "unusedBytes": 1479
+                                          "resourceBytes": 4760,
+                                          "unusedBytes": 1569
                                         },
                                         {
                                           "name": "search-result.ts?",
-                                          "resourceBytes": 3236,
-                                          "unusedBytes": 1243
+                                          "resourceBytes": 3303,
+                                          "unusedBytes": 1298
                                         },
                                         {
                                           "name": "sort-option.ts?",
-                                          "resourceBytes": 663,
+                                          "resourceBytes": 668,
                                           "unusedBytes": 157
                                         },
                                         {
                                           "name": "api-response.ts?",
-                                          "resourceBytes": 1039,
-                                          "unusedBytes": 377
+                                          "resourceBytes": 1066,
+                                          "unusedBytes": 397
                                         },
                                         {
                                           "name": "search-request.ts?",
-                                          "resourceBytes": 2640,
-                                          "unusedBytes": 727
+                                          "resourceBytes": 2717,
+                                          "unusedBytes": 797
                                         },
                                         {
                                           "name": "suggestion-data.ts?",
-                                          "resourceBytes": 1458,
-                                          "unusedBytes": 475
+                                          "resourceBytes": 1495,
+                                          "unusedBytes": 500
                                         },
                                         {
                                           "name": "search-result-type.ts?",
-                                          "resourceBytes": 1648,
+                                          "resourceBytes": 1658,
                                           "unusedBytes": 169
                                         },
                                         {
                                           "name": "search-store.ts?",
-                                          "resourceBytes": 1844,
+                                          "resourceBytes": 1849,
                                           "unusedBytes": 1060
                                         },
                                         {
                                           "name": "answer-card",
-                                          "resourceBytes": 6448,
-                                          "unusedBytes": 2370,
+                                          "resourceBytes": 7007,
+                                          "unusedBytes": 2605,
                                           "children": [
                                             {
                                               "name": "answer-response.ts?",
-                                              "resourceBytes": 3937,
-                                              "unusedBytes": 1502
+                                              "resourceBytes": 4048,
+                                              "unusedBytes": 1582
                                             },
                                             {
                                               "name": "answer-request.ts?",
-                                              "resourceBytes": 1192,
-                                              "unusedBytes": 297
+                                              "resourceBytes": 1635,
+                                              "unusedBytes": 452
                                             },
                                             {
                                               "name": "answer-store.ts?",
-                                              "resourceBytes": 1319,
+                                              "resourceBytes": 1324,
                                               "unusedBytes": 571
                                             }
                                           ]
                                         }
                                       ],
-                                      "unusedBytes": 24401
+                                      "unusedBytes": 25605
                                     },
                                     {
                                       "name": "actions/search-actions.ts?",
-                                      "resourceBytes": 591,
+                                      "resourceBytes": 596,
                                       "unusedBytes": 199
                                     },
                                     {
                                       "name": "constant",
-                                      "resourceBytes": 3000,
+                                      "resourceBytes": 3005,
                                       "children": [
                                         {
                                           "name": "search-trigger.ts?",
@@ -3119,7 +3285,7 @@
                                         },
                                         {
                                           "name": "result-stat-values.ts?",
-                                          "resourceBytes": 1166,
+                                          "resourceBytes": 1171,
                                           "unusedBytes": 587
                                         },
                                         {
@@ -3132,15 +3298,15 @@
                                     },
                                     {
                                       "name": "app/search-results.tsx?",
-                                      "resourceBytes": 13043,
-                                      "unusedBytes": 11862
+                                      "resourceBytes": 12896,
+                                      "unusedBytes": 11737
                                     }
                                   ],
-                                  "unusedBytes": 76568
+                                  "unusedBytes": 77247
                                 },
                                 {
                                   "name": "widget",
-                                  "resourceBytes": 23092,
+                                  "resourceBytes": 23169,
                                   "children": [
                                     {
                                       "name": "constants",
@@ -3158,18 +3324,18 @@
                                     },
                                     {
                                       "name": "actions/suggestion-actions.ts?",
-                                      "resourceBytes": 554,
+                                      "resourceBytes": 543,
                                       "unusedBytes": 178
                                     },
                                     {
                                       "name": "model",
-                                      "resourceBytes": 2155,
-                                      "unusedBytes": 800,
+                                      "resourceBytes": 2187,
+                                      "unusedBytes": 820,
                                       "children": [
                                         {
                                           "name": "suggestion.ts?",
-                                          "resourceBytes": 1182,
-                                          "unusedBytes": 249
+                                          "resourceBytes": 1214,
+                                          "unusedBytes": 269
                                         },
                                         {
                                           "name": "suggestion-store.ts?",
@@ -3185,7 +3351,7 @@
                                     },
                                     {
                                       "name": "component",
-                                      "resourceBytes": 18308,
+                                      "resourceBytes": 18363,
                                       "unusedBytes": 9386,
                                       "children": [
                                         {
@@ -3205,31 +3371,31 @@
                                         },
                                         {
                                           "name": "suggestions-footer.tsx?",
-                                          "resourceBytes": 1555,
+                                          "resourceBytes": 1560,
                                           "unusedBytes": 1136
                                         },
                                         {
                                           "name": "search-widget.tsx?",
-                                          "resourceBytes": 12894,
+                                          "resourceBytes": 12937,
                                           "unusedBytes": 6583
                                         },
                                         {
                                           "name": "header-search-widget.tsx?",
-                                          "resourceBytes": 2331,
+                                          "resourceBytes": 2338,
                                           "unusedBytes": 950
                                         }
                                       ]
                                     },
                                     {
                                       "name": "app.tsx?",
-                                      "resourceBytes": 1533,
+                                      "resourceBytes": 1534,
                                       "unusedBytes": 382
                                     }
                                   ],
-                                  "unusedBytes": 10888
+                                  "unusedBytes": 10908
                                 }
                               ],
-                              "unusedBytes": 87456
+                              "unusedBytes": 88155
                             },
                             {
                               "name": "aged-beef.ts?",
@@ -3237,41 +3403,41 @@
                             },
                             {
                               "name": "user",
-                              "resourceBytes": 16480,
+                              "resourceBytes": 16529,
                               "unusedBytes": 6536,
                               "children": [
                                 {
                                   "name": "store",
-                                  "resourceBytes": 14244,
+                                  "resourceBytes": 14263,
                                   "unusedBytes": 5047,
                                   "children": [
                                     {
                                       "name": "model",
-                                      "resourceBytes": 13133,
+                                      "resourceBytes": 13166,
                                       "unusedBytes": 4419,
                                       "children": [
                                         {
                                           "name": "user.ts?",
-                                          "resourceBytes": 1465,
+                                          "resourceBytes": 1484,
                                           "unusedBytes": 348
                                         },
                                         {
                                           "name": "user-details.ts?",
-                                          "resourceBytes": 11668,
+                                          "resourceBytes": 11682,
                                           "unusedBytes": 4071
                                         }
                                       ]
                                     },
                                     {
                                       "name": "user-store.ts?",
-                                      "resourceBytes": 1111,
+                                      "resourceBytes": 1097,
                                       "unusedBytes": 628
                                     }
                                   ]
                                 },
                                 {
                                   "name": "actions/user-actions.ts?",
-                                  "resourceBytes": 722,
+                                  "resourceBytes": 752,
                                   "unusedBytes": 54
                                 },
                                 {
@@ -3283,22 +3449,22 @@
                             },
                             {
                               "name": "dashboard2018",
-                              "resourceBytes": 13730,
-                              "unusedBytes": 11939,
+                              "resourceBytes": 13794,
+                              "unusedBytes": 11932,
                               "children": [
                                 {
                                   "name": "component",
-                                  "resourceBytes": 12519,
-                                  "unusedBytes": 10956,
+                                  "resourceBytes": 12589,
+                                  "unusedBytes": 10955,
                                   "children": [
                                     {
                                       "name": "marketplace/common/beta-tag.tsx?",
-                                      "resourceBytes": 867,
-                                      "unusedBytes": 843
+                                      "resourceBytes": 846,
+                                      "unusedBytes": 842
                                     },
                                     {
                                       "name": "nav-menu/index.tsx?",
-                                      "resourceBytes": 10268,
+                                      "resourceBytes": 10359,
                                       "unusedBytes": 8941
                                     },
                                     {
@@ -3319,18 +3485,18 @@
                                 },
                                 {
                                   "name": "dashboard-navbar-app.tsx?",
-                                  "resourceBytes": 424,
-                                  "unusedBytes": 341
+                                  "resourceBytes": 418,
+                                  "unusedBytes": 335
                                 }
                               ]
                             },
                             {
                               "name": "taxonomy/service/course-api-service.ts?",
-                              "resourceBytes": 303,
+                              "resourceBytes": 310,
                               "unusedBytes": 184
                             }
                           ],
-                          "unusedBytes": 175942
+                          "unusedBytes": 177431
                         },
                         {
                           "name": "external \"window.React\"?",
@@ -3347,143 +3513,6 @@
                         {
                           "name": "external \"window.ReactDOM\"?",
                           "resourceBytes": 110
-                        }
-                      ]
-                    },
-                    {
-                      "name": "Symfony/src/CourseHero",
-                      "resourceBytes": 67358,
-                      "unusedBytes": 63409,
-                      "children": [
-                        {
-                          "name": "LayoutBundle/Resources/assets/js",
-                          "resourceBytes": 1324,
-                          "unusedBytes": 1170,
-                          "children": [
-                            {
-                              "name": "ResponsiveHeader.js",
-                              "resourceBytes": 466,
-                              "unusedBytes": 466
-                            },
-                            {
-                              "name": "Utils.js",
-                              "resourceBytes": 858,
-                              "unusedBytes": 704
-                            }
-                          ]
-                        },
-                        {
-                          "name": "SearchBundle/Resources/assets/js/Smart/search.smart.widget.js",
-                          "resourceBytes": 8415,
-                          "unusedBytes": 8174
-                        },
-                        {
-                          "name": "UtilsBundle/Resources/assets/js",
-                          "resourceBytes": 35240,
-                          "unusedBytes": 33202,
-                          "children": [
-                            {
-                              "name": "Common",
-                              "resourceBytes": 34932,
-                              "unusedBytes": 33045,
-                              "children": [
-                                {
-                                  "name": "util.common.services.js",
-                                  "resourceBytes": 784,
-                                  "unusedBytes": 533
-                                },
-                                {
-                                  "name": "util.common.dispatcher.js",
-                                  "resourceBytes": 463,
-                                  "unusedBytes": 323
-                                },
-                                {
-                                  "name": "util.common.store.js",
-                                  "resourceBytes": 18603,
-                                  "unusedBytes": 17597
-                                },
-                                {
-                                  "name": "util.common.api.js",
-                                  "resourceBytes": 1306,
-                                  "unusedBytes": 1165
-                                },
-                                {
-                                  "name": "util.common.notifications.js",
-                                  "resourceBytes": 4684,
-                                  "unusedBytes": 4481
-                                },
-                                {
-                                  "name": "util.common.locale.js",
-                                  "resourceBytes": 9092,
-                                  "unusedBytes": 8946
-                                }
-                              ]
-                            },
-                            {
-                              "name": "Widgets/util.widgets.loader.js",
-                              "resourceBytes": 308,
-                              "unusedBytes": 157
-                            }
-                          ]
-                        },
-                        {
-                          "name": "AnalyticsBundle/Resources/assets/js",
-                          "resourceBytes": 768,
-                          "children": [
-                            {
-                              "name": "productThumbnailStatsService.js",
-                              "resourceBytes": 186
-                            },
-                            {
-                              "name": "productThumbnailStats.js",
-                              "resourceBytes": 582,
-                              "unusedBytes": 344
-                            }
-                          ],
-                          "unusedBytes": 344
-                        },
-                        {
-                          "name": "PaymentBundle/Resources/assets/js/Common",
-                          "resourceBytes": 11142,
-                          "unusedBytes": 10471,
-                          "children": [
-                            {
-                              "name": "payment.common.services.js",
-                              "resourceBytes": 693,
-                              "unusedBytes": 454
-                            },
-                            {
-                              "name": "payment.common.actions.js",
-                              "resourceBytes": 7165,
-                              "unusedBytes": 6948
-                            },
-                            {
-                              "name": "payment.common.store.js",
-                              "resourceBytes": 3284,
-                              "unusedBytes": 3069
-                            }
-                          ]
-                        },
-                        {
-                          "name": "UserBundle/Resources/assets/js/Common",
-                          "resourceBytes": 10469,
-                          "children": [
-                            {
-                              "name": "user.common.services.js",
-                              "resourceBytes": 175
-                            },
-                            {
-                              "name": "user.common.store.js",
-                              "resourceBytes": 4733,
-                              "unusedBytes": 4537
-                            },
-                            {
-                              "name": "user.common.actions.js",
-                              "resourceBytes": 5561,
-                              "unusedBytes": 5511
-                            }
-                          ],
-                          "unusedBytes": 10048
                         }
                       ]
                     },
@@ -3831,19 +3860,19 @@
               ]
             },
             {
-              "name": "https://www.coursehero.com/sym-assets/js/bundle-3593e6a-b36f775.js",
-              "resourceBytes": 5122,
-              "unusedBytes": 1254,
+              "name": "https://www.coursehero.com/sym-assets/js/bundle-3593e6a-b4f4ab4.js",
+              "resourceBytes": 5188,
+              "unusedBytes": 1315,
               "children": [
                 {
                   "name": "coursehero:///",
-                  "resourceBytes": 5122,
-                  "unusedBytes": 1254,
+                  "resourceBytes": 5188,
+                  "unusedBytes": 1315,
                   "children": [
                     {
                       "name": "js",
-                      "resourceBytes": 5018,
-                      "unusedBytes": 1254,
+                      "resourceBytes": 5084,
+                      "unusedBytes": 1315,
                       "children": [
                         {
                           "name": "webpack/bootstrap?",
@@ -3852,18 +3881,18 @@
                         },
                         {
                           "name": "node_modules/@babel/runtime/helpers/defineProperty.js?",
-                          "resourceBytes": 1481,
-                          "unusedBytes": 423
+                          "resourceBytes": 1531,
+                          "unusedBytes": 443
                         },
                         {
                           "name": "src/utils/service",
-                          "resourceBytes": 2624,
-                          "unusedBytes": 516,
+                          "resourceBytes": 2640,
+                          "unusedBytes": 557,
                           "children": [
                             {
                               "name": "amplitude-service.ts?",
-                              "resourceBytes": 2491,
-                              "unusedBytes": 516,
+                              "resourceBytes": 2507,
+                              "unusedBytes": 557,
                               "duplicatedNormalizedModuleName": "js/src/utils/service/amplitude-service.ts"
                             },
                             {
@@ -3883,90 +3912,130 @@
               ]
             },
             {
-              "name": "https://www.coursehero.com/sym-assets/js/homepage-app-059d0da-efa7599.js",
-              "resourceBytes": 702378,
-              "unusedBytes": 373772,
+              "name": "https://www.coursehero.com/sym-assets/js/homepage-app-059d0da-c076ede.js",
+              "resourceBytes": 702748,
+              "unusedBytes": 373882,
               "children": [
                 {
                   "name": "coursehero:///",
-                  "resourceBytes": 702378,
-                  "unusedBytes": 373772,
+                  "resourceBytes": 702748,
+                  "unusedBytes": 373882,
                   "children": [
                     {
-                      "name": "Control",
-                      "resourceBytes": 412829,
-                      "unusedBytes": 197463,
+                      "name": "run/monolith-build/src",
+                      "resourceBytes": 418557,
+                      "unusedBytes": 199998,
                       "children": [
                         {
-                          "name": "javascript",
-                          "resourceBytes": 45122,
-                          "unusedBytes": 5782,
+                          "name": "Control",
+                          "resourceBytes": 412829,
+                          "unusedBytes": 197463,
                           "children": [
                             {
-                              "name": "highlight.js/9.9.0/highlight.min.js",
-                              "resourceBytes": 44737,
-                              "unusedBytes": 5600
-                            },
-                            {
-                              "name": "common/amazon-partnership/amplitude-tracking.js",
-                              "resourceBytes": 385,
-                              "unusedBytes": 182
-                            }
-                          ]
-                        },
-                        {
-                          "name": "assets/js",
-                          "resourceBytes": 367707,
-                          "unusedBytes": 191681,
-                          "children": [
-                            {
-                              "name": "vendor",
-                              "resourceBytes": 359985,
-                              "unusedBytes": 185363,
+                              "name": "javascript",
+                              "resourceBytes": 45122,
+                              "unusedBytes": 5782,
                               "children": [
                                 {
-                                  "name": "katex.min.js",
-                                  "resourceBytes": 254880,
-                                  "unusedBytes": 115396,
-                                  "duplicatedNormalizedModuleName": "Control/assets/js/vendor/katex.min.js"
+                                  "name": "highlight.js/9.9.0/highlight.min.js",
+                                  "resourceBytes": 44737,
+                                  "unusedBytes": 5600
                                 },
                                 {
-                                  "name": "ng/select",
-                                  "resourceBytes": 57648,
-                                  "unusedBytes": 51214,
-                                  "children": [
-                                    {
-                                      "name": "select.js",
-                                      "resourceBytes": 48513,
-                                      "unusedBytes": 46095,
-                                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/select/select.js"
-                                    },
-                                    {
-                                      "name": "angular-sanitize.js",
-                                      "resourceBytes": 9135,
-                                      "unusedBytes": 5119,
-                                      "duplicatedNormalizedModuleName": "Control/assets/js/vendor/ng/select/angular-sanitize.js"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "jquery.readmore.js",
-                                  "resourceBytes": 3399,
-                                  "unusedBytes": 2991
-                                },
-                                {
-                                  "name": "owl.carousel.min.js",
-                                  "resourceBytes": 44058,
-                                  "unusedBytes": 15762
+                                  "name": "common/amazon-partnership/amplitude-tracking.js",
+                                  "resourceBytes": 385,
+                                  "unusedBytes": 182
                                 }
                               ]
                             },
                             {
-                              "name": "analytics/UserBehaviorEventTracking.js",
-                              "resourceBytes": 7722,
-                              "unusedBytes": 6318
+                              "name": "assets/js",
+                              "resourceBytes": 367707,
+                              "unusedBytes": 191681,
+                              "children": [
+                                {
+                                  "name": "vendor",
+                                  "resourceBytes": 359985,
+                                  "unusedBytes": 185363,
+                                  "children": [
+                                    {
+                                      "name": "katex.min.js",
+                                      "resourceBytes": 254880,
+                                      "unusedBytes": 115396,
+                                      "duplicatedNormalizedModuleName": "run/monolith-build/src/Control/assets/js/vendor/katex.min.js"
+                                    },
+                                    {
+                                      "name": "ng/select",
+                                      "resourceBytes": 57648,
+                                      "unusedBytes": 51214,
+                                      "children": [
+                                        {
+                                          "name": "select.js",
+                                          "resourceBytes": 48513,
+                                          "unusedBytes": 46095,
+                                          "duplicatedNormalizedModuleName": "run/monolith-build/src/Control/assets/js/vendor/ng/select/select.js"
+                                        },
+                                        {
+                                          "name": "angular-sanitize.js",
+                                          "resourceBytes": 9135,
+                                          "unusedBytes": 5119,
+                                          "duplicatedNormalizedModuleName": "run/monolith-build/src/Control/assets/js/vendor/ng/select/angular-sanitize.js"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "name": "jquery.readmore.js",
+                                      "resourceBytes": 3399,
+                                      "unusedBytes": 2991
+                                    },
+                                    {
+                                      "name": "owl.carousel.min.js",
+                                      "resourceBytes": 44058,
+                                      "unusedBytes": 15762
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "analytics/UserBehaviorEventTracking.js",
+                                  "resourceBytes": 7722,
+                                  "unusedBytes": 6318
+                                }
+                              ]
                             }
                           ]
+                        },
+                        {
+                          "name": "Symfony/src/CourseHero",
+                          "resourceBytes": 5728,
+                          "children": [
+                            {
+                              "name": "MarketingBundle/Resources/assets/js",
+                              "resourceBytes": 3217,
+                              "children": [
+                                {
+                                  "name": "Widgets/testimonials.js",
+                                  "resourceBytes": 2069
+                                },
+                                {
+                                  "name": "HomepageAmplitudeTracking.js",
+                                  "resourceBytes": 1148,
+                                  "unusedBytes": 843
+                                }
+                              ],
+                              "unusedBytes": 843
+                            },
+                            {
+                              "name": "BookBundle/Resources/assets/js/Video/youtube-player-factory.js",
+                              "resourceBytes": 1712,
+                              "unusedBytes": 1015
+                            },
+                            {
+                              "name": "QABundle/Resources/assets/js/Widget/bootstrapAskQuestion.js",
+                              "resourceBytes": 799,
+                              "unusedBytes": 677
+                            }
+                          ],
+                          "unusedBytes": 2535
                         }
                       ]
                     },
@@ -4602,8 +4671,8 @@
                     },
                     {
                       "name": "js",
-                      "resourceBytes": 69632,
-                      "unusedBytes": 38830,
+                      "resourceBytes": 70002,
+                      "unusedBytes": 38940,
                       "children": [
                         {
                           "name": "webpack/bootstrap?",
@@ -4612,13 +4681,13 @@
                         },
                         {
                           "name": "node_modules",
-                          "resourceBytes": 10196,
-                          "unusedBytes": 5130,
+                          "resourceBytes": 10329,
+                          "unusedBytes": 5127,
                           "children": [
                             {
                               "name": "@babel/runtime/helpers",
                               "resourceBytes": 4379,
-                              "unusedBytes": 1498,
+                              "unusedBytes": 1380,
                               "children": [
                                 {
                                   "name": "classCallCheck.js?",
@@ -4630,14 +4699,13 @@
                                   "resourceBytes": 496
                                 },
                                 {
-                                  "name": "getPrototypeOf.js?",
-                                  "resourceBytes": 334,
-                                  "unusedBytes": 197
+                                  "name": "defineProperty.js?",
+                                  "resourceBytes": 288
                                 },
                                 {
-                                  "name": "defineProperty.js?",
-                                  "resourceBytes": 313,
-                                  "unusedBytes": 118
+                                  "name": "getPrototypeOf.js?",
+                                  "resourceBytes": 359,
+                                  "unusedBytes": 197
                                 },
                                 {
                                   "name": "get.js?",
@@ -4688,7 +4756,7 @@
                             },
                             {
                               "name": "lodash-es",
-                              "resourceBytes": 5817,
+                              "resourceBytes": 5950,
                               "children": [
                                 {
                                   "name": "_freeGlobal.js?",
@@ -4814,9 +4882,19 @@
                                   "unusedBytes": 37
                                 },
                                 {
+                                  "name": "_trimmedEndIndex.js?",
+                                  "resourceBytes": 84,
+                                  "unusedBytes": 68
+                                },
+                                {
+                                  "name": "_baseTrim.js?",
+                                  "resourceBytes": 75,
+                                  "unusedBytes": 57
+                                },
+                                {
                                   "name": "toNumber.js?",
-                                  "resourceBytes": 370,
-                                  "unusedBytes": 270
+                                  "resourceBytes": 343,
+                                  "unusedBytes": 259
                                 },
                                 {
                                   "name": "toFinite.js?",
@@ -4835,12 +4913,12 @@
                                 },
                                 {
                                   "name": "truncate.js?",
-                                  "resourceBytes": 2032,
-                                  "unusedBytes": 1995,
+                                  "resourceBytes": 2033,
+                                  "unusedBytes": 1996,
                                   "duplicatedNormalizedModuleName": "node_modules/lodash-es/truncate.js"
                                 }
                               ],
-                              "unusedBytes": 3632
+                              "unusedBytes": 3747
                             }
                           ]
                         },
@@ -4862,18 +4940,18 @@
                         },
                         {
                           "name": "src",
-                          "resourceBytes": 56397,
-                          "unusedBytes": 32455,
+                          "resourceBytes": 56634,
+                          "unusedBytes": 32568,
                           "children": [
                             {
                               "name": "utils/service",
-                              "resourceBytes": 6002,
-                              "unusedBytes": 3098,
+                              "resourceBytes": 5961,
+                              "unusedBytes": 3014,
                               "children": [
                                 {
                                   "name": "amplitude-service.ts?",
-                                  "resourceBytes": 3913,
-                                  "unusedBytes": 2384,
+                                  "resourceBytes": 3862,
+                                  "unusedBytes": 2300,
                                   "duplicatedNormalizedModuleName": "js/src/utils/service/amplitude-service.ts"
                                 },
                                 {
@@ -4888,7 +4966,7 @@
                                 },
                                 {
                                   "name": "global-service.ts?",
-                                  "resourceBytes": 597,
+                                  "resourceBytes": 602,
                                   "unusedBytes": 182,
                                   "duplicatedNormalizedModuleName": "js/src/utils/service/global-service.ts"
                                 },
@@ -4899,20 +4977,20 @@
                                 },
                                 {
                                   "name": "api-service.ts?",
-                                  "resourceBytes": 476,
+                                  "resourceBytes": 481,
                                   "unusedBytes": 211
                                 }
                               ]
                             },
                             {
                               "name": "vendor-mods/quill",
-                              "resourceBytes": 7783,
-                              "unusedBytes": 6369,
+                              "resourceBytes": 7733,
+                              "unusedBytes": 6293,
                               "children": [
                                 {
                                   "name": "common/quill-typing.ts?",
-                                  "resourceBytes": 872,
-                                  "unusedBytes": 834
+                                  "resourceBytes": 873,
+                                  "unusedBytes": 835
                                 },
                                 {
                                   "name": "service/quill-helper.ts?",
@@ -4921,13 +4999,13 @@
                                 },
                                 {
                                   "name": "modules",
-                                  "resourceBytes": 2858,
-                                  "unusedBytes": 2080,
+                                  "resourceBytes": 2832,
+                                  "unusedBytes": 2042,
                                   "children": [
                                     {
                                       "name": "image-handler.ts?",
-                                      "resourceBytes": 2316,
-                                      "unusedBytes": 1827,
+                                      "resourceBytes": 2290,
+                                      "unusedBytes": 1789,
                                       "duplicatedNormalizedModuleName": "js/src/vendor-mods/quill/modules/image-handler.ts"
                                     },
                                     {
@@ -4939,53 +5017,53 @@
                                 },
                                 {
                                   "name": "app.ts?",
-                                  "resourceBytes": 3171,
-                                  "unusedBytes": 2755,
+                                  "resourceBytes": 3146,
+                                  "unusedBytes": 2716,
                                   "duplicatedNormalizedModuleName": "js/src/vendor-mods/quill/app.ts"
                                 }
                               ]
                             },
                             {
                               "name": "qa/attachment-uploader/service/uploader.ts?",
-                              "resourceBytes": 2916,
-                              "unusedBytes": 2485
+                              "resourceBytes": 2857,
+                              "unusedBytes": 2426
                             },
                             {
                               "name": "aged-beef.ts?",
-                              "resourceBytes": 616,
+                              "resourceBytes": 621,
                               "unusedBytes": 12
                             },
                             {
                               "name": "common",
-                              "resourceBytes": 10603,
+                              "resourceBytes": 10616,
                               "unusedBytes": 3817,
                               "children": [
                                 {
                                   "name": "base-component.ts?",
-                                  "resourceBytes": 216,
+                                  "resourceBytes": 232,
                                   "unusedBytes": 62
                                 },
                                 {
                                   "name": "input/keycode.ts?",
-                                  "resourceBytes": 645,
+                                  "resourceBytes": 650,
                                   "unusedBytes": 12
                                 },
                                 {
                                   "name": "component",
-                                  "resourceBytes": 9494,
+                                  "resourceBytes": 9486,
                                   "children": [
                                     {
                                       "name": "search",
-                                      "resourceBytes": 3633,
+                                      "resourceBytes": 3613,
                                       "children": [
                                         {
                                           "name": "course-search.tsx?",
-                                          "resourceBytes": 555,
+                                          "resourceBytes": 568,
                                           "duplicatedNormalizedModuleName": "js/src/common/component/search/course-search.tsx"
                                         },
                                         {
                                           "name": "abstract-taxonomy-search.tsx?",
-                                          "resourceBytes": 3078,
+                                          "resourceBytes": 3045,
                                           "unusedBytes": 1345,
                                           "duplicatedNormalizedModuleName": "js/src/common/component/search/abstract-taxonomy-search.tsx"
                                         }
@@ -4994,7 +5072,7 @@
                                     },
                                     {
                                       "name": "school-search.tsx?",
-                                      "resourceBytes": 5861,
+                                      "resourceBytes": 5873,
                                       "unusedBytes": 2258,
                                       "duplicatedNormalizedModuleName": "js/src/common/component/school-search.tsx"
                                     }
@@ -5010,36 +5088,36 @@
                             },
                             {
                               "name": "search/results",
-                              "resourceBytes": 24697,
-                              "unusedBytes": 16155,
+                              "resourceBytes": 25066,
+                              "unusedBytes": 16487,
                               "children": [
                                 {
                                   "name": "store",
-                                  "resourceBytes": 14789,
-                                  "unusedBytes": 11910,
+                                  "resourceBytes": 15138,
+                                  "unusedBytes": 12242,
                                   "children": [
                                     {
                                       "name": "filter-actions.ts?",
-                                      "resourceBytes": 946,
-                                      "unusedBytes": 844,
+                                      "resourceBytes": 1111,
+                                      "unusedBytes": 1025,
                                       "duplicatedNormalizedModuleName": "js/src/search/results/store/filter-actions.ts"
                                     },
                                     {
                                       "name": "item/resource-types.ts?",
-                                      "resourceBytes": 775,
+                                      "resourceBytes": 803,
                                       "unusedBytes": 453
                                     },
                                     {
                                       "name": "filter-store.ts?",
-                                      "resourceBytes": 13068,
-                                      "unusedBytes": 10613,
+                                      "resourceBytes": 13224,
+                                      "unusedBytes": 10764,
                                       "duplicatedNormalizedModuleName": "js/src/search/results/store/filter-store.ts"
                                     }
                                   ]
                                 },
                                 {
                                   "name": "view/filter",
-                                  "resourceBytes": 8934,
+                                  "resourceBytes": 8949,
                                   "unusedBytes": 4010,
                                   "children": [
                                     {
@@ -5050,13 +5128,13 @@
                                     },
                                     {
                                       "name": "autocomplete-filter.tsx?",
-                                      "resourceBytes": 4250,
+                                      "resourceBytes": 4255,
                                       "unusedBytes": 2654,
                                       "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-filter.tsx"
                                     },
                                     {
                                       "name": "autocomplete-filter-with-icon.tsx?",
-                                      "resourceBytes": 3541,
+                                      "resourceBytes": 3551,
                                       "unusedBytes": 315,
                                       "duplicatedNormalizedModuleName": "js/src/search/results/view/filter/autocomplete-filter-with-icon.tsx"
                                     }
@@ -5064,7 +5142,7 @@
                                 },
                                 {
                                   "name": "service/filter-api-service.ts?",
-                                  "resourceBytes": 974,
+                                  "resourceBytes": 979,
                                   "unusedBytes": 235
                                 }
                               ]
@@ -5091,39 +5169,6 @@
                       ]
                     },
                     {
-                      "name": "Symfony/src/CourseHero",
-                      "resourceBytes": 5728,
-                      "children": [
-                        {
-                          "name": "MarketingBundle/Resources/assets/js",
-                          "resourceBytes": 3217,
-                          "children": [
-                            {
-                              "name": "Widgets/testimonials.js",
-                              "resourceBytes": 2069
-                            },
-                            {
-                              "name": "HomepageAmplitudeTracking.js",
-                              "resourceBytes": 1148,
-                              "unusedBytes": 843
-                            }
-                          ],
-                          "unusedBytes": 843
-                        },
-                        {
-                          "name": "BookBundle/Resources/assets/js/Video/youtube-player-factory.js",
-                          "resourceBytes": 1712,
-                          "unusedBytes": 1015
-                        },
-                        {
-                          "name": "QABundle/Resources/assets/js/Widget/bootstrapAskQuestion.js",
-                          "resourceBytes": 799,
-                          "unusedBytes": 677
-                        }
-                      ],
-                      "unusedBytes": 2535
-                    },
-                    {
                       "name": "(unmapped)",
                       "resourceBytes": 98
                     }
@@ -5132,1379 +5177,1225 @@
               ]
             },
             {
-              "name": "https://www.coursehero.com/assets/js/compiled/qa/ask-expert-tutors/chunk.vendors~qa/ask-expert-tutors/app.de9bc9411fae437644a5.js",
-              "resourceBytes": 168172,
-              "unusedBytes": 106888,
+              "name": "https://www.coursehero.com/assets/js/compiled/qa/ask-expert-tutors/chunk.vendors~qa/ask-expert-tutors/app.b516eabb4825e0592af3.js",
+              "resourceBytes": 168175,
+              "unusedBytes": 106869,
               "children": [
                 {
-                  "name": "",
-                  "resourceBytes": 168172,
-                  "unusedBytes": 106888,
+                  "name": "js",
+                  "resourceBytes": 157879,
+                  "unusedBytes": 104037,
                   "children": [
                     {
-                      "name": "js",
-                      "resourceBytes": 157896,
-                      "unusedBytes": 104056,
+                      "name": "node_modules",
+                      "resourceBytes": 140337,
+                      "unusedBytes": 87862,
                       "children": [
                         {
-                          "name": "node_modules",
-                          "resourceBytes": 140354,
-                          "unusedBytes": 87881,
+                          "name": "classnames/index.js?",
+                          "resourceBytes": 446,
+                          "unusedBytes": 20
+                        },
+                        {
+                          "name": "prop-types",
+                          "resourceBytes": 701,
                           "children": [
                             {
-                              "name": "classnames/index.js?",
-                              "resourceBytes": 446,
-                              "unusedBytes": 20
+                              "name": "index.js?",
+                              "resourceBytes": 20
                             },
                             {
-                              "name": "prop-types",
-                              "resourceBytes": 701,
-                              "children": [
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 20
-                                },
-                                {
-                                  "name": "factoryWithThrowingShims.js?",
-                                  "resourceBytes": 623,
-                                  "unusedBytes": 295,
-                                  "duplicatedNormalizedModuleName": "node_modules/prop-types/factoryWithThrowingShims.js"
-                                },
-                                {
-                                  "name": "lib/ReactPropTypesSecret.js?",
-                                  "resourceBytes": 58
-                                }
-                              ],
-                              "unusedBytes": 295
+                              "name": "factoryWithThrowingShims.js?",
+                              "resourceBytes": 623,
+                              "unusedBytes": 295,
+                              "duplicatedNormalizedModuleName": "node_modules/prop-types/factoryWithThrowingShims.js"
                             },
                             {
-                              "name": "react-granite",
-                              "resourceBytes": 37160,
+                              "name": "lib/ReactPropTypesSecret.js?",
+                              "resourceBytes": 58
+                            }
+                          ],
+                          "unusedBytes": 295
+                        },
+                        {
+                          "name": "tslib/tslib.es6.js?",
+                          "resourceBytes": 394
+                        },
+                        {
+                          "name": "react-granite",
+                          "resourceBytes": 36833,
+                          "unusedBytes": 22999,
+                          "children": [
+                            {
+                              "name": "Box/index.js?",
+                              "resourceBytes": 414,
+                              "unusedBytes": 304
+                            },
+                            {
+                              "name": "common/index.js?",
+                              "resourceBytes": 576,
+                              "unusedBytes": 509
+                            },
+                            {
+                              "name": "Icon/index.js?",
+                              "resourceBytes": 332,
+                              "unusedBytes": 243
+                            },
+                            {
+                              "name": "node_modules",
+                              "resourceBytes": 18427,
+                              "unusedBytes": 7657,
                               "children": [
                                 {
-                                  "name": "node_modules",
-                                  "resourceBytes": 18627,
+                                  "name": "@reach/auto-id/es/index.js?",
+                                  "resourceBytes": 194,
+                                  "unusedBytes": 158
+                                },
+                                {
+                                  "name": "react-modal/lib",
+                                  "resourceBytes": 18233,
                                   "children": [
-                                    {
-                                      "name": "tslib/tslib.es6.js?",
-                                      "resourceBytes": 394
-                                    },
-                                    {
-                                      "name": "react-modal/lib",
-                                      "resourceBytes": 18233,
-                                      "children": [
-                                        {
-                                          "name": "helpers",
-                                          "resourceBytes": 5453,
-                                          "children": [
-                                            {
-                                              "name": "safeHTMLElement.js?",
-                                              "resourceBytes": 206
-                                            },
-                                            {
-                                              "name": "tabbable.js?",
-                                              "resourceBytes": 738,
-                                              "unusedBytes": 612,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/tabbable.js"
-                                            },
-                                            {
-                                              "name": "ariaAppHider.js?",
-                                              "resourceBytes": 969,
-                                              "unusedBytes": 487,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/ariaAppHider.js"
-                                            },
-                                            {
-                                              "name": "portalOpenInstances.js?",
-                                              "resourceBytes": 634,
-                                              "unusedBytes": 280,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/portalOpenInstances.js"
-                                            },
-                                            {
-                                              "name": "focusManager.js?",
-                                              "resourceBytes": 1028,
-                                              "unusedBytes": 777,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/focusManager.js"
-                                            },
-                                            {
-                                              "name": "scopeTab.js?",
-                                              "resourceBytes": 733,
-                                              "unusedBytes": 602,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/scopeTab.js"
-                                            },
-                                            {
-                                              "name": "classList.js?",
-                                              "resourceBytes": 472,
-                                              "unusedBytes": 373
-                                            },
-                                            {
-                                              "name": "bodyTrap.js?",
-                                              "resourceBytes": 673,
-                                              "unusedBytes": 571,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/bodyTrap.js"
-                                            }
-                                          ],
-                                          "unusedBytes": 3702
-                                        },
-                                        {
-                                          "name": "index.js?",
-                                          "resourceBytes": 141
-                                        },
-                                        {
-                                          "name": "components",
-                                          "resourceBytes": 12639,
-                                          "unusedBytes": 3797,
-                                          "children": [
-                                            {
-                                              "name": "Modal.js?",
-                                              "resourceBytes": 5302,
-                                              "unusedBytes": 810,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/components/Modal.js"
-                                            },
-                                            {
-                                              "name": "ModalPortal.js?",
-                                              "resourceBytes": 7337,
-                                              "unusedBytes": 2987,
-                                              "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/components/ModalPortal.js"
-                                            }
-                                          ]
-                                        }
-                                      ],
-                                      "unusedBytes": 7499
-                                    }
-                                  ],
-                                  "unusedBytes": 7499
-                                },
-                                {
-                                  "name": "Box/index.js?",
-                                  "resourceBytes": 414,
-                                  "unusedBytes": 304
-                                },
-                                {
-                                  "name": "common/index.js?",
-                                  "resourceBytes": 576,
-                                  "unusedBytes": 509
-                                },
-                                {
-                                  "name": "Icon/index.js?",
-                                  "resourceBytes": 332,
-                                  "unusedBytes": 243
-                                },
-                                {
-                                  "name": "Rover/index.js?",
-                                  "resourceBytes": 4284,
-                                  "unusedBytes": 4097
-                                },
-                                {
-                                  "name": "Button/index.js?",
-                                  "resourceBytes": 625,
-                                  "unusedBytes": 528
-                                },
-                                {
-                                  "name": "Spinner/index.js?",
-                                  "resourceBytes": 294,
-                                  "unusedBytes": 193
-                                },
-                                {
-                                  "name": "Modal/index.js?",
-                                  "resourceBytes": 1245,
-                                  "unusedBytes": 201
-                                },
-                                {
-                                  "name": "Tabs/index.js?",
-                                  "resourceBytes": 3068,
-                                  "unusedBytes": 2808
-                                },
-                                {
-                                  "name": "Accordion/index.js?",
-                                  "resourceBytes": 2274,
-                                  "unusedBytes": 2003
-                                },
-                                {
-                                  "name": "Dropdown/index.js?",
-                                  "resourceBytes": 3894,
-                                  "unusedBytes": 3163
-                                },
-                                {
-                                  "name": "LoadingButton/index.js?",
-                                  "resourceBytes": 822,
-                                  "unusedBytes": 732
-                                },
-                                {
-                                  "name": "Tooltip/index.js?",
-                                  "resourceBytes": 705,
-                                  "unusedBytes": 691
-                                }
-                              ],
-                              "unusedBytes": 22971
-                            },
-                            {
-                              "name": "@babel/runtime/helpers",
-                              "resourceBytes": 1296,
-                              "unusedBytes": 935,
-                              "children": [
-                                {
-                                  "name": "assertThisInitialized.js?",
-                                  "resourceBytes": 133,
-                                  "unusedBytes": 121
-                                },
-                                {
-                                  "name": "defineProperty.js?",
-                                  "resourceBytes": 130
-                                },
-                                {
-                                  "name": "esm",
-                                  "resourceBytes": 553,
-                                  "unusedBytes": 464,
-                                  "children": [
-                                    {
-                                      "name": "objectWithoutPropertiesLoose.js?",
-                                      "resourceBytes": 134,
-                                      "unusedBytes": 134
-                                    },
-                                    {
-                                      "name": "extends.js?",
-                                      "resourceBytes": 207,
-                                      "unusedBytes": 207
-                                    },
-                                    {
-                                      "name": "assertThisInitialized.js?",
-                                      "resourceBytes": 123,
-                                      "unusedBytes": 123
-                                    },
-                                    {
-                                      "name": "inheritsLoose.js?",
-                                      "resourceBytes": 89
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "extends.js?",
-                                  "resourceBytes": 231,
-                                  "unusedBytes": 218
-                                },
-                                {
-                                  "name": "inheritsLoose.js?",
-                                  "resourceBytes": 105
-                                },
-                                {
-                                  "name": "objectWithoutPropertiesLoose.js?",
-                                  "resourceBytes": 144,
-                                  "unusedBytes": 132
-                                }
-                              ]
-                            },
-                            {
-                              "name": "lodash-es",
-                              "resourceBytes": 23294,
-                              "children": [
-                                {
-                                  "name": "_root.js?",
-                                  "resourceBytes": 113
-                                },
-                                {
-                                  "name": "isArray.js?",
-                                  "resourceBytes": 27
-                                },
-                                {
-                                  "name": "isObject.js?",
-                                  "resourceBytes": 78
-                                },
-                                {
-                                  "name": "isObjectLike.js?",
-                                  "resourceBytes": 53
-                                },
-                                {
-                                  "name": "toString.js?",
-                                  "resourceBytes": 63,
-                                  "unusedBytes": 45
-                                },
-                                {
-                                  "name": "_getRawTag.js?",
-                                  "resourceBytes": 210
-                                },
-                                {
-                                  "name": "_objectToString.js?",
-                                  "resourceBytes": 64
-                                },
-                                {
-                                  "name": "_baseGetTag.js?",
-                                  "resourceBytes": 146
-                                },
-                                {
-                                  "name": "_Symbol.js?",
-                                  "resourceBytes": 28
-                                },
-                                {
-                                  "name": "isSymbol.js?",
-                                  "resourceBytes": 118,
-                                  "unusedBytes": 72
-                                },
-                                {
-                                  "name": "_hasUnicode.js?",
-                                  "resourceBytes": 135,
-                                  "unusedBytes": 29
-                                },
-                                {
-                                  "name": "_nodeUtil.js?",
-                                  "resourceBytes": 288
-                                },
-                                {
-                                  "name": "toNumber.js?",
-                                  "resourceBytes": 403,
-                                  "unusedBytes": 291
-                                },
-                                {
-                                  "name": "isBuffer.js?",
-                                  "resourceBytes": 213
-                                },
-                                {
-                                  "name": "_arrayMap.js?",
-                                  "resourceBytes": 99,
-                                  "unusedBytes": 92
-                                },
-                                {
-                                  "name": "_baseToString.js?",
-                                  "resourceBytes": 221,
-                                  "unusedBytes": 160
-                                },
-                                {
-                                  "name": "_freeGlobal.js?",
-                                  "resourceBytes": 70
-                                },
-                                {
-                                  "name": "_baseProperty.js?",
-                                  "resourceBytes": 65,
-                                  "unusedBytes": 39
-                                },
-                                {
-                                  "name": "_baseUnary.js?",
-                                  "resourceBytes": 50,
-                                  "unusedBytes": 44
-                                },
-                                {
-                                  "name": "now.js?",
-                                  "resourceBytes": 36,
-                                  "unusedBytes": 33
-                                },
-                                {
-                                  "name": "debounce.js?",
-                                  "resourceBytes": 933,
-                                  "unusedBytes": 880
-                                },
-                                {
-                                  "name": "throttle.js?",
-                                  "resourceBytes": 234,
-                                  "unusedBytes": 204
-                                },
-                                {
-                                  "name": "_asciiToArray.js?",
-                                  "resourceBytes": 38,
-                                  "unusedBytes": 31
-                                },
-                                {
-                                  "name": "_unicodeToArray.js?",
-                                  "resourceBytes": 427,
-                                  "unusedBytes": 34
-                                },
-                                {
-                                  "name": "_stringToArray.js?",
-                                  "resourceBytes": 50,
-                                  "unusedBytes": 44
-                                },
-                                {
-                                  "name": "_baseSlice.js?",
-                                  "resourceBytes": 155,
-                                  "unusedBytes": 148
-                                },
-                                {
-                                  "name": "_castSlice.js?",
-                                  "resourceBytes": 81,
-                                  "unusedBytes": 75
-                                },
-                                {
-                                  "name": "stubFalse.js?",
-                                  "resourceBytes": 26,
-                                  "unusedBytes": 20
-                                },
-                                {
-                                  "name": "isFunction.js?",
-                                  "resourceBytes": 197
-                                },
-                                {
-                                  "name": "_isMasked.js?",
-                                  "resourceBytes": 113
-                                },
-                                {
-                                  "name": "_coreJsData.js?",
-                                  "resourceBytes": 28
-                                },
-                                {
-                                  "name": "_toSource.js?",
-                                  "resourceBytes": 128
-                                },
-                                {
-                                  "name": "_baseIsNative.js?",
-                                  "resourceBytes": 317
-                                },
-                                {
-                                  "name": "_getValue.js?",
-                                  "resourceBytes": 48
-                                },
-                                {
-                                  "name": "_getNative.js?",
-                                  "resourceBytes": 55
-                                },
-                                {
-                                  "name": "_defineProperty.js?",
-                                  "resourceBytes": 85
-                                },
-                                {
-                                  "name": "_baseAssignValue.js?",
-                                  "resourceBytes": 107,
-                                  "unusedBytes": 100
-                                },
-                                {
-                                  "name": "_createBaseFor.js?",
-                                  "resourceBytes": 141,
-                                  "unusedBytes": 117
-                                },
-                                {
-                                  "name": "_baseFor.js?",
-                                  "resourceBytes": 5
-                                },
-                                {
-                                  "name": "_baseTimes.js?",
-                                  "resourceBytes": 71,
-                                  "unusedBytes": 64
-                                },
-                                {
-                                  "name": "_baseIsArguments.js?",
-                                  "resourceBytes": 83
-                                },
-                                {
-                                  "name": "isArguments.js?",
-                                  "resourceBytes": 177,
-                                  "unusedBytes": 75
-                                },
-                                {
-                                  "name": "_isIndex.js?",
-                                  "resourceBytes": 158,
-                                  "unusedBytes": 111
-                                },
-                                {
-                                  "name": "isLength.js?",
-                                  "resourceBytes": 83,
-                                  "unusedBytes": 57
-                                },
-                                {
-                                  "name": "_baseIsTypedArray.js?",
-                                  "resourceBytes": 642,
-                                  "unusedBytes": 68
-                                },
-                                {
-                                  "name": "isTypedArray.js?",
-                                  "resourceBytes": 45
-                                },
-                                {
-                                  "name": "_arrayLikeKeys.js?",
-                                  "resourceBytes": 342,
-                                  "unusedBytes": 301
-                                },
-                                {
-                                  "name": "_isPrototype.js?",
-                                  "resourceBytes": 111,
-                                  "unusedBytes": 85
-                                },
-                                {
-                                  "name": "_overArg.js?",
-                                  "resourceBytes": 53,
-                                  "unusedBytes": 27
-                                },
-                                {
-                                  "name": "_nativeKeys.js?",
-                                  "resourceBytes": 24
-                                },
-                                {
-                                  "name": "_baseKeys.js?",
-                                  "resourceBytes": 160,
-                                  "unusedBytes": 117
-                                },
-                                {
-                                  "name": "isArrayLike.js?",
-                                  "resourceBytes": 55,
-                                  "unusedBytes": 47
-                                },
-                                {
-                                  "name": "keys.js?",
-                                  "resourceBytes": 44,
-                                  "unusedBytes": 36
-                                },
-                                {
-                                  "name": "_baseForOwn.js?",
-                                  "resourceBytes": 42,
-                                  "unusedBytes": 34
-                                },
-                                {
-                                  "name": "_listCacheClear.js?",
-                                  "resourceBytes": 48,
-                                  "unusedBytes": 40
-                                },
-                                {
-                                  "name": "eq.js?",
-                                  "resourceBytes": 47,
-                                  "unusedBytes": 39
-                                },
-                                {
-                                  "name": "_assocIndexOf.js?",
-                                  "resourceBytes": 81,
-                                  "unusedBytes": 73
-                                },
-                                {
-                                  "name": "_listCacheDelete.js?",
-                                  "resourceBytes": 144,
-                                  "unusedBytes": 110
-                                },
-                                {
-                                  "name": "_listCacheGet.js?",
-                                  "resourceBytes": 76,
-                                  "unusedBytes": 68
-                                },
-                                {
-                                  "name": "_listCacheHas.js?",
-                                  "resourceBytes": 50,
-                                  "unusedBytes": 42
-                                },
-                                {
-                                  "name": "_listCacheSet.js?",
-                                  "resourceBytes": 106,
-                                  "unusedBytes": 98
-                                },
-                                {
-                                  "name": "_ListCache.js?",
-                                  "resourceBytes": 217,
-                                  "unusedBytes": 102
-                                },
-                                {
-                                  "name": "_stackClear.js?",
-                                  "resourceBytes": 52,
-                                  "unusedBytes": 44
-                                },
-                                {
-                                  "name": "_stackDelete.js?",
-                                  "resourceBytes": 80,
-                                  "unusedBytes": 72
-                                },
-                                {
-                                  "name": "_stackGet.js?",
-                                  "resourceBytes": 48,
-                                  "unusedBytes": 40
-                                },
-                                {
-                                  "name": "_stackHas.js?",
-                                  "resourceBytes": 48,
-                                  "unusedBytes": 40
-                                },
-                                {
-                                  "name": "_Map.js?",
-                                  "resourceBytes": 16
-                                },
-                                {
-                                  "name": "_nativeCreate.js?",
-                                  "resourceBytes": 22
-                                },
-                                {
-                                  "name": "_hashClear.js?",
-                                  "resourceBytes": 60
-                                },
-                                {
-                                  "name": "_hashDelete.js?",
-                                  "resourceBytes": 89,
-                                  "unusedBytes": 81
-                                },
-                                {
-                                  "name": "_hashGet.js?",
-                                  "resourceBytes": 179,
-                                  "unusedBytes": 105
-                                },
-                                {
-                                  "name": "_hashHas.js?",
-                                  "resourceBytes": 112,
-                                  "unusedBytes": 69
-                                },
-                                {
-                                  "name": "_hashSet.js?",
-                                  "resourceBytes": 137,
-                                  "unusedBytes": 98
-                                },
-                                {
-                                  "name": "_Hash.js?",
-                                  "resourceBytes": 217
-                                },
-                                {
-                                  "name": "_mapCacheClear.js?",
-                                  "resourceBytes": 89
-                                },
-                                {
-                                  "name": "_isKeyable.js?",
-                                  "resourceBytes": 118,
-                                  "unusedBytes": 110
-                                },
-                                {
-                                  "name": "_getMapData.js?",
-                                  "resourceBytes": 96,
-                                  "unusedBytes": 88
-                                },
-                                {
-                                  "name": "_mapCacheDelete.js?",
-                                  "resourceBytes": 73,
-                                  "unusedBytes": 65
-                                },
-                                {
-                                  "name": "_mapCacheGet.js?",
-                                  "resourceBytes": 45,
-                                  "unusedBytes": 37
-                                },
-                                {
-                                  "name": "_mapCacheHas.js?",
-                                  "resourceBytes": 45,
-                                  "unusedBytes": 37
-                                },
-                                {
-                                  "name": "_mapCacheSet.js?",
-                                  "resourceBytes": 96,
-                                  "unusedBytes": 88
-                                },
-                                {
-                                  "name": "_MapCache.js?",
-                                  "resourceBytes": 217
-                                },
-                                {
-                                  "name": "_stackSet.js?",
-                                  "resourceBytes": 219,
-                                  "unusedBytes": 204
-                                },
-                                {
-                                  "name": "_Stack.js?",
-                                  "resourceBytes": 177,
-                                  "unusedBytes": 62
-                                },
-                                {
-                                  "name": "_setCacheAdd.js?",
-                                  "resourceBytes": 87,
-                                  "unusedBytes": 48
-                                },
-                                {
-                                  "name": "_setCacheHas.js?",
-                                  "resourceBytes": 48,
-                                  "unusedBytes": 40
-                                },
-                                {
-                                  "name": "_SetCache.js?",
-                                  "resourceBytes": 160,
-                                  "unusedBytes": 92
-                                },
-                                {
-                                  "name": "_arraySome.js?",
-                                  "resourceBytes": 96,
-                                  "unusedBytes": 88
-                                },
-                                {
-                                  "name": "_cacheHas.js?",
-                                  "resourceBytes": 38,
-                                  "unusedBytes": 30
-                                },
-                                {
-                                  "name": "_equalArrays.js?",
-                                  "resourceBytes": 496,
-                                  "unusedBytes": 478
-                                },
-                                {
-                                  "name": "_Uint8Array.js?",
-                                  "resourceBytes": 18
-                                },
-                                {
-                                  "name": "_mapToArray.js?",
-                                  "resourceBytes": 95,
-                                  "unusedBytes": 87
-                                },
-                                {
-                                  "name": "_setToArray.js?",
-                                  "resourceBytes": 89,
-                                  "unusedBytes": 81
-                                },
-                                {
-                                  "name": "_equalByTag.js?",
-                                  "resourceBytes": 854,
-                                  "unusedBytes": 552
-                                },
-                                {
-                                  "name": "_arrayPush.js?",
-                                  "resourceBytes": 85,
-                                  "unusedBytes": 77
-                                },
-                                {
-                                  "name": "_baseGetAllKeys.js?",
-                                  "resourceBytes": 70,
-                                  "unusedBytes": 62
-                                },
-                                {
-                                  "name": "_arrayFilter.js?",
-                                  "resourceBytes": 114,
-                                  "unusedBytes": 106
-                                },
-                                {
-                                  "name": "stubArray.js?",
-                                  "resourceBytes": 28,
-                                  "unusedBytes": 20
-                                },
-                                {
-                                  "name": "_getSymbols.js?",
-                                  "resourceBytes": 172,
-                                  "unusedBytes": 89
-                                },
-                                {
-                                  "name": "_getAllKeys.js?",
-                                  "resourceBytes": 39,
-                                  "unusedBytes": 31
-                                },
-                                {
-                                  "name": "_equalObjects.js?",
-                                  "resourceBytes": 651,
-                                  "unusedBytes": 603
-                                },
-                                {
-                                  "name": "_DataView.js?",
-                                  "resourceBytes": 21
-                                },
-                                {
-                                  "name": "_Promise.js?",
-                                  "resourceBytes": 20
-                                },
-                                {
-                                  "name": "_Set.js?",
-                                  "resourceBytes": 16
-                                },
-                                {
-                                  "name": "_WeakMap.js?",
-                                  "resourceBytes": 20
-                                },
-                                {
-                                  "name": "_getTag.js?",
-                                  "resourceBytes": 540,
-                                  "unusedBytes": 271
-                                },
-                                {
-                                  "name": "_baseIsEqualDeep.js?",
-                                  "resourceBytes": 579,
-                                  "unusedBytes": 466
-                                },
-                                {
-                                  "name": "_baseIsEqual.js?",
-                                  "resourceBytes": 124,
-                                  "unusedBytes": 116
-                                },
-                                {
-                                  "name": "_baseIsMatch.js?",
-                                  "resourceBytes": 351,
-                                  "unusedBytes": 333
-                                },
-                                {
-                                  "name": "_isStrictComparable.js?",
-                                  "resourceBytes": 49,
-                                  "unusedBytes": 41
-                                },
-                                {
-                                  "name": "_getMatchData.js?",
-                                  "resourceBytes": 97,
-                                  "unusedBytes": 89
-                                },
-                                {
-                                  "name": "_matchesStrictComparable.js?",
-                                  "resourceBytes": 99,
-                                  "unusedBytes": 91
-                                },
-                                {
-                                  "name": "_baseMatches.js?",
-                                  "resourceBytes": 117,
-                                  "unusedBytes": 109
-                                },
-                                {
-                                  "name": "_isKey.js?",
-                                  "resourceBytes": 256,
-                                  "unusedBytes": 183
-                                },
-                                {
-                                  "name": "memoize.js?",
-                                  "resourceBytes": 328,
-                                  "unusedBytes": 143
-                                },
-                                {
-                                  "name": "_memoizeCapped.js?",
-                                  "resourceBytes": 101,
-                                  "unusedBytes": 44
-                                },
-                                {
-                                  "name": "_stringToPath.js?",
-                                  "resourceBytes": 256,
-                                  "unusedBytes": 132
-                                },
-                                {
-                                  "name": "_castPath.js?",
-                                  "resourceBytes": 78,
-                                  "unusedBytes": 70
-                                },
-                                {
-                                  "name": "_toKey.js?",
-                                  "resourceBytes": 116,
-                                  "unusedBytes": 101
-                                },
-                                {
-                                  "name": "_baseGet.js?",
-                                  "resourceBytes": 109,
-                                  "unusedBytes": 101
-                                },
-                                {
-                                  "name": "get.js?",
-                                  "resourceBytes": 75,
-                                  "unusedBytes": 67
-                                },
-                                {
-                                  "name": "_baseHasIn.js?",
-                                  "resourceBytes": 53,
-                                  "unusedBytes": 45
-                                },
-                                {
-                                  "name": "_hasPath.js?",
-                                  "resourceBytes": 205,
-                                  "unusedBytes": 197
-                                },
-                                {
-                                  "name": "hasIn.js?",
-                                  "resourceBytes": 49,
-                                  "unusedBytes": 41
-                                },
-                                {
-                                  "name": "_baseMatchesProperty.js?",
-                                  "resourceBytes": 138,
-                                  "unusedBytes": 120
-                                },
-                                {
-                                  "name": "identity.js?",
-                                  "resourceBytes": 29,
-                                  "unusedBytes": 21
-                                },
-                                {
-                                  "name": "_basePropertyDeep.js?",
-                                  "resourceBytes": 55,
-                                  "unusedBytes": 47
-                                },
-                                {
-                                  "name": "property.js?",
-                                  "resourceBytes": 59,
-                                  "unusedBytes": 51
-                                },
-                                {
-                                  "name": "_baseIteratee.js?",
-                                  "resourceBytes": 120,
-                                  "unusedBytes": 112
-                                },
-                                {
-                                  "name": "mapKeys.js?",
-                                  "resourceBytes": 89,
-                                  "unusedBytes": 83
-                                },
-                                {
-                                  "name": "_createCaseFirst.js?",
-                                  "resourceBytes": 174,
-                                  "unusedBytes": 150
-                                },
-                                {
-                                  "name": "upperFirst.js?",
-                                  "resourceBytes": 18
-                                },
-                                {
-                                  "name": "capitalize.js?",
-                                  "resourceBytes": 58,
-                                  "unusedBytes": 51
-                                },
-                                {
-                                  "name": "_arrayReduce.js?",
-                                  "resourceBytes": 108,
-                                  "unusedBytes": 101
-                                },
-                                {
-                                  "name": "_basePropertyOf.js?",
-                                  "resourceBytes": 63,
-                                  "unusedBytes": 39
-                                },
-                                {
-                                  "name": "_deburrLetter.js?",
-                                  "resourceBytes": 1536
-                                },
-                                {
-                                  "name": "deburr.js?",
-                                  "resourceBytes": 186,
-                                  "unusedBytes": 67
-                                },
-                                {
-                                  "name": "_asciiWords.js?",
-                                  "resourceBytes": 87,
-                                  "unusedBytes": 34
-                                },
-                                {
-                                  "name": "_hasUnicodeWord.js?",
-                                  "resourceBytes": 107,
-                                  "unusedBytes": 29
-                                },
-                                {
-                                  "name": "_unicodeWords.js?",
-                                  "resourceBytes": 1159,
-                                  "unusedBytes": 34
-                                },
-                                {
-                                  "name": "words.js?",
-                                  "resourceBytes": 101,
-                                  "unusedBytes": 94
-                                },
-                                {
-                                  "name": "_createCompounder.js?",
-                                  "resourceBytes": 94,
-                                  "unusedBytes": 49
-                                },
-                                {
-                                  "name": "camelCase.js?",
-                                  "resourceBytes": 68,
-                                  "unusedBytes": 54
-                                },
-                                {
-                                  "name": "_baseIsRegExp.js?",
-                                  "resourceBytes": 80,
-                                  "unusedBytes": 53
-                                },
-                                {
-                                  "name": "isRegExp.js?",
-                                  "resourceBytes": 41
-                                },
-                                {
-                                  "name": "_asciiSize.js?",
-                                  "resourceBytes": 24
-                                },
-                                {
-                                  "name": "_unicodeSize.js?",
-                                  "resourceBytes": 453,
-                                  "unusedBytes": 60
-                                },
-                                {
-                                  "name": "_stringSize.js?",
-                                  "resourceBytes": 51,
-                                  "unusedBytes": 44
-                                },
-                                {
-                                  "name": "toFinite.js?",
-                                  "resourceBytes": 121,
-                                  "unusedBytes": 84
-                                },
-                                {
-                                  "name": "toInteger.js?",
-                                  "resourceBytes": 58,
-                                  "unusedBytes": 51
-                                },
-                                {
-                                  "name": "truncate.js?",
-                                  "resourceBytes": 676,
-                                  "unusedBytes": 648,
-                                  "duplicatedNormalizedModuleName": "node_modules/lodash-es/truncate.js"
-                                }
-                              ],
-                              "unusedBytes": 12492
-                            },
-                            {
-                              "name": "axios",
-                              "resourceBytes": 12954,
-                              "unusedBytes": 9010,
-                              "children": [
-                                {
-                                  "name": "lib",
-                                  "resourceBytes": 12936,
-                                  "unusedBytes": 9010,
-                                  "children": [
-                                    {
-                                      "name": "utils.js?",
-                                      "resourceBytes": 2144,
-                                      "unusedBytes": 991,
-                                      "duplicatedNormalizedModuleName": "node_modules/axios/lib/utils.js"
-                                    },
                                     {
                                       "name": "helpers",
-                                      "resourceBytes": 2870,
-                                      "unusedBytes": 1862,
+                                      "resourceBytes": 5453,
                                       "children": [
                                         {
-                                          "name": "bind.js?",
-                                          "resourceBytes": 140,
-                                          "unusedBytes": 106
+                                          "name": "safeHTMLElement.js?",
+                                          "resourceBytes": 206
                                         },
                                         {
-                                          "name": "buildURL.js?",
-                                          "resourceBytes": 595,
+                                          "name": "tabbable.js?",
+                                          "resourceBytes": 738,
+                                          "unusedBytes": 612,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/tabbable.js"
+                                        },
+                                        {
+                                          "name": "ariaAppHider.js?",
+                                          "resourceBytes": 969,
+                                          "unusedBytes": 487,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/ariaAppHider.js"
+                                        },
+                                        {
+                                          "name": "portalOpenInstances.js?",
+                                          "resourceBytes": 634,
+                                          "unusedBytes": 280,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/portalOpenInstances.js"
+                                        },
+                                        {
+                                          "name": "focusManager.js?",
+                                          "resourceBytes": 1028,
+                                          "unusedBytes": 777,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/focusManager.js"
+                                        },
+                                        {
+                                          "name": "scopeTab.js?",
+                                          "resourceBytes": 733,
+                                          "unusedBytes": 602,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/scopeTab.js"
+                                        },
+                                        {
+                                          "name": "classList.js?",
+                                          "resourceBytes": 472,
+                                          "unusedBytes": 373
+                                        },
+                                        {
+                                          "name": "bodyTrap.js?",
+                                          "resourceBytes": 673,
                                           "unusedBytes": 571,
-                                          "duplicatedNormalizedModuleName": "node_modules/axios/lib/helpers/buildURL.js"
-                                        },
-                                        {
-                                          "name": "normalizeHeaderName.js?",
-                                          "resourceBytes": 131,
-                                          "unusedBytes": 107
-                                        },
-                                        {
-                                          "name": "cookies.js?",
-                                          "resourceBytes": 555,
-                                          "unusedBytes": 461,
-                                          "duplicatedNormalizedModuleName": "node_modules/axios/lib/helpers/cookies.js"
-                                        },
-                                        {
-                                          "name": "isAbsoluteURL.js?",
-                                          "resourceBytes": 70,
-                                          "unusedBytes": 58
-                                        },
-                                        {
-                                          "name": "combineURLs.js?",
-                                          "resourceBytes": 83,
-                                          "unusedBytes": 71
-                                        },
-                                        {
-                                          "name": "parseHeaders.js?",
-                                          "resourceBytes": 524,
-                                          "unusedBytes": 268,
-                                          "duplicatedNormalizedModuleName": "node_modules/axios/lib/helpers/parseHeaders.js"
-                                        },
-                                        {
-                                          "name": "isURLSameOrigin.js?",
-                                          "resourceBytes": 635,
-                                          "unusedBytes": 107,
-                                          "duplicatedNormalizedModuleName": "node_modules/axios/lib/helpers/isURLSameOrigin.js"
-                                        },
-                                        {
-                                          "name": "spread.js?",
-                                          "resourceBytes": 67,
-                                          "unusedBytes": 55
-                                        },
-                                        {
-                                          "name": "isAxiosError.js?",
-                                          "resourceBytes": 70,
-                                          "unusedBytes": 58
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/helpers/bodyTrap.js"
                                         }
-                                      ]
-                                    },
-                                    {
-                                      "name": "cancel",
-                                      "resourceBytes": 590,
-                                      "unusedBytes": 452,
-                                      "children": [
-                                        {
-                                          "name": "isCancel.js?",
-                                          "resourceBytes": 51,
-                                          "unusedBytes": 39
-                                        },
-                                        {
-                                          "name": "Cancel.js?",
-                                          "resourceBytes": 152,
-                                          "unusedBytes": 91
-                                        },
-                                        {
-                                          "name": "CancelToken.js?",
-                                          "resourceBytes": 387,
-                                          "unusedBytes": 322
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "name": "defaults.js?",
-                                      "resourceBytes": 1155,
-                                      "unusedBytes": 545,
-                                      "duplicatedNormalizedModuleName": "node_modules/axios/lib/defaults.js"
-                                    },
-                                    {
-                                      "name": "adapters/xhr.js?",
-                                      "resourceBytes": 1871,
-                                      "unusedBytes": 1786
-                                    },
-                                    {
-                                      "name": "core",
-                                      "resourceBytes": 3926,
-                                      "unusedBytes": 3302,
-                                      "children": [
-                                        {
-                                          "name": "createError.js?",
-                                          "resourceBytes": 84,
-                                          "unusedBytes": 59
-                                        },
-                                        {
-                                          "name": "mergeConfig.js?",
-                                          "resourceBytes": 1159,
-                                          "unusedBytes": 1135,
-                                          "duplicatedNormalizedModuleName": "node_modules/axios/lib/core/mergeConfig.js"
-                                        },
-                                        {
-                                          "name": "Axios.js?",
-                                          "resourceBytes": 1040,
-                                          "unusedBytes": 720,
-                                          "duplicatedNormalizedModuleName": "node_modules/axios/lib/core/Axios.js"
-                                        },
-                                        {
-                                          "name": "InterceptorManager.js?",
-                                          "resourceBytes": 322,
-                                          "unusedBytes": 210
-                                        },
-                                        {
-                                          "name": "dispatchRequest.js?",
-                                          "resourceBytes": 631,
-                                          "unusedBytes": 582,
-                                          "duplicatedNormalizedModuleName": "node_modules/axios/lib/core/dispatchRequest.js"
-                                        },
-                                        {
-                                          "name": "transformData.js?",
-                                          "resourceBytes": 86,
-                                          "unusedBytes": 62
-                                        },
-                                        {
-                                          "name": "settle.js?",
-                                          "resourceBytes": 177,
-                                          "unusedBytes": 153
-                                        },
-                                        {
-                                          "name": "enhanceError.js?",
-                                          "resourceBytes": 354,
-                                          "unusedBytes": 342
-                                        },
-                                        {
-                                          "name": "buildFullPath.js?",
-                                          "resourceBytes": 73,
-                                          "unusedBytes": 39
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "name": "axios.js?",
-                                      "resourceBytes": 380,
-                                      "unusedBytes": 72
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 18
-                                }
-                              ]
-                            },
-                            {
-                              "name": "compute-scroll-into-view/es/index.js?",
-                              "resourceBytes": 2197,
-                              "unusedBytes": 2190
-                            },
-                            {
-                              "name": "downshift/dist/downshift.esm.js?",
-                              "resourceBytes": 16831,
-                              "unusedBytes": 15184
-                            },
-                            {
-                              "name": "@reach/auto-id/es/index.js?",
-                              "resourceBytes": 194,
-                              "unusedBytes": 158
-                            },
-                            {
-                              "name": "warning/warning.js?",
-                              "resourceBytes": 32,
-                              "unusedBytes": 12
-                            },
-                            {
-                              "name": "function-bind",
-                              "resourceBytes": 732,
-                              "children": [
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 51
-                                },
-                                {
-                                  "name": "implementation.js?",
-                                  "resourceBytes": 681,
-                                  "unusedBytes": 561,
-                                  "duplicatedNormalizedModuleName": "node_modules/function-bind/implementation.js"
-                                }
-                              ],
-                              "unusedBytes": 561
-                            },
-                            {
-                              "name": "define-properties",
-                              "resourceBytes": 2763,
-                              "children": [
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 651,
-                                  "duplicatedNormalizedModuleName": "node_modules/define-properties/index.js"
-                                },
-                                {
-                                  "name": "node_modules/object-keys",
-                                  "resourceBytes": 2112,
-                                  "unusedBytes": 1946,
-                                  "children": [
-                                    {
-                                      "name": "isArguments.js?",
-                                      "resourceBytes": 246,
-                                      "unusedBytes": 202
+                                      ],
+                                      "unusedBytes": 3702
                                     },
                                     {
                                       "name": "index.js?",
-                                      "resourceBytes": 322,
-                                      "unusedBytes": 201
+                                      "resourceBytes": 141
                                     },
                                     {
-                                      "name": "implementation.js?",
-                                      "resourceBytes": 1544,
-                                      "unusedBytes": 1543,
-                                      "duplicatedNormalizedModuleName": "node_modules/object-keys/implementation.js"
-                                    }
-                                  ]
-                                }
-                              ],
-                              "unusedBytes": 1946
-                            },
-                            {
-                              "name": "create-react-context/lib",
-                              "resourceBytes": 2768,
-                              "children": [
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 159
-                                },
-                                {
-                                  "name": "implementation.js?",
-                                  "resourceBytes": 2609,
-                                  "unusedBytes": 2444,
-                                  "duplicatedNormalizedModuleName": "node_modules/create-react-context/lib/implementation.js"
-                                }
-                              ],
-                              "unusedBytes": 2444
-                            },
-                            {
-                              "name": "react-is",
-                              "resourceBytes": 2126,
-                              "children": [
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 18
-                                },
-                                {
-                                  "name": "cjs/react-is.production.min.js?",
-                                  "resourceBytes": 2108,
-                                  "unusedBytes": 929
-                                }
-                              ],
-                              "unusedBytes": 929
-                            },
-                            {
-                              "name": "dom-helpers",
-                              "resourceBytes": 3346,
-                              "children": [
-                                {
-                                  "name": "util",
-                                  "resourceBytes": 776,
-                                  "children": [
-                                    {
-                                      "name": "inDOM.js?",
-                                      "resourceBytes": 160
-                                    },
-                                    {
-                                      "name": "requestAnimationFrame.js?",
-                                      "resourceBytes": 616,
-                                      "unusedBytes": 215,
-                                      "duplicatedNormalizedModuleName": "node_modules/dom-helpers/util/requestAnimationFrame.js"
+                                      "name": "components",
+                                      "resourceBytes": 12639,
+                                      "unusedBytes": 3797,
+                                      "children": [
+                                        {
+                                          "name": "Modal.js?",
+                                          "resourceBytes": 5302,
+                                          "unusedBytes": 810,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/components/Modal.js"
+                                        },
+                                        {
+                                          "name": "ModalPortal.js?",
+                                          "resourceBytes": 7337,
+                                          "unusedBytes": 2987,
+                                          "duplicatedNormalizedModuleName": "node_modules/react-modal/lib/components/ModalPortal.js"
+                                        }
+                                      ]
                                     }
                                   ],
-                                  "unusedBytes": 215
-                                },
-                                {
-                                  "name": "class",
-                                  "resourceBytes": 847,
-                                  "unusedBytes": 622,
-                                  "children": [
-                                    {
-                                      "name": "addClass.js?",
-                                      "resourceBytes": 327,
-                                      "unusedBytes": 195
-                                    },
-                                    {
-                                      "name": "hasClass.js?",
-                                      "resourceBytes": 212,
-                                      "unusedBytes": 131
-                                    },
-                                    {
-                                      "name": "removeClass.js?",
-                                      "resourceBytes": 308,
-                                      "unusedBytes": 296
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "transition/properties.js?",
-                                  "resourceBytes": 1723,
-                                  "unusedBytes": 98
-                                }
-                              ],
-                              "unusedBytes": 935
-                            },
-                            {
-                              "name": "react-transition-group",
-                              "resourceBytes": 10631,
-                              "unusedBytes": 7313,
-                              "children": [
-                                {
-                                  "name": "utils",
-                                  "resourceBytes": 1406,
-                                  "unusedBytes": 821,
-                                  "children": [
-                                    {
-                                      "name": "PropTypes.js?",
-                                      "resourceBytes": 879,
-                                      "unusedBytes": 363,
-                                      "duplicatedNormalizedModuleName": "node_modules/react-transition-group/utils/PropTypes.js"
-                                    },
-                                    {
-                                      "name": "ChildMapping.js?",
-                                      "resourceBytes": 527,
-                                      "unusedBytes": 458,
-                                      "duplicatedNormalizedModuleName": "node_modules/react-transition-group/utils/ChildMapping.js"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "CSSTransitionGroup.js?",
-                                  "resourceBytes": 1841,
-                                  "unusedBytes": 986,
-                                  "duplicatedNormalizedModuleName": "node_modules/react-transition-group/CSSTransitionGroup.js"
-                                },
-                                {
-                                  "name": "TransitionGroup.js?",
-                                  "resourceBytes": 4014,
-                                  "unusedBytes": 3178,
-                                  "duplicatedNormalizedModuleName": "node_modules/react-transition-group/TransitionGroup.js"
-                                },
-                                {
-                                  "name": "node_modules/warning/browser.js?",
-                                  "resourceBytes": 24,
-                                  "unusedBytes": 12
-                                },
-                                {
-                                  "name": "CSSTransitionGroupChild.js?",
-                                  "resourceBytes": 3346,
-                                  "unusedBytes": 2316,
-                                  "duplicatedNormalizedModuleName": "node_modules/react-transition-group/CSSTransitionGroupChild.js"
+                                  "unusedBytes": 7499
                                 }
                               ]
                             },
                             {
-                              "name": "object-keys",
-                              "resourceBytes": 2163,
-                              "unusedBytes": 2021,
+                              "name": "Rover/index.js?",
+                              "resourceBytes": 4284,
+                              "unusedBytes": 4097
+                            },
+                            {
+                              "name": "Button/index.js?",
+                              "resourceBytes": 625,
+                              "unusedBytes": 528
+                            },
+                            {
+                              "name": "Spinner/index.js?",
+                              "resourceBytes": 294,
+                              "unusedBytes": 193
+                            },
+                            {
+                              "name": "Modal/index.js?",
+                              "resourceBytes": 1254,
+                              "unusedBytes": 207
+                            },
+                            {
+                              "name": "Tabs/index.js?",
+                              "resourceBytes": 2994,
+                              "unusedBytes": 2734
+                            },
+                            {
+                              "name": "Accordion/index.js?",
+                              "resourceBytes": 2212,
+                              "unusedBytes": 1941
+                            },
+                            {
+                              "name": "Dropdown/index.js?",
+                              "resourceBytes": 3894,
+                              "unusedBytes": 3163
+                            },
+                            {
+                              "name": "LoadingButton/index.js?",
+                              "resourceBytes": 822,
+                              "unusedBytes": 732
+                            },
+                            {
+                              "name": "Tooltip/index.js?",
+                              "resourceBytes": 705,
+                              "unusedBytes": 691
+                            }
+                          ]
+                        },
+                        {
+                          "name": "@babel/runtime/helpers",
+                          "resourceBytes": 1296,
+                          "unusedBytes": 935,
+                          "children": [
+                            {
+                              "name": "assertThisInitialized.js?",
+                              "resourceBytes": 133,
+                              "unusedBytes": 121
+                            },
+                            {
+                              "name": "defineProperty.js?",
+                              "resourceBytes": 130
+                            },
+                            {
+                              "name": "esm",
+                              "resourceBytes": 553,
+                              "unusedBytes": 464,
+                              "children": [
+                                {
+                                  "name": "objectWithoutPropertiesLoose.js?",
+                                  "resourceBytes": 134,
+                                  "unusedBytes": 134
+                                },
+                                {
+                                  "name": "extends.js?",
+                                  "resourceBytes": 207,
+                                  "unusedBytes": 207
+                                },
+                                {
+                                  "name": "assertThisInitialized.js?",
+                                  "resourceBytes": 123,
+                                  "unusedBytes": 123
+                                },
+                                {
+                                  "name": "inheritsLoose.js?",
+                                  "resourceBytes": 89
+                                }
+                              ]
+                            },
+                            {
+                              "name": "extends.js?",
+                              "resourceBytes": 231,
+                              "unusedBytes": 218
+                            },
+                            {
+                              "name": "inheritsLoose.js?",
+                              "resourceBytes": 105
+                            },
+                            {
+                              "name": "objectWithoutPropertiesLoose.js?",
+                              "resourceBytes": 144,
+                              "unusedBytes": 132
+                            }
+                          ]
+                        },
+                        {
+                          "name": "lodash-es",
+                          "resourceBytes": 23404,
+                          "children": [
+                            {
+                              "name": "_root.js?",
+                              "resourceBytes": 113
+                            },
+                            {
+                              "name": "isArray.js?",
+                              "resourceBytes": 27
+                            },
+                            {
+                              "name": "isObject.js?",
+                              "resourceBytes": 78
+                            },
+                            {
+                              "name": "isObjectLike.js?",
+                              "resourceBytes": 53
+                            },
+                            {
+                              "name": "toString.js?",
+                              "resourceBytes": 63,
+                              "unusedBytes": 45
+                            },
+                            {
+                              "name": "_getRawTag.js?",
+                              "resourceBytes": 210
+                            },
+                            {
+                              "name": "_objectToString.js?",
+                              "resourceBytes": 64
+                            },
+                            {
+                              "name": "_baseGetTag.js?",
+                              "resourceBytes": 146
+                            },
+                            {
+                              "name": "_Symbol.js?",
+                              "resourceBytes": 28
+                            },
+                            {
+                              "name": "isSymbol.js?",
+                              "resourceBytes": 118,
+                              "unusedBytes": 72
+                            },
+                            {
+                              "name": "_hasUnicode.js?",
+                              "resourceBytes": 135,
+                              "unusedBytes": 29
+                            },
+                            {
+                              "name": "_nodeUtil.js?",
+                              "resourceBytes": 288
+                            },
+                            {
+                              "name": "isBuffer.js?",
+                              "resourceBytes": 213
+                            },
+                            {
+                              "name": "_trimmedEndIndex.js?",
+                              "resourceBytes": 85,
+                              "unusedBytes": 67
+                            },
+                            {
+                              "name": "_baseTrim.js?",
+                              "resourceBytes": 71,
+                              "unusedBytes": 55
+                            },
+                            {
+                              "name": "toNumber.js?",
+                              "resourceBytes": 357,
+                              "unusedBytes": 280
+                            },
+                            {
+                              "name": "_arrayMap.js?",
+                              "resourceBytes": 99,
+                              "unusedBytes": 92
+                            },
+                            {
+                              "name": "_baseToString.js?",
+                              "resourceBytes": 221,
+                              "unusedBytes": 160
+                            },
+                            {
+                              "name": "_freeGlobal.js?",
+                              "resourceBytes": 70
+                            },
+                            {
+                              "name": "_baseUnary.js?",
+                              "resourceBytes": 50,
+                              "unusedBytes": 44
+                            },
+                            {
+                              "name": "_baseProperty.js?",
+                              "resourceBytes": 65,
+                              "unusedBytes": 39
+                            },
+                            {
+                              "name": "now.js?",
+                              "resourceBytes": 36,
+                              "unusedBytes": 33
+                            },
+                            {
+                              "name": "debounce.js?",
+                              "resourceBytes": 933,
+                              "unusedBytes": 880
+                            },
+                            {
+                              "name": "throttle.js?",
+                              "resourceBytes": 234,
+                              "unusedBytes": 204
+                            },
+                            {
+                              "name": "_asciiToArray.js?",
+                              "resourceBytes": 38,
+                              "unusedBytes": 31
+                            },
+                            {
+                              "name": "_unicodeToArray.js?",
+                              "resourceBytes": 427,
+                              "unusedBytes": 34
+                            },
+                            {
+                              "name": "_stringToArray.js?",
+                              "resourceBytes": 50,
+                              "unusedBytes": 44
+                            },
+                            {
+                              "name": "_baseSlice.js?",
+                              "resourceBytes": 155,
+                              "unusedBytes": 148
+                            },
+                            {
+                              "name": "_castSlice.js?",
+                              "resourceBytes": 81,
+                              "unusedBytes": 75
+                            },
+                            {
+                              "name": "stubFalse.js?",
+                              "resourceBytes": 26,
+                              "unusedBytes": 20
+                            },
+                            {
+                              "name": "isFunction.js?",
+                              "resourceBytes": 197
+                            },
+                            {
+                              "name": "_isMasked.js?",
+                              "resourceBytes": 113
+                            },
+                            {
+                              "name": "_coreJsData.js?",
+                              "resourceBytes": 28
+                            },
+                            {
+                              "name": "_toSource.js?",
+                              "resourceBytes": 128
+                            },
+                            {
+                              "name": "_baseIsNative.js?",
+                              "resourceBytes": 317
+                            },
+                            {
+                              "name": "_getValue.js?",
+                              "resourceBytes": 48
+                            },
+                            {
+                              "name": "_getNative.js?",
+                              "resourceBytes": 55
+                            },
+                            {
+                              "name": "_defineProperty.js?",
+                              "resourceBytes": 85
+                            },
+                            {
+                              "name": "_baseAssignValue.js?",
+                              "resourceBytes": 107,
+                              "unusedBytes": 100
+                            },
+                            {
+                              "name": "_createBaseFor.js?",
+                              "resourceBytes": 141,
+                              "unusedBytes": 117
+                            },
+                            {
+                              "name": "_baseFor.js?",
+                              "resourceBytes": 5
+                            },
+                            {
+                              "name": "_baseTimes.js?",
+                              "resourceBytes": 71,
+                              "unusedBytes": 64
+                            },
+                            {
+                              "name": "_baseIsArguments.js?",
+                              "resourceBytes": 83
+                            },
+                            {
+                              "name": "isArguments.js?",
+                              "resourceBytes": 177,
+                              "unusedBytes": 75
+                            },
+                            {
+                              "name": "_isIndex.js?",
+                              "resourceBytes": 158,
+                              "unusedBytes": 111
+                            },
+                            {
+                              "name": "isLength.js?",
+                              "resourceBytes": 83,
+                              "unusedBytes": 57
+                            },
+                            {
+                              "name": "_baseIsTypedArray.js?",
+                              "resourceBytes": 642,
+                              "unusedBytes": 68
+                            },
+                            {
+                              "name": "isTypedArray.js?",
+                              "resourceBytes": 45
+                            },
+                            {
+                              "name": "_arrayLikeKeys.js?",
+                              "resourceBytes": 342,
+                              "unusedBytes": 301
+                            },
+                            {
+                              "name": "_isPrototype.js?",
+                              "resourceBytes": 111,
+                              "unusedBytes": 85
+                            },
+                            {
+                              "name": "_overArg.js?",
+                              "resourceBytes": 53,
+                              "unusedBytes": 27
+                            },
+                            {
+                              "name": "_nativeKeys.js?",
+                              "resourceBytes": 24
+                            },
+                            {
+                              "name": "_baseKeys.js?",
+                              "resourceBytes": 160,
+                              "unusedBytes": 117
+                            },
+                            {
+                              "name": "isArrayLike.js?",
+                              "resourceBytes": 55,
+                              "unusedBytes": 47
+                            },
+                            {
+                              "name": "keys.js?",
+                              "resourceBytes": 44,
+                              "unusedBytes": 36
+                            },
+                            {
+                              "name": "_baseForOwn.js?",
+                              "resourceBytes": 42,
+                              "unusedBytes": 34
+                            },
+                            {
+                              "name": "_listCacheClear.js?",
+                              "resourceBytes": 48,
+                              "unusedBytes": 40
+                            },
+                            {
+                              "name": "eq.js?",
+                              "resourceBytes": 47,
+                              "unusedBytes": 39
+                            },
+                            {
+                              "name": "_assocIndexOf.js?",
+                              "resourceBytes": 81,
+                              "unusedBytes": 73
+                            },
+                            {
+                              "name": "_listCacheDelete.js?",
+                              "resourceBytes": 144,
+                              "unusedBytes": 110
+                            },
+                            {
+                              "name": "_listCacheGet.js?",
+                              "resourceBytes": 76,
+                              "unusedBytes": 68
+                            },
+                            {
+                              "name": "_listCacheHas.js?",
+                              "resourceBytes": 50,
+                              "unusedBytes": 42
+                            },
+                            {
+                              "name": "_listCacheSet.js?",
+                              "resourceBytes": 106,
+                              "unusedBytes": 98
+                            },
+                            {
+                              "name": "_ListCache.js?",
+                              "resourceBytes": 217,
+                              "unusedBytes": 102
+                            },
+                            {
+                              "name": "_stackClear.js?",
+                              "resourceBytes": 52,
+                              "unusedBytes": 44
+                            },
+                            {
+                              "name": "_stackDelete.js?",
+                              "resourceBytes": 80,
+                              "unusedBytes": 72
+                            },
+                            {
+                              "name": "_stackGet.js?",
+                              "resourceBytes": 48,
+                              "unusedBytes": 40
+                            },
+                            {
+                              "name": "_stackHas.js?",
+                              "resourceBytes": 48,
+                              "unusedBytes": 40
+                            },
+                            {
+                              "name": "_Map.js?",
+                              "resourceBytes": 16
+                            },
+                            {
+                              "name": "_nativeCreate.js?",
+                              "resourceBytes": 22
+                            },
+                            {
+                              "name": "_hashClear.js?",
+                              "resourceBytes": 60
+                            },
+                            {
+                              "name": "_hashDelete.js?",
+                              "resourceBytes": 89,
+                              "unusedBytes": 81
+                            },
+                            {
+                              "name": "_hashGet.js?",
+                              "resourceBytes": 179,
+                              "unusedBytes": 105
+                            },
+                            {
+                              "name": "_hashHas.js?",
+                              "resourceBytes": 112,
+                              "unusedBytes": 69
+                            },
+                            {
+                              "name": "_hashSet.js?",
+                              "resourceBytes": 137,
+                              "unusedBytes": 98
+                            },
+                            {
+                              "name": "_Hash.js?",
+                              "resourceBytes": 217
+                            },
+                            {
+                              "name": "_mapCacheClear.js?",
+                              "resourceBytes": 89
+                            },
+                            {
+                              "name": "_isKeyable.js?",
+                              "resourceBytes": 118,
+                              "unusedBytes": 110
+                            },
+                            {
+                              "name": "_getMapData.js?",
+                              "resourceBytes": 96,
+                              "unusedBytes": 88
+                            },
+                            {
+                              "name": "_mapCacheDelete.js?",
+                              "resourceBytes": 73,
+                              "unusedBytes": 65
+                            },
+                            {
+                              "name": "_mapCacheGet.js?",
+                              "resourceBytes": 45,
+                              "unusedBytes": 37
+                            },
+                            {
+                              "name": "_mapCacheHas.js?",
+                              "resourceBytes": 45,
+                              "unusedBytes": 37
+                            },
+                            {
+                              "name": "_mapCacheSet.js?",
+                              "resourceBytes": 96,
+                              "unusedBytes": 88
+                            },
+                            {
+                              "name": "_MapCache.js?",
+                              "resourceBytes": 217
+                            },
+                            {
+                              "name": "_stackSet.js?",
+                              "resourceBytes": 219,
+                              "unusedBytes": 204
+                            },
+                            {
+                              "name": "_Stack.js?",
+                              "resourceBytes": 177,
+                              "unusedBytes": 62
+                            },
+                            {
+                              "name": "_setCacheAdd.js?",
+                              "resourceBytes": 87,
+                              "unusedBytes": 48
+                            },
+                            {
+                              "name": "_setCacheHas.js?",
+                              "resourceBytes": 48,
+                              "unusedBytes": 40
+                            },
+                            {
+                              "name": "_SetCache.js?",
+                              "resourceBytes": 160,
+                              "unusedBytes": 92
+                            },
+                            {
+                              "name": "_arraySome.js?",
+                              "resourceBytes": 96,
+                              "unusedBytes": 88
+                            },
+                            {
+                              "name": "_cacheHas.js?",
+                              "resourceBytes": 38,
+                              "unusedBytes": 30
+                            },
+                            {
+                              "name": "_equalArrays.js?",
+                              "resourceBytes": 496,
+                              "unusedBytes": 478
+                            },
+                            {
+                              "name": "_Uint8Array.js?",
+                              "resourceBytes": 18
+                            },
+                            {
+                              "name": "_mapToArray.js?",
+                              "resourceBytes": 95,
+                              "unusedBytes": 87
+                            },
+                            {
+                              "name": "_setToArray.js?",
+                              "resourceBytes": 89,
+                              "unusedBytes": 81
+                            },
+                            {
+                              "name": "_equalByTag.js?",
+                              "resourceBytes": 854,
+                              "unusedBytes": 552
+                            },
+                            {
+                              "name": "_arrayPush.js?",
+                              "resourceBytes": 85,
+                              "unusedBytes": 77
+                            },
+                            {
+                              "name": "_baseGetAllKeys.js?",
+                              "resourceBytes": 70,
+                              "unusedBytes": 62
+                            },
+                            {
+                              "name": "_arrayFilter.js?",
+                              "resourceBytes": 114,
+                              "unusedBytes": 106
+                            },
+                            {
+                              "name": "stubArray.js?",
+                              "resourceBytes": 28,
+                              "unusedBytes": 20
+                            },
+                            {
+                              "name": "_getSymbols.js?",
+                              "resourceBytes": 172,
+                              "unusedBytes": 89
+                            },
+                            {
+                              "name": "_getAllKeys.js?",
+                              "resourceBytes": 39,
+                              "unusedBytes": 31
+                            },
+                            {
+                              "name": "_equalObjects.js?",
+                              "resourceBytes": 651,
+                              "unusedBytes": 603
+                            },
+                            {
+                              "name": "_DataView.js?",
+                              "resourceBytes": 21
+                            },
+                            {
+                              "name": "_Promise.js?",
+                              "resourceBytes": 20
+                            },
+                            {
+                              "name": "_Set.js?",
+                              "resourceBytes": 16
+                            },
+                            {
+                              "name": "_WeakMap.js?",
+                              "resourceBytes": 20
+                            },
+                            {
+                              "name": "_getTag.js?",
+                              "resourceBytes": 540,
+                              "unusedBytes": 271
+                            },
+                            {
+                              "name": "_baseIsEqualDeep.js?",
+                              "resourceBytes": 579,
+                              "unusedBytes": 466
+                            },
+                            {
+                              "name": "_baseIsEqual.js?",
+                              "resourceBytes": 124,
+                              "unusedBytes": 116
+                            },
+                            {
+                              "name": "_baseIsMatch.js?",
+                              "resourceBytes": 351,
+                              "unusedBytes": 333
+                            },
+                            {
+                              "name": "_isStrictComparable.js?",
+                              "resourceBytes": 49,
+                              "unusedBytes": 41
+                            },
+                            {
+                              "name": "_getMatchData.js?",
+                              "resourceBytes": 97,
+                              "unusedBytes": 89
+                            },
+                            {
+                              "name": "_matchesStrictComparable.js?",
+                              "resourceBytes": 99,
+                              "unusedBytes": 91
+                            },
+                            {
+                              "name": "_baseMatches.js?",
+                              "resourceBytes": 117,
+                              "unusedBytes": 109
+                            },
+                            {
+                              "name": "_isKey.js?",
+                              "resourceBytes": 256,
+                              "unusedBytes": 183
+                            },
+                            {
+                              "name": "memoize.js?",
+                              "resourceBytes": 328,
+                              "unusedBytes": 143
+                            },
+                            {
+                              "name": "_memoizeCapped.js?",
+                              "resourceBytes": 101,
+                              "unusedBytes": 44
+                            },
+                            {
+                              "name": "_stringToPath.js?",
+                              "resourceBytes": 256,
+                              "unusedBytes": 132
+                            },
+                            {
+                              "name": "_castPath.js?",
+                              "resourceBytes": 78,
+                              "unusedBytes": 70
+                            },
+                            {
+                              "name": "_toKey.js?",
+                              "resourceBytes": 116,
+                              "unusedBytes": 101
+                            },
+                            {
+                              "name": "_baseGet.js?",
+                              "resourceBytes": 109,
+                              "unusedBytes": 101
+                            },
+                            {
+                              "name": "get.js?",
+                              "resourceBytes": 75,
+                              "unusedBytes": 67
+                            },
+                            {
+                              "name": "_baseHasIn.js?",
+                              "resourceBytes": 53,
+                              "unusedBytes": 45
+                            },
+                            {
+                              "name": "_hasPath.js?",
+                              "resourceBytes": 205,
+                              "unusedBytes": 197
+                            },
+                            {
+                              "name": "hasIn.js?",
+                              "resourceBytes": 49,
+                              "unusedBytes": 41
+                            },
+                            {
+                              "name": "_baseMatchesProperty.js?",
+                              "resourceBytes": 138,
+                              "unusedBytes": 120
+                            },
+                            {
+                              "name": "identity.js?",
+                              "resourceBytes": 29,
+                              "unusedBytes": 21
+                            },
+                            {
+                              "name": "_basePropertyDeep.js?",
+                              "resourceBytes": 55,
+                              "unusedBytes": 47
+                            },
+                            {
+                              "name": "property.js?",
+                              "resourceBytes": 59,
+                              "unusedBytes": 51
+                            },
+                            {
+                              "name": "_baseIteratee.js?",
+                              "resourceBytes": 120,
+                              "unusedBytes": 112
+                            },
+                            {
+                              "name": "mapKeys.js?",
+                              "resourceBytes": 89,
+                              "unusedBytes": 83
+                            },
+                            {
+                              "name": "_createCaseFirst.js?",
+                              "resourceBytes": 174,
+                              "unusedBytes": 150
+                            },
+                            {
+                              "name": "upperFirst.js?",
+                              "resourceBytes": 18
+                            },
+                            {
+                              "name": "capitalize.js?",
+                              "resourceBytes": 58,
+                              "unusedBytes": 51
+                            },
+                            {
+                              "name": "_arrayReduce.js?",
+                              "resourceBytes": 108,
+                              "unusedBytes": 101
+                            },
+                            {
+                              "name": "_basePropertyOf.js?",
+                              "resourceBytes": 63,
+                              "unusedBytes": 39
+                            },
+                            {
+                              "name": "_deburrLetter.js?",
+                              "resourceBytes": 1536
+                            },
+                            {
+                              "name": "deburr.js?",
+                              "resourceBytes": 186,
+                              "unusedBytes": 67
+                            },
+                            {
+                              "name": "_asciiWords.js?",
+                              "resourceBytes": 87,
+                              "unusedBytes": 34
+                            },
+                            {
+                              "name": "_hasUnicodeWord.js?",
+                              "resourceBytes": 107,
+                              "unusedBytes": 29
+                            },
+                            {
+                              "name": "_unicodeWords.js?",
+                              "resourceBytes": 1159,
+                              "unusedBytes": 34
+                            },
+                            {
+                              "name": "words.js?",
+                              "resourceBytes": 101,
+                              "unusedBytes": 94
+                            },
+                            {
+                              "name": "_createCompounder.js?",
+                              "resourceBytes": 94,
+                              "unusedBytes": 49
+                            },
+                            {
+                              "name": "camelCase.js?",
+                              "resourceBytes": 68,
+                              "unusedBytes": 54
+                            },
+                            {
+                              "name": "_baseIsRegExp.js?",
+                              "resourceBytes": 80,
+                              "unusedBytes": 53
+                            },
+                            {
+                              "name": "isRegExp.js?",
+                              "resourceBytes": 41
+                            },
+                            {
+                              "name": "_asciiSize.js?",
+                              "resourceBytes": 24
+                            },
+                            {
+                              "name": "_unicodeSize.js?",
+                              "resourceBytes": 453,
+                              "unusedBytes": 60
+                            },
+                            {
+                              "name": "_stringSize.js?",
+                              "resourceBytes": 51,
+                              "unusedBytes": 44
+                            },
+                            {
+                              "name": "toFinite.js?",
+                              "resourceBytes": 121,
+                              "unusedBytes": 84
+                            },
+                            {
+                              "name": "toInteger.js?",
+                              "resourceBytes": 58,
+                              "unusedBytes": 51
+                            },
+                            {
+                              "name": "truncate.js?",
+                              "resourceBytes": 676,
+                              "unusedBytes": 648,
+                              "duplicatedNormalizedModuleName": "node_modules/lodash-es/truncate.js"
+                            }
+                          ],
+                          "unusedBytes": 12603
+                        },
+                        {
+                          "name": "axios",
+                          "resourceBytes": 12954,
+                          "unusedBytes": 9010,
+                          "children": [
+                            {
+                              "name": "lib",
+                              "resourceBytes": 12936,
+                              "unusedBytes": 9010,
+                              "children": [
+                                {
+                                  "name": "utils.js?",
+                                  "resourceBytes": 2144,
+                                  "unusedBytes": 991,
+                                  "duplicatedNormalizedModuleName": "node_modules/axios/lib/utils.js"
+                                },
+                                {
+                                  "name": "helpers",
+                                  "resourceBytes": 2870,
+                                  "unusedBytes": 1862,
+                                  "children": [
+                                    {
+                                      "name": "bind.js?",
+                                      "resourceBytes": 140,
+                                      "unusedBytes": 106
+                                    },
+                                    {
+                                      "name": "buildURL.js?",
+                                      "resourceBytes": 595,
+                                      "unusedBytes": 571,
+                                      "duplicatedNormalizedModuleName": "node_modules/axios/lib/helpers/buildURL.js"
+                                    },
+                                    {
+                                      "name": "normalizeHeaderName.js?",
+                                      "resourceBytes": 131,
+                                      "unusedBytes": 107
+                                    },
+                                    {
+                                      "name": "cookies.js?",
+                                      "resourceBytes": 555,
+                                      "unusedBytes": 461,
+                                      "duplicatedNormalizedModuleName": "node_modules/axios/lib/helpers/cookies.js"
+                                    },
+                                    {
+                                      "name": "isAbsoluteURL.js?",
+                                      "resourceBytes": 70,
+                                      "unusedBytes": 58
+                                    },
+                                    {
+                                      "name": "combineURLs.js?",
+                                      "resourceBytes": 83,
+                                      "unusedBytes": 71
+                                    },
+                                    {
+                                      "name": "parseHeaders.js?",
+                                      "resourceBytes": 524,
+                                      "unusedBytes": 268,
+                                      "duplicatedNormalizedModuleName": "node_modules/axios/lib/helpers/parseHeaders.js"
+                                    },
+                                    {
+                                      "name": "isURLSameOrigin.js?",
+                                      "resourceBytes": 635,
+                                      "unusedBytes": 107,
+                                      "duplicatedNormalizedModuleName": "node_modules/axios/lib/helpers/isURLSameOrigin.js"
+                                    },
+                                    {
+                                      "name": "spread.js?",
+                                      "resourceBytes": 67,
+                                      "unusedBytes": 55
+                                    },
+                                    {
+                                      "name": "isAxiosError.js?",
+                                      "resourceBytes": 70,
+                                      "unusedBytes": 58
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "cancel",
+                                  "resourceBytes": 590,
+                                  "unusedBytes": 452,
+                                  "children": [
+                                    {
+                                      "name": "isCancel.js?",
+                                      "resourceBytes": 51,
+                                      "unusedBytes": 39
+                                    },
+                                    {
+                                      "name": "Cancel.js?",
+                                      "resourceBytes": 152,
+                                      "unusedBytes": 91
+                                    },
+                                    {
+                                      "name": "CancelToken.js?",
+                                      "resourceBytes": 387,
+                                      "unusedBytes": 322
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "defaults.js?",
+                                  "resourceBytes": 1155,
+                                  "unusedBytes": 545,
+                                  "duplicatedNormalizedModuleName": "node_modules/axios/lib/defaults.js"
+                                },
+                                {
+                                  "name": "adapters/xhr.js?",
+                                  "resourceBytes": 1871,
+                                  "unusedBytes": 1786
+                                },
+                                {
+                                  "name": "core",
+                                  "resourceBytes": 3926,
+                                  "unusedBytes": 3302,
+                                  "children": [
+                                    {
+                                      "name": "createError.js?",
+                                      "resourceBytes": 84,
+                                      "unusedBytes": 59
+                                    },
+                                    {
+                                      "name": "mergeConfig.js?",
+                                      "resourceBytes": 1159,
+                                      "unusedBytes": 1135,
+                                      "duplicatedNormalizedModuleName": "node_modules/axios/lib/core/mergeConfig.js"
+                                    },
+                                    {
+                                      "name": "Axios.js?",
+                                      "resourceBytes": 1040,
+                                      "unusedBytes": 720,
+                                      "duplicatedNormalizedModuleName": "node_modules/axios/lib/core/Axios.js"
+                                    },
+                                    {
+                                      "name": "InterceptorManager.js?",
+                                      "resourceBytes": 322,
+                                      "unusedBytes": 210
+                                    },
+                                    {
+                                      "name": "dispatchRequest.js?",
+                                      "resourceBytes": 631,
+                                      "unusedBytes": 582,
+                                      "duplicatedNormalizedModuleName": "node_modules/axios/lib/core/dispatchRequest.js"
+                                    },
+                                    {
+                                      "name": "transformData.js?",
+                                      "resourceBytes": 86,
+                                      "unusedBytes": 62
+                                    },
+                                    {
+                                      "name": "settle.js?",
+                                      "resourceBytes": 177,
+                                      "unusedBytes": 153
+                                    },
+                                    {
+                                      "name": "enhanceError.js?",
+                                      "resourceBytes": 354,
+                                      "unusedBytes": 342
+                                    },
+                                    {
+                                      "name": "buildFullPath.js?",
+                                      "resourceBytes": 73,
+                                      "unusedBytes": 39
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "axios.js?",
+                                  "resourceBytes": 380,
+                                  "unusedBytes": 72
+                                }
+                              ]
+                            },
+                            {
+                              "name": "index.js?",
+                              "resourceBytes": 18
+                            }
+                          ]
+                        },
+                        {
+                          "name": "compute-scroll-into-view/es/index.js?",
+                          "resourceBytes": 2197,
+                          "unusedBytes": 2190
+                        },
+                        {
+                          "name": "downshift/dist/downshift.esm.js?",
+                          "resourceBytes": 16831,
+                          "unusedBytes": 15184
+                        },
+                        {
+                          "name": "warning/warning.js?",
+                          "resourceBytes": 32,
+                          "unusedBytes": 12
+                        },
+                        {
+                          "name": "function-bind",
+                          "resourceBytes": 732,
+                          "children": [
+                            {
+                              "name": "index.js?",
+                              "resourceBytes": 51
+                            },
+                            {
+                              "name": "implementation.js?",
+                              "resourceBytes": 681,
+                              "unusedBytes": 561,
+                              "duplicatedNormalizedModuleName": "node_modules/function-bind/implementation.js"
+                            }
+                          ],
+                          "unusedBytes": 561
+                        },
+                        {
+                          "name": "define-properties",
+                          "resourceBytes": 2763,
+                          "children": [
+                            {
+                              "name": "index.js?",
+                              "resourceBytes": 651,
+                              "duplicatedNormalizedModuleName": "node_modules/define-properties/index.js"
+                            },
+                            {
+                              "name": "node_modules/object-keys",
+                              "resourceBytes": 2112,
+                              "unusedBytes": 1946,
                               "children": [
                                 {
                                   "name": "isArguments.js?",
@@ -6514,1195 +6405,1378 @@
                                 {
                                   "name": "index.js?",
                                   "resourceBytes": 322,
-                                  "unusedBytes": 225
+                                  "unusedBytes": 201
                                 },
                                 {
                                   "name": "implementation.js?",
-                                  "resourceBytes": 1595,
-                                  "unusedBytes": 1594,
+                                  "resourceBytes": 1544,
+                                  "unusedBytes": 1543,
                                   "duplicatedNormalizedModuleName": "node_modules/object-keys/implementation.js"
                                 }
                               ]
+                            }
+                          ],
+                          "unusedBytes": 1946
+                        },
+                        {
+                          "name": "react-is",
+                          "resourceBytes": 2126,
+                          "children": [
+                            {
+                              "name": "index.js?",
+                              "resourceBytes": 18
                             },
                             {
-                              "name": "regexp.prototype.flags",
-                              "resourceBytes": 1158,
-                              "unusedBytes": 760,
+                              "name": "cjs/react-is.production.min.js?",
+                              "resourceBytes": 2108,
+                              "unusedBytes": 929
+                            }
+                          ],
+                          "unusedBytes": 929
+                        },
+                        {
+                          "name": "create-react-context/lib",
+                          "resourceBytes": 2768,
+                          "children": [
+                            {
+                              "name": "index.js?",
+                              "resourceBytes": 159
+                            },
+                            {
+                              "name": "implementation.js?",
+                              "resourceBytes": 2609,
+                              "unusedBytes": 2444,
+                              "duplicatedNormalizedModuleName": "node_modules/create-react-context/lib/implementation.js"
+                            }
+                          ],
+                          "unusedBytes": 2444
+                        },
+                        {
+                          "name": "dom-helpers",
+                          "resourceBytes": 3346,
+                          "children": [
+                            {
+                              "name": "util",
+                              "resourceBytes": 776,
                               "children": [
                                 {
-                                  "name": "implementation.js?",
-                                  "resourceBytes": 302,
-                                  "unusedBytes": 265
+                                  "name": "inDOM.js?",
+                                  "resourceBytes": 160
                                 },
                                 {
-                                  "name": "polyfill.js?",
-                                  "resourceBytes": 361,
-                                  "unusedBytes": 263
+                                  "name": "requestAnimationFrame.js?",
+                                  "resourceBytes": 616,
+                                  "unusedBytes": 215,
+                                  "duplicatedNormalizedModuleName": "node_modules/dom-helpers/util/requestAnimationFrame.js"
+                                }
+                              ],
+                              "unusedBytes": 215
+                            },
+                            {
+                              "name": "class",
+                              "resourceBytes": 847,
+                              "unusedBytes": 622,
+                              "children": [
+                                {
+                                  "name": "addClass.js?",
+                                  "resourceBytes": 327,
+                                  "unusedBytes": 195
                                 },
                                 {
-                                  "name": "index.js?",
-                                  "resourceBytes": 111
+                                  "name": "hasClass.js?",
+                                  "resourceBytes": 212,
+                                  "unusedBytes": 131
                                 },
                                 {
-                                  "name": "shim.js?",
-                                  "resourceBytes": 384,
-                                  "unusedBytes": 232
+                                  "name": "removeClass.js?",
+                                  "resourceBytes": 308,
+                                  "unusedBytes": 296
                                 }
                               ]
                             },
                             {
-                              "name": "react-popper",
-                              "resourceBytes": 5676,
-                              "unusedBytes": 5050,
+                              "name": "transition/properties.js?",
+                              "resourceBytes": 1723,
+                              "unusedBytes": 98
+                            }
+                          ],
+                          "unusedBytes": 935
+                        },
+                        {
+                          "name": "react-transition-group",
+                          "resourceBytes": 10631,
+                          "unusedBytes": 7313,
+                          "children": [
+                            {
+                              "name": "utils",
+                              "resourceBytes": 1406,
+                              "unusedBytes": 821,
                               "children": [
                                 {
-                                  "name": "node_modules/deep-equal/index.js?",
-                                  "resourceBytes": 1074,
-                                  "unusedBytes": 978
+                                  "name": "PropTypes.js?",
+                                  "resourceBytes": 879,
+                                  "unusedBytes": 363,
+                                  "duplicatedNormalizedModuleName": "node_modules/react-transition-group/utils/PropTypes.js"
                                 },
                                 {
-                                  "name": "lib/esm",
-                                  "resourceBytes": 4602,
-                                  "unusedBytes": 4072,
-                                  "children": [
-                                    {
-                                      "name": "Manager.js?",
-                                      "resourceBytes": 578,
-                                      "unusedBytes": 464,
-                                      "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Manager.js"
-                                    },
-                                    {
-                                      "name": "utils.js?",
-                                      "resourceBytes": 272,
-                                      "unusedBytes": 263
-                                    },
-                                    {
-                                      "name": "Reference.js?",
-                                      "resourceBytes": 662,
-                                      "unusedBytes": 564,
-                                      "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Reference.js"
-                                    },
-                                    {
-                                      "name": "Popper.js?",
-                                      "resourceBytes": 3090,
-                                      "unusedBytes": 2781,
-                                      "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Popper.js"
-                                    }
-                                  ]
+                                  "name": "ChildMapping.js?",
+                                  "resourceBytes": 527,
+                                  "unusedBytes": 458,
+                                  "duplicatedNormalizedModuleName": "node_modules/react-transition-group/utils/ChildMapping.js"
                                 }
                               ]
                             },
                             {
-                              "name": "chain-function/index.js?",
-                              "resourceBytes": 262,
-                              "unusedBytes": 250
+                              "name": "CSSTransitionGroup.js?",
+                              "resourceBytes": 1841,
+                              "unusedBytes": 986,
+                              "duplicatedNormalizedModuleName": "node_modules/react-transition-group/CSSTransitionGroup.js"
                             },
                             {
-                              "name": "process/browser.js?",
-                              "resourceBytes": 1661,
-                              "unusedBytes": 1182
+                              "name": "TransitionGroup.js?",
+                              "resourceBytes": 4014,
+                              "unusedBytes": 3178,
+                              "duplicatedNormalizedModuleName": "node_modules/react-transition-group/TransitionGroup.js"
                             },
                             {
-                              "name": "exenv/index.js?",
-                              "resourceBytes": 348
+                              "name": "node_modules/warning/browser.js?",
+                              "resourceBytes": 24,
+                              "unusedBytes": 12
                             },
                             {
-                              "name": "react-lifecycles-compat/react-lifecycles-compat.es.js?",
-                              "resourceBytes": 2357,
-                              "unusedBytes": 448
-                            },
-                            {
-                              "name": "gud/index.js?",
-                              "resourceBytes": 89,
-                              "unusedBytes": 35
-                            },
-                            {
-                              "name": "is-arguments/index.js?",
-                              "resourceBytes": 448,
-                              "unusedBytes": 165
-                            },
-                            {
-                              "name": "object-is/index.js?",
-                              "resourceBytes": 109,
-                              "unusedBytes": 90
-                            },
-                            {
-                              "name": "is-regex",
-                              "resourceBytes": 506,
-                              "unusedBytes": 253,
-                              "children": [
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 429,
-                                  "unusedBytes": 253
-                                },
-                                {
-                                  "name": "node_modules/has/src/index.js?",
-                                  "resourceBytes": 77
-                                }
-                              ]
-                            },
-                            {
-                              "name": "es-abstract",
-                              "resourceBytes": 6811,
-                              "unusedBytes": 93,
-                              "children": [
-                                {
-                                  "name": "helpers/callBind.js?",
-                                  "resourceBytes": 161,
-                                  "unusedBytes": 39
-                                },
-                                {
-                                  "name": "GetIntrinsic.js?",
-                                  "resourceBytes": 6650,
-                                  "unusedBytes": 54,
-                                  "duplicatedNormalizedModuleName": "node_modules/es-abstract/GetIntrinsic.js"
-                                }
-                              ]
-                            },
-                            {
-                              "name": "has-symbols",
-                              "resourceBytes": 1023,
-                              "children": [
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 184
-                                },
-                                {
-                                  "name": "shams.js?",
-                                  "resourceBytes": 839,
-                                  "duplicatedNormalizedModuleName": "node_modules/has-symbols/shams.js"
-                                }
-                              ]
-                            },
-                            {
-                              "name": "is-date-object/index.js?",
-                              "resourceBytes": 272,
-                              "unusedBytes": 139
+                              "name": "CSSTransitionGroupChild.js?",
+                              "resourceBytes": 3346,
+                              "unusedBytes": 2316,
+                              "duplicatedNormalizedModuleName": "node_modules/react-transition-group/CSSTransitionGroupChild.js"
                             }
                           ]
                         },
                         {
-                          "name": "(webpack)/buildin",
-                          "resourceBytes": 459,
+                          "name": "object-keys",
+                          "resourceBytes": 2163,
+                          "unusedBytes": 2021,
                           "children": [
                             {
-                              "name": "global.js?",
-                              "resourceBytes": 131
-                            },
-                            {
-                              "name": "harmony-module.js?",
-                              "resourceBytes": 328,
-                              "unusedBytes": 44
-                            }
-                          ],
-                          "unusedBytes": 44
-                        },
-                        {
-                          "name": "../../src",
-                          "resourceBytes": 17083,
-                          "children": [
-                            {
-                              "name": "utils",
-                              "resourceBytes": 8122,
-                              "children": [
-                                {
-                                  "name": "isBrowser.js?",
-                                  "resourceBytes": 94
-                                },
-                                {
-                                  "name": "debounce.js?",
-                                  "resourceBytes": 259,
-                                  "unusedBytes": 123
-                                },
-                                {
-                                  "name": "isFunction.js?",
-                                  "resourceBytes": 59,
-                                  "unusedBytes": 59
-                                },
-                                {
-                                  "name": "getStyleComputedProperty.js?",
-                                  "resourceBytes": 98,
-                                  "unusedBytes": 98
-                                },
-                                {
-                                  "name": "getParentNode.js?",
-                                  "resourceBytes": 57,
-                                  "unusedBytes": 57
-                                },
-                                {
-                                  "name": "getScrollParent.js?",
-                                  "resourceBytes": 188,
-                                  "unusedBytes": 188
-                                },
-                                {
-                                  "name": "getReferenceNode.js?",
-                                  "resourceBytes": 51,
-                                  "unusedBytes": 51
-                                },
-                                {
-                                  "name": "isIE.js?",
-                                  "resourceBytes": 143,
-                                  "unusedBytes": 37
-                                },
-                                {
-                                  "name": "getOffsetParent.js?",
-                                  "resourceBytes": 338,
-                                  "unusedBytes": 338
-                                },
-                                {
-                                  "name": "getRoot.js?",
-                                  "resourceBytes": 52,
-                                  "unusedBytes": 52
-                                },
-                                {
-                                  "name": "findCommonOffsetParent.js?",
-                                  "resourceBytes": 309,
-                                  "unusedBytes": 309
-                                },
-                                {
-                                  "name": "isOffsetContainer.js?",
-                                  "resourceBytes": 69,
-                                  "unusedBytes": 69
-                                },
-                                {
-                                  "name": "getScroll.js?",
-                                  "resourceBytes": 228,
-                                  "unusedBytes": 228
-                                },
-                                {
-                                  "name": "getBordersSize.js?",
-                                  "resourceBytes": 137,
-                                  "unusedBytes": 137
-                                },
-                                {
-                                  "name": "getWindowSizes.js?",
-                                  "resourceBytes": 345,
-                                  "unusedBytes": 345
-                                },
-                                {
-                                  "name": "getClientRect.js?",
-                                  "resourceBytes": 49,
-                                  "unusedBytes": 49
-                                },
-                                {
-                                  "name": "getBoundingClientRect.js?",
-                                  "resourceBytes": 408,
-                                  "unusedBytes": 408
-                                },
-                                {
-                                  "name": "getOffsetRectRelativeToArbitraryNode.js?",
-                                  "resourceBytes": 514,
-                                  "unusedBytes": 514
-                                },
-                                {
-                                  "name": "includeScroll.js?",
-                                  "resourceBytes": 152,
-                                  "unusedBytes": 152
-                                },
-                                {
-                                  "name": "getFixedPositionOffsetParent.js?",
-                                  "resourceBytes": 156,
-                                  "unusedBytes": 156
-                                },
-                                {
-                                  "name": "getBoundaries.js?",
-                                  "resourceBytes": 552,
-                                  "unusedBytes": 552
-                                },
-                                {
-                                  "name": "getViewportOffsetRectRelativeToArtbitraryNode.js?",
-                                  "resourceBytes": 283,
-                                  "unusedBytes": 283
-                                },
-                                {
-                                  "name": "isFixed.js?",
-                                  "resourceBytes": 95,
-                                  "unusedBytes": 95
-                                },
-                                {
-                                  "name": "computeAutoPlacement.js?",
-                                  "resourceBytes": 485,
-                                  "unusedBytes": 485
-                                },
-                                {
-                                  "name": "getReferenceOffsets.js?",
-                                  "resourceBytes": 104,
-                                  "unusedBytes": 104
-                                },
-                                {
-                                  "name": "getOuterSizes.js?",
-                                  "resourceBytes": 217,
-                                  "unusedBytes": 217
-                                },
-                                {
-                                  "name": "getOppositePlacement.js?",
-                                  "resourceBytes": 126,
-                                  "unusedBytes": 126
-                                },
-                                {
-                                  "name": "getPopperOffsets.js?",
-                                  "resourceBytes": 224,
-                                  "unusedBytes": 224
-                                },
-                                {
-                                  "name": "find.js?",
-                                  "resourceBytes": 62,
-                                  "unusedBytes": 62
-                                },
-                                {
-                                  "name": "runModifiers.js?",
-                                  "resourceBytes": 272,
-                                  "unusedBytes": 272
-                                },
-                                {
-                                  "name": "findIndex.js?",
-                                  "resourceBytes": 123,
-                                  "unusedBytes": 123
-                                },
-                                {
-                                  "name": "isModifierEnabled.js?",
-                                  "resourceBytes": 65,
-                                  "unusedBytes": 65
-                                },
-                                {
-                                  "name": "getSupportedPropertyName.js?",
-                                  "resourceBytes": 158,
-                                  "unusedBytes": 158
-                                },
-                                {
-                                  "name": "getWindow.js?",
-                                  "resourceBytes": 55,
-                                  "unusedBytes": 55
-                                },
-                                {
-                                  "name": "setupEventListeners.js?",
-                                  "resourceBytes": 320,
-                                  "unusedBytes": 320
-                                },
-                                {
-                                  "name": "removeEventListeners.js?",
-                                  "resourceBytes": 215,
-                                  "unusedBytes": 215
-                                },
-                                {
-                                  "name": "isNumeric.js?",
-                                  "resourceBytes": 57,
-                                  "unusedBytes": 57
-                                },
-                                {
-                                  "name": "setStyles.js?",
-                                  "resourceBytes": 151,
-                                  "unusedBytes": 151
-                                },
-                                {
-                                  "name": "isModifierRequired.js?",
-                                  "resourceBytes": 253,
-                                  "unusedBytes": 253
-                                },
-                                {
-                                  "name": "clockwise.js?",
-                                  "resourceBytes": 152,
-                                  "unusedBytes": 139
-                                },
-                                {
-                                  "name": "getOppositeVariation.js?",
-                                  "resourceBytes": 50,
-                                  "unusedBytes": 50
-                                },
-                                {
-                                  "name": "getRoundedOffsets.js?",
-                                  "resourceBytes": 303,
-                                  "unusedBytes": 303
-                                },
-                                {
-                                  "name": "setAttributes.js?",
-                                  "resourceBytes": 94,
-                                  "unusedBytes": 94
-                                }
-                              ],
-                              "unusedBytes": 7773
-                            },
-                            {
-                              "name": "methods",
-                              "resourceBytes": 1410,
-                              "unusedBytes": 1221,
-                              "children": [
-                                {
-                                  "name": "update.js?",
-                                  "resourceBytes": 616,
-                                  "unusedBytes": 616
-                                },
-                                {
-                                  "name": "destroy.js?",
-                                  "resourceBytes": 378,
-                                  "unusedBytes": 378
-                                },
-                                {
-                                  "name": "enableEventListeners.js?",
-                                  "resourceBytes": 109,
-                                  "unusedBytes": 109
-                                },
-                                {
-                                  "name": "disableEventListeners.js?",
-                                  "resourceBytes": 94,
-                                  "unusedBytes": 94
-                                },
-                                {
-                                  "name": "placements.js?",
-                                  "resourceBytes": 169
-                                },
-                                {
-                                  "name": "defaults.js?",
-                                  "resourceBytes": 44,
-                                  "unusedBytes": 24
-                                }
-                              ]
-                            },
-                            {
-                              "name": "modifiers",
-                              "resourceBytes": 6632,
-                              "unusedBytes": 6334,
-                              "children": [
-                                {
-                                  "name": "computeStyle.js?",
-                                  "resourceBytes": 963,
-                                  "unusedBytes": 916
-                                },
-                                {
-                                  "name": "flip.js?",
-                                  "resourceBytes": 1259,
-                                  "unusedBytes": 1212
-                                },
-                                {
-                                  "name": "offset.js?",
-                                  "resourceBytes": 1299,
-                                  "unusedBytes": 1298
-                                },
-                                {
-                                  "name": "index.js?",
-                                  "resourceBytes": 191
-                                },
-                                {
-                                  "name": "shift.js?",
-                                  "resourceBytes": 235,
-                                  "unusedBytes": 233
-                                },
-                                {
-                                  "name": "preventOverflow.js?",
-                                  "resourceBytes": 650,
-                                  "unusedBytes": 649
-                                },
-                                {
-                                  "name": "keepTogether.js?",
-                                  "resourceBytes": 275,
-                                  "unusedBytes": 273
-                                },
-                                {
-                                  "name": "arrow.js?",
-                                  "resourceBytes": 805,
-                                  "unusedBytes": 804
-                                },
-                                {
-                                  "name": "inner.js?",
-                                  "resourceBytes": 235,
-                                  "unusedBytes": 233
-                                },
-                                {
-                                  "name": "hide.js?",
-                                  "resourceBytes": 353,
-                                  "unusedBytes": 351
-                                },
-                                {
-                                  "name": "applyStyle.js?",
-                                  "resourceBytes": 367,
-                                  "unusedBytes": 365
-                                }
-                              ]
+                              "name": "isArguments.js?",
+                              "resourceBytes": 246,
+                              "unusedBytes": 202
                             },
                             {
                               "name": "index.js?",
-                              "resourceBytes": 919,
-                              "unusedBytes": 803
+                              "resourceBytes": 322,
+                              "unusedBytes": 225
+                            },
+                            {
+                              "name": "implementation.js?",
+                              "resourceBytes": 1595,
+                              "unusedBytes": 1594,
+                              "duplicatedNormalizedModuleName": "node_modules/object-keys/implementation.js"
                             }
-                          ],
-                          "unusedBytes": 16131
+                          ]
+                        },
+                        {
+                          "name": "react-popper",
+                          "resourceBytes": 13645,
+                          "unusedBytes": 5903,
+                          "children": [
+                            {
+                              "name": "node_modules",
+                              "resourceBytes": 9043,
+                              "unusedBytes": 1831,
+                              "children": [
+                                {
+                                  "name": "regexp.prototype.flags",
+                                  "resourceBytes": 1158,
+                                  "unusedBytes": 760,
+                                  "children": [
+                                    {
+                                      "name": "implementation.js?",
+                                      "resourceBytes": 302,
+                                      "unusedBytes": 265
+                                    },
+                                    {
+                                      "name": "polyfill.js?",
+                                      "resourceBytes": 361,
+                                      "unusedBytes": 263
+                                    },
+                                    {
+                                      "name": "index.js?",
+                                      "resourceBytes": 111
+                                    },
+                                    {
+                                      "name": "shim.js?",
+                                      "resourceBytes": 384,
+                                      "unusedBytes": 232
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "deep-equal/index.js?",
+                                  "resourceBytes": 1074,
+                                  "unusedBytes": 978
+                                },
+                                {
+                                  "name": "es-abstract",
+                                  "resourceBytes": 6811,
+                                  "unusedBytes": 93,
+                                  "children": [
+                                    {
+                                      "name": "helpers/callBind.js?",
+                                      "resourceBytes": 161,
+                                      "unusedBytes": 39
+                                    },
+                                    {
+                                      "name": "GetIntrinsic.js?",
+                                      "resourceBytes": 6650,
+                                      "unusedBytes": 54,
+                                      "duplicatedNormalizedModuleName": "node_modules/es-abstract/GetIntrinsic.js"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "lib/esm",
+                              "resourceBytes": 4602,
+                              "unusedBytes": 4072,
+                              "children": [
+                                {
+                                  "name": "Manager.js?",
+                                  "resourceBytes": 578,
+                                  "unusedBytes": 464,
+                                  "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Manager.js"
+                                },
+                                {
+                                  "name": "utils.js?",
+                                  "resourceBytes": 272,
+                                  "unusedBytes": 263
+                                },
+                                {
+                                  "name": "Reference.js?",
+                                  "resourceBytes": 662,
+                                  "unusedBytes": 564,
+                                  "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Reference.js"
+                                },
+                                {
+                                  "name": "Popper.js?",
+                                  "resourceBytes": 3090,
+                                  "unusedBytes": 2781,
+                                  "duplicatedNormalizedModuleName": "node_modules/react-popper/lib/esm/Popper.js"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "chain-function/index.js?",
+                          "resourceBytes": 262,
+                          "unusedBytes": 250
+                        },
+                        {
+                          "name": "process/browser.js?",
+                          "resourceBytes": 1661,
+                          "unusedBytes": 1182
+                        },
+                        {
+                          "name": "exenv/index.js?",
+                          "resourceBytes": 348
+                        },
+                        {
+                          "name": "react-lifecycles-compat/react-lifecycles-compat.es.js?",
+                          "resourceBytes": 2357,
+                          "unusedBytes": 448
+                        },
+                        {
+                          "name": "gud/index.js?",
+                          "resourceBytes": 89,
+                          "unusedBytes": 35
+                        },
+                        {
+                          "name": "is-arguments/index.js?",
+                          "resourceBytes": 448,
+                          "unusedBytes": 165
+                        },
+                        {
+                          "name": "object-is/index.js?",
+                          "resourceBytes": 109,
+                          "unusedBytes": 90
+                        },
+                        {
+                          "name": "is-regex",
+                          "resourceBytes": 506,
+                          "unusedBytes": 253,
+                          "children": [
+                            {
+                              "name": "index.js?",
+                              "resourceBytes": 429,
+                              "unusedBytes": 253
+                            },
+                            {
+                              "name": "node_modules/has/src/index.js?",
+                              "resourceBytes": 77
+                            }
+                          ]
+                        },
+                        {
+                          "name": "has-symbols",
+                          "resourceBytes": 1023,
+                          "children": [
+                            {
+                              "name": "index.js?",
+                              "resourceBytes": 184
+                            },
+                            {
+                              "name": "shams.js?",
+                              "resourceBytes": 839,
+                              "duplicatedNormalizedModuleName": "node_modules/has-symbols/shams.js"
+                            }
+                          ]
+                        },
+                        {
+                          "name": "is-date-object/index.js?",
+                          "resourceBytes": 272,
+                          "unusedBytes": 139
                         }
                       ]
                     },
                     {
-                      "name": "(unmapped)",
-                      "resourceBytes": 10276,
-                      "unusedBytes": 2832
+                      "name": "(webpack)/buildin",
+                      "resourceBytes": 459,
+                      "children": [
+                        {
+                          "name": "global.js?",
+                          "resourceBytes": 131
+                        },
+                        {
+                          "name": "harmony-module.js?",
+                          "resourceBytes": 328,
+                          "unusedBytes": 44
+                        }
+                      ],
+                      "unusedBytes": 44
+                    },
+                    {
+                      "name": "../../src",
+                      "resourceBytes": 17083,
+                      "children": [
+                        {
+                          "name": "utils",
+                          "resourceBytes": 8122,
+                          "children": [
+                            {
+                              "name": "isBrowser.js?",
+                              "resourceBytes": 94
+                            },
+                            {
+                              "name": "debounce.js?",
+                              "resourceBytes": 259,
+                              "unusedBytes": 123
+                            },
+                            {
+                              "name": "isFunction.js?",
+                              "resourceBytes": 59,
+                              "unusedBytes": 59
+                            },
+                            {
+                              "name": "getStyleComputedProperty.js?",
+                              "resourceBytes": 98,
+                              "unusedBytes": 98
+                            },
+                            {
+                              "name": "getParentNode.js?",
+                              "resourceBytes": 57,
+                              "unusedBytes": 57
+                            },
+                            {
+                              "name": "getScrollParent.js?",
+                              "resourceBytes": 188,
+                              "unusedBytes": 188
+                            },
+                            {
+                              "name": "getReferenceNode.js?",
+                              "resourceBytes": 51,
+                              "unusedBytes": 51
+                            },
+                            {
+                              "name": "isIE.js?",
+                              "resourceBytes": 143,
+                              "unusedBytes": 37
+                            },
+                            {
+                              "name": "getOffsetParent.js?",
+                              "resourceBytes": 338,
+                              "unusedBytes": 338
+                            },
+                            {
+                              "name": "getRoot.js?",
+                              "resourceBytes": 52,
+                              "unusedBytes": 52
+                            },
+                            {
+                              "name": "findCommonOffsetParent.js?",
+                              "resourceBytes": 309,
+                              "unusedBytes": 309
+                            },
+                            {
+                              "name": "isOffsetContainer.js?",
+                              "resourceBytes": 69,
+                              "unusedBytes": 69
+                            },
+                            {
+                              "name": "getScroll.js?",
+                              "resourceBytes": 228,
+                              "unusedBytes": 228
+                            },
+                            {
+                              "name": "getBordersSize.js?",
+                              "resourceBytes": 137,
+                              "unusedBytes": 137
+                            },
+                            {
+                              "name": "getWindowSizes.js?",
+                              "resourceBytes": 345,
+                              "unusedBytes": 345
+                            },
+                            {
+                              "name": "getClientRect.js?",
+                              "resourceBytes": 49,
+                              "unusedBytes": 49
+                            },
+                            {
+                              "name": "getBoundingClientRect.js?",
+                              "resourceBytes": 408,
+                              "unusedBytes": 408
+                            },
+                            {
+                              "name": "getOffsetRectRelativeToArbitraryNode.js?",
+                              "resourceBytes": 514,
+                              "unusedBytes": 514
+                            },
+                            {
+                              "name": "includeScroll.js?",
+                              "resourceBytes": 152,
+                              "unusedBytes": 152
+                            },
+                            {
+                              "name": "getFixedPositionOffsetParent.js?",
+                              "resourceBytes": 156,
+                              "unusedBytes": 156
+                            },
+                            {
+                              "name": "getBoundaries.js?",
+                              "resourceBytes": 552,
+                              "unusedBytes": 552
+                            },
+                            {
+                              "name": "getViewportOffsetRectRelativeToArtbitraryNode.js?",
+                              "resourceBytes": 283,
+                              "unusedBytes": 283
+                            },
+                            {
+                              "name": "isFixed.js?",
+                              "resourceBytes": 95,
+                              "unusedBytes": 95
+                            },
+                            {
+                              "name": "computeAutoPlacement.js?",
+                              "resourceBytes": 485,
+                              "unusedBytes": 485
+                            },
+                            {
+                              "name": "getReferenceOffsets.js?",
+                              "resourceBytes": 104,
+                              "unusedBytes": 104
+                            },
+                            {
+                              "name": "getOuterSizes.js?",
+                              "resourceBytes": 217,
+                              "unusedBytes": 217
+                            },
+                            {
+                              "name": "getOppositePlacement.js?",
+                              "resourceBytes": 126,
+                              "unusedBytes": 126
+                            },
+                            {
+                              "name": "getPopperOffsets.js?",
+                              "resourceBytes": 224,
+                              "unusedBytes": 224
+                            },
+                            {
+                              "name": "find.js?",
+                              "resourceBytes": 62,
+                              "unusedBytes": 62
+                            },
+                            {
+                              "name": "runModifiers.js?",
+                              "resourceBytes": 272,
+                              "unusedBytes": 272
+                            },
+                            {
+                              "name": "findIndex.js?",
+                              "resourceBytes": 123,
+                              "unusedBytes": 123
+                            },
+                            {
+                              "name": "isModifierEnabled.js?",
+                              "resourceBytes": 65,
+                              "unusedBytes": 65
+                            },
+                            {
+                              "name": "getSupportedPropertyName.js?",
+                              "resourceBytes": 158,
+                              "unusedBytes": 158
+                            },
+                            {
+                              "name": "getWindow.js?",
+                              "resourceBytes": 55,
+                              "unusedBytes": 55
+                            },
+                            {
+                              "name": "setupEventListeners.js?",
+                              "resourceBytes": 320,
+                              "unusedBytes": 320
+                            },
+                            {
+                              "name": "removeEventListeners.js?",
+                              "resourceBytes": 215,
+                              "unusedBytes": 215
+                            },
+                            {
+                              "name": "isNumeric.js?",
+                              "resourceBytes": 57,
+                              "unusedBytes": 57
+                            },
+                            {
+                              "name": "setStyles.js?",
+                              "resourceBytes": 151,
+                              "unusedBytes": 151
+                            },
+                            {
+                              "name": "isModifierRequired.js?",
+                              "resourceBytes": 253,
+                              "unusedBytes": 253
+                            },
+                            {
+                              "name": "clockwise.js?",
+                              "resourceBytes": 152,
+                              "unusedBytes": 139
+                            },
+                            {
+                              "name": "getOppositeVariation.js?",
+                              "resourceBytes": 50,
+                              "unusedBytes": 50
+                            },
+                            {
+                              "name": "getRoundedOffsets.js?",
+                              "resourceBytes": 303,
+                              "unusedBytes": 303
+                            },
+                            {
+                              "name": "setAttributes.js?",
+                              "resourceBytes": 94,
+                              "unusedBytes": 94
+                            }
+                          ],
+                          "unusedBytes": 7773
+                        },
+                        {
+                          "name": "methods",
+                          "resourceBytes": 1410,
+                          "unusedBytes": 1221,
+                          "children": [
+                            {
+                              "name": "update.js?",
+                              "resourceBytes": 616,
+                              "unusedBytes": 616
+                            },
+                            {
+                              "name": "destroy.js?",
+                              "resourceBytes": 378,
+                              "unusedBytes": 378
+                            },
+                            {
+                              "name": "enableEventListeners.js?",
+                              "resourceBytes": 109,
+                              "unusedBytes": 109
+                            },
+                            {
+                              "name": "disableEventListeners.js?",
+                              "resourceBytes": 94,
+                              "unusedBytes": 94
+                            },
+                            {
+                              "name": "placements.js?",
+                              "resourceBytes": 169
+                            },
+                            {
+                              "name": "defaults.js?",
+                              "resourceBytes": 44,
+                              "unusedBytes": 24
+                            }
+                          ]
+                        },
+                        {
+                          "name": "modifiers",
+                          "resourceBytes": 6632,
+                          "unusedBytes": 6334,
+                          "children": [
+                            {
+                              "name": "computeStyle.js?",
+                              "resourceBytes": 963,
+                              "unusedBytes": 916
+                            },
+                            {
+                              "name": "flip.js?",
+                              "resourceBytes": 1259,
+                              "unusedBytes": 1212
+                            },
+                            {
+                              "name": "offset.js?",
+                              "resourceBytes": 1299,
+                              "unusedBytes": 1298
+                            },
+                            {
+                              "name": "index.js?",
+                              "resourceBytes": 191
+                            },
+                            {
+                              "name": "shift.js?",
+                              "resourceBytes": 235,
+                              "unusedBytes": 233
+                            },
+                            {
+                              "name": "preventOverflow.js?",
+                              "resourceBytes": 650,
+                              "unusedBytes": 649
+                            },
+                            {
+                              "name": "keepTogether.js?",
+                              "resourceBytes": 275,
+                              "unusedBytes": 273
+                            },
+                            {
+                              "name": "arrow.js?",
+                              "resourceBytes": 805,
+                              "unusedBytes": 804
+                            },
+                            {
+                              "name": "inner.js?",
+                              "resourceBytes": 235,
+                              "unusedBytes": 233
+                            },
+                            {
+                              "name": "hide.js?",
+                              "resourceBytes": 353,
+                              "unusedBytes": 351
+                            },
+                            {
+                              "name": "applyStyle.js?",
+                              "resourceBytes": 367,
+                              "unusedBytes": 365
+                            }
+                          ]
+                        },
+                        {
+                          "name": "index.js?",
+                          "resourceBytes": 919,
+                          "unusedBytes": 803
+                        }
+                      ],
+                      "unusedBytes": 16131
                     }
                   ]
+                },
+                {
+                  "name": "(unmapped)",
+                  "resourceBytes": 10296,
+                  "unusedBytes": 2832
                 }
               ]
             },
             {
-              "name": "https://www.coursehero.com/assets/js/compiled/qa/ask-expert-tutors/app.65b89e69d7c41a8ae68d.js",
-              "resourceBytes": 209989,
-              "unusedBytes": 69130,
+              "name": "https://www.coursehero.com/assets/js/compiled/qa/ask-expert-tutors/app.6dc151323a6bcc879cf3.js",
+              "resourceBytes": 214564,
+              "unusedBytes": 72592,
               "children": [
                 {
-                  "name": "",
-                  "resourceBytes": 209989,
-                  "unusedBytes": 69130,
+                  "name": "js",
+                  "resourceBytes": 208417,
+                  "unusedBytes": 71718,
                   "children": [
                     {
-                      "name": "js",
-                      "resourceBytes": 203954,
-                      "unusedBytes": 68256,
+                      "name": "webpack/bootstrap?",
+                      "resourceBytes": 3953,
+                      "unusedBytes": 2709
+                    },
+                    {
+                      "name": "external \"window.React\"?",
+                      "resourceBytes": 24
+                    },
+                    {
+                      "name": "src",
+                      "resourceBytes": 204386,
                       "children": [
                         {
-                          "name": "webpack/bootstrap?",
-                          "resourceBytes": 3953,
-                          "unusedBytes": 2709
-                        },
-                        {
-                          "name": "external \"window.React\"?",
-                          "resourceBytes": 24
-                        },
-                        {
-                          "name": "src",
-                          "resourceBytes": 199923,
+                          "name": "common",
+                          "resourceBytes": 37078,
                           "children": [
                             {
-                              "name": "common",
-                              "resourceBytes": 37009,
+                              "name": "component",
+                              "resourceBytes": 35639,
                               "children": [
                                 {
-                                  "name": "component",
-                                  "resourceBytes": 35617,
+                                  "name": "autocomplete-icon",
+                                  "resourceBytes": 488,
                                   "children": [
                                     {
-                                      "name": "autocomplete-icon",
-                                      "resourceBytes": 488,
-                                      "children": [
-                                        {
-                                          "name": "autocomplete-icon.scss?",
-                                          "resourceBytes": 90
-                                        },
-                                        {
-                                          "name": "autocomplete-icon.tsx?",
-                                          "resourceBytes": 398,
-                                          "unusedBytes": 365
-                                        }
-                                      ],
+                                      "name": "autocomplete-icon.scss?",
+                                      "resourceBytes": 90
+                                    },
+                                    {
+                                      "name": "autocomplete-icon.tsx?",
+                                      "resourceBytes": 398,
                                       "unusedBytes": 365
-                                    },
-                                    {
-                                      "name": "emphasized-item",
-                                      "resourceBytes": 429,
-                                      "children": [
-                                        {
-                                          "name": "emphasized-item.scss?",
-                                          "resourceBytes": 82
-                                        },
-                                        {
-                                          "name": "emphasized-item.tsx?",
-                                          "resourceBytes": 347,
-                                          "unusedBytes": 338
-                                        }
-                                      ],
-                                      "unusedBytes": 338
-                                    },
-                                    {
-                                      "name": "school-dropdown",
-                                      "resourceBytes": 5743,
-                                      "children": [
-                                        {
-                                          "name": "school-dropdown.scss?",
-                                          "resourceBytes": 1296
-                                        },
-                                        {
-                                          "name": "school.ts?",
-                                          "resourceBytes": 214,
-                                          "unusedBytes": 132
-                                        },
-                                        {
-                                          "name": "school-dropdown-message.tsx?",
-                                          "resourceBytes": 384,
-                                          "unusedBytes": 375
-                                        },
-                                        {
-                                          "name": "school-label.tsx?",
-                                          "resourceBytes": 622,
-                                          "unusedBytes": 599
-                                        },
-                                        {
-                                          "name": "school-menu.tsx?",
-                                          "resourceBytes": 614,
-                                          "unusedBytes": 585
-                                        },
-                                        {
-                                          "name": "get-school-options-api.ts?",
-                                          "resourceBytes": 234,
-                                          "unusedBytes": 225
-                                        },
-                                        {
-                                          "name": "school-dropdown.tsx?",
-                                          "resourceBytes": 2379,
-                                          "unusedBytes": 2341
-                                        }
-                                      ],
-                                      "unusedBytes": 4257
-                                    },
-                                    {
-                                      "name": "subject-tagger",
-                                      "resourceBytes": 11548,
-                                      "children": [
-                                        {
-                                          "name": "components",
-                                          "resourceBytes": 9952,
-                                          "children": [
-                                            {
-                                              "name": "mobile",
-                                              "resourceBytes": 4024,
-                                              "children": [
-                                                {
-                                                  "name": "subject-tagger-mobile.module.scss?",
-                                                  "resourceBytes": 1398
-                                                },
-                                                {
-                                                  "name": "subject-category-submenu.tsx?",
-                                                  "resourceBytes": 1703,
-                                                  "unusedBytes": 1694
-                                                },
-                                                {
-                                                  "name": "subject-tagger-mobile.tsx?",
-                                                  "resourceBytes": 923,
-                                                  "unusedBytes": 920
-                                                }
-                                              ],
-                                              "unusedBytes": 2614
-                                            },
-                                            {
-                                              "name": "desktop",
-                                              "resourceBytes": 5928,
-                                              "children": [
-                                                {
-                                                  "name": "subject-tagger-desktop",
-                                                  "resourceBytes": 2416,
-                                                  "children": [
-                                                    {
-                                                      "name": "subject-tagger-desktop.module.scss?",
-                                                      "resourceBytes": 746
-                                                    },
-                                                    {
-                                                      "name": "subject-tagger-desktop.tsx?",
-                                                      "resourceBytes": 1670,
-                                                      "unusedBytes": 1667
-                                                    }
-                                                  ],
-                                                  "unusedBytes": 1667
-                                                },
-                                                {
-                                                  "name": "subject-family-list",
-                                                  "resourceBytes": 2615,
-                                                  "children": [
-                                                    {
-                                                      "name": "subject-family-list.module.scss?",
-                                                      "resourceBytes": 1375
-                                                    },
-                                                    {
-                                                      "name": "subject-family-list.tsx?",
-                                                      "resourceBytes": 1240,
-                                                      "unusedBytes": 1231
-                                                    }
-                                                  ],
-                                                  "unusedBytes": 1231
-                                                },
-                                                {
-                                                  "name": "subject-item",
-                                                  "resourceBytes": 474,
-                                                  "children": [
-                                                    {
-                                                      "name": "subject-item.module.scss?",
-                                                      "resourceBytes": 204
-                                                    },
-                                                    {
-                                                      "name": "subject-item.tsx?",
-                                                      "resourceBytes": 270,
-                                                      "unusedBytes": 261
-                                                    }
-                                                  ],
-                                                  "unusedBytes": 261
-                                                },
-                                                {
-                                                  "name": "subject-category-body",
-                                                  "resourceBytes": 423,
-                                                  "unusedBytes": 297,
-                                                  "children": [
-                                                    {
-                                                      "name": "subject-category-body.tsx?",
-                                                      "resourceBytes": 306,
-                                                      "unusedBytes": 297
-                                                    },
-                                                    {
-                                                      "name": "subject-category-body.module.scss?",
-                                                      "resourceBytes": 117
-                                                    }
-                                                  ]
-                                                }
-                                              ],
-                                              "unusedBytes": 3456
-                                            }
-                                          ],
-                                          "unusedBytes": 6070
-                                        },
-                                        {
-                                          "name": "index.ts?",
-                                          "resourceBytes": 221,
-                                          "unusedBytes": 79
-                                        },
-                                        {
-                                          "name": "subject-tagger.module.scss?",
-                                          "resourceBytes": 367
-                                        },
-                                        {
-                                          "name": "constants.ts?",
-                                          "resourceBytes": 61,
-                                          "unusedBytes": 20
-                                        },
-                                        {
-                                          "name": "subject-tagger.tsx?",
-                                          "resourceBytes": 947,
-                                          "unusedBytes": 937
-                                        }
-                                      ],
-                                      "unusedBytes": 7106
-                                    },
-                                    {
-                                      "name": "course-selector",
-                                      "resourceBytes": 17126,
-                                      "children": [
-                                        {
-                                          "name": "course-creator",
-                                          "resourceBytes": 8299,
-                                          "children": [
-                                            {
-                                              "name": "course-creator.module.scss?",
-                                              "resourceBytes": 4498
-                                            },
-                                            {
-                                              "name": "department-acronym-dropdown.tsx?",
-                                              "resourceBytes": 1649,
-                                              "unusedBytes": 1641
-                                            },
-                                            {
-                                              "name": "course-creator.tsx?",
-                                              "resourceBytes": 2012,
-                                              "unusedBytes": 2003
-                                            },
-                                            {
-                                              "name": "create-course-request.ts?",
-                                              "resourceBytes": 140,
-                                              "unusedBytes": 137
-                                            }
-                                          ],
-                                          "unusedBytes": 3781
-                                        },
-                                        {
-                                          "name": "interfaces.ts?",
-                                          "resourceBytes": 53
-                                        },
-                                        {
-                                          "name": "course-selector",
-                                          "resourceBytes": 6263,
-                                          "children": [
-                                            {
-                                              "name": "course-selector.module.scss?",
-                                              "resourceBytes": 4079
-                                            },
-                                            {
-                                              "name": "course-selector.tsx?",
-                                              "resourceBytes": 2184,
-                                              "unusedBytes": 2175
-                                            }
-                                          ],
-                                          "unusedBytes": 2175
-                                        },
-                                        {
-                                          "name": "course-dropdown",
-                                          "resourceBytes": 2329,
-                                          "children": [
-                                            {
-                                              "name": "course-dropdown.module.scss?",
-                                              "resourceBytes": 799
-                                            },
-                                            {
-                                              "name": "course-dropdown.tsx?",
-                                              "resourceBytes": 1530,
-                                              "unusedBytes": 1516
-                                            }
-                                          ],
-                                          "unusedBytes": 1516
-                                        },
-                                        {
-                                          "name": "utils.ts?",
-                                          "resourceBytes": 182,
-                                          "unusedBytes": 170
-                                        }
-                                      ],
-                                      "unusedBytes": 7642
-                                    },
-                                    {
-                                      "name": "subject-selector.tsx?",
-                                      "resourceBytes": 4
-                                    },
-                                    {
-                                      "name": "smart-spinner.tsx?",
-                                      "resourceBytes": 279,
-                                      "unusedBytes": 272
                                     }
                                   ],
-                                  "unusedBytes": 19980
+                                  "unusedBytes": 365
                                 },
                                 {
-                                  "name": "base-model.ts?",
-                                  "resourceBytes": 54,
-                                  "unusedBytes": 40
-                                },
-                                {
-                                  "name": "helper/smooth-scroll-to.ts?",
-                                  "resourceBytes": 549,
-                                  "unusedBytes": 540
-                                },
-                                {
-                                  "name": "hooks",
-                                  "resourceBytes": 550,
-                                  "unusedBytes": 528,
+                                  "name": "emphasized-item",
+                                  "resourceBytes": 429,
                                   "children": [
                                     {
-                                      "name": "use-window-width.ts?",
-                                      "resourceBytes": 290,
-                                      "unusedBytes": 274
+                                      "name": "emphasized-item.scss?",
+                                      "resourceBytes": 82
                                     },
                                     {
-                                      "name": "use-is-visible.ts?",
-                                      "resourceBytes": 260,
-                                      "unusedBytes": 254
+                                      "name": "emphasized-item.tsx?",
+                                      "resourceBytes": 347,
+                                      "unusedBytes": 338
                                     }
-                                  ]
+                                  ],
+                                  "unusedBytes": 338
                                 },
                                 {
-                                  "name": "decorators/debounce.ts?",
-                                  "resourceBytes": 239,
-                                  "unusedBytes": 148
-                                }
-                              ],
-                              "unusedBytes": 21236
-                            },
-                            {
-                              "name": "qa",
-                              "resourceBytes": 147253,
-                              "children": [
-                                {
-                                  "name": "ask-expert-tutors",
-                                  "resourceBytes": 144281,
+                                  "name": "school-dropdown",
+                                  "resourceBytes": 5743,
                                   "children": [
                                     {
-                                      "name": "assets",
-                                      "resourceBytes": 103702,
+                                      "name": "school-dropdown.scss?",
+                                      "resourceBytes": 1296
+                                    },
+                                    {
+                                      "name": "school.ts?",
+                                      "resourceBytes": 214,
+                                      "unusedBytes": 132
+                                    },
+                                    {
+                                      "name": "school-dropdown-message.tsx?",
+                                      "resourceBytes": 384,
+                                      "unusedBytes": 375
+                                    },
+                                    {
+                                      "name": "school-label.tsx?",
+                                      "resourceBytes": 622,
+                                      "unusedBytes": 599
+                                    },
+                                    {
+                                      "name": "school-menu.tsx?",
+                                      "resourceBytes": 614,
+                                      "unusedBytes": 585
+                                    },
+                                    {
+                                      "name": "get-school-options-api.ts?",
+                                      "resourceBytes": 234,
+                                      "unusedBytes": 225
+                                    },
+                                    {
+                                      "name": "school-dropdown.tsx?",
+                                      "resourceBytes": 2379,
+                                      "unusedBytes": 2341
+                                    }
+                                  ],
+                                  "unusedBytes": 4257
+                                },
+                                {
+                                  "name": "subject-tagger",
+                                  "resourceBytes": 11593,
+                                  "children": [
+                                    {
+                                      "name": "components",
+                                      "resourceBytes": 10003,
                                       "children": [
                                         {
-                                          "name": "ask-expert-tutors/ask-expert-tutors.scss?",
-                                          "resourceBytes": 32350
-                                        },
-                                        {
-                                          "name": "ask-question/ask-question.scss?",
-                                          "resourceBytes": 70123
-                                        },
-                                        {
-                                          "name": "common",
-                                          "resourceBytes": 1229,
+                                          "name": "mobile",
+                                          "resourceBytes": 4036,
                                           "children": [
                                             {
-                                              "name": "student-questions-info.scss?",
-                                              "resourceBytes": 1140
+                                              "name": "subject-tagger-mobile.module.scss?",
+                                              "resourceBytes": 1398
                                             },
                                             {
-                                              "name": "legal-agreements.scss?",
-                                              "resourceBytes": 89
+                                              "name": "subject-category-submenu.tsx?",
+                                              "resourceBytes": 1715,
+                                              "unusedBytes": 1706
+                                            },
+                                            {
+                                              "name": "subject-tagger-mobile.tsx?",
+                                              "resourceBytes": 923,
+                                              "unusedBytes": 920
                                             }
-                                          ]
+                                          ],
+                                          "unusedBytes": 2626
+                                        },
+                                        {
+                                          "name": "desktop",
+                                          "resourceBytes": 5967,
+                                          "children": [
+                                            {
+                                              "name": "subject-tagger-desktop",
+                                              "resourceBytes": 2433,
+                                              "children": [
+                                                {
+                                                  "name": "subject-tagger-desktop.module.scss?",
+                                                  "resourceBytes": 746
+                                                },
+                                                {
+                                                  "name": "subject-tagger-desktop.tsx?",
+                                                  "resourceBytes": 1687,
+                                                  "unusedBytes": 1678
+                                                }
+                                              ],
+                                              "unusedBytes": 1678
+                                            },
+                                            {
+                                              "name": "subject-family-list",
+                                              "resourceBytes": 2637,
+                                              "children": [
+                                                {
+                                                  "name": "subject-family-list.module.scss?",
+                                                  "resourceBytes": 1375
+                                                },
+                                                {
+                                                  "name": "subject-family-list.tsx?",
+                                                  "resourceBytes": 1262,
+                                                  "unusedBytes": 1253
+                                                }
+                                              ],
+                                              "unusedBytes": 1253
+                                            },
+                                            {
+                                              "name": "subject-item",
+                                              "resourceBytes": 474,
+                                              "children": [
+                                                {
+                                                  "name": "subject-item.module.scss?",
+                                                  "resourceBytes": 204
+                                                },
+                                                {
+                                                  "name": "subject-item.tsx?",
+                                                  "resourceBytes": 270,
+                                                  "unusedBytes": 261
+                                                }
+                                              ],
+                                              "unusedBytes": 261
+                                            },
+                                            {
+                                              "name": "subject-category-body",
+                                              "resourceBytes": 423,
+                                              "unusedBytes": 297,
+                                              "children": [
+                                                {
+                                                  "name": "subject-category-body.tsx?",
+                                                  "resourceBytes": 306,
+                                                  "unusedBytes": 297
+                                                },
+                                                {
+                                                  "name": "subject-category-body.module.scss?",
+                                                  "resourceBytes": 117
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "unusedBytes": 3489
                                         }
-                                      ]
+                                      ],
+                                      "unusedBytes": 6115
                                     },
                                     {
-                                      "name": "component",
-                                      "resourceBytes": 28505,
-                                      "unusedBytes": 24993,
+                                      "name": "index.ts?",
+                                      "resourceBytes": 221,
+                                      "unusedBytes": 79
+                                    },
+                                    {
+                                      "name": "subject-tagger.module.scss?",
+                                      "resourceBytes": 367
+                                    },
+                                    {
+                                      "name": "constants.ts?",
+                                      "resourceBytes": 55,
+                                      "unusedBytes": 20
+                                    },
+                                    {
+                                      "name": "subject-tagger.tsx?",
+                                      "resourceBytes": 947,
+                                      "unusedBytes": 937
+                                    }
+                                  ],
+                                  "unusedBytes": 7151
+                                },
+                                {
+                                  "name": "course-selector",
+                                  "resourceBytes": 17103,
+                                  "children": [
+                                    {
+                                      "name": "course-creator",
+                                      "resourceBytes": 8299,
                                       "children": [
                                         {
-                                          "name": "ask-expert-tutors",
-                                          "resourceBytes": 7990,
-                                          "unusedBytes": 4734,
-                                          "children": [
-                                            {
-                                              "name": "modal-body.tsx?",
-                                              "resourceBytes": 1180,
-                                              "unusedBytes": 877
-                                            },
-                                            {
-                                              "name": "modal-header.tsx?",
-                                              "resourceBytes": 1235,
-                                              "unusedBytes": 1228
-                                            },
-                                            {
-                                              "name": "ask-expert-tutors.tsx?",
-                                              "resourceBytes": 5575,
-                                              "unusedBytes": 2629
-                                            }
-                                          ]
+                                          "name": "course-creator.module.scss?",
+                                          "resourceBytes": 4498
                                         },
                                         {
-                                          "name": "homework-help/homework-help-v2.tsx?",
-                                          "resourceBytes": 3458,
-                                          "unusedBytes": 3369
+                                          "name": "department-acronym-dropdown.tsx?",
+                                          "resourceBytes": 1649,
+                                          "unusedBytes": 1641
                                         },
                                         {
-                                          "name": "common",
-                                          "resourceBytes": 4501,
-                                          "unusedBytes": 4486,
-                                          "children": [
-                                            {
-                                              "name": "legal-agreements.tsx?",
-                                              "resourceBytes": 2388,
-                                              "unusedBytes": 2381
-                                            },
-                                            {
-                                              "name": "student-questions-info.tsx?",
-                                              "resourceBytes": 2113,
-                                              "unusedBytes": 2105
-                                            }
-                                          ]
+                                          "name": "course-creator.tsx?",
+                                          "resourceBytes": 2012,
+                                          "unusedBytes": 2003
                                         },
                                         {
-                                          "name": "ask-question",
-                                          "resourceBytes": 12556,
-                                          "unusedBytes": 12404,
-                                          "children": [
-                                            {
-                                              "name": "question-content.tsx?",
-                                              "resourceBytes": 2624,
-                                              "unusedBytes": 2617
-                                            },
-                                            {
-                                              "name": "question-course.tsx?",
-                                              "resourceBytes": 4597,
-                                              "unusedBytes": 4589
-                                            },
-                                            {
-                                              "name": "question-subject.tsx?",
-                                              "resourceBytes": 2325,
-                                              "unusedBytes": 2194
-                                            },
-                                            {
-                                              "name": "ask-question.tsx?",
-                                              "resourceBytes": 3010,
-                                              "unusedBytes": 3004
-                                            }
-                                          ]
+                                          "name": "create-course-request.ts?",
+                                          "resourceBytes": 140,
+                                          "unusedBytes": 137
                                         }
-                                      ]
-                                    },
-                                    {
-                                      "name": "reducer.ts?",
-                                      "resourceBytes": 3553,
-                                      "unusedBytes": 833
-                                    },
-                                    {
-                                      "name": "app.tsx?",
-                                      "resourceBytes": 513
+                                      ],
+                                      "unusedBytes": 3781
                                     },
                                     {
                                       "name": "interfaces.ts?",
-                                      "resourceBytes": 334,
-                                      "unusedBytes": 40
+                                      "resourceBytes": 53
                                     },
                                     {
-                                      "name": "constants",
-                                      "resourceBytes": 2598,
-                                      "unusedBytes": 228,
+                                      "name": "course-selector",
+                                      "resourceBytes": 6240,
                                       "children": [
                                         {
-                                          "name": "steps.ts?",
-                                          "resourceBytes": 1438,
-                                          "unusedBytes": 168
+                                          "name": "course-selector.module.scss?",
+                                          "resourceBytes": 4079
                                         },
                                         {
-                                          "name": "actions.ts?",
-                                          "resourceBytes": 1160,
-                                          "unusedBytes": 60
+                                          "name": "course-selector.tsx?",
+                                          "resourceBytes": 2161,
+                                          "unusedBytes": 2152
                                         }
-                                      ]
+                                      ],
+                                      "unusedBytes": 2152
                                     },
                                     {
-                                      "name": "aet-tracking-service.ts?",
-                                      "resourceBytes": 719,
-                                      "unusedBytes": 680
+                                      "name": "course-dropdown",
+                                      "resourceBytes": 2329,
+                                      "children": [
+                                        {
+                                          "name": "course-dropdown.module.scss?",
+                                          "resourceBytes": 799
+                                        },
+                                        {
+                                          "name": "course-dropdown.tsx?",
+                                          "resourceBytes": 1530,
+                                          "unusedBytes": 1516
+                                        }
+                                      ],
+                                      "unusedBytes": 1516
                                     },
                                     {
-                                      "name": "context.ts?",
-                                      "resourceBytes": 245,
-                                      "unusedBytes": 139
-                                    },
-                                    {
-                                      "name": "dispatch-actions.ts?",
-                                      "resourceBytes": 4112,
-                                      "unusedBytes": 3094
+                                      "name": "utils.ts?",
+                                      "resourceBytes": 182,
+                                      "unusedBytes": 170
                                     }
                                   ],
-                                  "unusedBytes": 30007
+                                  "unusedBytes": 7619
                                 },
                                 {
-                                  "name": "service/amplitude-service.ts?",
-                                  "resourceBytes": 356,
-                                  "unusedBytes": 187
+                                  "name": "subject-selector.tsx?",
+                                  "resourceBytes": 4
                                 },
                                 {
-                                  "name": "attachment-uploader/service/uploader.ts?",
-                                  "resourceBytes": 2616,
-                                  "unusedBytes": 2565
+                                  "name": "smart-spinner.tsx?",
+                                  "resourceBytes": 279,
+                                  "unusedBytes": 272
                                 }
                               ],
-                              "unusedBytes": 32759
+                              "unusedBytes": 20002
                             },
                             {
-                              "name": "vendor-mods/quill",
-                              "resourceBytes": 13322,
+                              "name": "base-model.ts?",
+                              "resourceBytes": 54,
+                              "unusedBytes": 40
+                            },
+                            {
+                              "name": "hooks",
+                              "resourceBytes": 597,
+                              "unusedBytes": 546,
                               "children": [
                                 {
-                                  "name": "assets/quill-widget.scss?",
-                                  "resourceBytes": 2924
+                                  "name": "use-is-visible.ts?",
+                                  "resourceBytes": 307,
+                                  "unusedBytes": 272
                                 },
                                 {
-                                  "name": "common/quill-typing.ts?",
-                                  "resourceBytes": 23
-                                },
-                                {
-                                  "name": "service/quill-helper.ts?",
-                                  "resourceBytes": 680,
-                                  "unusedBytes": 636
-                                },
-                                {
-                                  "name": "modules",
-                                  "resourceBytes": 2053,
-                                  "unusedBytes": 1748,
-                                  "children": [
-                                    {
-                                      "name": "image-handler.ts?",
-                                      "resourceBytes": 1713,
-                                      "unusedBytes": 1603,
-                                      "duplicatedNormalizedModuleName": "js/src/vendor-mods/quill/modules/image-handler.ts"
-                                    },
-                                    {
-                                      "name": "quill-highlight.ts?",
-                                      "resourceBytes": 340,
-                                      "unusedBytes": 145
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "app.ts?",
-                                  "resourceBytes": 2891,
-                                  "unusedBytes": 2778,
-                                  "duplicatedNormalizedModuleName": "js/src/vendor-mods/quill/app.ts"
-                                },
-                                {
-                                  "name": "component/quill-widget.tsx?",
-                                  "resourceBytes": 4751,
-                                  "unusedBytes": 4513
-                                }
-                              ],
-                              "unusedBytes": 9675
-                            },
-                            {
-                              "name": "textbook-solutions/components/Spinner.tsx?",
-                              "resourceBytes": 259,
-                              "unusedBytes": 252
-                            },
-                            {
-                              "name": "document/express-unlock",
-                              "resourceBytes": 132,
-                              "children": [
-                                {
-                                  "name": "interfaces.ts?",
-                                  "resourceBytes": 100
-                                },
-                                {
-                                  "name": "actions.ts?",
-                                  "resourceBytes": 12,
-                                  "unusedBytes": 12
-                                },
-                                {
-                                  "name": "constants/actions.ts?",
-                                  "resourceBytes": 20,
-                                  "unusedBytes": 20
-                                }
-                              ],
-                              "unusedBytes": 32
-                            },
-                            {
-                              "name": "utils",
-                              "resourceBytes": 1894,
-                              "unusedBytes": 1593,
-                              "children": [
-                                {
-                                  "name": "service",
-                                  "resourceBytes": 1829,
-                                  "unusedBytes": 1546,
-                                  "children": [
-                                    {
-                                      "name": "amplitude-service.ts?",
-                                      "resourceBytes": 1513,
-                                      "unusedBytes": 1297,
-                                      "duplicatedNormalizedModuleName": "js/src/utils/service/amplitude-service.ts"
-                                    },
-                                    {
-                                      "name": "url-service.ts?",
-                                      "resourceBytes": 205,
-                                      "unusedBytes": 182
-                                    },
-                                    {
-                                      "name": "dev-log.ts?",
-                                      "resourceBytes": 111,
-                                      "unusedBytes": 67
-                                    }
-                                  ]
-                                },
-                                {
-                                  "name": "track.ts?",
-                                  "resourceBytes": 65,
-                                  "unusedBytes": 47
+                                  "name": "use-window-width.ts?",
+                                  "resourceBytes": 290,
+                                  "unusedBytes": 274
                                 }
                               ]
                             },
                             {
-                              "name": "shims/rollbar-shim.ts?",
-                              "resourceBytes": 54
+                              "name": "helper/smooth-scroll-to.ts?",
+                              "resourceBytes": 549,
+                              "unusedBytes": 540
+                            },
+                            {
+                              "name": "decorators/debounce.ts?",
+                              "resourceBytes": 239,
+                              "unusedBytes": 148
                             }
                           ],
-                          "unusedBytes": 65547
+                          "unusedBytes": 21276
                         },
                         {
-                          "name": "external \"window.ReactDOM\"?",
-                          "resourceBytes": 27
+                          "name": "qa",
+                          "resourceBytes": 151772,
+                          "children": [
+                            {
+                              "name": "ask-expert-tutors",
+                              "resourceBytes": 147608,
+                              "children": [
+                                {
+                                  "name": "assets",
+                                  "resourceBytes": 103770,
+                                  "children": [
+                                    {
+                                      "name": "ask-expert-tutors/ask-expert-tutors.scss?",
+                                      "resourceBytes": 32350
+                                    },
+                                    {
+                                      "name": "ask-question/ask-question.scss?",
+                                      "resourceBytes": 70191
+                                    },
+                                    {
+                                      "name": "common",
+                                      "resourceBytes": 1229,
+                                      "children": [
+                                        {
+                                          "name": "student-questions-info.scss?",
+                                          "resourceBytes": 1140
+                                        },
+                                        {
+                                          "name": "legal-agreements.scss?",
+                                          "resourceBytes": 89
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "component",
+                                  "resourceBytes": 31296,
+                                  "unusedBytes": 27417,
+                                  "children": [
+                                    {
+                                      "name": "ask-expert-tutors",
+                                      "resourceBytes": 8014,
+                                      "unusedBytes": 4734,
+                                      "children": [
+                                        {
+                                          "name": "modal-body.tsx?",
+                                          "resourceBytes": 1180,
+                                          "unusedBytes": 877
+                                        },
+                                        {
+                                          "name": "modal-header.tsx?",
+                                          "resourceBytes": 1235,
+                                          "unusedBytes": 1228
+                                        },
+                                        {
+                                          "name": "ask-expert-tutors.tsx?",
+                                          "resourceBytes": 5599,
+                                          "unusedBytes": 2629
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "name": "homework-help/homework-help-v2.tsx?",
+                                      "resourceBytes": 3526,
+                                      "unusedBytes": 3437
+                                    },
+                                    {
+                                      "name": "common",
+                                      "resourceBytes": 4155,
+                                      "unusedBytes": 4140,
+                                      "children": [
+                                        {
+                                          "name": "legal-agreements.tsx?",
+                                          "resourceBytes": 2004,
+                                          "unusedBytes": 1997
+                                        },
+                                        {
+                                          "name": "student-questions-info.tsx?",
+                                          "resourceBytes": 2151,
+                                          "unusedBytes": 2143
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "name": "ask-question",
+                                      "resourceBytes": 15601,
+                                      "unusedBytes": 15106,
+                                      "children": [
+                                        {
+                                          "name": "question-helpers.ts?",
+                                          "resourceBytes": 117,
+                                          "unusedBytes": 111
+                                        },
+                                        {
+                                          "name": "question-content.tsx?",
+                                          "resourceBytes": 3238,
+                                          "unusedBytes": 2963
+                                        },
+                                        {
+                                          "name": "question-course.tsx?",
+                                          "resourceBytes": 4630,
+                                          "unusedBytes": 4622
+                                        },
+                                        {
+                                          "name": "question-subject.tsx?",
+                                          "resourceBytes": 3169,
+                                          "unusedBytes": 2969
+                                        },
+                                        {
+                                          "name": "ask-question.tsx?",
+                                          "resourceBytes": 4447,
+                                          "unusedBytes": 4441
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "reducer.ts?",
+                                  "resourceBytes": 3641,
+                                  "unusedBytes": 877
+                                },
+                                {
+                                  "name": "app.tsx?",
+                                  "resourceBytes": 513
+                                },
+                                {
+                                  "name": "constants",
+                                  "resourceBytes": 2598,
+                                  "unusedBytes": 228,
+                                  "children": [
+                                    {
+                                      "name": "steps.ts?",
+                                      "resourceBytes": 1438,
+                                      "unusedBytes": 168
+                                    },
+                                    {
+                                      "name": "actions.ts?",
+                                      "resourceBytes": 1160,
+                                      "unusedBytes": 60
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "interfaces.ts?",
+                                  "resourceBytes": 334,
+                                  "unusedBytes": 40
+                                },
+                                {
+                                  "name": "aet-tracking-service.ts?",
+                                  "resourceBytes": 719,
+                                  "unusedBytes": 680
+                                },
+                                {
+                                  "name": "context.ts?",
+                                  "resourceBytes": 245,
+                                  "unusedBytes": 139
+                                },
+                                {
+                                  "name": "dispatch-actions.ts?",
+                                  "resourceBytes": 4156,
+                                  "unusedBytes": 3094
+                                },
+                                {
+                                  "name": "api.ts?",
+                                  "resourceBytes": 336,
+                                  "unusedBytes": 336
+                                }
+                              ],
+                              "unusedBytes": 32811
+                            },
+                            {
+                              "name": "service/amplitude-service.ts?",
+                              "resourceBytes": 493,
+                              "unusedBytes": 265
+                            },
+                            {
+                              "name": "component/suggested-subjects",
+                              "resourceBytes": 1114,
+                              "children": [
+                                {
+                                  "name": "suggested-subjects.module.scss?",
+                                  "resourceBytes": 378
+                                },
+                                {
+                                  "name": "suggested-subjects.tsx?",
+                                  "resourceBytes": 736,
+                                  "unusedBytes": 726
+                                }
+                              ],
+                              "unusedBytes": 726
+                            },
+                            {
+                              "name": "attachment-uploader/service/uploader.ts?",
+                              "resourceBytes": 2557,
+                              "unusedBytes": 2506
+                            }
+                          ],
+                          "unusedBytes": 36308
                         },
                         {
-                          "name": "external \"window.BeefFlux\"?",
-                          "resourceBytes": 27
+                          "name": "vendor-mods/quill",
+                          "resourceBytes": 13237,
+                          "children": [
+                            {
+                              "name": "assets/quill-widget.scss?",
+                              "resourceBytes": 2924
+                            },
+                            {
+                              "name": "common/quill-typing.ts?",
+                              "resourceBytes": 23
+                            },
+                            {
+                              "name": "service/quill-helper.ts?",
+                              "resourceBytes": 680,
+                              "unusedBytes": 636
+                            },
+                            {
+                              "name": "modules",
+                              "resourceBytes": 2015,
+                              "unusedBytes": 1710,
+                              "children": [
+                                {
+                                  "name": "image-handler.ts?",
+                                  "resourceBytes": 1675,
+                                  "unusedBytes": 1565,
+                                  "duplicatedNormalizedModuleName": "js/src/vendor-mods/quill/modules/image-handler.ts"
+                                },
+                                {
+                                  "name": "quill-highlight.ts?",
+                                  "resourceBytes": 340,
+                                  "unusedBytes": 145
+                                }
+                              ]
+                            },
+                            {
+                              "name": "app.ts?",
+                              "resourceBytes": 2852,
+                              "unusedBytes": 2739,
+                              "duplicatedNormalizedModuleName": "js/src/vendor-mods/quill/app.ts"
+                            },
+                            {
+                              "name": "component/quill-widget.tsx?",
+                              "resourceBytes": 4743,
+                              "unusedBytes": 4505
+                            }
+                          ],
+                          "unusedBytes": 9590
+                        },
+                        {
+                          "name": "textbook-solutions/components/Spinner.tsx?",
+                          "resourceBytes": 259,
+                          "unusedBytes": 252
+                        },
+                        {
+                          "name": "document/express-unlock",
+                          "resourceBytes": 132,
+                          "children": [
+                            {
+                              "name": "interfaces.ts?",
+                              "resourceBytes": 100
+                            },
+                            {
+                              "name": "actions.ts?",
+                              "resourceBytes": 12,
+                              "unusedBytes": 12
+                            },
+                            {
+                              "name": "constants/actions.ts?",
+                              "resourceBytes": 20,
+                              "unusedBytes": 20
+                            }
+                          ],
+                          "unusedBytes": 32
+                        },
+                        {
+                          "name": "utils",
+                          "resourceBytes": 1854,
+                          "unusedBytes": 1551,
+                          "children": [
+                            {
+                              "name": "service",
+                              "resourceBytes": 1789,
+                              "unusedBytes": 1504,
+                              "children": [
+                                {
+                                  "name": "amplitude-service.ts?",
+                                  "resourceBytes": 1473,
+                                  "unusedBytes": 1255,
+                                  "duplicatedNormalizedModuleName": "js/src/utils/service/amplitude-service.ts"
+                                },
+                                {
+                                  "name": "url-service.ts?",
+                                  "resourceBytes": 205,
+                                  "unusedBytes": 182
+                                },
+                                {
+                                  "name": "dev-log.ts?",
+                                  "resourceBytes": 111,
+                                  "unusedBytes": 67
+                                }
+                              ]
+                            },
+                            {
+                              "name": "track.ts?",
+                              "resourceBytes": 65,
+                              "unusedBytes": 47
+                            }
+                          ]
+                        },
+                        {
+                          "name": "shims/rollbar-shim.ts?",
+                          "resourceBytes": 54
                         }
-                      ]
+                      ],
+                      "unusedBytes": 69009
                     },
                     {
-                      "name": "(unmapped)",
-                      "resourceBytes": 6035,
-                      "unusedBytes": 874
+                      "name": "external \"window.ReactDOM\"?",
+                      "resourceBytes": 27
+                    },
+                    {
+                      "name": "external \"window.BeefFlux\"?",
+                      "resourceBytes": 27
                     }
                   ]
+                },
+                {
+                  "name": "(unmapped)",
+                  "resourceBytes": 6147,
+                  "unusedBytes": 874
                 }
               ]
             },
@@ -7712,24 +7786,24 @@
               "unusedBytes": 12793
             },
             {
-              "name": "https://www.coursehero.com/_Incapsula_Resource?SWJIYLWA=719d34d31c8e3a6e6fffd425f7e032f3&ns=1&cb=880892222",
-              "resourceBytes": 148404,
-              "unusedBytes": 0
-            },
-            {
               "name": "https://www.google.com/recaptcha/api.js",
               "resourceBytes": 850,
               "unusedBytes": 49
             },
             {
               "name": "https://apis.google.com/js/platform.js",
-              "resourceBytes": 54938,
-              "unusedBytes": 32802
+              "resourceBytes": 54957,
+              "unusedBytes": 32787
             },
             {
               "name": "https://connect.facebook.net/en_US/sdk.js",
               "resourceBytes": 3224,
               "unusedBytes": 369
+            },
+            {
+              "name": "https://www.coursehero.com/_Incapsula_Resource?SWJIYLWA=719d34d31c8e3a6e6fffd425f7e032f3&ns=1&cb=1598870484",
+              "resourceBytes": 144326,
+              "unusedBytes": 0
             },
             {
               "name": "https://pixel-static.spotify.com/conversion.min.js",
@@ -7743,8 +7817,8 @@
             },
             {
               "name": "https://zn1ttxdo6pi4mebp8-coursehero.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_1TtxDO6Pi4MeBP8",
-              "resourceBytes": 61756,
-              "unusedBytes": 39327
+              "resourceBytes": 55803,
+              "unusedBytes": 33938
             },
             {
               "name": "https://analytics.twitter.com/i/adsct?type=javascript&version=1.1.0&p_id=Twitter&p_user_id=0&txn_id=o1962&events=%5B%5B%22pageview%22%2Cnull%5D%5D&tw_sale_amount=0&tw_order_quantity=0&tw_iframe_status=0&tpx_cb=twttr.conversion.loadPixels&tw_document_href=https%3A%2F%2Fwww.coursehero.com%2F",
@@ -7753,7 +7827,7 @@
             },
             {
               "name": "https://radar.cedexis.com/1/22246/radar.js",
-              "resourceBytes": 44892,
+              "resourceBytes": 44897,
               "unusedBytes": 26596
             },
             {
@@ -7765,11 +7839,11 @@
               "resourceBytes": 60
             },
             {
-              "name": "https://track.adform.net/Serving/TrackPoint/?CC=1&pm=364845&ADFPageName=CourseHero%7CHomepage&ADFdivider=%7C&ord=869686766831&Set1=en-US%7Cen-US%7C360x640%7C30&ADFtpmode=2&loc=https%3A%2F%2Fwww.coursehero.com%2F",
+              "name": "https://track.adform.net/Serving/TrackPoint/?CC=1&pm=364845&ADFPageName=CourseHero%7CHomepage&ADFdivider=%7C&ord=387208348173&Set1=en-US%7Cen-US%7C360x640%7C30&ADFtpmode=2&loc=https%3A%2F%2Fwww.coursehero.com%2F",
               "resourceBytes": 211
             },
             {
-              "name": "https://radar.cedexis.com/1593429750/radar.js",
+              "name": "https://radar.cedexis.com/1621860284/radar.js",
               "resourceBytes": 45
             }
           ]

--- a/lighthouse-treemap/app/src/main.js
+++ b/lighthouse-treemap/app/src/main.js
@@ -568,7 +568,7 @@ class TreemapViewer {
     const total = this.currentTreemapRoot[partitionBy];
 
     const parts = [
-      TreemapUtil.elide(node.name, 60),
+      TreemapUtil.elide(node.name || '', 60),
     ];
 
     if (bytes !== undefined && total !== undefined) {


### PR DESCRIPTION
While testing the treemap button in PSI, I noticed errors b/c of how we drop empty string values in the LHR.

![image](https://user-images.githubusercontent.com/4071474/119741932-8cd43f00-be3b-11eb-9786-3f98b048db0a.png)

1) `script-treemap-data` wraps the nodes for a bundle in two layers: top is the script src node, second is the sourceRoot node. But sourceRoot can be an empty string/not there, so this resulted in nodes where name was `''`. There's an extra complication w/ the `collapse` functionality, but it isn't relevant to the issue so I won't describe it in detail.
2) I also suspect that sources like `root//b.js` exist and will make annoying extra layers of nodes named `/` or (b/c collapsing) `/b.js`. so I do an extra check in the `.split` forEach to prevent that.
3) Just to be safe, I made the `makeCaption` function not totally kill everything when name is missing.