### PR TITLE
core(manifest-parser): pwa background color to support rgba

### DIFF
--- a/lighthouse-core/test/lib/manifest-parser-test.js
+++ b/lighthouse-core/test/lib/manifest-parser-test.js
@@ -526,7 +526,7 @@ describe('Manifest Parser', function() {
     });
 
     it('correctly parses RGB/RGBA colors', () => {
-      const bgColor = 'rgb(222, 184, 135)';
+      const bgColor = 'rgba(222, 184, 135, 1.0)';
       const themeColor = 'rgba(5%, 10%, 20%, 0.4)';
       const parsedManifest = getParsedManifest(bgColor, themeColor).value;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
`bgColor` will support `rgba` value instead of `rgb`
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
bugfix
<!-- Describe the need for this change -->
This is Not recognised:
`bgColor = "rgb(222, 184, 135)";`

**Related Issues/PRs**
[#12708](https://github.com/GoogleChrome/lighthouse/issues/12708)