### PR TITLE
misc(scripts): check for UIStrings text before using require

### DIFF
--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -538,17 +538,14 @@ function collectAllStringsInDir(dir) {
     if (!process.env.CI) console.log('Collecting from', relativeToRootPath);
 
     const content = fs.readFileSync(absolutePath, 'utf8');
-    const exportVars = require(absolutePath);
     const regexMatch = content.match(UISTRINGS_REGEX);
-    const exportedUIStrings = exportVars.UIStrings;
-
     if (!regexMatch) {
-      // No UIStrings found in the file text or exports, so move to the next.
-      if (!exportedUIStrings) continue;
-
-      throw new Error('UIStrings exported but no definition found');
+      // No UIStrings found in the file text, so move to the next.
+      continue;
     }
 
+    const exportVars = require(absolutePath);
+    const exportedUIStrings = exportVars.UIStrings;
     if (!exportedUIStrings) {
       throw new Error('UIStrings defined in file but not exported');
     }


### PR DESCRIPTION
minor change, needed to play nice with `standalone.js` in #12702 (requiring causes script to error b/c `document`, etc. does not exist)