### PR TITLE
deps: update lighthouse-logger to 1.3.0

### DIFF
--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -205,8 +205,6 @@ async function potentiallyKillChrome(launchedChrome) {
 async function runLighthouseWithFraggleRock(url, flags, config, launchedChrome) {
   const fraggleRock = require('../lighthouse-core/fraggle-rock/api.js');
   const puppeteer = require('puppeteer');
-  // @ts-expect-error - FIXME: lighthouse-logger is greedy and takes over `debug` for all packages
-  require('debug').enable('-puppeteer:*');
   const browser = await puppeteer.connect({browserURL: `http://localhost:${launchedChrome.port}`});
   const page = await browser.newPage();
   flags.channel = 'fraggle-rock-cli';

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "intl-messageformat": "^4.4.0",
     "jpeg-js": "^0.4.1",
     "js-library-detector": "^6.4.0",
-    "lighthouse-logger": "^1.2.0",
+    "lighthouse-logger": "^1.3.0",
     "lighthouse-stack-packs": "^1.5.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,7 +2862,7 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -5585,13 +5585,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lighthouse-logger@^1.0.0, lighthouse-logger@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz#b76d56935e9c137e86a04741f6bb9b2776e886ca"
-  integrity sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==
+lighthouse-logger@^1.0.0, lighthouse-logger@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/lighthouse-logger/-/lighthouse-logger-1.3.0.tgz#ba6303e739307c4eee18f08249524e7dafd510db"
+  integrity sha512-BbqAKApLb9ywUli+0a+PcV04SyJ/N1q/8qgCNe6U97KbPCS1BTksEuHFLYdvc8DltuhfxIUBqDZsC0bBGtl3lA==
   dependencies:
-    debug "^2.6.8"
-    marky "^1.2.0"
+    debug "^2.6.9"
+    marky "^1.2.2"
 
 lighthouse-plugin-publisher-ads@^1.4.1:
   version "1.4.1"
@@ -5835,7 +5835,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marky@^1.2.0:
+marky@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.2.tgz#4456765b4de307a13d263a69b0c79bf226e68323"
   integrity sha512-k1dB2HNeaNyORco8ulVEhctyEGkKHb2YWAhDsxeFlW2nROIirsctBYzKwwS3Vza+sKTS1zO4Z+n9/+9WbGLIxQ==


### PR DESCRIPTION
**Summary**
Removes the wart introduced by #12805 and bumps our use of lighthouse-logger to be prefixed with `LH:`

**Related Issues/PRs**
ref #11313 #12805 
