### PR TITLE
tests: add explicit small-icu detection for i18n

### DIFF
--- a/lighthouse-core/test/config/config-helpers-test.js
+++ b/lighthouse-core/test/config/config-helpers-test.js
@@ -21,6 +21,7 @@ const Runner = require('../../runner.js');
 const Gatherer = require('../../gather/gatherers/gatherer.js');
 const ImageElementsGatherer = require('../../gather/gatherers/image-elements.js');
 const UserTimingsAudit = require('../../audits/user-timings.js');
+const {isNode12SmallIcu} = require('../test-utils.js');
 
 jest.mock('process', () => ({
   cwd: () => jest.fn(),
@@ -150,7 +151,7 @@ describe('.resolveSettings', () => {
   it('resolves the locale', () => {
     const settings = resolveSettings({locale: 'zh-CN'});
     // COMPAT: Node 12 only has 'en' by default.
-    if (process.versions.node.startsWith('12')) {
+    if (isNode12SmallIcu()) {
       expect(settings.locale).toEqual('en');
       return;
     }

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -14,6 +14,7 @@ const log = require('lighthouse-logger');
 const Gatherer = require('../../gather/gatherers/gatherer.js');
 const Audit = require('../../audits/audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
+const {isNode12SmallIcu} = require('../test-utils.js');
 
 /* eslint-env jest */
 
@@ -829,7 +830,7 @@ describe('Config', () => {
       const locale = 'ar-XB';
       const config = new Config({settings: {locale}});
       // COMPAT: Node 12 only has 'en' by default.
-      if (process.versions.node.startsWith('12')) return;
+      if (isNode12SmallIcu()) return;
       assert.strictEqual(config.settings.locale, locale);
     });
 
@@ -838,7 +839,7 @@ describe('Config', () => {
       const flagsLocale = 'ar-XB';
       const config = new Config({settings: {locale: settingsLocale}}, {locale: flagsLocale});
       // COMPAT: Node 12 only has 'en' by default.
-      if (process.versions.node.startsWith('12')) return;
+      if (isNode12SmallIcu()) return;
       assert.strictEqual(config.settings.locale, flagsLocale);
     });
   });

--- a/lighthouse-core/test/lib/i18n/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n/i18n-test.js
@@ -8,6 +8,7 @@
 const path = require('path');
 const i18n = require('../../../lib/i18n/i18n.js');
 const log = require('lighthouse-logger');
+const {isNode12SmallIcu} = require('../../test-utils.js');
 
 /* eslint-env jest */
 
@@ -158,7 +159,7 @@ describe('i18n', () => {
       expect(i18n.lookupLocale(invalidLocale)).toEqual('en');
 
       // COMPAT: Node 12 logs an extra warning that full-icu is not available.
-      if (process.versions.node.startsWith('12')) {
+      if (isNode12SmallIcu()) {
         expect(logListener).toBeCalledTimes(2);
         expect(logListener).toHaveBeenNthCalledWith(1, ['i18n',
           expect.stringMatching(/Requested locale not available in this version of node/)]);
@@ -176,7 +177,7 @@ describe('i18n', () => {
 
     it('falls back to root tag prefix if specific locale not available', () => {
       // COMPAT: Node 12 only has 'en' by default.
-      if (process.versions.node.startsWith('12')) {
+      if (isNode12SmallIcu()) {
         expect(i18n.lookupLocale('es-JKJK')).toEqual('en');
         return;
       }

--- a/lighthouse-core/test/lib/i18n/swap-locale-test.js
+++ b/lighthouse-core/test/lib/i18n/swap-locale-test.js
@@ -6,13 +6,14 @@
 'use strict';
 
 const swapLocale = require('../../../lib/i18n/swap-locale.js');
+const {isNode12SmallIcu} = require('../../test-utils.js');
 
 const lhr = require('../../results/sample_v2.json');
 
 /* eslint-env jest */
 describe('swap-locale', () => {
   // COMPAT: Node 12 only has 'en' by default. Skip these tests since they're all about swapping locales.
-  if (process.versions.node.startsWith('12')) {
+  if (isNode12SmallIcu()) {
     // Jest requires at least one test per suite.
     it('runs even if other locales are not supported', () => {
       /** @type {LH.Result} */

--- a/lighthouse-core/test/test-utils.js
+++ b/lighthouse-core/test/test-utils.js
@@ -271,6 +271,18 @@ function makeMocksForGatherRunner() {
   }));
 }
 
+/**
+ * Returns whether this is running in Node 12 with what we suspect is the default
+ * `small-icu` build. Limited to Node 12 so it's not accidentally hitting this
+ * path in Node 13+ in CI and we can be certain the `full-icu` path is being exercised.
+ * @return {boolean}
+ */
+function isNode12SmallIcu() {
+  // COMPAT: Remove when Node 12 is retired and `full-icu` is the default everywhere.
+  return process.versions.node.startsWith('12') &&
+    Intl.NumberFormat.supportedLocalesOf('es').length === 0;
+}
+
 module.exports = {
   getProtoRoundTrip,
   loadSourceMapFixture,
@@ -280,5 +292,6 @@ module.exports = {
   createDecomposedPromise,
   flushAllTimersAndMicrotasks,
   makeMocksForGatherRunner,
+  isNode12SmallIcu,
   ...mockCommands,
 };

--- a/report/test/renderer/i18n-test.js
+++ b/report/test/renderer/i18n-test.js
@@ -8,6 +8,7 @@
 const assert = require('assert').strict;
 const Util = require('../../renderer/util.js');
 const I18n = require('../../renderer/i18n.js');
+const {isNode12SmallIcu} = require('../../../lighthouse-core/test/test-utils.js');
 
 // Require i18n to make sure Intl is polyfilled in Node without full-icu for testing.
 // When Util is run in a browser, Intl will be supplied natively (IE11+).
@@ -107,7 +108,7 @@ describe('util helpers', () => {
 
   it('formats numbers based on locale', () => {
     // COMPAT: Node 12 only has 'en' by default.
-    if (process.versions.node.startsWith('12')) return;
+    if (isNode12SmallIcu()) return;
 
     // Requires full-icu or Intl polyfill.
     const number = 12346.858558;
@@ -121,7 +122,7 @@ describe('util helpers', () => {
 
   it('uses decimal comma with en-XA test locale', () => {
     // COMPAT: Node 12 only has 'en' by default.
-    if (process.versions.node.startsWith('12')) return;
+    if (isNode12SmallIcu()) return;
 
     // Requires full-icu or Intl polyfill.
     const number = 12346.858558;


### PR DESCRIPTION
the node 12 compat checks added to unit tests in #12426 don't work if your Node 12 also happened to be built with `full-icu`, as @victorporof's seems to have been :)

This adds an explicit check for better-than-small ICU support to the existing node 12 checks. As before, we can remove all this when we move to a Node 14 minimum.