### PR TITLE
Update csp_evaluator to 1.0.2 for `trusted-types 'none'`

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "axe-core": "4.2.3",
     "chrome-launcher": "^0.14.0",
     "configstore": "^5.0.1",
-    "csp_evaluator": "^1.0.1",
+    "csp_evaluator": "^1.0.2",
     "cssstyle": "1.2.1",
     "enquirer": "^2.3.6",
     "http-link-header": "^0.8.0",


### PR DESCRIPTION
The csp_evaluator library has just been updated to support `trusted-types 'none'`.

**Summary**
This should stop the error message `'none' seems to be an invalid keyword`.

https://github.com/google/csp-evaluator/issues/33