### PR TITLE
core: better type checking of evaluate() code

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -148,10 +148,11 @@ async function minifyScript(filePath) {
       comments: /^!/,
       max_line_len: 1000,
     },
-    // The config relies on class names for gatherers.
-    keep_classnames: true,
-    // Runtime.evaluate errors if function names are elided.
-    keep_fnames: true,
+    // Class and function names are needed for things like loading gatherers by
+    // name and accessing functions by name in Runtime.evaluate. Instead, just
+    // rely on whitespace elimination for the large savings.
+    compress: false,
+    mangle: false,
     sourceMap: DEBUG && {
       content: JSON.parse(fs.readFileSync(`${filePath}.map`, 'utf-8')),
       url: path.basename(`${filePath}.map`),

--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -21,6 +21,8 @@ const terser = require('terser');
 const {minifyFileTransform} = require('./build-utils.js');
 const {LH_ROOT} = require('../root.js');
 
+const pageFunctions = require('../lighthouse-core/lib/page-functions.js');
+
 const COMMIT_HASH = require('child_process')
   .execSync('git rev-parse HEAD')
   .toString().trim();
@@ -148,11 +150,12 @@ async function minifyScript(filePath) {
       comments: /^!/,
       max_line_len: 1000,
     },
-    // Class and function names are needed for things like loading gatherers by
-    // name and accessing functions by name in Runtime.evaluate. Instead, just
-    // rely on whitespace elimination for the large savings.
-    compress: false,
-    mangle: false,
+    // The config relies on class names for gatherers.
+    keep_classnames: true,
+    // Runtime.evaluate errors if function names are elided.
+    keep_fnames: true,
+    // Preserve page-function function names for references in Runtime.evaluate.
+    mangle: {reserved: Object.keys(pageFunctions)},
     sourceMap: DEBUG && {
       content: JSON.parse(fs.readFileSync(`${filePath}.map`, 'utf-8')),
       url: path.basename(`${filePath}.map`),

--- a/lighthouse-core/gather/driver/execution-context.js
+++ b/lighthouse-core/gather/driver/execution-context.js
@@ -94,7 +94,7 @@ class ExecutionContext {
         return new Promise(function (resolve) {
           return Promise.resolve()
             .then(_ => ${expression})
-            .catch(${pageFunctions.wrapRuntimeEvalErrorInBrowserString})
+            .catch(${pageFunctions.wrapRuntimeEvalErrorInBrowser.toString()})
             .then(resolve);
         });
       }())`,

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -5,11 +5,11 @@
  */
 'use strict';
 
-/* global window, document, getNodeDetails */
+/* global window, document */
 
 const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const axeLibSource = require('../../lib/axe.js').source;
-const pageFunctions = require('../../lib/page-functions.js');
+const {getNodeDetails} = require('../../lib/page-functions.js');
 
 /**
  * This is run in the page, not Lighthouse itself.
@@ -84,7 +84,6 @@ function createAxeRuleResultArtifact(result) {
   const nodes = result.nodes.map(node => {
     const {target, failureSummary, element} = node;
     // TODO: with `elementRef: true`, `element` _should_ always be defined, but need to verify.
-    // @ts-expect-error - getNodeDetails put into scope via stringification
     const nodeDetails = getNodeDetails(/** @type {HTMLElement} */ (element));
 
     return {
@@ -135,7 +134,7 @@ class Accessibility extends FRGatherer {
       useIsolation: true,
       deps: [
         axeLibSource,
-        pageFunctions.getNodeDetailsString,
+        getNodeDetails,
         createAxeRuleResultArtifact,
       ],
     });

--- a/lighthouse-core/gather/gatherers/anchor-elements.js
+++ b/lighthouse-core/gather/gatherers/anchor-elements.js
@@ -5,11 +5,9 @@
  */
 'use strict';
 
-/* global getNodeDetails */
-
 const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const dom = require('../driver/dom.js');
-const pageFunctions = require('../../lib/page-functions.js');
+const {getElementsInDocument, getNodeDetails} = require('../../lib/page-functions.js');
 
 /* eslint-env browser, node */
 
@@ -39,9 +37,9 @@ function collectAnchorElements() {
     return onclick.slice(0, 1024);
   }
 
+  // Manually widen type to include SVG. See https://github.com/GoogleChrome/lighthouse/issues/12011.
   /** @type {Array<HTMLAnchorElement|SVGAElement>} */
-  // @ts-expect-error - put into scope via stringification
-  const anchorElements = getElementsInDocument('a'); // eslint-disable-line no-undef
+  const anchorElements = getElementsInDocument('a');
 
   return anchorElements.map(node => {
     if (node instanceof HTMLAnchorElement) {
@@ -54,7 +52,6 @@ function collectAnchorElements() {
         text: node.innerText, // we don't want to return hidden text, so use innerText
         rel: node.rel,
         target: node.target,
-        // @ts-expect-error - getNodeDetails put into scope via stringification
         node: getNodeDetails(node),
       };
     }
@@ -67,7 +64,6 @@ function collectAnchorElements() {
       text: node.textContent || '',
       rel: '',
       target: node.target.baseVal || '',
-      // @ts-expect-error - getNodeDetails put into scope via stringification
       node: getNodeDetails(node),
     };
   });
@@ -107,8 +103,8 @@ class AnchorElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getElementsInDocumentString,
-        pageFunctions.getNodeDetailsString,
+        getElementsInDocument,
+        getNodeDetails,
       ],
     });
     await session.sendCommand('DOM.enable');

--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -9,12 +9,12 @@
  * and total number of elements used on the page.
  */
 
-/* global getNodeDetails document */
+/* global document */
 
 'use strict';
 
 const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
-const pageFunctions = require('../../../lib/page-functions.js');
+const {getNodeDetails} = require('../../../lib/page-functions.js');
 
 /**
  * Calculates the maximum tree depth of the DOM.
@@ -24,11 +24,13 @@ const pageFunctions = require('../../../lib/page-functions.js');
  */
 /* c8 ignore start */
 function getDOMStats(element = document.body, deep = true) {
-  let deepestElement = null;
+  /** @type {Element|ShadowRoot} */
+  let deepestElement = element;
   let maxDepth = -1;
   let maxWidth = -1;
   let numElements = 0;
-  let parentWithMostChildren = null;
+  /** @type {Element|ShadowRoot} */
+  let parentWithMostChildren = element;
 
   /**
    * @param {Element|ShadowRoot} element
@@ -63,12 +65,10 @@ function getDOMStats(element = document.body, deep = true) {
   return {
     depth: {
       max: result.maxDepth,
-      // @ts-expect-error - getNodeDetails put into scope via stringification
       ...getNodeDetails(deepestElement),
     },
     width: {
       max: result.maxWidth,
-      // @ts-expect-error - getNodeDetails put into scope via stringification
       ...getNodeDetails(parentWithMostChildren),
     },
     totalBodyElements: result.numElements,
@@ -93,7 +93,7 @@ class DOMStats extends FRGatherer {
     const results = await driver.executionContext.evaluate(getDOMStats, {
       args: [],
       useIsolation: true,
-      deps: [pageFunctions.getNodeDetailsString],
+      deps: [getNodeDetails],
     });
     await driver.defaultSession.sendCommand('DOM.disable');
     return results;

--- a/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
@@ -5,10 +5,10 @@
  */
 'use strict';
 
-/* global document ClipboardEvent getNodeDetails */
+/* global document ClipboardEvent */
 
 const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
-const pageFunctions = require('../../../lib/page-functions.js');
+const {getNodeDetails} = require('../../../lib/page-functions.js');
 
 /**
  * @return {LH.Artifacts['PasswordInputsWithPreventedPaste']}
@@ -22,7 +22,6 @@ function findPasswordInputsWithPreventedPaste() {
       )
     )
     .map(passwordInput => ({
-      // @ts-expect-error - getNodeDetails put into scope via stringification
       node: getNodeDetails(passwordInput),
     }));
 }
@@ -41,7 +40,7 @@ class PasswordInputsWithPreventedPaste extends FRGatherer {
   getArtifact(passContext) {
     return passContext.driver.executionContext.evaluate(findPasswordInputsWithPreventedPaste, {
       args: [],
-      deps: [pageFunctions.getNodeDetailsString],
+      deps: [getNodeDetails],
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/full-page-screenshot.js
+++ b/lighthouse-core/gather/gatherers/full-page-screenshot.js
@@ -5,11 +5,11 @@
  */
 'use strict';
 
-/* globals window document getBoundingClientRect */
+/* globals window document */
 
 const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const emulation = require('../../lib/emulation.js');
-const pageFunctions = require('../../lib/page-functions.js');
+const {getBoundingClientRect, getMaxTextureSize} = require('../../lib/page-functions.js');
 
 // JPEG quality setting
 // Exploration and examples of reports using different quality settings: https://docs.google.com/document/d/1ZSffucIca9XDW2eEwfoevrk-OTl7WQFeMf0CgeJAA8M/edit#
@@ -34,7 +34,7 @@ class FullPageScreenshot extends FRGatherer {
    * @see https://bugs.chromium.org/p/chromium/issues/detail?id=770769
    */
   async getMaxScreenshotHeight(context) {
-    return await context.driver.executionContext.evaluate(pageFunctions.getMaxTextureSize, {
+    return await context.driver.executionContext.evaluate(getMaxTextureSize, {
       args: [],
       useIsolation: true,
       deps: [],
@@ -104,7 +104,6 @@ class FullPageScreenshot extends FRGatherer {
 
       const lhIdToElements = window.__lighthouseNodesDontTouchOrAllVarianceGoesAway;
       for (const [node, id] of lhIdToElements.entries()) {
-        // @ts-expect-error - getBoundingClientRect put into scope via stringification
         const rect = getBoundingClientRect(node);
         nodes[id] = rect;
       }
@@ -119,7 +118,7 @@ class FullPageScreenshot extends FRGatherer {
       return context.driver.executionContext.evaluate(resolveNodes, {
         args: [],
         useIsolation,
-        deps: [pageFunctions.getBoundingClientRectString],
+        deps: [getBoundingClientRect],
       });
     }
 

--- a/lighthouse-core/gather/gatherers/iframe-elements.js
+++ b/lighthouse-core/gather/gatherers/iframe-elements.js
@@ -5,10 +5,12 @@
  */
 'use strict';
 
-/* global getNodeDetails */
-
 const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
-const pageFunctions = require('../../lib/page-functions.js');
+const {
+  getElementsInDocument,
+  isPositionFixed,
+  getNodeDetails,
+} = require('../../lib/page-functions.js');
 
 /* eslint-env browser, node */
 
@@ -17,18 +19,15 @@ const pageFunctions = require('../../lib/page-functions.js');
  */
 /* c8 ignore start */
 function collectIFrameElements() {
-  // @ts-expect-error - put into scope via stringification
-  const iFrameElements = getElementsInDocument('iframe'); // eslint-disable-line no-undef
-  return iFrameElements.map(/** @param {HTMLIFrameElement} node */ (node) => {
+  const iFrameElements = getElementsInDocument('iframe');
+  return iFrameElements.map(node => {
     const clientRect = node.getBoundingClientRect();
     const {top, bottom, left, right, width, height} = clientRect;
     return {
       id: node.id,
       src: node.src,
       clientRect: {top, bottom, left, right, width, height},
-      // @ts-expect-error - put into scope via stringification
-      isPositionFixed: isPositionFixed(node), // eslint-disable-line no-undef
-      // @ts-expect-error - getNodeDetails put into scope via stringification
+      isPositionFixed: isPositionFixed(node),
       node: getNodeDetails(node),
     };
   });
@@ -53,9 +52,9 @@ class IFrameElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getElementsInDocumentString,
-        pageFunctions.isPositionFixedString,
-        pageFunctions.getNodeDetailsString,
+        getElementsInDocument,
+        isPositionFixed,
+        getNodeDetails,
       ],
     });
     return iframeElements;

--- a/lighthouse-core/gather/gatherers/link-elements.js
+++ b/lighthouse-core/gather/gatherers/link-elements.js
@@ -10,10 +10,10 @@ const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const {URL} = require('../../lib/url-shim.js');
 const NetworkRecords = require('../../computed/network-records.js');
 const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-analyzer.js');
-const pageFunctions = require('../../lib/page-functions.js');
+const {getNodeDetails, getElementsInDocument} = require('../../lib/page-functions.js');
 const DevtoolsLog = require('./devtools-log.js');
 
-/* globals HTMLLinkElement getNodeDetails */
+/* globals HTMLLinkElement */
 
 /**
  * @fileoverview
@@ -50,9 +50,7 @@ function getCrossoriginFromHeader(value) {
  */
 /* c8 ignore start */
 function getLinkElementsInDOM() {
-  /** @type {Array<HTMLOrSVGElement>} */
-  // @ts-expect-error - getElementsInDocument put into scope via stringification
-  const browserElements = getElementsInDocument('link'); // eslint-disable-line no-undef
+  const browserElements = getElementsInDocument('link');
   /** @type {LH.Artifacts['LinkElements']} */
   const linkElements = [];
 
@@ -72,7 +70,6 @@ function getLinkElementsInDOM() {
       crossOrigin: link.crossOrigin,
       hrefRaw,
       source,
-      // @ts-expect-error - put into scope via stringification
       node: getNodeDetails(link),
     });
   }
@@ -106,8 +103,8 @@ class LinkElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getNodeDetailsString,
-        pageFunctions.getElementsInDocument,
+        getNodeDetails,
+        getElementsInDocument,
       ],
     });
   }

--- a/lighthouse-core/gather/gatherers/meta-elements.js
+++ b/lighthouse-core/gather/gatherers/meta-elements.js
@@ -6,20 +6,11 @@
 'use strict';
 
 const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
-const pageFunctions = require('../../lib/page-functions.js');
-
-/* globals getElementsInDocument getNodeDetails */
+const {getElementsInDocument, getNodeDetails} = require('../../lib/page-functions.js');
 
 /* c8 ignore start */
 function collectMetaElements() {
-  const functions = /** @type {typeof pageFunctions} */({
-    // @ts-expect-error - getElementsInDocument put into scope via stringification
-    getElementsInDocument,
-    // @ts-expect-error - getNodeDetails put into scope via stringification
-    getNodeDetails,
-  });
-
-  const metas = functions.getElementsInDocument('head meta');
+  const metas = getElementsInDocument('head meta');
   return metas.map(meta => {
     /** @param {string} name */
     const getAttribute = name => {
@@ -33,7 +24,7 @@ function collectMetaElements() {
       property: getAttribute('property'),
       httpEquiv: meta.httpEquiv ? meta.httpEquiv.toLowerCase() : undefined,
       charset: getAttribute('charset'),
-      node: functions.getNodeDetails(meta),
+      node: getNodeDetails(meta),
     };
   });
 }
@@ -58,8 +49,8 @@ class MetaElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getElementsInDocument,
-        pageFunctions.getNodeDetailsString,
+        getElementsInDocument,
+        getNodeDetails,
       ],
     });
   }

--- a/lighthouse-core/gather/gatherers/script-elements.js
+++ b/lighthouse-core/gather/gatherers/script-elements.js
@@ -9,21 +9,17 @@ const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const NetworkRecords = require('../../computed/network-records.js');
 const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-analyzer.js');
 const NetworkRequest = require('../../lib/network-request.js');
-const pageFunctions = require('../../lib/page-functions.js');
+const {getElementsInDocument, getNodeDetails} = require('../../lib/page-functions.js');
 const {fetchResponseBodyFromCache} = require('../driver/network.js');
 const DevtoolsLog = require('./devtools-log.js');
 const HostFormFactor = require('./host-form-factor.js');
-
-/* global getNodeDetails */
 
 /**
  * @return {LH.Artifacts['ScriptElements']}
  */
 /* c8 ignore start */
 function collectAllScriptElements() {
-  /** @type {HTMLScriptElement[]} */
-  // @ts-expect-error - getElementsInDocument put into scope via stringification
-  const scripts = getElementsInDocument('script'); // eslint-disable-line no-undef
+  const scripts = getElementsInDocument('script');
 
   return scripts.map(script => {
     return {
@@ -35,7 +31,6 @@ function collectAllScriptElements() {
       source: script.closest('head') ? 'head' : 'body',
       content: script.src ? null : script.text,
       requestId: null,
-      // @ts-expect-error - getNodeDetails put into scope via stringification
       node: getNodeDetails(script),
     };
   });
@@ -88,8 +83,8 @@ class ScriptElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getNodeDetailsString,
-        pageFunctions.getElementsInDocument,
+        getNodeDetails,
+        getElementsInDocument,
       ],
     });
 

--- a/lighthouse-core/gather/gatherers/seo/embedded-content.js
+++ b/lighthouse-core/gather/gatherers/seo/embedded-content.js
@@ -5,24 +5,14 @@
  */
 'use strict';
 
-/* globals getElementsInDocument getNodeDetails */
-
 const FRGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
-const pageFunctions = require('../../../lib/page-functions.js');
+const {getElementsInDocument, getNodeDetails} = require('../../../lib/page-functions.js');
 
 /**
  * @return {LH.Artifacts.EmbeddedContentInfo[]}
  */
 function getEmbeddedContent() {
-  const functions = /** @type {typeof pageFunctions} */ ({
-    // @ts-expect-error - getElementsInDocument put into scope via stringification
-    getElementsInDocument,
-    // @ts-expect-error - getNodeDetails put into scope via stringification
-    getNodeDetails,
-  });
-
-  const selector = 'object, embed, applet';
-  const elements = functions.getElementsInDocument(selector);
+  const elements = getElementsInDocument('object, embed, applet');
   return elements
     .map(node => ({
       tagName: node.tagName,
@@ -36,7 +26,7 @@ function getEmbeddedContent() {
           name: el.getAttribute('name') || '',
           value: el.getAttribute('value') || '',
         })),
-      node: functions.getNodeDetails(node),
+      node: getNodeDetails(node),
     }));
 }
 
@@ -54,8 +44,8 @@ class EmbeddedContent extends FRGatherer {
     return passContext.driver.executionContext.evaluate(getEmbeddedContent, {
       args: [],
       deps: [
-        pageFunctions.getElementsInDocument,
-        pageFunctions.getNodeDetailsString,
+        getElementsInDocument,
+        getNodeDetails,
       ],
     });
   }

--- a/lighthouse-core/gather/gatherers/trace-elements.js
+++ b/lighthouse-core/gather/gatherers/trace-elements.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* global getNodeDetails */
+/* global document */
 
 /**
  * @fileoverview
@@ -15,7 +15,7 @@
 
 const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 const {resolveNodeIdToObjectId} = require('../driver/dom.js');
-const pageFunctions = require('../../lib/page-functions.js');
+const {getNodeDetails} = require('../../lib/page-functions.js');
 const RectHelpers = require('../../lib/rect-helpers.js');
 const Sentry = require('../../lib/sentry.js');
 const Trace = require('./trace.js');
@@ -26,14 +26,13 @@ const LighthouseError = require('../../lib/lh-error.js');
 /** @typedef {{nodeId: number, score?: number, animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[]}} TraceElementData */
 
 /**
- * @this {HTMLElement}
+ * @this {Element}
  */
 /* c8 ignore start */
 function getNodeDetailsData() {
-  const elem = this.nodeType === document.ELEMENT_NODE ? this : this.parentElement; // eslint-disable-line no-undef
+  const elem = this.nodeType === document.ELEMENT_NODE ? this : this.parentElement;
   let traceElement;
   if (elem) {
-    // @ts-expect-error - getNodeDetails put into scope via stringification
     traceElement = {node: getNodeDetails(elem)};
   }
   return traceElement;
@@ -294,7 +293,7 @@ class TraceElements extends FRGatherer {
             objectId,
             functionDeclaration: `function () {
               ${getNodeDetailsData.toString()};
-              ${pageFunctions.getNodeDetailsString};
+              ${getNodeDetails.toString()};
               return getNodeDetailsData.call(this);
             }`,
             returnByValue: true,

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -13,10 +13,11 @@
  * the c8 code coverage tool. See c8.sh
  *
  * Important: this module should only be imported like this:
- *     const pageFunctions = require('...');
- * Never like this:
  *     const {justWhatINeed} = require('...');
- * Otherwise, minification will mangle the variable names and break usage.
+ * Never like this:
+ *     const pageFunctions = require('...');
+ * Otherwise, `function justWhatINeed() {...}` won't be callable by the
+ * invocation `pageFunctions.justWhatINeed`.
  */
 
 /**
@@ -48,9 +49,11 @@ function wrapRuntimeEvalErrorInBrowser(err) {
 }
 
 /**
+ * Get all elements in the document matching `selector`, whether in the regular
+ * or a shadow DOM.
  * @template {string} T
- * @param {T} selector Optional simple CSS selector to filter nodes on.
- *     Combinators are not supported.
+ * @param {T} selector Simple CSS selector to filter nodes on.
+ *     Combinators are not supported since they won't match across shadow boundaries.
  * @return {Array<ParseSelector<T>>}
  */
 function getElementsInDocument(selector) {
@@ -515,34 +518,31 @@ function getNodeDetails(element) {
   return details;
 }
 
-const getNodeDetailsString = `function getNodeDetails(element) {
-  ${getNodePath.toString()};
-  ${getNodeSelector.toString()};
-  ${getBoundingClientRect.toString()};
-  ${getOuterHTMLSnippet.toString()};
-  ${getNodeLabel.toString()};
-  return (${getNodeDetails.toString()})(element);
-}`;
+// HACK: `getNodeDetails` is a function used in many places with multiple deps
+// that would need to be listed in the `evaluate()` call every time it's used.
+// The deps could be inlined, but they need to be available externally for
+// testing. So, override `getNodeDetails.toString()` to include all the deps.
+/** @type {string} */
+const originalgetNodeDetailsToString = getNodeDetails.toString();
+getNodeDetails.toString = () => `
+  ${getNodePath.toString()}
+  ${getNodeSelector.toString()}
+  ${getBoundingClientRect.toString()}
+  ${getOuterHTMLSnippet.toString()}
+  ${getNodeLabel.toString()}
+  ${originalgetNodeDetailsToString}`;
 
 module.exports = {
-  wrapRuntimeEvalErrorInBrowserString: wrapRuntimeEvalErrorInBrowser.toString(),
   wrapRuntimeEvalErrorInBrowser,
   getElementsInDocument,
-  getElementsInDocumentString: getElementsInDocument.toString(),
-  getOuterHTMLSnippetString: getOuterHTMLSnippet.toString(),
-  getOuterHTMLSnippet: getOuterHTMLSnippet,
-  computeBenchmarkIndex: computeBenchmarkIndex,
-  computeBenchmarkIndexString: computeBenchmarkIndex.toString(),
+  getOuterHTMLSnippet,
+  computeBenchmarkIndex,
   getMaxTextureSize,
-  getNodeDetailsString,
   getNodeDetails,
-  getNodePathString: getNodePath.toString(),
-  getNodeSelectorString: getNodeSelector.toString(),
   getNodePath,
-  getNodeSelector: getNodeSelector,
-  getNodeLabel: getNodeLabel,
-  getNodeLabelString: getNodeLabel.toString(),
-  isPositionFixedString: isPositionFixed.toString(),
+  getNodeSelector,
+  getNodeLabel,
+  isPositionFixed,
   wrapRequestIdleCallback,
-  getBoundingClientRectString: getBoundingClientRect.toString(),
+  getBoundingClientRect,
 };


### PR DESCRIPTION
see https://github.com/GoogleChrome/lighthouse/pull/12771#discussion_r668293056

explicitly require individual functions that are going to be `deps` for an `evaluate()` call. This continues the blurred line between Node and `evaluate()` code that runs in the browser, but a) they're already intermixed and b) this allows the results to be type checked instead of always `any` via `// @ts-expect-error`.

- get rid of `*String` properties on `pageFunctions`, just use the function directly
- downside is some terser minification options have to be disabled, resulting in 20% larger bundle (10% after brotli). This doesn't seem like a big deal to me (we used to only remove indentation whitespace not long ago), but there are more options I'll mention below if we'd rather take more fragile approaches
- includes a hackish `toString` approach for `getNodeDetails()` so we can keep using it as it has been. See below for discussion