### PR TITLE
report: remove save-as-html

### DIFF
--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -7085,7 +7085,6 @@
       "dropdownPrintExpanded": "Print Expanded",
       "dropdownPrintSummary": "Print Summary",
       "dropdownSaveGist": "Save as Gist",
-      "dropdownSaveHTML": "Save as HTML",
       "dropdownSaveJSON": "Save as JSON",
       "dropdownViewer": "Open in Viewer",
       "errorLabel": "Error!",

--- a/lighthouse-core/util-commonjs.js
+++ b/lighthouse-core/util-commonjs.js
@@ -591,8 +591,6 @@ Util.UIStrings = {
   dropdownPrintExpanded: 'Print Expanded',
   /** Option in a dropdown menu that copies the Lighthouse JSON object to the system clipboard. */
   dropdownCopyJSON: 'Copy JSON',
-  /** Option in a dropdown menu that saves the Lighthouse report HTML locally to the system as a '.html' file. */
-  dropdownSaveHTML: 'Save as HTML',
   /** Option in a dropdown menu that saves the Lighthouse JSON object to the local system as a '.json' file. */
   dropdownSaveJSON: 'Save as JSON',
   /** Option in a dropdown menu that opens the current report in the Lighthouse Viewer Application. */

--- a/lighthouse-viewer/app/src/viewer-ui-features.js
+++ b/lighthouse-viewer/app/src/viewer-ui-features.js
@@ -40,15 +40,6 @@ class ViewerUIFeatures extends ReportUIFeatures {
   }
 
   /**
-   * Uses ReportGenerator to create the html that recreates this report.
-   * @return {string}
-   * @override
-   */
-  getReportHtml() {
-    return ReportGenerator.generateReportHtml(this.json);
-  }
-
-  /**
    * @override
    */
   saveAsGist() {

--- a/report/assets/templates.html
+++ b/report/assets/templates.html
@@ -391,7 +391,6 @@ limitations under the License.
         <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--print" data-i18n="dropdownPrintSummary" data-action="print-summary"></a>
         <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--print" data-i18n="dropdownPrintExpanded" data-action="print-expanded"></a>
         <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--copy" data-i18n="dropdownCopyJSON" data-action="copy"></a>
-        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--download" data-i18n="dropdownSaveHTML" data-action="save-html"></a>
         <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--download" data-i18n="dropdownSaveJSON" data-action="save-json"></a>
         <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--open" data-i18n="dropdownViewer" data-action="open-viewer"></a>
         <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--open" data-i18n="dropdownSaveGist" data-action="save-gist"></a>

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -493,17 +493,6 @@ export class ReportUIFeatures {
         this._saveFile(new Blob([jsonStr], {type: 'application/json'}));
         break;
       }
-      case 'save-html': {
-        const htmlStr = this.getReportHtml();
-        try {
-          this._saveFile(new Blob([htmlStr], {type: 'text/html'}));
-        } catch (/** @type {Error} */ e) {
-          this._fireEventOn('lh-log', this._document, {
-            cmd: 'error', msg: 'Could not export as HTML. ' + e.message,
-          });
-        }
-        break;
-      }
       case 'open-viewer': {
         ReportUIFeatures.openTabAndSendJsonReportToViewer(this.json);
         break;
@@ -670,16 +659,6 @@ export class ReportUIFeatures {
         }
       });
     }
-  }
-
-  /**
-   * Returns the html that recreates this report.
-   * @return {string}
-   * @protected
-   */
-  getReportHtml() {
-    this._resetUIState();
-    return this._document.documentElement.outerHTML;
   }
 
   /**

--- a/report/renderer/util.js
+++ b/report/renderer/util.js
@@ -588,8 +588,6 @@ Util.UIStrings = {
   dropdownPrintExpanded: 'Print Expanded',
   /** Option in a dropdown menu that copies the Lighthouse JSON object to the system clipboard. */
   dropdownCopyJSON: 'Copy JSON',
-  /** Option in a dropdown menu that saves the Lighthouse report HTML locally to the system as a '.html' file. */
-  dropdownSaveHTML: 'Save as HTML',
   /** Option in a dropdown menu that saves the Lighthouse JSON object to the local system as a '.json' file. */
   dropdownSaveJSON: 'Save as JSON',
   /** Option in a dropdown menu that opens the current report in the Lighthouse Viewer Application. */

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-export-run.js
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-export-run.js
@@ -21,24 +21,6 @@
         (filename, content) => resolve(content));
     });
   }
-
-  async function testExportHtml() {
-    const reportHtmlPromise = waitForSave();
-    toolsMenu.querySelector('a[data-action="save-html"').click();
-    const reportHtml = await reportHtmlPromise;
-
-    let auditElements = resultsElement.querySelectorAll('.lh-audit');
-    TestRunner.addResult(`\n# of .lh-audit divs (original): ${auditElements.length}`);
-
-    const exportedReportIframe = resultsElement.ownerDocument.createElement('iframe');
-    exportedReportIframe.srcdoc = reportHtml;
-    resultsElement.parentElement.append(exportedReportIframe);
-    await new Promise(resolve => exportedReportIframe.addEventListener('load', resolve));
-
-    auditElements = exportedReportIframe.contentDocument.querySelectorAll('.lh-audit');
-    TestRunner.addResult(`\n# of .lh-audit divs (exported html): ${auditElements.length}`);
-  }
-
   async function testExportJson() {
     const reportJsonPromise = waitForSave();
     toolsMenu.querySelector('a[data-action="save-json"').click();
@@ -46,9 +28,6 @@
     const lhr = JSON.parse(reportJson);
     TestRunner.addResult(`\n# of audits (json): ${Object.keys(lhr.audits).length}`);
   }
-
-  TestRunner.addResult('++++++++ testExportHtml');
-  await testExportHtml();
 
   TestRunner.addResult('\n++++++++ testExportJson');
   await testExportJson();


### PR DESCRIPTION
We discussed this previously and I remember broad support. Hopefully I'm not mistaken? :) 

Motivation: Doing this opens the path to removing the report-generator

Justification: the JSON is the canonical asset and we'd rather have that be saved.  We don't have viewer analytics on popularity of this option, unfortunately.