### PR TITLE
tests: don't double count server network requests on retry

### DIFF
--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -209,6 +209,9 @@ async function runSmokeTest(testOptions) {
         networkRequests: takeNetworkRequestUrls ? takeNetworkRequestUrls() : undefined,
       };
     } catch (e) {
+      // Clear the network requests so that when we retry, we don't see duplicates.
+      if (takeNetworkRequestUrls) takeNetworkRequestUrls();
+
       logChildProcessError(localConsole, e);
       continue; // Retry, if possible.
     }


### PR DESCRIPTION
**Summary**
Our tests have been very flaky on ToT lately due to more `PROTOCOL_TIMEOUT` issues. This was exacerbated by our retry logic failing because of server assertions. Basically we forgot to clear network requests in between attempts so even if it passed later, our assertion on the count of requests would fail.

We'll give this a go and see if it helps while I try to repro PROTOCOL_TIMEOUT.
 
**Related Issues/PRs**
ref #12773 
