### PR TITLE
core(fr): add timespan support to viewport-dimensions

### DIFF
--- a/lighthouse-core/gather/gatherers/viewport-dimensions.js
+++ b/lighthouse-core/gather/gatherers/viewport-dimensions.js
@@ -30,7 +30,7 @@ function getViewportDimensions() {
 class ViewportDimensions extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
-    supportedModes: ['snapshot', 'navigation'],
+    supportedModes: ['snapshot', 'timespan', 'navigation'],
   }
 
   /**

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -1297,7 +1297,7 @@ describe('Config', () => {
 
       const expectedInstance = {
         meta: {
-          supportedModes: ['snapshot', 'navigation'],
+          supportedModes: ['snapshot', 'timespan', 'navigation'],
         },
       };
       assert.deepEqual(mergedJson[0].gatherers,

--- a/lighthouse-core/test/fraggle-rock/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/api-test-pptr.js
@@ -121,7 +121,7 @@ describe('Fraggle Rock API', () => {
 
       const {auditResults, erroredAudits, failedAudits} = getAuditsBreakdown(lhr);
       // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
-      expect(auditResults.length).toMatchInlineSnapshot(`38`);
+      expect(auditResults.length).toMatchInlineSnapshot(`40`);
 
       expect(erroredAudits).toHaveLength(0);
       expect(failedAudits.map(audit => audit.id)).toContain('errors-in-console');


### PR DESCRIPTION
[Opportunity conversion doc](https://docs.google.com/document/d/1z6Cm4jJmN-1i5S2ryfC1hLPyo46NlW6X8QMXRDqq1_Y/edit?resourcekey=0-r0zHmcvw4Y2Wg4DI96d4KA#)

This is some pretty low-hanging fruit. We are just getting viewport dimensions from the end of the timespan.

Only issue would be if viewport changes during the timespan, but such an event could also affect the dimensions in navigation mode. We could surface a warning if the viewport changes.