### PR TITLE
misc: add prefix to lighthouse-logger debug scope

### DIFF
--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -61,6 +61,7 @@ class Log {
   }
 
   static loggerfn(title) {
+    title = `LH:${title}`;
     let log = loggersByTitle[title];
     if (!log) {
       log = debug(title);
@@ -82,16 +83,16 @@ class Log {
     level_ = level;
     switch (level) {
       case 'silent':
-        debug.enable('-*');
+        debug.enable('-LH:*');
         break;
       case 'verbose':
-        debug.enable('*');
+        debug.enable('LH:*');
         break;
       case 'error':
-        debug.enable('-*, *:error');
+        debug.enable('-LH:*, LH:*:error');
         break;
       default:
-        debug.enable('*, -*:verbose');
+        debug.enable('LH:*, -LH:*:verbose');
     }
   }
 

--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-logger",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^2.6.9",


### PR DESCRIPTION
**Summary**
Fixes our longstanding disrespect for other packages logging ;) Prefixes all of our log messages with `LH:` so that it does not clobber the other prefixes using the same instance of `debug` (like `puppeteer`). 

Will require immediate followup with a publish and version bump in our own deps.

Note that the impact of this is more limited than it appears because we are using an ancient debug, so most modern packages get their own instance :)

**Related Issues/PRs**
ref #12805 #11313 
