### PR TITLE
misc: remove nyc config

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,21 +207,5 @@
   "bugs": {
     "url": "https://github.com/GoogleChrome/lighthouse/issues"
   },
-  "nyc": {
-    "reporter": [
-      "text-summary"
-    ],
-    "tempDirectory": "./coverage",
-    "include": [
-      "**/lighthouse-core/**/*.js",
-      "**/lighthouse-cli/**/*.js",
-      "**/lighthouse-viewer/**/*.js"
-    ],
-    "exclude": [
-      "**/third_party/**",
-      "**/test/",
-      "**/scripts/"
-    ]
-  },
   "homepage": "https://github.com/GoogleChrome/lighthouse#readme"
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

coverage reporter has been changed to `c8` from `nyc`.

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
