### PR TITLE
report: templates refactor

### DIFF
--- a/build/build-report.js
+++ b/build/build-report.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 function concatRendererCode() {
   return [
     fs.readFileSync(__dirname + '/../report/renderer/util.js', 'utf8'),
+    fs.readFileSync(__dirname + '/../report/renderer/template-components.js', 'utf8'),
     fs.readFileSync(__dirname + '/../report/renderer/dom.js', 'utf8'),
     fs.readFileSync(__dirname + '/../report/renderer/details-renderer.js', 'utf8'),
     fs.readFileSync(__dirname + '/../report/renderer/crc-details-renderer.js', 'utf8'),
@@ -23,7 +24,6 @@ function concatRendererCode() {
     fs.readFileSync(__dirname + '/../report/renderer/pwa-category-renderer.js', 'utf8'),
     fs.readFileSync(__dirname + '/../report/renderer/report-renderer.js', 'utf8'),
     fs.readFileSync(__dirname + '/../report/renderer/i18n.js', 'utf8'),
-    fs.readFileSync(__dirname + '/../report/renderer/template-components.js', 'utf8'),
     fs.readFileSync(__dirname + '/../report/renderer/text-encoding.js', 'utf8'),
   ].join(';\n');
 }

--- a/build/build-report.js
+++ b/build/build-report.js
@@ -23,6 +23,7 @@ function concatRendererCode() {
     fs.readFileSync(__dirname + '/../report/renderer/pwa-category-renderer.js', 'utf8'),
     fs.readFileSync(__dirname + '/../report/renderer/report-renderer.js', 'utf8'),
     fs.readFileSync(__dirname + '/../report/renderer/i18n.js', 'utf8'),
+    fs.readFileSync(__dirname + '/../report/renderer/template-components.js', 'utf8'),
     fs.readFileSync(__dirname + '/../report/renderer/text-encoding.js', 'utf8'),
   ].join(';\n');
 }

--- a/lighthouse-core/scripts/build-report-for-autodeployment.js
+++ b/lighthouse-core/scripts/build-report-for-autodeployment.js
@@ -11,6 +11,11 @@
 const fs = require('fs');
 const path = require('path');
 const swapLocale = require('../lib/i18n/swap-locale.js');
+
+const buildReport = require('../../build/build-report.js');
+// Needs to be build _before_ report-generator is required.
+buildReport.buildStandaloneReport();
+
 const ReportGenerator = require('../../report/report-generator.js');
 const {defaultSettings} = require('../config/constants.js');
 const lighthouse = require('../index.js');

--- a/report/assets/styles.css
+++ b/report/assets/styles.css
@@ -1669,4 +1669,540 @@
   cursor: zoom-in;
 }
 
+/**
+ * Lighthouse score container
+ */
+
+.lh-scores-container {
+  display: flex;
+  flex-direction: column;
+  padding: var(--scores-container-padding);
+  position: relative;
+  width: 100%;
+}
+
+.lh-sticky-header {
+  --gauge-circle-size: 36px;
+  --plugin-badge-size: 18px;
+  --plugin-icon-size: 75%;
+  --gauge-wrapper-width: 60px;
+  --gauge-percentage-font-size: 13px;
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: var(--topbar-height);
+  font-weight: 700;
+  display: none;
+  justify-content: center;
+  background-color: var(--sticky-header-background-color);
+  border-bottom: 1px solid var(--color-gray-200);
+  padding-top: var(--score-container-padding);
+  padding-bottom: 4px;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.lh-devtools .lh-sticky-header {
+  /* The report within DevTools is placed in a container with overflow, which changes the placement of this header unless we change `position` to `sticky.` */
+  position: sticky;
+}
+
+.lh-sticky-header--visible {
+  display: grid;
+  grid-auto-flow: column;
+  pointer-events: auto;
+}
+
+/* Disable the gauge arc animation for the sticky header, so toggling display: none
+    does not play the animation. */
+.lh-sticky-header .lh-gauge-arc {
+  animation: none;
+}
+
+.lh-sticky-header .lh-gauge__label {
+  display: none;
+}
+
+.lh-highlighter {
+  width: var(--gauge-wrapper-width);
+  height: 1px;
+  background-color: var(--highlighter-background-color);
+  /* Position at bottom of first gauge in sticky header. */
+  position: absolute;
+  grid-column: 1;
+  bottom: -1px;
+}
+
+.lh-gauge__wrapper:first-of-type {
+  contain: none;
+}
+
+/**
+ * Lighthouse topbar
+ */
+
+.lh-topbar {
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  height: var(--topbar-height);
+  background-color: var(--topbar-background-color);
+  padding: var(--topbar-padding);
+}
+
+.lh-topbar__logo {
+  width: var(--topbar-logo-size);
+  height: var(--topbar-logo-size);
+  user-select: none;
+  flex: none;
+}
+.lh-topbar__logo .shape {
+  fill: var(--report-text-color);
+}
+
+.lh-topbar__url {
+  margin: var(--topbar-padding);
+  text-decoration: none;
+  color: var(--report-text-color);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.lh-tools {
+  margin-left: auto;
+  will-change: transform;
+  min-width: var(--report-icon-size);
+}
+.lh-tools__button {
+  width: var(--report-icon-size);
+  height: var(--report-icon-size);
+  cursor: pointer;
+  margin-right: 5px;
+  /* This is actually a button element, but we want to style it like a transparent div. */
+  display: flex;
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  outline: inherit;
+}
+.lh-tools__button svg {
+  fill: var(--tools-icon-color);
+}
+.dark .lh-tools__button svg {
+  filter: invert(1);
+}
+.lh-tools__button.active + .lh-tools__dropdown {
+  opacity: 1;
+  clip: rect(-1px, 194px, 242px, -3px);
+  visibility: visible;
+}
+.lh-tools__dropdown {
+  position: absolute;
+  background-color: var(--report-background-color);
+  border: 1px solid var(--report-border-color);
+  border-radius: 3px;
+  padding: calc(var(--default-padding) / 2) 0;
+  cursor: pointer;
+  top: 36px;
+  right: 0;
+  box-shadow: 1px 1px 3px #ccc;
+  min-width: 125px;
+  clip: rect(0, 164px, 0, 0);
+  visibility: hidden;
+  opacity: 0;
+  transition: all 200ms cubic-bezier(0,0,0.2,1);
+}
+.lh-tools__dropdown a {
+  color: currentColor;
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 0 12px;
+  line-height: 2;
+}
+.lh-tools__dropdown a:hover,
+.lh-tools__dropdown a:focus {
+  background-color: var(--color-gray-200);
+  outline: none;
+}
+/* save-gist option hidden in report. */
+.lh-tools__dropdown a[data-action='save-gist'] {
+  display: none;
+}
+
+@media screen and (max-width: 964px) {
+  .lh-tools__dropdown {
+    right: 0;
+    left: initial;
+  }
+}
+@media print {
+  .lh-topbar {
+    position: static;
+    margin-left: 0;
+  }
+
+  .lh-tools__dropdown {
+    display: none;
+  }
+}
+
+/**
+ * Lighthouse header
+ */
+
+/* CSS Fireworks. Originally by Eddie Lin
+    https://codepen.io/paulirish/pen/yEVMbP
+*/
+.pyro {
+  display: none;
+  z-index: 1;
+  pointer-events: none;
+}
+.score100 .pyro {
+  display: block;
+}
+.score100 .lh-lighthouse stop:first-child {
+  stop-color: hsla(200, 12%, 95%, 0);
+}
+.score100 .lh-lighthouse stop:last-child {
+  stop-color: hsla(65, 81%, 76%, 1);
+}
+
+.pyro > .before, .pyro > .after {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 2.5px;
+  box-shadow: 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff;
+  animation: 1s bang ease-out infinite backwards,  1s gravity ease-in infinite backwards,  5s position linear infinite backwards;
+  animation-delay: 1s, 1s, 1s;
+}
+
+.pyro > .after {
+  animation-delay: 2.25s, 2.25s, 2.25s;
+  animation-duration: 1.25s, 1.25s, 6.25s;
+}
+.fireworks-paused .pyro > div {
+  animation-play-state: paused;
+}
+
+@keyframes bang {
+  to {
+    box-shadow: -70px -115.67px #47ebbc, -28px -99.67px #eb47a4, 58px -31.67px #7eeb47, 13px -141.67px #eb47c5, -19px 6.33px #7347eb, -2px -74.67px #ebd247, 24px -151.67px #eb47e0, 57px -138.67px #b4eb47, -51px -104.67px #479eeb, 62px 8.33px #ebcf47, -93px 0.33px #d547eb, -16px -118.67px #47bfeb, 53px -84.67px #47eb83, 66px -57.67px #eb47bf, -93px -65.67px #91eb47, 30px -13.67px #86eb47, -2px -59.67px #83eb47, -44px 1.33px #eb47eb, 61px -58.67px #47eb73, 5px -22.67px #47e8eb, -66px -28.67px #ebe247, 42px -123.67px #eb5547, -75px 26.33px #7beb47, 15px -52.67px #a147eb, 36px -51.67px #eb8347, -38px -12.67px #eb5547, -46px -59.67px #47eb81, 78px -114.67px #eb47ba, 15px -156.67px #eb47bf, -36px 1.33px #eb4783, -72px -86.67px #eba147, 31px -46.67px #ebe247, -68px 29.33px #47e2eb, -55px 19.33px #ebe047, -56px 27.33px #4776eb, -13px -91.67px #eb5547, -47px -138.67px #47ebc7, -18px -96.67px #eb47ac, 11px -88.67px #4783eb, -67px -28.67px #47baeb, 53px 10.33px #ba47eb, 11px 19.33px #5247eb, -5px -11.67px #eb4791, -68px -4.67px #47eba7, 95px -37.67px #eb478b, -67px -162.67px #eb5d47, -54px -120.67px #eb6847, 49px -12.67px #ebe047, 88px 8.33px #47ebda, 97px 33.33px #eb8147, 6px -71.67px #ebbc47;
+  }
+}
+@keyframes gravity {
+  to {
+    transform: translateY(80px);
+    opacity: 0;
+  }
+}
+@keyframes position {
+  0%, 19.9% {
+    margin-top: 4%;
+    margin-left: 47%;
+  }
+  20%, 39.9% {
+    margin-top: 7%;
+    margin-left: 30%;
+  }
+  40%, 59.9% {
+    margin-top: 6%;
+    margin-left: 70%;
+  }
+  60%, 79.9% {
+    margin-top: 3%;
+    margin-left: 20%;
+  }
+  80%, 99.9% {
+    margin-top: 3%;
+    margin-left: 80%;
+  }
+}
+
+
+/**
+ * Lighthouse footer
+ */
+
+.lh-footer {
+  padding: var(--footer-padding-vertical) calc(var(--default-padding) * 2);
+  max-width: var(--report-width);
+  margin: 0 auto;
+}
+.lh-footer .lh-generated {
+  text-align: center;
+}
+.lh-env__title {
+  font-size: var(--env-item-font-size-big);
+  line-height: var(--env-item-line-height-big);
+  text-align: center;
+  padding: var(--score-container-padding);
+}
+.lh-env {
+  padding: var(--default-padding) 0;
+}
+.lh-env__items {
+  padding-left: 16px;
+  margin: 0 0 var(--audits-margin-bottom);
+  padding: 0;
+}
+.lh-env__items .lh-env__item:nth-child(2n) {
+  background-color: var(--env-item-background-color);
+}
+.lh-env__item {
+  display: flex;
+  padding: var(--env-item-padding);
+  position: relative;
+}
+span.lh-env__name {
+  font-weight: bold;
+  min-width: var(--env-name-min-width);
+  flex: 0.5;
+  padding: 0 8px;
+}
+span.lh-env__description {
+  text-align: left;
+  flex: 1;
+}
+
+/**
+ * Lighthouse PWA badge gauge
+ */
+
+.lh-gauge--pwa .lh-gauge--pwa__component {
+  display: none;
+}
+.lh-gauge--pwa__wrapper:not(.lh-badged--all) .lh-gauge--pwa__logo > path {
+  /* Gray logo unless everything is passing. */
+  fill: #B0B0B0;
+}
+
+.lh-gauge--pwa__disc {
+  fill: var(--color-gray-200);
+}
+
+.lh-gauge--pwa__logo--primary-color {
+  fill: #304FFE;
+}
+
+.lh-gauge--pwa__logo--secondary-color {
+  fill: #3D3D3D;
+}
+.dark .lh-gauge--pwa__logo--secondary-color {
+  fill: #D8B6B6;
+}
+
+/* No passing groups. */
+.lh-gauge--pwa__wrapper:not([class*='lh-badged--']) .lh-gauge--pwa__na-line {
+  display: inline;
+}
+/* Just optimized. Same n/a line as no passing groups. */
+.lh-gauge--pwa__wrapper.lh-badged--pwa-optimized:not(.lh-badged--pwa-installable) .lh-gauge--pwa__na-line {
+  display: inline;
+}
+
+/* Just installable. */
+.lh-gauge--pwa__wrapper.lh-badged--pwa-installable .lh-gauge--pwa__installable-badge {
+  display: inline;
+}
+
+/* All passing groups. */
+.lh-gauge--pwa__wrapper.lh-badged--all .lh-gauge--pwa__check-circle {
+  display: inline;
+}
+
+
+/**
+ * Lighthouse crtiical request chains component
+ */
+
+.lh-crc .tree-marker {
+  width: 12px;
+  height: 26px;
+  display: block;
+  float: left;
+  background-position: top left;
+}
+.lh-crc .horiz-down {
+  background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><g fill="%23D8D8D8" fill-rule="evenodd"><path d="M16 12v2H-2v-2z"/><path d="M9 12v14H7V12z"/></g></svg>');
+}
+.lh-crc .right {
+  background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M16 12v2H0v-2z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+}
+.lh-crc .up-right {
+  background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v14H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+}
+.lh-crc .vert-right {
+  background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v27H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+}
+.lh-crc .vert {
+  background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v26H7z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+}
+.lh-crc .crc-tree {
+  font-size: 14px;
+  width: 100%;
+  overflow-x: auto;
+}
+.lh-crc .crc-node {
+  height: 26px;
+  line-height: 26px;
+  white-space: nowrap;
+}
+.lh-crc .crc-node__tree-value {
+  margin-left: 10px;
+}
+.lh-crc .crc-node__tree-value div {
+  display: inline;
+}
+.lh-crc .crc-node__chain-duration {
+  font-weight: 700;
+}
+.lh-crc .crc-initial-nav {
+  color: #595959;
+  font-style: italic;
+}
+.lh-crc__summary-value {
+  margin-bottom: 10px;
+}
+
+
+/**
+ * third-party filter
+ */
+.lh-3p-filter {
+  background-color: var(--table-higlight-background-color);
+  color: var(--color-gray-600);
+  float: right;
+  padding: 6px;
+}
+.lh-3p-filter-label, .lh-3p-filter-input {
+  vertical-align: middle;
+  user-select: none;
+}
+.lh-3p-filter-input:disabled + .lh-3p-ui-string {
+  text-decoration: line-through;
+}
+
+
+/**
+ * Lighthouse snippet component
+ */
+:root {
+  --snippet-highlight-light: #fbf1f2;
+  --snippet-highlight-dark: #ffd6d8;
+}
+
+.lh-snippet__header {
+  position: relative;
+  overflow: hidden;
+  padding: 10px;
+  border-bottom: none;
+  color: var(--snippet-color);
+  background-color: var(--snippet-background-color);
+  border: 1px solid var(--report-border-color-secondary);
+}
+.lh-snippet__title {
+  font-weight: bold;
+  float: left;
+}
+.lh-snippet__node {
+  float: left;
+  margin-left: 4px;
+}
+.lh-snippet__toggle-expand {
+  padding: 1px 7px;
+  margin-top: -1px;
+  margin-right: -7px;
+  float: right;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #0c50c7;
+}
+
+.lh-snippet__snippet {
+  overflow: auto;
+  border: 1px solid var(--report-border-color-secondary);
+}
+/* Container needed so that all children grow to the width of the scroll container */
+.lh-snippet__snippet-inner {
+  display: inline-block;
+  min-width: 100%;
+}
+
+.lh-snippet:not(.lh-snippet--expanded) .lh-snippet__show-if-expanded {
+  display: none;
+}
+.lh-snippet.lh-snippet--expanded .lh-snippet__show-if-collapsed {
+  display: none;
+}
+
+.lh-snippet__line {
+  background: white;
+  white-space: pre;
+  display: flex;
+}
+.lh-snippet__line:not(.lh-snippet__line--message):first-child {
+  padding-top: 4px;
+}
+.lh-snippet__line:not(.lh-snippet__line--message):last-child {
+  padding-bottom: 4px;
+}
+.lh-snippet__line--content-highlighted {
+  background: var(--snippet-highlight-dark);
+}
+.lh-snippet__line--message {
+  background: var(--snippet-highlight-light);
+}
+.lh-snippet__line--message .lh-snippet__line-number {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+.lh-snippet__line--message code {
+  padding: 10px;
+  padding-left: 5px;
+  color: var(--color-fail);
+  font-family: var(--report-font-family);
+}
+.lh-snippet__line--message code {
+  white-space: normal;
+}
+.lh-snippet__line-icon {
+  padding-top: 10px;
+  display: none;
+}
+.lh-snippet__line--message .lh-snippet__line-icon {
+  display: block;
+}
+.lh-snippet__line-icon:before {
+  content: "";
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 4px;
+  width: var(--score-icon-size);
+  height: var(--score-icon-size);
+  background-image: var(--fail-icon-url);
+}
+.lh-snippet__line-number {
+  flex-shrink: 0;
+  width: 40px;
+  text-align: right;
+  font-family: monospace;
+  padding-right: 5px;
+  margin-right: 5px;
+  color: var(--color-gray-600);
+  user-select: none;
+}
+
+
+
 /*# sourceURL=report-styles.css */

--- a/report/assets/templates.html
+++ b/report/assets/templates.html
@@ -155,71 +155,7 @@ limitations under the License.
 
 <!-- Lighthouse score container -->
 <template id="tmpl-lh-scores-wrapper">
-  <style>
-    .lh-scores-container {
-      display: flex;
-      flex-direction: column;
-      padding: var(--scores-container-padding);
-      position: relative;
-      width: 100%;
-    }
 
-    .lh-sticky-header {
-      --gauge-circle-size: 36px;
-      --plugin-badge-size: 18px;
-      --plugin-icon-size: 75%;
-      --gauge-wrapper-width: 60px;
-      --gauge-percentage-font-size: 13px;
-      position: fixed;
-      left: 0;
-      right: 0;
-      top: var(--topbar-height);
-      font-weight: 700;
-      display: none;
-      justify-content: center;
-      background-color: var(--sticky-header-background-color);
-      border-bottom: 1px solid var(--color-gray-200);
-      padding-top: var(--score-container-padding);
-      padding-bottom: 4px;
-      z-index: 1;
-      pointer-events: none;
-    }
-
-    .lh-devtools .lh-sticky-header {
-      /* The report within DevTools is placed in a container with overflow, which changes the placement of this header unless we change `position` to `sticky.` */
-      position: sticky;
-    }
-
-    .lh-sticky-header--visible {
-      display: grid;
-      grid-auto-flow: column;
-      pointer-events: auto;
-    }
-
-    /* Disable the gauge arc animation for the sticky header, so toggling display: none
-       does not play the animation. */
-    .lh-sticky-header .lh-gauge-arc {
-      animation: none;
-    }
-
-    .lh-sticky-header .lh-gauge__label {
-      display: none;
-    }
-
-    .lh-highlighter {
-      width: var(--gauge-wrapper-width);
-      height: 1px;
-      background-color: var(--highlighter-background-color);
-      /* Position at bottom of first gauge in sticky header. */
-      position: absolute;
-      grid-column: 1;
-      bottom: -1px;
-    }
-
-    .lh-gauge__wrapper:first-of-type {
-      contain: none;
-    }
-  </style>
   <div class="lh-scores-wrapper">
     <div class="lh-scores-container">
       <div class="pyro">
@@ -232,119 +168,7 @@ limitations under the License.
 
 <!-- Lighthouse topbar -->
 <template id="tmpl-lh-topbar">
-  <style>
-    .lh-topbar {
-      position: sticky;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 1000;
-      display: flex;
-      align-items: center;
-      height: var(--topbar-height);
-      background-color: var(--topbar-background-color);
-      padding: var(--topbar-padding);
-    }
 
-    .lh-topbar__logo {
-      width: var(--topbar-logo-size);
-      height: var(--topbar-logo-size);
-      user-select: none;
-      flex: none;
-    }
-    .lh-topbar__logo .shape {
-      fill: var(--report-text-color);
-    }
-
-    .lh-topbar__url {
-      margin: var(--topbar-padding);
-      text-decoration: none;
-      color: var(--report-text-color);
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-    }
-
-    .lh-tools {
-      margin-left: auto;
-      will-change: transform;
-      min-width: var(--report-icon-size);
-    }
-    .lh-tools__button {
-      width: var(--report-icon-size);
-      height: var(--report-icon-size);
-      cursor: pointer;
-      margin-right: 5px;
-      /* This is actually a button element, but we want to style it like a transparent div. */
-      display: flex;
-      background: none;
-      color: inherit;
-      border: none;
-      padding: 0;
-      font: inherit;
-      outline: inherit;
-    }
-    .lh-tools__button svg {
-      fill: var(--tools-icon-color);
-    }
-    .dark .lh-tools__button svg {
-      filter: invert(1);
-    }
-    .lh-tools__button.active + .lh-tools__dropdown {
-      opacity: 1;
-      clip: rect(-1px, 194px, 242px, -3px);
-      visibility: visible;
-    }
-    .lh-tools__dropdown {
-      position: absolute;
-      background-color: var(--report-background-color);
-      border: 1px solid var(--report-border-color);
-      border-radius: 3px;
-      padding: calc(var(--default-padding) / 2) 0;
-      cursor: pointer;
-      top: 36px;
-      right: 0;
-      box-shadow: 1px 1px 3px #ccc;
-      min-width: 125px;
-      clip: rect(0, 164px, 0, 0);
-      visibility: hidden;
-      opacity: 0;
-      transition: all 200ms cubic-bezier(0,0,0.2,1);
-    }
-    .lh-tools__dropdown a {
-      color: currentColor;
-      text-decoration: none;
-      white-space: nowrap;
-      padding: 0 12px;
-      line-height: 2;
-    }
-    .lh-tools__dropdown a:hover,
-    .lh-tools__dropdown a:focus {
-      background-color: var(--color-gray-200);
-      outline: none;
-    }
-    /* save-gist option hidden in report. */
-    .lh-tools__dropdown a[data-action='save-gist'] {
-      display: none;
-    }
-
-    @media screen and (max-width: 964px) {
-      .lh-tools__dropdown {
-        right: 0;
-        left: initial;
-      }
-    }
-    @media print {
-      .lh-topbar {
-        position: static;
-        margin-left: 0;
-      }
-
-      .lh-tools__dropdown {
-        display: none;
-      }
-    }
-  </style>
 
   <div class="lh-topbar">
     <!-- Lighthouse logo.  -->
@@ -403,77 +227,6 @@ limitations under the License.
 
 <!-- Lighthouse header -->
 <template id="tmpl-lh-heading">
-  <style>
-    /* CSS Fireworks. Originally by Eddie Lin
-       https://codepen.io/paulirish/pen/yEVMbP
-    */
-    .pyro {
-      display: none;
-      z-index: 1;
-      pointer-events: none;
-    }
-    .score100 .pyro {
-      display: block;
-    }
-    .score100 .lh-lighthouse stop:first-child {
-      stop-color: hsla(200, 12%, 95%, 0);
-    }
-    .score100 .lh-lighthouse stop:last-child {
-      stop-color: hsla(65, 81%, 76%, 1);
-    }
-
-    .pyro > .before, .pyro > .after {
-      position: absolute;
-      width: 5px;
-      height: 5px;
-      border-radius: 2.5px;
-      box-shadow: 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff;
-      animation: 1s bang ease-out infinite backwards,  1s gravity ease-in infinite backwards,  5s position linear infinite backwards;
-      animation-delay: 1s, 1s, 1s;
-    }
-
-    .pyro > .after {
-      animation-delay: 2.25s, 2.25s, 2.25s;
-      animation-duration: 1.25s, 1.25s, 6.25s;
-    }
-    .fireworks-paused .pyro > div {
-      animation-play-state: paused;
-    }
-
-    @keyframes bang {
-      to {
-        box-shadow: -70px -115.67px #47ebbc, -28px -99.67px #eb47a4, 58px -31.67px #7eeb47, 13px -141.67px #eb47c5, -19px 6.33px #7347eb, -2px -74.67px #ebd247, 24px -151.67px #eb47e0, 57px -138.67px #b4eb47, -51px -104.67px #479eeb, 62px 8.33px #ebcf47, -93px 0.33px #d547eb, -16px -118.67px #47bfeb, 53px -84.67px #47eb83, 66px -57.67px #eb47bf, -93px -65.67px #91eb47, 30px -13.67px #86eb47, -2px -59.67px #83eb47, -44px 1.33px #eb47eb, 61px -58.67px #47eb73, 5px -22.67px #47e8eb, -66px -28.67px #ebe247, 42px -123.67px #eb5547, -75px 26.33px #7beb47, 15px -52.67px #a147eb, 36px -51.67px #eb8347, -38px -12.67px #eb5547, -46px -59.67px #47eb81, 78px -114.67px #eb47ba, 15px -156.67px #eb47bf, -36px 1.33px #eb4783, -72px -86.67px #eba147, 31px -46.67px #ebe247, -68px 29.33px #47e2eb, -55px 19.33px #ebe047, -56px 27.33px #4776eb, -13px -91.67px #eb5547, -47px -138.67px #47ebc7, -18px -96.67px #eb47ac, 11px -88.67px #4783eb, -67px -28.67px #47baeb, 53px 10.33px #ba47eb, 11px 19.33px #5247eb, -5px -11.67px #eb4791, -68px -4.67px #47eba7, 95px -37.67px #eb478b, -67px -162.67px #eb5d47, -54px -120.67px #eb6847, 49px -12.67px #ebe047, 88px 8.33px #47ebda, 97px 33.33px #eb8147, 6px -71.67px #ebbc47;
-      }
-    }
-    @keyframes gravity {
-      to {
-        transform: translateY(80px);
-        opacity: 0;
-      }
-    }
-    @keyframes position {
-      0%, 19.9% {
-        margin-top: 4%;
-        margin-left: 47%;
-      }
-      20%, 39.9% {
-        margin-top: 7%;
-        margin-left: 30%;
-      }
-      40%, 59.9% {
-        margin-top: 6%;
-        margin-left: 70%;
-      }
-      60%, 79.9% {
-        margin-top: 3%;
-        margin-left: 20%;
-      }
-      80%, 99.9% {
-        margin-top: 3%;
-        margin-left: 80%;
-      }
-    }
-  </style>
 
   <div class="lh-header-container">
     <div class="lh-scores-wrapper-placeholder"></div>
@@ -483,48 +236,7 @@ limitations under the License.
 
 <!-- Lighthouse footer -->
 <template id="tmpl-lh-footer">
-  <style>
-    .lh-footer {
-      padding: var(--footer-padding-vertical) calc(var(--default-padding) * 2);
-      max-width: var(--report-width);
-      margin: 0 auto;
-    }
-    .lh-footer .lh-generated {
-      text-align: center;
-    }
-    .lh-env__title {
-      font-size: var(--env-item-font-size-big);
-      line-height: var(--env-item-line-height-big);
-      text-align: center;
-      padding: var(--score-container-padding);
-    }
-    .lh-env {
-      padding: var(--default-padding) 0;
-    }
-    .lh-env__items {
-      padding-left: 16px;
-      margin: 0 0 var(--audits-margin-bottom);
-      padding: 0;
-    }
-    .lh-env__items .lh-env__item:nth-child(2n) {
-      background-color: var(--env-item-background-color);
-    }
-    .lh-env__item {
-      display: flex;
-      padding: var(--env-item-padding);
-      position: relative;
-    }
-    span.lh-env__name {
-      font-weight: bold;
-      min-width: var(--env-name-min-width);
-      flex: 0.5;
-      padding: 0 8px;
-    }
-    span.lh-env__description {
-      text-align: left;
-      flex: 1;
-    }
-  </style>
+
   <footer class="lh-footer">
     <!-- TODO(i18n): localize runtime settings -->
     <div class="lh-env">
@@ -566,49 +278,7 @@ limitations under the License.
 
 <!-- Lighthouse PWA badge gauge -->
 <template id="tmpl-lh-gauge--pwa">
-  <style>
-    .lh-gauge--pwa .lh-gauge--pwa__component {
-      display: none;
-    }
-    .lh-gauge--pwa__wrapper:not(.lh-badged--all) .lh-gauge--pwa__logo > path {
-      /* Gray logo unless everything is passing. */
-      fill: #B0B0B0;
-    }
 
-    .lh-gauge--pwa__disc {
-      fill: var(--color-gray-200);
-    }
-
-    .lh-gauge--pwa__logo--primary-color {
-      fill: #304FFE;
-    }
-
-    .lh-gauge--pwa__logo--secondary-color {
-      fill: #3D3D3D;
-    }
-    .dark .lh-gauge--pwa__logo--secondary-color {
-      fill: #D8B6B6;
-    }
-
-    /* No passing groups. */
-    .lh-gauge--pwa__wrapper:not([class*='lh-badged--']) .lh-gauge--pwa__na-line {
-      display: inline;
-    }
-    /* Just optimized. Same n/a line as no passing groups. */
-    .lh-gauge--pwa__wrapper.lh-badged--pwa-optimized:not(.lh-badged--pwa-installable) .lh-gauge--pwa__na-line {
-      display: inline;
-    }
-
-    /* Just installable. */
-    .lh-gauge--pwa__wrapper.lh-badged--pwa-installable .lh-gauge--pwa__installable-badge {
-      display: inline;
-    }
-
-    /* All passing groups. */
-    .lh-gauge--pwa__wrapper.lh-badged--all .lh-gauge--pwa__check-circle {
-      display: inline;
-    }
-  </style>
 
   <a href="#" class="lh-gauge__wrapper lh-gauge--pwa__wrapper">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" class="lh-gauge lh-gauge--pwa">
@@ -661,56 +331,7 @@ limitations under the License.
 <!-- Lighthouse crtiical request chains component -->
 <template id="tmpl-lh-crc">
   <div class="lh-crc-container">
-    <style>
-      .lh-crc .tree-marker {
-        width: 12px;
-        height: 26px;
-        display: block;
-        float: left;
-        background-position: top left;
-      }
-      .lh-crc .horiz-down {
-        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><g fill="%23D8D8D8" fill-rule="evenodd"><path d="M16 12v2H-2v-2z"/><path d="M9 12v14H7V12z"/></g></svg>');
-      }
-      .lh-crc .right {
-        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M16 12v2H0v-2z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
-      }
-      .lh-crc .up-right {
-        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v14H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
-      }
-      .lh-crc .vert-right {
-        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v27H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
-      }
-      .lh-crc .vert {
-        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v26H7z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
-      }
-      .lh-crc .crc-tree {
-        font-size: 14px;
-        width: 100%;
-        overflow-x: auto;
-      }
-      .lh-crc .crc-node {
-        height: 26px;
-        line-height: 26px;
-        white-space: nowrap;
-      }
-      .lh-crc .crc-node__tree-value {
-        margin-left: 10px;
-      }
-      .lh-crc .crc-node__tree-value div {
-        display: inline;
-      }
-      .lh-crc .crc-node__chain-duration {
-        font-weight: 700;
-      }
-      .lh-crc .crc-initial-nav {
-        color: #595959;
-        font-style: italic;
-      }
-      .lh-crc__summary-value {
-        margin-bottom: 10px;
-      }
-    </style>
+
     <div>
       <div class="lh-crc__summary-value">
         <span class="lh-crc__longest_duration_label"></span> <b class="lh-crc__longest_duration"></b>
@@ -734,21 +355,7 @@ limitations under the License.
 </template>
 
 <template id="tmpl-lh-3p-filter">
-  <style>
-    .lh-3p-filter {
-      background-color: var(--table-higlight-background-color);
-      color: var(--color-gray-600);
-      float: right;
-      padding: 6px;
-    }
-    .lh-3p-filter-label, .lh-3p-filter-input {
-      vertical-align: middle;
-      user-select: none;
-    }
-    .lh-3p-filter-input:disabled + .lh-3p-ui-string {
-      text-decoration: line-through;
-    }
-  </style>
+
   <div class="lh-3p-filter">
     <label class="lh-3p-filter-label">
       <input type="checkbox" class="lh-3p-filter-input" checked />
@@ -760,115 +367,7 @@ limitations under the License.
 <!-- Lighthouse snippet component -->
 <template id="tmpl-lh-snippet">
     <div class="lh-snippet">
-      <style>
-          :root {
-            --snippet-highlight-light: #fbf1f2;
-            --snippet-highlight-dark: #ffd6d8;
-          }
 
-         .lh-snippet__header {
-          position: relative;
-          overflow: hidden;
-          padding: 10px;
-          border-bottom: none;
-          color: var(--snippet-color);
-          background-color: var(--snippet-background-color);
-          border: 1px solid var(--report-border-color-secondary);
-        }
-        .lh-snippet__title {
-          font-weight: bold;
-          float: left;
-        }
-        .lh-snippet__node {
-          float: left;
-          margin-left: 4px;
-        }
-        .lh-snippet__toggle-expand {
-          padding: 1px 7px;
-          margin-top: -1px;
-          margin-right: -7px;
-          float: right;
-          background: transparent;
-          border: none;
-          cursor: pointer;
-          font-size: 14px;
-          color: #0c50c7;
-        }
-
-        .lh-snippet__snippet {
-          overflow: auto;
-          border: 1px solid var(--report-border-color-secondary);
-        }
-        /* Container needed so that all children grow to the width of the scroll container */
-        .lh-snippet__snippet-inner {
-          display: inline-block;
-          min-width: 100%;
-        }
-
-        .lh-snippet:not(.lh-snippet--expanded) .lh-snippet__show-if-expanded {
-          display: none;
-        }
-        .lh-snippet.lh-snippet--expanded .lh-snippet__show-if-collapsed {
-          display: none;
-        }
-
-        .lh-snippet__line {
-          background: white;
-          white-space: pre;
-          display: flex;
-        }
-        .lh-snippet__line:not(.lh-snippet__line--message):first-child {
-          padding-top: 4px;
-        }
-        .lh-snippet__line:not(.lh-snippet__line--message):last-child {
-          padding-bottom: 4px;
-        }
-        .lh-snippet__line--content-highlighted {
-          background: var(--snippet-highlight-dark);
-        }
-        .lh-snippet__line--message {
-          background: var(--snippet-highlight-light);
-        }
-        .lh-snippet__line--message .lh-snippet__line-number {
-          padding-top: 10px;
-          padding-bottom: 10px;
-        }
-        .lh-snippet__line--message code {
-          padding: 10px;
-          padding-left: 5px;
-          color: var(--color-fail);
-          font-family: var(--report-font-family);
-        }
-        .lh-snippet__line--message code {
-          white-space: normal;
-        }
-        .lh-snippet__line-icon {
-          padding-top: 10px;
-          display: none;
-        }
-        .lh-snippet__line--message .lh-snippet__line-icon {
-          display: block;
-        }
-        .lh-snippet__line-icon:before {
-          content: "";
-          display: inline-block;
-          vertical-align: middle;
-          margin-right: 4px;
-          width: var(--score-icon-size);
-          height: var(--score-icon-size);
-          background-image: var(--fail-icon-url);
-        }
-        .lh-snippet__line-number {
-          flex-shrink: 0;
-          width: 40px;
-          text-align: right;
-          font-family: monospace;
-          padding-right: 5px;
-          margin-right: 5px;
-          color: var(--color-gray-600);
-          user-select: none;
-        }
-      </style>
       <template id="tmpl-lh-snippet__header">
         <div class="lh-snippet__header">
           <div class="lh-snippet__title"></div>
@@ -912,4 +411,3 @@ limitations under the License.
     </div>
   </div>
 </template>
-

--- a/report/assets/templates.html
+++ b/report/assets/templates.html
@@ -23,15 +23,6 @@ limitations under the License.
   </div>
 </template>
 
-<!-- Lighthouse score scale -->
-<template id="tmpl-lh-scorescale">
-  <div class="lh-scorescale">
-      <span class="lh-scorescale-range lh-scorescale-range--fail">0&ndash;49</span>
-      <span class="lh-scorescale-range lh-scorescale-range--average">50&ndash;89</span>
-      <span class="lh-scorescale-range lh-scorescale-range--pass">90&ndash;100</span>
-  </div>
-</template>
-
 <!-- Toggle arrow chevron -->
 <template id="tmpl-lh-chevron">
   <svg class="lh-chevron" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 100">
@@ -87,26 +78,6 @@ limitations under the License.
   </div>
 </template>
 
-<!-- Lighthouse audit -->
-<template id="tmpl-lh-audit">
-  <div class="lh-audit">
-    <details class="lh-expandable-details">
-      <summary>
-        <div class="lh-audit__header lh-expandable-details__summary">
-          <span class="lh-audit__score-icon"></span>
-          <span class="lh-audit__title-and-text">
-            <span class="lh-audit__title"></span>
-            <span class="lh-audit__display-text"></span>
-          </span>
-          <div class="lh-chevron-container"></div>
-        </div>
-      </summary>
-      <div class="lh-audit__description"></div>
-      <div class="lh-audit__stackpacks"></div>
-    </details>
-  </div>
-</template>
-
 <!-- Lighthouse perf metric -->
 <template id="tmpl-lh-metric">
   <div class="lh-metric">
@@ -118,32 +89,6 @@ limitations under the License.
   </div>
 </template>
 
-<!-- Lighthouse perf opportunity -->
-<template id="tmpl-lh-opportunity">
-  <div class="lh-audit lh-audit--load-opportunity">
-    <details class="lh-expandable-details">
-        <summary>
-          <div class="lh-audit__header lh-expandable-details__summary">
-            <div class="lh-load-opportunity__cols">
-              <div class="lh-load-opportunity__col lh-load-opportunity__col--one">
-                <span class="lh-audit__score-icon"></span>
-                <div class="lh-audit__title"></div>
-              </div>
-              <div class="lh-load-opportunity__col lh-load-opportunity__col--two">
-                <div class="lh-load-opportunity__sparkline">
-                  <div class="lh-sparkline"><div class="lh-sparkline__bar"></div></div>
-                </div>
-                <div class="lh-audit__display-text"></div>
-                <div class="lh-chevron-container"></div>
-              </div>
-            </div>
-          </div>
-        </summary>
-      <div class="lh-audit__description"></div>
-      <div class="lh-audit__stackpacks"></div>
-    </details>
-  </div>
-</template>
 
 <!-- Lighthouse perf opportunity header -->
 <template id="tmpl-lh-opportunity-header">
@@ -166,64 +111,6 @@ limitations under the License.
   </div>
 </template>
 
-<!-- Lighthouse topbar -->
-<template id="tmpl-lh-topbar">
-
-
-  <div class="lh-topbar">
-    <!-- Lighthouse logo.  -->
-    <svg class="lh-topbar__logo" viewBox="0 0 24 24">
-      <defs>
-        <linearGradient x1="57.456%" y1="13.086%" x2="18.259%" y2="72.322%" id="lh-topbar__logo--a">
-          <stop stop-color="#262626" stop-opacity=".1" offset="0%"/>
-          <stop stop-color="#262626" stop-opacity="0" offset="100%"/>
-        </linearGradient>
-        <linearGradient x1="100%" y1="50%" x2="0%" y2="50%" id="lh-topbar__logo--b">
-          <stop stop-color="#262626" stop-opacity=".1" offset="0%"/>
-          <stop stop-color="#262626" stop-opacity="0" offset="100%"/>
-        </linearGradient>
-        <linearGradient x1="58.764%" y1="65.756%" x2="36.939%" y2="50.14%" id="lh-topbar__logo--c">
-          <stop stop-color="#262626" stop-opacity=".1" offset="0%"/>
-          <stop stop-color="#262626" stop-opacity="0" offset="100%"/>
-        </linearGradient>
-        <linearGradient x1="41.635%" y1="20.358%" x2="72.863%" y2="85.424%" id="lh-topbar__logo--d">
-          <stop stop-color="#FFF" stop-opacity=".1" offset="0%"/>
-          <stop stop-color="#FFF" stop-opacity="0" offset="100%"/>
-        </linearGradient>
-      </defs>
-      <g fill="none" fill-rule="evenodd">
-        <path d="M12 3l4.125 2.625v3.75H18v2.25h-1.688l1.5 9.375H6.188l1.5-9.375H6v-2.25h1.875V5.648L12 3zm2.201 9.938L9.54 14.633 9 18.028l5.625-2.062-.424-3.028zM12.005 5.67l-1.88 1.207v2.498h3.75V6.86l-1.87-1.19z" fill="#F44B21"/>
-        <path fill="#FFF" d="M14.201 12.938L9.54 14.633 9 18.028l5.625-2.062z"/>
-        <path d="M6 18c-2.042 0-3.95-.01-5.813 0l1.5-9.375h4.326L6 18z" fill="url(#lh-topbar__logo--a)" fill-rule="nonzero" transform="translate(6 3)"/>
-        <path fill="#FFF176" fill-rule="nonzero" d="M13.875 9.375v-2.56l-1.87-1.19-1.88 1.207v2.543z"/>
-        <path fill="url(#lh-topbar__logo--b)" fill-rule="nonzero" d="M0 6.375h6v2.25H0z" transform="translate(6 3)"/>
-        <path fill="url(#lh-topbar__logo--c)" fill-rule="nonzero" d="M6 6.375H1.875v-3.75L6 0z" transform="translate(6 3)"/>
-        <path fill="url(#lh-topbar__logo--d)" fill-rule="nonzero" d="M6 0l4.125 2.625v3.75H12v2.25h-1.688l1.5 9.375H.188l1.5-9.375H0v-2.25h1.875V2.648z" transform="translate(6 3)"/>
-      </g>
-    </svg>
-
-    <a href="" class="lh-topbar__url" target="_blank" rel="noopener"></a>
-
-    <div class="lh-tools">
-      <button id="lh-tools-button" class="lh-tools__button" title="Tools menu" aria-label="Toggle report tools menu" aria-haspopup="menu" aria-expanded="false" aria-controls="lh-tools-dropdown">
-        <svg width="100%" height="100%" viewBox="0 0 24 24">
-            <path d="M0 0h24v24H0z" fill="none"/>
-            <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
-        </svg>
-      </button>
-      <div id="lh-tools-dropdown" role="menu" class="lh-tools__dropdown" aria-labelledby="lh-tools-button">
-        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--print" data-i18n="dropdownPrintSummary" data-action="print-summary"></a>
-        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--print" data-i18n="dropdownPrintExpanded" data-action="print-expanded"></a>
-        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--copy" data-i18n="dropdownCopyJSON" data-action="copy"></a>
-        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--download" data-i18n="dropdownSaveHTML" data-action="save-html"></a>
-        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--download" data-i18n="dropdownSaveJSON" data-action="save-json"></a>
-        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--open" data-i18n="dropdownViewer" data-action="open-viewer"></a>
-        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--open" data-i18n="dropdownSaveGist" data-action="save-gist"></a>
-        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--dark" data-i18n="dropdownDarkTheme" data-action="toggle-dark"></a>
-      </div>
-    </div>
-  </div>
-</template>
 
 <!-- Lighthouse header -->
 <template id="tmpl-lh-heading">

--- a/report/renderer/category-renderer.js
+++ b/report/renderer/category-renderer.js
@@ -57,19 +57,18 @@ class CategoryRenderer {
    * @return {Element}
    */
   renderAudit(audit) {
-    const tmpl = this.dom.cloneTemplate('#tmpl-lh-audit', this.templateContext);
-    return this.populateAuditValues(audit, tmpl);
+    const auditEl = this.dom.getComponent('audit');
+    return this.populateAuditValues(audit, auditEl);
   }
 
   /**
    * Populate an DOM tree with audit details. Used by renderAudit and renderOpportunity
    * @param {LH.ReportResult.AuditRef} audit
-   * @param {DocumentFragment} tmpl
+   * @param {HTMLElement} auditEl
    * @return {!Element}
    */
-  populateAuditValues(audit, tmpl) {
+  populateAuditValues(audit, auditEl) {
     const strings = Util.i18n.strings;
-    const auditEl = this.dom.find('.lh-audit', tmpl);
     auditEl.id = audit.result.id;
     const scoreDisplayMode = audit.result.scoreDisplayMode;
 

--- a/report/renderer/dom.js
+++ b/report/renderer/dom.js
@@ -56,19 +56,15 @@ class DOM {
   }
 
   /**
-   * @param {string} namespaceURI
    * @param {string} name
-   * @param {string=} className
    * @param {Object<string, (string|undefined)>=} attrs Attribute key/val pairs.
    *     Note: if an attribute key has an undefined value, this method does not
    *     set the attribute on the node.
    * @return {Element}
    */
-  createElementNS(namespaceURI, name, className, attrs = {}) {
+  createElementSVG(name, attrs = {}) {
+    const namespaceURI = 'http://www.w3.org/2000/svg';
     const element = this._document.createElementNS(namespaceURI, name);
-    if (className) {
-      element.className = className;
-    }
     Object.keys(attrs).forEach(key => {
       const value = attrs[key];
       if (typeof value !== 'undefined') {

--- a/report/renderer/dom.js
+++ b/report/renderer/dom.js
@@ -16,7 +16,7 @@
  */
 'use strict';
 
-/* globals self Util */
+/* globals self Util, TemplateComponents */
 
 /** @typedef {HTMLElementTagNameMap & {[id: string]: HTMLElement}} HTMLElementByTagName */
 /** @template {string} T @typedef {import('typed-query-selector/parser').ParseSelector<T, Element>} ParseSelector */
@@ -30,6 +30,8 @@ class DOM {
     this._document = document;
     /** @type {string} */
     this._lighthouseChannel = 'unknown';
+    /** @type {Map<string, HTMLElement>} */
+    this.componentCache = new Map();
   }
 
   /**
@@ -119,6 +121,23 @@ class DOM {
     template.setAttribute('data-stamped', 'true');
 
     return clone;
+  }
+
+  /**
+   * @param {LH.Renderer.componentIds} id
+   * @returns {HTMLElement}
+   * @throws {Error}
+   */
+  getComponent(id) {
+    if (!this.componentCache.has(id)) {
+      if (!TemplateComponents || typeof TemplateComponents[id] !== 'function') {
+        throw new Error(`DOM template component for ${id} not found`);
+      }
+      const elem = TemplateComponents[id](this);
+      this.componentCache.set(id, elem);
+    }
+    const goldenEl = /** @type {HTMLElement} */ (this.componentCache.get(id));
+    return /** @type {HTMLElement} */ (goldenEl.cloneNode(true));
   }
 
   /**

--- a/report/renderer/dom.js
+++ b/report/renderer/dom.js
@@ -100,6 +100,7 @@ class DOM {
   }
 
   /**
+   * @deprecated Please migrate to a template component instead.
    * @param {string} selector
    * @param {ParentNode} context
    * @return {!DocumentFragment} A clone of the template content.
@@ -113,12 +114,10 @@ class DOM {
 
     const clone = this._document.importNode(template.content, true);
 
-    // Prevent duplicate styles in the DOM. After a template has been stamped
-    // for the first time, remove the clone's styles so they're not re-added.
-    if (template.hasAttribute('data-stamped')) {
-      this.findAll('style', clone).forEach(style => style.remove());
+    const style = this.findAll('style', clone);
+    if (style.length) {
+      throw new Error('CSS should be added to style.css instead');
     }
-    template.setAttribute('data-stamped', 'true');
 
     return clone;
   }

--- a/report/renderer/element-screenshot-renderer.js
+++ b/report/renderer/element-screenshot-renderer.js
@@ -121,8 +121,7 @@ class ElementScreenshotRenderer {
       `${right},${top} 1,${top}       1,${bottom}       ${right},${bottom}`,
     ];
     for (const points of polygonsPoints) {
-      clipPathEl.append(dom.createElementNS(
-        'http://www.w3.org/2000/svg', 'polygon', undefined, {points}));
+      clipPathEl.append(dom.createElementSVG('polygon', {points}));
     }
   }
 

--- a/report/renderer/performance-category-renderer.js
+++ b/report/renderer/performance-category-renderer.js
@@ -57,8 +57,8 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
    * @return {!Element}
    */
   _renderOpportunity(audit, scale) {
-    const oppTmpl = this.dom.cloneTemplate('#tmpl-lh-opportunity', this.templateContext);
-    const element = this.populateAuditValues(audit, oppTmpl);
+    const auditEl = this.dom.getComponent('opportunity');
+    const element = this.populateAuditValues(audit, auditEl);
     element.id = audit.result.id;
 
     if (!audit.result.details || audit.result.scoreDisplayMode === 'error') {

--- a/report/renderer/psi.js
+++ b/report/renderer/psi.js
@@ -77,8 +77,7 @@ function prepareLabData(LHResult, document) {
 
   const finalScreenshotDataUri = _getFinalScreenshot(perfCategory);
 
-  const clonedScoreTemplate = dom.cloneTemplate('#tmpl-lh-scorescale', dom.document());
-  const scoreScaleEl = dom.find('.lh-scorescale', clonedScoreTemplate);
+  const scoreScaleEl = dom.getComponent('scorescale');
 
   const reportUIFeatures = new ReportUIFeatures(dom);
   reportUIFeatures.json = lhResult;

--- a/report/renderer/report-renderer.js
+++ b/report/renderer/report-renderer.js
@@ -26,7 +26,7 @@
 /** @typedef {import('./category-renderer')} CategoryRenderer */
 /** @typedef {import('./dom.js')} DOM */
 
-/* globals self, Util, DetailsRenderer, CategoryRenderer, I18n, PerformanceCategoryRenderer, PwaCategoryRenderer, ElementScreenshotRenderer */
+/* globals self, Util, DetailsRenderer, CategoryRenderer, I18n, PerformanceCategoryRenderer, PwaCategoryRenderer, ElementScreenshotRenderer, TemplateComponents */
 
 class ReportRenderer {
   /**
@@ -69,7 +69,7 @@ class ReportRenderer {
    * @return {DocumentFragment}
    */
   _renderReportTopbar(report) {
-    const el = this._dom.cloneTemplate('#tmpl-lh-topbar', this._templateContext);
+    const el = TemplateComponents.topbar(this._dom);
     const metadataUrl = this._dom.find('a.lh-topbar__url', el);
     metadataUrl.href = metadataUrl.textContent = report.finalUrl;
     metadataUrl.title = report.finalUrl;
@@ -237,7 +237,7 @@ class ReportRenderer {
     }
 
     if (scoreHeader) {
-      const scoreScale = this._dom.cloneTemplate('#tmpl-lh-scorescale', this._templateContext);
+      const scoreScale = TemplateComponents.scorescale(this._dom)
       const scoresContainer = this._dom.find('.lh-scores-container', headerContainer);
       scoreHeader.append(
         ...this._renderScoreGauges(report, categoryRenderer, specificCategoryRenderers));

--- a/report/renderer/report-renderer.js
+++ b/report/renderer/report-renderer.js
@@ -26,7 +26,7 @@
 /** @typedef {import('./category-renderer')} CategoryRenderer */
 /** @typedef {import('./dom.js')} DOM */
 
-/* globals self, Util, DetailsRenderer, CategoryRenderer, I18n, PerformanceCategoryRenderer, PwaCategoryRenderer, ElementScreenshotRenderer, TemplateComponents */
+/* globals self, Util, DetailsRenderer, CategoryRenderer, I18n, PerformanceCategoryRenderer, PwaCategoryRenderer, ElementScreenshotRenderer */
 
 class ReportRenderer {
   /**
@@ -66,10 +66,10 @@ class ReportRenderer {
 
   /**
    * @param {LH.ReportResult} report
-   * @return {DocumentFragment}
+   * @return {HTMLElement}
    */
   _renderReportTopbar(report) {
-    const el = TemplateComponents.topbar(this._dom);
+    const el = this._dom.getComponent('topbar');
     const metadataUrl = this._dom.find('a.lh-topbar__url', el);
     metadataUrl.href = metadataUrl.textContent = report.finalUrl;
     metadataUrl.title = report.finalUrl;
@@ -237,7 +237,7 @@ class ReportRenderer {
     }
 
     if (scoreHeader) {
-      const scoreScale = TemplateComponents.scorescale(this._dom)
+      const scoreScale = this._dom.getComponent('scorescale');
       const scoresContainer = this._dom.find('.lh-scores-container', headerContainer);
       scoreHeader.append(
         ...this._renderScoreGauges(report, categoryRenderer, specificCategoryRenderers));
@@ -260,9 +260,9 @@ class ReportRenderer {
     }
 
     const reportFragment = this._dom.createFragment();
-    const topbarDocumentFragment = this._renderReportTopbar(report);
+    const topBarEl = this._renderReportTopbar(report);
 
-    reportFragment.appendChild(topbarDocumentFragment);
+    reportFragment.appendChild(topBarEl);
     reportFragment.appendChild(reportContainer);
     reportContainer.appendChild(headerContainer);
     reportContainer.appendChild(reportSection);

--- a/report/renderer/template-components.js
+++ b/report/renderer/template-components.js
@@ -1,0 +1,260 @@
+/**
+ * @license
+ * Copyright 2017 The Lighthouse Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+
+/** @typedef {import('./dom.js')} DOM */
+
+// Thanks very much to https://domtool.yakshavings.co.uk/ for making this slightly straightforward
+
+/**
+ *
+ * @param {DOM} dom
+ * @return {HTMLDivElement}
+ */
+function scorescale(dom) {
+  const div1 = dom.createElement('div');
+  div1.className = 'lh-scorescale';
+  const span1 = dom.createElement('span');
+  span1.className = 'lh-scorescale-range lh-scorescale-range--fail';
+  div1.appendChild(span1);
+  span1.textContent = '0–49';
+  const span2 = dom.createElement('span');
+  span2.className = 'lh-scorescale-range lh-scorescale-range--average';
+  div1.appendChild(span2);
+  span2.textContent = '50–89';
+  const span3 = dom.createElement('span');
+  span3.className = 'lh-scorescale-range lh-scorescale-range--pass';
+  div1.appendChild(span3);
+  span3.textContent = '90–100';
+  return div1;
+}
+
+
+/**
+ *
+ * @param {DOM} dom
+ * @return {HTMLDivElement}
+ */
+function topbar(dom) {
+  const div1 = dom.createElement('div', 'lh-topbar');
+
+  // LH logo in svg
+  const svg1 = dom.createElement('svg', 'lh-topbar__logo', {
+    'viewBox': '0 0 24 24',
+  });
+  div1.append(svg1);
+  const defs1 = dom.createElementSVG('defs');
+  svg1.append(defs1);
+  const lineargradient1 = dom.createElementSVG('lineargradient', {
+    'x1': '57.456%',
+    'y1': '13.086%',
+    'x2': '18.259%',
+    'y2': '72.322%',
+    'id': 'lh-topbar__logo--a',
+  });
+  defs1.append(lineargradient1);
+  const stop1 = dom.createElementSVG('stop', {
+    'stop-color': '#262626',
+    'stop-opacity': '.1',
+    'offset': '0%',
+  });
+  lineargradient1.append(stop1);
+  const stop2 = dom.createElementSVG('stop', {
+    'stop-color': '#262626',
+    'stop-opacity': '0',
+    'offset': '100%',
+  });
+  lineargradient1.append(stop2);
+  const lineargradient2 = dom.createElementSVG('lineargradient', {
+    'x1': '100%',
+    'y1': '50%',
+    'x2': '0%',
+    'y2': '50%',
+    'id': 'lh-topbar__logo--b',
+  });
+  defs1.append(lineargradient2);
+  const stop3 = dom.createElementSVG('stop', {
+    'stop-color': '#262626',
+    'stop-opacity': '.1',
+    'offset': '0%',
+  });
+  lineargradient2.append(stop3);
+  const stop4 = dom.createElementSVG('stop', {
+    'stop-color': '#262626',
+    'stop-opacity': '0',
+    'offset': '100%',
+  });
+  lineargradient2.append(stop4);
+  const lineargradient3 = dom.createElementSVG('lineargradient', {
+    'x1': '58.764%',
+    'y1': '65.756%',
+    'x2': '36.939%',
+    'y2': '50.14%',
+    'id': 'lh-topbar__logo--c',
+  });
+  defs1.append(lineargradient3);
+  const stop5 = dom.createElementSVG('stop', {
+    'stop-color': '#262626',
+    'stop-opacity': '.1',
+    'offset': '0%',
+  });
+  lineargradient3.append(stop5);
+  const stop6 = dom.createElementSVG('stop', {
+    'stop-color': '#262626',
+    'stop-opacity': '0',
+    'offset': '100%',
+  });
+  lineargradient3.append(stop6);
+  const lineargradient4 = dom.createElementSVG('lineargradient', {
+    'x1': '41.635%',
+    'y1': '20.358%',
+    'x2': '72.863%',
+    'y2': '85.424%',
+    'id': 'lh-topbar__logo--d',
+  });
+  defs1.append(lineargradient4);
+  const stop7 = dom.createElementSVG('stop', {
+    'stop-color': '#FFF',
+    'stop-opacity': '.1',
+    'offset': '0%',
+  });
+  lineargradient4.append(stop7);
+  const stop8 = dom.createElementSVG('stop', {
+    'stop-color': '#FFF',
+    'stop-opacity': '0',
+    'offset': '100%',
+  });
+  lineargradient4.append(stop8);
+  const g1 = dom.createElementSVG('g', {
+    'fill': 'none',
+    'fill-rule': 'evenodd',
+  });
+  svg1.append(g1);
+  const path1 = dom.createElementSVG('path', {
+    'd': 'M12 3l4.125 2.625v3.75H18v2.25h-1.688l1.5 9.375H6.188l1.5-9.375H6v-2.25h1.875V5.648L12 3zm2.201 9.938L9.54 14.633 9 18.028l5.625-2.062-.424-3.028zM12.005 5.67l-1.88 1.207v2.498h3.75V6.86l-1.87-1.19z',
+    'fill': '#F44B21',
+  });
+  g1.append(path1);
+  const path2 = dom.createElementSVG('path', {
+    'fill': '#FFF',
+    'd': 'M14.201 12.938L9.54 14.633 9 18.028l5.625-2.062z',
+  });
+  g1.append(path2);
+  const path3 = dom.createElementSVG('path', {
+    'd': 'M6 18c-2.042 0-3.95-.01-5.813 0l1.5-9.375h4.326L6 18z',
+    'fill': 'url(#lh-topbar__logo--a)',
+    'fill-rule': 'nonzero',
+    'transform': 'translate(6 3)',
+  });
+  g1.append(path3);
+  const path4 = dom.createElementSVG('path', {
+    'fill': '#FFF176',
+    'fill-rule': 'nonzero',
+    'd': 'M13.875 9.375v-2.56l-1.87-1.19-1.88 1.207v2.543z',
+  });
+  g1.append(path4);
+  const path5 = dom.createElementSVG('path', {
+    'fill': 'url(#lh-topbar__logo--b)',
+    'fill-rule': 'nonzero',
+    'd': 'M0 6.375h6v2.25H0z',
+    'transform': 'translate(6 3)',
+  });
+  g1.append(path5);
+  const path6 = dom.createElementSVG('path', {
+    'fill': 'url(#lh-topbar__logo--c)',
+    'fill-rule': 'nonzero',
+    'd': 'M6 6.375H1.875v-3.75L6 0z',
+    'transform': 'translate(6 3)',
+  });
+  g1.append(path6);
+  const path7 = dom.createElementSVG('path', {
+    'fill': 'url(#lh-topbar__logo--d)',
+    'fill-rule': 'nonzero',
+    'd': 'M6 0l4.125 2.625v3.75H12v2.25h-1.688l1.5 9.375H.188l1.5-9.375H0v-2.25h1.875V2.648z',
+    'transform': 'translate(6 3)',
+  });
+  g1.append(path7);
+
+
+  const a1 = dom.createElement('a', 'lh-topbar__url', {
+    'target': '_blank',
+    'rel': 'noopener',
+  });
+  div1.append(a1);
+  const div2 = dom.createElement('div', 'lh-tools');
+  div1.append(div2);
+  const button1 = dom.createElement('button', 'lh-tools__button', {
+    'id': 'lh-tools-button',
+    'title': 'Tools menu',
+    'aria-label': 'Toggle report tools menu',
+    'aria-haspopup': 'menu',
+    'aria-expanded': 'false',
+    'aria-controls': 'lh-tools-dropdown',
+  });
+  div2.append(button1);
+  const svg2 = dom.createElement('svg', {
+    'width': '100%',
+    'height': '100%',
+    'viewBox': '0 0 24 24',
+  });
+  button1.append(svg2);
+  const path8 = dom.createElementSVG('path', {
+    'd': 'M0 0h24v24H0z',
+    'fill': 'none',
+  });
+  svg2.append(path8);
+  const path9 = dom.createElementSVG('path', {
+    'd': 'M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z',
+  });
+  svg2.append(path9);
+  const div3 = dom.createElement('div', 'lh-tools__dropdown', {
+    'id': 'lh-tools-dropdown',
+    'role': 'menu',
+    'aria-labelledby': 'lh-tools-button',
+  });
+  div2.append(div3);
+
+  const menuItems = [
+    ['report-icon report-icon--print', 'dropdownPrintSummary', 'print-summary'],
+    ['report-icon report-icon--print', 'dropdownPrintExpanded', 'print-expanded'],
+    ['report-icon report-icon--copy', 'dropdownCopyJSON', 'copy'],
+    ['report-icon report-icon--download', 'dropdownSaveHTML', 'save-html'],
+    ['report-icon report-icon--download', 'dropdownSaveJSON', 'save-json'],
+    ['report-icon report-icon--open', 'dropdownViewer', 'open-viewer'],
+    ['report-icon report-icon--open', 'dropdownSaveGist', 'save-gist'],
+    ['report-icon report-icon--dark', 'dropdownDarkTheme', 'toggle-dark'],
+  ];
+
+  for (const [className, di18n, action] of menuItems) {
+    const a2 = dom.createElement('a', className, {
+      'role': 'menuitem',
+      'tabindex': '-1',
+      'href': '#',
+      'data-i18n': di18n,
+      'data-action': action,
+    });
+    div3.append(a2);
+  }
+  return div1;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {scorescale, topbar};
+} else {
+  self.TemplateComponents = {scorescale, topbar};
+}

--- a/report/renderer/template-components.js
+++ b/report/renderer/template-components.js
@@ -1,25 +1,20 @@
 /**
- * @license
- * Copyright 2017 The Lighthouse Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 'use strict';
 
+/**
+ * @fileoverview Common report components can be created with the DOM methods below.
+ * These components were ported from report/assets/templates.html where each component had lived as
+ * HTML, however writing that file as HTML introduced many challenges for report embedders.
+ *
+ * Thanks very much to https://domtool.yakshavings.co.uk/ for enabling this HTML=>DOM conversion
+ */
 
+/* global self */
 /** @typedef {import('./dom.js')} DOM */
-
-// Thanks very much to https://domtool.yakshavings.co.uk/ for making this slightly straightforward
 
 /**
  *
@@ -253,6 +248,7 @@ function topbar(dom) {
     });
     div3.append(a2);
   }
+
   return div1;
 }
 

--- a/report/renderer/template-components.js
+++ b/report/renderer/template-components.js
@@ -29,18 +29,18 @@
 function scorescale(dom) {
   const div1 = dom.createElement('div');
   div1.className = 'lh-scorescale';
-  const span1 = dom.createElement('span');
-  span1.className = 'lh-scorescale-range lh-scorescale-range--fail';
-  div1.appendChild(span1);
-  span1.textContent = '0–49';
-  const span2 = dom.createElement('span');
-  span2.className = 'lh-scorescale-range lh-scorescale-range--average';
-  div1.appendChild(span2);
-  span2.textContent = '50–89';
-  const span3 = dom.createElement('span');
-  span3.className = 'lh-scorescale-range lh-scorescale-range--pass';
-  div1.appendChild(span3);
-  span3.textContent = '90–100';
+
+  const ranges = [
+    ['lh-scorescale-range--fail', '0–49'],
+    ['lh-scorescale-range--average', '50–89'],
+    ['lh-scorescale-range--pass', '90–100'],
+  ];
+
+  for (const [classNameModifier, text] of ranges) {
+    const span = dom.createElement('span', `lh-scorescale-range ${classNameModifier}`);
+    span.textContent = text;
+    div1.append(span);
+  }
   return div1;
 }
 
@@ -54,13 +54,14 @@ function topbar(dom) {
   const div1 = dom.createElement('div', 'lh-topbar');
 
   // LH logo in svg
-  const svg1 = dom.createElement('svg', 'lh-topbar__logo', {
+  const svg1 = dom.createElementSVG('svg', {
     'viewBox': '0 0 24 24',
   });
+  svg1.classList.add('lh-topbar__logo');
   div1.append(svg1);
   const defs1 = dom.createElementSVG('defs');
   svg1.append(defs1);
-  const lineargradient1 = dom.createElementSVG('lineargradient', {
+  const lineargradient1 = dom.createElementSVG('linearGradient', {
     'x1': '57.456%',
     'y1': '13.086%',
     'x2': '18.259%',
@@ -80,7 +81,7 @@ function topbar(dom) {
     'offset': '100%',
   });
   lineargradient1.append(stop2);
-  const lineargradient2 = dom.createElementSVG('lineargradient', {
+  const lineargradient2 = dom.createElementSVG('linearGradient', {
     'x1': '100%',
     'y1': '50%',
     'x2': '0%',
@@ -100,7 +101,7 @@ function topbar(dom) {
     'offset': '100%',
   });
   lineargradient2.append(stop4);
-  const lineargradient3 = dom.createElementSVG('lineargradient', {
+  const lineargradient3 = dom.createElementSVG('linearGradient', {
     'x1': '58.764%',
     'y1': '65.756%',
     'x2': '36.939%',
@@ -120,7 +121,7 @@ function topbar(dom) {
     'offset': '100%',
   });
   lineargradient3.append(stop6);
-  const lineargradient4 = dom.createElementSVG('lineargradient', {
+  const lineargradient4 = dom.createElementSVG('linearGradient', {
     'x1': '41.635%',
     'y1': '20.358%',
     'x2': '72.863%',
@@ -146,7 +147,7 @@ function topbar(dom) {
   });
   svg1.append(g1);
   const path1 = dom.createElementSVG('path', {
-    'd': 'M12 3l4.125 2.625v3.75H18v2.25h-1.688l1.5 9.375H6.188l1.5-9.375H6v-2.25h1.875V5.648L12 3zm2.201 9.938L9.54 14.633 9 18.028l5.625-2.062-.424-3.028zM12.005 5.67l-1.88 1.207v2.498h3.75V6.86l-1.87-1.19z',
+    'd': 'M12 3l4.125 2.625v3.75H18v2.25h-1.688l1.5 9.375H6.188l1.5-9.375H6v-2.25h1.875V5.648L12 3zm2.201 9.938L9.54 14.633 9 18.028l5.625-2.062-.424-3.028zM12.005 5.67l-1.88 1.207v2.498h3.75V6.86l-1.87-1.19z', // eslint-disable-line max-len
     'fill': '#F44B21',
   });
   g1.append(path1);
@@ -207,7 +208,9 @@ function topbar(dom) {
     'aria-controls': 'lh-tools-dropdown',
   });
   div2.append(button1);
-  const svg2 = dom.createElement('svg', {
+
+  // 3-dots SVG
+  const svg2 = dom.createElementSVG('svg', {
     'width': '100%',
     'height': '100%',
     'viewBox': '0 0 24 24',
@@ -219,7 +222,7 @@ function topbar(dom) {
   });
   svg2.append(path8);
   const path9 = dom.createElementSVG('path', {
-    'd': 'M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z',
+    'd': 'M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z', // eslint-disable-line max-len
   });
   svg2.append(path9);
   const div3 = dom.createElement('div', 'lh-tools__dropdown', {

--- a/report/renderer/template-components.js
+++ b/report/renderer/template-components.js
@@ -17,7 +17,7 @@
 /** @typedef {import('./dom.js')} DOM */
 
 /**
- *
+ * Lighthouse score scale
  * @param {DOM} dom
  * @return {HTMLDivElement}
  */
@@ -41,7 +41,7 @@ function scorescale(dom) {
 
 
 /**
- *
+ * Lighthouse header
  * @param {DOM} dom
  * @return {HTMLDivElement}
  */
@@ -252,8 +252,73 @@ function topbar(dom) {
   return div1;
 }
 
+/**
+ * Lighthouse audit
+ * @param {DOM} dom
+ * @return {HTMLDivElement}
+ */
+function audit(dom) {
+  const div1 = dom.createElement('div', 'lh-audit');
+  const details1 = dom.createElement('details', 'lh-expandable-details');
+  div1.append(details1);
+  const summary1 = dom.createElement('summary');
+  const div2 = dom.createElement('div', 'lh-audit__header lh-expandable-details__summary');
+  summary1.append(div2);
+  const span1 = dom.createElement('span', 'lh-audit__score-icon');
+  const span2 = dom.createElement('span', 'lh-audit__title-and-text');
+  const span3 = dom.createElement('span', 'lh-audit__title');
+  const span4 = dom.createElement('span', 'lh-audit__display-text');
+  span2.append(span3, span4);
+  const div3 = dom.createElement('div', 'lh-chevron-container');
+  div2.append(span1, span2, div3);
+  const div4 = dom.createElement('div', 'lh-audit__description');
+  const div5 = dom.createElement('div', 'lh-audit__stackpacks');
+  details1.append(summary1, div4, div5);
+  return div1;
+}
+
+/**
+ * Lighthouse perf opportunity
+ * @param {DOM} dom
+ * @return {HTMLDivElement}
+ */
+function opportunity(dom) {
+  const div1 = dom.createElement('div', 'lh-audit lh-audit--load-opportunity');
+  const details1 = dom.createElement('details', 'lh-expandable-details');
+  div1.append(details1);
+  const summary1 = dom.createElement('summary');
+  const div2 = dom.createElement('div', 'lh-audit__header lh-expandable-details__summary');
+  summary1.append(div2);
+  const div3 = dom.createElement('div', 'lh-load-opportunity__cols');
+  div2.append(div3);
+  const div4 = dom.createElement('div', 'lh-load-opportunity__col lh-load-opportunity__col--one');
+  const span1 = dom.createElement('span', 'lh-audit__score-icon');
+  const div5 = dom.createElement('div', 'lh-audit__title');
+  div4.append(span1, div5);
+  const div6 = dom.createElement('div', 'lh-load-opportunity__col lh-load-opportunity__col--two');
+  div3.append(div4, div6);
+  const div7 = dom.createElement('div', 'lh-load-opportunity__sparkline');
+  const div8 = dom.createElement('div', 'lh-sparkline');
+  div7.append(div8);
+  const div9 = dom.createElement('div', 'lh-sparkline__bar');
+  div8.append(div9);
+  const div10 = dom.createElement('div', 'lh-audit__display-text');
+  const div11 = dom.createElement('div', 'lh-chevron-container');
+  div6.append(div7, div10, div11);
+  const div12 = dom.createElement('div', 'lh-audit__description');
+  const div13 = dom.createElement('div', 'lh-audit__stackpacks');
+  details1.append(summary1, div12, div13);
+  return div1;
+}
+
+/**
+ * Lighthouse perf opportunity
+ * @param {DOM} dom
+ * @return {HTMLDivElement}
+ */
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = {scorescale, topbar};
+  module.exports = {scorescale, topbar, audit, opportunity};
 } else {
-  self.TemplateComponents = {scorescale, topbar};
+  self.TemplateComponents = {scorescale, topbar, audit, opportunity};
 }

--- a/report/test/renderer/dom-test.js
+++ b/report/test/renderer/dom-test.js
@@ -50,7 +50,7 @@ describe('DOM', () => {
 
   describe('cloneTemplate', () => {
     it('should clone a template', () => {
-      const clone = dom.cloneTemplate('#tmpl-lh-audit', dom.document());
+      const clone = dom.cloneTemplate('#tmpl-lh-metric', dom.document());
       assert.ok(clone.querySelector('.lh-audit'));
     });
 
@@ -65,7 +65,7 @@ describe('DOM', () => {
     });
 
     it('fails when a template context isn\'t provided', () => {
-      assert.throws(() => dom.cloneTemplate('#tmpl-lh-audit'));
+      assert.throws(() => dom.cloneTemplate('#tmpl-lh-metric'));
     });
 
     it('does not inject duplicate styles', () => {

--- a/types/html-renderer.d.ts
+++ b/types/html-renderer.d.ts
@@ -5,6 +5,7 @@
  */
 
 import _CategoryRenderer = require('../report/renderer/category-renderer.js');
+import _TemplateComponents = require('../report/renderer/template-components.js');
 import _CriticalRequestChainRenderer = require('../report/renderer/crc-details-renderer.js');
 import _SnippetRenderer = require('../report/renderer/snippet-renderer.js');
 import _ElementScreenshotRenderer = require('../report/renderer/element-screenshot-renderer.js');
@@ -34,6 +35,7 @@ declare global {
   var ReportRenderer: typeof _ReportRenderer;
   var ReportUIFeatures: typeof _ReportUIFeatures;
   var Util: typeof _Util;
+  var TemplateComponents: typeof _TemplateComponents;
   var TextEncoding: typeof _TextEncoding;
   var prepareLabData: typeof _prepareLabData;
   var CompressionStream: {
@@ -58,6 +60,7 @@ declare global {
     ReportRenderer: typeof _ReportRenderer;
     ReportUIFeatures: typeof _ReportUIFeatures;
     Util: typeof _Util;
+    TemplateComponents: typeof _TemplateComponents;
     prepareLabData: typeof _prepareLabData;
   }
 
@@ -86,6 +89,10 @@ declare global {
         /** The stack-specific description for this audit. */
         description: string;
       }
+    }
+    export module Renderer {
+      /** String enum of possible component ids to clone */
+      export type componentIds = 'scorescale' | 'topbar';
     }
   }
 }

--- a/types/html-renderer.d.ts
+++ b/types/html-renderer.d.ts
@@ -92,7 +92,7 @@ declare global {
     }
     export module Renderer {
       /** String enum of possible component ids to clone */
-      export type componentIds = 'scorescale' | 'topbar';
+      export type componentIds = 'scorescale' | 'topbar' | 'audit' | 'opportunity';
     }
   }
 }


### PR DESCRIPTION
Currently a number of "component"s have their HTML source defined in [report/assets/templates.html](https://github.com/GoogleChrome/lighthouse/blob/master/report/assets/templates.html). However,  for many embedders, including that file in the build process creates some challenges.. especially when we want to easily roll the latest Lighthouse somewhere. 

I'm proposing a refactor for the stuff in `templates.html`: build out those items with standard DOM calls.  We're already using this pattern pretty heavily in the report.

-------

In this PR:

- the styles that lives in templates.html move to the complete styles.css. (These styles were also adding extra headaches for _some_ embedders ;)
- created template components for 4 examples.  scorescale, audit, opportunity, topbar.
- created a lazy & cached thing to get the components. same basic effect as what cloneTemplate did.
- i left out the unit test changes, but they're very straightforward and boring.


----

looking for any high-level feedback on this approach. 