### PR TITLE
i18n: allow strings with duplicate message and descriptions

### DIFF
--- a/lighthouse-core/audits/accessibility/aria-command-name.js
+++ b/lighthouse-core/audits/accessibility/aria-command-name.js
@@ -18,7 +18,7 @@ const UIStrings = {
   title: '`button`, `link`, and `menuitem` elements have accessible names',
   /** Title of an accessibility audit that evaluates if important HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: '`button`, `link`, and `menuitem` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for command elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more](https://web.dev/aria-name/).',
 };
 

--- a/lighthouse-core/audits/accessibility/aria-meter-name.js
+++ b/lighthouse-core/audits/accessibility/aria-meter-name.js
@@ -18,7 +18,7 @@ const UIStrings = {
   title: 'ARIA `meter` elements have accessible names',
   /** Title of an accessibility audit that evaluates if meter HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'ARIA `meter` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for meter elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more](https://web.dev/aria-name/).',
 };
 

--- a/lighthouse-core/audits/accessibility/aria-tooltip-name.js
+++ b/lighthouse-core/audits/accessibility/aria-tooltip-name.js
@@ -18,7 +18,7 @@ const UIStrings = {
   title: 'ARIA `tooltip` elements have accessible names',
   /** Title of an accessibility audit that evaluates if tooltip HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'ARIA `tooltip` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for tooltips. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more](https://web.dev/aria-name/).',
 };
 

--- a/lighthouse-core/audits/accessibility/aria-treeitem-name.js
+++ b/lighthouse-core/audits/accessibility/aria-treeitem-name.js
@@ -18,7 +18,7 @@ const UIStrings = {
   title: 'ARIA `treeitem` elements have accessible names',
   /** Title of an accessibility audit that evaluates if treeitem HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
   failureTitle: 'ARIA `treeitem` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more](https://web.dev/aria-name/).',
 };
 

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -598,54 +598,43 @@ function writeStringsToCtcFiles(locale, strings) {
 }
 
 /**
- * This function does three things:
+ * This function does two things:
  *
- *    - Add `meaning` property to ctc messages that have the same message so TC can disambiguate (otherwise it fails to import).
- *    - Throw if the `meaning` of any collisions *also* collides (can't disambiguate messages).
+ *    - Add `meaning` property to ctc messages that have the same message but different descriptions so TC can disambiguate.
  *    - Throw if the known collisions has changed at all.
  *
  * @param {Record<string, CtcMessage>} strings
  */
 function resolveMessageCollisions(strings) {
-  /** @type {Map<string, Array<[string, CtcMessage]>>} */
+  /** @type {Map<string, Array<CtcMessage>>} */
   const stringsByMessage = new Map();
 
   // Group all the strings by their message.
-  for (const entry of Object.entries(strings)) {
-    const collisions = stringsByMessage.get(entry[1].message) || [];
-    collisions.push(entry);
-    stringsByMessage.set(entry[1].message, collisions);
+  for (const ctc of Object.values(strings)) {
+    const collisions = stringsByMessage.get(ctc.message) || [];
+    collisions.push(ctc);
+    stringsByMessage.set(ctc.message, collisions);
   }
 
-  /** @type {Array<[string, CtcMessage]>} */
+  /** @type {Array<CtcMessage>} */
   const allCollisions = [];
-  for (const group of stringsByMessage.values()) {
+  for (const messageGroup of stringsByMessage.values()) {
     // If this message didn't collide with anything else, skip it.
-    if (group.length <= 1) continue;
-    allCollisions.push(...group);
+    if (messageGroup.length <= 1) continue;
 
-    // We have a message collision, time to check collisions on the `meaning` property.
-    /** @type {Map<string|undefined, Array<[string, CtcMessage]>>} */
-    const stringsByMeaning = new Map();
-    for (const [key, ctc] of group) {
+    // If group shares both message and description, they can be translated as if a single string.
+    const descriptions = new Set(messageGroup.map(ctc => ctc.description));
+    if (descriptions.size <= 1) continue;
+
+    // We have duplicate messages with different descriptions. Disambiguate using `meaning` for TC.
+    for (const ctc of messageGroup) {
       ctc.meaning = ctc.description;
-
-      const collisions = stringsByMeaning.get(ctc.meaning) || [];
-      collisions.push([key, ctc]);
-      stringsByMeaning.set(ctc.meaning, collisions);
     }
-
-    for (const meaningGroup of stringsByMeaning.values()) {
-      if (meaningGroup.length <= 1) continue;
-
-      const debugMeaningList = meaningGroup.map(entry => [entry[0], entry[1].meaning].join('\n'));
-      const debugCollisionsMessage = `${meaningGroup[0][1].message}\n\n${debugMeaningList.join('\n\n')}`;
-      throw new Error(`Each strings' \`message\` or \`description\` must be different for the translation pipeline. The following keys did not have unique \`meaning\` values:\n\n${debugCollisionsMessage}`);
-    }
+    allCollisions.push(...messageGroup);
   }
 
-  // We survived fatal collisions, now check that the known collisions match our known list.
-  const collidingMessages = allCollisions.map(collision => collision[1].message).sort();
+  // Check that the known collisions match our known list.
+  const collidingMessages = allCollisions.map(collision => collision.message).sort();
 
   try {
     expect(collidingMessages).toEqual([
@@ -676,13 +665,9 @@ function resolveMessageCollisions(strings) {
       'Potential Savings',
       'URL',
       'URL',
-      'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. $LINK_START_0$Learn more$LINK_END_0$.',
-      'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. $LINK_START_0$Learn more$LINK_END_0$.',
-      'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. $LINK_START_0$Learn more$LINK_END_0$.',
-      'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. $LINK_START_0$Learn more$LINK_END_0$.',
     ]);
   } catch (err) {
-    console.log('The number of duplicate strings have changed, update this assertion if that is expected, or reword strings');
+    console.log('The number of duplicate strings has changed. Consider duplicating the `description` to match existing strings so they\'re translated together or update this assertion if they must absolutely be translated separately');
     console.log('copy/paste this to pass check:');
     console.log(collidingMessages);
     throw new Error(err.message);


### PR DESCRIPTION
I started looking into fatal `collect-strings` collisions after https://github.com/GoogleChrome/lighthouse/pull/12697/files#r658831618 when it became clear that that `lighthouse-core/audits/accessibility/aria-progressbar-name.js | description` has been accidentally colliding with `lighthouse-core/audits/accessibility/aria-treeitem-name.js | description` for quite some time and we (and TC) haven't noticed.

It seems like something has changed with collisions. At least from what I can understand from inspecting some of the intermediate files in the pipeline, internally those two strings got deduped into a single message for translation (they share an ID which is hashed from the `message` and `meaning`), then properly duplicated again when dumped into our LHL format. Basically exactly what you'd hope for. From docs I've looked at now, it's actually encouraged that we allow colliding strings and only add a `meaning` if we _really_ want the strings to be translated separately, so it's possible this was a bug in the handler that ingested our CTC format that was incidentally fixed in the last few years.

To test this, I took four currently colliding accessibility messages and made their descriptions the same as well so they'd be full collisions. They appear to have gone through a full TC roundtrip once, but I'm running again just to be sure :)

If this all looks good, we can probably follow up with setting a lot of the current collision list be full duplicates (no reason each stack pack needs "WordPress"/"Drupal"/"Joomla" in their descriptions when the string is just about using "HTML5 video"). Sometimes an explicit approach like @adamraine's in https://github.com/GoogleChrome/lighthouse/pull/12714#discussion_r660887254 will make more sense when a lot of strings are explicitly being shared between files, but it's also nice to know that strings that collide by happenstance are no big deal.