### PR TITLE
core(fr): more precise AnyFRInterface types

### DIFF
--- a/lighthouse-core/fraggle-rock/config/config.js
+++ b/lighthouse-core/fraggle-rock/config/config.js
@@ -57,9 +57,9 @@ function resolveWorkingCopy(configJSON, context) {
  * Looks up the required artifact IDs for each dependency, throwing if no earlier artifact satisfies the dependency.
  *
  * @param {LH.Config.ArtifactJson} artifact
- * @param {LH.Config.FRGathererDefn} gatherer
- * @param {Map<Symbol, LH.Config.ArtifactDefn>} artifactDefnsBySymbol
- * @return {LH.Config.ArtifactDefn['dependencies']}
+ * @param {LH.Config.AnyFRGathererDefn} gatherer
+ * @param {Map<Symbol, LH.Config.AnyArtifactDefn>} artifactDefnsBySymbol
+ * @return {LH.Config.AnyArtifactDefn['dependencies']}
  */
 function resolveArtifactDependencies(artifact, gatherer, artifactDefnsBySymbol) {
   if (!('dependencies' in gatherer.instance.meta)) return undefined;
@@ -86,7 +86,7 @@ function resolveArtifactDependencies(artifact, gatherer, artifactDefnsBySymbol) 
  *
  * @param {LH.Config.ArtifactJson[]|null|undefined} artifacts
  * @param {string|undefined} configDir
- * @return {LH.Config.ArtifactDefn[] | null}
+ * @return {LH.Config.AnyArtifactDefn[] | null}
  */
 function resolveArtifactsToDefns(artifacts, configDir) {
   if (!artifacts) return null;
@@ -94,7 +94,7 @@ function resolveArtifactsToDefns(artifacts, configDir) {
   const status = {msg: 'Resolve artifact definitions', id: 'lh:config:resolveArtifactsToDefns'};
   log.time(status, 'verbose');
 
-  /** @type {Map<Symbol, LH.Config.ArtifactDefn>} */
+  /** @type {Map<Symbol, LH.Config.AnyArtifactDefn>} */
   const artifactDefnsBySymbol = new Map();
 
   const coreGathererList = Runner.getGathererList();
@@ -108,7 +108,9 @@ function resolveArtifactsToDefns(artifacts, configDir) {
       throw new Error(`${gatherer.instance.name} gatherer does not support Fraggle Rock`);
     }
 
-    /** @type {LH.Config.ArtifactDefn<LH.Gatherer.DependencyKey>} */
+    /** @type {LH.Config.AnyArtifactDefn} */
+    // @ts-expect-error - Typescript can't validate the gatherer and dependencies match
+    // even though it knows that they're each valid on their own.
     const artifact = {
       id: artifactJson.id,
       gatherer,
@@ -127,7 +129,7 @@ function resolveArtifactsToDefns(artifacts, configDir) {
 /**
  *
  * @param {LH.Config.NavigationJson[]|null|undefined} navigations
- * @param {LH.Config.ArtifactDefn[]|null|undefined} artifactDefns
+ * @param {LH.Config.AnyArtifactDefn[]|null|undefined} artifactDefns
  * @return {LH.Config.NavigationDefn[] | null}
  */
 function resolveNavigationsToDefns(navigations, artifactDefns) {

--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -38,7 +38,7 @@ function filterArtifactsByGatherMode(artifacts, mode) {
  * Filters an array of audits down to the set that can be computed using only the specified artifacts.
  *
  * @param {LH.Config.FRConfig['audits']} audits
- * @param {Array<LH.Config.ArtifactDefn>} availableArtifacts
+ * @param {Array<LH.Config.AnyArtifactDefn>} availableArtifacts
  * @return {LH.Config.FRConfig['audits']}
  */
 function filterAuditsByAvailableArtifacts(audits, availableArtifacts) {

--- a/lighthouse-core/fraggle-rock/config/validation.js
+++ b/lighthouse-core/fraggle-rock/config/validation.js
@@ -6,8 +6,8 @@
 'use strict';
 
 /**
- * @param {LH.Config.GathererDefn | LH.Config.FRGathererDefn} gathererDefn
- * @return {gathererDefn is LH.Config.FRGathererDefn}
+ * @param {LH.Config.GathererDefn | LH.Config.AnyFRGathererDefn} gathererDefn
+ * @return {gathererDefn is LH.Config.AnyFRGathererDefn}
  */
 function isFRGathererDefn(gathererDefn) {
   return 'meta' in gathererDefn.instance;
@@ -17,8 +17,8 @@ function isFRGathererDefn(gathererDefn) {
  * Determines if the artifact dependency direction is valid. The dependency's minimum supported mode
  * must be less than or equal to the dependent's.
  *
- * @param {LH.Config.FRGathererDefn} dependent The artifact that depends on the other.
- * @param {LH.Config.FRGathererDefn} dependency The artifact that is being depended on by the other.
+ * @param {LH.Config.AnyFRGathererDefn} dependent The artifact that depends on the other.
+ * @param {LH.Config.AnyFRGathererDefn} dependency The artifact that is being depended on by the other.
  * @return {boolean}
  */
 function isValidArtifactDependency(dependent, dependency) {

--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -8,7 +8,7 @@
 /**
  * @typedef CollectPhaseArtifactOptions
  * @property {import('./driver.js')} driver
- * @property {Array<LH.Config.ArtifactDefn>} artifactDefinitions
+ * @property {Array<LH.Config.AnyArtifactDefn>} artifactDefinitions
  * @property {ArtifactState} artifactState
  * @property {LH.Gatherer.FRGatherPhase} phase
  * @property {LH.Gatherer.GatherMode} gatherMode
@@ -99,7 +99,7 @@ async function collectPhaseArtifacts(options) {
 }
 
 /**
- * @param {LH.Config.ArtifactDefn} artifact
+ * @param {LH.Config.AnyArtifactDefn} artifact
  * @param {Record<string, LH.Gatherer.PhaseResult>} artifactsById
  * @return {Promise<Dependencies>}
  */

--- a/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
+++ b/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
@@ -40,7 +40,7 @@ function createMockSession() {
 }
 
 /**
- * @param {LH.Gatherer.FRGathererInstance<keyof LH.GathererArtifacts>['meta']|LH.Gatherer.FRGathererInstance<LH.Gatherer.DefaultDependenciesKey>['meta']} meta
+ * @param {LH.Gatherer.AnyFRGathererInstance['meta']} meta
  */
 function createMockGathererInstance(meta) {
   return {

--- a/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
+++ b/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
@@ -40,7 +40,7 @@ function createMockSession() {
 }
 
 /**
- * @param {LH.Gatherer.FRGathererInstance<LH.Gatherer.DependencyKey>['meta']} meta
+ * @param {LH.Gatherer.FRGathererInstance<keyof LH.GathererArtifacts>['meta']|LH.Gatherer.FRGathererInstance<LH.Gatherer.DefaultDependenciesKey>['meta']} meta
  */
 function createMockGathererInstance(meta) {
   return {
@@ -51,7 +51,7 @@ function createMockGathererInstance(meta) {
     stopSensitiveInstrumentation: jest.fn(),
     getArtifact: jest.fn(),
 
-    /** @return {LH.Gatherer.FRGathererInstance} */
+    /** @return {LH.Gatherer.AnyFRGathererInstance} */
     asGatherer() {
       // @ts-expect-error - We'll rely on the tests passing to know this matches.
       return this;

--- a/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
@@ -31,7 +31,7 @@ describe('NavigationRunner', () => {
   /** @type {Map<string, LH.ArbitraryEqualityMap>} */
   let computedCache;
 
-  /** @return {LH.Config.FRGathererDefn} */
+  /** @return {LH.Config.AnyFRGathererDefn} */
   function createGathererDefn() {
     return {
       instance: {

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -49,7 +49,7 @@ declare global {
        */
       export interface FRConfig {
         settings: Settings;
-        artifacts: ArtifactDefn[] | null;
+        artifacts: AnyArtifactDefn[] | null;
         navigations: NavigationDefn[] | null;
         audits: AuditDefn[] | null;
         categories: Record<string, Category> | null;
@@ -160,7 +160,7 @@ declare global {
       }
 
       export interface NavigationDefn extends Omit<Required<NavigationJson>, 'artifacts'> {
-        artifacts: ArtifactDefn[];
+        artifacts: AnyArtifactDefn[];
       }
 
       export interface ArtifactDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
@@ -171,11 +171,26 @@ declare global {
           Record<Exclude<TDependencies, Gatherer.DefaultDependenciesKey>, {id: string}>;
       }
 
+      type ArtifactDefnExpander<TDependencies extends Gatherer.DependencyKey> =
+        // Lack of brackets intentional here to convert to the union of all individual dependencies.
+        TDependencies extends Gatherer.DefaultDependenciesKey ?
+          ArtifactDefn<Gatherer.DefaultDependenciesKey> :
+          ArtifactDefn<TDependencies>
+      export type AnyArtifactDefn = ArtifactDefnExpander<Gatherer.DefaultDependenciesKey>|ArtifactDefnExpander<Gatherer.DependencyKey>
+
       export interface FRGathererDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
         implementation?: ClassOf<Gatherer.FRGathererInstance<TDependencies>>;
         instance: Gatherer.FRGathererInstance<TDependencies>;
         path?: string;
       }
+
+      type FRGathererDefnExpander<TDependencies extends Gatherer.DependencyKey> =
+        // Lack of brackets intentional here to convert to the union of all individual dependencies.
+        TDependencies extends Gatherer.DefaultDependenciesKey ?
+          FRGathererDefn<Gatherer.DefaultDependenciesKey> :
+          FRGathererDefn<TDependencies>
+      export type AnyFRGathererDefn = FRGathererDefnExpander<Gatherer.DefaultDependenciesKey>|FRGathererDefnExpander<Gatherer.DependencyKey>
+
 
       export interface GathererDefn {
         implementation?: ClassOf<Gatherer.GathererInstance>;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -191,7 +191,6 @@ declare global {
           FRGathererDefn<TDependencies>
       export type AnyFRGathererDefn = FRGathererDefnExpander<Gatherer.DefaultDependenciesKey>|FRGathererDefnExpander<Gatherer.DependencyKey>
 
-
       export interface GathererDefn {
         implementation?: ClassOf<Gatherer.GathererInstance>;
         instance: Gatherer.GathererInstance;

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -126,7 +126,6 @@ declare global {
         FRGathererInstance<Exclude<TDependencies, DefaultDependenciesKey>>
     export type AnyFRGathererInstance = FRGathererInstanceExpander<Gatherer.DependencyKey>
 
-
     namespace Simulation {
       export type GraphNode = import('../lighthouse-core/lib/dependency-graph/base-node').Node;
       export type GraphNetworkNode = _NetworkNode;

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -87,7 +87,7 @@ declare global {
     }
 
     interface GathererMetaWithDependencies<
-      TDependencies extends DependencyKey = DefaultDependenciesKey
+      TDependencies extends Exclude<DependencyKey, DefaultDependenciesKey>
     > extends GathererMetaNoDependencies {
       /**
        * The set of required dependencies that this gatherer needs before it can compute its results.
@@ -96,9 +96,9 @@ declare global {
     }
 
     export type GathererMeta<TDependencies extends DependencyKey = DefaultDependenciesKey> =
-      TDependencies extends DefaultDependenciesKey ?
+      [TDependencies] extends [DefaultDependenciesKey] ?
         GathererMetaNoDependencies :
-        GathererMetaWithDependencies<TDependencies>;
+        GathererMetaWithDependencies<Exclude<TDependencies, DefaultDependenciesKey>>;
 
     export interface GathererInstance {
       name: keyof LH.GathererArtifacts;
@@ -114,10 +114,18 @@ declare global {
       meta: GathererMeta<TDependencies>;
       startInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
       startSensitiveInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
-      stopSensitiveInstrumentation(context: FRTransitionalContext<TDependencies>): Promise<void>|void;
-      stopInstrumentation(context: FRTransitionalContext<TDependencies>): Promise<void>|void;
+      stopSensitiveInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
+      stopInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
       getArtifact(context: FRTransitionalContext<TDependencies>): PhaseResult;
     }
+
+    type FRGathererInstanceExpander<TDependencies extends Gatherer.DependencyKey> =
+      // Lack of brackets intentional here to convert to the union of all individual dependencies.
+      TDependencies extends Gatherer.DefaultDependenciesKey ?
+        FRGathererInstance<Gatherer.DefaultDependenciesKey> :
+        FRGathererInstance<Exclude<TDependencies, DefaultDependenciesKey>>
+    export type AnyFRGathererInstance = FRGathererInstanceExpander<Gatherer.DependencyKey>
+
 
     namespace Simulation {
       export type GraphNode = import('../lighthouse-core/lib/dependency-graph/base-node').Node;


### PR DESCRIPTION
**Summary**
Fixes the issue raised in https://github.com/GoogleChrome/lighthouse/issues/12619

The type violations were in fact valid and stemmed from my abuse of `Interface<AllPossibleKeys>` to be a substitute for `Interface<Key1> | Interface<Key2> | Interface<Key3>`. I introduced `AnyInterface` types to more accurately reflect when a function accepts or returns *any possible* artifact/gatherer/dependency object instead. This still has the limitation that it doesn't programmatically generate the combinatorial versions, but I haven't bumped into a scenario where the handling differs/matters yet. 

Solves @adamraine 's original point (see screenshot)

![image](https://user-images.githubusercontent.com/2301202/120854423-c6dfc800-c542-11eb-9866-73d766964017.png)

**Related Issues/PRs**
fixes https://github.com/GoogleChrome/lighthouse/issues/12619
ref #11313 
