### PR TITLE
core(tap-targets): add stylesheet over protocol

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/csp/csp-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/csp/csp-expectations.js
@@ -63,13 +63,6 @@ module.exports = [
             isReportOnly: false,
             contentSecurityPolicyViolationType: 'kURLViolation',
           },
-          {
-            // TODO: Fix style-src-elem violation when checking tap targets.
-            // https://github.com/GoogleChrome/lighthouse/issues/11862
-            violatedDirective: 'style-src-elem',
-            isReportOnly: false,
-            contentSecurityPolicyViolationType: 'kInlineViolation',
-          },
         ],
       },
       SourceMaps: [{
@@ -98,13 +91,6 @@ module.exports = [
       },
       InspectorIssues: {
         contentSecurityPolicy: [
-          {
-            // TODO: Fix style-src-elem violation when checking tap targets.
-            // https://github.com/GoogleChrome/lighthouse/issues/11862
-            violatedDirective: 'style-src-elem',
-            isReportOnly: false,
-            contentSecurityPolicyViolationType: 'kInlineViolation',
-          },
         ],
       },
       SourceMaps: [{

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -304,10 +304,8 @@ class TapTargets extends FRGatherer {
       styleSheetId,
       text: ruleText,
     });
-    await session.sendCommand('CSS.disable');
-    await session.sendCommand('DOM.disable');
 
-    return passContext.driver.executionContext.evaluate(gatherTapTargets, {
+    const tapTargets = await passContext.driver.executionContext.evaluate(gatherTapTargets, {
       args: [tapTargetsSelector, className],
       useIsolation: true,
       deps: [
@@ -326,6 +324,16 @@ class TapTargets extends FRGatherer {
         pageFunctions.getNodeLabel,
       ],
     });
+
+    // Remove lighthouse style rule
+    await session.sendCommand('CSS.setStyleSheetText', {
+      styleSheetId,
+      text: '',
+    });
+    await session.sendCommand('CSS.disable');
+    await session.sendCommand('DOM.disable');
+
+    return tapTargets;
   }
 }
 

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -166,15 +166,11 @@ function elementCenterIsAtZAxisTop(el, elCenterPoint) {
 /**
  * Finds all position sticky/absolute elements on the page and adds a class
  * that disables pointer events on them.
+ * @param {string} className
  * @return {() => void} - undo function to re-enable pointer events
  */
 /* c8 ignore start */
-function disableFixedAndStickyElementPointerEvents() {
-  const className = 'lighthouse-disable-pointer-events';
-  const styleTag = document.createElement('style');
-  styleTag.textContent = `.${className} { pointer-events: none !important }`;
-  document.body.appendChild(styleTag);
-
+function disableFixedAndStickyElementPointerEvents(className) {
   document.querySelectorAll('*').forEach(el => {
     const position = getComputedStyle(el).position;
     if (position === 'fixed' || position === 'sticky') {
@@ -186,17 +182,17 @@ function disableFixedAndStickyElementPointerEvents() {
     Array.from(document.getElementsByClassName(className)).forEach(el => {
       el.classList.remove(className);
     });
-    styleTag.remove();
   };
 }
 /* c8 ignore stop */
 
 /**
  * @param {string} tapTargetsSelector
+ * @param {string} className
  * @return {LH.Artifacts.TapTarget[]}
  */
 /* c8 ignore start */
-function gatherTapTargets(tapTargetsSelector) {
+function gatherTapTargets(tapTargetsSelector, className) {
   /** @type {LH.Artifacts.TapTarget[]} */
   const targets = [];
 
@@ -237,7 +233,8 @@ function gatherTapTargets(tapTargetsSelector) {
   // Disable pointer events so that tap targets below them don't get
   // detected as non-tappable (they are tappable, just not while the viewport
   // is at the current scroll position)
-  const reenableFixedAndStickyElementPointerEvents = disableFixedAndStickyElementPointerEvents();
+  const reenableFixedAndStickyElementPointerEvents
+    = disableFixedAndStickyElementPointerEvents(className);
 
   /** @type {{
     tapTargetElement: Element,
@@ -292,9 +289,26 @@ class TapTargets extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    * @return {Promise<LH.Artifacts.TapTarget[]>} All visible tap targets with their positions and sizes
    */
-  getArtifact(passContext) {
+  async getArtifact(passContext) {
+    // Add CSS rule to page without violating CSP
+    const session = passContext.driver.defaultSession;
+    await session.sendCommand('DOM.enable');
+    await session.sendCommand('CSS.enable');
+    const frameTreeResponse = await session.sendCommand('Page.getFrameTree');
+    const {styleSheetId} = await session.sendCommand('CSS.createStyleSheet', {
+      frameId: frameTreeResponse.frameTree.frame.id,
+    });
+    const className = 'lighthouse-disable-pointer-events';
+    const ruleText = `.${className} { pointer-events: none !important }`;
+    await session.sendCommand('CSS.setStyleSheetText', {
+      styleSheetId,
+      text: ruleText,
+    });
+    await session.sendCommand('CSS.disable');
+    await session.sendCommand('DOM.disable');
+
     return passContext.driver.executionContext.evaluate(gatherTapTargets, {
-      args: [tapTargetsSelector],
+      args: [tapTargetsSelector, className],
       useIsolation: true,
       deps: [
         pageFunctions.getNodeDetailsString,


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse/issues/11862

Adding the rule using the protocol will create a stylesheet that is not blocked by the CSP.
