### PR TITLE
tests(treemap): add test for node coverage shading

### DIFF
--- a/lighthouse-treemap/test/treemap-test-pptr.js
+++ b/lighthouse-treemap/test/treemap-test-pptr.js
@@ -173,7 +173,7 @@ describe('Lighthouse Treemap', () => {
       // Determine visual red shading percentage.
       const percentRed = await gtmElemHandle.evaluate(node => {
         const redWidthPx = parseInt(window.getComputedStyle(node, ':before').width);
-        const completeWidthPx = node.offsetWidth;
+        const completeWidthPx = node.getBoundingClientRect().width;
         return redWidthPx / completeWidthPx;
       });
 

--- a/lighthouse-treemap/test/treemap-test-pptr.js
+++ b/lighthouse-treemap/test/treemap-test-pptr.js
@@ -179,6 +179,7 @@ describe('Lighthouse Treemap', () => {
 
       // Reminder! UNUSED == RED
       const percentDataUnused = gtmNode.unusedBytes / gtmNode.resourceBytes;
+      expect(percentDataUnused).toBeGreaterThan(0);
 
       // Assert 0.2520 ~= 0.2602 w/ 1 decimal place of precision.
       // CSS pixels won't let us go to 2 decimal places.

--- a/lighthouse-treemap/test/treemap-test-pptr.js
+++ b/lighthouse-treemap/test/treemap-test-pptr.js
@@ -45,8 +45,7 @@ describe('Lighthouse Treemap', () => {
   beforeEach(async () => {
     if (!browser) {
       browser = await puppeteer.launch({
-        headless: false,
-        slowMo: true,
+        headless: true,
       });
     }
     page = await browser.newPage();

--- a/lighthouse-treemap/test/treemap-test-pptr.js
+++ b/lighthouse-treemap/test/treemap-test-pptr.js
@@ -12,7 +12,7 @@
 const fs = require('fs');
 const puppeteer = require('puppeteer');
 const {server} = require('../../lighthouse-cli/test/fixtures/static-server.js');
-const portNumber = 10200;
+const portNumber = 20202;
 const treemapUrl = `http://localhost:${portNumber}/dist/gh-pages/treemap/index.html`;
 const debugOptions = require('../app/debug.json');
 
@@ -45,7 +45,8 @@ describe('Lighthouse Treemap', () => {
   beforeEach(async () => {
     if (!browser) {
       browser = await puppeteer.launch({
-        headless: true,
+        headless: false,
+        slowMo: true,
       });
     }
     page = await browser.newPage();
@@ -139,6 +140,50 @@ describe('Lighthouse Treemap', () => {
 
       const optionsInPage = await page.evaluate(() => window.__treemapOptions);
       expect(optionsInPage.lhr.requestedUrl).toBe(options.lhr.requestedUrl);
+    });
+  });
+
+  describe('renders correctly', () => {
+    it('correctly shades coverage of gtm node', async () => {
+      await page.goto(`${treemapUrl}?debug`, {
+        waitUntil: 'networkidle0',
+        timeout: 30000,
+      });
+
+      await page.click('#view-mode--unused-bytes');
+      await page.waitForSelector('.lh-treemap--view-mode--unused-bytes', {visible: true});
+
+      // Identify the JS data
+      const gtmNode = await page.evaluate(() => {
+        const d1Nodes = window.__treemapOptions.lhr.audits['script-treemap-data'].details.nodes;
+        const gtmNode = d1Nodes.find(n => n.name.includes('gtm.js'));
+        return gtmNode;
+      });
+
+      expect(gtmNode.unusedBytes).toBeGreaterThan(20_000);
+      expect(gtmNode.resourceBytes).toBeGreaterThan(20_000);
+
+      // Identify the DOM node
+      const gtmElemHandle = await page.evaluateHandle(() => {
+        const captionEls = Array.from(document.querySelectorAll('.webtreemap-caption'));
+        return captionEls.find(el => el.textContent.includes('gtm.js')).parentElement;
+      });
+
+      expect(await gtmElemHandle.isIntersectingViewport()).toBeTruthy();
+
+      // Determine visual red shading percentage
+      const percentRed = await gtmElemHandle.evaluate(node => {
+        const redWidthPx = parseInt(window.getComputedStyle(node, ':before').width);
+        const completeWidthPx = node.offsetWidth;
+        return redWidthPx / completeWidthPx;
+      });
+
+      // Reminder! UNUSED == RED
+      const percentDataUnused = gtmNode.unusedBytes / gtmNode.resourceBytes;
+
+      // Assert 0.2520 ~= 0.2602 w/ 1 decimal place of precision.
+      // CSS pixels won't let us go to 2 decimal places.
+      expect(percentRed).toBeApproximately(percentDataUnused, 1);
     });
   });
 });

--- a/lighthouse-treemap/test/treemap-test-pptr.js
+++ b/lighthouse-treemap/test/treemap-test-pptr.js
@@ -150,9 +150,9 @@ describe('Lighthouse Treemap', () => {
       });
 
       await page.click('#view-mode--unused-bytes');
-      await page.waitForSelector('.lh-treemap--view-mode--unused-bytes', {visible: true});
+      await page.waitForSelector('.lh-treemap--view-mode--unused-bytes');
 
-      // Identify the JS data
+      // Identify the JS data.
       const gtmNode = await page.evaluate(() => {
         const d1Nodes = window.__treemapOptions.lhr.audits['script-treemap-data'].details.nodes;
         const gtmNode = d1Nodes.find(n => n.name.includes('gtm.js'));
@@ -162,7 +162,7 @@ describe('Lighthouse Treemap', () => {
       expect(gtmNode.unusedBytes).toBeGreaterThan(20_000);
       expect(gtmNode.resourceBytes).toBeGreaterThan(20_000);
 
-      // Identify the DOM node
+      // Identify the DOM node.
       const gtmElemHandle = await page.evaluateHandle(() => {
         const captionEls = Array.from(document.querySelectorAll('.webtreemap-caption'));
         return captionEls.find(el => el.textContent.includes('gtm.js')).parentElement;
@@ -170,7 +170,7 @@ describe('Lighthouse Treemap', () => {
 
       expect(await gtmElemHandle.isIntersectingViewport()).toBeTruthy();
 
-      // Determine visual red shading percentage
+      // Determine visual red shading percentage.
       const percentRed = await gtmElemHandle.evaluate(node => {
         const redWidthPx = parseInt(window.getComputedStyle(node, ':before').width);
         const completeWidthPx = node.offsetWidth;


### PR DESCRIPTION
followup from https://github.com/GoogleChrome/lighthouse/pull/12603#issuecomment-853288185

i wrote the code that was wrong, so here's my penance.

---

driveby change of port number... no reason it needs to conflict w/ 10200 and i'm always happy to avoid stopping my servers.