### PR TITLE
misc: fix null return on querySelector

### DIFF
--- a/lighthouse-treemap/app/src/main.js
+++ b/lighthouse-treemap/app/src/main.js
@@ -15,6 +15,9 @@ const DUPLICATED_MODULES_IGNORE_THRESHOLD = 1024;
 const DUPLICATED_MODULES_IGNORE_ROOT_RATIO = 0.01;
 
 const logEl = document.querySelector('#lh-log');
+if (!logEl) {
+  throw new Error('logger element not found');
+}
 const logger = new Logger(logEl);
 
 /** @type {TreemapViewer} */

--- a/report/clients/psi.js
+++ b/report/clients/psi.js
@@ -121,9 +121,10 @@ export function prepareLabData(LHResult, document) {
 
     const showTreemapApp =
       lhResult.audits['script-treemap-data'] && lhResult.audits['script-treemap-data'].details;
-    if (showTreemapApp) {
+    const buttonContainer = reportEl.querySelector('.lh-audit-group--metrics');
+    if (showTreemapApp && buttonContainer) {
       reportUIFeatures.addButton({
-        container: reportEl.querySelector('.lh-audit-group--metrics'),
+        container: buttonContainer,
         text: Util.i18n.strings.viewTreemapLabel,
         icon: 'treemap',
         onClick: () => ReportUIFeatures.openTreemap(lhResult),

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -417,7 +417,7 @@ declare global {
 
   // Stricter querySelector/querySelectorAll using typed-query-selector.
   interface ParentNode {
-    querySelector<S extends string>(selector: S): QuerySelectorParse<S>;
+    querySelector<S extends string>(selector: S): QuerySelectorParse<S> | null;
     querySelectorAll<S extends string>(selector: S): NodeListOf<QuerySelectorParse<S>>;
   }
 }


### PR DESCRIPTION
embarrassingly slipped through #12013 and not noticed since then because it really only affects the reports (where we usually go through some version of `dom.find()`) and page-functions (where we usually go through the battle-tested `getElementsInDocument`)