### PR TITLE
tests(devtools): fix after renaming standalone-template.html

### DIFF
--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -38,8 +38,8 @@ writeFile('report-generator.d.ts', 'export {}');
 
 const pathToReportAssets = require.resolve('../clients/devtools-report-assets.js');
 browserify(generatorFilename, {standalone: 'Lighthouse.ReportGenerator'})
-  // Shims './html/html-report-assets.js' to resolve to devtools-report-assets.js
-  .require(pathToReportAssets, {expose: './html/html-report-assets.js'})
+  // Shims './report/report-assets.js' to resolve to devtools-report-assets.js
+  .require(pathToReportAssets, {expose: './report-assets.js'})
   .bundle((err, src) => {
     if (err) throw err;
     fs.writeFileSync(bundleOutFile, src.toString());

--- a/report/assets/standalone-template.html
+++ b/report/assets/standalone-template.html
@@ -33,6 +33,7 @@ limitations under the License.
 
   <script>window.__LIGHTHOUSE_JSON__ = %%LIGHTHOUSE_JSON%%;</script>
   <script>%%LIGHTHOUSE_JAVASCRIPT%%
+  __initLighthouseReport__();
   //# sourceURL=compiled-reportrenderer.js
   </script>
   <script>console.log('window.__LIGHTHOUSE_JSON__', __LIGHTHOUSE_JSON__);</script>

--- a/report/clients/standalone.js
+++ b/report/clients/standalone.js
@@ -7,7 +7,9 @@
 
 /* global document window ga DOM ReportRenderer ReportUIFeatures Logger */
 
-(function __initLighthouseReport__() {
+// Used by standalone.html
+// eslint-disable-next-line no-unused-vars
+function __initLighthouseReport__() {
   const dom = new DOM(document);
   const renderer = new ReportRenderer(dom);
   const container = dom.find('main', document);
@@ -20,33 +22,33 @@
   // is in the document.
   const features = new ReportUIFeatures(dom);
   features.initFeatures(lhr);
-})();
 
-document.addEventListener('lh-analytics', /** @param {Event} e */ e => {
-  // @ts-expect-error
-  if (window.ga) ga(e.detail.cmd, e.detail.fields);
-});
+  document.addEventListener('lh-analytics', /** @param {Event} e */ e => {
+    // @ts-expect-error
+    if (window.ga) ga(e.detail.cmd, e.detail.fields);
+  });
 
-document.addEventListener('lh-log', /** @param {Event} e */ e => {
-  const el = document.querySelector('#lh-log');
-  if (!el) return;
+  document.addEventListener('lh-log', /** @param {Event} e */ e => {
+    const el = document.querySelector('#lh-log');
+    if (!el) return;
 
-  const logger = new Logger(el);
-  // @ts-expect-error
-  const detail = e.detail;
+    const logger = new Logger(el);
+    // @ts-expect-error
+    const detail = e.detail;
 
-  switch (detail.cmd) {
-    case 'log':
-      logger.log(detail.msg);
-      break;
-    case 'warn':
-      logger.warn(detail.msg);
-      break;
-    case 'error':
-      logger.error(detail.msg);
-      break;
-    case 'hide':
-      logger.hide();
-      break;
-  }
-});
+    switch (detail.cmd) {
+      case 'log':
+        logger.log(detail.msg);
+        break;
+      case 'warn':
+        logger.warn(detail.msg);
+        break;
+      case 'error':
+        logger.error(detail.msg);
+        break;
+      case 'hide':
+        logger.hide();
+        break;
+    }
+  });
+}


### PR DESCRIPTION
https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/3003137

Also move calling the standalone init function to the html file. Current devtools LH integration is evaluating the `report.js` to export things to global scope (see my pending [CL](https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2939422/13/front_end/panels/lighthouse/lighthouse.ts) that changes this), so this prevents that function from running in the wrong contexts.