### PR TITLE
report: set url arg default as empty string

### DIFF
--- a/report/renderer/dom.js
+++ b/report/renderer/dom.js
@@ -153,7 +153,7 @@ export class DOM {
    * @param {HTMLAnchorElement} elem
    * @param {string} url
    */
-  safelySetHref(elem, url) {
+  safelySetHref(elem, url = '') {
     // In-page anchor links are safe.
     if (url.startsWith('#')) {
       elem.href = url;


### PR DESCRIPTION
**Summary**

This PR will fix issue #12868 by setting the default value of  URL arg in the `safelySetHref` function as an empty string to prevent the `startsWith` of undefined error.

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/issues/12868
