### PR TITLE
core(canonical): proper explanation for url misuse

### DIFF
--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -32,7 +32,7 @@ const UIStrings = {
    * @description Explanatory message stating that there was a failure in an audit caused by a URL being relative instead of absolute.
    * @example {https://example.com/} url
    * */
-  explanationRelative: 'Relative URL ({url})',
+  explanationRelative: 'Is not an absolute URL ({url})',
   /**
    * @description Explanatory message stating that there was a failure in an audit caused by a URL pointing to a different hreflang than the current context.'hreflang' is an HTML attribute and should not be translated.
    * @example {https://example.com/} url

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -1200,7 +1200,7 @@
     "message": "Points to another `hreflang` location ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "Relative URL ({url})"
+    "message": "Is not an absolute URL ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "Points to the domain's root URL (the homepage), instead of an equivalent page of content"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -1200,7 +1200,7 @@
     "message": "P̂óîńt̂ś t̂ó âńôt́ĥér̂ `hreflang` ĺôćât́îón̂ ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRelative": {
-    "message": "R̂él̂át̂ív̂é ÛŔL̂ ({url})"
+    "message": "Îś n̂ót̂ án̂ áb̂śôĺût́ê ÚR̂Ĺ ({url})"
   },
   "lighthouse-core/audits/seo/canonical.js | explanationRoot": {
     "message": "P̂óîńt̂ś t̂ó t̂h́ê d́ôḿâín̂'ś r̂óôt́ ÛŔL̂ (t́ĥé ĥóm̂ép̂áĝé), îńŝt́êád̂ óf̂ án̂ éq̂úîv́âĺêńt̂ ṕâǵê óf̂ ćôńt̂én̂t́"

--- a/lighthouse-core/test/audits/seo/canonical-test.js
+++ b/lighthouse-core/test/audits/seo/canonical-test.js
@@ -101,7 +101,7 @@ describe('SEO: Document has valid canonical link', () => {
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
       const {score, explanation} = auditResult;
       assert.equal(score, 0);
-      expect(explanation).toBeDisplayString('Relative URL (/)');
+      expect(explanation).toBeDisplayString('Is not an absolute URL (/)');
     });
   });
 


### PR DESCRIPTION
**Summary**
Modified explanationRelative from ```Relative URL ({url})``` to ```Is not an absolute URL ({url})```

Related Issues/PRs
Fixes #12463
Closes #12479