### PR TITLE
core(network-request): consider HSTS redirects secure

### DIFF
--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -493,7 +493,23 @@ class NetworkRequest {
   static isSecureRequest(record) {
     return URL.isSecureScheme(record.parsedURL.scheme) ||
         URL.isSecureScheme(record.protocol) ||
-        URL.isLikeLocalhost(record.parsedURL.host);
+        URL.isLikeLocalhost(record.parsedURL.host) ||
+        NetworkRequest.isHstsRequest(record);
+  }
+
+  /**
+   * Returns whether the network request was an HSTS redirect request.
+   * @param {NetworkRequest} record
+   * @return {boolean}
+   */
+  static isHstsRequest(record) {
+    const destination = record.redirectDestination;
+    if (!destination) return false;
+
+    const reasonHeader = record.responseHeaders
+      .find(header => header.name === 'Non-Authoritative-Reason');
+    const reason = reasonHeader && reasonHeader.value;
+    return reason === 'HSTS' && NetworkRequest.isSecureRequest(destination);
   }
 }
 


### PR DESCRIPTION
**Summary**
Often the HTTPS audit fails because the original URL audited was `http`, so even if it redirects then you still have the original redirect request over HTTP. We can kinda explain why this is desirable (though I'm not really sold it's worth the annoyance), but it's definitely not the case in HSTS internal redirects that happen in the browser, which is the whole point of HSTS. This applies to entire TLDs in some cases (`.app`/`.dev`), so we should handle those cases appropriately.


**Related Issues/PRs**
fixes https://github.com/GoogleChrome/lighthouse/issues/12674
