### PR TITLE
deps(axe-core): upgrade to 4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "webtreemap-cdt": "^3.2.1"
   },
   "dependencies": {
-    "axe-core": "4.2.1",
+    "axe-core": "4.2.3",
     "chrome-launcher": "^0.14.0",
     "configstore": "^5.0.1",
     "csp_evaluator": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,10 +1544,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.1.tgz#2e50bcf10ee5b819014f6e342e41e45096239e34"
-  integrity sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==
+axe-core@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.3.tgz#2a3afc332f0031b42f602f4a3de03c211ca98f72"
+  integrity sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==
 
 babel-jest@^27.0.2:
   version "27.0.2"


### PR DESCRIPTION
**Summary**
Bumps axe-core to 4.2.3. to fix common fatal bug (see changelog [4.2.2](https://github.com/dequelabs/axe-core/pull/2976/commits) [4.2.3](https://github.com/dequelabs/axe-core/releases/tag/v4.2.3)). No new rules, just bug fixes, so shouldn't interfere with the other ongoing a11y audit work in #12536 #12699 #12700


**Related Issues/PRs**
closes #12705 
