### PR TITLE
misc(treemap): add locale to html tag

### DIFF
--- a/lighthouse-treemap/app/index.html
+++ b/lighthouse-treemap/app/index.html
@@ -5,7 +5,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 -->
 
 <!doctype html>
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

This fixes #12730

<!-- Describe the need for this change -->

The page is missing `lang="en"` attribute. When loading page in Edge it offered to translate the page from Maltese to English for me. Specifying the lang will tell the browser it's in English already.

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
