### PR TITLE
misc: npmignore all of dist/ except standalone report

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,6 @@
 assets/
 build/
 coverage/
-dist/
 proto/
 docs/
 
@@ -54,6 +53,8 @@ results.html
 *.lcov
 
 # generated files needed for publish
+dist/*
+dist/report/*
 !dist/report/standalone.js
 
 # large files


### PR DESCRIPTION
fixes #8084

we have to explicitly ignore `dist/*` (not just `dist/`) to then be able to unignore `dist/report/standalone.js`