### PR TITLE
tests: tweak variability assertion for load-things transferSize

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -82,7 +82,7 @@ module.exports = [
               {resourceType: 'font', requestCount: 2, transferSize: '81000±1000'},
               {resourceType: 'script', requestCount: 3, transferSize: '55000±1000'},
               {resourceType: 'image', requestCount: 2, transferSize: '28000±1000'},
-              {resourceType: 'document', requestCount: 1, transferSize: '2200±100'},
+              {resourceType: 'document', requestCount: 1, transferSize: '2200±150'},
               {resourceType: 'other', requestCount: 1, transferSize: '1030±100'},
               {resourceType: 'stylesheet', requestCount: 1, transferSize: '450±100'},
               {resourceType: 'media', requestCount: 0, transferSize: 0},


### PR DESCRIPTION
This upstreams a change created by the JS web build team.  🔒  http://cl/379821904 THANK YOU to Elena and Jan! 😻

As noted by them:

> **For the `document` resource**: the new transfer size is just outside current bounds of `'2200±100'`
> The transfer size differences appear to be caused by header changes (where with the node14 upgrade, there is an additional header, `Keep-Alive: timeout=5`).

