### PR TITLE
core(scoring): update TBT score curve

### DIFF
--- a/lighthouse-core/audits/metrics/total-blocking-time.js
+++ b/lighthouse-core/audits/metrics/total-blocking-time.js
@@ -37,11 +37,18 @@ class TotalBlockingTime extends Audit {
   static get defaultOptions() {
     return {
       mobile: {
-        // According to a cluster telemetry run over top 10k sites on mobile, 5th percentile was 0ms,
-        // 25th percentile was 270ms and median was 895ms. These numbers include 404 pages. Picking
-        // thresholds according to our 25/75-th rule will be quite harsh scoring (a single 350ms task)
-        // after FCP will yield a score of .5. The following coefficients are semi-arbitrarily chosen,
-        // but start to approach the 25/75 numbers.
+        // If determined from HTTP Archive data…
+        //     SELECT
+        //         APPROX_QUANTILES(tbt_value, 100)[OFFSET(8)] AS p08_tbt,
+        //         APPROX_QUANTILES(tbt_value, 100)[OFFSET(25)] AS p25_tbt
+        //     FROM (
+        //         SELECT CAST(JSON_EXTRACT_SCALAR(report, '$.audits.total-blocking-time.numericValue') AS FLOAT64) AS tbt_value
+        //         FROM `httparchive.lighthouse.2021_05_01_mobile`
+        //         WHERE report is not NULL
+        //     )
+        // …we'd use control points of 19 and 189, which leads to surprisingly harsh scoring.
+        //
+        // The following coefficients are semi-arbitrarily chosen, but start to approach the "correct" ones:
         // See https://www.desmos.com/calculator/pwcgna1cvf go/lh8-tbt-curves
         scoring: {
           p10: 200,

--- a/lighthouse-core/audits/metrics/total-blocking-time.js
+++ b/lighthouse-core/audits/metrics/total-blocking-time.js
@@ -40,11 +40,11 @@ class TotalBlockingTime extends Audit {
         // According to a cluster telemetry run over top 10k sites on mobile, 5th percentile was 0ms,
         // 25th percentile was 270ms and median was 895ms. These numbers include 404 pages. Picking
         // thresholds according to our 25/75-th rule will be quite harsh scoring (a single 350ms task)
-        // after FCP will yield a score of .5. The following coefficients are semi-arbitrarily picked
-        // to give 600ms jank a score of .5 and 100ms jank a score of .999. We can tweak these numbers
-        // in the future. See https://www.desmos.com/calculator/bbsv8fedg5
+        // after FCP will yield a score of .5. The following coefficients are semi-arbitrarily chosen,
+        // but start to approach the 25/75 numbers.
+        // See https://www.desmos.com/calculator/pwcgna1cvf go/lh8-tbt-curves
         scoring: {
-          p10: 287,
+          p10: 200,
           median: 600,
         },
       },

--- a/lighthouse-core/test/audits/metrics/total-blocking-time-test.js
+++ b/lighthouse-core/test/audits/metrics/total-blocking-time-test.js
@@ -58,7 +58,7 @@ describe('Performance: total-blocking-time audit', () => {
 
     const outputMobile = await TBTAudit.audit(artifactsMobile, contextMobile);
     expect(outputMobile.numericValue).toBeCloseTo(333, 1);
-    expect(outputMobile.score).toBe(0.85);
+    expect(outputMobile.score).toBe(0.75);
     expect(outputMobile.displayValue).toBeDisplayString('330\xa0ms');
 
     const artifactsDesktop = generateArtifacts({trace: lcpTrace,

--- a/lighthouse-core/test/report/report-generator-test.js
+++ b/lighthouse-core/test/report/report-generator-test.js
@@ -104,7 +104,7 @@ describe('ReportGenerator', () => {
       expect(lines.length).toBeGreaterThan(100);
       expect(lines.slice(0, 3).join('\n')).toMatchInlineSnapshot(`
         "requestedUrl,finalUrl,category,name,title,type,score
-        \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"performance-score\\",\\"Overall Performance Category Score\\",\\"numeric\\",\\"0.6\\"
+        \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"performance-score\\",\\"Overall Performance Category Score\\",\\"numeric\\",\\"0.59\\"
         \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"Performance\\",\\"first-contentful-paint\\",\\"First Contentful Paint\\",\\"numeric\\",\\"0.24\\"
         "
       `);

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -185,7 +185,7 @@
       "id": "total-blocking-time",
       "title": "Total Blocking Time",
       "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more](https://web.dev/lighthouse-total-blocking-time/).",
-      "score": 1,
+      "score": 0.97,
       "scoreDisplayMode": "numeric",
       "numericValue": 116.79800000000023,
       "numericUnit": "millisecond",
@@ -5276,7 +5276,7 @@
         }
       ],
       "id": "performance",
-      "score": 0.6
+      "score": 0.59
     },
     "accessibility": {
       "title": "Accessibility",


### PR DESCRIPTION
Part of #11866

Updates the Total Blocking Time control points to be closer to the intended methodology laid out in https://web.dev/performance-scoring/#metric-scores  


In addition, if we were picking entirely new control points, the May 2021 HTTP Archive run gives

HA p08 - 19ms 
HA p25 - 189ms

But we think these as our control points would be too jarring and aggressive for now. Still, there's room to improve, so we're doing a small shift of TBT being scored more strictly.

p10: 200
median: 600

Desktop remains unchanged.