### PR TITLE
misc(treemap): elide origin from url if same as requestedUrl

### DIFF
--- a/lighthouse-treemap/app/src/main.js
+++ b/lighthouse-treemap/app/src/main.js
@@ -71,11 +71,13 @@ class TreemapViewer {
     // These depth one node uses the network URL for the name, but we want
     // to elide common parts of the URL so text fits better in the UI.
     for (const node of this.depthOneNodesByGroup.scripts) {
-      const url = new URL(node.name);
-      node.name = TreemapUtil.elideUrl(url, this.documentUrl);
-      if (url.href === this.documentUrl.href) {
-        node.name += ' (inline)';
-      }
+      try {
+        const url = new URL(node.name);
+        node.name = TreemapUtil.elideSameOrigin(url, this.documentUrl);
+        if (url.href === this.documentUrl.href) {
+          node.name += ' (inline)';
+        }
+      } catch {}
     }
 
     /* eslint-disable no-unused-expressions */

--- a/lighthouse-treemap/app/src/util.js
+++ b/lighthouse-treemap/app/src/util.js
@@ -63,6 +63,15 @@ class TreemapUtil {
   }
 
   /**
+   * @param {URL} url
+   * @param {URL} fromRelativeUrl
+   */
+  static elideUrl(url, fromRelativeUrl) {
+    if (url.origin !== fromRelativeUrl.origin) return url.toString();
+    return url.toString().replace(fromRelativeUrl.origin, '');
+  }
+
+  /**
    * @template {string} T
    * @param {T} name
    * @param {string=} className

--- a/lighthouse-treemap/app/src/util.js
+++ b/lighthouse-treemap/app/src/util.js
@@ -66,7 +66,7 @@ class TreemapUtil {
    * @param {URL} url
    * @param {URL} fromRelativeUrl
    */
-  static elideUrl(url, fromRelativeUrl) {
+  static elideSameOrigin(url, fromRelativeUrl) {
     if (url.origin !== fromRelativeUrl.origin) return url.toString();
     return url.toString().replace(fromRelativeUrl.origin, '');
   }


### PR DESCRIPTION
The depth one script nodes have really long names because they are the entire URL of the network resource. We should elide if they share the same origin as the requested URL.

I did this in the Treemap UI instead of `script-treemap-data` because I thought it'd be nice to preserve the property that the names in the LHR are valid URLs.

Also added an `(inline)` tag to make the inline JS node apparent.

https://lighthouse-git-tm-url-elide-googlechrome.vercel.app/gh-pages/treemap/?debug

https://lighthouse-git-tm-url-elide-googlechrome.vercel.app/gh-pages/treemap/?gist=682f30fc539d16905557e8ce092adecf

ref #11254