### PR TITLE
core(fr): add audit mode filter

### DIFF
--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -65,7 +65,7 @@ function filterAuditsByGatherMode(audits, mode) {
 
   return audits.filter(audit => {
     const meta = audit.implementation.meta;
-    return !meta.applicableModes || meta.applicableModes.includes(mode);
+    return !meta.supportedModes || meta.supportedModes.includes(mode);
   });
 }
 

--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -43,7 +43,7 @@ function filterArtifactsByGatherMode(artifacts, mode) {
  * @param {LH.Gatherer.GatherMode} mode
  * @return {LH.Config.FRConfig['audits']}
  */
-function filterAudits(audits, availableArtifacts, mode) {
+function filterAuditsByAvailableArtifacts(audits, availableArtifacts, mode) {
   if (!audits) return null;
 
   const availableArtifactIds = new Set(
@@ -104,7 +104,7 @@ function filterCategoriesByAvailableAudits(categories, availableAudits) {
  */
 function filterConfigByGatherMode(config, mode) {
   const artifacts = filterArtifactsByGatherMode(config.artifacts, mode);
-  const audits = filterAudits(config.audits, artifacts || [], mode);
+  const audits = filterAuditsByAvailableArtifacts(config.audits, artifacts || [], mode);
   const categories = filterCategoriesByAvailableAudits(config.categories, audits || []);
 
   return {
@@ -118,6 +118,6 @@ function filterConfigByGatherMode(config, mode) {
 module.exports = {
   filterConfigByGatherMode,
   filterArtifactsByGatherMode,
-  filterAudits,
+  filterAuditsByAvailableArtifacts,
   filterCategoriesByAvailableAudits,
 };

--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -54,7 +54,7 @@ function filterAuditsByAvailableArtifacts(audits, availableArtifacts) {
 }
 
 /**
- * Optional `applicableModes` property can explicitly exclude an audit even if all required artifacts are available.
+ * Optional `supportedModes` property can explicitly exclude an audit even if all required artifacts are available.
  *
  * @param {LH.Config.FRConfig['audits']} audits
  * @param {LH.Gatherer.GatherMode} mode

--- a/lighthouse-core/test/fraggle-rock/config/filters-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/filters-test.js
@@ -85,12 +85,14 @@ describe('Fraggle Rock Config Filtering', () => {
 
   describe('filterAuditsByAvailableArtifacts', () => {
     it('should handle null', () => {
-      expect(filters.filterAudits(null, [], 'navigation')).toBe(null);
+      expect(filters.filterAuditsByAvailableArtifacts(null, [], 'navigation')).toBe(null);
     });
 
     it('should filter when partial artifacts available', () => {
       const partialArtifacts = [{id: 'Snapshot', gatherer: {instance: snapshotGatherer}}];
-      expect(filters.filterAudits(audits, partialArtifacts, 'snapshot')).toEqual([
+      expect(
+        filters.filterAuditsByAvailableArtifacts(audits, partialArtifacts, 'snapshot')
+      ).toEqual([
         {implementation: SnapshotAudit, options: {}},
         {implementation: ManualAudit, options: {}},
       ]);
@@ -111,12 +113,18 @@ describe('Fraggle Rock Config Filtering', () => {
       }));
       const partialArtifacts = [{id: 'Snapshot', gatherer: {instance: snapshotGatherer}}];
       expect(
-        filters.filterAudits(auditsWithBaseArtifacts, partialArtifacts, 'navigation')
+        filters.filterAuditsByAvailableArtifacts(
+          auditsWithBaseArtifacts,
+          partialArtifacts,
+          'navigation'
+        )
       ).toEqual([{implementation: SnapshotWithBase, options: {}}]);
     });
 
     it('should be noop when all artifacts available', () => {
-      expect(filters.filterAudits(audits, artifacts, 'navigation')).toEqual(audits);
+      expect(
+        filters.filterAuditsByAvailableArtifacts(audits, artifacts, 'navigation')
+      ).toEqual(audits);
     });
 
     it('should not compute audit in non-applicable mode', () => {
@@ -125,10 +133,10 @@ describe('Fraggle Rock Config Filtering', () => {
         options: {},
       }];
       expect(
-        filters.filterAudits(modeSpecificAudits, artifacts, 'navigation')
+        filters.filterAuditsByAvailableArtifacts(modeSpecificAudits, artifacts, 'navigation')
       ).toEqual(modeSpecificAudits);
       expect(
-        filters.filterAudits(modeSpecificAudits, artifacts, 'timespan')
+        filters.filterAuditsByAvailableArtifacts(modeSpecificAudits, artifacts, 'timespan')
       ).toHaveLength(0);
     });
   });

--- a/lighthouse-core/test/fraggle-rock/config/filters-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/filters-test.js
@@ -73,7 +73,7 @@ describe('Fraggle Rock Config Filtering', () => {
     static meta = {
       id: 'navigation-only',
       requiredArtifacts: /** @type {any} */ (['Snapshot', 'Timespan']),
-      applicableModes: /** @type {['navigation']} */ (['navigation']),
+      supportedModes: /** @type {['navigation']} */ (['navigation']),
       ...auditMeta,
     };
   }

--- a/lighthouse-core/test/fraggle-rock/config/filters-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/filters-test.js
@@ -85,14 +85,12 @@ describe('Fraggle Rock Config Filtering', () => {
 
   describe('filterAuditsByAvailableArtifacts', () => {
     it('should handle null', () => {
-      expect(filters.filterAuditsByAvailableArtifacts(null, [], 'navigation')).toBe(null);
+      expect(filters.filterAuditsByAvailableArtifacts(null, [])).toBe(null);
     });
 
     it('should filter when partial artifacts available', () => {
       const partialArtifacts = [{id: 'Snapshot', gatherer: {instance: snapshotGatherer}}];
-      expect(
-        filters.filterAuditsByAvailableArtifacts(audits, partialArtifacts, 'snapshot')
-      ).toEqual([
+      expect(filters.filterAuditsByAvailableArtifacts(audits, partialArtifacts)).toEqual([
         {implementation: SnapshotAudit, options: {}},
         {implementation: ManualAudit, options: {}},
       ]);
@@ -113,31 +111,12 @@ describe('Fraggle Rock Config Filtering', () => {
       }));
       const partialArtifacts = [{id: 'Snapshot', gatherer: {instance: snapshotGatherer}}];
       expect(
-        filters.filterAuditsByAvailableArtifacts(
-          auditsWithBaseArtifacts,
-          partialArtifacts,
-          'navigation'
-        )
+        filters.filterAuditsByAvailableArtifacts(auditsWithBaseArtifacts, partialArtifacts)
       ).toEqual([{implementation: SnapshotWithBase, options: {}}]);
     });
 
     it('should be noop when all artifacts available', () => {
-      expect(
-        filters.filterAuditsByAvailableArtifacts(audits, artifacts, 'navigation')
-      ).toEqual(audits);
-    });
-
-    it('should not compute audit in non-applicable mode', () => {
-      const modeSpecificAudits = [{
-        implementation: NavigationOnlyAudit,
-        options: {},
-      }];
-      expect(
-        filters.filterAuditsByAvailableArtifacts(modeSpecificAudits, artifacts, 'navigation')
-      ).toEqual(modeSpecificAudits);
-      expect(
-        filters.filterAuditsByAvailableArtifacts(modeSpecificAudits, artifacts, 'timespan')
-      ).toHaveLength(0);
+      expect(filters.filterAuditsByAvailableArtifacts(audits, artifacts)).toEqual(audits);
     });
   });
 
@@ -206,6 +185,33 @@ describe('Fraggle Rock Config Filtering', () => {
 
     it('should be noop when all audits available', () => {
       expect(filters.filterCategoriesByAvailableAudits(categories, audits)).toEqual(categories);
+    });
+  });
+
+  describe('filterAuditsByGatherMode', () => {
+    it('should handle null', () => {
+      expect(filters.filterAuditsByGatherMode(null, 'timespan')).toBeNull();
+    });
+
+    it('should filter unsupported audits', () => {
+      const timespanAudits = [TimespanAudit, NavigationOnlyAudit].map(audit => ({
+        implementation: audit,
+        options: {},
+      }));
+      expect(filters.filterAuditsByGatherMode(timespanAudits, 'timespan')).toEqual([
+        {implementation: TimespanAudit, options: {}},
+      ]);
+    });
+
+    it('should keep audits without explicit modes defined', () => {
+      const timespanAudits = [TimespanAudit, NavigationAudit].map(audit => ({
+        implementation: audit,
+        options: {},
+      }));
+      expect(filters.filterAuditsByGatherMode(timespanAudits, 'timespan')).toEqual([
+        {implementation: TimespanAudit, options: {}},
+        {implementation: NavigationAudit, options: {}},
+      ]);
     });
   });
 

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -58,7 +58,7 @@ declare global {
       /** A string identifying how the score should be interpreted for display. */
       scoreDisplayMode?: Audit.ScoreDisplayMode;
       /** A list of gather modes that this audit is applicable to. */
-      applicableModes?: Gatherer.GatherMode[],
+      supportedModes?: Gatherer.GatherMode[],
     }
 
     export interface ByteEfficiencyItem extends Audit.Details.OpportunityItem {

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -57,6 +57,8 @@ declare global {
       __internalOptionalArtifacts?: Array<keyof Artifacts>;
       /** A string identifying how the score should be interpreted for display. */
       scoreDisplayMode?: Audit.ScoreDisplayMode;
+      /** A list of gather modes that this audit is applicable to. */
+      applicableModes?: Gatherer.GatherMode[],
     }
 
     export interface ByteEfficiencyItem extends Audit.Details.OpportunityItem {


### PR DESCRIPTION
Implementation of our ideas in https://github.com/GoogleChrome/lighthouse/pull/12595#discussion_r645172157

This feels good to me, but I would be receptive to making `applicableModes` required for two reasons:
- It's more explicit about when the audit will be run.
- It would be helpful to throw an error if the available artifacts don't meet our expectations, instead of silently skipping any audits that have a missing artifact.