### PR TITLE
misc: npmignore larger unnecessary files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,9 @@ build/
 coverage/
 dist/
 proto/
+docs/
 
+lighthouse-core/lib/sd-validation/
 lighthouse-core/scripts/*
 lighthouse-core/test/
 lighthouse-core/third_party/src/
@@ -51,6 +53,9 @@ npm-debug.log
 yarn-error.log
 results.html
 *.lcov
+
+# large files
+changelog.md
 
 # dev files
 .DS_Store


### PR DESCRIPTION
going through our npm packed files, a few more large ones jumped out that aren't needed for a production run (basically all the files >100KiB that aren't a locale file):

- one of the recipes under `docs/`
- prebuilt json schemas under `sd-validation/`
- our 360KiB (and growing) changelog

npmignoring these saves about 1MiB in our installed package size (package size: 2.5 MB -> 2.2 MB, unpacked size: 12.6 MB -> 11.6 MB).

I never go into an installed package to get docs about that package (I go to `npm` or direct to the repo), but if that is a use case worth preserving we could ignore just `docs/recipes/` and keep the changelog and still get like half of the savings.