### PR TITLE
WIP: Add snapshot support to byte efficiency audits

### DIFF
--- a/be-test.js
+++ b/be-test.js
@@ -1,0 +1,19 @@
+'use strict';
+const puppeteer = require('puppeteer');
+const lighthouse = require('./lighthouse-core/fraggle-rock/api.js');
+
+async function run() {
+  const browser = await puppeteer.launch({
+    headless: false,
+  });
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/responsive-image.html');
+
+  const result = await lighthouse.snapshot({page});
+
+  console.log(JSON.stringify(result.lhr, null, 2));
+
+  await page.close();
+  await browser.close();
+}
+run();

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -106,6 +106,10 @@ class UnusedBytes extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static audit(artifacts, context) {
+    if (artifacts.GatherContext && artifacts.GatherContext.gatherMode === 'snapshot') {
+      return this.auditSnapshot_(artifacts, context);
+    }
+
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const settings = context && context.settings || {};
@@ -228,6 +232,15 @@ class UnusedBytes extends Audit {
    */
   static audit_(artifacts, networkRecords, context) {
     throw new Error('audit_ unimplemented');
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @param {LH.Audit.Context} context
+   * @return {Promise<LH.Audit.Product>}
+   */
+  static auditSnapshot_(artifacts, context) {
+    throw new Error('auditSnapshot_ unimplemented');
   }
 
   /* eslint-enable no-unused-vars */

--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -49,6 +49,7 @@ function filterAuditsByAvailableArtifacts(audits, availableArtifacts) {
   );
   return audits.filter(audit => {
     const meta = audit.implementation.meta;
+    if (meta.supportedModes) return true;
     return meta.requiredArtifacts.every(id => availableArtifactIds.has(id));
   });
 }

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -320,7 +320,9 @@ class Runner {
         if (noArtifact || noRequiredTrace || noRequiredDevtoolsLog) {
           log.warn('Runner',
               `${artifactName} gatherer, required by audit ${audit.meta.id}, did not run.`);
-          throw new LHError(LHError.errors.MISSING_REQUIRED_ARTIFACT, {artifactName});
+          if (!audit.meta.supportedModes) {
+            throw new LHError(LHError.errors.MISSING_REQUIRED_ARTIFACT, {artifactName});
+          }
         }
 
         // If artifact was an error, output error result on behalf of audit.


### PR DESCRIPTION
This PR adds split functionality to `ByteEfficiency` audits with a new function `auditSnapshot_`. For this to be possible, we need a way to make timespan/navigation specific artifacts optional.

The current implementation makes all artifacts optional when `supportedModes` is specified. This works fine, but I'm open to adding a more explicit `artifactsAreOptional` flag or something.

As an example, I added snapshot support to `uses-responsive-images`:

<img width="980" alt="Screen Shot 2021-06-23 at 12 43 41 PM" src="https://user-images.githubusercontent.com/6752989/123136195-a5c31680-d420-11eb-9d12-5f8813153877.png">
