### PR TITLE
tests(smoke): relative source map hash

### DIFF
--- a/lighthouse-cli/test/fixtures/csp.html
+++ b/lighthouse-cli/test/fixtures/csp.html
@@ -7,7 +7,7 @@
   <head>
     <script>
       // Use a source map so we can test the injected iframe fetcher.
-      //# sourceMappingURL=http://localhost:10200/source-map/script.js.map
+      //# sourceMappingURL=source-map/script.js.map
     </script>
   </head>
   <body>

--- a/lighthouse-cli/test/smokehouse/test-definitions/csp/csp-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/csp/csp-expectations.js
@@ -19,7 +19,7 @@ function headersParam(headers) {
 // Easiest way to get script contents with whitespace is by copying script node in DevTools.
 const blockAllExceptInlineScriptCsp = headersParam([[
   'Content-Security-Policy',
-  `default-src 'none'; script-src 'sha256-qZLV55/xxILbIrha9pgX0OdkZMhOlaIgfpEo/6Dly2U='`,
+  `default-src 'none'; script-src 'sha256-NCWlI90TxQpIfghtBWJyNU5Y92Nj8XhO+AYMm0gqGfQ='`,
 ]]);
 
 /**


### PR DESCRIPTION
We were getting failures in g3 because of the port number, which we dynamically change.