### PR TITLE
deps: update lighthouse-plugin-publisher-ads to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "jsdom": "^12.2.0",
     "jsonld": "^5.2.0",
     "jsonlint-mod": "^1.7.6",
-    "lighthouse-plugin-publisher-ads": "^1.3.0",
+    "lighthouse-plugin-publisher-ads": "^1.4.1",
     "mime-types": "^2.1.30",
     "node-fetch": "^2.6.1",
     "npm-run-posix-or-windows": "^2.0.2",

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -376,6 +376,8 @@ Computing artifact: TagLoadTime
 Computing artifact: LanternTagLoadTime
 Auditing: Ad density is within recommended range
 Auditing: Cumulative ad shift
+Auditing: Deprecated GPT API Usage
+Auditing: GPT Errors
 Generating results...
 
 =============== Lighthouse Results ===============
@@ -434,6 +436,7 @@ cumulative-layout-shift: numeric
 custom-controls-labels: manual
 custom-controls-roles: manual
 definition-list: notApplicable
+deprecated-gpt-api-usage: informative
 deprecations: pass
 diagnostics: informative
 dlitem: notApplicable
@@ -460,6 +463,7 @@ frame-title: notApplicable
 full-page-screenshot: informative
 geolocation-on-start: pass
 gpt-bids-parallel: notApplicable
+gpt-errors-overall: informative
 heading-order: notApplicable
 hreflang: pass
 html-has-lang: fail
@@ -565,7 +569,7 @@ viewport: fail
 viewport-ad-density: notApplicable
 visual-order-follows-dom: manual
 
-# of .lh-audit divs: 157
+# of .lh-audit divs: 159
 
 .lh-audit divs:
 accesskeys
@@ -611,6 +615,7 @@ cumulative-ad-shift
 custom-controls-labels
 custom-controls-roles
 definition-list
+deprecated-gpt-api-usage
 deprecations
 dlitem
 doctype
@@ -633,6 +638,7 @@ form-field-multiple-labels
 frame-title
 geolocation-on-start
 gpt-bids-parallel
+gpt-errors-overall
 heading-order
 hreflang
 html-has-lang

--- a/yarn.lock
+++ b/yarn.lock
@@ -5300,10 +5300,10 @@ lighthouse-logger@^1.0.0, lighthouse-logger@^1.2.0:
     debug "^2.6.8"
     marky "^1.2.0"
 
-lighthouse-plugin-publisher-ads@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/lighthouse-plugin-publisher-ads/-/lighthouse-plugin-publisher-ads-1.3.0.tgz#ed4fa2500371d5e3e3607af562210498928f609a"
-  integrity sha512-1y90fx8wH1VxsrMhqsxeQCLv7rDepzVxuh143ZvhznoBVnioE4UJ38XjUi2VaxDidd1Yfk6hPscT5IAfx559Xg==
+lighthouse-plugin-publisher-ads@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/lighthouse-plugin-publisher-ads/-/lighthouse-plugin-publisher-ads-1.4.1.tgz#37527648d801c91914a7a59808d4924797c075a4"
+  integrity sha512-nhdrufiajU7BTFqnmBw+kSa2NSvWTFR1uFDCcN+XG744avu2g8qjzS4F3vqdH4SZV5km6QRrTYXsrhILl746uQ==
   dependencies:
     "@tusbar/cache-control" "^0.3.1"
     esprima "^4.0.1"


### PR DESCRIPTION
get the [plugin updates](https://github.com/googleads/publisher-ads-lighthouse-plugin/releases) since the last bump in november into 8.0