### PR TITLE
core(fr): timespan/snapshot specific audit groups

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -155,6 +155,7 @@ class Runner {
           icuMessagePaths: {},
         },
         stackPacks: stackPacks.getStackPacks(artifacts.Stacks),
+        gatherMode: artifacts.GatherContext.gatherMode,
       };
 
       // Replace ICU message references with localized strings; save replaced paths in lhr.

--- a/report/renderer/report-renderer.js
+++ b/report/renderer/report-renderer.js
@@ -254,6 +254,15 @@ export class ReportRenderer {
 
     const categories = reportSection.appendChild(this._dom.createElement('div', 'lh-categories'));
     for (const category of Object.values(report.categories)) {
+      // Change audit group based on gather mode.
+      for (const audit of category.auditRefs) {
+        if (report.gatherMode === 'timespan' && audit.timespanGroup) {
+          audit.group = audit.timespanGroup;
+        }
+        if (report.gatherMode === 'snapshot' && audit.snapshotGroup) {
+          audit.group = audit.snapshotGroup;
+        }
+      }
       const renderer = specificCategoryRenderers[category.id] || categoryRenderer;
       // .lh-category-wrapper is full-width and provides horizontal rules between categories.
       // .lh-category within has the max-width: var(--report-width);

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -156,6 +156,8 @@ declare global {
         id: string;
         weight: number;
         group?: string;
+        timespanGroup?: string;
+        snapshotGroup?: string;
         acronym?: string;
         relevantAudits?: string[];
       }

--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -56,6 +56,8 @@ declare global {
       i18n: {rendererFormattedStrings: I18NRendererStrings, icuMessagePaths?: IcuMessagePaths};
       /** An array containing the result of all stack packs. */
       stackPacks?: Result.StackPack[];
+      /** Gather mode used to collect artifacts. */
+      gatherMode?: Gatherer.GatherMode;
     }
 
     // Result namespace
@@ -87,6 +89,10 @@ declare global {
         weight: number;
         /** Optional grouping within the category. Matches the key of a Result.Group. */
         group?: string;
+        /** Optional grouping within the category for timespan mode. Matches the key of a Result.Group. */
+        timespanGroup?: string;
+        /** Optional grouping within the category for snapshot mode. Matches the key of a Result.Group. */
+        snapshotGroup?: string;
         /** The conventional acronym for the audit/metric. */
         acronym?: string;
         /** Any audit IDs closely relevant to this one. */


### PR DESCRIPTION
Closes #12828

Pretty simple solution, just requires `gatherMode` to be added to LHR. I imagine we would need to do that at some point anyway.

Another option would be to modify the group on the LHR before emitting.