### PR TITLE
core: convert audit types to modules

### DIFF
--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -42,15 +42,15 @@ class CriticalRequestChains extends Audit {
     };
   }
 
-  /** @typedef {{depth: number, id: string, chainDuration: number, chainTransferSize: number, node: LH.Audit.SimpleCriticalRequestNode[string]}} CrcNodeInfo */
+  /** @typedef {{depth: number, id: string, chainDuration: number, chainTransferSize: number, node: LH.Audit.Details.SimpleCriticalRequestNode[string]}} CrcNodeInfo */
 
   /**
-   * @param {LH.Audit.SimpleCriticalRequestNode} tree
+   * @param {LH.Audit.Details.SimpleCriticalRequestNode} tree
    * @param {function(CrcNodeInfo): void} cb
    */
   static _traverse(tree, cb) {
     /**
-     * @param {LH.Audit.SimpleCriticalRequestNode} node
+     * @param {LH.Audit.Details.SimpleCriticalRequestNode} node
      * @param {number} depth
      * @param {number=} startTime
      * @param {number=} transferSize
@@ -87,7 +87,7 @@ class CriticalRequestChains extends Audit {
 
   /**
    * Get stats about the longest initiator chain (as determined by time duration)
-   * @param {LH.Audit.SimpleCriticalRequestNode} tree
+   * @param {LH.Audit.Details.SimpleCriticalRequestNode} tree
    * @return {{duration: number, length: number, transferSize: number}}
    */
   static _getLongestChain(tree) {
@@ -111,12 +111,12 @@ class CriticalRequestChains extends Audit {
 
   /**
    * @param {LH.Artifacts.CriticalRequestNode} tree
-   * @return {LH.Audit.SimpleCriticalRequestNode}
+   * @return {LH.Audit.Details.SimpleCriticalRequestNode}
    */
   static flattenRequests(tree) {
-    /** @type {LH.Audit.SimpleCriticalRequestNode} */
+    /** @type {LH.Audit.Details.SimpleCriticalRequestNode} */
     const flattendChains = {};
-    /** @type {Map<string, LH.Audit.SimpleCriticalRequestNode[string]>} */
+    /** @type {Map<string, LH.Audit.Details.SimpleCriticalRequestNode[string]>} */
     const chainMap = new Map();
 
     /** @param {CrcNodeInfo} opts */
@@ -143,7 +143,7 @@ class CriticalRequestChains extends Audit {
       if (opts.node.children) {
         for (const chainId of Object.keys(opts.node.children)) {
           // Note: cast should be Partial<>, but filled in when child node is traversed.
-          const childChain = /** @type {LH.Audit.SimpleCriticalRequestNode[string]} */ ({
+          const childChain = /** @type {LH.Audit.Details.SimpleCriticalRequestNode[string]} */ ({
             request: {},
           });
           chainMap.set(chainId, childChain);
@@ -174,7 +174,7 @@ class CriticalRequestChains extends Audit {
     return ComputedChains.request({devtoolsLog, trace, URL}, context).then(chains => {
       let chainCount = 0;
       /**
-       * @param {LH.Audit.SimpleCriticalRequestNode} node
+       * @param {LH.Audit.Details.SimpleCriticalRequestNode} node
        * @param {number} depth
        */
       function walk(node, depth) {

--- a/report/renderer/crc-details-renderer.js
+++ b/report/renderer/crc-details-renderer.js
@@ -29,8 +29,8 @@ import {Util} from './util.js';
 export class CriticalRequestChainRenderer {
   /**
    * Create render context for critical-request-chain tree display.
-   * @param {LH.Audit.SimpleCriticalRequestNode} tree
-   * @return {{tree: LH.Audit.SimpleCriticalRequestNode, startTime: number, transferSize: number}}
+   * @param {LH.Audit.Details.SimpleCriticalRequestNode} tree
+   * @return {{tree: LH.Audit.Details.SimpleCriticalRequestNode, startTime: number, transferSize: number}}
    */
   static initTree(tree) {
     let startTime = 0;
@@ -48,7 +48,7 @@ export class CriticalRequestChainRenderer {
    * parent. Calculates if this node is the last child, whether it has any
    * children itself and what the tree looks like all the way back up to the root,
    * so the tree markers can be drawn correctly.
-   * @param {LH.Audit.SimpleCriticalRequestNode} parent
+   * @param {LH.Audit.Details.SimpleCriticalRequestNode} parent
    * @param {string} id
    * @param {number} startTime
    * @param {number} transferSize
@@ -194,7 +194,7 @@ export class CriticalRequestChainRenderer {
 const CRCRenderer = CriticalRequestChainRenderer;
 
 /** @typedef {{
-      node: LH.Audit.SimpleCriticalRequestNode[string],
+      node: LH.Audit.Details.SimpleCriticalRequestNode[string],
       isLastChild: boolean,
       hasChildren: boolean,
       startTime: number,

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -4,298 +4,306 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-declare global {
-  module LH.Audit {
-    export type Details =
-      Details.CriticalRequestChain |
-      Details.DebugData |
-      Details.TreemapData |
-      Details.Filmstrip |
-      Details.List |
-      Details.Opportunity |
-      Details.Screenshot |
-      Details.FullPageScreenshot |
-      Details.Table;
+type Details =
+  Details.CriticalRequestChain |
+  Details.DebugData |
+  Details.TreemapData |
+  Details.Filmstrip |
+  Details.List |
+  Details.Opportunity |
+  Details.Screenshot |
+  Details.FullPageScreenshot |
+  Details.Table;
 
-    // Details namespace.
-    export module Details {
-      export interface CriticalRequestChain {
-        type: 'criticalrequestchain';
-        longestChain: {
-          duration: number;
-          length: number;
-          transferSize: number;
-        };
-        chains: Audit.SimpleCriticalRequestNode;
-      }
+// Details namespace.
+declare module Details {
+  interface CriticalRequestChain {
+    type: 'criticalrequestchain';
+    longestChain: {
+      duration: number;
+      length: number;
+      transferSize: number;
+    };
+    chains: SimpleCriticalRequestNode;
+  }
 
-      export interface Filmstrip {
-        type: 'filmstrip';
-        scale: number;
-        items: {
-          /** The relative time from navigationStart to this frame, in milliseconds. */
-          timing: number;
-          /** The raw timestamp of this frame, in microseconds. */
-          timestamp: number;
-          /** The data URL encoding of this frame. */
-          data: string;
-        }[];
-      }
-
-      export interface List {
-        type: 'list';
-        items: SnippetValue[]
-      }
-
-      export interface Opportunity {
-        type: 'opportunity';
-        overallSavingsMs: number;
-        overallSavingsBytes?: number;
-        headings: OpportunityColumnHeading[];
-        items: OpportunityItem[];
-        debugData?: DebugData;
-      }
-
-      export interface Screenshot {
-        type: 'screenshot';
-        timing: number;
-        timestamp: number;
-        data: string;
-      }
-
-      /**
-       * A screenshot of the entire page, including width and height information,
-       * and the locations of interesting nodes.
-       * Used by element screenshots renderer.
-       */
-      export interface FullPageScreenshot extends LH.Artifacts.FullPageScreenshot {
-        type: 'full-page-screenshot';
-      }
-
-      export interface Table {
-        type: 'table';
-        headings: TableColumnHeading[];
-        items: TableItem[];
-        summary?: {
-          wastedMs?: number;
-          wastedBytes?: number;
-        };
-        debugData?: DebugData;
-      }
-
-      /** A table item for rows that are nested within a top-level TableItem (row). */
-      export interface TableSubItems {
-        type: 'subitems';
-        items: TableItem[];
-      }
-
-      /**
-       * A details type that is not rendered in the final report; usually used
-       * for including debug information in the LHR. Can contain anything.
-       */
-      export interface DebugData {
-        type: 'debugdata';
-        [p: string]: any;
-      }
-
-      export interface TreemapData {
-        type: 'treemap-data';
-        nodes: LH.Treemap.Node[];
-      }
-
-      /** String enum of possible types of values found within table items. */
-      type ItemValueType = 'bytes' | 'code' | 'link' | 'ms' | 'multi' | 'node' | 'source-location' | 'numeric' | 'text' | 'thumbnail' | 'timespanMs' | 'url';
-
-      /** Possible types of values found within table items. */
-      type ItemValue = string | number | boolean | DebugData | NodeValue | SourceLocationValue | LinkValue | UrlValue | CodeValue | NumericValue | IcuMessage | TableSubItems;
-
-      // TODO: drop TableColumnHeading, rename OpportunityColumnHeading to TableColumnHeading and
-      // use that for all table-like audit details.
-
-      export interface TableColumnHeading {
-        /**
-         * The name of the property within items being described.
-         * If null, subItemsHeading must be defined, and the first table row in this column for
-         * every item will be empty.
-         * See legacy-javascript for an example.
-         */
-        key: string|null;
-        /** Readable text label of the field. */
-        text: IcuMessage | string;
-        /**
-         * The data format of the column of values being described. Usually
-         * those values will be primitives rendered as this type, but the values
-         * could also be objects with their own type to override this field.
-         */
-        itemType: ItemValueType;
-        /**
-         * Optional - defines an inner table of values that correspond to this column.
-         * Key is required - if other properties are not provided, the value for the heading is used.
-         */
-        subItemsHeading?: {key: string, itemType?: ItemValueType, displayUnit?: string, granularity?: number};
-
-        displayUnit?: string;
-        granularity?: number;
-      }
-
-      export interface TableItem {
-        debugData?: DebugData;
-        subItems?: TableSubItems;
-        [p: string]: undefined | ItemValue;
-      }
-
-      export interface OpportunityColumnHeading {
-        /**
-        * The name of the property within items being described.
-         * If null, subItemsHeading must be defined, and the first table row in this column for
-         * every item will be empty.
-         * See legacy-javascript for an example.
-         */
-        key: string|null;
-        /** Readable text label of the field. */
-        label: IcuMessage | string;
-        /**
-         * The data format of the column of values being described. Usually
-         * those values will be primitives rendered as this type, but the values
-         * could also be objects with their own type to override this field.
-         */
-        valueType: ItemValueType;
-        /**
-         * Optional - defines an inner table of values that correspond to this column.
-         * Key is required - if other properties are not provided, the value for the heading is used.
-         */
-        subItemsHeading?: {key: string, valueType?: ItemValueType, displayUnit?: string, granularity?: number};
-
-        // NOTE: not used by opportunity details, but used in the renderer until table/opportunity unification.
-        displayUnit?: string;
-        granularity?: number;
-      }
-
-      /** A more specific table element used for `opportunity` tables. */
-      export interface OpportunityItem extends TableItem {
+  type SimpleCriticalRequestNode = {
+    [id: string]: {
+      request: {
         url: string;
-        wastedBytes?: number;
-        totalBytes?: number;
-        wastedMs?: number;
-        debugData?: DebugData;
-        [p: string]: undefined | ItemValue;
-      }
-
-      /**
-       * A value used within a details object, intended to be displayed as code,
-       * regardless of the controlling heading's valueType.
-       */
-      export interface CodeValue {
-        type: 'code';
-        value: IcuMessage | string;
-      }
-
-      /**
-       * A value used within a details object, intended to be displayed as a
-       * link with text, regardless of the controlling heading's valueType.
-       * If URL is the empty string, fallsback to a basic `TextValue`.
-       */
-      export interface LinkValue {
-        type: 'link',
-        text: string;
-        url: string;
-      }
-
-      /**
-       * A value used within a details object, intended to be displayed an HTML
-       * node, regardless of the controlling heading's valueType.
-       */
-      export interface NodeValue {
-        type: 'node';
-        /** Unique identifier. */
-        lhId?: string;
-        path?: string;
-        selector?: string;
-        boundingRect?: Artifacts.Rect;
-        /** An HTML snippet used to identify the node. */
-        snippet?: string;
-        /** A human-friendly text descriptor that's used to identify the node more quickly. */
-        nodeLabel?: string;
-      }
-
-      /**
-       * A value used within a details object, intended to be displayed as a URL
-       * encoded with line and column info (url:line:column).
-       */
-      export interface SourceLocationValue {
-        type: 'source-location';
-        /** A "url" representing the source file. May not be a valid URL, see `urlProvider`. */
-        url: string;
-        /**
-         * - `network` when the url is the actual, observed resource url. This is always a valid URL.
-         * - `comment` when the url comes from a sourceURL comment. This could be anything, really.
-         */
-        urlProvider: 'network' | 'comment';
-        /** Zero-indexed. */
-        line: number;
-        column: number;
-        /** The original file location from the source map. */
-        original?: {
-          /** The relevant file from the map's `sources` array. */
-          file: string;
-          line: number;
-          column: number;
-        };
-      }
-
-      /**
-       * A value used within a details object, intended to be displayed as a
-       * linkified URL, regardless of the controlling heading's valueType.
-       */
-      export interface UrlValue {
-        type: 'url';
-        value: string;
-      }
-
-      /**
-       * Snippet of text with line numbers and annotations.
-       */
-      export interface SnippetValue {
-        type: 'snippet',
-        title: string,
-        /** Node where the content of this snippet came from. */
-        node?: NodeValue,
-        /**
-         * The lines that should be rendered. For long snippets we only include important lines
-         * in the audit result.
-         */
-        lines: {
-          content: string
-          /** Line number, starting from 1. */
-          lineNumber: number;
-          truncated?: boolean
-        }[],
-        /** The total number of lines in the snippet, equal to lines.length for short snippets. */
-        lineCount: number,
-        /** Messages that provide information about a specific lines. */
-        lineMessages: {
-          /** Line number, starting from 1. */
-          lineNumber: number,
-          message: string
-        }[];
-        /** Messages that provide information about the snippet in general. */
-        generalMessages: {
-          message: string
-        }[];
-      }
-
-      /**
-       * A value used within a details object, intended to be displayed as a ms timing
-       * or a numeric value based on the metric name.
-       */
-      export interface NumericValue {
-        type: 'numeric',
-        value: number,
-        granularity?: number,
-      }
+        startTime: number;
+        endTime: number;
+        responseReceivedTime: number;
+        transferSize: number;
+      };
+      children?: SimpleCriticalRequestNode;
     }
+  }
+
+  interface Filmstrip {
+    type: 'filmstrip';
+    scale: number;
+    items: {
+      /** The relative time from navigationStart to this frame, in milliseconds. */
+      timing: number;
+      /** The raw timestamp of this frame, in microseconds. */
+      timestamp: number;
+      /** The data URL encoding of this frame. */
+      data: string;
+    }[];
+  }
+
+  interface List {
+    type: 'list';
+    items: SnippetValue[]
+  }
+
+  interface Opportunity {
+    type: 'opportunity';
+    overallSavingsMs: number;
+    overallSavingsBytes?: number;
+    headings: OpportunityColumnHeading[];
+    items: OpportunityItem[];
+    debugData?: DebugData;
+  }
+
+  interface Screenshot {
+    type: 'screenshot';
+    timing: number;
+    timestamp: number;
+    data: string;
+  }
+
+  /**
+   * A screenshot of the entire page, including width and height information,
+   * and the locations of interesting nodes.
+   * Used by element screenshots renderer.
+   */
+  interface FullPageScreenshot extends LH.Artifacts.FullPageScreenshot {
+    type: 'full-page-screenshot';
+  }
+
+  interface Table {
+    type: 'table';
+    headings: TableColumnHeading[];
+    items: TableItem[];
+    summary?: {
+      wastedMs?: number;
+      wastedBytes?: number;
+    };
+    debugData?: DebugData;
+  }
+
+  /** A table item for rows that are nested within a top-level TableItem (row). */
+  interface TableSubItems {
+    type: 'subitems';
+    items: TableItem[];
+  }
+
+  /**
+   * A details type that is not rendered in the final report; usually used
+   * for including debug information in the LHR. Can contain anything.
+   */
+  interface DebugData {
+    type: 'debugdata';
+    [p: string]: any;
+  }
+
+  interface TreemapData {
+    type: 'treemap-data';
+    nodes: LH.Treemap.Node[];
+  }
+
+  /** String enum of possible types of values found within table items. */
+  type ItemValueType = 'bytes' | 'code' | 'link' | 'ms' | 'multi' | 'node' | 'source-location' | 'numeric' | 'text' | 'thumbnail' | 'timespanMs' | 'url';
+
+  /** Possible types of values found within table items. */
+  type ItemValue = string | number | boolean | DebugData | NodeValue | SourceLocationValue | LinkValue | UrlValue | CodeValue | NumericValue | LH.IcuMessage | TableSubItems;
+
+  // TODO: drop TableColumnHeading, rename OpportunityColumnHeading to TableColumnHeading and
+  // use that for all table-like audit details.
+
+  interface TableColumnHeading {
+    /**
+     * The name of the property within items being described.
+     * If null, subItemsHeading must be defined, and the first table row in this column for
+     * every item will be empty.
+     * See legacy-javascript for an example.
+     */
+    key: string|null;
+    /** Readable text label of the field. */
+    text: LH.IcuMessage | string;
+    /**
+     * The data format of the column of values being described. Usually
+     * those values will be primitives rendered as this type, but the values
+     * could also be objects with their own type to override this field.
+     */
+    itemType: ItemValueType;
+    /**
+     * Optional - defines an inner table of values that correspond to this column.
+     * Key is required - if other properties are not provided, the value for the heading is used.
+     */
+    subItemsHeading?: {key: string, itemType?: ItemValueType, displayUnit?: string, granularity?: number};
+
+    displayUnit?: string;
+    granularity?: number;
+  }
+
+  interface TableItem {
+    debugData?: DebugData;
+    subItems?: TableSubItems;
+    [p: string]: undefined | ItemValue;
+  }
+
+  interface OpportunityColumnHeading {
+    /**
+    * The name of the property within items being described.
+      * If null, subItemsHeading must be defined, and the first table row in this column for
+      * every item will be empty.
+      * See legacy-javascript for an example.
+      */
+    key: string|null;
+    /** Readable text label of the field. */
+    label: LH.IcuMessage | string;
+    /**
+     * The data format of the column of values being described. Usually
+     * those values will be primitives rendered as this type, but the values
+     * could also be objects with their own type to override this field.
+     */
+    valueType: ItemValueType;
+    /**
+     * Optional - defines an inner table of values that correspond to this column.
+     * Key is required - if other properties are not provided, the value for the heading is used.
+     */
+    subItemsHeading?: {key: string, valueType?: ItemValueType, displayUnit?: string, granularity?: number};
+
+    // NOTE: not used by opportunity details, but used in the renderer until table/opportunity unification.
+    displayUnit?: string;
+    granularity?: number;
+  }
+
+  /** A more specific table element used for `opportunity` tables. */
+  interface OpportunityItem extends TableItem {
+    url: string;
+    wastedBytes?: number;
+    totalBytes?: number;
+    wastedMs?: number;
+    debugData?: DebugData;
+    [p: string]: undefined | ItemValue;
+  }
+
+  /**
+   * A value used within a details object, intended to be displayed as code,
+   * regardless of the controlling heading's valueType.
+   */
+  interface CodeValue {
+    type: 'code';
+    value: LH.IcuMessage | string;
+  }
+
+  /**
+   * A value used within a details object, intended to be displayed as a
+   * link with text, regardless of the controlling heading's valueType.
+   * If URL is the empty string, fallsback to a basic `TextValue`.
+   */
+  interface LinkValue {
+    type: 'link',
+    text: string;
+    url: string;
+  }
+
+  /**
+   * A value used within a details object, intended to be displayed an HTML
+   * node, regardless of the controlling heading's valueType.
+   */
+  interface NodeValue {
+    type: 'node';
+    /** Unique identifier. */
+    lhId?: string;
+    path?: string;
+    selector?: string;
+    boundingRect?: LH.Artifacts.Rect;
+    /** An HTML snippet used to identify the node. */
+    snippet?: string;
+    /** A human-friendly text descriptor that's used to identify the node more quickly. */
+    nodeLabel?: string;
+  }
+
+  /**
+   * A value used within a details object, intended to be displayed as a URL
+   * encoded with line and column info (url:line:column).
+   */
+  interface SourceLocationValue {
+    type: 'source-location';
+    /** A "url" representing the source file. May not be a valid URL, see `urlProvider`. */
+    url: string;
+    /**
+     * - `network` when the url is the actual, observed resource url. This is always a valid URL.
+     * - `comment` when the url comes from a sourceURL comment. This could be anything, really.
+     */
+    urlProvider: 'network' | 'comment';
+    /** Zero-indexed. */
+    line: number;
+    column: number;
+    /** The original file location from the source map. */
+    original?: {
+      /** The relevant file from the map's `sources` array. */
+      file: string;
+      line: number;
+      column: number;
+    };
+  }
+
+  /**
+   * A value used within a details object, intended to be displayed as a
+   * linkified URL, regardless of the controlling heading's valueType.
+   */
+  interface UrlValue {
+    type: 'url';
+    value: string;
+  }
+
+  /**
+   * Snippet of text with line numbers and annotations.
+   */
+  interface SnippetValue {
+    type: 'snippet',
+    title: string,
+    /** Node where the content of this snippet came from. */
+    node?: NodeValue,
+    /**
+     * The lines that should be rendered. For long snippets we only include important lines
+     * in the audit result.
+     */
+    lines: {
+      content: string
+      /** Line number, starting from 1. */
+      lineNumber: number;
+      truncated?: boolean
+    }[],
+    /** The total number of lines in the snippet, equal to lines.length for short snippets. */
+    lineCount: number,
+    /** Messages that provide information about a specific lines. */
+    lineMessages: {
+      /** Line number, starting from 1. */
+      lineNumber: number,
+      message: string
+    }[];
+    /** Messages that provide information about the snippet in general. */
+    generalMessages: {
+      message: string
+    }[];
+  }
+
+  /**
+   * A value used within a details object, intended to be displayed as a ms timing
+   * or a numeric value based on the metric name.
+   */
+  interface NumericValue {
+    type: 'numeric',
+    value: number,
+    granularity?: number,
   }
 }
 
-// empty export to keep file a module
-export {}
+export default Details;

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -4,10 +4,13 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality-map.js');
+import AuditDetails from './audit-details';
 
 declare global {
   module LH.Audit {
+    // Export in global scope.
+    export import Details = AuditDetails;
+
     export type Context = Immutable<{
       /** audit options */
       options: Record<string, any>;
@@ -61,7 +64,7 @@ declare global {
       supportedModes?: Gatherer.GatherMode[],
     }
 
-    export interface ByteEfficiencyItem extends Audit.Details.OpportunityItem {
+    export interface ByteEfficiencyItem extends AuditDetails.OpportunityItem {
       url: string;
       wastedBytes: number;
       totalBytes: number;
@@ -84,7 +87,7 @@ declare global {
       /** Overrides scoreDisplayMode with notApplicable if set to true */
       notApplicable?: boolean;
       /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
-      details?: Audit.Details;
+      details?: AuditDetails;
       /** If an audit encounters unusual execution circumstances, strings can be put in this optional array to add top-level warnings to the LHR. */
       runWarnings?: Array<IcuMessage>;
     }
@@ -136,24 +139,11 @@ declare global {
       /** The unit of `numericValue`, used when the consumer wishes to convert numericValue to a display string. */
       numericUnit?: string;
       /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
-      details?: FormattedIcu<LH.Audit.Details>;
+      details?: FormattedIcu<AuditDetails>;
     }
 
     export interface Results {
       [metric: string]: Result;
-    }
-
-    export type SimpleCriticalRequestNode = {
-      [id: string]: {
-        request: {
-          url: string;
-          startTime: number;
-          endTime: number;
-          responseReceivedTime: number;
-          transferSize: number;
-        };
-        children?: SimpleCriticalRequestNode;
-      }
     }
 
     type MultiCheckAuditP1 = Partial<Record<Artifacts.ManifestValueCheckID, boolean>>;

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -6,157 +6,153 @@
 
 import AuditDetails from './audit-details';
 
-declare global {
-  module LH.Audit {
-    // Export in global scope.
-    export import Details = AuditDetails;
+declare module Audit {
+  export import Details = AuditDetails;
 
-    export type Context = Immutable<{
-      /** audit options */
-      options: Record<string, any>;
-      settings: Config.Settings;
-      /**
-       * Nested cache for already-computed computed artifacts. Keyed first on
-       * the computed artifact's `name` property, then on input artifact(s).
-       * Values are Promises resolving to the computedArtifact result.
-       */
-      computedCache: Map<string, ArbitraryEqualityMap>;
-    }>;
+  type Context = Immutable<{
+    /** audit options */
+    options: Record<string, any>;
+    settings: LH.Config.Settings;
+    /**
+     * Nested cache for already-computed computed artifacts. Keyed first on
+     * the computed artifact's `name` property, then on input artifact(s).
+     * Values are Promises resolving to the computedArtifact result.
+     */
+    computedCache: Map<string, LH.ArbitraryEqualityMap>;
+  }>;
 
-    export interface ScoreOptions {
-      p10: number;
-      median: number;
-    }
-
-    export interface ScoreDisplayModes {
-      /** Scores of 0-1 (map to displayed scores of 0-100). */
-      NUMERIC: 'numeric';
-      /** Pass/fail audit (0 and 1 are only possible scores). */
-      BINARY: 'binary';
-      /** The audit exists only to tell you to review something yourself. Score is null and should be ignored. */
-      MANUAL: 'manual';
-      /** The audit is an FYI only, and can't be interpreted as pass/fail. Score is null and should be ignored. */
-      INFORMATIVE: 'informative';
-      /** The audit turned out to not apply to the page. Score is null and should be ignored. */
-      NOT_APPLICABLE: 'notApplicable';
-      /** There was an error while running the audit (check `errorMessage` for details). Score is null and should be ignored. */
-      ERROR: 'error';
-    }
-
-    export type ScoreDisplayMode = Audit.ScoreDisplayModes[keyof Audit.ScoreDisplayModes];
-
-    export interface Meta {
-      /** The string identifier of the audit, in kebab case. */
-      id: string;
-      /** Short, user-visible title for the audit when successful. */
-      title: string | IcuMessage;
-      /** Short, user-visible title for the audit when failing. */
-      failureTitle?: string | IcuMessage;
-      /** A more detailed description that describes why the audit is important and links to Lighthouse documentation on the audit; markdown links supported. */
-      description: string | IcuMessage;
-      /** A list of the members of LH.Artifacts that must be present for the audit to execute. */
-      requiredArtifacts: Array<keyof Artifacts>;
-      /** A list of the members of LH.Artifacts that augment the audit, but aren't necessary. For internal use only with experimental-config. */
-      __internalOptionalArtifacts?: Array<keyof Artifacts>;
-      /** A string identifying how the score should be interpreted for display. */
-      scoreDisplayMode?: Audit.ScoreDisplayMode;
-      /** A list of gather modes that this audit is applicable to. */
-      supportedModes?: Gatherer.GatherMode[],
-    }
-
-    export interface ByteEfficiencyItem extends AuditDetails.OpportunityItem {
-      url: string;
-      wastedBytes: number;
-      totalBytes: number;
-      wastedPercent?: number;
-    }
-
-    // TODO: consider making some of the `string | IcuMessage` into just `IcuMessage` to require i18n.
-
-    /** The shared properties of an Audit.Product whether it has a numericValue or not. We want to enforce `numericUnit` accompanying `numericValue` whenever it is set, so the final Audit.Product type is a discriminated union on `'numericValue' in audit`*/
-    interface ProductBase {
-      /** The scored value of the audit, provided in the range `0-1`, or null if `scoreDisplayMode` indicates not scored. */
-      score: number | null;
-      /** The i18n'd string value that the audit wishes to display for its results. This value is not necessarily the string version of the `numericValue`. */
-      displayValue?: string | IcuMessage;
-      /** An explanation of why the audit failed on the test page. */
-      explanation?: string | IcuMessage;
-      /** Error message from any exception thrown while running this audit. */
-      errorMessage?: string | IcuMessage;
-      warnings?: Array<string | IcuMessage>;
-      /** Overrides scoreDisplayMode with notApplicable if set to true */
-      notApplicable?: boolean;
-      /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
-      details?: AuditDetails;
-      /** If an audit encounters unusual execution circumstances, strings can be put in this optional array to add top-level warnings to the LHR. */
-      runWarnings?: Array<IcuMessage>;
-    }
-
-    /** The Audit.Product type for audits that do not return a `numericValue`. */
-    interface NonNumericProduct extends ProductBase {
-      numericValue?: never;
-    }
-
-    /** The Audit.Product type for audits that do return a `numericValue`. */
-    interface NumericProduct extends ProductBase {
-      /** A numeric value that has a meaning specific to the audit, e.g. the number of nodes in the DOM or the timestamp of a specific load event. More information can be found in the audit details, if present. */
-      numericValue: number;
-      /** The unit of `numericValue`, used when the consumer wishes to convert numericValue to a display string. A superset of https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier */
-      numericUnit: 'byte'|'millisecond'|'element'|'unitless';
-    }
-
-    /** Type returned by Audit.audit(). Only score is required.  */
-    export type Product = NonNumericProduct | NumericProduct;
-
-    /* Audit result returned in Lighthouse report. All audits offer a description and score of 0-1. */
-    export interface Result {
-      displayValue?: string;
-      /** An explanation of why the audit failed on the test page. */
-      explanation?: string;
-      /** Error message from any exception thrown while running this audit. */
-      errorMessage?: string;
-      warnings?: string[];
-      /** The scored value of the audit, provided in the range `0-1`, or null if `scoreDisplayMode` indicates not scored. */
-      score: number|null;
-      /**
-       * A string identifying how the score should be interpreted:
-       * - 'binary': pass/fail audit (0 and 1 are only possible scores).
-       * - 'numeric': scores of 0-1 (map to displayed scores of 0-100).
-       * - 'informative': the audit is an FYI only, and can't be interpreted as pass/fail. Score is null and should be ignored.
-       * - 'notApplicable': the audit turned out to not apply to the page. Score is null and should be ignored.
-       * - 'manual': The audit exists only to tell you to review something yourself. Score is null and should be ignored.
-       * - 'error': There was an error while running the audit (check `errorMessage` for details). Score is null and should be ignored.
-       */
-      scoreDisplayMode: ScoreDisplayMode;
-      /** Short, user-visible title for the audit. The text can change depending on if the audit passed or failed. */
-      title: string;
-      /** The string identifier of the audit, in kebab case. */
-      id: string;
-      /** A more detailed description that describes why the audit is important and links to Lighthouse documentation on the audit; markdown links supported. */
-      description: string;
-      /** A numeric value that has a meaning specific to the audit, e.g. the number of nodes in the DOM or the timestamp of a specific load event. More information can be found in the audit details, if present. */
-      numericValue?: number;
-      /** The unit of `numericValue`, used when the consumer wishes to convert numericValue to a display string. */
-      numericUnit?: string;
-      /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
-      details?: FormattedIcu<AuditDetails>;
-    }
-
-    export interface Results {
-      [metric: string]: Result;
-    }
-
-    type MultiCheckAuditP1 = Partial<Record<Artifacts.ManifestValueCheckID, boolean>>;
-    type MultiCheckAuditP2 = Partial<Artifacts.ManifestValues>;
-    interface MultiCheckAuditP3 {
-      failures: Array<string>;
-      manifestValues?: undefined;
-      allChecks?: undefined;
-    }
-
-    export type MultiCheckAuditDetails = MultiCheckAuditP1 & MultiCheckAuditP2 & MultiCheckAuditP3;
+  interface ScoreOptions {
+    p10: number;
+    median: number;
   }
+
+  interface ScoreDisplayModes {
+    /** Scores of 0-1 (map to displayed scores of 0-100). */
+    NUMERIC: 'numeric';
+    /** Pass/fail audit (0 and 1 are only possible scores). */
+    BINARY: 'binary';
+    /** The audit exists only to tell you to review something yourself. Score is null and should be ignored. */
+    MANUAL: 'manual';
+    /** The audit is an FYI only, and can't be interpreted as pass/fail. Score is null and should be ignored. */
+    INFORMATIVE: 'informative';
+    /** The audit turned out to not apply to the page. Score is null and should be ignored. */
+    NOT_APPLICABLE: 'notApplicable';
+    /** There was an error while running the audit (check `errorMessage` for details). Score is null and should be ignored. */
+    ERROR: 'error';
+  }
+
+  type ScoreDisplayMode = Audit.ScoreDisplayModes[keyof Audit.ScoreDisplayModes];
+
+  interface Meta {
+    /** The string identifier of the audit, in kebab case. */
+    id: string;
+    /** Short, user-visible title for the audit when successful. */
+    title: string | LH.IcuMessage;
+    /** Short, user-visible title for the audit when failing. */
+    failureTitle?: string | LH.IcuMessage;
+    /** A more detailed description that describes why the audit is important and links to Lighthouse documentation on the audit; markdown links supported. */
+    description: string | LH.IcuMessage;
+    /** A list of the members of LH.Artifacts that must be present for the audit to execute. */
+    requiredArtifacts: Array<keyof LH.Artifacts>;
+    /** A list of the members of LH.Artifacts that augment the audit, but aren't necessary. For internal use only with experimental-config. */
+    __internalOptionalArtifacts?: Array<keyof LH.Artifacts>;
+    /** A string identifying how the score should be interpreted for display. */
+    scoreDisplayMode?: Audit.ScoreDisplayMode;
+    /** A list of gather modes that this audit is applicable to. */
+    supportedModes?: LH.Gatherer.GatherMode[],
+  }
+
+  interface ByteEfficiencyItem extends AuditDetails.OpportunityItem {
+    url: string;
+    wastedBytes: number;
+    totalBytes: number;
+    wastedPercent?: number;
+  }
+
+  // TODO: consider making some of the `string | IcuMessage` into just `IcuMessage` to require i18n.
+
+  /** The shared properties of an Audit.Product whether it has a numericValue or not. We want to enforce `numericUnit` accompanying `numericValue` whenever it is set, so the final Audit.Product type is a discriminated union on `'numericValue' in audit`*/
+  interface ProductBase {
+    /** The scored value of the audit, provided in the range `0-1`, or null if `scoreDisplayMode` indicates not scored. */
+    score: number | null;
+    /** The i18n'd string value that the audit wishes to display for its results. This value is not necessarily the string version of the `numericValue`. */
+    displayValue?: string | LH.IcuMessage;
+    /** An explanation of why the audit failed on the test page. */
+    explanation?: string | LH.IcuMessage;
+    /** Error message from any exception thrown while running this audit. */
+    errorMessage?: string | LH.IcuMessage;
+    warnings?: Array<string | LH.IcuMessage>;
+    /** Overrides scoreDisplayMode with notApplicable if set to true */
+    notApplicable?: boolean;
+    /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
+    details?: AuditDetails;
+    /** If an audit encounters unusual execution circumstances, strings can be put in this optional array to add top-level warnings to the LHR. */
+    runWarnings?: Array<LH.IcuMessage>;
+  }
+
+  /** The Audit.Product type for audits that do not return a `numericValue`. */
+  interface NonNumericProduct extends ProductBase {
+    numericValue?: never;
+  }
+
+  /** The Audit.Product type for audits that do return a `numericValue`. */
+  interface NumericProduct extends ProductBase {
+    /** A numeric value that has a meaning specific to the audit, e.g. the number of nodes in the DOM or the timestamp of a specific load event. More information can be found in the audit details, if present. */
+    numericValue: number;
+    /** The unit of `numericValue`, used when the consumer wishes to convert numericValue to a display string. A superset of https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier */
+    numericUnit: 'byte'|'millisecond'|'element'|'unitless';
+  }
+
+  /** Type returned by Audit.audit(). Only score is required.  */
+  type Product = NonNumericProduct | NumericProduct;
+
+  /* Audit result returned in Lighthouse report. All audits offer a description and score of 0-1. */
+  interface Result {
+    displayValue?: string;
+    /** An explanation of why the audit failed on the test page. */
+    explanation?: string;
+    /** Error message from any exception thrown while running this audit. */
+    errorMessage?: string;
+    warnings?: string[];
+    /** The scored value of the audit, provided in the range `0-1`, or null if `scoreDisplayMode` indicates not scored. */
+    score: number|null;
+    /**
+     * A string identifying how the score should be interpreted:
+     * - 'binary': pass/fail audit (0 and 1 are only possible scores).
+     * - 'numeric': scores of 0-1 (map to displayed scores of 0-100).
+     * - 'informative': the audit is an FYI only, and can't be interpreted as pass/fail. Score is null and should be ignored.
+     * - 'notApplicable': the audit turned out to not apply to the page. Score is null and should be ignored.
+     * - 'manual': The audit exists only to tell you to review something yourself. Score is null and should be ignored.
+     * - 'error': There was an error while running the audit (check `errorMessage` for details). Score is null and should be ignored.
+     */
+    scoreDisplayMode: ScoreDisplayMode;
+    /** Short, user-visible title for the audit. The text can change depending on if the audit passed or failed. */
+    title: string;
+    /** The string identifier of the audit, in kebab case. */
+    id: string;
+    /** A more detailed description that describes why the audit is important and links to Lighthouse documentation on the audit; markdown links supported. */
+    description: string;
+    /** A numeric value that has a meaning specific to the audit, e.g. the number of nodes in the DOM or the timestamp of a specific load event. More information can be found in the audit details, if present. */
+    numericValue?: number;
+    /** The unit of `numericValue`, used when the consumer wishes to convert numericValue to a display string. */
+    numericUnit?: string;
+    /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
+    details?: LH.FormattedIcu<AuditDetails>;
+  }
+
+  interface Results {
+    [metric: string]: Result;
+  }
+
+  type MultiCheckAuditP1 = Partial<Record<LH.Artifacts.ManifestValueCheckID, boolean>>;
+  type MultiCheckAuditP2 = Partial<LH.Artifacts.ManifestValues>;
+  interface MultiCheckAuditP3 {
+    failures: Array<string>;
+    manifestValues?: undefined;
+    allChecks?: undefined;
+  }
+
+  type MultiCheckAuditDetails = MultiCheckAuditP1 & MultiCheckAuditP2 & MultiCheckAuditP3;
 }
 
-// empty export to keep file a module
-export {}
+export default Audit;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -5,7 +5,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import Audit = require('../lighthouse-core/audits/audit.js');
+import AuditClass = require('../lighthouse-core/audits/audit.js');
 
 interface ClassOf<T> {
   new (): T;
@@ -144,9 +144,9 @@ declare global {
         path: string,
         options?: {};
       } | {
-        implementation: typeof Audit;
+        implementation: typeof AuditClass;
         options?: {};
-      } | typeof Audit | string;
+      } | typeof AuditClass | string;
 
       /**
        * Reference to an audit member of a category and how its score should be
@@ -208,7 +208,7 @@ declare global {
       }
 
       export interface AuditDefn {
-        implementation: typeof Audit;
+        implementation: typeof AuditClass;
         path?: string;
         options: {};
       }

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -1,0 +1,14 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import Audit_ from './audit';
+
+declare global {
+  // Construct hierarchy of global types under the LH namespace.
+  module LH {
+    export import Audit = Audit_;
+  }
+}


### PR DESCRIPTION
To give an idea of what #12860 would look like, this moves `audit.d.ts` and `audit-details.d.ts` to exports instead of directly writing to `global.LH.*` types, then starts a centralized place to do the global declaration to maintain current type behavior.

Much easier to review with [`?w=1`](https://github.com/GoogleChrome/lighthouse/pull/12870/files?w=1) since there's an indentation change. Also divided into two commits if you want to see the changes to the two files (and associated references) separately.