### PR TITLE
core(total-byte-weight): count partially finished requests

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -7,6 +7,7 @@
 
 const ByteEfficiencyAudit = require('./byte-efficiency-audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
+const NetworkRequest = require('../../lib/network-request.js');
 const NetworkRecords = require('../../computed/network-records.js');
 
 const UIStrings = {
@@ -66,9 +67,9 @@ class TotalByteWeight extends ByteEfficiencyAudit {
     /** @type {Array<{url: string, totalBytes: number}>} */
     let results = [];
     records.forEach(record => {
-      // exclude data URIs since their size is reflected in other resources
-      // exclude unfinished requests since they won't have transfer size information
-      if (record.parsedURL.scheme === 'data' || !record.finished) return;
+      // Exclude non-network URIs since their size is reflected in other resources.
+      // Exclude records without transfer size information (or 0 bytes which won't matter anyway).
+      if (NetworkRequest.isNonNetworkRequest(record) || !record.transferSize) return;
 
       const result = {
         url: record.url,

--- a/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
@@ -90,4 +90,25 @@ describe('Total byte weight audit', () => {
       assert.strictEqual(result.score, 0);
     });
   });
+
+  it('ignores non-network requests', async () => {
+    const artifacts = generateArtifacts([
+      {url: 'https://example.com/file.js', transferSize: 10_000},
+      {url: 'data:image/jpeg;base64,', protocol: 'data', transferSize: 100_000},
+      {url: 'blob:1234', protocol: 'blob', transferSize: 100_000},
+    ]);
+
+    const result = await TotalByteWeight.audit(artifacts, {options, computedCache: new Map()});
+    expect(result.numericValue).toEqual(10_000);
+  });
+
+  it('does not throw on requests with NaN transferSize', async () => {
+    const artifacts = generateArtifacts([
+      {url: 'https://example.com/file.html', transferSize: 5_000},
+      {url: 'https://example.com/file.js', transferSize: NaN},
+    ]);
+
+    const result = await TotalByteWeight.audit(artifacts, {options, computedCache: new Map()});
+    expect(result.numericValue).toEqual(5_000);
+  });
 });

--- a/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
@@ -102,7 +102,7 @@ describe('Total byte weight audit', () => {
     expect(result.numericValue).toEqual(10_000);
   });
 
-  it('does not throw on requests with NaN transferSize', async () => {
+  it('ignores requests with falsy transfer size', async () => {
     const artifacts = generateArtifacts([
       {url: 'https://example.com/file.html', transferSize: 5_000},
       {url: 'https://example.com/file.js', transferSize: NaN},

--- a/lighthouse-core/test/network-records-to-devtools-log.js
+++ b/lighthouse-core/test/network-records-to-devtools-log.js
@@ -115,7 +115,8 @@ function getResponseReceivedEvent(networkRecord, index) {
         connectionId: networkRecord.connectionId || 140,
         fromDiskCache: networkRecord.fromDiskCache || false,
         fromServiceWorker: networkRecord.fetchedViaServiceWorker || false,
-        encodedDataLength: networkRecord.transferSize || 0,
+        encodedDataLength: typeof networkRecord.transferSize === 'undefined' ?
+          0 : networkRecord.transferSize,
         timing,
         protocol: networkRecord.protocol || 'http/1.1',
       },
@@ -134,7 +135,8 @@ function getDataReceivedEvent(networkRecord, index) {
     params: {
       requestId: getBaseRequestId(networkRecord) || `${idBase}.${index}`,
       dataLength: networkRecord.resourceSize || 0,
-      encodedDataLength: networkRecord.transferSize || 0,
+      encodedDataLength: typeof networkRecord.transferSize === 'undefined' ?
+        0 : networkRecord.transferSize,
     },
   };
 }
@@ -149,7 +151,8 @@ function getLoadingFinishedEvent(networkRecord, index) {
     params: {
       requestId: getBaseRequestId(networkRecord) || `${idBase}.${index}`,
       timestamp: networkRecord.endTime || 3,
-      encodedDataLength: networkRecord.transferSize || 0,
+      encodedDataLength: typeof networkRecord.transferSize === 'undefined' ?
+        0 : networkRecord.transferSize,
     },
   };
 }

--- a/lighthouse-core/test/network-records-to-devtools-log.js
+++ b/lighthouse-core/test/network-records-to-devtools-log.js
@@ -115,7 +115,7 @@ function getResponseReceivedEvent(networkRecord, index) {
         connectionId: networkRecord.connectionId || 140,
         fromDiskCache: networkRecord.fromDiskCache || false,
         fromServiceWorker: networkRecord.fetchedViaServiceWorker || false,
-        encodedDataLength: typeof networkRecord.transferSize === 'undefined' ?
+        encodedDataLength: networkRecord.transferSize === undefined ?
           0 : networkRecord.transferSize,
         timing,
         protocol: networkRecord.protocol || 'http/1.1',
@@ -135,7 +135,7 @@ function getDataReceivedEvent(networkRecord, index) {
     params: {
       requestId: getBaseRequestId(networkRecord) || `${idBase}.${index}`,
       dataLength: networkRecord.resourceSize || 0,
-      encodedDataLength: typeof networkRecord.transferSize === 'undefined' ?
+      encodedDataLength: networkRecord.transferSize === undefined ?
         0 : networkRecord.transferSize,
     },
   };
@@ -151,7 +151,7 @@ function getLoadingFinishedEvent(networkRecord, index) {
     params: {
       requestId: getBaseRequestId(networkRecord) || `${idBase}.${index}`,
       timestamp: networkRecord.endTime || 3,
-      encodedDataLength: typeof networkRecord.transferSize === 'undefined' ?
+      encodedDataLength: networkRecord.transferSize === undefined ?
         0 : networkRecord.transferSize,
     },
   };


### PR DESCRIPTION
**Summary**
Removes the total byte weight policy that ignored partially downloaded resources (like videos). IMO, this dramatically understates the weight of a page in some cases (see #12664).

The check was added [way back in 2017](https://github.com/GoogleChrome/lighthouse/pull/2023#discussion_r114909191) _by me_ as part of __adding visibility into inflight records__ 🤯 . This was also before we used our own network request class that initializes transferSize that prevents the `undefined` concern that prompted the original.

Nonetheless, I added a test to ensure spirit of the condition is still handled.

**Related Issues/PRs**
closes #12664
