### PR TITLE
core(fr): add snapshot and timespan support to no-unload-listeners audit

### DIFF
--- a/lighthouse-core/gather/gatherers/global-listeners.js
+++ b/lighthouse-core/gather/gatherers/global-listeners.js
@@ -17,7 +17,7 @@ const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
 class GlobalListeners extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
-    supportedModes: ['snapshot', 'navigation'],
+    supportedModes: ['snapshot', 'timespan', 'navigation'],
   }
 
   /**

--- a/lighthouse-core/gather/gatherers/js-usage.js
+++ b/lighthouse-core/gather/gatherers/js-usage.js
@@ -80,7 +80,7 @@ class JsUsage extends FRGatherer {
     /** @type {Record<string, Array<LH.Crdp.Profiler.ScriptCoverage>>} */
     const usageByUrl = {};
 
-    // Return url to scriptId mappings in snapshot mode.
+    // Force `Debugger.scriptParsed` events for url to scriptId mappings in snapshot mode.
     if (context.gatherMode === 'snapshot') {
       await this.startSensitiveInstrumentation(context);
       await this.stopSensitiveInstrumentation(context);

--- a/lighthouse-core/test/fraggle-rock/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/api-test-pptr.js
@@ -99,7 +99,7 @@ describe('Fraggle Rock API', () => {
 
       const {auditResults, erroredAudits, failedAudits} = getAuditsBreakdown(lhr);
       // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
-      expect(auditResults.length).toMatchInlineSnapshot(`79`);
+      expect(auditResults.length).toMatchInlineSnapshot(`80`);
 
       expect(erroredAudits).toHaveLength(0);
       expect(failedAudits.map(audit => audit.id)).toContain('label');
@@ -130,7 +130,7 @@ describe('Fraggle Rock API', () => {
         notApplicableAudits,
       } = getAuditsBreakdown(lhr);
       // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
-      expect(auditResults.length).toMatchInlineSnapshot(`59`);
+      expect(auditResults.length).toMatchInlineSnapshot(`60`);
 
       expect(notApplicableAudits.length).toMatchInlineSnapshot(`7`);
       expect(notApplicableAudits.map(audit => audit.id)).not.toContain('server-response-time');
@@ -172,7 +172,7 @@ describe('Fraggle Rock API', () => {
       if (!result) throw new Error('Lighthouse failed to produce a result');
 
       const {auditResults, erroredAudits, notApplicableAudits} = getAuditsBreakdown(result.lhr);
-      expect(auditResults.length).toMatchInlineSnapshot(`59`);
+      expect(auditResults.length).toMatchInlineSnapshot(`60`);
 
       expect(notApplicableAudits.length).toMatchInlineSnapshot(`9`);
       expect(notApplicableAudits.map(audit => audit.id)).toContain('server-response-time');


### PR DESCRIPTION
`JsUsage` was missing some source URL -> script id mappings in timespan mode, so this PR fills in the gaps with empty usages.

I'm concerned that empty usages won't be interpreted the same way as no usages, in which case a new gatherer specifically for source URL -> script id mappings should be considered.