### PR TITLE
clients(psi): fix scorecalc link

### DIFF
--- a/report/renderer/psi.js
+++ b/report/renderer/psi.js
@@ -48,6 +48,7 @@ function prepareLabData(LHResult, document) {
     ...reportLHR.i18n.rendererFormattedStrings,
   });
   Util.i18n = i18n;
+  Util.reportJson = reportLHR;
 
   const perfCategory = reportLHR.categories.performance;
   if (!perfCategory) throw new Error(`No performance category. Can't make lab data section`);


### PR DESCRIPTION
resolves bug where "version" parameter is not set in psi scorecalc link

cl/377163048 fixed this but it wasn't upstreamed.