### PR TITLE
misc: get LH_ROOT via new file root.js

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -14,12 +14,12 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert').strict;
 const mkdir = fs.promises.mkdir;
-
 const LighthouseRunner = require('../lighthouse-core/runner.js');
 const exorcist = require('exorcist');
 const browserify = require('browserify');
 const terser = require('terser');
 const {minifyFileTransform} = require('./build-utils.js');
+const {LH_ROOT} = require('../root.js');
 
 const COMMIT_HASH = require('child_process')
   .execSync('git rev-parse HEAD')
@@ -31,7 +31,7 @@ const audits = LighthouseRunner.getAuditList()
 const gatherers = LighthouseRunner.getGathererList()
     .map(f => './lighthouse-core/gather/gatherers/' + f.replace(/\.js$/, ''));
 
-const locales = fs.readdirSync(__dirname + '/../lighthouse-core/lib/i18n/locales/')
+const locales = fs.readdirSync(LH_ROOT + '/lighthouse-core/lib/i18n/locales/')
     .map(f => require.resolve(`../lighthouse-core/lib/i18n/locales/${f}`));
 
 // HACK: manually include the lighthouse-plugin-publisher-ads audits.

--- a/build/build-cdt-lib.js
+++ b/build/build-cdt-lib.js
@@ -9,8 +9,9 @@
 
 const fs = require('fs');
 const ts = require('typescript');
+const {LH_ROOT} = require('../root.js');
 
-const outDir = `${__dirname}/../lighthouse-core/lib/cdt/generated`;
+const outDir = `${LH_ROOT}/lighthouse-core/lib/cdt/generated`;
 const files = {
   'node_modules/chrome-devtools-frontend/front_end/sdk/SourceMap.js': 'SourceMap.js',
 };

--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -9,8 +9,9 @@ const browserify = require('browserify');
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert').strict;
+const {LH_ROOT} = require('../root.js');
 
-const distDir = path.join(__dirname, '..', 'dist', 'dt-report-resources');
+const distDir = path.join(LH_ROOT, 'dist', 'dt-report-resources');
 const bundleOutFile = `${distDir}/report-generator.js`;
 const generatorFilename = `./report/report-generator.js`;
 const htmlReportAssets = require('../report/report-assets.js');

--- a/build/build-extension.js
+++ b/build/build-extension.js
@@ -7,11 +7,11 @@
 
 const fs = require('fs');
 const mkdir = fs.promises.mkdir;
-
 const archiver = require('archiver');
 const cpy = require('cpy');
 const browserify = require('browserify');
 const path = require('path');
+const {LH_ROOT} = require('../root.js');
 
 const argv = process.argv.slice(2);
 const browserBrand = argv[0];
@@ -19,8 +19,8 @@ const browserBrand = argv[0];
 const sourceName = 'popup.js';
 const distName = 'popup-bundle.js';
 
-const sourceDir = `${__dirname}/../clients/extension`;
-const distDir = `${__dirname}/../dist/extension-${browserBrand}`;
+const sourceDir = `${LH_ROOT}/clients/extension`;
+const distDir = `${LH_ROOT}/dist/extension-${browserBrand}`;
 const packagePath = `${distDir}/../extension-${browserBrand}-package`;
 
 const manifestVersion = require(`${sourceDir}/manifest.json`).version;

--- a/build/build-lightrider-bundles.js
+++ b/build/build-lightrider-bundles.js
@@ -10,9 +10,10 @@ const fs = require('fs');
 const path = require('path');
 const bundleBuilder = require('./build-bundle.js');
 const {minifyFileTransform} = require('./build-utils.js');
+const {LH_ROOT} = require('../root.js');
 
-const distDir = path.join(__dirname, '..', 'dist', 'lightrider');
-const sourceDir = __dirname + '/../clients/lightrider';
+const distDir = path.join(LH_ROOT, 'dist', 'lightrider');
+const sourceDir = path.join(LH_ROOT, 'clients', 'lightrider');
 
 const bundleOutFile = `${distDir}/report-generator-bundle.js`;
 const generatorFilename = `./report/report-generator.js`;

--- a/build/build-smokehouse-bundle.js
+++ b/build/build-smokehouse-bundle.js
@@ -7,8 +7,9 @@
 
 const browserify = require('browserify');
 const fs = require('fs');
+const {LH_ROOT} = require('../root.js');
 
-const distDir = `${__dirname}/../dist`;
+const distDir = `${LH_ROOT}/dist`;
 const bundleOutFile = `${distDir}/smokehouse-bundle.js`;
 const smokehouseLibFilename = './lighthouse-cli/test/smokehouse/frontends/lib.js';
 

--- a/build/build-treemap.js
+++ b/build/build-treemap.js
@@ -9,6 +9,7 @@
 
 const fs = require('fs');
 const GhPagesApp = require('./gh-pages-app.js');
+const {LH_ROOT} = require('../root.js');
 
 /**
  * Extract only the strings needed for lighthouse-treemap into
@@ -46,7 +47,7 @@ function buildStrings() {
 async function run() {
   const app = new GhPagesApp({
     name: 'treemap',
-    appDir: `${__dirname}/../lighthouse-treemap/app`,
+    appDir: `${LH_ROOT}/lighthouse-treemap/app`,
     html: {path: 'index.html'},
     stylesheets: [
       fs.readFileSync(require.resolve('tabulator-tables/dist/css/tabulator.min.css'), 'utf8'),

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -10,13 +10,14 @@ const browserify = require('browserify');
 const GhPagesApp = require('./gh-pages-app.js');
 const {minifyFileTransform} = require('./build-utils.js');
 const htmlReportAssets = require('../report/report-assets.js');
+const {LH_ROOT} = require('../root.js');
 
 /**
  * Build viewer, optionally deploying to gh-pages if `--deploy` flag was set.
  */
 async function run() {
   // JS bundle from browserified ReportGenerator.
-  const generatorFilename = `${__dirname}/../report/report-generator.js`;
+  const generatorFilename = `${LH_ROOT}/report/report-generator.js`;
   const generatorBrowserify = browserify(generatorFilename, {standalone: 'ReportGenerator'})
     .transform('@wardpeet/brfs', {
       readFileSyncTransform: minifyFileTransform,
@@ -32,7 +33,7 @@ async function run() {
 
   const app = new GhPagesApp({
     name: 'viewer',
-    appDir: `${__dirname}/../lighthouse-viewer/app`,
+    appDir: `${LH_ROOT}/lighthouse-viewer/app`,
     html: {path: 'index.html'},
     htmlReplacements: {
       '%%LIGHTHOUSE_TEMPLATES%%': htmlReportAssets.REPORT_TEMPLATES,

--- a/build/changelog-generator/index.js
+++ b/build/changelog-generator/index.js
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 'use strict';
+
 const readFileSync = require('fs').readFileSync;
 const resolve = require('path').resolve;
 const mainTemplate = readFileSync(resolve(__dirname, 'templates/template.hbs')).toString();

--- a/build/gh-pages-app.js
+++ b/build/gh-pages-app.js
@@ -7,14 +7,14 @@
 
 const fs = require('fs');
 const path = require('path');
-
 const cpy = require('cpy');
 const ghPages = require('gh-pages');
 const glob = require('glob');
 const lighthousePackage = require('../package.json');
 const terser = require('terser');
+const {LH_ROOT} = require('../root.js');
 
-const ghPagesDistDir = `${__dirname}/../dist/gh-pages`;
+const ghPagesDistDir = `${LH_ROOT}/dist/gh-pages`;
 
 const license = `/*
 * @license Copyright 2020 The Lighthouse Authors. All Rights Reserved.

--- a/clients/test/extension/popup-test.js
+++ b/clients/test/extension/popup-test.js
@@ -11,8 +11,9 @@ const path = require('path');
 const puppeteer = require('puppeteer');
 const {DEFAULT_CATEGORIES, STORAGE_KEYS} =
   require('../../extension/scripts/settings-controller.js');
+const {LH_ROOT} = require('../../../root.js');
 
-const lighthouseExtensionPath = path.resolve(__dirname, '../../../dist/extension-chrome');
+const lighthouseExtensionPath = path.resolve(LH_ROOT, 'dist/extension-chrome');
 
 const mockStorage = {
   [STORAGE_KEYS.Categories]: {

--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -5,11 +5,8 @@
  */
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-
-/*
- * The relationship between these CLI modules:
+/**
+ * @fileoverview The relationship between these CLI modules:
  *
  *   index.js     : only calls bin.js's begin()
  *   cli-flags.js : leverages yargs to read argv, outputs LH.CliFlags
@@ -21,24 +18,25 @@ const path = require('path');
  *               cli-flags        lh-core/index
  */
 
+const fs = require('fs');
+const path = require('path');
 const commands = require('./commands/commands.js');
 const printer = require('./printer.js');
 const {getFlags} = require('./cli-flags.js');
 const {runLighthouse} = require('./run.js');
 const {generateConfig} = require('../lighthouse-core/index.js');
-
 const log = require('lighthouse-logger');
 const pkg = require('../package.json');
 const Sentry = require('../lighthouse-core/lib/sentry.js');
-
 const updateNotifier = require('update-notifier');
 const {askPermission} = require('./sentry-prompt.js');
+const {LH_ROOT} = require('../root.js');
 
 /**
  * @return {boolean}
  */
 function isDev() {
-  return fs.existsSync(path.join(__dirname, '../.git'));
+  return fs.existsSync(path.join(LH_ROOT, '/.git'));
 }
 
 /**

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -9,9 +9,10 @@
 const assert = require('assert').strict;
 const path = require('path');
 const fs = require('fs');
-
 const run = require('../../run.js');
 const parseChromeFlags = require('../../run.js').parseChromeFlags;
+const {LH_ROOT} = require('../../../root.js');
+
 /** @type {LH.Config.Json} */
 const testConfig = {
   'extends': 'lighthouse:default',
@@ -39,7 +40,7 @@ describe('CLI run', function() {
     beforeAll(async () => {
       const url = 'http://localhost:10200/dobetterweb/dbw_tester.html';
       // eslint-disable-next-line max-len
-      const samplev2ArtifactsPath = __dirname + '/../../../lighthouse-core/test/results/artifacts/';
+      const samplev2ArtifactsPath = LH_ROOT + '/lighthouse-core/test/results/artifacts/';
 
       // eslint-disable-next-line max-len
       const flags = getFlags([

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -17,9 +17,9 @@ const mime = require('mime-types');
 const parseQueryString = require('querystring').parse;
 const parseURL = require('url').parse;
 const URLSearchParams = require('url').URLSearchParams;
-const HEADER_SAFELIST = new Set(['x-robots-tag', 'link', 'content-security-policy']);
+const {LH_ROOT} = require('../../../root.js');
 
-const lhRootDirPath = path.join(__dirname, '../../../');
+const HEADER_SAFELIST = new Set(['x-robots-tag', 'link', 'content-security-policy']);
 
 class Server {
   baseDir = __dirname;
@@ -192,7 +192,7 @@ class Server {
 
     // Disallow file requests outside of LH folder
     const filePathDir = path.parse(absoluteFilePath).dir;
-    if (!filePathDir.startsWith(lhRootDirPath)) {
+    if (!filePathDir.startsWith(LH_ROOT)) {
       return readFileCallback(new Error('Disallowed path'));
     }
 

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -13,13 +13,13 @@ const lookupClosestLocale = require('lookup-closest-locale');
 const LOCALES = require('./locales.js');
 const {isObjectOfUnknownValues, isObjectOrArrayOfUnknownValues} = require('../type-verifiers.js');
 const log = require('lighthouse-logger');
+const {LH_ROOT} = require('../../../root.js');
 
 const DEFAULT_LOCALE = 'en';
 
 /** @typedef {import('intl-messageformat-parser').Element} MessageElement */
 /** @typedef {import('intl-messageformat-parser').ArgumentElement} ArgumentElement */
 
-const LH_ROOT = path.join(__dirname, '../../../');
 const MESSAGE_I18N_ID_REGEX = / | [^\s]+$/;
 
 const UIStrings = {

--- a/lighthouse-core/scripts/build-report-for-autodeployment.js
+++ b/lighthouse-core/scripts/build-report-for-autodeployment.js
@@ -11,13 +11,13 @@
 const fs = require('fs');
 const path = require('path');
 const swapLocale = require('../lib/i18n/swap-locale.js');
-
 const ReportGenerator = require('../../report/report-generator.js');
 const {defaultSettings} = require('../config/constants.js');
 const lighthouse = require('../index.js');
 const lhr = /** @type {LH.Result} */ (require('../../lighthouse-core/test/results/sample_v2.json'));
+const {LH_ROOT} = require('../../root.js');
 
-const DIST = path.join(__dirname, `../../dist/now`);
+const DIST = path.join(LH_ROOT, `dist/now`);
 
 (async function() {
   addPluginCategory(lhr);

--- a/lighthouse-core/scripts/compare-runs.js
+++ b/lighthouse-core/scripts/compare-runs.js
@@ -21,10 +21,10 @@ const glob = require('glob');
 const util = require('util');
 const execFile = util.promisify(require('child_process').execFile);
 const yargs = require('yargs');
+const {LH_ROOT} = require('../../root.js');
 
 const {ProgressLogger} = require('./lantern/collect/common.js');
 
-const LH_ROOT = `${__dirname}/../..`;
 const ROOT_OUTPUT_DIR = `${LH_ROOT}/timings-data`;
 
 const rawArgv = yargs

--- a/lighthouse-core/scripts/gcp-collection/fleet-create-directories.js
+++ b/lighthouse-core/scripts/gcp-collection/fleet-create-directories.js
@@ -14,8 +14,8 @@
 
 const fs = require('fs');
 const path = require('path');
+const {LH_ROOT} = require('../../../root.js');
 
-const LH_ROOT = path.join(__dirname, '../../../');
 const TMP_DIR = path.join(LH_ROOT, '.tmp/gcp-instances');
 const URLS_LIST = process.argv[2]
   ? path.resolve(process.cwd(), process.argv[2])

--- a/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
+++ b/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
@@ -10,8 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-
-const LH_ROOT = path.join(__dirname, '../../../');
+const {LH_ROOT} = require('../../../root.js');
 
 /**
  * @typedef CtcMessage

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -18,8 +18,8 @@ const Util = require('../../../report/renderer/util.js');
 const {collectAndBakeCtcStrings} = require('./bake-ctc-to-lhl.js');
 const {pruneObsoleteLhlMessages} = require('./prune-obsolete-lhl-messages.js');
 const {countTranslatedMessages} = require('./count-translated.js');
+const {LH_ROOT} = require('../../../root.js');
 
-const LH_ROOT = path.join(__dirname, '../../../');
 const UISTRINGS_REGEX = /UIStrings = .*?\};\n/s;
 
 /** @typedef {import('./bake-ctc-to-lhl.js').CtcMessage} CtcMessage */

--- a/lighthouse-core/scripts/i18n/count-translated.js
+++ b/lighthouse-core/scripts/i18n/count-translated.js
@@ -9,9 +9,10 @@
 
 const fs = require('fs');
 const glob = require('glob');
+const path = require('path');
+const {LH_ROOT} = require('../../../root.js');
 
-const lhRoot = `${__dirname}/../../../`;
-const enUsLhlFilename = lhRoot + 'lighthouse-core/lib/i18n/locales/en-US.json';
+const enUsLhlFilename = LH_ROOT + '/lighthouse-core/lib/i18n/locales/en-US.json';
 /** @type {LhlMessages} */
 const enUsLhl = JSON.parse(fs.readFileSync(enUsLhlFilename, 'utf8'));
 
@@ -30,7 +31,7 @@ function countTranslatedMessages() {
   const globPattern = 'lighthouse-core/lib/i18n/locales/**/+([-a-zA-Z0-9]).json';
   const localeFilenames = glob.sync(globPattern, {
     ignore,
-    cwd: lhRoot,
+    cwd: LH_ROOT,
   });
 
   /** @type {Array<[string, number]>} */
@@ -40,7 +41,7 @@ function countTranslatedMessages() {
   for (const localeFilename of localeFilenames) {
     // Use readFileSync in case other code in this process has altered the require()d form.
     /** @type {LhlMessages} */
-    const localeLhl = JSON.parse(fs.readFileSync(lhRoot + localeFilename, 'utf-8'));
+    const localeLhl = JSON.parse(fs.readFileSync(path.join(LH_ROOT, localeFilename), 'utf-8'));
 
     for (const localeKey of Object.keys(localeLhl)) {
       const messageCount = countPerMessage.get(localeKey);

--- a/lighthouse-core/scripts/i18n/prune-obsolete-lhl-messages.js
+++ b/lighthouse-core/scripts/i18n/prune-obsolete-lhl-messages.js
@@ -9,8 +9,8 @@ const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
 const MessageParser = require('intl-messageformat-parser').default;
-
 const {collectAllCustomElementsFromICU} = require('../../lib/i18n/i18n.js');
+const {LH_ROOT} = require('../../../root.js');
 
 /** @typedef {Record<string, {message: string}>} LhlMessages */
 
@@ -125,16 +125,15 @@ function pruneObsoleteLhlMessages() {
     '**/en-XL.json',
   ];
   const globPattern = 'lighthouse-core/lib/i18n/locales/**/+([-a-zA-Z0-9]).json';
-  const lhRoot = `${__dirname}/../../../`;
   const localePaths = glob.sync(globPattern, {
     ignore,
-    cwd: lhRoot,
+    cwd: LH_ROOT,
   });
 
   /** @type {Set<string>} */
   const alreadyLoggedPrunes = new Set();
   for (const localePath of localePaths) {
-    const absoluteLocalePath = path.join(lhRoot, localePath);
+    const absoluteLocalePath = path.join(LH_ROOT, localePath);
     // readFileSync so that the file is pulled again once updated by a collect-strings run
     const localeLhl = JSON.parse(fs.readFileSync(absoluteLocalePath, 'utf-8'));
     const prunedLocale = pruneLocale(goldenLocaleArgumentIds, localeLhl, alreadyLoggedPrunes);

--- a/lighthouse-core/scripts/internal-analysis/analyze-issues.js
+++ b/lighthouse-core/scripts/internal-analysis/analyze-issues.js
@@ -10,6 +10,7 @@
 const fs = require('fs');
 const path = require('path');
 const log = require('lighthouse-logger');
+const {LH_ROOT} = require('../../../root.js');
 
 /**
  * @fileoverview Used in conjunction with `./download-issues.js` to analyze our Issue and PR response times as a team.
@@ -62,7 +63,7 @@ function normalizeIssue(issue) {
   return issue;
 }
 
-const ISSUES_PATH = path.join(__dirname, '../../../.tmp', '_issues.json');
+const ISSUES_PATH = path.join(LH_ROOT, '.tmp/_issues.json');
 /** @type {Array<AugmentedGitHubIssue>} */
 const _ISSUES = JSON.parse(fs.readFileSync(ISSUES_PATH, 'utf8')).map(normalizeIssue);
 const _ISSUES_SINCE = _ISSUES.filter(issue => new Date(issue.created_at).getTime() > START_AT);

--- a/lighthouse-core/scripts/internal-analysis/download-issues.js
+++ b/lighthouse-core/scripts/internal-analysis/download-issues.js
@@ -23,6 +23,7 @@
 const fs = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
+const {LH_ROOT} = require('../../../root.js');
 
 const DAY_FILTER = 90;
 const HOUR_IN_MS = 60 * 60 * 1000;
@@ -132,7 +133,7 @@ async function downloadIssues(urlToStartAt) {
 async function go() {
   const issues = await downloadIssues();
   fs.writeFileSync(
-    path.join(__dirname, '../../../.tmp', '_issues.json'),
+    path.join(LH_ROOT, '.tmp/_issues.json'),
     JSON.stringify(issues, null, 2)
   );
 }

--- a/lighthouse-core/scripts/lantern/collect/collect.js
+++ b/lighthouse-core/scripts/lantern/collect/collect.js
@@ -14,8 +14,8 @@ const {execFile} = require('child_process');
 const {promisify} = require('util');
 const execFileAsync = promisify(execFile);
 const common = require('./common.js');
+const {LH_ROOT} = require('../../../../root.js');
 
-const LH_ROOT = `${__dirname}/../../../..`;
 const SAMPLES = process.env.SAMPLES ? Number(process.env.SAMPLES) : 9;
 const TEST_URLS = process.env.TEST_URLS ? process.env.TEST_URLS.split(' ') : require('./urls.js');
 

--- a/lighthouse-core/scripts/lantern/collect/common.js
+++ b/lighthouse-core/scripts/lantern/collect/common.js
@@ -15,8 +15,8 @@ const readline = require('readline');
 const {promisify} = require('util');
 const archiver = require('archiver');
 const streamFinished = promisify(require('stream').finished);
+const {LH_ROOT} = require('../../../../root.js');
 
-const LH_ROOT = `${__dirname}/../../../..`;
 const collectFolder = `${LH_ROOT}/dist/collect-lantern-traces`;
 const summaryPath = `${collectFolder}/summary.json`;
 const goldenFolder = `${LH_ROOT}/dist/golden-lantern-traces`;

--- a/lighthouse-core/scripts/lantern/run-once.js
+++ b/lighthouse-core/scripts/lantern/run-once.js
@@ -11,6 +11,7 @@ const path = require('path');
 const PredictivePerf = require('../../audits/predictive-perf.js');
 const Simulator = require('../../lib/dependency-graph/simulator/simulator.js');
 const traceSaver = require('../../lib/lantern-trace-saver.js');
+const {LH_ROOT} = require('../../../root.js');
 
 if (process.argv.length !== 4) throw new Error('Usage $0 <trace file> <devtools file>');
 
@@ -32,7 +33,7 @@ async function run() {
   const pessimisticTTINodeTimings = Simulator.ALL_NODE_TIMINGS.get('pessimisticInteractive');
   if (process.env.LANTERN_DEBUG && pessimisticTTINodeTimings) {
     const outputTraceFile = path.basename(tracePath).replace(/.trace.json$/, '.lantern.trace.json');
-    const outputTracePath = path.join(__dirname, '../../../.tmp', outputTraceFile);
+    const outputTracePath = path.join(LH_ROOT, '.tmp', outputTraceFile);
     const trace = traceSaver.convertNodeTimingsToTrace(pessimisticTTINodeTimings);
     fs.writeFileSync(outputTracePath, JSON.stringify(trace, null, 2));
   }

--- a/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
+++ b/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
@@ -21,9 +21,9 @@ const path = require('path');
 const colors = require('colors');
 const LegacyJavascript = require('../../audits/byte-efficiency/legacy-javascript.js');
 const i18n = require('../../lib/i18n/i18n.js');
+const {LH_ROOT} = require('../../../root.js');
 
-const LH_ROOT_DIR = path.join(__dirname, '../../../');
-const LATEST_RUN_DIR = path.join(LH_ROOT_DIR, 'latest-run');
+const LATEST_RUN_DIR = path.join(LH_ROOT, 'latest-run');
 
 /** @param {LH.DevtoolsLog} log */
 function requestUrlToId(log) {

--- a/lighthouse-core/test/test-utils.js
+++ b/lighthouse-core/test/test-utils.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const i18n = require('../lib/i18n/i18n.js');
 const mockCommands = require('./gather/mock-commands.js');
 const {default: {toBeCloseTo}} = require('expect/build/matchers.js');
+const {LH_ROOT} = require('../../root.js');
 
 expect.extend({
   toBeDisplayString(received, expected) {
@@ -89,7 +90,7 @@ function getProtoRoundTrip() {
   let itIfProtoExists;
   try {
     sampleResultsRoundtripStr =
-      fs.readFileSync(__dirname + '/../../.tmp/sample_v2_round_trip.json', 'utf-8');
+      fs.readFileSync(LH_ROOT + '/.tmp/sample_v2_round_trip.json', 'utf-8');
     describeIfProtoExists = describe;
     itIfProtoExists = it;
   } catch (err) {

--- a/lighthouse-viewer/test/viewer-test-pptr.js
+++ b/lighthouse-viewer/test/viewer-test-pptr.js
@@ -11,14 +11,15 @@ const path = require('path');
 const fs = require('fs');
 const assert = require('assert').strict;
 const puppeteer = require('puppeteer');
-
 const {server} = require('../../lighthouse-cli/test/fixtures/static-server.js');
+const {LH_ROOT} = require('../../root.js');
+
 const portNumber = 10200;
 const viewerUrl = `http://localhost:${portNumber}/dist/gh-pages/viewer/index.html`;
-const sampleLhr = __dirname + '/../../lighthouse-core/test/results/sample_v2.json';
+const sampleLhr = LH_ROOT + '/lighthouse-core/test/results/sample_v2.json';
 
 const defaultConfig =
-  require(path.resolve(__dirname, '../../lighthouse-core/config/default-config.js'));
+  require(path.resolve(LH_ROOT, './lighthouse-core/config/default-config.js'));
 const lighthouseCategories = Object.keys(defaultConfig.categories);
 const getAuditsOfCategory = category => defaultConfig.categories[category].auditRefs;
 

--- a/report/test/renderer/psi-test.js
+++ b/report/test/renderer/psi-test.js
@@ -21,10 +21,11 @@ const DetailsRenderer = require('../../renderer/details-renderer.js');
 const CriticalRequestChainRenderer = require('../../renderer/crc-details-renderer.js');
 const ElementScreenshotRenderer = require('../../renderer/element-screenshot-renderer.js');
 const ReportUIFeatures = require('../../renderer/report-ui-features.js');
+const {LH_ROOT} = require('../../../root.js');
 
 const {itIfProtoExists, sampleResultsRoundtripStr} = testUtils.getProtoRoundTrip();
 const sampleResultsStr =
-  fs.readFileSync(__dirname + '/../../../lighthouse-core/test/results/sample_v2.json', 'utf-8');
+  fs.readFileSync(LH_ROOT + '/lighthouse-core/test/results/sample_v2.json', 'utf-8');
 
 /* eslint-env jest */
 

--- a/root.js
+++ b/root.js
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+module.exports.LH_ROOT = __dirname;

--- a/third-party/chromium-synchronization/inspector-issueAdded-types-test.js
+++ b/third-party/chromium-synchronization/inspector-issueAdded-types-test.js
@@ -7,9 +7,10 @@
 
 const fs = require('fs');
 const fetch = require('node-fetch');
+const {LH_ROOT} = require('../../../root.js');
 
-const inspectorIssuesGathererPath = __dirname +
-    '/../../lighthouse-core/gather/gatherers/inspector-issues.js';
+const inspectorIssuesGathererPath = LH_ROOT +
+  '/lighthouse-core/gather/gatherers/inspector-issues.js';
 const inspectorIssuesGathererSource = fs.readFileSync(inspectorIssuesGathererPath, 'utf-8');
 
 /* eslint-env jest */

--- a/third-party/download-content-shell/download-content-shell.js
+++ b/third-party/download-content-shell/download-content-shell.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const shell = require('child_process').execSync;
 const utils = require('./utils.js');
-const {LH_ROOT} = require('../../../root.js');
+const {LH_ROOT} = require('../../root.js');
 
 const TARGET = 'Release';
 const CONTENT_SHELL_ZIP = 'content-shell.zip';

--- a/third-party/download-content-shell/download-content-shell.js
+++ b/third-party/download-content-shell/download-content-shell.js
@@ -11,12 +11,13 @@ const fs = require('fs');
 const path = require('path');
 const shell = require('child_process').execSync;
 const utils = require('./utils.js');
+const {LH_ROOT} = require('../../../root.js');
 
 const TARGET = 'Release';
 const CONTENT_SHELL_ZIP = 'content-shell.zip';
 const MAX_CONTENT_SHELLS = 10;
 const PLATFORM = getPlatform();
-const LH_ROOT = `${__dirname}/../..`;
+
 const CACHE_PATH = path.resolve(LH_ROOT, '.tmp', 'chromium-web-tests', 'content-shells');
 const COMMIT_POSITION_UPDATE_PERIOD = 420;
 


### PR DESCRIPTION
Replaces all the `LH_ROOT = '../../../'` madness with `const {LH_ROOT} = require('../../../root.js')`. This does a few things:

* Can just type `LH_ROO+<enter>` to auto-import this value to a file
* Statically verified (no more doing directory calculus to know how many levels up to go) (is this only hard for me?)
* Prepares the way for #12689 (getting the directory of current file is no longer as simple as `__dirname`, so having the code in one place means less future boilerplate)

Beyond changing all instances of `LH_ROOT = ...`, I also grokked for lines that use `__dirname` to form a path that goes to the root, and changed them to use `LH_ROOT`.

_____

I did not modify any files that use `__dirname` w/o crossing over the root directory (ex: `report-assets.js` does `__dirname + '/renderer/util.js'`)–I have some ideas for that, maybe worth discussing here:

1) could have a function `getRelativePathEsm(importMeta, ...pathSegments)` (usage: `getRelativePathEsm(import.meta, 'somefile.json')`)
2) `root.js` could also export all the top-level directories (`LH_CORE`, `LH_CLI`, etc...)
3) could just use `LH_ROOT` for everything, and have all paths used in code be relative to root

( the motivation is to avoid this code everywhere https://stackoverflow.com/a/50052194/2788187 )