### PR TITLE
core(fr): override quiet windows for observed performance

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -106,7 +106,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - name: yarn smoke --fraggle-rock
-      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=1 --retries=2 a11y lantern seo-passing seo-failing csp
+      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=1 --retries=2 a11y lantern seo-passing seo-failing csp metrics
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code


### PR DESCRIPTION
**Summary**
Overrides the quiet windows when throttlingMethod isn't simulate and enables the metrics Fraggle Rock smoke tests to prevent regressions.

**Related Issues/PRs**
ref #12861 #11313 
