### PR TITLE
core(fr): add config extension support

### DIFF
--- a/lighthouse-core/fraggle-rock/config/default-config.js
+++ b/lighthouse-core/fraggle-rock/config/default-config.js
@@ -191,7 +191,13 @@ const defaultConfig = {
     },
   ],
   settings: legacyDefaultConfig.settings,
-  audits: [...(legacyDefaultConfig.audits || []), ...frAudits],
+  audits: [
+    ...(legacyDefaultConfig.audits || []).map(audit => {
+      if (typeof audit === 'string') return {path: audit};
+      return audit;
+    }),
+    ...frAudits,
+  ],
   categories: mergeCategories(),
   groups: legacyDefaultConfig.groups,
 };

--- a/lighthouse-core/test/config/config-helpers-test.js
+++ b/lighthouse-core/test/config/config-helpers-test.js
@@ -16,6 +16,7 @@ const {
   resolveAuditsToDefns,
   resolveModulePath,
   mergeConfigFragment,
+  mergeConfigFragmentArrayByKey,
 } = require('../../config/config-helpers.js');
 const Runner = require('../../runner.js');
 const Gatherer = require('../../gather/gatherers/gatherer.js');
@@ -80,6 +81,44 @@ describe('.mergeConfigFragment', () => {
     expect(() => mergeConfigFragment('foo', [])).toThrow();
     expect(() => mergeConfigFragment({}, [])).toThrow();
     expect(() => mergeConfigFragment([], {})).toThrow();
+  });
+});
+
+describe('.mergeConfigFragmentArrayByKey', () => {
+  it('should use mergeConfigFragment to merge items', () => {
+    const base = [{a: 1, b: 'yes', c: true}];
+    const extension = [{a: 2, c: false, d: 123}];
+    const merged = mergeConfigFragmentArrayByKey(base, extension, () => 'key');
+    expect(merged).toBe(base);
+    expect(merged).toEqual([{a: 2, b: 'yes', c: false, d: 123}]);
+  });
+
+  it('should merge by the keyFn', () => {
+    const base = [{id: 'a', value: 1}, {id: 'b', value: 2}];
+    const extension = [{id: 'b', value: 1}, {id: 'a', value: 2}, {id: 'c'}];
+    const merged = mergeConfigFragmentArrayByKey(base, extension, item => item.id);
+    expect(merged).toEqual([{id: 'a', value: 2}, {id: 'b', value: 1}, {id: 'c'}]);
+  });
+
+  it('should merge recursively', () => {
+    const base = [{foo: {bar: 1}}];
+    const extension = [{foo: {baz: 2, bam: 3}}];
+    const merged = mergeConfigFragmentArrayByKey(base, extension, () => 'key');
+    expect(merged).toEqual([{foo: {bar: 1, baz: 2, bam: 3}}]);
+  });
+
+  it('should handle null items in base', () => {
+    const base = [null];
+    const extension = [{x: 1}];
+    const merged = mergeConfigFragmentArrayByKey(base, extension, () => '');
+    expect(merged).toEqual([{x: 1}]);
+  });
+
+  it('should handle undefined items in extension', () => {
+    const base = [{x: 1}];
+    const extension = [undefined];
+    const merged = mergeConfigFragmentArrayByKey(base, extension, () => '');
+    expect(merged).toEqual([undefined]);
   });
 });
 

--- a/lighthouse-core/test/fraggle-rock/config/config-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/config-test.js
@@ -331,12 +331,14 @@ describe('Fraggle Rock Config', () => {
       });
     });
 
-    it('should extend the default config', () => {
+    it('should extend the default config with filters', () => {
       const gatherMode = 'navigation';
-      const {config} = initializeConfig({extends: 'lighthouse:default'}, {gatherMode});
+      const {config} = initializeConfig({
+        extends: 'lighthouse:default',
+        settings: {onlyCategories: ['accessibility']},
+      }, {gatherMode});
       if (!config.artifacts) throw new Error(`No artifacts created`);
       if (!config.audits) throw new Error(`No audits created`);
-
 
       const hasAccessibilityArtifact = config.artifacts.some(a => a.id === 'Accessibility');
       if (!hasAccessibilityArtifact) expect(config.artifacts).toContain('Accessibility');
@@ -345,7 +347,8 @@ describe('Fraggle Rock Config', () => {
         some(a => a.implementation.meta.id === 'color-contrast');
       if (!hasAccessibilityAudit) expect(config.audits).toContain('color-contrast');
 
-      expect(config.categories).toHaveProperty('performance');
+      expect(config.categories).toHaveProperty('accessibility');
+      expect(config.categories).not.toHaveProperty('performance');
     });
 
     it('should merge in artifacts', () => {

--- a/lighthouse-core/test/fraggle-rock/config/config-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/config-test.js
@@ -5,6 +5,7 @@
  */
 'use strict';
 
+const BaseAudit = require('../../../audits/audit.js');
 const BaseGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const {initializeConfig} = require('../../../fraggle-rock/config/config.js');
 
@@ -262,9 +263,128 @@ describe('Fraggle Rock Config', () => {
     });
   });
 
-  it.todo('should support extension');
+  describe('.resolveExtensions', () => {
+    /** @type {LH.Config.Json} */
+    let extensionConfig;
+
+    beforeEach(() => {
+      const gatherer = new BaseGatherer();
+      gatherer.meta = {supportedModes: ['navigation']};
+
+      class ExtraAudit extends BaseAudit {
+        static get meta() {
+          return {
+            id: 'extra-audit',
+            title: 'Extra',
+            description: 'Extra',
+            requiredArtifacts: /** @type {*} */ (['ExtraArtifact']),
+          };
+        }
+
+        /** @return {LH.Audit.Product} */
+        static audit() {
+          throw new Error('Unimplemented');
+        }
+      }
+
+      extensionConfig = {
+        extends: 'lighthouse:default',
+        artifacts: [
+          {id: 'ExtraArtifact', gatherer: {instance: gatherer}},
+        ],
+        navigations: [
+          {id: 'default', artifacts: ['ExtraArtifact']},
+        ],
+        audits: [
+          {implementation: ExtraAudit},
+        ],
+        categories: {
+          performance: {
+            title: 'Performance',
+            auditRefs: [
+              {id: 'extra-audit', weight: 0},
+            ],
+          },
+        },
+      };
+    });
+
+    it('should do nothing when not extending', () => {
+      const {config} = initializeConfig({
+        artifacts: [
+          {id: 'Accessibility', gatherer: 'accessibility'},
+        ],
+        navigations: [
+          {id: 'default', artifacts: ['Accessibility']},
+        ],
+      }, {gatherMode: 'navigation'});
+
+      expect(config).toMatchObject({
+        audits: null,
+        groups: null,
+        artifacts: [
+          {id: 'Accessibility'},
+        ],
+        navigations: [
+          {id: 'default', artifacts: [{id: 'Accessibility'}]},
+        ],
+      });
+    });
+
+    it('should extend the default config', () => {
+      const gatherMode = 'navigation';
+      const {config} = initializeConfig({extends: 'lighthouse:default'}, {gatherMode});
+      if (!config.artifacts) throw new Error(`No artifacts created`);
+      if (!config.audits) throw new Error(`No audits created`);
+
+
+      const hasAccessibilityArtifact = config.artifacts.some(a => a.id === 'Accessibility');
+      if (!hasAccessibilityArtifact) expect(config.artifacts).toContain('Accessibility');
+
+      const hasAccessibilityAudit = config.audits.
+        some(a => a.implementation.meta.id === 'color-contrast');
+      if (!hasAccessibilityAudit) expect(config.audits).toContain('color-contrast');
+
+      expect(config.categories).toHaveProperty('performance');
+    });
+
+    it('should merge in artifacts', () => {
+      const {config} = initializeConfig(extensionConfig, {gatherMode: 'navigation'});
+      if (!config.artifacts) throw new Error(`No artifacts created`);
+
+      const hasExtraArtifact = config.artifacts.some(a => a.id === 'ExtraArtifact');
+      if (!hasExtraArtifact) expect(config.artifacts).toContain('ExtraArtifact');
+    });
+
+    it('should merge in navigations', () => {
+      const {config} = initializeConfig(extensionConfig, {gatherMode: 'navigation'});
+      if (!config.navigations) throw new Error(`No navigations created`);
+
+      expect(config.navigations).toHaveLength(1);
+      const hasNavigation = config.navigations[0].artifacts.
+        some(a => a.id === 'ExtraArtifact');
+      if (!hasNavigation) expect(config.navigations[0].artifacts).toContain('ExtraArtifact');
+    });
+
+    it('should merge in audits', () => {
+      const {config} = initializeConfig(extensionConfig, {gatherMode: 'navigation'});
+      if (!config.audits) throw new Error(`No audits created`);
+
+      const hasExtraAudit = config.audits.
+        some(a => a.implementation.meta.id === 'extra-audit');
+      if (!hasExtraAudit) expect(config.audits).toContain('extra-audit');
+    });
+
+    it('should merge in categories', () => {
+      const {config} = initializeConfig(extensionConfig, {gatherMode: 'navigation'});
+      if (!config.categories) throw new Error(`No categories created`);
+
+      const hasCategory = config.categories.performance.auditRefs.some(a => a.id === 'extra-audit');
+      if (!hasCategory) expect(config.categories.performance.auditRefs).toContain('extra-audit');
+    });
+  });
+
   it.todo('should support plugins');
   it.todo('should adjust default pass options for throttling method');
   it.todo('should validate audit/gatherer interdependencies');
-  it.todo('should validate gatherers do not support all 3 modes');
 });


### PR DESCRIPTION
**Summary**
Another piece of FR parity needed for smoketest support, adds config extension support to the FR config. Only the basic use cases of extension+filters and adding a new artifact/navigation/audit/category to the default is supported so far, no newfangled extension logic.

**Related Issues/PRs**
ref #11313 
