### PR TITLE
tests(smoke): convert core tests to single-expectations format

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # The smokehouse tests run by job `test set 1`. `test set 2` will run the rest.
-      SMOKE_BATCH_1: a11y oopif pwa pwa2 pwa3 dbw redirects errors offline
+      SMOKE_BATCH_1: a11y oopif pwa dbw redirects errors offline
     # Job named e.g. "Chrome stable, test set 1".
     name: Chrome ${{ matrix.chrome-channel }}, batch ${{ matrix.smoke-test-invert == false && '1' || '2' }}
 

--- a/lighthouse-cli/test/smokehouse/frontends/lib.js
+++ b/lighthouse-cli/test/smokehouse/frontends/lib.js
@@ -16,7 +16,6 @@
 const cloneDeep = require('lodash.clonedeep');
 const smokeTests = require('../test-definitions/core-tests.js');
 const {runSmokehouse} = require('../smokehouse.js');
-const {updateTestDefnFormat} = require('./back-compat-util.js');
 
 /**
  * @param {Smokehouse.SmokehouseLibOptions} options
@@ -24,8 +23,7 @@ const {updateTestDefnFormat} = require('./back-compat-util.js');
 async function smokehouse(options) {
   const {urlFilterRegex, skip, modify, ...smokehouseOptions} = options;
 
-  const updatedCoreTests = updateTestDefnFormat(smokeTests);
-  const clonedTests = cloneDeep(updatedCoreTests);
+  const clonedTests = cloneDeep(smokeTests);
   const modifiedTests = [];
   for (const test of clonedTests) {
     if (urlFilterRegex && !test.expectations.lhr.requestedUrl.match(urlFilterRegex)) {

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -74,7 +74,7 @@ async function runSmokehouse(smokeTestDefns, smokehouseOptions) {
   const failingDefns = testResults.filter(result => result.failed);
   if (failingDefns.length) {
     const testNames = failingDefns.map(d => d.id).join(', ');
-    console.error(log.redify(`We have ${failingDefns.length} failing smoketest(s): ${testNames}`));
+    console.log(log.redify(`We have ${failingDefns.length} failing smoketest(s): ${testNames}`));
     return {success: false, testResults};
   }
 

--- a/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
@@ -8,691 +8,689 @@
 /* eslint-disable max-len */
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
+ * @type {Smokehouse.ExpectedRunnerResult}
  * Expected Lighthouse audit values for byte efficiency tests
  */
-const expectations = [
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/a11y/a11y_tester.html',
-      finalUrl: 'http://localhost:10200/a11y/a11y_tester.html',
-      audits: {
-        'aria-allowed-attr': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#aria-allowed-attr',
-                  'snippet': '<div id="aria-allowed-attr" role="alert" aria-checked="true">',
-                  'explanation': 'Fix any of the following:\n  ARIA attribute is not allowed: aria-checked="true"',
-                  'nodeLabel': 'body > section > div#aria-allowed-attr',
-                },
+const expectations = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/a11y/a11y_tester.html',
+    finalUrl: 'http://localhost:10200/a11y/a11y_tester.html',
+    audits: {
+      'aria-allowed-attr': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#aria-allowed-attr',
+                'snippet': '<div id="aria-allowed-attr" role="alert" aria-checked="true">',
+                'explanation': 'Fix any of the following:\n  ARIA attribute is not allowed: aria-checked="true"',
+                'nodeLabel': 'body > section > div#aria-allowed-attr',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-hidden-body': {
-          score: 1,
-          details: {
-            'type': 'table',
-            'headings': [],
-            'items': [],
-          },
+      },
+      'aria-hidden-body': {
+        score: 1,
+        details: {
+          'type': 'table',
+          'headings': [],
+          'items': [],
         },
-        'aria-hidden-focus': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'boundingRect': {
-                    'width': '>0',
-                    'height': '>0',
-                  },
-                  'selector': 'body > section > div#aria-hidden-focus',
-                  'snippet': '<div id="aria-hidden-focus" aria-hidden="true">',
-                  'explanation': 'Fix all of the following:\n  Focusable content should be disabled or be removed from the DOM',
-                  'nodeLabel': 'Focusable Button',
+      },
+      'aria-hidden-focus': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'boundingRect': {
+                  'width': '>0',
+                  'height': '>0',
                 },
+                'selector': 'body > section > div#aria-hidden-focus',
+                'snippet': '<div id="aria-hidden-focus" aria-hidden="true">',
+                'explanation': 'Fix all of the following:\n  Focusable content should be disabled or be removed from the DOM',
+                'nodeLabel': 'Focusable Button',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-input-field-name': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'boundingRect': {
-                    'width': '>0',
-                    'height': '>0',
-                  },
-                  'selector': 'body > section > div#aria-input-field-name',
-                  'snippet': '<div id="aria-input-field-name" role="textbox">',
-                  'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                  'nodeLabel': 'text-in-a-box',
+      },
+      'aria-input-field-name': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'boundingRect': {
+                  'width': '>0',
+                  'height': '>0',
                 },
+                'selector': 'body > section > div#aria-input-field-name',
+                'snippet': '<div id="aria-input-field-name" role="textbox">',
+                'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+                'nodeLabel': 'text-in-a-box',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-meter-name': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'boundingRect': {
-                    'width': '>0',
-                    'height': '>0',
-                  },
-                  'selector': 'body > section > div#aria-meter-name',
-                  'snippet': '<div id="aria-meter-name" role="meter">',
-                  'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                  'nodeLabel': 'text-in-a-box',
+      },
+      'aria-meter-name': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'boundingRect': {
+                  'width': '>0',
+                  'height': '>0',
                 },
+                'selector': 'body > section > div#aria-meter-name',
+                'snippet': '<div id="aria-meter-name" role="meter">',
+                'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+                'nodeLabel': 'text-in-a-box',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-progressbar-name': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'boundingRect': {
-                    'width': '>0',
-                    'height': '>0',
-                  },
-                  'selector': 'body > section > div#aria-progressbar-name',
-                  'snippet': '<div id="aria-progressbar-name" role="progressbar">',
-                  'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                  'nodeLabel': 'text-in-a-box',
+      },
+      'aria-progressbar-name': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'boundingRect': {
+                  'width': '>0',
+                  'height': '>0',
                 },
+                'selector': 'body > section > div#aria-progressbar-name',
+                'snippet': '<div id="aria-progressbar-name" role="progressbar">',
+                'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+                'nodeLabel': 'text-in-a-box',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-treeitem-name': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'boundingRect': {
-                    'width': '>0',
-                    'height': 0,
-                  },
-                  'selector': 'body > section > div > div#aria-treeitem-name',
-                  'snippet': '<div id="aria-treeitem-name" role="treeitem">',
-                  'explanation': 'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                  'nodeLabel': 'body > section > div > div#aria-treeitem-name',
+      },
+      'aria-treeitem-name': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'boundingRect': {
+                  'width': '>0',
+                  'height': 0,
                 },
+                'selector': 'body > section > div > div#aria-treeitem-name',
+                'snippet': '<div id="aria-treeitem-name" role="treeitem">',
+                'explanation': 'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+                'nodeLabel': 'body > section > div > div#aria-treeitem-name',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-command-name': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'boundingRect': {
-                    'width': '>0',
-                    'height': 0,
-                  },
-                  'selector': 'body > section > div#aria-command-name',
-                  'snippet': '<div id="aria-command-name" role="button">',
-                  'explanation': 'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                  'nodeLabel': 'body > section > div#aria-command-name',
+      },
+      'aria-command-name': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'boundingRect': {
+                  'width': '>0',
+                  'height': 0,
                 },
+                'selector': 'body > section > div#aria-command-name',
+                'snippet': '<div id="aria-command-name" role="button">',
+                'explanation': 'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+                'nodeLabel': 'body > section > div#aria-command-name',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-tooltip-name': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'boundingRect': {
-                    'width': '>0',
-                    'height': 0,
-                  },
-                  'selector': 'body > section > div#aria-tooltip-name',
-                  'snippet': '<div id="aria-tooltip-name" role="tooltip">',
-                  'explanation': 'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                  'nodeLabel': 'body > section > div#aria-tooltip-name',
+      },
+      'aria-tooltip-name': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'boundingRect': {
+                  'width': '>0',
+                  'height': 0,
                 },
+                'selector': 'body > section > div#aria-tooltip-name',
+                'snippet': '<div id="aria-tooltip-name" role="tooltip">',
+                'explanation': 'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+                'nodeLabel': 'body > section > div#aria-tooltip-name',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-required-children': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#aria-required-children',
-                  'snippet': '<div id="aria-required-children" role="radiogroup">',
-                  'explanation': 'Fix any of the following:\n  Required ARIA child role not present: radio',
-                  'nodeLabel': 'body > section > div#aria-required-children',
-                },
+      },
+      'aria-required-children': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#aria-required-children',
+                'snippet': '<div id="aria-required-children" role="radiogroup">',
+                'explanation': 'Fix any of the following:\n  Required ARIA child role not present: radio',
+                'nodeLabel': 'body > section > div#aria-required-children',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-required-parent': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div > div#aria-required-parent',
-                  'snippet': '<div id="aria-required-parent" role="option">',
-                  'explanation': 'Fix any of the following:\n  Required ARIA parent role not present: listbox',
-                  'nodeLabel': 'body > section > div > div#aria-required-parent',
-                },
+      },
+      'aria-required-parent': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div > div#aria-required-parent',
+                'snippet': '<div id="aria-required-parent" role="option">',
+                'explanation': 'Fix any of the following:\n  Required ARIA parent role not present: listbox',
+                'nodeLabel': 'body > section > div > div#aria-required-parent',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-roles': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div',
-                  'snippet': '<div role="foo">',
-                  'explanation': 'Fix all of the following:\n  Role must be one of the valid ARIA roles: foo',
-                  'nodeLabel': 'body > section > div',
-                },
+      },
+      'aria-roles': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div',
+                'snippet': '<div role="foo">',
+                'explanation': 'Fix all of the following:\n  Role must be one of the valid ARIA roles: foo',
+                'nodeLabel': 'body > section > div',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-toggle-field-name': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#aria-required-attr',
-                  'path': '2,HTML,1,BODY,19,SECTION,0,DIV',
-                  'snippet': '<div id="aria-required-attr" role="checkbox">',
-                  'explanation': 'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                  'nodeLabel': 'body > section > div#aria-required-attr',
-                },
+      },
+      'aria-toggle-field-name': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#aria-required-attr',
+                'path': '2,HTML,1,BODY,19,SECTION,0,DIV',
+                'snippet': '<div id="aria-required-attr" role="checkbox">',
+                'explanation': 'Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+                'nodeLabel': 'body > section > div#aria-required-attr',
               },
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div > div#aria-required-parent',
-                  'path': '2,HTML,1,BODY,23,SECTION,0,DIV,0,DIV',
-                  'snippet': '<div id="aria-required-parent" role="option">',
-                  'nodeLabel': 'body > section > div > div#aria-required-parent',
-                },
+            },
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div > div#aria-required-parent',
+                'path': '2,HTML,1,BODY,23,SECTION,0,DIV,0,DIV',
+                'snippet': '<div id="aria-required-parent" role="option">',
+                'nodeLabel': 'body > section > div > div#aria-required-parent',
               },
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#aria-valid-attr',
-                  'path': '2,HTML,1,BODY,27,SECTION,0,DIV',
-                  'snippet': '<div id="aria-valid-attr" role="checkbox" aria-chked="true">',
-                  'nodeLabel': 'body > section > div#aria-valid-attr',
-                },
+            },
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#aria-valid-attr',
+                'path': '2,HTML,1,BODY,27,SECTION,0,DIV',
+                'snippet': '<div id="aria-valid-attr" role="checkbox" aria-chked="true">',
+                'nodeLabel': 'body > section > div#aria-valid-attr',
               },
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#aria-valid-attr-value',
-                  'path': '2,HTML,1,BODY,29,SECTION,0,DIV',
-                  'snippet': '<div id="aria-valid-attr-value" role="checkbox" aria-checked="0">',
-                  'nodeLabel': 'body > section > div#aria-valid-attr-value',
-                },
+            },
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#aria-valid-attr-value',
+                'path': '2,HTML,1,BODY,29,SECTION,0,DIV',
+                'snippet': '<div id="aria-valid-attr-value" role="checkbox" aria-checked="0">',
+                'nodeLabel': 'body > section > div#aria-valid-attr-value',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-valid-attr-value': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#aria-valid-attr-value',
-                  'snippet': '<div id="aria-valid-attr-value" role="checkbox" aria-checked="0">',
-                  'explanation': 'Fix all of the following:\n  Invalid ARIA attribute value: aria-checked="0"',
-                  'nodeLabel': 'body > section > div#aria-valid-attr-value',
-                },
+      },
+      'aria-valid-attr-value': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#aria-valid-attr-value',
+                'snippet': '<div id="aria-valid-attr-value" role="checkbox" aria-checked="0">',
+                'explanation': 'Fix all of the following:\n  Invalid ARIA attribute value: aria-checked="0"',
+                'nodeLabel': 'body > section > div#aria-valid-attr-value',
               },
-            ],
-          },
+            },
+          ],
         },
-        'aria-valid-attr': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#aria-valid-attr',
-                  'snippet': '<div id="aria-valid-attr" role="checkbox" aria-chked="true">',
-                  'explanation': 'Fix any of the following:\n  Invalid ARIA attribute name: aria-chked',
-                  'nodeLabel': 'body > section > div#aria-valid-attr',
-                },
+      },
+      'aria-valid-attr': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#aria-valid-attr',
+                'snippet': '<div id="aria-valid-attr" role="checkbox" aria-chked="true">',
+                'explanation': 'Fix any of the following:\n  Invalid ARIA attribute name: aria-chked',
+                'nodeLabel': 'body > section > div#aria-valid-attr',
               },
-            ],
-          },
+            },
+          ],
         },
-        'button-name': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > button#button-name',
-                  'snippet': '<button id="button-name">',
-                  'explanation': 'Fix any of the following:\n  Element does not have inner text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element\'s default semantics were not overridden with role="none" or role="presentation"',
-                  'nodeLabel': 'body > section > button#button-name',
-                },
+      },
+      'button-name': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > button#button-name',
+                'snippet': '<button id="button-name">',
+                'explanation': 'Fix any of the following:\n  Element does not have inner text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element\'s default semantics were not overridden with role="none" or role="presentation"',
+                'nodeLabel': 'body > section > button#button-name',
               },
-            ],
-          },
+            },
+          ],
         },
-        'bypass': {
-          score: 1,
-          details: {
-            type: 'table',
-            headings: [],
-            items: [],
-          },
+      },
+      'bypass': {
+        score: 1,
+        details: {
+          type: 'table',
+          headings: [],
+          items: [],
         },
-        'color-contrast': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#color-contrast',
-                  'snippet': '<div id="color-contrast" style="background-color: red; color: pink;">',
-                  // Default font size is different depending on the platform (e.g. 28.5 on travis, 30.0 on Mac), and the px-converted units may have variable precision, so use \d+.\d+.
-                  'explanation': /^Fix any of the following:\n {2}Element has insufficient color contrast of 2\.59 \(foreground color: #ffc0cb, background color: #ff0000, font size: \d+.\d+pt \(\d+.\d+px\), font weight: normal\). Expected contrast ratio of 3:1$/,
-                  'nodeLabel': 'Hello',
-                },
+      },
+      'color-contrast': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#color-contrast',
+                'snippet': '<div id="color-contrast" style="background-color: red; color: pink;">',
+                // Default font size is different depending on the platform (e.g. 28.5 on travis, 30.0 on Mac), and the px-converted units may have variable precision, so use \d+.\d+.
+                'explanation': /^Fix any of the following:\n {2}Element has insufficient color contrast of 2\.59 \(foreground color: #ffc0cb, background color: #ff0000, font size: \d+.\d+pt \(\d+.\d+px\), font weight: normal\). Expected contrast ratio of 3:1$/,
+                'nodeLabel': 'Hello',
               },
-            ],
-          },
+            },
+          ],
         },
-        'definition-list': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > dl#definition-list',
-                  'snippet': '<dl id="definition-list">',
-                  'explanation': 'Fix all of the following:\n  List element has direct children that are not allowed inside <dt> or <dd> elements',
-                  'nodeLabel': 'body > section > dl#definition-list',
-                },
+      },
+      'definition-list': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > dl#definition-list',
+                'snippet': '<dl id="definition-list">',
+                'explanation': 'Fix all of the following:\n  List element has direct children that are not allowed inside <dt> or <dd> elements',
+                'nodeLabel': 'body > section > dl#definition-list',
               },
-            ],
-          },
+            },
+          ],
         },
-        'dlitem': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#dlitem > dd',
-                  'snippet': '<dd>',
-                  'explanation': 'Fix any of the following:\n  Description list item does not have a <dl> parent element',
-                  'nodeLabel': 'body > section > div#dlitem > dd',
-                },
+      },
+      'dlitem': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#dlitem > dd',
+                'snippet': '<dd>',
+                'explanation': 'Fix any of the following:\n  Description list item does not have a <dl> parent element',
+                'nodeLabel': 'body > section > div#dlitem > dd',
               },
-            ],
-          },
+            },
+          ],
         },
-        'document-title': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'html',
-                  'snippet': '<html>',
-                  'explanation': 'Fix any of the following:\n  Document does not have a non-empty <title> element',
-                  'nodeLabel': 'html',
-                },
+      },
+      'document-title': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'html',
+                'snippet': '<html>',
+                'explanation': 'Fix any of the following:\n  Document does not have a non-empty <title> element',
+                'nodeLabel': 'html',
               },
-            ],
+            },
+          ],
 
-          },
         },
-        'duplicate-id-active': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > textarea#duplicate-id-active',
-                  'path': '2,HTML,1,BODY,39,SECTION,0,TEXTAREA',
-                  'snippet': '<textarea id="duplicate-id-active" aria-label="text1">',
-                  'explanation': 'Fix any of the following:\n  Document has active elements with the same id attribute: duplicate-id-active',
-                  'nodeLabel': 'text1',
-                },
+      },
+      'duplicate-id-active': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > textarea#duplicate-id-active',
+                'path': '2,HTML,1,BODY,39,SECTION,0,TEXTAREA',
+                'snippet': '<textarea id="duplicate-id-active" aria-label="text1">',
+                'explanation': 'Fix any of the following:\n  Document has active elements with the same id attribute: duplicate-id-active',
+                'nodeLabel': 'text1',
               },
-            ],
-          },
+            },
+          ],
         },
-        'duplicate-id-aria': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#duplicate-id-aria',
-                  'path': '2,HTML,1,BODY,41,SECTION,0,DIV',
-                  'snippet': '<div id="duplicate-id-aria" class="duplicate-id-aria">',
-                  'explanation': 'Fix any of the following:\n  Document has multiple elements referenced with ARIA with the same id attribute: duplicate-id-aria',
-                  'nodeLabel': 'body > section > div#duplicate-id-aria',
-                },
+      },
+      'duplicate-id-aria': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#duplicate-id-aria',
+                'path': '2,HTML,1,BODY,41,SECTION,0,DIV',
+                'snippet': '<div id="duplicate-id-aria" class="duplicate-id-aria">',
+                'explanation': 'Fix any of the following:\n  Document has multiple elements referenced with ARIA with the same id attribute: duplicate-id-aria',
+                'nodeLabel': 'body > section > div#duplicate-id-aria',
               },
-            ],
-          },
+            },
+          ],
         },
-        'form-field-multiple-labels': {
-          score: null,
-          scoreDisplayMode: 'informative',
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > input#form-field-multiple-labels',
-                  'path': '2,HTML,1,BODY,43,SECTION,2,INPUT',
-                  'snippet': '<input type="checkbox" id="form-field-multiple-labels">',
-                  'explanation': 'Fix all of the following:\n  Multiple label elements is not widely supported in assistive technologies. Ensure the first label contains all necessary information.',
-                  'nodeLabel': 'body > section > input#form-field-multiple-labels',
-                },
+      },
+      'form-field-multiple-labels': {
+        score: null,
+        scoreDisplayMode: 'informative',
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > input#form-field-multiple-labels',
+                'path': '2,HTML,1,BODY,43,SECTION,2,INPUT',
+                'snippet': '<input type="checkbox" id="form-field-multiple-labels">',
+                'explanation': 'Fix all of the following:\n  Multiple label elements is not widely supported in assistive technologies. Ensure the first label contains all necessary information.',
+                'nodeLabel': 'body > section > input#form-field-multiple-labels',
               },
-            ],
-          },
+            },
+          ],
         },
-        'frame-title': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > iframe#frame-title',
-                  'snippet': '<iframe id="frame-title">',
-                  'explanation': 'Fix any of the following:\n  Element has no title attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element\'s default semantics were not overridden with role="none" or role="presentation"',
-                  'nodeLabel': 'body > section > iframe#frame-title',
-                },
+      },
+      'frame-title': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > iframe#frame-title',
+                'snippet': '<iframe id="frame-title">',
+                'explanation': 'Fix any of the following:\n  Element has no title attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element\'s default semantics were not overridden with role="none" or role="presentation"',
+                'nodeLabel': 'body > section > iframe#frame-title',
               },
-            ],
-          },
+            },
+          ],
         },
-        'heading-order': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > h3',
-                  'path': '2,HTML,1,BODY,47,SECTION,1,H3',
-                  'snippet': '<h3>',
-                  'explanation': 'Fix any of the following:\n  Heading order invalid',
-                  'nodeLabel': 'sub-sub-header',
-                },
+      },
+      'heading-order': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > h3',
+                'path': '2,HTML,1,BODY,47,SECTION,1,H3',
+                'snippet': '<h3>',
+                'explanation': 'Fix any of the following:\n  Heading order invalid',
+                'nodeLabel': 'sub-sub-header',
               },
-            ],
-          },
+            },
+          ],
         },
-        'html-has-lang': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'html',
-                  'snippet': '<html>',
-                  'explanation': 'Fix any of the following:\n  The <html> element does not have a lang attribute',
-                  'nodeLabel': 'html',
-                },
+      },
+      'html-has-lang': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'html',
+                'snippet': '<html>',
+                'explanation': 'Fix any of the following:\n  The <html> element does not have a lang attribute',
+                'nodeLabel': 'html',
               },
-            ],
-          },
+            },
+          ],
         },
-        'image-alt': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > img#image-alt',
-                  'snippet': '<img id="image-alt" src="./bogus.jpg">',
-                  'explanation': 'Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element\'s default semantics were not overridden with role="none" or role="presentation"',
-                  'nodeLabel': 'body > section > img#image-alt',
-                },
+      },
+      'image-alt': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > img#image-alt',
+                'snippet': '<img id="image-alt" src="./bogus.jpg">',
+                'explanation': 'Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element\'s default semantics were not overridden with role="none" or role="presentation"',
+                'nodeLabel': 'body > section > img#image-alt',
               },
-            ],
-          },
+            },
+          ],
         },
-        'input-image-alt': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > input#input-image-alt',
-                  'snippet': '<input type="image" id="input-image-alt">',
-                  'explanation': 'Fix any of the following:\n  Element has no alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                  'nodeLabel': 'body > section > input#input-image-alt',
-                },
+      },
+      'input-image-alt': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > input#input-image-alt',
+                'snippet': '<input type="image" id="input-image-alt">',
+                'explanation': 'Fix any of the following:\n  Element has no alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+                'nodeLabel': 'body > section > input#input-image-alt',
               },
-            ],
-          },
+            },
+          ],
         },
-        // TODO(paulirish): restore when we stop using --enable-features=AutofillShowTypePredictions
-        // See https://github.com/GoogleChrome/lighthouse/pull/11342
-        // 'label': {
-        //   score: 0,
-        //   details: {
-        //     items: [
-        //       {
-        //         node: {
-        //           'type': 'node',
-        //           'selector': '#label',
-        //           'snippet': '<input id="label" type="text">',
-        //           'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty',
-        //           'nodeLabel': 'input',
-        //         },
-        //       },
-        //     ],
-        //   },
-        // },
-        'link-name': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > a#link-name',
-                  'snippet': '<a id="link-name" href="google.com">',
-                  'explanation': 'Fix all of the following:\n  Element is in tab order and does not have accessible text\n\nFix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
-                  'nodeLabel': 'body > section > a#link-name',
-                },
+      },
+      // TODO(paulirish): restore when we stop using --enable-features=AutofillShowTypePredictions
+      // See https://github.com/GoogleChrome/lighthouse/pull/11342
+      // 'label': {
+      //   score: 0,
+      //   details: {
+      //     items: [
+      //       {
+      //         node: {
+      //           'type': 'node',
+      //           'selector': '#label',
+      //           'snippet': '<input id="label" type="text">',
+      //           'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty',
+      //           'nodeLabel': 'input',
+      //         },
+      //       },
+      //     ],
+      //   },
+      // },
+      'link-name': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > a#link-name',
+                'snippet': '<a id="link-name" href="google.com">',
+                'explanation': 'Fix all of the following:\n  Element is in tab order and does not have accessible text\n\nFix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute',
+                'nodeLabel': 'body > section > a#link-name',
               },
-            ],
-          },
+            },
+          ],
         },
-        'list': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > ul#list',
-                  'snippet': '<ul id="list">',
-                  'explanation': 'Fix all of the following:\n  List element has direct children that are not allowed inside <li> elements',
-                  'nodeLabel': 'body > section > ul#list',
-                },
+      },
+      'list': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > ul#list',
+                'snippet': '<ul id="list">',
+                'explanation': 'Fix all of the following:\n  List element has direct children that are not allowed inside <li> elements',
+                'nodeLabel': 'body > section > ul#list',
               },
-            ],
-          },
+            },
+          ],
         },
-        'listitem': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > li#listitem',
-                  'snippet': '<li id="listitem">',
-                  'explanation': 'Fix any of the following:\n  List item does not have a <ul>, <ol> parent element',
-                  'nodeLabel': 'body > section > li#listitem',
-                },
+      },
+      'listitem': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > li#listitem',
+                'snippet': '<li id="listitem">',
+                'explanation': 'Fix any of the following:\n  List item does not have a <ul>, <ol> parent element',
+                'nodeLabel': 'body > section > li#listitem',
               },
-            ],
-          },
+            },
+          ],
         },
-        'meta-viewport': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'head > meta',
-                  'snippet': '<meta name="viewport" content="user-scalable=no, maximum-scale=1.0">',
-                  'explanation': 'Fix any of the following:\n  user-scalable=no on <meta> tag disables zooming on mobile devices',
-                  'nodeLabel': 'head > meta',
-                },
+      },
+      'meta-viewport': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'head > meta',
+                'snippet': '<meta name="viewport" content="user-scalable=no, maximum-scale=1.0">',
+                'explanation': 'Fix any of the following:\n  user-scalable=no on <meta> tag disables zooming on mobile devices',
+                'nodeLabel': 'head > meta',
               },
-            ],
-          },
+            },
+          ],
         },
-        'object-alt': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > object#object-alt',
-                  'snippet': '<object id="object-alt">',
-                  'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element\'s default semantics were not overridden with role="none" or role="presentation"',
-                  'nodeLabel': 'body > section > object#object-alt',
-                },
+      },
+      'object-alt': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > object#object-alt',
+                'snippet': '<object id="object-alt">',
+                'explanation': 'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute\n  Element\'s default semantics were not overridden with role="none" or role="presentation"',
+                'nodeLabel': 'body > section > object#object-alt',
               },
-            ],
-          },
+            },
+          ],
         },
-        'tabindex': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > div#tabindex',
-                  'snippet': '<div id="tabindex" tabindex="10">',
-                  'explanation': 'Fix any of the following:\n  Element has a tabindex greater than 0',
-                  'nodeLabel': 'body > section > div#tabindex',
-                },
+      },
+      'tabindex': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > div#tabindex',
+                'snippet': '<div id="tabindex" tabindex="10">',
+                'explanation': 'Fix any of the following:\n  Element has a tabindex greater than 0',
+                'nodeLabel': 'body > section > div#tabindex',
               },
-            ],
-          },
+            },
+          ],
         },
-        'td-headers-attr': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > table#td-headers-attr',
-                  'snippet': '<table id="td-headers-attr">',
-                  'explanation': 'Fix all of the following:\n  The headers attribute is not exclusively used to refer to other cells in the table',
-                  'nodeLabel': 'FOO\nfoo',
-                },
+      },
+      'td-headers-attr': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > table#td-headers-attr',
+                'snippet': '<table id="td-headers-attr">',
+                'explanation': 'Fix all of the following:\n  The headers attribute is not exclusively used to refer to other cells in the table',
+                'nodeLabel': 'FOO\nfoo',
               },
-            ],
-          },
+            },
+          ],
         },
-        'valid-lang': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > p#valid-lang',
-                  'snippet': '<p id="valid-lang" lang="foo">',
-                  'explanation': 'Fix all of the following:\n  Value of lang attribute not included in the list of valid languages',
-                  'nodeLabel': 'foo',
-                },
+      },
+      'valid-lang': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > p#valid-lang',
+                'snippet': '<p id="valid-lang" lang="foo">',
+                'explanation': 'Fix all of the following:\n  Value of lang attribute not included in the list of valid languages',
+                'nodeLabel': 'foo',
               },
-            ],
-          },
+            },
+          ],
         },
-        'accesskeys': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  'type': 'node',
-                  'selector': 'body > section > button#accesskeys1',
-                  'snippet': '<button id="accesskeys1" accesskey="s">',
-                  'explanation': 'Fix all of the following:\n  Document has multiple elements with the same accesskey',
-                  'nodeLabel': 'Foo',
-                },
+      },
+      'accesskeys': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                'type': 'node',
+                'selector': 'body > section > button#accesskeys1',
+                'snippet': '<button id="accesskeys1" accesskey="s">',
+                'explanation': 'Fix all of the following:\n  Document has multiple elements with the same accesskey',
+                'nodeLabel': 'Foo',
               },
-            ],
-          },
+            },
+          ],
         },
       },
     },
   },
-];
+};
 
 module.exports = expectations;

--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency/expectations.js
@@ -6,317 +6,323 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for byte efficiency tests
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results for byte efficiency audits.
  */
-const expectations = [
-  {
-    artifacts: {
-      ScriptElements: [
-        {
-          type: null,
-          src: null,
-          async: false,
-          defer: false,
-          source: 'head',
-          // Only do a single assertion for `devtoolsNodePath`: this can be flaky for elements
-          // deep in the DOM, and the sample LHR test has plenty of places that would catch
-          // a regression in `devtoolsNodePath` calculation. Keep just one for the benefit
-          // of other smoke test runners.
-          node: {
-            devtoolsNodePath: '2,HTML,0,HEAD,3,SCRIPT',
-          },
+const efficiency = {
+  artifacts: {
+    ScriptElements: [
+      {
+        type: null,
+        src: null,
+        async: false,
+        defer: false,
+        source: 'head',
+        // Only do a single assertion for `devtoolsNodePath`: this can be flaky for elements
+        // deep in the DOM, and the sample LHR test has plenty of places that would catch
+        // a regression in `devtoolsNodePath` calculation. Keep just one for the benefit
+        // of other smoke test runners.
+        node: {
+          devtoolsNodePath: '2,HTML,0,HEAD,3,SCRIPT',
         },
-        {
-          type: 'application/javascript',
-          src: 'http://localhost:10200/byte-efficiency/script.js',
-          async: false,
-          defer: false,
-          source: 'head',
-        },
-        {
-          type: null,
-          src: 'http://localhost:10200/byte-efficiency/bundle.js',
-          async: false,
-          defer: false,
-          source: 'head',
-        },
-        {
-          type: null,
-          src: null,
-          async: false,
-          defer: false,
-          source: 'body',
-          content: /shadowRoot/,
-        },
-        {
-          type: null,
-          src: null,
-          async: false,
-          defer: false,
-          source: 'body',
-          content: /generateInlineStyleWithSize/,
-        },
-        {
-          type: null,
-          src: null,
-          async: false,
-          defer: false,
-          source: 'body',
-          content: /Used block #1/,
-        },
-        {
-          type: null,
-          src: null,
-          async: false,
-          defer: false,
-          source: 'body',
-          content: /Unused block #1/,
-        },
-        {
-          type: null,
-          src: 'http://localhost:10200/byte-efficiency/delay-complete.js?delay=8000',
-          async: true,
-          defer: false,
-          source: 'body',
-        },
+      },
+      {
+        type: 'application/javascript',
+        src: 'http://localhost:10200/byte-efficiency/script.js',
+        async: false,
+        defer: false,
+        source: 'head',
+      },
+      {
+        type: null,
+        src: 'http://localhost:10200/byte-efficiency/bundle.js',
+        async: false,
+        defer: false,
+        source: 'head',
+      },
+      {
+        type: null,
+        src: null,
+        async: false,
+        defer: false,
+        source: 'body',
+        content: /shadowRoot/,
+      },
+      {
+        type: null,
+        src: null,
+        async: false,
+        defer: false,
+        source: 'body',
+        content: /generateInlineStyleWithSize/,
+      },
+      {
+        type: null,
+        src: null,
+        async: false,
+        defer: false,
+        source: 'body',
+        content: /Used block #1/,
+      },
+      {
+        type: null,
+        src: null,
+        async: false,
+        defer: false,
+        source: 'body',
+        content: /Unused block #1/,
+      },
+      {
+        type: null,
+        src: 'http://localhost:10200/byte-efficiency/delay-complete.js?delay=8000',
+        async: true,
+        defer: false,
+        source: 'body',
+      },
+    ],
+    JsUsage: {
+      // ScriptParsedEvent.embedderName wasn't added to the protocol until M86,
+      // and `some-custom-url.js` won't show without it.
+      // https://chromiumdash.appspot.com/commit/52ed57138d0b83e8afd9de25e60655c6ace7527c
+      '_minChromiumMilestone': 86,
+      'http://localhost:10200/byte-efficiency/tester.html': [
+        {url: 'http://localhost:10200/byte-efficiency/tester.html'},
+        {url: 'http://localhost:10200/byte-efficiency/tester.html'},
+        {url: 'http://localhost:10200/byte-efficiency/tester.html'},
+        {url: 'http://localhost:10200/byte-efficiency/tester.html'},
+        {url: '/some-custom-url.js'},
       ],
-      JsUsage: {
-        // ScriptParsedEvent.embedderName wasn't added to the protocol until M86,
-        // and `some-custom-url.js` won't show without it.
+      'http://localhost:10200/byte-efficiency/script.js': [
+        {url: 'http://localhost:10200/byte-efficiency/script.js'},
+      ],
+      'http://localhost:10200/byte-efficiency/bundle.js': [
+        {url: 'http://localhost:10200/byte-efficiency/bundle.js'},
+      ],
+    },
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/byte-efficiency/tester.html',
+    finalUrl: 'http://localhost:10200/byte-efficiency/tester.html',
+    audits: {
+      'uses-http2': {
+        score: 1,
+        details: {
+          items: {
+            // localhost gets a free pass on uses-h2
+            length: 0,
+          },
+        },
+      },
+      'unminified-css': {
+        details: {
+          overallSavingsBytes: '>17000',
+          items: {
+            length: 2,
+          },
+        },
+      },
+      'unminified-javascript': {
+        score: '<1',
+        details: {
+          // the specific ms value is not meaningful for this smoketest
+          // *some largish amount* of savings should be reported
+          overallSavingsMs: '>500',
+          overallSavingsBytes: '>45000',
+          items: [
+            {
+              url: 'http://localhost:10200/byte-efficiency/script.js',
+              wastedBytes: '46481 +/- 100',
+              wastedPercent: '87 +/- 5',
+            },
+            {
+              url: 'inline: \n  function unusedFunction() {\n    // Un...',
+              wastedBytes: '6700 +/- 100',
+              wastedPercent: '99.6 +/- 0.1',
+            },
+            {
+              url: 'inline: \n  // Used block #1\n  // FILLER DATA JUS...',
+              wastedBytes: '6559 +/- 100',
+              wastedPercent: 100,
+            },
+            {
+              url: 'http://localhost:10200/byte-efficiency/bundle.js',
+              totalBytes: '13000 +/- 1000',
+              wastedBytes: '2350 +/- 100',
+              wastedPercent: '19 +/- 5',
+            },
+          ],
+        },
+      },
+      'unused-css-rules': {
+        details: {
+          overallSavingsBytes: '>40000',
+          items: {
+            length: 2,
+          },
+        },
+      },
+      'unused-javascript': {
+        // ScriptParsedEvent.embedderName wasn't added to the protocol until M86.
         // https://chromiumdash.appspot.com/commit/52ed57138d0b83e8afd9de25e60655c6ace7527c
-        '_minChromiumMilestone': 86,
-        'http://localhost:10200/byte-efficiency/tester.html': [
-          {url: 'http://localhost:10200/byte-efficiency/tester.html'},
-          {url: 'http://localhost:10200/byte-efficiency/tester.html'},
-          {url: 'http://localhost:10200/byte-efficiency/tester.html'},
-          {url: 'http://localhost:10200/byte-efficiency/tester.html'},
-          {url: '/some-custom-url.js'},
-        ],
-        'http://localhost:10200/byte-efficiency/script.js': [
-          {url: 'http://localhost:10200/byte-efficiency/script.js'},
-        ],
-        'http://localhost:10200/byte-efficiency/bundle.js': [
-          {url: 'http://localhost:10200/byte-efficiency/bundle.js'},
-        ],
+        _minChromiumMilestone: 86,
+        score: '<1',
+        details: {
+          // the specific ms value here is not meaningful for this smoketest
+          // *some* savings should be reported
+          overallSavingsMs: '>0',
+          overallSavingsBytes: '35000 +/- 1000',
+          items: [
+            {
+              url: 'http://localhost:10200/byte-efficiency/script.js',
+              totalBytes: '53000 +/- 1000',
+              wastedBytes: '22000 +/- 1000',
+            },
+            {
+              url: 'http://localhost:10200/byte-efficiency/tester.html',
+              totalBytes: '15000 +/- 1000',
+              wastedBytes: '6500 +/- 1000',
+            },
+            {
+              url: 'http://localhost:10200/byte-efficiency/bundle.js',
+              totalBytes: '12913 +/- 1000',
+              wastedBytes: '5827 +/- 200',
+              subItems: {
+                items: [
+                  {source: '…./b.js', sourceBytes: '4417 +/- 50', sourceWastedBytes: '2191 +/- 50'},
+                  {source: '…./c.js', sourceBytes: '2200 +/- 50', sourceWastedBytes: '2182 +/- 50'},
+                  {source: '…webpack/bootstrap', sourceBytes: '2809 +/- 50', sourceWastedBytes: '1259 +/- 50'},
+                ],
+              },
+            },
+          ],
+        },
       },
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/byte-efficiency/tester.html',
-      finalUrl: 'http://localhost:10200/byte-efficiency/tester.html',
-      audits: {
-        'uses-http2': {
-          score: 1,
-          details: {
-            items: {
-              // localhost gets a free pass on uses-h2
-              length: 0,
+      'offscreen-images': {
+        details: {
+          items: [
+            {
+              url: /lighthouse-unoptimized.jpg$/,
+            }, {
+              url: /lighthouse-480x320.webp$/,
+            }, {
+              url: /lighthouse-480x320.webp\?invisible$/,
+            }, {
+              url: /large.svg$/,
             },
+          ],
+        },
+      },
+      'modern-image-formats': {
+        details: {
+          overallSavingsBytes: '137000 +/- 10000',
+          items: [
+            {url: /lighthouse-1024x680.jpg$/},
+            {url: /lighthouse-unoptimized.jpg$/},
+            {url: /lighthouse-480x320.jpg$/},
+            {url: /lighthouse-480x320.jpg\?attributesized/},
+            {url: /lighthouse-480x320.jpg\?css/},
+            {url: /lighthouse-480x320.jpg\?sprite/},
+          ],
+        },
+      },
+      'uses-text-compression': {
+        score: '<1',
+        details: {
+          // the specific ms value is not meaningful for this smoketest
+          // *some largish amount* of savings should be reported
+          overallSavingsMs: '>700',
+          overallSavingsBytes: '>50000',
+          items: {
+            length: 3,
           },
         },
-        'unminified-css': {
-          details: {
-            overallSavingsBytes: '>17000',
-            items: {
-              length: 2,
-            },
+      },
+      'uses-optimized-images': {
+        details: {
+          overallSavingsBytes: '>10000',
+          items: {
+            length: 1,
           },
         },
-        'unminified-javascript': {
-          score: '<1',
-          details: {
-            // the specific ms value is not meaningful for this smoketest
-            // *some largish amount* of savings should be reported
-            overallSavingsMs: '>500',
-            overallSavingsBytes: '>45000',
-            items: [
-              {
-                url: 'http://localhost:10200/byte-efficiency/script.js',
-                wastedBytes: '46481 +/- 100',
-                wastedPercent: '87 +/- 5',
-              },
-              {
-                url: 'inline: \n  function unusedFunction() {\n    // Un...',
-                wastedBytes: '6700 +/- 100',
-                wastedPercent: '99.6 +/- 0.1',
-              },
-              {
-                url: 'inline: \n  // Used block #1\n  // FILLER DATA JUS...',
-                wastedBytes: '6559 +/- 100',
-                wastedPercent: 100,
-              },
-              {
-                url: 'http://localhost:10200/byte-efficiency/bundle.js',
-                totalBytes: '13000 +/- 1000',
-                wastedBytes: '2350 +/- 100',
-                wastedPercent: '19 +/- 5',
-              },
-            ],
-          },
+      },
+      // Check that images aren't TOO BIG.
+      'uses-responsive-images': {
+        details: {
+          overallSavingsBytes: '113000 +/- 5000',
+          items: [
+            {wastedPercent: '56 +/- 5', url: /lighthouse-1024x680.jpg/},
+            {wastedPercent: '78 +/- 5', url: /lighthouse-2048x1356.webp\?size0/},
+            {wastedPercent: '56 +/- 5', url: /lighthouse-480x320.webp/},
+            {wastedPercent: '20 +/- 5', url: /lighthouse-480x320.jpg/},
+            {wastedPercent: '20 +/- 5', url: /lighthouse-480x320\.jpg\?attributesized/},
+          ],
         },
-        'unused-css-rules': {
-          details: {
-            overallSavingsBytes: '>40000',
-            items: {
-              length: 2,
-            },
-          },
+      },
+      // Checks that images aren't TOO SMALL.
+      'image-size-responsive': {
+        details: {
+          items: [
+            // One of these is the ?duplicate variant and another is the
+            // ?cssauto variant but sort order isn't guaranteed
+            // since the pixel diff is equivalent for identical images.
+            {url: /lighthouse-320x212-poor.jpg/},
+            {url: /lighthouse-320x212-poor.jpg/},
+            {url: /lighthouse-320x212-poor.jpg/},
+          ],
         },
-        'unused-javascript': {
-          // ScriptParsedEvent.embedderName wasn't added to the protocol until M86.
-          // https://chromiumdash.appspot.com/commit/52ed57138d0b83e8afd9de25e60655c6ace7527c
-          _minChromiumMilestone: 86,
-          score: '<1',
-          details: {
-            // the specific ms value here is not meaningful for this smoketest
-            // *some* savings should be reported
-            overallSavingsMs: '>0',
-            overallSavingsBytes: '35000 +/- 1000',
-            items: [
-              {
-                url: 'http://localhost:10200/byte-efficiency/script.js',
-                totalBytes: '53000 +/- 1000',
-                wastedBytes: '22000 +/- 1000',
-              },
-              {
-                url: 'http://localhost:10200/byte-efficiency/tester.html',
-                totalBytes: '15000 +/- 1000',
-                wastedBytes: '6500 +/- 1000',
-              },
-              {
-                url: 'http://localhost:10200/byte-efficiency/bundle.js',
-                totalBytes: '12913 +/- 1000',
-                wastedBytes: '5827 +/- 200',
-                subItems: {
-                  items: [
-                    {source: '…./b.js', sourceBytes: '4417 +/- 50', sourceWastedBytes: '2191 +/- 50'},
-                    {source: '…./c.js', sourceBytes: '2200 +/- 50', sourceWastedBytes: '2182 +/- 50'},
-                    {source: '…webpack/bootstrap', sourceBytes: '2809 +/- 50', sourceWastedBytes: '1259 +/- 50'},
-                  ],
-                },
-              },
-            ],
-          },
-        },
-        'offscreen-images': {
-          details: {
-            items: [
-              {
-                url: /lighthouse-unoptimized.jpg$/,
-              }, {
-                url: /lighthouse-480x320.webp$/,
-              }, {
-                url: /lighthouse-480x320.webp\?invisible$/,
-              }, {
-                url: /large.svg$/,
-              },
-            ],
-          },
-        },
-        'modern-image-formats': {
-          details: {
-            overallSavingsBytes: '137000 +/- 10000',
-            items: [
-              {url: /lighthouse-1024x680.jpg$/},
-              {url: /lighthouse-unoptimized.jpg$/},
-              {url: /lighthouse-480x320.jpg$/},
-              {url: /lighthouse-480x320.jpg\?attributesized/},
-              {url: /lighthouse-480x320.jpg\?css/},
-              {url: /lighthouse-480x320.jpg\?sprite/},
-            ],
-          },
-        },
-        'uses-text-compression': {
-          score: '<1',
-          details: {
-            // the specific ms value is not meaningful for this smoketest
-            // *some largish amount* of savings should be reported
-            overallSavingsMs: '>700',
-            overallSavingsBytes: '>50000',
-            items: {
-              length: 3,
-            },
-          },
-        },
-        'uses-optimized-images': {
-          details: {
-            overallSavingsBytes: '>10000',
-            items: {
-              length: 1,
-            },
-          },
-        },
-        // Check that images aren't TOO BIG.
-        'uses-responsive-images': {
-          details: {
-            overallSavingsBytes: '113000 +/- 5000',
-            items: [
-              {wastedPercent: '56 +/- 5', url: /lighthouse-1024x680.jpg/},
-              {wastedPercent: '78 +/- 5', url: /lighthouse-2048x1356.webp\?size0/},
-              {wastedPercent: '56 +/- 5', url: /lighthouse-480x320.webp/},
-              {wastedPercent: '20 +/- 5', url: /lighthouse-480x320.jpg/},
-              {wastedPercent: '20 +/- 5', url: /lighthouse-480x320\.jpg\?attributesized/},
-            ],
-          },
-        },
-        // Checks that images aren't TOO SMALL.
-        'image-size-responsive': {
-          details: {
-            items: [
-              // One of these is the ?duplicate variant and another is the
-              // ?cssauto variant but sort order isn't guaranteed
-              // since the pixel diff is equivalent for identical images.
-              {url: /lighthouse-320x212-poor.jpg/},
-              {url: /lighthouse-320x212-poor.jpg/},
-              {url: /lighthouse-320x212-poor.jpg/},
-            ],
-          },
-        },
-        'unsized-images': {
-          details: {
-            items: [
-              {url: /lighthouse-320x212-poor\.jpg/},
-              {url: /lighthouse-320x212-poor\.jpg\?cssauto/},
-            ],
-          },
+      },
+      'unsized-images': {
+        details: {
+          items: [
+            {url: /lighthouse-320x212-poor\.jpg/},
+            {url: /lighthouse-320x212-poor\.jpg\?cssauto/},
+          ],
         },
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
-      finalUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
-      audits: {
-        'network-requests': {
-          details: {
-            items: [
-              {
-                url: 'http://localhost:10200/byte-efficiency/gzip.html',
-                finished: true,
-              },
-              {
-                url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
-                transferSize: '1200 +/- 150',
-                resourceSize: '53000 +/- 1000',
-                finished: true,
-              },
-              {
-                url: 'http://localhost:10200/byte-efficiency/script.js',
-                transferSize: '53200 +/- 1000',
-                resourceSize: '53000 +/- 1000',
-                finished: true,
-              },
-              {
-                url: 'http://localhost:10200/favicon.ico',
-                finished: true,
-              },
-            ],
-          },
-        },
-      },
-    },
-  },
-];
+};
 
-module.exports = expectations;
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results testing gzipped requests.
+ */
+const gzip = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+    finalUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+    audits: {
+      'network-requests': {
+        details: {
+          items: [
+            {
+              url: 'http://localhost:10200/byte-efficiency/gzip.html',
+              finished: true,
+            },
+            {
+              url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
+              transferSize: '1200 +/- 150',
+              resourceSize: '53000 +/- 1000',
+              finished: true,
+            },
+            {
+              url: 'http://localhost:10200/byte-efficiency/script.js',
+              transferSize: '53200 +/- 1000',
+              resourceSize: '53000 +/- 1000',
+              finished: true,
+            },
+            {
+              url: 'http://localhost:10200/favicon.ico',
+              finished: true,
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+module.exports = {
+  efficiency,
+  gzip,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js
@@ -235,16 +235,16 @@ const smokeTests = [{
   expectations: require('./screenshot/expectations.js'),
   config: require('./screenshot/screenshot-config.js'),
 }, {
-  id: 'csp-base',
-  expectations: csp.base,
+  id: 'csp-allow-all',
+  expectations: csp.allowAll,
   config: require('./csp/csp-config.js'),
 }, {
-  id: 'csp-except-inline',
-  expectations: csp.exceptInline,
+  id: 'csp-block-all-m91',
+  expectations: csp.blockAllM91,
   config: require('./csp/csp-config.js'),
 }, {
-  id: 'csp-except-inline-m92',
-  expectations: csp.exceptInlineM92,
+  id: 'csp-block-all',
+  expectations: csp.blockAll,
   config: require('./csp/csp-config.js'),
 }];
 

--- a/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js
@@ -87,8 +87,8 @@ const smokeTests = [{
   expectations: redirects.singleClient,
   config: require('./redirects/redirects-config.js'),
 }, {
-  id: 'redirects-client-paint-server-2',
-  expectations: redirects.clientPaintServer2,
+  id: 'redirects-history-push-state',
+  expectations: redirects.historyPushState,
   config: require('./redirects/redirects-config.js'),
 }, {
   id: 'seo-passing',
@@ -103,7 +103,7 @@ const smokeTests = [{
   expectations: seo.status403,
   config: require('./seo/seo-config.js'),
 }, {
-  id: 'seo-tap-target',
+  id: 'seo-tap-targets',
   expectations: seo.tapTargets,
   config: require('./seo/seo-config.js'),
 }, {
@@ -190,12 +190,12 @@ const smokeTests = [{
   expectations: lantern.xhr,
   config: require('./lantern/lantern-config.js'),
 }, {
-  id: 'lantern-ric-short',
-  expectations: lantern.ricShort,
+  id: 'lantern-idle-callback-short',
+  expectations: lantern.idleCallbackShort,
   config: require('./lantern/lantern-config.js'),
 }, {
-  id: 'lantern-ric-long',
-  expectations: lantern.ricLong,
+  id: 'lantern-idle-callback-long',
+  expectations: lantern.idleCallbackLong,
   config: require('./lantern/lantern-config.js'),
 }, {
   id: 'metrics-tricky-tti',

--- a/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js
@@ -5,14 +5,37 @@
  */
 'use strict';
 
-/** @type {ReadonlyArray<Smokehouse.BackCompatTestDefn>} */
+const errors = require('./errors/error-expectations.js');
+const pwa = require('./pwa/pwa-expectations.js');
+const pwa2 = require('./pwa/pwa2-expectations.js');
+const redirects = require('./redirects/expectations.js');
+const seo = require('./seo/expectations.js');
+const offline = require('./offline-local/offline-expectations.js');
+const byte = require('./byte-efficiency/expectations.js');
+const perf = require('./perf/expectations.js');
+const diagnostics = require('./perf-diagnostics/expectations.js');
+const lantern = require('./lantern/lantern-expectations.js');
+const metrics = require('./tricky-metrics/expectations.js');
+const csp = require('./csp/csp-expectations.js');
+
+/** @type {ReadonlyArray<Smokehouse.TestDfn>} */
 const smokeTests = [{
   id: 'a11y',
   expectations: require('./a11y/expectations.js'),
   config: require('./a11y/a11y-config.js'),
 }, {
-  id: 'errors',
-  expectations: require('./errors/error-expectations.js'),
+  id: 'errors-infinite-loop',
+  expectations: errors.infiniteLoop,
+  config: require('./errors/error-config.js'),
+  runSerially: true,
+}, {
+  id: 'errors-expired-ssl',
+  expectations: errors.expiredSsl,
+  config: require('./errors/error-config.js'),
+  runSerially: true,
+}, {
+  id: 'errors-iframe-expired-ssl',
+  expectations: errors.iframeBadSsl,
   config: require('./errors/error-config.js'),
   runSerially: true,
 }, {
@@ -20,16 +43,24 @@ const smokeTests = [{
   expectations: require('./oopif/oopif-expectations.js'),
   config: require('./oopif/oopif-config.js'),
 }, {
-  id: 'pwa',
-  expectations: require('./pwa/pwa-expectations.js'),
+  id: 'pwa-airhorner',
+  expectations: pwa.airhorner,
   config: require('./pwa/pwa-config.js'),
 }, {
-  id: 'pwa2',
-  expectations: require('./pwa/pwa2-expectations.js'),
+  id: 'pwa-chromestatus',
+  expectations: pwa.chromestatus,
   config: require('./pwa/pwa-config.js'),
 }, {
-  id: 'pwa3',
-  expectations: require('./pwa/pwa3-expectations.js'),
+  id: 'pwa-svgomg',
+  expectations: pwa2.svgomg,
+  config: require('./pwa/pwa-config.js'),
+}, {
+  id: 'pwa-caltrain',
+  expectations: pwa2.caltrain,
+  config: require('./pwa/pwa-config.js'),
+}, {
+  id: 'pwa-rocks',
+  expectations: require('./pwa/pwa3-expectations.js').pwarocks,
   config: require('./pwa/pwa-config.js'),
 }, {
   id: 'dbw',
@@ -37,39 +68,154 @@ const smokeTests = [{
   config: require('./dobetterweb/dbw-config.js'),
   runSerially: true, // Need access to network request assertions.
 }, {
-  id: 'redirects',
-  expectations: require('./redirects/expectations.js'),
+  id: 'issues-mixed-content',
+  expectations: require('./issues/mixed-content.js'),
+}, {
+  id: 'redirects-single-server',
+  expectations: redirects.singleServer,
   config: require('./redirects/redirects-config.js'),
 }, {
-  id: 'seo',
-  expectations: require('./seo/expectations.js'),
+  id: 'redirects-multiple-server',
+  expectations: redirects.multipleServer,
+  config: require('./redirects/redirects-config.js'),
+}, {
+  id: 'redirects-client-paint-server',
+  expectations: redirects.clientPaintServer,
+  config: require('./redirects/redirects-config.js'),
+}, {
+  id: 'redirects-single-client',
+  expectations: redirects.singleClient,
+  config: require('./redirects/redirects-config.js'),
+}, {
+  id: 'redirects-client-paint-server-2',
+  expectations: redirects.clientPaintServer2,
+  config: require('./redirects/redirects-config.js'),
+}, {
+  id: 'seo-passing',
+  expectations: seo.passing,
   config: require('./seo/seo-config.js'),
 }, {
-  id: 'offline',
-  expectations: require('./offline-local/offline-expectations.js'),
+  id: 'seo-failing',
+  expectations: seo.failing,
+  config: require('./seo/seo-config.js'),
+}, {
+  id: 'seo-status-403',
+  expectations: seo.status403,
+  config: require('./seo/seo-config.js'),
+}, {
+  id: 'seo-tap-target',
+  expectations: seo.tapTargets,
+  config: require('./seo/seo-config.js'),
+}, {
+  id: 'offline-online-only',
+  expectations: offline.onlineOnly,
   config: require('./offline-local/offline-config.js'),
   runSerially: true,
 }, {
-  id: 'byte',
-  expectations: require('./byte-efficiency/expectations.js'),
+  id: 'offline-ready',
+  expectations: offline.ready,
+  config: require('./offline-local/offline-config.js'),
+  runSerially: true,
+}, {
+  id: 'offline-sw-broken',
+  expectations: offline.swBroken,
+  config: require('./offline-local/offline-config.js'),
+  runSerially: true,
+}, {
+  id: 'offline-sw-slow',
+  expectations: offline.swSlow,
+  config: require('./offline-local/offline-config.js'),
+  runSerially: true,
+}, {
+  id: 'byte-efficiency',
+  expectations: byte.efficiency,
   config: require('./byte-efficiency/byte-config.js'),
   runSerially: true,
 }, {
-  id: 'perf',
-  expectations: require('./perf/expectations.js'),
+  id: 'byte-gzip',
+  expectations: byte.gzip,
+  config: require('./byte-efficiency/byte-config.js'),
+  runSerially: true,
+}, {
+  id: 'perf-preload',
+  expectations: perf.preload,
   config: require('./perf/perf-config.js'),
   runSerially: true,
 }, {
-  id: 'perf-diagnostics',
-  expectations: require('./perf-diagnostics/expectations.js'),
+  id: 'perf-budgets',
+  expectations: perf.budgets,
+  config: require('./perf/perf-config.js'),
+  runSerially: true,
+}, {
+  id: 'perf-fonts',
+  expectations: perf.fonts,
+  config: require('./perf/perf-config.js'),
+  runSerially: true,
+}, {
+  id: 'perf-trace-elements',
+  expectations: perf.traceElements,
+  config: require('./perf/perf-config.js'),
+  runSerially: true,
+}, {
+  id: 'perf-frame-metrics',
+  expectations: perf.frameMetrics,
+  config: require('./perf/perf-config.js'),
+  runSerially: true,
+}, {
+  id: 'perf-diagnostics-animations',
+  expectations: diagnostics.animations,
   config: require('./perf-diagnostics/perf-diagnostics-config.js'),
 }, {
-  id: 'lantern',
-  expectations: require('./lantern/lantern-expectations.js'),
+  id: 'perf-diagnostics-third-party',
+  expectations: diagnostics.thirdParty,
+  config: require('./perf-diagnostics/perf-diagnostics-config.js'),
+}, {
+  id: 'perf-diagnostics-unsized-images',
+  expectations: diagnostics.unsizedImages,
+  config: require('./perf-diagnostics/perf-diagnostics-config.js'),
+}, {
+  id: 'lantern-online',
+  expectations: lantern.online,
   config: require('./lantern/lantern-config.js'),
 }, {
-  id: 'metrics',
-  expectations: require('./tricky-metrics/expectations.js'),
+  id: 'lantern-settimeout',
+  expectations: lantern.setTimeout,
+  config: require('./lantern/lantern-config.js'),
+}, {
+  id: 'lantern-fetch',
+  expectations: lantern.fetch,
+  config: require('./lantern/lantern-config.js'),
+}, {
+  id: 'lantern-xhr',
+  expectations: lantern.xhr,
+  config: require('./lantern/lantern-config.js'),
+}, {
+  id: 'lantern-ric-short',
+  expectations: lantern.ricShort,
+  config: require('./lantern/lantern-config.js'),
+}, {
+  id: 'lantern-ric-long',
+  expectations: lantern.ricLong,
+  config: require('./lantern/lantern-config.js'),
+}, {
+  id: 'metrics-tricky-tti',
+  expectations: metrics.trickyTti,
+  config: require('./tricky-metrics/no-throttling-config.js'),
+}, {
+  id: 'metrics-tricky-tti-late-fcp',
+  expectations: metrics.trickyTtiLateFcp,
+  config: require('./tricky-metrics/no-throttling-config.js'),
+}, {
+  id: 'metrics-delayed-lcp',
+  expectations: metrics.delayedLcp,
+  config: require('./tricky-metrics/no-throttling-config.js'),
+}, {
+  id: 'metrics-delayed-fcp',
+  expectations: metrics.delayedFcp,
+  config: require('./tricky-metrics/no-throttling-config.js'),
+}, {
+  id: 'metrics-debugger',
+  expectations: metrics.debuggerStatement,
   config: require('./tricky-metrics/no-throttling-config.js'),
 }, {
   id: 'legacy-javascript',
@@ -89,8 +235,16 @@ const smokeTests = [{
   expectations: require('./screenshot/expectations.js'),
   config: require('./screenshot/screenshot-config.js'),
 }, {
-  id: 'csp',
-  expectations: require('./csp/csp-expectations.js'),
+  id: 'csp-base',
+  expectations: csp.base,
+  config: require('./csp/csp-config.js'),
+}, {
+  id: 'csp-except-inline',
+  expectations: csp.exceptInline,
+  config: require('./csp/csp-config.js'),
+}, {
+  id: 'csp-except-inline-m92',
+  expectations: csp.exceptInlineM92,
   config: require('./csp/csp-config.js'),
 }];
 

--- a/lighthouse-cli/test/smokehouse/test-definitions/csp/csp-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/csp/csp-expectations.js
@@ -23,86 +23,99 @@ const blockAllExceptInlineScriptCsp = headersParam([[
 ]]);
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expectations of CSP results with a defalt Lighthouse run.
  */
-module.exports = [
-  {
-    artifacts: {
-      RobotsTxt: {
-        status: 404,
-        content: null,
-      },
-      InspectorIssues: {contentSecurityPolicy: []},
-      SourceMaps: [{
-        sourceMapUrl: 'http://localhost:10200/source-map/script.js.map',
-        map: {},
-        errorMessage: undefined,
-      }],
+const base = {
+  artifacts: {
+    RobotsTxt: {
+      status: 404,
+      content: null,
     },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/csp.html',
-      finalUrl: 'http://localhost:10200/csp.html',
-      audits: {},
-    },
+    InspectorIssues: {contentSecurityPolicy: []},
+    SourceMaps: [{
+      sourceMapUrl: 'http://localhost:10200/source-map/script.js.map',
+      map: {},
+      errorMessage: undefined,
+    }],
   },
-  {
-    artifacts: {
-      _maxChromiumMilestone: 91,
-      RobotsTxt: {
-        status: null,
-        content: null,
-      },
-      InspectorIssues: {
-        contentSecurityPolicy: [
-          {
-            // https://github.com/GoogleChrome/lighthouse/issues/10225
-            //
-            // Fixed with new fetcher using M92.
-            blockedURL: 'http://localhost:10200/robots.txt',
-            violatedDirective: 'connect-src',
-            isReportOnly: false,
-            contentSecurityPolicyViolationType: 'kURLViolation',
-          },
-        ],
-      },
-      SourceMaps: [{
-        // Doesn't trigger a CSP violation because iframe is injected after InspectorIssues gatherer finishes.
-        // https://github.com/GoogleChrome/lighthouse/pull/12044#issuecomment-788274938
-        //
-        // Fixed with new fetcher using M92.
-        sourceMapUrl: 'http://localhost:10200/source-map/script.js.map',
-        errorMessage: 'Error: Timed out fetching resource.',
-        map: undefined,
-      }],
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/csp.html?' + blockAllExceptInlineScriptCsp,
-      finalUrl: 'http://localhost:10200/csp.html?' + blockAllExceptInlineScriptCsp,
-      audits: {},
-    },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/csp.html',
+    finalUrl: 'http://localhost:10200/csp.html',
+    audits: {},
   },
-  {
-    // Same CSP as above, but verifies correct behavior for M92.
-    artifacts: {
-      _minChromiumMilestone: 92,
-      RobotsTxt: {
-        status: 404,
-        content: null,
-      },
-      InspectorIssues: {
-        contentSecurityPolicy: [
-        ],
-      },
-      SourceMaps: [{
-        sourceMapUrl: 'http://localhost:10200/source-map/script.js.map',
-        map: {},
-        errorMessage: undefined,
-      }],
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const exceptInline = {
+  artifacts: {
+    _maxChromiumMilestone: 91,
+    RobotsTxt: {
+      status: null,
+      content: null,
     },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/csp.html?' + blockAllExceptInlineScriptCsp,
-      finalUrl: 'http://localhost:10200/csp.html?' + blockAllExceptInlineScriptCsp,
-      audits: {},
+    InspectorIssues: {
+      contentSecurityPolicy: [
+        {
+          // https://github.com/GoogleChrome/lighthouse/issues/10225
+          //
+          // Fixed with new fetcher using M92.
+          blockedURL: 'http://localhost:10200/robots.txt',
+          violatedDirective: 'connect-src',
+          isReportOnly: false,
+          contentSecurityPolicyViolationType: 'kURLViolation',
+        },
+      ],
     },
+    SourceMaps: [{
+      // Doesn't trigger a CSP violation because iframe is injected after InspectorIssues gatherer finishes.
+      // https://github.com/GoogleChrome/lighthouse/pull/12044#issuecomment-788274938
+      //
+      // Fixed with new fetcher using M92.
+      sourceMapUrl: 'http://localhost:10200/source-map/script.js.map',
+      errorMessage: 'Error: Timed out fetching resource.',
+      map: undefined,
+    }],
   },
-];
+  lhr: {
+    requestedUrl: 'http://localhost:10200/csp.html?' + blockAllExceptInlineScriptCsp,
+    finalUrl: 'http://localhost:10200/csp.html?' + blockAllExceptInlineScriptCsp,
+    audits: {},
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const exceptInlineM92 = {
+  // Same CSP as above, but verifies correct behavior for M92.
+  artifacts: {
+    _minChromiumMilestone: 92,
+    RobotsTxt: {
+      status: 404,
+      content: null,
+    },
+    InspectorIssues: {
+      contentSecurityPolicy: [
+      ],
+    },
+    SourceMaps: [{
+      sourceMapUrl: 'http://localhost:10200/source-map/script.js.map',
+      map: {},
+      errorMessage: undefined,
+    }],
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/csp.html?' + blockAllExceptInlineScriptCsp,
+    finalUrl: 'http://localhost:10200/csp.html?' + blockAllExceptInlineScriptCsp,
+    audits: {},
+  },
+};
+
+module.exports = {
+  base,
+  exceptInline,
+  exceptInlineM92,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/csp/csp-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/csp/csp-expectations.js
@@ -26,7 +26,7 @@ const blockAllExceptInlineScriptCsp = headersParam([[
  * @type {Smokehouse.ExpectedRunnerResult}
  * Expectations of CSP results with a defalt Lighthouse run.
  */
-const base = {
+const allowAll = {
   artifacts: {
     RobotsTxt: {
       status: 404,
@@ -49,7 +49,7 @@ const base = {
 /**
  * @type {Smokehouse.ExpectedRunnerResult}
  */
-const exceptInline = {
+const blockAllM91 = {
   artifacts: {
     _maxChromiumMilestone: 91,
     RobotsTxt: {
@@ -89,7 +89,7 @@ const exceptInline = {
 /**
  * @type {Smokehouse.ExpectedRunnerResult}
  */
-const exceptInlineM92 = {
+const blockAll = {
   // Same CSP as above, but verifies correct behavior for M92.
   artifacts: {
     _minChromiumMilestone: 92,
@@ -115,7 +115,7 @@ const exceptInlineM92 = {
 };
 
 module.exports = {
-  base,
-  exceptInline,
-  exceptInlineM92,
+  allowAll,
+  blockAllM91,
+  blockAll,
 };

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -6,462 +6,433 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
+ * @type {Smokehouse.ExpectedRunnerResult}
  * Expected Lighthouse audit values for Do Better Web tests.
  */
-const expectations = [
-  {
-    networkRequests: {
-      // 50 requests made for normal page testing.
-      // 6 extra requests made because stylesheets are evicted from the cache by the time DT opens.
-      // 3 extra requests made to /dobetterweb/clock.appcache
-      length: 59,
-    },
-    artifacts: {
-      HostFormFactor: 'desktop',
-      Stacks: [{
-        id: 'jquery',
-      }, {
-        id: 'jquery-fast',
-        name: 'jQuery (Fast path)',
-      }, {
-        id: 'wordpress',
-      }],
-      MainDocumentContent: /^<!doctype html>.*DoBetterWeb Mega Tester.*aggressive-promise-polyfill.*<\/html>[\r\n]*$/s,
-      LinkElements: [
-        {
-          rel: 'stylesheet',
-          href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=100',
-          hrefRaw: './dbw_tester.css?delay=100',
-          hreflang: '',
-          as: '',
-          crossOrigin: null,
-          source: 'head',
+const expectations = {
+  networkRequests: {
+    // 50 requests made for normal page testing.
+    // 6 extra requests made because stylesheets are evicted from the cache by the time DT opens.
+    // 3 extra requests made to /dobetterweb/clock.appcache
+    length: 59,
+  },
+  artifacts: {
+    HostFormFactor: 'desktop',
+    Stacks: [{
+      id: 'jquery',
+    }, {
+      id: 'jquery-fast',
+      name: 'jQuery (Fast path)',
+    }, {
+      id: 'wordpress',
+    }],
+    MainDocumentContent: /^<!doctype html>.*DoBetterWeb Mega Tester.*aggressive-promise-polyfill.*<\/html>[\r\n]*$/s,
+    LinkElements: [
+      {
+        rel: 'stylesheet',
+        href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=100',
+        hrefRaw: './dbw_tester.css?delay=100',
+        hreflang: '',
+        as: '',
+        crossOrigin: null,
+        source: 'head',
+      },
+      {
+        rel: 'stylesheet',
+        href: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
+        hrefRaw: './unknown404.css?delay=200',
+        hreflang: '',
+        as: '',
+        crossOrigin: null,
+        source: 'head',
+      },
+      {
+        rel: 'stylesheet',
+        href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200',
+        hrefRaw: './dbw_tester.css?delay=2200',
+        hreflang: '',
+        as: '',
+        crossOrigin: null,
+        source: 'head',
+      },
+      {
+        rel: 'stylesheet',
+        href: 'http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled',
+        hrefRaw: './dbw_disabled.css?delay=200&isdisabled',
+        hreflang: '',
+        as: '',
+        crossOrigin: null,
+        source: 'head',
+      },
+      {
+        rel: 'stylesheet',
+        href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
+        hrefRaw: './dbw_tester.css?delay=3000&capped',
+        hreflang: '',
+        as: '',
+        crossOrigin: null,
+        source: 'head',
+      },
+      {
+        rel: 'stylesheet',
+        href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true',
+        hrefRaw: './dbw_tester.css?delay=2000&async=true',
+        hreflang: '',
+        as: 'style',
+        crossOrigin: null,
+        source: 'head',
+      },
+      {
+        rel: 'stylesheet',
+        href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true',
+        hrefRaw: './dbw_tester.css?delay=3000&async=true',
+        hreflang: '',
+        as: '',
+        crossOrigin: null,
+        source: 'head',
+      },
+      {
+        rel: 'alternate stylesheet',
+        href: 'http://localhost:10200/dobetterweb/empty.css',
+        hrefRaw: './empty.css',
+        hreflang: '',
+        as: '',
+        crossOrigin: null,
+        source: 'head',
+      },
+      {
+        rel: 'stylesheet',
+        href: 'http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200',
+        hrefRaw: './dbw_tester.css?scriptActivated&delay=200',
+        hreflang: '',
+        as: '',
+        crossOrigin: null,
+        source: 'head',
+      },
+    ],
+    MetaElements: [
+      {
+        name: '',
+        content: '',
+        charset: 'utf-8',
+      },
+      {
+        name: 'viewport',
+        content: 'width=device-width, initial-scale=1, minimum-scale=1',
+      },
+      {
+        name: '',
+        content: 'Open Graph smoke test description',
+        property: 'og:description',
+      },
+    ],
+    TagsBlockingFirstPaint: [
+      {
+        tag: {
+          tagName: 'LINK',
+          url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=100',
         },
-        {
-          rel: 'stylesheet',
-          href: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-          hrefRaw: './unknown404.css?delay=200',
-          hreflang: '',
-          as: '',
-          crossOrigin: null,
-          source: 'head',
+      },
+      {
+        tag: {
+          tagName: 'LINK',
+          url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
         },
-        {
-          rel: 'stylesheet',
-          href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200',
-          hrefRaw: './dbw_tester.css?delay=2200',
-          hreflang: '',
-          as: '',
-          crossOrigin: null,
-          source: 'head',
+      },
+      {
+        tag: {
+          tagName: 'LINK',
+          url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200',
         },
-        {
-          rel: 'stylesheet',
-          href: 'http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled',
-          hrefRaw: './dbw_disabled.css?delay=200&isdisabled',
-          hreflang: '',
-          as: '',
-          crossOrigin: null,
-          source: 'head',
-        },
-        {
-          rel: 'stylesheet',
-          href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
-          hrefRaw: './dbw_tester.css?delay=3000&capped',
-          hreflang: '',
-          as: '',
-          crossOrigin: null,
-          source: 'head',
-        },
-        {
-          rel: 'stylesheet',
-          href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true',
-          hrefRaw: './dbw_tester.css?delay=2000&async=true',
-          hreflang: '',
-          as: 'style',
-          crossOrigin: null,
-          source: 'head',
-        },
-        {
-          rel: 'stylesheet',
-          href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true',
-          hrefRaw: './dbw_tester.css?delay=3000&async=true',
-          hreflang: '',
-          as: '',
-          crossOrigin: null,
-          source: 'head',
-        },
-        {
-          rel: 'alternate stylesheet',
-          href: 'http://localhost:10200/dobetterweb/empty.css',
-          hrefRaw: './empty.css',
-          hreflang: '',
-          as: '',
-          crossOrigin: null,
-          source: 'head',
-        },
-        {
-          rel: 'stylesheet',
-          href: 'http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200',
-          hrefRaw: './dbw_tester.css?scriptActivated&delay=200',
-          hreflang: '',
-          as: '',
-          crossOrigin: null,
-          source: 'head',
-        },
-      ],
-      MetaElements: [
-        {
-          name: '',
-          content: '',
-          charset: 'utf-8',
-        },
-        {
-          name: 'viewport',
-          content: 'width=device-width, initial-scale=1, minimum-scale=1',
-        },
-        {
-          name: '',
-          content: 'Open Graph smoke test description',
-          property: 'og:description',
-        },
-      ],
-      TagsBlockingFirstPaint: [
-        {
-          tag: {
-            tagName: 'LINK',
-            url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=100',
-          },
-        },
-        {
-          tag: {
-            tagName: 'LINK',
-            url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-          },
-        },
-        {
-          tag: {
-            tagName: 'LINK',
-            url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200',
-          },
 
-        },
-        {
-          tag: {
-            tagName: 'LINK',
-            url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
-            mediaChanges: [
-              {
-                href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
-                media: 'not-matching',
-                matches: false,
-              },
-              {
-                href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
-                media: 'screen',
-                matches: true,
-              },
-            ],
-          },
-        },
-        {
-          tag: {
-            tagName: 'SCRIPT',
-            url: 'http://localhost:10200/dobetterweb/dbw_tester.js',
-          },
-        },
-        {
-          tag: {
-            tagName: 'SCRIPT',
-            url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
-          },
-        },
-      ],
-      GlobalListeners: [{
-        type: 'unload',
-        scriptId: /^\d+$/,
-        lineNumber: '>300',
-        columnNumber: '>30',
-      }],
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-      finalUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-      audits: {
-        'errors-in-console': {
-          score: 0,
-          details: {
-            items: [
-              {
-                source: 'other',
-                description: 'Application Cache Error event: Manifest fetch failed (404) http://localhost:10200/dobetterweb/clock.appcache',
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-              },
-              {
-                source: 'exception',
-                description: /^Error: A distinctive error\s+at http:\/\/localhost:10200\/dobetterweb\/dbw_tester.html:\d+:\d+$/,
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-              },
-              {
-                source: 'console.error',
-                description: 'Error! Error!',
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-              },
-              {
-                source: 'network',
-                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-                url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-              },
-              {
-                source: 'network',
-                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-                url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
-              },
-              {
-                source: 'network',
-                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-                url: 'http://localhost:10200/favicon.ico',
-              },
-              {
-                source: 'network',
-                description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-                url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-              },
-            ],
-          },
-        },
-        'is-on-https': {
-          score: 0,
-          details: {
-            items: [
-              {
-                url: 'http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js',
-                resolution: 'Allowed',
-              },
-            ],
-          },
-        },
-        'external-anchors-use-rel-noopener': {
-          score: 0,
-          warnings: [/Unable to determine.*<a target="_blank">/],
-          details: {
-            items: {
-              length: 3,
-            },
-          },
-        },
-        'appcache-manifest': {
-          score: 0,
-          displayValue: 'Found "clock.appcache"',
-        },
-        'geolocation-on-start': {
-          score: 0,
-        },
-        'no-document-write': {
-          score: 0,
-          details: {
-            items: {
-              length: 3,
-            },
-          },
-        },
-        'no-vulnerable-libraries': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
-          },
-        },
-        'notification-on-start': {
-          score: 0,
-        },
-        'render-blocking-resources': {
-          score: '<1',
-          numericValue: '>100',
-          details: {
-            items: [
-              {
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=100',
-              },
-              {
-                url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-              },
-              {
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200',
-              },
-              {
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
-              },
-              {
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.js',
-              },
-              {
-                url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
-              },
-            ],
-          },
-        },
-        'uses-passive-event-listeners': {
-          score: 0,
-          details: {
-            items: {
-            // Note: Originally this was 7 but M56 defaults document-level
-            // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
-            // Note: It was 4, but {passive:false} doesn't get a warning as of M63: https://crbug.com/770208
-            // Note: It was 3, but wheel events are now also passive as of field trial in M71 https://crbug.com/626196
-              length: '>=1',
-            },
-          },
-        },
-        'deprecations': {
-          score: 0,
-          details: {
-            items: {
-            // Note: HTML Imports added to deprecations in m70, so 3 before, 4 after.
-              length: '>=3',
-            },
-          },
-        },
-        'password-inputs-can-be-pasted-into': {
-          score: 0,
-          details: {
-            items: {
-              length: 2,
-            },
-          },
-        },
-        'image-aspect-ratio': {
-          score: 0,
-          details: {
-            items: {
-              0: {
-                displayedAspectRatio: /^120 x 15/,
-                url: 'http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?iar1',
-              },
-              length: 1,
-            },
-          },
-        },
-        'image-size-responsive': {
-          score: 0,
-          details: {
-            items: {
-              0: {
-                url: 'http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?isr1',
-              },
-              length: 1,
-            },
-          },
-        },
-        'efficient-animated-content': {
-          score: '<0.5',
-          details: {
-            overallSavingsMs: '>2000',
-            items: [
-              {
-                url: 'http://localhost:10200/dobetterweb/lighthouse-rotating.gif',
-                totalBytes: 934285,
-                wastedBytes: 682028,
-              },
-            ],
-          },
-        },
-        'js-libraries': {
-          score: 1,
-          details: {
-            items: [{
-              name: 'jQuery',
+      },
+      {
+        tag: {
+          tagName: 'LINK',
+          url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
+          mediaChanges: [
+            {
+              href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
+              media: 'not-matching',
+              matches: false,
             },
             {
-              name: 'WordPress',
-            }],
-          },
-        },
-        'dom-size': {
-          score: 1,
-          numericValue: 149,
-          details: {
-            items: [
-              {statistic: 'Total DOM Elements', value: 149},
-              {statistic: 'Maximum DOM Depth', value: 4},
-              {
-                statistic: 'Maximum Child Elements',
-                value: 100,
-                node: {snippet: '<div id="shadow-root-container">'},
-              },
-            ],
-          },
-        },
-        'no-unload-listeners': {
-          score: 0,
-          details: {
-            items: [{
-              source: {
-                type: 'source-location',
-                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-                urlProvider: 'network',
-                line: '>300',
-                column: '>30',
-              },
-            }],
-          },
-        },
-        'full-page-screenshot': {
-          score: null,
-          details: {
-            type: 'full-page-screenshot',
-            screenshot: {
-              width: 360,
-              // Allow for differences in platforms.
-              height: '1350±20',
-              data: /^data:image\/jpeg;.{500,}/,
+              href: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
+              media: 'screen',
+              matches: true,
             },
-            nodes: {
-              'page-0-IMG': {
-                // Test that these are numbers and in the ballpark.
-                top: '650±50',
-                bottom: '650±50',
-                left: '10±10',
-                right: '120±20',
-                width: '120±20',
-                height: '20±20',
-              },
-              // And then many more nodes.
+          ],
+        },
+      },
+      {
+        tag: {
+          tagName: 'SCRIPT',
+          url: 'http://localhost:10200/dobetterweb/dbw_tester.js',
+        },
+      },
+      {
+        tag: {
+          tagName: 'SCRIPT',
+          url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
+        },
+      },
+    ],
+    GlobalListeners: [{
+      type: 'unload',
+      scriptId: /^\d+$/,
+      lineNumber: '>300',
+      columnNumber: '>30',
+    }],
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+    finalUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+    audits: {
+      'errors-in-console': {
+        score: 0,
+        details: {
+          items: [
+            {
+              source: 'other',
+              description: 'Application Cache Error event: Manifest fetch failed (404) http://localhost:10200/dobetterweb/clock.appcache',
+              url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
             },
+            {
+              source: 'exception',
+              description: /^Error: A distinctive error\s+at http:\/\/localhost:10200\/dobetterweb\/dbw_tester.html:\d+:\d+$/,
+              url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+            },
+            {
+              source: 'console.error',
+              description: 'Error! Error!',
+              url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+            },
+            {
+              source: 'network',
+              description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+              url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
+            },
+            {
+              source: 'network',
+              description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+              url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
+            },
+            {
+              source: 'network',
+              description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+              url: 'http://localhost:10200/favicon.ico',
+            },
+            {
+              source: 'network',
+              description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+              url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
+            },
+          ],
+        },
+      },
+      'is-on-https': {
+        score: 0,
+        details: {
+          items: [
+            {
+              url: 'http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js',
+              resolution: 'Allowed',
+            },
+          ],
+        },
+      },
+      'external-anchors-use-rel-noopener': {
+        score: 0,
+        warnings: [/Unable to determine.*<a target="_blank">/],
+        details: {
+          items: {
+            length: 3,
           },
         },
       },
-    },
-  },
-  {
-    artifacts: {
-      InspectorIssues: {
-        mixedContent: [
+      'appcache-manifest': {
+        score: 0,
+        displayValue: 'Found "clock.appcache"',
+      },
+      'geolocation-on-start': {
+        score: 0,
+      },
+      'no-document-write': {
+        score: 0,
+        details: {
+          items: {
+            length: 3,
+          },
+        },
+      },
+      'no-vulnerable-libraries': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
+          },
+        },
+      },
+      'notification-on-start': {
+        score: 0,
+      },
+      'render-blocking-resources': {
+        score: '<1',
+        numericValue: '>100',
+        details: {
+          items: [
+            {
+              url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=100',
+            },
+            {
+              url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
+            },
+            {
+              url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200',
+            },
+            {
+              url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
+            },
+            {
+              url: 'http://localhost:10200/dobetterweb/dbw_tester.js',
+            },
+            {
+              url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
+            },
+          ],
+        },
+      },
+      'uses-passive-event-listeners': {
+        score: 0,
+        details: {
+          items: {
+          // Note: Originally this was 7 but M56 defaults document-level
+          // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
+          // Note: It was 4, but {passive:false} doesn't get a warning as of M63: https://crbug.com/770208
+          // Note: It was 3, but wheel events are now also passive as of field trial in M71 https://crbug.com/626196
+            length: '>=1',
+          },
+        },
+      },
+      'deprecations': {
+        score: 0,
+        details: {
+          items: {
+          // Note: HTML Imports added to deprecations in m70, so 3 before, 4 after.
+            length: '>=3',
+          },
+        },
+      },
+      'password-inputs-can-be-pasted-into': {
+        score: 0,
+        details: {
+          items: {
+            length: 2,
+          },
+        },
+      },
+      'image-aspect-ratio': {
+        score: 0,
+        details: {
+          items: {
+            0: {
+              displayedAspectRatio: /^120 x 15/,
+              url: 'http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?iar1',
+            },
+            length: 1,
+          },
+        },
+      },
+      'image-size-responsive': {
+        score: 0,
+        details: {
+          items: {
+            0: {
+              url: 'http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?isr1',
+            },
+            length: 1,
+          },
+        },
+      },
+      'efficient-animated-content': {
+        score: '<0.5',
+        details: {
+          overallSavingsMs: '>2000',
+          items: [
+            {
+              url: 'http://localhost:10200/dobetterweb/lighthouse-rotating.gif',
+              totalBytes: 934285,
+              wastedBytes: 682028,
+            },
+          ],
+        },
+      },
+      'js-libraries': {
+        score: 1,
+        details: {
+          items: [{
+            name: 'jQuery',
+          },
           {
-            _minChromiumMilestone: 88, // We went from Warning to AutoUpgrade in https://chromium-review.googlesource.com/c/chromium/src/+/2480817
-            resourceType: 'Image',
-            resolutionStatus: 'MixedContentAutomaticallyUpgraded',
-            insecureURL: 'http://www.mixedcontentexamples.com/Content/Test/steveholt.jpg',
-            mainResourceURL: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
-            request: {
-              url: 'http://www.mixedcontentexamples.com/Content/Test/steveholt.jpg',
-            },
-          },
-        ],
+            name: 'WordPress',
+          }],
+        },
       },
-    },
-    lhr: {
-      requestedUrl: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
-      finalUrl: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
-      audits: {
-        'is-on-https': {
-          score: 0,
+      'dom-size': {
+        score: 1,
+        numericValue: 149,
+        details: {
+          items: [
+            {statistic: 'Total DOM Elements', value: 149},
+            {statistic: 'Maximum DOM Depth', value: 4},
+            {
+              statistic: 'Maximum Child Elements',
+              value: 100,
+              node: {snippet: '<div id="shadow-root-container">'},
+            },
+          ],
+        },
+      },
+      'no-unload-listeners': {
+        score: 0,
+        details: {
+          items: [{
+            source: {
+              type: 'source-location',
+              url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+              urlProvider: 'network',
+              line: '>300',
+              column: '>30',
+            },
+          }],
+        },
+      },
+      'full-page-screenshot': {
+        score: null,
+        details: {
+          type: 'full-page-screenshot',
+          screenshot: {
+            width: 360,
+            // Allow for differences in platforms.
+            height: '1350±20',
+            data: /^data:image\/jpeg;.{500,}/,
+          },
+          nodes: {
+            'page-0-IMG': {
+              // Test that these are numbers and in the ballpark.
+              top: '650±50',
+              bottom: '650±50',
+              left: '10±10',
+              right: '120±20',
+              width: '120±20',
+              height: '20±20',
+            },
+            // And then many more nodes.
+          },
         },
       },
     },
   },
-];
+};
 
 module.exports = expectations;

--- a/lighthouse-cli/test/smokehouse/test-definitions/errors/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/errors/error-expectations.js
@@ -12,78 +12,91 @@ const NONEMPTY_ARRAY = {
 };
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for sites with various errors.
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results for a site with a JS infinite loop.
  */
-const expectations = [
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/infinite-loop.html',
-      finalUrl: 'http://localhost:10200/infinite-loop.html',
-      runtimeError: {code: 'PAGE_HUNG'},
-      runWarnings: ['Lighthouse was unable to reliably load the URL you requested because the page stopped responding.'],
-      audits: {
-        'first-contentful-paint': {
-          scoreDisplayMode: 'error',
-          errorMessage: 'Required traces gatherer did not run.',
-        },
-      },
-    },
-    artifacts: {
-      PageLoadError: {code: 'PAGE_HUNG'},
-      devtoolsLogs: {
-        'pageLoadError-defaultPass': NONEMPTY_ARRAY,
-      },
-      traces: {
-        'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY},
+const infiniteLoop = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/infinite-loop.html',
+    finalUrl: 'http://localhost:10200/infinite-loop.html',
+    runtimeError: {code: 'PAGE_HUNG'},
+    runWarnings: ['Lighthouse was unable to reliably load the URL you requested because the page stopped responding.'],
+    audits: {
+      'first-contentful-paint': {
+        scoreDisplayMode: 'error',
+        errorMessage: 'Required traces gatherer did not run.',
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'https://expired.badssl.com',
-      finalUrl: 'https://expired.badssl.com/',
-      runtimeError: {code: 'INSECURE_DOCUMENT_REQUEST'},
-      runWarnings: ['The URL you have provided does not have a valid security certificate. net::ERR_CERT_DATE_INVALID'],
-      audits: {
-        'first-contentful-paint': {
-          scoreDisplayMode: 'error',
-          errorMessage: 'Required traces gatherer did not run.',
-        },
-      },
+  artifacts: {
+    PageLoadError: {code: 'PAGE_HUNG'},
+    devtoolsLogs: {
+      'pageLoadError-defaultPass': NONEMPTY_ARRAY,
     },
-    artifacts: {
-      PageLoadError: {code: 'INSECURE_DOCUMENT_REQUEST'},
-      devtoolsLogs: {
-        'pageLoadError-defaultPass': NONEMPTY_ARRAY,
-      },
-      traces: {
-        'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY},
-      },
+    traces: {
+      'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY},
     },
   },
-  {
-    lhr: {
-      // Our interstitial error handling used to be quite aggressive, so we'll test a page
-      // that has a bad iframe to make sure LH audits successfully.
-      // https://github.com/GoogleChrome/lighthouse/issues/9562
-      requestedUrl: 'http://localhost:10200/badssl-iframe.html',
-      finalUrl: 'http://localhost:10200/badssl-iframe.html',
-      audits: {
-        'first-contentful-paint': {
-          scoreDisplayMode: 'numeric',
-        },
-      },
-    },
-    artifacts: {
-      devtoolsLogs: {
-        defaultPass: NONEMPTY_ARRAY,
-      },
-      traces: {
-        defaultPass: {traceEvents: NONEMPTY_ARRAY},
-      },
-    },
-  },
-];
+};
 
-module.exports = expectations;
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results for a site with an expired certificate.
+ */
+const expiredSsl = {
+  lhr: {
+    requestedUrl: 'https://expired.badssl.com',
+    finalUrl: 'https://expired.badssl.com/',
+    runtimeError: {code: 'INSECURE_DOCUMENT_REQUEST'},
+    runWarnings: ['The URL you have provided does not have a valid security certificate. net::ERR_CERT_DATE_INVALID'],
+    audits: {
+      'first-contentful-paint': {
+        scoreDisplayMode: 'error',
+        errorMessage: 'Required traces gatherer did not run.',
+      },
+    },
+  },
+  artifacts: {
+    PageLoadError: {code: 'INSECURE_DOCUMENT_REQUEST'},
+    devtoolsLogs: {
+      'pageLoadError-defaultPass': NONEMPTY_ARRAY,
+    },
+    traces: {
+      'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY},
+    },
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results for a site with an iframe containing a site with
+ * an expired certificate.
+ */
+const iframeBadSsl = {
+  lhr: {
+    // Our interstitial error handling used to be quite aggressive, so we'll test a page
+    // that has a bad iframe to make sure LH audits successfully.
+    // https://github.com/GoogleChrome/lighthouse/issues/9562
+    requestedUrl: 'http://localhost:10200/badssl-iframe.html',
+    finalUrl: 'http://localhost:10200/badssl-iframe.html',
+    audits: {
+      'first-contentful-paint': {
+        scoreDisplayMode: 'numeric',
+      },
+    },
+  },
+  artifacts: {
+    devtoolsLogs: {
+      defaultPass: NONEMPTY_ARRAY,
+    },
+    traces: {
+      defaultPass: {traceEvents: NONEMPTY_ARRAY},
+    },
+  },
+};
+
+module.exports = {
+  infiniteLoop,
+  expiredSsl,
+  iframeBadSsl,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/forms/form-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/forms/form-expectations.js
@@ -6,580 +6,578 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse artifacts from Form gatherer
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse artifacts from Form gatherer and autocomplete audit.
  */
-const expectations = [
-  {
-    artifacts: {
-      FormElements: [
-        {
-          attributes: {
-            id: 'checkout',
-            name: 'checkout',
-            autocomplete: 'on',
-          },
-          inputs: [
-            {
-              id: 'name_cc1',
-              name: 'name_cc1',
-              placeholder: 'John Doe',
-              autocomplete: {
-                property: '',
-                attribute: 'sectio-red shipping cc-namez',
-                prediction: 'UNKNOWN_TYPE',
-              },
-              node: {
-                nodeLabel: 'textarea',
-                snippet:
-                '<textarea type="text" id="name_cc1" name="name_cc1" autocomplete="sectio-red shipping cc-namez" placeholder="John Doe">',
-              }},
-            {
-              id: 'CCNo1',
-              name: 'CCNo1',
-              placeholder: '5555 5555 5555 5555',
-              autocomplete: {
-                property: 'cc-number',
-                attribute: 'cc-number',
-                prediction: 'HTML_TYPE_CREDIT_CARD_NUMBER',
-              },
-              node: {
-                nodeLabel: 'input',
-                snippet:
-                '<input type="text" id="CCNo1" name="CCNo1" autocomplete="cc-number" placeholder="5555 5555 5555 5555">',
-              }},
-            {
-              id: 'CCExpiresMonth1',
-              name: 'CCExpiresMonth1',
-              autocomplete: {
-                property: 'cc-exp-month',
-                attribute: 'cc-exp-month',
-                prediction: 'HTML_TYPE_CREDIT_CARD_EXP_MONTH',
-              },
-              node: {
-                nodeLabel: 'MM\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12',
-                snippet:
-                '<select id="CCExpiresMonth1" name="CCExpiresMonth1" autocomplete="cc-exp-month">'},
-            },
-            {
-              id: 'CCExpiresYear1',
-              name: '',
-              autocomplete: {
-                property: 'section-red billing cc-exp-year',
-                attribute: 'section-red billing cc-exp-year',
-                prediction: 'HTML_TYPE_CREDIT_CARD_EXP_YEAR',
-              },
-              node: {
-                nodeLabel: 'YY\n2019\n2020\n2021\n2022\n2023\n2024\n2025\n2026\n2027\n2028\n2029',
-                snippet:
-                '<select id="CCExpiresYear1" autocomplete="section-red billing cc-exp-year">',
-              }},
-            {
-              id: 'cvc1',
-              name: 'cvc1',
-              placeholder: '555',
-              autocomplete: {
-                property: 'cc-csc',
-                attribute: 'cc-csc',
-                prediction: 'HTML_TYPE_CREDIT_CARD_VERIFICATION_CODE',
-              },
-              node: {
-                nodeLabel: 'input',
-                snippet: '<input id="cvc1" name="cvc1" autocomplete="cc-csc" placeholder="555">'},
-            },
-          ],
-          labels: [
-            {
-              for: 'name_cc1',
-              node: {
-                nodeLabel: 'Name on card:',
-                snippet: '<label for="name_cc1">'},
-            },
-            {
-              for: 'CCNo1',
-              node: {
-                nodeLabel: 'Credit card number:',
-                snippet: '<label for="CCNo1">'},
-            },
-            {
-              for: 'CCExpiresMonth1',
-              node: {
-                nodeLabel: 'Expiry Date:',
-                snippet: '<label for="CCExpiresMonth1">',
-              },
-            },
-            {
-              for: 'cvc1',
-              node: {
-                nodeLabel: 'CVC:',
-                snippet: '<label for="cvc1">',
-              },
-            },
-          ],
-          node: {
-            nodeLabel:
-            'Name on card: \nCredit card number: \nExpiry Date: \nMM\n01\n02\n03\n04\n05\n06\n07\n08\n09…',
-            snippet: '<form id="checkout" name="checkout" action="../done.html" method="post">',
-          },
+const expectations = {
+  artifacts: {
+    FormElements: [
+      {
+        attributes: {
+          id: 'checkout',
+          name: 'checkout',
+          autocomplete: 'on',
         },
-        {
-          inputs: [
+        inputs: [
+          {
+            id: 'name_cc1',
+            name: 'name_cc1',
+            placeholder: 'John Doe',
+            autocomplete: {
+              property: '',
+              attribute: 'sectio-red shipping cc-namez',
+              prediction: 'UNKNOWN_TYPE',
+            },
+            node: {
+              nodeLabel: 'textarea',
+              snippet:
+              '<textarea type="text" id="name_cc1" name="name_cc1" autocomplete="sectio-red shipping cc-namez" placeholder="John Doe">',
+            }},
+          {
+            id: 'CCNo1',
+            name: 'CCNo1',
+            placeholder: '5555 5555 5555 5555',
+            autocomplete: {
+              property: 'cc-number',
+              attribute: 'cc-number',
+              prediction: 'HTML_TYPE_CREDIT_CARD_NUMBER',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet:
+              '<input type="text" id="CCNo1" name="CCNo1" autocomplete="cc-number" placeholder="5555 5555 5555 5555">',
+            }},
+          {
+            id: 'CCExpiresMonth1',
+            name: 'CCExpiresMonth1',
+            autocomplete: {
+              property: 'cc-exp-month',
+              attribute: 'cc-exp-month',
+              prediction: 'HTML_TYPE_CREDIT_CARD_EXP_MONTH',
+            },
+            node: {
+              nodeLabel: 'MM\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12',
+              snippet:
+              '<select id="CCExpiresMonth1" name="CCExpiresMonth1" autocomplete="cc-exp-month">'},
+          },
+          {
+            id: 'CCExpiresYear1',
+            name: '',
+            autocomplete: {
+              property: 'section-red billing cc-exp-year',
+              attribute: 'section-red billing cc-exp-year',
+              prediction: 'HTML_TYPE_CREDIT_CARD_EXP_YEAR',
+            },
+            node: {
+              nodeLabel: 'YY\n2019\n2020\n2021\n2022\n2023\n2024\n2025\n2026\n2027\n2028\n2029',
+              snippet:
+              '<select id="CCExpiresYear1" autocomplete="section-red billing cc-exp-year">',
+            }},
+          {
+            id: 'cvc1',
+            name: 'cvc1',
+            placeholder: '555',
+            autocomplete: {
+              property: 'cc-csc',
+              attribute: 'cc-csc',
+              prediction: 'HTML_TYPE_CREDIT_CARD_VERIFICATION_CODE',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet: '<input id="cvc1" name="cvc1" autocomplete="cc-csc" placeholder="555">'},
+          },
+        ],
+        labels: [
+          {
+            for: 'name_cc1',
+            node: {
+              nodeLabel: 'Name on card:',
+              snippet: '<label for="name_cc1">'},
+          },
+          {
+            for: 'CCNo1',
+            node: {
+              nodeLabel: 'Credit card number:',
+              snippet: '<label for="CCNo1">'},
+          },
+          {
+            for: 'CCExpiresMonth1',
+            node: {
+              nodeLabel: 'Expiry Date:',
+              snippet: '<label for="CCExpiresMonth1">',
+            },
+          },
+          {
+            for: 'cvc1',
+            node: {
+              nodeLabel: 'CVC:',
+              snippet: '<label for="cvc1">',
+            },
+          },
+        ],
+        node: {
+          nodeLabel:
+          'Name on card: \nCredit card number: \nExpiry Date: \nMM\n01\n02\n03\n04\n05\n06\n07\n08\n09…',
+          snippet: '<form id="checkout" name="checkout" action="../done.html" method="post">',
+        },
+      },
+      {
+        inputs: [
+          {
+            id: 'name_shipping',
+            name: '',
+            placeholder: 'John Doe',
+            autocomplete: {
+              property: 'name',
+              attribute: 'name',
+              prediction: 'HTML_TYPE_NAME',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet:
+              '<input type="text" id="name_shipping" autocomplete="name" placeholder="John Doe">',
+            }},
+          {
+            id: 'address_shipping',
+            name: '',
+            placeholder: 'Your address',
+            autocomplete: {
+              property: '',
+              attribute: 'shippin street-address',
+              prediction: 'ADDRESS_HOME_LINE1',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet:
+              '<input type="text" id="address_shipping" autocomplete="shippin street-address" placeholder="Your address">',
+            }},
+          {
+            id: 'city_shipping',
+            name: '',
+            placeholder: 'city you live',
+            autocomplete: {
+              property: '',
+              attribute: 'mobile section-red shipping address-level2',
+              prediction: 'ADDRESS_HOME_CITY',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet:
+              '<input type="text" id="city_shipping" placeholder="city you live" autocomplete="mobile section-red shipping address-level2">',
+            }},
+          {
+            id: 'state_shipping',
+            name: '',
+            autocomplete: {
+              property: '',
+              attribute: null,
+              prediction: 'ADDRESS_HOME_STATE',
+            },
+            node: {
+              nodeLabel: 'Select a state\nCA\nMA\nNY\nMD\nOR\nOH\nIL\nDC',
+              snippet: '<select id="state_shipping">'},
+          },
+          {
+            id: 'zip_shipping',
+            name: '',
+            placeholder: '',
+            autocomplete: {
+              property: '',
+              attribute: null,
+              prediction: 'ADDRESS_HOME_ZIP',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet: '<input type="text" id="zip_shipping">'},
+          },
+          {
+            id: 'name_billing',
+            name: 'name_billing',
+            placeholder: 'your name',
+            autocomplete: {
+              property: '',
+              attribute: 'sectio-red billing name',
+              prediction: 'NAME_FULL',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet:
+              '<input type="text" id="name_billing" name="name_billing" placeholder="your name" autocomplete="sectio-red billing name">',
+            }},
+          {
+            id: 'address_billing',
+            name: 'address_billing',
+            placeholder: 'your address',
+            autocomplete: {
+              property: 'billing street-address',
+              attribute: 'billing street-address',
+              prediction: 'HTML_TYPE_STREET_ADDRESS',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet:
+              '<input type="text" id="address_billing" name="address_billing" autocomplete="billing street-address" placeholder="your address">',
+            }},
+          {
+            id: 'city_billing',
+            name: 'city_billing',
+            placeholder: 'city you live in',
+            autocomplete: {
+              property: '',
+              attribute: 'section-red shipping ',
+              prediction: 'UNKNOWN_TYPE',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet:
+              '<input type="text" id="city_billing" name="city_billing" placeholder="city you live in" autocomplete="section-red shipping ">',
+            }},
+          {
+            id: 'state_billing',
+            name: 'state_billing',
+            autocomplete: {
+              property: '',
+              attribute: null,
+              prediction: 'ADDRESS_HOME_STATE',
+            },
+            node: {
+              nodeLabel:
+              '\n            Select a state\n            CA\n            MA\n            NY\n      …',
+              snippet: '<select id="state_billing" name="state_billing">',
+            }},
+          {
+            id: 'zip_billing',
+            name: '',
+            placeholder: '',
+            autocomplete: {
+              property: '',
+              attribute: null,
+              prediction: 'ADDRESS_HOME_ZIP',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet: '<input type="text" id="zip_billing">',
+            }},
+          {
+            id: 'name_cc2',
+            name: 'name_cc2',
+            placeholder: '',
+            autocomplete: {
+              property: 'cc-name',
+              attribute: 'cc-name',
+              prediction: 'HTML_TYPE_CREDIT_CARD_NAME_FULL',
+            },
+            node: {
+              nodeLabel: 'textarea',
+              snippet:
+              '<textarea type="text" id="name_cc2" name="name_cc2" autocomplete="cc-name">',
+            }},
+          {
+            id: 'CCNo2',
+            name: 'CCNo2',
+            placeholder: '',
+            autocomplete: {
+              property: 'section-red cc-number',
+              attribute: 'section-red cc-number',
+              prediction: 'HTML_TYPE_CREDIT_CARD_NUMBER',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet:
+              '<input type="text" id="CCNo2" name="CCNo2" autocomplete="section-red cc-number">',
+            }},
+          {
+            id: 'CCExpiresMonth2',
+            name: 'CCExpiresMonth2',
+            autocomplete: {
+              property: '',
+              attribute: null,
+              prediction: 'CREDIT_CARD_EXP_MONTH',
+            },
+            node: {
+              nodeLabel: 'MM\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12',
+              snippet: '<select id="CCExpiresMonth2" name="CCExpiresMonth2">',
+            }},
+          {
+            id: 'CCExpiresYear',
+            name: '',
+            autocomplete: {
+              property: '',
+              attribute: null,
+              prediction: 'CREDIT_CARD_EXP_4_DIGIT_YEAR',
+            },
+            node: {
+              nodeLabel: 'YY\n2019\n2020\n2021\n2022\n2023\n2024\n2025\n2026\n2027\n2028\n2029',
+              snippet: '<select id="CCExpiresYear">'},
+          },
+          {
+            id: 'cvc2',
+            name: 'cvc2',
+            placeholder: '',
+            autocomplete: {
+              property: 'cc-csc',
+              attribute: 'cc-csc',
+              prediction: 'HTML_TYPE_CREDIT_CARD_VERIFICATION_CODE',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet: '<input id="cvc2" name="cvc2" autocomplete="cc-csc">',
+            }},
+          {
+            id: 'mobile-number',
+            name: 'mobile-number',
+            placeholder: '',
+            autocomplete: {
+              property: 'section-red shipping mobile tel',
+              attribute: 'section-red shipping mobile tel',
+              prediction: 'HTML_TYPE_TEL',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet:
+              '<input type="text" name="mobile-number" id="mobile-number" autocomplete="section-red shipping mobile tel">',
+            }},
+          {
+            id: 'random',
+            name: 'random',
+            placeholder: '',
+            autocomplete: {
+              property: '',
+              attribute: null,
+              prediction: 'UNKNOWN_TYPE',
+            },
+            node: {
+              nodeLabel: 'input',
+              snippet: '<input type="text" name="random" id="random">'},
+          },
+        ],
+        labels: [
+          {
+            for: 'name_shipping',
+            node: {
+              nodeLabel: 'Name:',
+              snippet: '<label for="name_shipping">'},
+          },
+          {
+            for: 'address_shipping',
+            node: {
+              nodeLabel: 'Address:',
+              snippet: '<label for="address_shipping">'},
+          },
+          {
+            for: 'city_shipping',
+            node: {
+              nodeLabel: 'City:',
+              snippet: '<label for="city_shipping">'},
+          },
+          {
+            for: 'Sstate_shipping',
+            node: {
+              nodeLabel: 'State:',
+              snippet: '<label for="Sstate_shipping">'},
+          },
+          {
+            for: 'zip_shipping',
+            node: {
+              nodeLabel: 'Zip:',
+              snippet: '<label for="zip_shipping">'},
+          },
+          {
+            for: 'name_billing',
+            node: {
+              nodeLabel: 'Name:',
+              snippet: '<label for="name_billing">'},
+          },
+          {
+            for: 'address_billing',
+            node: {
+              nodeLabel: 'Address:',
+              snippet: '<label for="address_billing">'},
+          },
+          {
+            for: 'city_billing',
+            node: {
+              nodeLabel: 'City:',
+              snippet: '<label for="city_billing">'},
+          },
+          {
+            for: 'state_billing',
+            node: {
+              nodeLabel: 'State:',
+              snippet: '<label for="state_billing">'},
+          },
+          {
+            for: 'zip_billing',
+            node: {
+              nodeLabel: 'Zip:',
+              snippet: '<label for="zip_billing">'},
+          },
+          {
+            for: 'name_cc2',
+            node: {
+              nodeLabel: 'Name on card:',
+              snippet: '<label for="name_cc2">'},
+          },
+          {
+            for: 'CCNo2',
+            node: {
+              nodeLabel: 'Credit card number:',
+              snippet: '<label for="CCNo2">'},
+          },
+          {
+            for: 'CCExpiresMonth2',
+            node: {
+              nodeLabel: 'Expiry Date:',
+              snippet: '<label for="CCExpiresMonth2">'},
+          },
+          {
+            for: 'cvc2',
+            node: {
+              nodeLabel: 'CVC:',
+              snippet: '<label for="cvc2">'},
+          },
+          {
+            for: 'mobile-number',
+            node: {
+              nodeLabel: 'Mobile phone Number:',
+              snippet: '<label for="mobile-number">'},
+          },
+          {
+            for: 'random',
+            node: {
+              nodeLabel: 'Random Page Input:',
+              snippet: '<label for="random">'},
+          },
+        ],
+      },
+    ],
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/form.html',
+    finalUrl: 'http://localhost:10200/form.html',
+    audits: {
+      autocomplete: {
+        score: 0,
+        warnings: [
+          '`autocomplete` token(s): "sectio-red shipping cc-namez" is invalid in <textarea type="text" id="name_cc1" name="name_cc1" autocomplete="sectio-red shipping cc-namez" placeholder="John Doe">',
+          '`autocomplete` token(s): "shippin street-address" is invalid in <input type="text" id="address_shipping" autocomplete="shippin street-address" placeholder="Your address">',
+          '`autocomplete` token(s): "mobile section-red shipping address-level2" is invalid in <input type="text" id="city_shipping" placeholder="city you live" autocomplete="mobile section-red shipping address-level2">',
+          'Review order of tokens: "mobile section-red shipping address-level2" in <input type="text" id="city_shipping" placeholder="city you live" autocomplete="mobile section-red shipping address-level2">',
+          '`autocomplete` token(s): "sectio-red billing name" is invalid in <input type="text" id="name_billing" name="name_billing" placeholder="your name" autocomplete="sectio-red billing name">',
+          '`autocomplete` token(s): "section-red shipping " is invalid in <input type="text" id="city_billing" name="city_billing" placeholder="city you live in" autocomplete="section-red shipping ">',
+        ],
+        details: {
+          items: [
             {
-              id: 'name_shipping',
-              name: '',
-              placeholder: 'John Doe',
-              autocomplete: {
-                property: 'name',
-                attribute: 'name',
-                prediction: 'HTML_TYPE_NAME',
-              },
               node: {
-                nodeLabel: 'input',
+                type: 'node',
                 snippet:
-                '<input type="text" id="name_shipping" autocomplete="name" placeholder="John Doe">',
-              }},
-            {
-              id: 'address_shipping',
-              name: '',
-              placeholder: 'Your address',
-              autocomplete: {
-                property: '',
-                attribute: 'shippin street-address',
-                prediction: 'ADDRESS_HOME_LINE1',
+                  '<textarea type="text" id="name_cc1" name="name_cc1" autocomplete="sectio-red shipping cc-namez" placeholder="John Doe">',
+                nodeLabel: 'textarea',
               },
+              suggestion: 'Requires manual review',
+              current: 'sectio-red shipping cc-namez',
+            },
+            {
               node: {
-                nodeLabel: 'input',
+                type: 'node',
                 snippet:
-                '<input type="text" id="address_shipping" autocomplete="shippin street-address" placeholder="Your address">',
-              }},
-            {
-              id: 'city_shipping',
-              name: '',
-              placeholder: 'city you live',
-              autocomplete: {
-                property: '',
-                attribute: 'mobile section-red shipping address-level2',
-                prediction: 'ADDRESS_HOME_CITY',
-              },
-              node: {
+                  '<input type="text" id="address_shipping" autocomplete="shippin street-address" placeholder="Your address">',
                 nodeLabel: 'input',
-                snippet:
-                '<input type="text" id="city_shipping" placeholder="city you live" autocomplete="mobile section-red shipping address-level2">',
-              }},
-            {
-              id: 'state_shipping',
-              name: '',
-              autocomplete: {
-                property: '',
-                attribute: null,
-                prediction: 'ADDRESS_HOME_STATE',
               },
+              suggestion: 'address-line1',
+              current: 'shippin street-address',
+            },
+            {
               node: {
+                type: 'node',
+                snippet:
+                  '<input type="text" id="city_shipping" placeholder="city you live" autocomplete="mobile section-red shipping address-level2">',
+                nodeLabel: 'input',
+              },
+              suggestion: 'Review order of tokens',
+              current: 'mobile section-red shipping address-level2',
+            },
+            {
+              node: {
+                type: 'node',
+                snippet: '<select id="state_shipping">',
                 nodeLabel: 'Select a state\nCA\nMA\nNY\nMD\nOR\nOH\nIL\nDC',
-                snippet: '<select id="state_shipping">'},
+              },
+              suggestion: 'address-level1',
+              current: '',
             },
             {
-              id: 'zip_shipping',
-              name: '',
-              placeholder: '',
-              autocomplete: {
-                property: '',
-                attribute: null,
-                prediction: 'ADDRESS_HOME_ZIP',
-              },
               node: {
+                type: 'node',
+                snippet: '<input type="text" id="zip_shipping">',
                 nodeLabel: 'input',
-                snippet: '<input type="text" id="zip_shipping">'},
+              },
+              suggestion: 'postal-code',
+              current: '',
             },
             {
-              id: 'name_billing',
-              name: 'name_billing',
-              placeholder: 'your name',
-              autocomplete: {
-                property: '',
-                attribute: 'sectio-red billing name',
-                prediction: 'NAME_FULL',
-              },
               node: {
-                nodeLabel: 'input',
+                type: 'node',
                 snippet:
-                '<input type="text" id="name_billing" name="name_billing" placeholder="your name" autocomplete="sectio-red billing name">',
-              }},
-            {
-              id: 'address_billing',
-              name: 'address_billing',
-              placeholder: 'your address',
-              autocomplete: {
-                property: 'billing street-address',
-                attribute: 'billing street-address',
-                prediction: 'HTML_TYPE_STREET_ADDRESS',
-              },
-              node: {
+                  '<input type="text" id="name_billing" name="name_billing" placeholder="your name" autocomplete="sectio-red billing name">',
                 nodeLabel: 'input',
-                snippet:
-                '<input type="text" id="address_billing" name="address_billing" autocomplete="billing street-address" placeholder="your address">',
-              }},
-            {
-              id: 'city_billing',
-              name: 'city_billing',
-              placeholder: 'city you live in',
-              autocomplete: {
-                property: '',
-                attribute: 'section-red shipping ',
-                prediction: 'UNKNOWN_TYPE',
               },
+              suggestion: 'name',
+              current: 'sectio-red billing name',
+            },
+            {
               node: {
+                type: 'node',
+                snippet:
+                  '<input type="text" id="city_billing" name="city_billing" placeholder="city you live in" autocomplete="section-red shipping ">',
                 nodeLabel: 'input',
-                snippet:
-                '<input type="text" id="city_billing" name="city_billing" placeholder="city you live in" autocomplete="section-red shipping ">',
-              }},
-            {
-              id: 'state_billing',
-              name: 'state_billing',
-              autocomplete: {
-                property: '',
-                attribute: null,
-                prediction: 'ADDRESS_HOME_STATE',
               },
+              suggestion: 'Requires manual review',
+              current: 'section-red shipping ',
+            },
+            {
               node: {
-                nodeLabel:
-                '\n            Select a state\n            CA\n            MA\n            NY\n      …',
+                type: 'node',
                 snippet: '<select id="state_billing" name="state_billing">',
-              }},
-            {
-              id: 'zip_billing',
-              name: '',
-              placeholder: '',
-              autocomplete: {
-                property: '',
-                attribute: null,
-                prediction: 'ADDRESS_HOME_ZIP',
+                nodeLabel:
+                  '\n            Select a state\n            CA\n            MA\n            NY\n      …',
               },
+              suggestion: 'address-level1',
+              current: '',
+            },
+            {
               node: {
-                nodeLabel: 'input',
+                type: 'node',
                 snippet: '<input type="text" id="zip_billing">',
-              }},
-            {
-              id: 'name_cc2',
-              name: 'name_cc2',
-              placeholder: '',
-              autocomplete: {
-                property: 'cc-name',
-                attribute: 'cc-name',
-                prediction: 'HTML_TYPE_CREDIT_CARD_NAME_FULL',
-              },
-              node: {
-                nodeLabel: 'textarea',
-                snippet:
-                '<textarea type="text" id="name_cc2" name="name_cc2" autocomplete="cc-name">',
-              }},
-            {
-              id: 'CCNo2',
-              name: 'CCNo2',
-              placeholder: '',
-              autocomplete: {
-                property: 'section-red cc-number',
-                attribute: 'section-red cc-number',
-                prediction: 'HTML_TYPE_CREDIT_CARD_NUMBER',
-              },
-              node: {
                 nodeLabel: 'input',
-                snippet:
-                '<input type="text" id="CCNo2" name="CCNo2" autocomplete="section-red cc-number">',
-              }},
-            {
-              id: 'CCExpiresMonth2',
-              name: 'CCExpiresMonth2',
-              autocomplete: {
-                property: '',
-                attribute: null,
-                prediction: 'CREDIT_CARD_EXP_MONTH',
               },
+              suggestion: 'postal-code',
+              current: '',
+            },
+            {
               node: {
-                nodeLabel: 'MM\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12',
+                type: 'node',
                 snippet: '<select id="CCExpiresMonth2" name="CCExpiresMonth2">',
-              }},
-            {
-              id: 'CCExpiresYear',
-              name: '',
-              autocomplete: {
-                property: '',
-                attribute: null,
-                prediction: 'CREDIT_CARD_EXP_4_DIGIT_YEAR',
+                nodeLabel: 'MM\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12',
               },
+              suggestion: 'cc-exp-month',
+              current: '',
+            },
+            {
               node: {
+                type: 'node',
+                snippet: '<select id="CCExpiresYear">',
                 nodeLabel: 'YY\n2019\n2020\n2021\n2022\n2023\n2024\n2025\n2026\n2027\n2028\n2029',
-                snippet: '<select id="CCExpiresYear">'},
-            },
-            {
-              id: 'cvc2',
-              name: 'cvc2',
-              placeholder: '',
-              autocomplete: {
-                property: 'cc-csc',
-                attribute: 'cc-csc',
-                prediction: 'HTML_TYPE_CREDIT_CARD_VERIFICATION_CODE',
               },
-              node: {
-                nodeLabel: 'input',
-                snippet: '<input id="cvc2" name="cvc2" autocomplete="cc-csc">',
-              }},
-            {
-              id: 'mobile-number',
-              name: 'mobile-number',
-              placeholder: '',
-              autocomplete: {
-                property: 'section-red shipping mobile tel',
-                attribute: 'section-red shipping mobile tel',
-                prediction: 'HTML_TYPE_TEL',
-              },
-              node: {
-                nodeLabel: 'input',
-                snippet:
-                '<input type="text" name="mobile-number" id="mobile-number" autocomplete="section-red shipping mobile tel">',
-              }},
-            {
-              id: 'random',
-              name: 'random',
-              placeholder: '',
-              autocomplete: {
-                property: '',
-                attribute: null,
-                prediction: 'UNKNOWN_TYPE',
-              },
-              node: {
-                nodeLabel: 'input',
-                snippet: '<input type="text" name="random" id="random">'},
+              suggestion: 'cc-exp-year',
+              current: '',
             },
           ],
-          labels: [
-            {
-              for: 'name_shipping',
-              node: {
-                nodeLabel: 'Name:',
-                snippet: '<label for="name_shipping">'},
-            },
-            {
-              for: 'address_shipping',
-              node: {
-                nodeLabel: 'Address:',
-                snippet: '<label for="address_shipping">'},
-            },
-            {
-              for: 'city_shipping',
-              node: {
-                nodeLabel: 'City:',
-                snippet: '<label for="city_shipping">'},
-            },
-            {
-              for: 'Sstate_shipping',
-              node: {
-                nodeLabel: 'State:',
-                snippet: '<label for="Sstate_shipping">'},
-            },
-            {
-              for: 'zip_shipping',
-              node: {
-                nodeLabel: 'Zip:',
-                snippet: '<label for="zip_shipping">'},
-            },
-            {
-              for: 'name_billing',
-              node: {
-                nodeLabel: 'Name:',
-                snippet: '<label for="name_billing">'},
-            },
-            {
-              for: 'address_billing',
-              node: {
-                nodeLabel: 'Address:',
-                snippet: '<label for="address_billing">'},
-            },
-            {
-              for: 'city_billing',
-              node: {
-                nodeLabel: 'City:',
-                snippet: '<label for="city_billing">'},
-            },
-            {
-              for: 'state_billing',
-              node: {
-                nodeLabel: 'State:',
-                snippet: '<label for="state_billing">'},
-            },
-            {
-              for: 'zip_billing',
-              node: {
-                nodeLabel: 'Zip:',
-                snippet: '<label for="zip_billing">'},
-            },
-            {
-              for: 'name_cc2',
-              node: {
-                nodeLabel: 'Name on card:',
-                snippet: '<label for="name_cc2">'},
-            },
-            {
-              for: 'CCNo2',
-              node: {
-                nodeLabel: 'Credit card number:',
-                snippet: '<label for="CCNo2">'},
-            },
-            {
-              for: 'CCExpiresMonth2',
-              node: {
-                nodeLabel: 'Expiry Date:',
-                snippet: '<label for="CCExpiresMonth2">'},
-            },
-            {
-              for: 'cvc2',
-              node: {
-                nodeLabel: 'CVC:',
-                snippet: '<label for="cvc2">'},
-            },
-            {
-              for: 'mobile-number',
-              node: {
-                nodeLabel: 'Mobile phone Number:',
-                snippet: '<label for="mobile-number">'},
-            },
-            {
-              for: 'random',
-              node: {
-                nodeLabel: 'Random Page Input:',
-                snippet: '<label for="random">'},
-            },
-          ],
-        },
-      ],
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/form.html',
-      finalUrl: 'http://localhost:10200/form.html',
-      audits: {
-        autocomplete: {
-          score: 0,
-          warnings: [
-            '`autocomplete` token(s): "sectio-red shipping cc-namez" is invalid in <textarea type="text" id="name_cc1" name="name_cc1" autocomplete="sectio-red shipping cc-namez" placeholder="John Doe">',
-            '`autocomplete` token(s): "shippin street-address" is invalid in <input type="text" id="address_shipping" autocomplete="shippin street-address" placeholder="Your address">',
-            '`autocomplete` token(s): "mobile section-red shipping address-level2" is invalid in <input type="text" id="city_shipping" placeholder="city you live" autocomplete="mobile section-red shipping address-level2">',
-            'Review order of tokens: "mobile section-red shipping address-level2" in <input type="text" id="city_shipping" placeholder="city you live" autocomplete="mobile section-red shipping address-level2">',
-            '`autocomplete` token(s): "sectio-red billing name" is invalid in <input type="text" id="name_billing" name="name_billing" placeholder="your name" autocomplete="sectio-red billing name">',
-            '`autocomplete` token(s): "section-red shipping " is invalid in <input type="text" id="city_billing" name="city_billing" placeholder="city you live in" autocomplete="section-red shipping ">',
-          ],
-          details: {
-            items: [
-              {
-                node: {
-                  type: 'node',
-                  snippet:
-                    '<textarea type="text" id="name_cc1" name="name_cc1" autocomplete="sectio-red shipping cc-namez" placeholder="John Doe">',
-                  nodeLabel: 'textarea',
-                },
-                suggestion: 'Requires manual review',
-                current: 'sectio-red shipping cc-namez',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet:
-                    '<input type="text" id="address_shipping" autocomplete="shippin street-address" placeholder="Your address">',
-                  nodeLabel: 'input',
-                },
-                suggestion: 'address-line1',
-                current: 'shippin street-address',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet:
-                    '<input type="text" id="city_shipping" placeholder="city you live" autocomplete="mobile section-red shipping address-level2">',
-                  nodeLabel: 'input',
-                },
-                suggestion: 'Review order of tokens',
-                current: 'mobile section-red shipping address-level2',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet: '<select id="state_shipping">',
-                  nodeLabel: 'Select a state\nCA\nMA\nNY\nMD\nOR\nOH\nIL\nDC',
-                },
-                suggestion: 'address-level1',
-                current: '',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet: '<input type="text" id="zip_shipping">',
-                  nodeLabel: 'input',
-                },
-                suggestion: 'postal-code',
-                current: '',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet:
-                    '<input type="text" id="name_billing" name="name_billing" placeholder="your name" autocomplete="sectio-red billing name">',
-                  nodeLabel: 'input',
-                },
-                suggestion: 'name',
-                current: 'sectio-red billing name',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet:
-                    '<input type="text" id="city_billing" name="city_billing" placeholder="city you live in" autocomplete="section-red shipping ">',
-                  nodeLabel: 'input',
-                },
-                suggestion: 'Requires manual review',
-                current: 'section-red shipping ',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet: '<select id="state_billing" name="state_billing">',
-                  nodeLabel:
-                    '\n            Select a state\n            CA\n            MA\n            NY\n      …',
-                },
-                suggestion: 'address-level1',
-                current: '',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet: '<input type="text" id="zip_billing">',
-                  nodeLabel: 'input',
-                },
-                suggestion: 'postal-code',
-                current: '',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet: '<select id="CCExpiresMonth2" name="CCExpiresMonth2">',
-                  nodeLabel: 'MM\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12',
-                },
-                suggestion: 'cc-exp-month',
-                current: '',
-              },
-              {
-                node: {
-                  type: 'node',
-                  snippet: '<select id="CCExpiresYear">',
-                  nodeLabel: 'YY\n2019\n2020\n2021\n2022\n2023\n2024\n2025\n2026\n2027\n2028\n2029',
-                },
-                suggestion: 'cc-exp-year',
-                current: '',
-              },
-            ],
-          },
         },
       },
     },
   },
-];
+};
 
 module.exports = expectations;

--- a/lighthouse-cli/test/smokehouse/test-definitions/issues/mixed-content.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/issues/mixed-content.js
@@ -1,0 +1,42 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/** @fileoverview Expected Lighthouse audit values for various sites with stable(ish) PWA results. */
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results a site with mixed-content issues.
+ */
+const mixedContent = {
+  artifacts: {
+    InspectorIssues: {
+      mixedContent: [
+        {
+          _minChromiumMilestone: 88, // We went from Warning to AutoUpgrade in https://chromium-review.googlesource.com/c/chromium/src/+/2480817
+          resourceType: 'Image',
+          resolutionStatus: 'MixedContentAutomaticallyUpgraded',
+          insecureURL: 'http://www.mixedcontentexamples.com/Content/Test/steveholt.jpg',
+          mainResourceURL: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
+          request: {
+            url: 'http://www.mixedcontentexamples.com/Content/Test/steveholt.jpg',
+          },
+        },
+      ],
+    },
+  },
+  lhr: {
+    requestedUrl: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
+    finalUrl: 'https://www.mixedcontentexamples.com/Test/NonSecureImage',
+    audits: {
+      'is-on-https': {
+        score: 0,
+      },
+    },
+  },
+};
+
+module.exports = mixedContent;

--- a/lighthouse-cli/test/smokehouse/test-definitions/lantern/lantern-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/lantern/lantern-expectations.js
@@ -112,7 +112,7 @@ const xhr = {
 /**
  * @type {Smokehouse.ExpectedRunnerResult}
  */
-const ricShort = {
+const idleCallbackShort = {
   lhr: {
     requestedUrl: 'http://localhost:10200/ric-shim.html?short',
     finalUrl: 'http://localhost:10200/ric-shim.html?short',
@@ -129,7 +129,7 @@ const ricShort = {
 /**
  * @type {Smokehouse.ExpectedRunnerResult}
  */
-const ricLong = {
+const idleCallbackLong = {
   lhr: {
     requestedUrl: 'http://localhost:10200/ric-shim.html?long',
     finalUrl: 'http://localhost:10200/ric-shim.html?long',
@@ -150,6 +150,6 @@ module.exports = {
   setTimeout,
   fetch,
   xhr,
-  ricShort,
-  ricLong,
+  idleCallbackShort,
+  idleCallbackLong,
 };

--- a/lighthouse-cli/test/smokehouse/test-definitions/lantern/lantern-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/lantern/lantern-expectations.js
@@ -6,120 +6,150 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for lantern smoketests
+ * @fileoverview Expected Lighthouse audit values for lantern smoketests.
  */
-module.exports = [
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/online-only.html',
-      finalUrl: 'http://localhost:10200/online-only.html',
-      audits: {
-        'first-contentful-paint': {
-          numericValue: '>2000',
-        },
-        'interactive': {
-          numericValue: '>2000',
-        },
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const online = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/online-only.html',
+    finalUrl: 'http://localhost:10200/online-only.html',
+    audits: {
+      'first-contentful-paint': {
+        numericValue: '>2000',
+      },
+      'interactive': {
+        numericValue: '>2000',
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
-      finalUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
-      audits: {
-        'interactive': {
-          // Make sure all of the CPU time is reflected in the perf metrics as well.
-          // The scripts stalls for 3 seconds and lantern has a 4x multiplier so 12s minimum.
-          numericValue: '>12000',
-        },
-        'bootup-time': {
-          details: {
-            items: {
-              0: {
-                url: /main-thread-consumer/,
-                scripting: '>1000',
-              },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const setTimeout = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
+    finalUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
+    audits: {
+      'interactive': {
+        // Make sure all of the CPU time is reflected in the perf metrics as well.
+        // The scripts stalls for 3 seconds and lantern has a 4x multiplier so 12s minimum.
+        numericValue: '>12000',
+      },
+      'bootup-time': {
+        details: {
+          items: {
+            0: {
+              url: /main-thread-consumer/,
+              scripting: '>1000',
             },
           },
         },
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
-      finalUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
-      audits: {
-        'interactive': {
-          // Make sure all of the CPU time is reflected in the perf metrics as well.
-          // The scripts stalls for 3 seconds and lantern has a 4x multiplier so 12s minimum.
-          numericValue: '>12000',
-        },
-        'bootup-time': {
-          details: {
-            items: {
-              0: {
-              // TODO: requires sampling profiler and async stacks, see https://github.com/GoogleChrome/lighthouse/issues/8526
-              // url: /main-thread-consumer/,
-                scripting: '>1000',
-              },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const fetch = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
+    finalUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
+    audits: {
+      'interactive': {
+        // Make sure all of the CPU time is reflected in the perf metrics as well.
+        // The scripts stalls for 3 seconds and lantern has a 4x multiplier so 12s minimum.
+        numericValue: '>12000',
+      },
+      'bootup-time': {
+        details: {
+          items: {
+            0: {
+            // TODO: requires sampling profiler and async stacks, see https://github.com/GoogleChrome/lighthouse/issues/8526
+            // url: /main-thread-consumer/,
+              scripting: '>1000',
             },
           },
         },
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/tricky-main-thread.html?xhr',
-      finalUrl: 'http://localhost:10200/tricky-main-thread.html?xhr',
-      audits: {
-        'interactive': {
-          // Make sure all of the CPU time is reflected in the perf metrics as well.
-          // The scripts stalls for 3 seconds and lantern has a 4x multiplier so 12s minimum.
-          numericValue: '>12000',
-        },
-        'bootup-time': {
-          details: {
-            items: {
-              0: {
-                url: /main-thread-consumer/,
-                scripting: '>9000',
-              },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const xhr = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/tricky-main-thread.html?xhr',
+    finalUrl: 'http://localhost:10200/tricky-main-thread.html?xhr',
+    audits: {
+      'interactive': {
+        // Make sure all of the CPU time is reflected in the perf metrics as well.
+        // The scripts stalls for 3 seconds and lantern has a 4x multiplier so 12s minimum.
+        numericValue: '>12000',
+      },
+      'bootup-time': {
+        details: {
+          items: {
+            0: {
+              url: /main-thread-consumer/,
+              scripting: '>9000',
             },
           },
         },
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/ric-shim.html?short',
-      finalUrl: 'http://localhost:10200/ric-shim.html?short',
-      audits: {
-        'total-blocking-time': {
-          // With the requestIdleCallback shim in place 1ms tasks should not block at all and should max add up to
-          // 12.5 ms each, which would result in 50ms under a 4x simulated throttling multiplier and therefore in 0 tbt
-          numericValue: '<=100',
-        },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const ricShort = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/ric-shim.html?short',
+    finalUrl: 'http://localhost:10200/ric-shim.html?short',
+    audits: {
+      'total-blocking-time': {
+        // With the requestIdleCallback shim in place 1ms tasks should not block at all and should max add up to
+        // 12.5 ms each, which would result in 50ms under a 4x simulated throttling multiplier and therefore in 0 tbt
+        numericValue: '<=100',
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/ric-shim.html?long',
-      finalUrl: 'http://localhost:10200/ric-shim.html?long',
-      audits: {
-        'total-blocking-time': {
-          // With a 4x throttling multiplier in place each 50ms task takes 200ms, which results in 150ms blocking time
-          // each. We iterate ~40 times, so the true amount of blocking time we expect is ~6s, but
-          // sometimes Chrome's requestIdleCallback won't fire the full 40 if the machine is under load,
-          // so be generous with how much slack to give in the expectations.
-          numericValue: '>2500',
-        },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const ricLong = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/ric-shim.html?long',
+    finalUrl: 'http://localhost:10200/ric-shim.html?long',
+    audits: {
+      'total-blocking-time': {
+        // With a 4x throttling multiplier in place each 50ms task takes 200ms, which results in 150ms blocking time
+        // each. We iterate ~40 times, so the true amount of blocking time we expect is ~6s, but
+        // sometimes Chrome's requestIdleCallback won't fire the full 40 if the machine is under load,
+        // so be generous with how much slack to give in the expectations.
+        numericValue: '>2500',
       },
     },
   },
-];
+};
+
+module.exports = {
+  online,
+  setTimeout,
+  fetch,
+  xhr,
+  ricShort,
+  ricLong,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/legacy-javascript/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/legacy-javascript/expectations.js
@@ -6,90 +6,91 @@
 'use strict';
 
 /**
+ * @type {Smokehouse.ExpectedRunnerResult}
  * Expected Lighthouse audit values for sites with polyfills.
  */
-module.exports = [
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/legacy-javascript.html',
-      finalUrl: 'http://localhost:10200/legacy-javascript.html',
-      audits: {
-        'legacy-javascript': {
-          details: {
-            items: [
-              {
-                url: 'http://localhost:10200/legacy-javascript.js',
-                wastedBytes: '78000 +/- 2000',
-                subItems: {
-                  items: [
-                    {signal: 'Array.prototype.fill'},
-                    {signal: 'Array.prototype.filter'},
-                    {signal: 'Array.prototype.findIndex'},
-                    {signal: 'Array.prototype.find'},
-                    {signal: 'Array.prototype.forEach'},
-                    {signal: 'Array.from'},
-                    {signal: 'Array.prototype.includes'},
-                    {signal: 'Array.isArray'},
-                    {signal: 'Array.prototype.map'},
-                    {signal: 'Array.of'},
-                    {signal: 'Array.prototype.reduceRight'},
-                    {signal: 'Array.prototype.reduce'},
-                    {signal: 'Array.prototype.some'},
-                    {signal: 'Date.now'},
-                    {signal: 'Date.prototype.toISOString'},
-                    {signal: 'Date.prototype.toJSON'},
-                    {signal: 'Number.isInteger'},
-                    {signal: 'Number.isSafeInteger'},
-                    {signal: 'Number.parseInt'},
-                    {signal: 'Object.defineProperties'},
-                    {signal: 'Object.defineProperty'},
-                    {signal: 'Object.entries'},
-                    {signal: 'Object.freeze'},
-                    {signal: 'Object.getOwnPropertyDescriptors'},
-                    {signal: 'Object.getOwnPropertyNames'},
-                    {signal: 'Object.getPrototypeOf'},
-                    {signal: 'Object.isExtensible'},
-                    {signal: 'Object.isFrozen'},
-                    {signal: 'Object.isSealed'},
-                    {signal: 'Object.keys'},
-                    {signal: 'Object.preventExtensions'},
-                    {signal: 'Object.seal'},
-                    {signal: 'Object.setPrototypeOf'},
-                    {signal: 'Object.values'},
-                    {signal: 'Reflect.apply'},
-                    {signal: 'Reflect.construct'},
-                    {signal: 'Reflect.defineProperty'},
-                    {signal: 'Reflect.deleteProperty'},
-                    {signal: 'Reflect.getOwnPropertyDescriptor'},
-                    {signal: 'Reflect.getPrototypeOf'},
-                    {signal: 'Reflect.get'},
-                    {signal: 'Reflect.has'},
-                    {signal: 'Reflect.isExtensible'},
-                    {signal: 'Reflect.ownKeys'},
-                    {signal: 'Reflect.preventExtensions'},
-                    {signal: 'Reflect.setPrototypeOf'},
-                    {signal: 'String.prototype.codePointAt'},
-                    {signal: 'String.fromCodePoint'},
-                    {signal: 'String.raw'},
-                    {signal: 'String.prototype.repeat'},
-                    {signal: '@babel/plugin-transform-classes'},
-                    {signal: '@babel/plugin-transform-regenerator'},
-                    {signal: '@babel/plugin-transform-spread'},
-                  ],
-                },
+const expectations = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/legacy-javascript.html',
+    finalUrl: 'http://localhost:10200/legacy-javascript.html',
+    audits: {
+      'legacy-javascript': {
+        details: {
+          items: [
+            {
+              url: 'http://localhost:10200/legacy-javascript.js',
+              wastedBytes: '78000 +/- 2000',
+              subItems: {
+                items: [
+                  {signal: 'Array.prototype.fill'},
+                  {signal: 'Array.prototype.filter'},
+                  {signal: 'Array.prototype.findIndex'},
+                  {signal: 'Array.prototype.find'},
+                  {signal: 'Array.prototype.forEach'},
+                  {signal: 'Array.from'},
+                  {signal: 'Array.prototype.includes'},
+                  {signal: 'Array.isArray'},
+                  {signal: 'Array.prototype.map'},
+                  {signal: 'Array.of'},
+                  {signal: 'Array.prototype.reduceRight'},
+                  {signal: 'Array.prototype.reduce'},
+                  {signal: 'Array.prototype.some'},
+                  {signal: 'Date.now'},
+                  {signal: 'Date.prototype.toISOString'},
+                  {signal: 'Date.prototype.toJSON'},
+                  {signal: 'Number.isInteger'},
+                  {signal: 'Number.isSafeInteger'},
+                  {signal: 'Number.parseInt'},
+                  {signal: 'Object.defineProperties'},
+                  {signal: 'Object.defineProperty'},
+                  {signal: 'Object.entries'},
+                  {signal: 'Object.freeze'},
+                  {signal: 'Object.getOwnPropertyDescriptors'},
+                  {signal: 'Object.getOwnPropertyNames'},
+                  {signal: 'Object.getPrototypeOf'},
+                  {signal: 'Object.isExtensible'},
+                  {signal: 'Object.isFrozen'},
+                  {signal: 'Object.isSealed'},
+                  {signal: 'Object.keys'},
+                  {signal: 'Object.preventExtensions'},
+                  {signal: 'Object.seal'},
+                  {signal: 'Object.setPrototypeOf'},
+                  {signal: 'Object.values'},
+                  {signal: 'Reflect.apply'},
+                  {signal: 'Reflect.construct'},
+                  {signal: 'Reflect.defineProperty'},
+                  {signal: 'Reflect.deleteProperty'},
+                  {signal: 'Reflect.getOwnPropertyDescriptor'},
+                  {signal: 'Reflect.getPrototypeOf'},
+                  {signal: 'Reflect.get'},
+                  {signal: 'Reflect.has'},
+                  {signal: 'Reflect.isExtensible'},
+                  {signal: 'Reflect.ownKeys'},
+                  {signal: 'Reflect.preventExtensions'},
+                  {signal: 'Reflect.setPrototypeOf'},
+                  {signal: 'String.prototype.codePointAt'},
+                  {signal: 'String.fromCodePoint'},
+                  {signal: 'String.raw'},
+                  {signal: 'String.prototype.repeat'},
+                  {signal: '@babel/plugin-transform-classes'},
+                  {signal: '@babel/plugin-transform-regenerator'},
+                  {signal: '@babel/plugin-transform-spread'},
+                ],
               },
-              {
-                url: 'http://localhost:10200/legacy-javascript.html',
-                subItems: {
-                  items: [
-                    {signal: 'Array.prototype.findIndex'},
-                  ],
-                },
+            },
+            {
+              url: 'http://localhost:10200/legacy-javascript.html',
+              subItems: {
+                items: [
+                  {signal: 'Array.prototype.findIndex'},
+                ],
               },
-            ],
-          },
+            },
+          ],
         },
       },
     },
   },
-];
+};
+
+module.exports = expectations;

--- a/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/offline-local/offline-expectations.js
@@ -6,218 +6,235 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse results from testing the defaut audits on local test
- * pages, one of which works offline with a service worker and one of which does
- * not.
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results from testing a page that does not work offline.
  */
-module.exports = [
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/online-only.html',
-      finalUrl: 'http://localhost:10200/online-only.html',
-      audits: {
-        'is-on-https': {
-          score: 1,
-        },
-        'external-anchors-use-rel-noopener': {
-          score: 1,
-        },
-        'appcache-manifest': {
-          score: 1,
-        },
-        'geolocation-on-start': {
-          score: 1,
-        },
-        'render-blocking-resources': {
-          score: 1,
-        },
-        'password-inputs-can-be-pasted-into': {
-          score: 1,
-        },
-        'redirects-http': {
-          score: null,
-          scoreDisplayMode: 'notApplicable',
-        },
-        'service-worker': {
-          score: 0,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'user-timings': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'critical-request-chains': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'installable-manifest': {
-          score: 0,
-          details: {items: [{reason: 'No manifest was fetched'}]},
-        },
-        'splash-screen': {
-          score: 0,
-        },
-        'themed-omnibox': {
-          score: 0,
-        },
-        'aria-valid-attr': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'aria-allowed-attr': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'color-contrast': {
-          score: 1,
-        },
-        'image-alt': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'label': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'tabindex': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'content-width': {
-          score: 1,
-        },
+const onlineOnly = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/online-only.html',
+    finalUrl: 'http://localhost:10200/online-only.html',
+    audits: {
+      'is-on-https': {
+        score: 1,
+      },
+      'external-anchors-use-rel-noopener': {
+        score: 1,
+      },
+      'appcache-manifest': {
+        score: 1,
+      },
+      'geolocation-on-start': {
+        score: 1,
+      },
+      'render-blocking-resources': {
+        score: 1,
+      },
+      'password-inputs-can-be-pasted-into': {
+        score: 1,
+      },
+      'redirects-http': {
+        score: null,
+        scoreDisplayMode: 'notApplicable',
+      },
+      'service-worker': {
+        score: 0,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'user-timings': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'critical-request-chains': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'installable-manifest': {
+        score: 0,
+        details: {items: [{reason: 'No manifest was fetched'}]},
+      },
+      'splash-screen': {
+        score: 0,
+      },
+      'themed-omnibox': {
+        score: 0,
+      },
+      'aria-valid-attr': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'aria-allowed-attr': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'color-contrast': {
+        score: 1,
+      },
+      'image-alt': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'label': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'tabindex': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'content-width': {
+        score: 1,
       },
     },
   },
-  {
-    artifacts: {
-      WebAppManifest: {
-        value: {
-          icons: {
-            value: [
-              {value: {src: {value: 'http://localhost:10503/launcher-icon-0-75x.png'}}},
-              {value: {src: {value: 'http://localhost:10503/launcher-icon-1x.png'}}},
-              {value: {src: {value: 'http://localhost:10503/launcher-icon-1-5x.png'}}},
-              {value: {src: {value: 'http://localhost:10503/launcher-icon-2x.png'}}},
-              {value: {src: {value: 'http://localhost:10503/launcher-icon-3x.png'}}},
-            ],
-          },
-        },
-      },
-      InstallabilityErrors: {
-        errors: {
-          length: 1,
-          0: {
-            // For a few days in m89, the warn-not-offline-capable error also showed up here.
-            // https://github.com/GoogleChrome/lighthouse/issues/11800
-            errorId: /no-icon-available/,
-          },
-        },
-      },
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10503/offline-ready.html',
-      finalUrl: 'http://localhost:10503/offline-ready.html',
-      audits: {
-        'is-on-https': {
-          score: 1,
-        },
-        'redirects-http': {
-          score: null,
-          scoreDisplayMode: 'notApplicable',
-        },
-        'service-worker': {
-          score: 1,
-          details: {
-            scriptUrl: 'http://localhost:10503/offline-ready-sw.js',
-            scopeUrl: 'http://localhost:10503/',
-          },
-        },
-        'viewport': {
-          score: 1,
-        },
-        'user-timings': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'critical-request-chains': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'installable-manifest': {
-          score: 0,
-          details: {items: [{reason: 'Downloaded icon was empty or corrupted'}]},
-        },
-        'splash-screen': {
-          score: 0,
-        },
-        'themed-omnibox': {
-          score: 0,
-        },
-        'aria-valid-attr': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'aria-allowed-attr': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'color-contrast': {
-          score: 1,
-        },
-        'image-alt': {
-          score: 0,
-        },
-        'label': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'tabindex': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'content-width': {
-          score: 1,
-        },
-      },
-    },
-  },
+};
 
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10503/offline-ready.html?broken',
-      // This page's SW has a `fetch` handler that doesn't provide a 200 response.
-      finalUrl: 'http://localhost:10503/offline-ready.html?broken',
-      audits: {
-        'installable-manifest': {
-          score: 0,
-          details: {items: {length: 1}},
-          // TODO: 'warn-not-offline-capable' was disabled in m91. Turn back on once
-          // issues are addressed and check is re-enabled: https://crbug.com/1187668#c22
-          // warnings: {length: 1},
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results from testing the a local test page that works
+ * offline with a service worker.
+ */
+const ready = {
+  artifacts: {
+    WebAppManifest: {
+      value: {
+        icons: {
+          value: [
+            {value: {src: {value: 'http://localhost:10503/launcher-icon-0-75x.png'}}},
+            {value: {src: {value: 'http://localhost:10503/launcher-icon-1x.png'}}},
+            {value: {src: {value: 'http://localhost:10503/launcher-icon-1-5x.png'}}},
+            {value: {src: {value: 'http://localhost:10503/launcher-icon-2x.png'}}},
+            {value: {src: {value: 'http://localhost:10503/launcher-icon-3x.png'}}},
+          ],
         },
       },
     },
-    artifacts: {
-      InstallabilityErrors: {
-        // COMPAT: `warn-not-offline-capable` occurs in m89 but may be cherry-picked out of m90.
-        _minChromiumMilestone: 91,
-        errors: {
-          length: 1,
-          // 0: {
-          //   errorId: /warn-not-offline-capable/,
-          // },
-          0: {
-            errorId: /no-icon-available/,
-          },
+    InstallabilityErrors: {
+      errors: {
+        length: 1,
+        0: {
+          // For a few days in m89, the warn-not-offline-capable error also showed up here.
+          // https://github.com/GoogleChrome/lighthouse/issues/11800
+          errorId: /no-icon-available/,
         },
       },
     },
   },
+  lhr: {
+    requestedUrl: 'http://localhost:10503/offline-ready.html',
+    finalUrl: 'http://localhost:10503/offline-ready.html',
+    audits: {
+      'is-on-https': {
+        score: 1,
+      },
+      'redirects-http': {
+        score: null,
+        scoreDisplayMode: 'notApplicable',
+      },
+      'service-worker': {
+        score: 1,
+        details: {
+          scriptUrl: 'http://localhost:10503/offline-ready-sw.js',
+          scopeUrl: 'http://localhost:10503/',
+        },
+      },
+      'viewport': {
+        score: 1,
+      },
+      'user-timings': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'critical-request-chains': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'installable-manifest': {
+        score: 0,
+        details: {items: [{reason: 'Downloaded icon was empty or corrupted'}]},
+      },
+      'splash-screen': {
+        score: 0,
+      },
+      'themed-omnibox': {
+        score: 0,
+      },
+      'aria-valid-attr': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'aria-allowed-attr': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'color-contrast': {
+        score: 1,
+      },
+      'image-alt': {
+        score: 0,
+      },
+      'label': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'tabindex': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'content-width': {
+        score: 1,
+      },
+    },
+  },
+};
 
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10503/offline-ready.html?slow',
-      finalUrl: 'http://localhost:10503/offline-ready.html?slow',
-      audits: {
-        'service-worker': {
-          score: 1,
-          details: {
-            scriptUrl: 'http://localhost:10503/offline-ready-sw.js?delay=5000&slow',
-            scopeUrl: 'http://localhost:10503/',
-          },
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results from testing the a local test page with a broken service worker.
+ */
+const swBroken = {
+  lhr: {
+    requestedUrl: 'http://localhost:10503/offline-ready.html?broken',
+    // This page's SW has a `fetch` handler that doesn't provide a 200 response.
+    finalUrl: 'http://localhost:10503/offline-ready.html?broken',
+    audits: {
+      'installable-manifest': {
+        score: 0,
+        details: {items: {length: 1}},
+        // TODO: 'warn-not-offline-capable' was disabled in m91. Turn back on once
+        // issues are addressed and check is re-enabled: https://crbug.com/1187668#c22
+        // warnings: {length: 1},
+      },
+    },
+  },
+  artifacts: {
+    InstallabilityErrors: {
+      // COMPAT: `warn-not-offline-capable` occurs in m89 but may be cherry-picked out of m90.
+      _minChromiumMilestone: 91,
+      errors: {
+        length: 1,
+        // 0: {
+        //   errorId: /warn-not-offline-capable/,
+        // },
+        0: {
+          errorId: /no-icon-available/,
         },
       },
     },
   },
-];
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results from testing the a local test page with a slow service worker.
+ */
+const swSlow = {
+  lhr: {
+    requestedUrl: 'http://localhost:10503/offline-ready.html?slow',
+    finalUrl: 'http://localhost:10503/offline-ready.html?slow',
+    audits: {
+      'service-worker': {
+        score: 1,
+        details: {
+          scriptUrl: 'http://localhost:10503/offline-ready-sw.js?delay=5000&slow',
+          scopeUrl: 'http://localhost:10503/',
+        },
+      },
+    },
+  },
+};
+
+module.exports = {
+  onlineOnly,
+  ready,
+  swBroken,
+  swSlow,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/oopif/oopif-expectations.js
@@ -6,49 +6,47 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
+ * @type {Smokehouse.ExpectedRunnerResult}
  * Expected Lighthouse audit values for sites with OOPIFS.
  */
-module.exports = [
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/oopif.html',
-      finalUrl: 'http://localhost:10200/oopif.html',
-      audits: {
-        'network-requests': {
-          details: {
-            items: {
-            // We want to make sure we are finding the iframe's requests (paulirish.com) *AND*
-            // the iframe's iframe's iframe's requests (youtube.com/doubleclick/etc).
-            // - paulirish.com ~40-60 requests
-            // - paulirish.com + all descendant iframes ~80-90 requests
-              length: '>70',
-            },
+module.exports = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/oopif.html',
+    finalUrl: 'http://localhost:10200/oopif.html',
+    audits: {
+      'network-requests': {
+        details: {
+          items: {
+          // We want to make sure we are finding the iframe's requests (paulirish.com) *AND*
+          // the iframe's iframe's iframe's requests (youtube.com/doubleclick/etc).
+          // - paulirish.com ~40-60 requests
+          // - paulirish.com + all descendant iframes ~80-90 requests
+            length: '>70',
           },
         },
       },
     },
-    artifacts: {
-      IFrameElements: [
-        {
-          id: 'oopif',
-          src: 'https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/',
-          clientRect: {
-            width: '>0',
-            height: '>0',
-          },
-          isPositionFixed: false,
-        },
-        {
-          id: 'outer-iframe',
-          src: 'http://localhost:10200/online-only.html',
-          clientRect: {
-            width: '>0',
-            height: '>0',
-          },
-          isPositionFixed: true,
-        },
-      ],
-    },
   },
-];
+  artifacts: {
+    IFrameElements: [
+      {
+        id: 'oopif',
+        src: 'https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/',
+        clientRect: {
+          width: '>0',
+          height: '>0',
+        },
+        isPositionFixed: false,
+      },
+      {
+        id: 'outer-iframe',
+        src: 'http://localhost:10200/online-only.html',
+        clientRect: {
+          width: '>0',
+          height: '>0',
+        },
+        isPositionFixed: true,
+      },
+    ],
+  },
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf-diagnostics/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf-diagnostics/expectations.js
@@ -6,124 +6,140 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for perf diagnostics tests which do not need to be run serially.
+ * @fileoverview Expected Lighthouse audit values for perf diagnostics tests which
+ * do not need to be run serially.
  */
-module.exports = [
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/perf/animations.html',
-      finalUrl: 'http://localhost:10200/perf/animations.html',
-      audits: {
-        'non-composited-animations': {
-          // Requires compositor failure reasons to be in the trace
-          // https://chromiumdash.appspot.com/commit/995baabedf9e70d16deafc4bc37a2b215a9b8ec9
-          _minChromiumMilestone: 86,
-          score: null,
-          displayValue: '1 animated element found',
-          details: {
-            items: [
-              {
-                node: {
-                  type: 'node',
-                  path: '2,HTML,1,BODY,1,DIV',
-                  selector: 'body > div#animated-boi',
-                  nodeLabel: 'This is changing font size',
-                  snippet: '<div id="animated-boi">',
-                },
-                subItems: {
-                  items: [
-                    {
-                      // From JavaScript `.animate` which has no animation display name
-                      failureReason: 'Unsupported CSS Property: width',
-                    },
-                    {
-                      failureReason: 'Unsupported CSS Property: height',
-                      animation: 'alpha',
-                    },
-                    {
-                      failureReason: 'Unsupported CSS Property: font-size',
-                      animation: 'beta',
-                    },
-                  ],
-                },
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const animations = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/perf/animations.html',
+    finalUrl: 'http://localhost:10200/perf/animations.html',
+    audits: {
+      'non-composited-animations': {
+        // Requires compositor failure reasons to be in the trace
+        // https://chromiumdash.appspot.com/commit/995baabedf9e70d16deafc4bc37a2b215a9b8ec9
+        _minChromiumMilestone: 86,
+        score: null,
+        displayValue: '1 animated element found',
+        details: {
+          items: [
+            {
+              node: {
+                type: 'node',
+                path: '2,HTML,1,BODY,1,DIV',
+                selector: 'body > div#animated-boi',
+                nodeLabel: 'This is changing font size',
+                snippet: '<div id="animated-boi">',
               },
-            ],
-          },
-        },
-      },
-    },
-  },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/perf/third-party.html',
-      finalUrl: 'http://localhost:10200/perf/third-party.html',
-      audits: {
-        'third-party-facades': {
-          score: 0,
-          displayValue: '1 facade alternative available',
-          details: {
-            items: [
-              {
-                product: 'YouTube Embedded Player (Video)',
-                blockingTime: 0, // Note: Only 0 if the iframe was out-of-process
-                transferSize: '>400000', // Transfer size is imprecise.
-                subItems: {
-                  type: 'subitems',
-                  items: {
-                    length: '>5', // We don't care exactly how many it has, just ensure we surface the subresources.
+              subItems: {
+                items: [
+                  {
+                    // From JavaScript `.animate` which has no animation display name
+                    failureReason: 'Unsupported CSS Property: width',
                   },
-                },
+                  {
+                    failureReason: 'Unsupported CSS Property: height',
+                    animation: 'alpha',
+                  },
+                  {
+                    failureReason: 'Unsupported CSS Property: font-size',
+                    animation: 'beta',
+                  },
+                ],
               },
-            ],
-          },
+            },
+          ],
         },
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/perf/unsized-images.html',
-      finalUrl: 'http://localhost:10200/perf/unsized-images.html',
-      audits: {
-        'unsized-images': {
-          score: 0,
-          details: {
-            items: [
-              {
-                node: {
-                  snippet: '<img src="../launcher-icon-100x100.png" width="100">',
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const thirdParty = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/perf/third-party.html',
+    finalUrl: 'http://localhost:10200/perf/third-party.html',
+    audits: {
+      'third-party-facades': {
+        score: 0,
+        displayValue: '1 facade alternative available',
+        details: {
+          items: [
+            {
+              product: 'YouTube Embedded Player (Video)',
+              blockingTime: 0, // Note: Only 0 if the iframe was out-of-process
+              transferSize: '>400000', // Transfer size is imprecise.
+              subItems: {
+                type: 'subitems',
+                items: {
+                  length: '>5', // We don't care exactly how many it has, just ensure we surface the subresources.
                 },
               },
-              {
-                node: {
-                  snippet: '<img src="../launcher-icon-100x100.png" height="100">',
-                },
-              },
-              {
-                node: {
-                  snippet: '<img src="../launcher-icon-100x100.png" style="width: 100;">',
-                },
-              },
-              {
-                node: {
-                  snippet: '<img src="../launcher-icon-100x100.png" style="height: 100;">',
-                },
-              },
-              {
-                node: {
-                  snippet: '<img src="../launcher-icon-100x100.png" style="aspect-ratio: 1 / 1;">',
-                },
-              },
-              {
-                node: {
-                  snippet: '<img src="../launcher-icon-100x100.png" style="width: 100; height: auto;">',
-                },
-              },
-            ],
-          },
+            },
+          ],
         },
       },
     },
   },
-];
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const unsizedImages = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/perf/unsized-images.html',
+    finalUrl: 'http://localhost:10200/perf/unsized-images.html',
+    audits: {
+      'unsized-images': {
+        score: 0,
+        details: {
+          items: [
+            {
+              node: {
+                snippet: '<img src="../launcher-icon-100x100.png" width="100">',
+              },
+            },
+            {
+              node: {
+                snippet: '<img src="../launcher-icon-100x100.png" height="100">',
+              },
+            },
+            {
+              node: {
+                snippet: '<img src="../launcher-icon-100x100.png" style="width: 100;">',
+              },
+            },
+            {
+              node: {
+                snippet: '<img src="../launcher-icon-100x100.png" style="height: 100;">',
+              },
+            },
+            {
+              node: {
+                snippet: '<img src="../launcher-icon-100x100.png" style="aspect-ratio: 1 / 1;">',
+              },
+            },
+            {
+              node: {
+                snippet: '<img src="../launcher-icon-100x100.png" style="width: 100; height: auto;">',
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+module.exports = {
+  animations,
+  thirdParty,
+  unsizedImages,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf/expectations.js
@@ -6,340 +6,366 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for perf tests.
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for preload tests.
  */
-module.exports = [
-  {
-    networkRequests: {
-      // 8 requests made for normal page testing.
-      // 1 extra request made because stylesheets are evicted from the cache by the time DT opens.
-      length: 9,
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/preload.html',
-      finalUrl: 'http://localhost:10200/preload.html',
-      audits: {
-        'speed-index': {
-          score: '>=0.80', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
-        },
-        'first-meaningful-paint': {
-          score: '>=0.90', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
-        },
-        'interactive': {
-          score: '>=0.90', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
-        },
-        'server-response-time': {
-          // Can be flaky, so test float numericValue instead of binary score
-          numericValue: '<1000',
-        },
-        'network-requests': {
-          details: {
-            items: {
-              length: '>5',
-            },
+const preload = {
+  networkRequests: {
+    // 8 requests made for normal page testing.
+    // 1 extra request made because stylesheets are evicted from the cache by the time DT opens.
+    length: 9,
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/preload.html',
+    finalUrl: 'http://localhost:10200/preload.html',
+    audits: {
+      'speed-index': {
+        score: '>=0.80', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
+      },
+      'first-meaningful-paint': {
+        score: '>=0.90', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
+      },
+      'interactive': {
+        score: '>=0.90', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
+      },
+      'server-response-time': {
+        // Can be flaky, so test float numericValue instead of binary score
+        numericValue: '<1000',
+      },
+      'network-requests': {
+        details: {
+          items: {
+            length: '>5',
           },
         },
-        'uses-rel-preload': {
-          scoreDisplayMode: 'notApplicable',
-          // Disabled for now, see https://github.com/GoogleChrome/lighthouse/issues/11960
-          // score: '<1',
-          // numericValue: '>500',
-          // warnings: {
-          //   0: /level-2.*warning/,
-          //   length: 1,
-          // },
-          // details: {
-          //   items: {
-          //     length: 1,
-          //   },
-          // },
-        },
-        'uses-rel-preconnect': {
-          score: 1,
-          warnings: {
-            0: /fonts.googleapis/,
-            length: 1,
-          },
+      },
+      'uses-rel-preload': {
+        scoreDisplayMode: 'notApplicable',
+        // Disabled for now, see https://github.com/GoogleChrome/lighthouse/issues/11960
+        // score: '<1',
+        // numericValue: '>500',
+        // warnings: {
+        //   0: /level-2.*warning/,
+        //   length: 1,
+        // },
+        // details: {
+        //   items: {
+        //     length: 1,
+        //   },
+        // },
+      },
+      'uses-rel-preconnect': {
+        score: 1,
+        warnings: {
+          0: /fonts.googleapis/,
+          length: 1,
         },
       },
     },
   },
-  {
-    networkRequests: {
-      length: 8,
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/perf/perf-budgets/load-things.html',
-      finalUrl: 'http://localhost:10200/perf/perf-budgets/load-things.html',
-      audits: {
-        'resource-summary': {
-          score: null,
-          displayValue: '10 requests • 164 KiB',
-          details: {
-            items: [
-              {resourceType: 'total', requestCount: 10, transferSize: '168000±1000'},
-              {resourceType: 'font', requestCount: 2, transferSize: '81000±1000'},
-              {resourceType: 'script', requestCount: 3, transferSize: '55000±1000'},
-              {resourceType: 'image', requestCount: 2, transferSize: '28000±1000'},
-              {resourceType: 'document', requestCount: 1, transferSize: '2200±150'},
-              {resourceType: 'other', requestCount: 1, transferSize: '1030±100'},
-              {resourceType: 'stylesheet', requestCount: 1, transferSize: '450±100'},
-              {resourceType: 'media', requestCount: 0, transferSize: 0},
-              {resourceType: 'third-party', requestCount: 0, transferSize: 0},
-            ],
-          },
-        },
-        'performance-budget': {
-          score: null,
-          details: {
-            // Undefined items are asserting that the property isn't included in the table item.
-            items: [
-              {
-                resourceType: 'total',
-                countOverBudget: '2 requests',
-                sizeOverBudget: '65000±1000',
-              },
-              {
-                resourceType: 'script',
-                countOverBudget: '2 requests',
-                sizeOverBudget: '25000±1000',
-              },
-              {
-                resourceType: 'font',
-                countOverBudget: undefined,
-                sizeOverBudget: '4000±500',
-              },
-              {
-                resourceType: 'document',
-                countOverBudget: '1 request',
-                sizeOverBudget: '1200±50',
-              },
-              {
-                resourceType: 'stylesheet',
-                countOverBudget: undefined,
-                sizeOverBudget: '450±100',
-              },
-              {
-                resourceType: 'image',
-                countOverBudget: '1 request',
-                sizeOverBudget: undefined,
-              },
-              {
-                resourceType: 'media',
-                countOverBudget: undefined,
-                sizeOverBudget: undefined,
-              },
-              {
-                resourceType: 'other',
-                countOverBudget: undefined,
-                sizeOverBudget: undefined,
-              },
-              {
-                resourceType: 'third-party',
-                countOverBudget: undefined,
-                sizeOverBudget: undefined,
-              },
-            ],
-          },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for testing budgets.
+ */
+const budgets = {
+  networkRequests: {
+    length: 8,
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/perf/perf-budgets/load-things.html',
+    finalUrl: 'http://localhost:10200/perf/perf-budgets/load-things.html',
+    audits: {
+      'resource-summary': {
+        score: null,
+        displayValue: '10 requests • 164 KiB',
+        details: {
+          items: [
+            {resourceType: 'total', requestCount: 10, transferSize: '168000±1000'},
+            {resourceType: 'font', requestCount: 2, transferSize: '81000±1000'},
+            {resourceType: 'script', requestCount: 3, transferSize: '55000±1000'},
+            {resourceType: 'image', requestCount: 2, transferSize: '28000±1000'},
+            {resourceType: 'document', requestCount: 1, transferSize: '2200±150'},
+            {resourceType: 'other', requestCount: 1, transferSize: '1030±100'},
+            {resourceType: 'stylesheet', requestCount: 1, transferSize: '450±100'},
+            {resourceType: 'media', requestCount: 0, transferSize: 0},
+            {resourceType: 'third-party', requestCount: 0, transferSize: 0},
+          ],
         },
       },
-    },
-  },
-  {
-    networkRequests: {
-      length: 5,
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/perf/fonts.html',
-      finalUrl: 'http://localhost:10200/perf/fonts.html',
-      audits: {
-        'font-display': {
-          score: 0,
-          details: {
-            items: [
-              {
-                url: 'http://localhost:10200/perf/lobster-v20-latin-regular.woff2',
-              },
-            ],
-          },
-        },
-        'preload-fonts': {
-          scoreDisplayMode: 'notApplicable',
-          // Disabled for now, see https://github.com/GoogleChrome/lighthouse/issues/11960
-          // score: 0,
-          // details: {
-          //   items: [
-          //     {
-          //       url: 'http://localhost:10200/perf/lobster-two-v10-latin-700.woff2?delay=1000',
-          //     },
-          //   ],
-          // },
-        },
-      },
-    },
-  },
-  {
-    networkRequests: {
-      length: 3,
-    },
-    artifacts: {
-      TraceElements: [
-        {
-          traceEventType: 'largest-contentful-paint',
-          node: {
-            nodeLabel: 'section > img',
-            snippet: '<img src="../dobetterweb/lighthouse-480x318.jpg">',
-            boundingRect: {
-              top: 108,
-              bottom: 426,
-              left: 8,
-              right: 488,
-              width: 480,
-              height: 318,
-            },
-          },
-        },
-        {
-          traceEventType: 'layout-shift',
-          node: {
-            selector: 'body > h1',
-            nodeLabel: 'Please don\'t move me',
-            snippet: '<h1>',
-            boundingRect: {
-              top: 465,
-              bottom: 502,
-              left: 8,
-              right: 352,
-              width: 344,
-              height: 37,
-            },
-          },
-          score: '0.058 +/- 0.01',
-        },
-        {
-          traceEventType: 'layout-shift',
-          node: {
-            nodeLabel: 'Sorry!',
-            snippet: '<div style="height: 18px;">',
-            boundingRect: {
-              top: 426,
-              bottom: 444,
-              left: 8,
-              right: 352,
-              width: 344,
-              height: 18,
-            },
-          },
-          score: '0.026 +/- 0.01',
-        },
-        {
-          // Requires compositor failure reasons to be in the trace
-          // for `failureReasonsMask` and `unsupportedProperties`
-          // https://chromiumdash.appspot.com/commit/995baabedf9e70d16deafc4bc37a2b215a9b8ec9
-          _minChromiumMilestone: 86,
-          traceEventType: 'animation',
-          node: {
-            selector: 'body > div#animate-me',
-            nodeLabel: 'This is changing font size',
-            snippet: '<div id="animate-me">',
-            boundingRect: {
-              top: 8,
-              bottom: 108,
-              left: 8,
-              right: 108,
-              width: 100,
-              height: 100,
-            },
-          },
-          animations: [
+      'performance-budget': {
+        score: null,
+        details: {
+          // Undefined items are asserting that the property isn't included in the table item.
+          items: [
             {
-              name: 'anim',
-              failureReasonsMask: 8224,
-              unsupportedProperties: ['font-size'],
+              resourceType: 'total',
+              countOverBudget: '2 requests',
+              sizeOverBudget: '65000±1000',
+            },
+            {
+              resourceType: 'script',
+              countOverBudget: '2 requests',
+              sizeOverBudget: '25000±1000',
+            },
+            {
+              resourceType: 'font',
+              countOverBudget: undefined,
+              sizeOverBudget: '4000±500',
+            },
+            {
+              resourceType: 'document',
+              countOverBudget: '1 request',
+              sizeOverBudget: '1200±50',
+            },
+            {
+              resourceType: 'stylesheet',
+              countOverBudget: undefined,
+              sizeOverBudget: '450±100',
+            },
+            {
+              resourceType: 'image',
+              countOverBudget: '1 request',
+              sizeOverBudget: undefined,
+            },
+            {
+              resourceType: 'media',
+              countOverBudget: undefined,
+              sizeOverBudget: undefined,
+            },
+            {
+              resourceType: 'other',
+              countOverBudget: undefined,
+              sizeOverBudget: undefined,
+            },
+            {
+              resourceType: 'third-party',
+              countOverBudget: undefined,
+              sizeOverBudget: undefined,
             },
           ],
         },
-      ],
+      },
     },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/perf/trace-elements.html',
-      finalUrl: 'http://localhost:10200/perf/trace-elements.html',
-      audits: {
-        'largest-contentful-paint-element': {
-          score: null,
-          displayValue: '1 element found',
-          details: {
-            items: [
-              {
-                node: {
-                  type: 'node',
-                  nodeLabel: 'section > img',
-                  path: '0,HTML,1,BODY,1,DIV,a,#document-fragment,0,SECTION,0,IMG',
-                },
-              },
-            ],
-          },
-        },
-        'layout-shift-elements': {
-          score: null,
-          displayValue: '2 elements found',
-          details: {
-            items: {
-              length: 2,
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for testing font perf.
+ */
+const fonts = {
+  networkRequests: {
+    length: 5,
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/perf/fonts.html',
+    finalUrl: 'http://localhost:10200/perf/fonts.html',
+    audits: {
+      'font-display': {
+        score: 0,
+        details: {
+          items: [
+            {
+              url: 'http://localhost:10200/perf/lobster-v20-latin-regular.woff2',
             },
+          ],
+        },
+      },
+      'preload-fonts': {
+        scoreDisplayMode: 'notApplicable',
+        // Disabled for now, see https://github.com/GoogleChrome/lighthouse/issues/11960
+        // score: 0,
+        // details: {
+        //   items: [
+        //     {
+        //       url: 'http://localhost:10200/perf/lobster-two-v10-latin-700.woff2?delay=1000',
+        //     },
+        //   ],
+        // },
+      },
+    },
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for testing key elements from the trace.
+ */
+const traceElements = {
+  networkRequests: {
+    length: 3,
+  },
+  artifacts: {
+    TraceElements: [
+      {
+        traceEventType: 'largest-contentful-paint',
+        node: {
+          nodeLabel: 'section > img',
+          snippet: '<img src="../dobetterweb/lighthouse-480x318.jpg">',
+          boundingRect: {
+            top: 108,
+            bottom: 426,
+            left: 8,
+            right: 488,
+            width: 480,
+            height: 318,
           },
         },
-        'long-tasks': {
-          score: null,
-          details: {
-            items: {
-              0: {
-                url: 'http://localhost:10200/perf/delayed-element.js',
-                duration: '>500',
-                startTime: '5000 +/- 5000', // make sure it's on the right time scale, but nothing more
+      },
+      {
+        traceEventType: 'layout-shift',
+        node: {
+          selector: 'body > h1',
+          nodeLabel: 'Please don\'t move me',
+          snippet: '<h1>',
+          boundingRect: {
+            top: 465,
+            bottom: 502,
+            left: 8,
+            right: 352,
+            width: 344,
+            height: 37,
+          },
+        },
+        score: '0.058 +/- 0.01',
+      },
+      {
+        traceEventType: 'layout-shift',
+        node: {
+          nodeLabel: 'Sorry!',
+          snippet: '<div style="height: 18px;">',
+          boundingRect: {
+            top: 426,
+            bottom: 444,
+            left: 8,
+            right: 352,
+            width: 344,
+            height: 18,
+          },
+        },
+        score: '0.026 +/- 0.01',
+      },
+      {
+        // Requires compositor failure reasons to be in the trace
+        // for `failureReasonsMask` and `unsupportedProperties`
+        // https://chromiumdash.appspot.com/commit/995baabedf9e70d16deafc4bc37a2b215a9b8ec9
+        _minChromiumMilestone: 86,
+        traceEventType: 'animation',
+        node: {
+          selector: 'body > div#animate-me',
+          nodeLabel: 'This is changing font size',
+          snippet: '<div id="animate-me">',
+          boundingRect: {
+            top: 8,
+            bottom: 108,
+            left: 8,
+            right: 108,
+            width: 100,
+            height: 100,
+          },
+        },
+        animations: [
+          {
+            name: 'anim',
+            failureReasonsMask: 8224,
+            unsupportedProperties: ['font-size'],
+          },
+        ],
+      },
+    ],
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/perf/trace-elements.html',
+    finalUrl: 'http://localhost:10200/perf/trace-elements.html',
+    audits: {
+      'largest-contentful-paint-element': {
+        score: null,
+        displayValue: '1 element found',
+        details: {
+          items: [
+            {
+              node: {
+                type: 'node',
+                nodeLabel: 'section > img',
+                path: '0,HTML,1,BODY,1,DIV,a,#document-fragment,0,SECTION,0,IMG',
               },
+            },
+          ],
+        },
+      },
+      'layout-shift-elements': {
+        score: null,
+        displayValue: '2 elements found',
+        details: {
+          items: {
+            length: 2,
+          },
+        },
+      },
+      'long-tasks': {
+        score: null,
+        details: {
+          items: {
+            0: {
+              url: 'http://localhost:10200/perf/delayed-element.js',
+              duration: '>500',
+              startTime: '5000 +/- 5000', // make sure it's on the right time scale, but nothing more
             },
           },
         },
       },
     },
   },
-  {
-    networkRequests: {
-      length: 2,
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/perf/frame-metrics.html',
-      finalUrl: 'http://localhost:10200/perf/frame-metrics.html',
-      audits: {
-        'metrics': {
-          score: null,
-          details: {
-            type: 'debugdata',
-            items: [
-              {
-                // Weighted CLS score was added to the trace in m90:
-                // https://bugs.chromium.org/p/chromium/issues/detail?id=1173139
-                //
-                // Weighted score on emulated mobile bug fixed in m92:
-                // https://chromium.googlesource.com/chromium/src/+/042fbfb4cc6a675da0dff4bf3fc08622af42422b
-                _minChromiumMilestone: 92,
-                firstContentfulPaint: '>5000',
-                firstContentfulPaintAllFrames: '<5000',
-                largestContentfulPaint: '>5000',
-                largestContentfulPaintAllFrames: '<5000',
-                cumulativeLayoutShift: '0.197 +/- 0.001',
-                cumulativeLayoutShiftMainFrame: '0.001 +/- 0.0005',
-                totalCumulativeLayoutShift: '0.001 +/- 0.0005',
-              },
-              {
-                lcpInvalidated: false,
-              },
-            ],
-          },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for testing cross-frame-metrics.
+ */
+const frameMetrics = {
+  networkRequests: {
+    length: 2,
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/perf/frame-metrics.html',
+    finalUrl: 'http://localhost:10200/perf/frame-metrics.html',
+    audits: {
+      'metrics': {
+        score: null,
+        details: {
+          type: 'debugdata',
+          items: [
+            {
+              // Weighted CLS score was added to the trace in m90:
+              // https://bugs.chromium.org/p/chromium/issues/detail?id=1173139
+              //
+              // Weighted score on emulated mobile bug fixed in m92:
+              // https://chromium.googlesource.com/chromium/src/+/042fbfb4cc6a675da0dff4bf3fc08622af42422b
+              _minChromiumMilestone: 92,
+              firstContentfulPaint: '>5000',
+              firstContentfulPaintAllFrames: '<5000',
+              largestContentfulPaint: '>5000',
+              largestContentfulPaintAllFrames: '<5000',
+              cumulativeLayoutShift: '0.197 +/- 0.001',
+              cumulativeLayoutShiftMainFrame: '0.001 +/- 0.0005',
+              totalCumulativeLayoutShift: '0.001 +/- 0.0005',
+            },
+            {
+              lcpInvalidated: false,
+            },
+          ],
         },
       },
     },
   },
-];
+};
+
+module.exports = {
+  preload,
+  budgets,
+  fonts,
+  traceElements,
+  frameMetrics,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa-expectations.js
@@ -5,111 +5,117 @@
  */
 'use strict';
 
+/** @fileoverview Expected Lighthouse audit values for various sites with stable(ish) PWA results. */
+
 const pwaDetailsExpectations = require('./pwa-expectations-details.js');
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for various sites with stable(ish) PWA
- * results.
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results for airhorner.com.
  */
-const expectations = [
-  {
-    lhr: {
-      requestedUrl: 'https://airhorner.com',
-      finalUrl: 'https://airhorner.com/',
-      audits: {
-        'redirects-http': {
-          score: 1,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'installable-manifest': {
-          score: 1,
-          details: {items: [], debugData: {manifestUrl: 'https://airhorner.com/manifest.json'}},
-        },
-        'splash-screen': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'themed-omnibox': {
-          score: 1,
-          details: {items: [{...pwaDetailsExpectations, themeColor: '#2196F3'}]},
-        },
-        'content-width': {
-          score: 1,
-        },
-        'apple-touch-icon': {
-          score: 1,
-        },
+const airhorner = {
+  lhr: {
+    requestedUrl: 'https://airhorner.com',
+    finalUrl: 'https://airhorner.com/',
+    audits: {
+      'redirects-http': {
+        score: 1,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'installable-manifest': {
+        score: 1,
+        details: {items: [], debugData: {manifestUrl: 'https://airhorner.com/manifest.json'}},
+      },
+      'splash-screen': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'themed-omnibox': {
+        score: 1,
+        details: {items: [{...pwaDetailsExpectations, themeColor: '#2196F3'}]},
+      },
+      'content-width': {
+        score: 1,
+      },
+      'apple-touch-icon': {
+        score: 1,
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },
+};
 
-  {
-    lhr: {
-      requestedUrl: 'https://www.chromestatus.com/features',
-      finalUrl: 'https://www.chromestatus.com/features',
-      audits: {
-        'redirects-http': {
-          score: 1,
-        },
-        'service-worker': {
-          score: 0,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'installable-manifest': {
-          score: 0,
-          details: {items: [{reason: 'No manifest was fetched'}]},
-        },
-        'splash-screen': {
-          score: 0,
-        },
-        'themed-omnibox': {
-          score: 0,
-        },
-        'content-width': {
-          score: 1,
-        },
-        'apple-touch-icon': {
-          score: 1,
-        },
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results for chromestatus.com.
+ */
+const chromestatus = {
+  lhr: {
+    requestedUrl: 'https://www.chromestatus.com/features',
+    finalUrl: 'https://www.chromestatus.com/features',
+    audits: {
+      'redirects-http': {
+        score: 1,
+      },
+      'service-worker': {
+        score: 0,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'installable-manifest': {
+        score: 0,
+        details: {items: [{reason: 'No manifest was fetched'}]},
+      },
+      'splash-screen': {
+        score: 0,
+      },
+      'themed-omnibox': {
+        score: 0,
+      },
+      'content-width': {
+        score: 1,
+      },
+      'apple-touch-icon': {
+        score: 1,
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },
-];
+};
 
-module.exports = expectations;
+module.exports = {
+  airhorner,
+  chromestatus,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa2-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa2-expectations.js
@@ -5,114 +5,122 @@
  */
 'use strict';
 
+/** @fileoverview Expected Lighthouse audit values for various sites with stable(ish) PWA results. */
+
 const pwaDetailsExpectations = require('./pwa-expectations-details.js');
 const jakeExpectations = {...pwaDetailsExpectations, hasShortName: false};
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for various sites with stable(ish) PWA
- * results.
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results for svgomg.
  */
-module.exports = [
-  {
-    lhr: {
-      requestedUrl: 'https://jakearchibald.github.io/svgomg/',
-      finalUrl: 'https://jakearchibald.github.io/svgomg/',
-      audits: {
-        'redirects-http': {
-          score: 1,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'installable-manifest': {
-          score: 1,
-          details: {items: [], debugData: {manifestUrl: 'https://jakearchibald.github.io/svgomg/manifest.json'}},
-        },
-        'splash-screen': {
-          score: 1,
-          details: {items: [jakeExpectations]},
-        },
-        'themed-omnibox': {
-          score: 1,
-          details: {items: [jakeExpectations]},
-        },
-        'content-width': {
-          score: 1,
-        },
-        'apple-touch-icon': {
-          score: 1,
-          warnings: [
-            /apple-touch-icon-precomposed/,
-          ],
-        },
+const svgomg = {
+  lhr: {
+    requestedUrl: 'https://jakearchibald.github.io/svgomg/',
+    finalUrl: 'https://jakearchibald.github.io/svgomg/',
+    audits: {
+      'redirects-http': {
+        score: 1,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'installable-manifest': {
+        score: 1,
+        details: {items: [], debugData: {manifestUrl: 'https://jakearchibald.github.io/svgomg/manifest.json'}},
+      },
+      'splash-screen': {
+        score: 1,
+        details: {items: [jakeExpectations]},
+      },
+      'themed-omnibox': {
+        score: 1,
+        details: {items: [jakeExpectations]},
+      },
+      'content-width': {
+        score: 1,
+      },
+      'apple-touch-icon': {
+        score: 1,
+        warnings: [
+          /apple-touch-icon-precomposed/,
+        ],
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },
+};
 
-  {
-    lhr: {
-      requestedUrl: 'https://caltrainschedule.io/',
-      finalUrl: 'https://caltrainschedule.io/',
-      audits: {
-        'redirects-http': {
-          score: 1,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'installable-manifest': {
-          score: 1,
-          details: {items: [], debugData: {manifestUrl: 'https://caltrainschedule.io/manifest.json'}},
-        },
-        'splash-screen': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'themed-omnibox': {
-          score: 0,
-        },
-        'content-width': {
-          score: 1,
-        },
-        'apple-touch-icon': {
-          score: 1,
-        },
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results for caltrainschedule.io.
+ */
+const caltrain = {
+  lhr: {
+    requestedUrl: 'https://caltrainschedule.io/',
+    finalUrl: 'https://caltrainschedule.io/',
+    audits: {
+      'redirects-http': {
+        score: 1,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'installable-manifest': {
+        score: 1,
+        details: {items: [], debugData: {manifestUrl: 'https://caltrainschedule.io/manifest.json'}},
+      },
+      'splash-screen': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'themed-omnibox': {
+        score: 0,
+      },
+      'content-width': {
+        score: 1,
+      },
+      'apple-touch-icon': {
+        score: 1,
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },
-];
+};
+
+module.exports = {
+  svgomg,
+  caltrain,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa3-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa3-expectations.js
@@ -5,64 +5,67 @@
  */
 'use strict';
 
+/** @fileoverview Expected Lighthouse audit values for various sites with stable(ish) PWA results. */
+
 const pwaDetailsExpectations = require('./pwa-expectations-details.js');
 const pwaRocksExpectations = {...pwaDetailsExpectations, hasIconsAtLeast512px: false};
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for various sites with stable(ish) PWA
- * results.
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse results for (the archived) pwa.rocks.
  */
-module.exports = [
-  {
-    lhr: {
-      // Archived version of https://github.com/pwarocks/pwa.rocks
-      // Fork is here: https://github.com/connorjclark/pwa.rocks
-      requestedUrl: 'https://connorjclark.github.io/pwa.rocks/',
-      finalUrl: 'https://connorjclark.github.io/pwa.rocks/',
-      audits: {
-        'redirects-http': {
-          score: 1,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'installable-manifest': {
-          score: 1,
-          details: {items: [], debugData: {manifestUrl: 'https://connorjclark.github.io/pwa.rocks/pwa.webmanifest'}},
-        },
-        'splash-screen': {
-          score: 0,
-          details: {items: [pwaRocksExpectations]},
-        },
-        'themed-omnibox': {
-          score: 0,
-          details: {items: [pwaRocksExpectations]},
-        },
-        'content-width': {
-          score: 1,
-        },
-        'apple-touch-icon': {
-          score: 1,
-        },
+const pwarocks = {
+  lhr: {
+    // Archived version of https://github.com/pwarocks/pwa.rocks
+    // Fork is here: https://github.com/connorjclark/pwa.rocks
+    requestedUrl: 'https://connorjclark.github.io/pwa.rocks/',
+    finalUrl: 'https://connorjclark.github.io/pwa.rocks/',
+    audits: {
+      'redirects-http': {
+        score: 1,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'installable-manifest': {
+        score: 1,
+        details: {items: [], debugData: {manifestUrl: 'https://connorjclark.github.io/pwa.rocks/pwa.webmanifest'}},
+      },
+      'splash-screen': {
+        score: 0,
+        details: {items: [pwaRocksExpectations]},
+      },
+      'themed-omnibox': {
+        score: 0,
+        details: {items: [pwaRocksExpectations]},
+      },
+      'content-width': {
+        score: 1,
+      },
+      'apple-touch-icon': {
+        score: 1,
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },
-];
+};
+
+module.exports = {
+  pwarocks,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects/expectations.js
@@ -126,13 +126,12 @@ const singleClient = {
   },
 };
 
-// TODO: what's the describable difference between this and the above? Also, better names.
 /**
  * @type {Smokehouse.ExpectedRunnerResult}
  * Expected Lighthouse audit values for a site with a client-side redirect (2s + 5s),
- * paints at 2s, then a server-side redirect (1s).
+ * paints at 2s, then a server-side redirect (1s), followed by a history.pushState to an unrelated URL.
  */
-const clientPaintServer2 = {
+const historyPushState = {
   // TODO: Assert performance metrics on client-side redirects, see https://github.com/GoogleChrome/lighthouse/pull/10325
   lhr: {
     requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fonline-only.html%3Fdelay%3D1000%26redirect%3D%2Fredirects-final.html%253FpushState`,
@@ -152,5 +151,5 @@ module.exports = {
   multipleServer,
   clientPaintServer,
   singleClient,
-  clientPaintServer2,
+  historyPushState,
 };

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects/expectations.js
@@ -6,129 +6,151 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for redirects tests
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for a site with a single server-side redirect (2s).
  */
-const expectations = [
-  {
-    // Single server-side redirect (2s)
-    lhr: {
-      requestedUrl: `http://localhost:10200/online-only.html?delay=2000&redirect=%2Fredirects-final.html`,
-      finalUrl: 'http://localhost:10200/redirects-final.html',
-      audits: {
-        'first-contentful-paint': {
-          numericValue: '>=2000',
-        },
-        'interactive': {
-          numericValue: '>=2000',
-        },
-        'speed-index': {
-          numericValue: '>=2000',
-        },
-        'redirects': {
-          score: 1,
-          numericValue: '>=2000',
-          details: {
-            items: {
-              length: 2,
-            },
+const singleServer = {
+  lhr: {
+    requestedUrl: `http://localhost:10200/online-only.html?delay=2000&redirect=%2Fredirects-final.html`,
+    finalUrl: 'http://localhost:10200/redirects-final.html',
+    audits: {
+      'first-contentful-paint': {
+        numericValue: '>=2000',
+      },
+      'interactive': {
+        numericValue: '>=2000',
+      },
+      'speed-index': {
+        numericValue: '>=2000',
+      },
+      'redirects': {
+        score: 1,
+        numericValue: '>=2000',
+        details: {
+          items: {
+            length: 2,
           },
         },
       },
-      runWarnings: [
-        /The page may not be loading as expected because your test URL \(.*online-only.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
-      ],
     },
+    runWarnings: [
+      /The page may not be loading as expected because your test URL \(.*online-only.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+    ],
   },
-  {
-    // Multiple server-side redirects (3 x 1s)
-    lhr: {
-      requestedUrl: `http://localhost:10200/online-only.html?delay=1000&redirect_count=3&redirect=%2Fredirects-final.html`,
-      finalUrl: 'http://localhost:10200/redirects-final.html',
-      audits: {
-        'first-contentful-paint': {
-          numericValue: '>=3000',
-        },
-        'interactive': {
-          numericValue: '>=3000',
-        },
-        'speed-index': {
-          numericValue: '>=3000',
-        },
-        'redirects': {
-          score: '<1',
-          details: {
-            items: {
-              length: 4,
-            },
-          },
-        },
-      },
-      runWarnings: [
-        /The page may not be loading as expected because your test URL \(.*online-only.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
-      ],
-    },
-  },
-  {
-    // Client-side redirect (2s + 5s), paints at 2s, server-side redirect (1s)
-    // TODO: Assert performance metrics on client-side redirects, see https://github.com/GoogleChrome/lighthouse/pull/10325
-    lhr: {
-      requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fonline-only.html%3Fdelay%3D1000%26redirect%3D%2Fredirects-final.html`,
-      finalUrl: 'http://localhost:10200/redirects-final.html',
-      audits: {
-        // Just captures the server-side at the moment, should be 8s in the future
-        'first-contentful-paint': {
-          numericValue: '>=1000',
-        },
-        'interactive': {
-          numericValue: '>=1000',
-        },
-        'speed-index': {
-          numericValue: '>=1000',
-        },
-        'redirects': {
-          score: '<1',
-          numericValue: '>=8000',
-          details: {
-            items: {
-              length: 3,
-            },
-          },
-        },
-      },
-      runWarnings: [
-        /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
-      ],
-    },
-  },
-  {
-    // Client-side redirect (2s + 5s), no paint
-    // TODO: Assert performance metrics on client-side redirects, see https://github.com/GoogleChrome/lighthouse/pull/10325
-    lhr: {
-      requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fredirects-final.html`,
-      finalUrl: 'http://localhost:10200/redirects-final.html',
-      audits: {
-      },
-      runWarnings: [
-        /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
-      ],
-    },
-  },
-  {
-    // Client-side redirect (2s + 5s), paints at 2s, server-side redirect (1s)
-    // TODO: Assert performance metrics on client-side redirects, see https://github.com/GoogleChrome/lighthouse/pull/10325
-    lhr: {
-      requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fonline-only.html%3Fdelay%3D1000%26redirect%3D%2Fredirects-final.html%253FpushState`,
-      // Note that the final URL is the URL of the network requested resource and not that page we end up on.
-      // http://localhost:10200/push-state
-      finalUrl: 'http://localhost:10200/redirects-final.html?pushState',
-      audits: {
-      },
-      runWarnings: [
-        /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html\?pushState. Try testing the second URL directly./,
-      ],
-    },
-  },
-];
+};
 
-module.exports = expectations;
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for a site with multiple server-side redirects (3 x 1s).
+ */
+const multipleServer = {
+  lhr: {
+    requestedUrl: `http://localhost:10200/online-only.html?delay=1000&redirect_count=3&redirect=%2Fredirects-final.html`,
+    finalUrl: 'http://localhost:10200/redirects-final.html',
+    audits: {
+      'first-contentful-paint': {
+        numericValue: '>=3000',
+      },
+      'interactive': {
+        numericValue: '>=3000',
+      },
+      'speed-index': {
+        numericValue: '>=3000',
+      },
+      'redirects': {
+        score: '<1',
+        details: {
+          items: {
+            length: 4,
+          },
+        },
+      },
+    },
+    runWarnings: [
+      /The page may not be loading as expected because your test URL \(.*online-only.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+    ],
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for a site with a client-side redirect (2s + 5s),
+ * paints at 2s, then a server-side redirect (1s).
+ */
+const clientPaintServer = {
+  // TODO: Assert performance metrics on client-side redirects, see https://github.com/GoogleChrome/lighthouse/pull/10325
+  lhr: {
+    requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fonline-only.html%3Fdelay%3D1000%26redirect%3D%2Fredirects-final.html`,
+    finalUrl: 'http://localhost:10200/redirects-final.html',
+    audits: {
+      // Just captures the server-side at the moment, should be 8s in the future
+      'first-contentful-paint': {
+        numericValue: '>=1000',
+      },
+      'interactive': {
+        numericValue: '>=1000',
+      },
+      'speed-index': {
+        numericValue: '>=1000',
+      },
+      'redirects': {
+        score: '<1',
+        numericValue: '>=8000',
+        details: {
+          items: {
+            length: 3,
+          },
+        },
+      },
+    },
+    runWarnings: [
+      /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+    ],
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for a site with a client-side redirect (2s + 5s), no paint.
+ */
+const singleClient = {
+  // TODO: Assert performance metrics on client-side redirects, see https://github.com/GoogleChrome/lighthouse/pull/10325
+  lhr: {
+    requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fredirects-final.html`,
+    finalUrl: 'http://localhost:10200/redirects-final.html',
+    audits: {
+    },
+    runWarnings: [
+      /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+    ],
+  },
+};
+
+// TODO: what's the describable difference between this and the above? Also, better names.
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for a site with a client-side redirect (2s + 5s),
+ * paints at 2s, then a server-side redirect (1s).
+ */
+const clientPaintServer2 = {
+  // TODO: Assert performance metrics on client-side redirects, see https://github.com/GoogleChrome/lighthouse/pull/10325
+  lhr: {
+    requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fonline-only.html%3Fdelay%3D1000%26redirect%3D%2Fredirects-final.html%253FpushState`,
+    // Note that the final URL is the URL of the network requested resource and not that page we end up on.
+    // http://localhost:10200/push-state
+    finalUrl: 'http://localhost:10200/redirects-final.html?pushState',
+    audits: {
+    },
+    runWarnings: [
+      /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html\?pushState. Try testing the second URL directly./,
+    ],
+  },
+};
+
+module.exports = {
+  singleServer,
+  multipleServer,
+  clientPaintServer,
+  singleClient,
+  clientPaintServer2,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/screenshot/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/screenshot/expectations.js
@@ -6,57 +6,55 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
+ * @type {Smokehouse.ExpectedRunnerResult}
  */
-const expectations = [
-  {
-    artifacts: {
-      FullPageScreenshot: {
-        screenshot: {
-          width: '>1000',
-          height: '>1000',
-          data: /data:image\/jpeg;base64,.{10000,}$/,
+const expectations = {
+  artifacts: {
+    FullPageScreenshot: {
+      screenshot: {
+        width: '>1000',
+        height: '>1000',
+        data: /data:image\/jpeg;base64,.{10000,}$/,
+      },
+      nodes: {
+        'page-0-BODY': {
+          top: 8,
+          bottom: 1008,
+          left: 8,
+          right: 1008,
+          width: 1000,
+          height: 1000,
         },
-        nodes: {
-          'page-0-BODY': {
-            top: 8,
-            bottom: 1008,
-            left: 8,
-            right: 1008,
-            width: 1000,
-            height: 1000,
-          },
-          // The following 2 are the same element (from different JS contexts). This element
-          // starts with height ~18 and grows over time. See screenshot.html.
-          'page-1-P': {
-            top: 8,
-            left: 8,
-            height: '>40',
-          },
-          // Note: The first number (5) in these ids comes from an executionContextId, and has the potential to change
-          '5-1-P': {
-            top: 8,
-            left: 8,
-            height: '>40',
-          },
-          '5-2-BODY': {
-            top: 8,
-            bottom: 1008,
-            left: 8,
-            right: 1008,
-            width: 1000,
-            height: 1000,
-          },
-          '5-3-HTML': {},
+        // The following 2 are the same element (from different JS contexts). This element
+        // starts with height ~18 and grows over time. See screenshot.html.
+        'page-1-P': {
+          top: 8,
+          left: 8,
+          height: '>40',
         },
+        // Note: The first number (5) in these ids comes from an executionContextId, and has the potential to change
+        '5-1-P': {
+          top: 8,
+          left: 8,
+          height: '>40',
+        },
+        '5-2-BODY': {
+          top: 8,
+          bottom: 1008,
+          left: 8,
+          right: 1008,
+          width: 1000,
+          height: 1000,
+        },
+        '5-3-HTML': {},
       },
     },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/screenshot.html?width=1000px&height=1000px',
-      finalUrl: 'http://localhost:10200/screenshot.html?width=1000px&height=1000px',
-      audits: {},
-    },
   },
-];
+  lhr: {
+    requestedUrl: 'http://localhost:10200/screenshot.html?width=1000px&height=1000px',
+    finalUrl: 'http://localhost:10200/screenshot.html?width=1000px&height=1000px',
+    audits: {},
+  },
+};
 
 module.exports = expectations;

--- a/lighthouse-cli/test/smokehouse/test-definitions/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/seo/expectations.js
@@ -130,338 +130,358 @@ const passHeaders = headersParam([[
 ]]);
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for seo tests
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for a site that passes seo tests.
  */
-const expectations = [
-  {
-    lhr: {
-      requestedUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
-      finalUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
-      audits: {
-        'viewport': {
-          score: 1,
-        },
-        'document-title': {
-          score: 1,
-        },
-        'meta-description': {
-          score: 1,
-        },
-        'http-status-code': {
-          score: 1,
-        },
-        'font-size': {
-          score: 1,
-          details: {
-            items: [
-              {
-                source: {
-                  url: /seo-tester\.html.+$/,
-                  urlProvider: 'network',
-                  line: 23,
-                  column: 12,
-                },
-                selector: '.small',
-                fontSize: '11px',
+const passing = {
+  lhr: {
+    requestedUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
+    finalUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
+    audits: {
+      'viewport': {
+        score: 1,
+      },
+      'document-title': {
+        score: 1,
+      },
+      'meta-description': {
+        score: 1,
+      },
+      'http-status-code': {
+        score: 1,
+      },
+      'font-size': {
+        score: 1,
+        details: {
+          items: [
+            {
+              source: {
+                url: /seo-tester\.html.+$/,
+                urlProvider: 'network',
+                line: 23,
+                column: 12,
               },
-              {
-                source: {
-                  url: /seo-tester\.html.+$/,
-                  urlProvider: 'network',
-                  line: 27,
-                  column: 55,
-                },
-                selector: '.small-2',
-                fontSize: '11px',
+              selector: '.small',
+              fontSize: '11px',
+            },
+            {
+              source: {
+                url: /seo-tester\.html.+$/,
+                urlProvider: 'network',
+                line: 27,
+                column: 55,
               },
-              {
-                source: {
-                  url: /seo-tester-inline-magic\.css$/,
-                  urlProvider: 'comment',
-                  line: 2,
-                  column: 14,
-                },
-                selector: '.small-3',
-                fontSize: '6px',
+              selector: '.small-2',
+              fontSize: '11px',
+            },
+            {
+              source: {
+                url: /seo-tester-inline-magic\.css$/,
+                urlProvider: 'comment',
+                line: 2,
+                column: 14,
               },
-              {
-                source: {
-                  url: /seo-tester-styles-magic\.css$/,
-                  urlProvider: 'comment',
-                  line: 2,
-                  column: 10,
-                },
-                selector: '.small-4',
-                fontSize: '6px',
+              selector: '.small-3',
+              fontSize: '6px',
+            },
+            {
+              source: {
+                url: /seo-tester-styles-magic\.css$/,
+                urlProvider: 'comment',
+                line: 2,
+                column: 10,
               },
-              {
-                source: {type: 'code', value: 'User Agent Stylesheet'},
-                selector: 'h6',
-                fontSize: '10.72px',
+              selector: '.small-4',
+              fontSize: '6px',
+            },
+            {
+              source: {type: 'code', value: 'User Agent Stylesheet'},
+              selector: 'h6',
+              fontSize: '10.72px',
+            },
+            {
+              source: {type: 'url', value: /seo-tester\.html.+$/},
+              selector: {
+                type: 'node',
+                selector: 'body',
+                snippet: '<font size="1">',
               },
-              {
-                source: {type: 'url', value: /seo-tester\.html.+$/},
-                selector: {
-                  type: 'node',
-                  selector: 'body',
-                  snippet: '<font size="1">',
-                },
-                fontSize: '10px',
+              fontSize: '10px',
+            },
+            {
+              source: {type: 'url', value: /seo-tester\.html.+$/},
+              selector: {
+                type: 'node',
+                selector: 'font',
+                snippet: '<b>',
               },
-              {
-                source: {type: 'url', value: /seo-tester\.html.+$/},
-                selector: {
-                  type: 'node',
-                  selector: 'font',
-                  snippet: '<b>',
-                },
-                fontSize: '10px',
+              fontSize: '10px',
+            },
+            {
+              source: {type: 'url', value: /seo-tester\.html.+$/},
+              selector: {
+                type: 'node',
+                selector: 'div',
+                snippet: '<p style="font-size:10px">',
               },
-              {
-                source: {type: 'url', value: /seo-tester\.html.+$/},
-                selector: {
-                  type: 'node',
-                  selector: 'div',
-                  snippet: '<p style="font-size:10px">',
-                },
-                fontSize: '10px',
-              },
-              {
-                source: {type: 'code', value: 'Legible text'},
-                selector: '',
-                fontSize: '≥ 12px',
-              },
-            ],
-          },
-        },
-        'crawlable-anchors': {
-          score: 1,
-        },
-        'link-text': {
-          score: 1,
-        },
-        'is-crawlable': {
-          score: 1,
-        },
-        'hreflang': {
-          score: 1,
-        },
-        'plugins': {
-          score: 1,
-        },
-        'canonical': {
-          score: 1,
-        },
-        'robots-txt': {
-          score: null,
-          scoreDisplayMode: 'notApplicable',
+              fontSize: '10px',
+            },
+            {
+              source: {type: 'code', value: 'Legible text'},
+              selector: '',
+              fontSize: '≥ 12px',
+            },
+          ],
         },
       },
-    }},
-  {
-    lhr: {
-      requestedUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
-      finalUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
-      audits: {
-        'viewport': {
-          score: 0,
-        },
-        'document-title': {
-          score: 0,
-        },
-        'meta-description': {
-          score: 0,
-        },
-        'http-status-code': {
-          score: 1,
-        },
-        'font-size': {
-          score: 0,
-          explanation:
-          'Text is illegible because there\'s no viewport meta tag optimized for mobile screens.',
-        },
-        'crawlable-anchors': {
-          score: 0,
-          details: {
-            items: {
-              length: 4,
-            },
-          },
-        },
-        'link-text': {
-          score: 0,
-          displayValue: '4 links found',
-          details: {
-            items: {
-              length: 4,
-            },
-          },
-        },
-        'is-crawlable': {
-          score: 0,
-          details: {
-            items: {
-              length: 2,
-            },
-          },
-        },
-        'hreflang': {
-          score: 0,
-          details: {
-            items: {
-              length: 5,
-            },
-          },
-        },
-        'plugins': {
-          score: 0,
-          details: {
-            items: {
-              length: 3,
-            },
-          },
-        },
-        'canonical': {
-          score: 0,
-          explanation: 'Multiple conflicting URLs (https://example.com/other, https://example.com/)',
-        },
+      'crawlable-anchors': {
+        score: 1,
+      },
+      'link-text': {
+        score: 1,
+      },
+      'is-crawlable': {
+        score: 1,
+      },
+      'hreflang': {
+        score: 1,
+      },
+      'plugins': {
+        score: 1,
+      },
+      'canonical': {
+        score: 1,
+      },
+      'robots-txt': {
+        score: null,
+        scoreDisplayMode: 'notApplicable',
       },
     },
   },
-  {
-    lhr: {
-      // Note: most scores are null (audit error) because the page 403ed.
-      requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
-      finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
-      runtimeError: {
-        code: 'ERRORED_DOCUMENT_REQUEST',
-        message: /Status code: 403/,
-      },
-      runWarnings: ['Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests. (Status code: 403)'],
-      audits: {
-        'http-status-code': {
-          score: null,
-        },
-        'viewport': {
-          score: null,
-        },
-        'document-title': {
-          score: null,
-        },
-        'meta-description': {
-          score: null,
-        },
-        'font-size': {
-          score: null,
-        },
-        'crawlable-anchors': {
-          score: null,
-        },
-        'link-text': {
-          score: null,
-        },
-        'is-crawlable': {
-          score: null,
-        },
-        'hreflang': {
-          score: null,
-        },
-        'plugins': {
-          score: null,
-        },
-        'canonical': {
-          score: null,
-        },
-      },
-    }},
-  {
-    lhr: {
-      finalUrl: BASE_URL + 'seo-tap-targets.html',
-      requestedUrl: BASE_URL + 'seo-tap-targets.html',
-      audits: {
-        'tap-targets': {
-          score: (() => {
-            const totalTapTargets = expectedGatheredTapTargets.length;
-            const passingTapTargets = expectedGatheredTapTargets.filter(t => !t.shouldFail).length;
-            const SCORE_FACTOR = 0.89;
-            return Math.round(passingTapTargets / totalTapTargets * SCORE_FACTOR * 100) / 100;
-          })(),
-          details: {
-            items: [
-              {
-                'tapTarget': {
-                  'type': 'node',
-                  /* eslint-disable max-len */
-                  'snippet': '<a data-gathered-target="zero-width-tap-target-with-overflowing-child-content" style="display: block; width: 0; white-space: nowrap">',
-                  'path': '2,HTML,1,BODY,14,DIV,0,A',
-                  'selector': 'body > div > a',
-                  'nodeLabel': 'zero width target',
-                },
-                'overlappingTarget': {
-                  'type': 'node',
-                  /* eslint-disable max-len */
-                  'snippet': '<a data-gathered-target="passing-tap-target-next-to-zero-width-target" style="display: block; width: 110px; height: 100px;background: #aaa;">',
-                  'path': '2,HTML,1,BODY,14,DIV,1,A',
-                  'selector': 'body > div > a',
-                  'nodeLabel': 'passing target',
-                },
-                'tapTargetScore': 864,
-                'overlappingTargetScore': 720,
-                'overlapScoreRatio': 0.8333333333333334,
-                'size': '110x18',
-                'width': 110,
-                'height': 18,
-              },
-              {
-                'tapTarget': {
-                  'type': 'node',
-                  'path': '2,HTML,1,BODY,10,DIV,0,DIV,1,A',
-                  'selector': 'body > div > div > a',
-                  'nodeLabel': 'too small target',
-                },
-                'overlappingTarget': {
-                  'type': 'node',
-                  'path': '2,HTML,1,BODY,10,DIV,0,DIV,2,A',
-                  'selector': 'body > div > div > a',
-                  'nodeLabel': 'big enough target',
-                },
-                'tapTargetScore': 1440,
-                'overlappingTargetScore': 432,
-                'overlapScoreRatio': 0.3,
-                'size': '100x30',
-                'width': 100,
-                'height': 30,
-              },
-              {
-                'tapTarget': {
-                  'type': 'node',
-                  'path': '2,HTML,1,BODY,3,DIV,24,A',
-                  'selector': 'body > div > a',
-                  'nodeLabel': 'left',
-                },
-                'overlappingTarget': {
-                  'type': 'node',
-                  'path': '2,HTML,1,BODY,3,DIV,25,A',
-                  'selector': 'body > div > a',
-                  'nodeLabel': 'right',
-                },
-                'tapTargetScore': 1920,
-                'overlappingTargetScore': 560,
-                'overlapScoreRatio': 0.2916666666666667,
-                'size': '40x40',
-                'width': 40,
-                'height': 40,
-              },
-            ],
-          },
-        },
-      },
-    },
-    artifacts: {
-      TapTargets: expectedGatheredTapTargets.map(({node}) => ({node})),
-    },
-  },
-];
+};
 
-module.exports = expectations;
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for a site that fails seo tests.
+ */
+const failing = {
+  lhr: {
+    requestedUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
+    finalUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
+    audits: {
+      'viewport': {
+        score: 0,
+      },
+      'document-title': {
+        score: 0,
+      },
+      'meta-description': {
+        score: 0,
+      },
+      'http-status-code': {
+        score: 1,
+      },
+      'font-size': {
+        score: 0,
+        explanation:
+        'Text is illegible because there\'s no viewport meta tag optimized for mobile screens.',
+      },
+      'crawlable-anchors': {
+        score: 0,
+        details: {
+          items: {
+            length: 4,
+          },
+        },
+      },
+      'link-text': {
+        score: 0,
+        displayValue: '4 links found',
+        details: {
+          items: {
+            length: 4,
+          },
+        },
+      },
+      'is-crawlable': {
+        score: 0,
+        details: {
+          items: {
+            length: 2,
+          },
+        },
+      },
+      'hreflang': {
+        score: 0,
+        details: {
+          items: {
+            length: 5,
+          },
+        },
+      },
+      'plugins': {
+        score: 0,
+        details: {
+          items: {
+            length: 3,
+          },
+        },
+      },
+      'canonical': {
+        score: 0,
+        explanation: 'Multiple conflicting URLs (https://example.com/other, https://example.com/)',
+      },
+    },
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for a site served with http status 403.
+ */
+const status403 = {
+  lhr: {
+    // Note: most scores are null (audit error) because the page 403ed.
+    requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+    finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+    runtimeError: {
+      code: 'ERRORED_DOCUMENT_REQUEST',
+      message: /Status code: 403/,
+    },
+    runWarnings: ['Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests. (Status code: 403)'],
+    audits: {
+      'http-status-code': {
+        score: null,
+      },
+      'viewport': {
+        score: null,
+      },
+      'document-title': {
+        score: null,
+      },
+      'meta-description': {
+        score: null,
+      },
+      'font-size': {
+        score: null,
+      },
+      'crawlable-anchors': {
+        score: null,
+      },
+      'link-text': {
+        score: null,
+      },
+      'is-crawlable': {
+        score: null,
+      },
+      'hreflang': {
+        score: null,
+      },
+      'plugins': {
+        score: null,
+      },
+      'canonical': {
+        score: null,
+      },
+    },
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for a site exercising tap targets.
+ */
+const tapTargets = {
+  lhr: {
+    finalUrl: BASE_URL + 'seo-tap-targets.html',
+    requestedUrl: BASE_URL + 'seo-tap-targets.html',
+    audits: {
+      'tap-targets': {
+        score: (() => {
+          const totalTapTargets = expectedGatheredTapTargets.length;
+          const passingTapTargets = expectedGatheredTapTargets.filter(t => !t.shouldFail).length;
+          const SCORE_FACTOR = 0.89;
+          return Math.round(passingTapTargets / totalTapTargets * SCORE_FACTOR * 100) / 100;
+        })(),
+        details: {
+          items: [
+            {
+              'tapTarget': {
+                'type': 'node',
+                /* eslint-disable max-len */
+                'snippet': '<a data-gathered-target="zero-width-tap-target-with-overflowing-child-content" style="display: block; width: 0; white-space: nowrap">',
+                'path': '2,HTML,1,BODY,14,DIV,0,A',
+                'selector': 'body > div > a',
+                'nodeLabel': 'zero width target',
+              },
+              'overlappingTarget': {
+                'type': 'node',
+                /* eslint-disable max-len */
+                'snippet': '<a data-gathered-target="passing-tap-target-next-to-zero-width-target" style="display: block; width: 110px; height: 100px;background: #aaa;">',
+                'path': '2,HTML,1,BODY,14,DIV,1,A',
+                'selector': 'body > div > a',
+                'nodeLabel': 'passing target',
+              },
+              'tapTargetScore': 864,
+              'overlappingTargetScore': 720,
+              'overlapScoreRatio': 0.8333333333333334,
+              'size': '110x18',
+              'width': 110,
+              'height': 18,
+            },
+            {
+              'tapTarget': {
+                'type': 'node',
+                'path': '2,HTML,1,BODY,10,DIV,0,DIV,1,A',
+                'selector': 'body > div > div > a',
+                'nodeLabel': 'too small target',
+              },
+              'overlappingTarget': {
+                'type': 'node',
+                'path': '2,HTML,1,BODY,10,DIV,0,DIV,2,A',
+                'selector': 'body > div > div > a',
+                'nodeLabel': 'big enough target',
+              },
+              'tapTargetScore': 1440,
+              'overlappingTargetScore': 432,
+              'overlapScoreRatio': 0.3,
+              'size': '100x30',
+              'width': 100,
+              'height': 30,
+            },
+            {
+              'tapTarget': {
+                'type': 'node',
+                'path': '2,HTML,1,BODY,3,DIV,24,A',
+                'selector': 'body > div > a',
+                'nodeLabel': 'left',
+              },
+              'overlappingTarget': {
+                'type': 'node',
+                'path': '2,HTML,1,BODY,3,DIV,25,A',
+                'selector': 'body > div > a',
+                'nodeLabel': 'right',
+              },
+              'tapTargetScore': 1920,
+              'overlappingTargetScore': 560,
+              'overlapScoreRatio': 0.2916666666666667,
+              'size': '40x40',
+              'width': 40,
+              'height': 40,
+            },
+          ],
+        },
+      },
+    },
+  },
+  artifacts: {
+    TapTargets: expectedGatheredTapTargets.map(({node}) => ({node})),
+  },
+};
+
+module.exports = {
+  passing,
+  failing,
+  status403,
+  tapTargets,
+};

--- a/lighthouse-cli/test/smokehouse/test-definitions/source-maps/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/source-maps/expectations.js
@@ -12,34 +12,32 @@ const mapJson =
 const map = JSON.parse(mapJson);
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
- * Expected Lighthouse audit values for seo tests
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse values for source map artifacts.
  *
  * We have experienced timeouts in the past when fetching source maps.
  * We should verify the timing issue in Chromium if this gets flaky.
  */
-const expectations = [
-  {
-    artifacts: {
-      SourceMaps: [
-        {
-          scriptUrl: 'http://localhost:10200/source-map/source-map-tester.html',
-          sourceMapUrl: 'http://localhost:10200/source-map/script.js.map',
-          map,
-        },
-        {
-          scriptUrl: 'http://localhost:10200/source-map/source-map-tester.html',
-          sourceMapUrl: 'http://localhost:10503/source-map/script.js.map',
-          map,
-        },
-      ],
-    },
-    lhr: {
-      requestedUrl: 'http://localhost:10200/source-map/source-map-tester.html',
-      finalUrl: 'http://localhost:10200/source-map/source-map-tester.html',
-      audits: {},
-    },
+const expectations = {
+  artifacts: {
+    SourceMaps: [
+      {
+        scriptUrl: 'http://localhost:10200/source-map/source-map-tester.html',
+        sourceMapUrl: 'http://localhost:10200/source-map/script.js.map',
+        map,
+      },
+      {
+        scriptUrl: 'http://localhost:10200/source-map/source-map-tester.html',
+        sourceMapUrl: 'http://localhost:10503/source-map/script.js.map',
+        map,
+      },
+    ],
   },
-];
+  lhr: {
+    requestedUrl: 'http://localhost:10200/source-map/source-map-tester.html',
+    finalUrl: 'http://localhost:10200/source-map/source-map-tester.html',
+    audits: {},
+  },
+};
 
 module.exports = expectations;

--- a/lighthouse-cli/test/smokehouse/test-definitions/tricky-metrics/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/tricky-metrics/expectations.js
@@ -6,68 +6,96 @@
 'use strict';
 
 /**
- * @type {Array<Smokehouse.ExpectedRunnerResult>}
+ * @fileoverview
  * Expected Lighthouse audit values for tricky metrics tests that previously failed to be computed.
  * We only place lower bounds because we are checking that these metrics *can* be computed and that
  * we wait long enough to compute them. Upper bounds aren't very helpful here and tend to cause flaky failures.
  */
-module.exports = [
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/tricky-tti.html',
-      finalUrl: 'http://localhost:10200/tricky-tti.html',
-      audits: {
-        'interactive': {
-          // stalls for ~5 seconds, ~5 seconds out, so should be at least ~10s
-          numericValue: '>9900',
-        },
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const trickyTti = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/tricky-tti.html',
+    finalUrl: 'http://localhost:10200/tricky-tti.html',
+    audits: {
+      'interactive': {
+        // stalls for ~5 seconds, ~5 seconds out, so should be at least ~10s
+        numericValue: '>9900',
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/tricky-tti-late-fcp.html',
-      finalUrl: 'http://localhost:10200/tricky-tti-late-fcp.html',
-      audits: {
-        'interactive': {
-          // FCP at least ~5 seconds out
-          numericValue: '>4900',
-        },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const trickyTtiLateFcp = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/tricky-tti-late-fcp.html',
+    finalUrl: 'http://localhost:10200/tricky-tti-late-fcp.html',
+    audits: {
+      'interactive': {
+        // FCP at least ~5 seconds out
+        numericValue: '>4900',
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/delayed-lcp.html',
-      finalUrl: 'http://localhost:10200/delayed-lcp.html',
-      audits: {
-        'largest-contentful-paint': {
-          // LCP is after the ~7s XHR and the ~7s image.
-          numericValue: '>14000',
-        },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const delayedLcp = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/delayed-lcp.html',
+    finalUrl: 'http://localhost:10200/delayed-lcp.html',
+    audits: {
+      'largest-contentful-paint': {
+        // LCP is after the ~7s XHR and the ~7s image.
+        numericValue: '>14000',
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/delayed-fcp.html',
-      finalUrl: 'http://localhost:10200/delayed-fcp.html',
-      audits: {
-        'first-contentful-paint': {
-          numericValue: '>1', // We just want to check that it doesn't error
-        },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const delayedFcp = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/delayed-fcp.html',
+    finalUrl: 'http://localhost:10200/delayed-fcp.html',
+    audits: {
+      'first-contentful-paint': {
+        numericValue: '>1', // We just want to check that it doesn't error
       },
     },
   },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/debugger.html',
-      finalUrl: 'http://localhost:10200/debugger.html',
-      audits: {
-        'first-contentful-paint': {
-          numericValue: '>1', // We just want to check that it doesn't error
-        },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Lighthouse expecations that metrics are computed even if a debugger statement
+ * is left in the page's JS.
+ */
+const debuggerStatement = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/debugger.html',
+    finalUrl: 'http://localhost:10200/debugger.html',
+    audits: {
+      'first-contentful-paint': {
+        numericValue: '>1', // We just want to check that it doesn't error
       },
     },
   },
-];
+};
+
+module.exports = {
+  trickyTti,
+  trickyTtiLateFcp,
+  delayedLcp,
+  delayedFcp,
+  debuggerStatement,
+};


### PR DESCRIPTION
part 2/2 of #11950. PR currently based on top of #12818

This splits up our core tests so there's a separate testDefn and ID for every smoke expectation. The splitting up is done here and tentative IDs are chosen, but I wanted some bike shedding input before I tried to put everything in the same format.

For reviewers:
- this is much, _much_ easier to review with [?w=1](https://github.com/GoogleChrome/lighthouse/pull/12819/files?w=1). Lots of indentation changes.
- Most important file is `core-tests.js`, as that's where the test IDs are set.
   (I'll be honest: there are a lot of these, and about halfway through this I stopped trying very hard with the names if the tests weren't super obvious how they were different from each other. I'm looking at you `redirects` and `csp` :P Please suggest better IDs than I have here)
- expectations are functionally all the same, but feel free to pick a smoke file you care about and double check it's still good and offer opinions on the changes in them.

For bikeshedders:
- IDs!
- #11950 suggested a file per expectation, but in some cases there are shared properties between expectations, and multiple named exports could maybe work ok. Do we want to go all the way and still do a file per expectation (and import shared stuff), or have a mixture of single and multiples, or...? Splitting into different files should be easy now, so I'm happy to go either way.
- We have grouped IDs where e.g. the old `errors` becomes `errors-infinite-loop`, `errors-expired-ssl` etc. Handy for running with just `yarn smoke errors`, but:
  - do we want to formalize a `category-specific` naming format?
  - are one-off tests ok? e.g. there's only one `oopif` tests, so it's still just called `oopif`. Is that ok or should we preemptively call it `oopif-requests` just in case one day we have `oopif-some-other-thing`?