### PR TITLE
core(css-usage): ignore removed stylesheets

### DIFF
--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -20,7 +20,7 @@ class CSSUsage extends FRGatherer {
     /** @param {LH.Crdp.CSS.StyleSheetRemovedEvent} sheet */
     this._onStylesheetRemoved = sheet => {
       // We can't fetch the content of removed stylesheets, so we ignore them completely.
-      // TODO(FR-COMPAT): Refactor use of CSSUsage artifact to not *always* rely on the content of stylesheets. 
+      // TODO(FR-COMPAT): Refactor use of CSSUsage artifact to not *always* rely on the content of stylesheets.
       const styleSheetId = sheet.styleSheetId;
       this._stylesheets = this._stylesheets.filter(s => s.header.styleSheetId !== styleSheetId);
     };

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -19,6 +19,8 @@ class CSSUsage extends FRGatherer {
     this._onStylesheetAdded = sheet => this._stylesheets.push(sheet);
     /** @param {LH.Crdp.CSS.StyleSheetRemovedEvent} sheet */
     this._onStylesheetRemoved = sheet => {
+      // We can't fetch the content of removed stylesheets, so we ignore them completely.
+      // TODO(FR-COMPAT): Refactor use of CSSUsage artifact to not *always* rely on the content of stylesheets. 
       const styleSheetId = sheet.styleSheetId;
       this._stylesheets = this._stylesheets.filter(s => s.header.styleSheetId !== styleSheetId);
     };

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -17,6 +17,11 @@ class CSSUsage extends FRGatherer {
     this._stylesheets = [];
     /** @param {LH.Crdp.CSS.StyleSheetAddedEvent} sheet */
     this._onStylesheetAdded = sheet => this._stylesheets.push(sheet);
+    /** @param {LH.Crdp.CSS.StyleSheetRemovedEvent} sheet */
+    this._onStylesheetRemoved = sheet => {
+      const styleSheetId = sheet.styleSheetId;
+      this._stylesheets = this._stylesheets.filter(s => s.header.styleSheetId !== styleSheetId);
+    };
     /**
      * Initialize as undefined so we can assert results are fetched.
      * @type {LH.Crdp.CSS.RuleUsage[]|undefined}
@@ -35,6 +40,7 @@ class CSSUsage extends FRGatherer {
   async startCSSUsageTracking(context) {
     const session = context.driver.defaultSession;
     session.on('CSS.styleSheetAdded', this._onStylesheetAdded);
+    session.on('CSS.styleSheetRemoved', this._onStylesheetRemoved);
 
     await session.sendCommand('DOM.enable');
     await session.sendCommand('CSS.enable');
@@ -57,6 +63,7 @@ class CSSUsage extends FRGatherer {
     const coverageResponse = await session.sendCommand('CSS.stopRuleUsageTracking');
     this._ruleUsage = coverageResponse.ruleUsage;
     session.off('CSS.styleSheetAdded', this._onStylesheetAdded);
+    session.off('CSS.styleSheetRemoved', this._onStylesheetRemoved);
   }
 
   /**

--- a/lighthouse-core/test/gather/gatherers/css-usage-test.js
+++ b/lighthouse-core/test/gather/gatherers/css-usage-test.js
@@ -10,6 +10,9 @@
 const CSSUsage = require('../../../gather/gatherers/css-usage.js');
 const {defaultSettings} = require('../../../config/constants.js');
 const {createMockDriver} = require('../../fraggle-rock/gather/mock-driver.js');
+const {flushAllTimersAndMicrotasks} = require('../../test-utils.js');
+
+jest.useFakeTimers();
 
 describe('.getArtifact', () => {
   it('gets CSS usage', async () => {
@@ -19,7 +22,8 @@ describe('.getArtifact', () => {
       .mockEvent('CSS.styleSheetAdded', {header: {styleSheetId: '2'}});
     driver.defaultSession.sendCommand
       .mockResponse('DOM.enable')
-      .mockResponse('CSS.enable', undefined, 1) // Force events to emit
+      // @ts-ignore - Force events to emit.
+      .mockResponse('CSS.enable', flushAllTimersAndMicrotasks)
       .mockResponse('CSS.startRuleUsageTracking')
       .mockResponse('CSS.getStyleSheetText', {text: 'CSS text 1'})
       .mockResponse('CSS.getStyleSheetText', {text: 'CSS text 2'})
@@ -68,6 +72,60 @@ describe('.getArtifact', () => {
     });
   });
 
+  it('ignores removed stylesheets', async () => {
+    const driver = createMockDriver();
+    driver.defaultSession.on
+      .mockEvent('CSS.styleSheetAdded', {header: {styleSheetId: '1'}})
+      .mockEvent('CSS.styleSheetAdded', {header: {styleSheetId: '2'}})
+      .mockEvent('CSS.styleSheetRemoved', {styleSheetId: '1'});
+    driver.defaultSession.sendCommand
+      .mockResponse('DOM.enable')
+      .mockResponse('CSS.enable')
+      .mockResponse('CSS.startRuleUsageTracking')
+      .mockResponse('CSS.getStyleSheetText', {text: 'CSS text 2'})
+      .mockResponse('CSS.stopRuleUsageTracking', {
+        ruleUsage: [
+          {styleSheetId: '2', used: false},
+        ],
+      })
+      .mockResponse('CSS.disable')
+      .mockResponse('DOM.disable');
+
+    /** @type {LH.Gatherer.FRTransitionalContext} */
+    const context = {
+      driver: driver.asDriver(),
+      url: 'https://example.com',
+      gatherMode: 'timespan',
+      computedCache: new Map(),
+      dependencies: {},
+      settings: defaultSettings,
+    };
+
+    const gatherer = new CSSUsage();
+    await gatherer.startInstrumentation(context);
+
+    // Force events to emit.
+    await flushAllTimersAndMicrotasks(1);
+
+    await gatherer.stopInstrumentation(context);
+    const artifact = await gatherer.getArtifact(context);
+
+    expect(artifact).toEqual({
+      stylesheets: [
+        {
+          header: {styleSheetId: '2'},
+          content: 'CSS text 2',
+        },
+      ],
+      rules: [
+        {
+          styleSheetId: '2',
+          used: false,
+        },
+      ],
+    });
+  });
+
   it('dedupes stylesheets', async () => {
     const driver = createMockDriver();
     driver.defaultSession.on
@@ -75,7 +133,8 @@ describe('.getArtifact', () => {
       .mockEvent('CSS.styleSheetAdded', {header: {styleSheetId: '1'}});
     driver.defaultSession.sendCommand
       .mockResponse('DOM.enable')
-      .mockResponse('CSS.enable', undefined, 1) // Force events to emit
+      // @ts-ignore - Force events to emit.
+      .mockResponse('CSS.enable', flushAllTimersAndMicrotasks)
       .mockResponse('CSS.startRuleUsageTracking')
       .mockResponse('CSS.getStyleSheetText', {text: 'CSS text 1'})
       .mockResponse('CSS.getStyleSheetText', {text: 'CSS text 1'})

--- a/lighthouse-core/test/gather/gatherers/css-usage-test.js
+++ b/lighthouse-core/test/gather/gatherers/css-usage-test.js
@@ -22,7 +22,7 @@ describe('.getArtifact', () => {
       .mockEvent('CSS.styleSheetAdded', {header: {styleSheetId: '2'}});
     driver.defaultSession.sendCommand
       .mockResponse('DOM.enable')
-      // @ts-ignore - Force events to emit.
+      // @ts-expect-error - Force events to emit.
       .mockResponse('CSS.enable', flushAllTimersAndMicrotasks)
       .mockResponse('CSS.startRuleUsageTracking')
       .mockResponse('CSS.getStyleSheetText', {text: 'CSS text 1'})

--- a/lighthouse-core/test/gather/gatherers/css-usage-test.js
+++ b/lighthouse-core/test/gather/gatherers/css-usage-test.js
@@ -133,7 +133,7 @@ describe('.getArtifact', () => {
       .mockEvent('CSS.styleSheetAdded', {header: {styleSheetId: '1'}});
     driver.defaultSession.sendCommand
       .mockResponse('DOM.enable')
-      // @ts-ignore - Force events to emit.
+      // @ts-expect-error - Force events to emit.
       .mockResponse('CSS.enable', flushAllTimersAndMicrotasks)
       .mockResponse('CSS.startRuleUsageTracking')
       .mockResponse('CSS.getStyleSheetText', {text: 'CSS text 1'})


### PR DESCRIPTION
`CSS.getStyleSheetText` throws an error if the style sheet was removed. This causes issues in FR timespan mode because style sheets discovered during the timespan can be removed later in the timespan. Example:

```js
const puppeteer = require('puppeteer');
const fs = require('fs');
const open = require('open');
const defaultConfig = require('./lighthouse-core/fraggle-rock/config/default-config.js');
const lighthouse = require('./lighthouse-core/fraggle-rock/api.js');

async function run() {
  const browser = await puppeteer.launch({
    headless: false,
  })
  const page = await browser.newPage();
  const url = 'https://espn.com';

  const config = {
    ...defaultConfig,
    // audits: defaultConfig.audits.filter(a => a === 'byte-efficiency/unminified-css'),
    settings: {
      output: 'html'
    },
  };
  const run = await lighthouse.startTimespan({page, config});

  await page.goto(url);

  const {artifacts, report, lhr} = await run.endTimespan();
  fs.writeFileSync('lhr.json', JSON.stringify(lhr));
  fs.writeFileSync('artifacts.json', JSON.stringify(artifacts));
  fs.writeFileSync('fr-report.html', report);
  open('fr-report.html');

  await page.close();
  await browser.close();
}
run();

```

Simplest solution is to ignore any style sheet that was removed, which is implemented here. This does mean that styles are only tracked if they persist until the end of the timespan.

I experimented with a solution that ran `CSS.getStyleSheetText` as `CSS.styleSheetAdded` events rolled in rather than doing a batch run in `getArtifact`. Unfortunately, this didn't completely eliminate the risk of the style sheet being removed by the time `CSS.getStyleSheetText` is run.
