### PR TITLE
core: convert core d.ts files to modules

### DIFF
--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -5,11 +5,12 @@
  */
 
 import parseManifest = require('../lighthouse-core/lib/manifest-parser.js');
-import _LanternSimulator = require('../lighthouse-core/lib/dependency-graph/simulator/simulator.js');
+import LanternSimulator = require('../lighthouse-core/lib/dependency-graph/simulator/simulator.js');
+import LighthouseError = require('../lighthouse-core/lib/lh-error.js');
 import _NetworkRequest = require('../lighthouse-core/lib/network-request.js');
 import speedline = require('speedline-core');
 import TextSourceMap = require('../lighthouse-core/lib/cdt/generated/SourceMap.js');
-import _ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality-map.js');
+import ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality-map.js');
 
 type _TaskNode = import('../lighthouse-core/lib/tracehouse/main-thread-tasks.js').TaskNode;
 
@@ -17,884 +18,873 @@ import Config from './config';
 import Gatherer from './gatherer';
 import {IcuMessage} from './i18n';
 
-type LanternSimulator = InstanceType<typeof _LanternSimulator>;
-
-declare global {
-  module LH {
-    export interface Artifacts extends BaseArtifacts, GathererArtifacts {}
-
-    export type FRArtifacts = StrictOmit<Artifacts,
-      | 'Fonts'
-      | 'HTTPRedirect'
-      | 'Manifest'
-      | 'MixedContent'
-      | keyof FRBaseArtifacts
-    >;
-
-    /**
-     * Artifacts always created by gathering. These artifacts are available to Lighthouse plugins.
-     * NOTE: any breaking changes here are considered breaking Lighthouse changes that must be done
-     * on a major version bump.
-     */
-    export type BaseArtifacts = UniversalBaseArtifacts & ContextualBaseArtifacts & LegacyBaseArtifacts
-
-    export type FRBaseArtifacts = UniversalBaseArtifacts & ContextualBaseArtifacts;
-
-    /**
-     * The set of base artifacts that are available in every mode of Lighthouse operation.
-     */
-    export interface UniversalBaseArtifacts {
-      /** The ISO-8601 timestamp of when the test page was fetched and artifacts collected. */
-      fetchTime: string;
-      /** A set of warnings about unexpected things encountered while loading and testing the page. */
-      LighthouseRunWarnings: Array<string | IcuMessage>;
-      /** The benchmark index that indicates rough device class. */
-      BenchmarkIndex: number;
-      /** An object containing information about the testing configuration used by Lighthouse. */
-      settings: Config.Settings;
-      /** The timing instrumentation of the gather portion of a run. */
-      Timing: Artifacts.MeasureEntry[];
-    }
-
-    /**
-     * The set of base artifacts whose semantics differ or may be valueless in certain Lighthouse gather modes.
-     */
-    export interface ContextualBaseArtifacts {
-      /** The URL initially requested and the post-redirects URL that was actually loaded. */
-      URL: {requestedUrl: string, finalUrl: string};
-      /** If loading the page failed, value is the error that caused it. Otherwise null. */
-      PageLoadError: LighthouseError | null;
-    }
-
-    /**
-     * The set of base artifacts that were replaced by standard gatherers in Fraggle Rock.
-     */
-    export interface LegacyBaseArtifacts {
-      /** Device which Chrome is running on. */
-      HostFormFactor: 'desktop'|'mobile';
-      /** The user agent string of the version of Chrome used. */
-      HostUserAgent: string;
-      /** The user agent string that Lighthouse used to load the page. Set to the empty string if unknown. */
-      NetworkUserAgent: string;
-      /** Information on detected tech stacks (e.g. JS libraries) used by the page. */
-      Stacks: Artifacts.DetectedStack[];
-      /** Parsed version of the page's Web App Manifest, or null if none found. This moved to a regular artifact in Fraggle Rock. */
-      WebAppManifest: Artifacts.Manifest | null;
-      /** Errors preventing page being installable as PWA. This moved to a regular artifact in Fraggle Rock. */
-      InstallabilityErrors: Artifacts.InstallabilityErrors;
-      /** A set of page-load traces, keyed by passName. */
-      traces: {[passName: string]: Trace};
-      /** A set of DevTools debugger protocol records, keyed by passName. */
-      devtoolsLogs: {[passName: string]: DevtoolsLog};
-    }
-
-    /**
-     * Artifacts provided by the default gatherers that are exposed to plugins with a hardended API.
-     * NOTE: any breaking changes here are considered breaking Lighthouse changes that must be done
-     * on a major version bump.
-     */
-    export interface PublicGathererArtifacts {
-      /** ConsoleMessages deprecation and intervention warnings, console API calls, and exceptions logged by Chrome during page load. */
-      ConsoleMessages: Artifacts.ConsoleMessage[];
-      /** All the iframe elements in the page. */
-      IFrameElements: Artifacts.IFrameElement[];
-      /** The contents of the main HTML document network resource. */
-      MainDocumentContent: string;
-      /** Information on size and loading for all the images in the page. Natural size information for `picture` and CSS images is only available if the image was one of the largest 50 images. */
-      ImageElements: Artifacts.ImageElement[];
-      /** All the link elements on the page or equivalently declared in `Link` headers. @see https://html.spec.whatwg.org/multipage/links.html */
-      LinkElements: Artifacts.LinkElement[];
-      /** The values of the <meta> elements in the head. */
-      MetaElements: Array<{name?: string, content?: string, property?: string, httpEquiv?: string, charset?: string, node: LH.Artifacts.NodeDetails}>;
-      /** Information on all script elements in the page. Also contains the content of all requested scripts and the networkRecord requestId that contained their content. Note, HTML documents will have one entry per script tag, all with the same requestId. */
-      ScriptElements: Array<Artifacts.ScriptElement>;
-      /** The dimensions and devicePixelRatio of the loaded viewport. */
-      ViewportDimensions: Artifacts.ViewportDimensions;
-    }
-
-    /**
-     * Artifacts provided by the default gatherers. Augment this interface when adding additional
-     * gatherers. Changes to these artifacts are not considered a breaking Lighthouse change.
-     */
-    export interface GathererArtifacts extends PublicGathererArtifacts,LegacyBaseArtifacts {
-      /** The results of running the aXe accessibility tests on the page. */
-      Accessibility: Artifacts.Accessibility;
-      /** Array of all anchors on the page. */
-      AnchorElements: Artifacts.AnchorElement[];
-      /** The value of the page's <html> manifest attribute, or null if not defined */
-      AppCacheManifest: string | null;
-      /** Array of all URLs cached in CacheStorage. */
-      CacheContents: string[];
-      /** CSS coverage information for styles used by page's final state. */
-      CSSUsage: {rules: Crdp.CSS.RuleUsage[], stylesheets: Artifacts.CSSStyleSheetInfo[]};
-      /** The primary log of devtools protocol activity. Used in Fraggle Rock gathering. */
-      DevtoolsLog: DevtoolsLog;
-      /** Information on the document's doctype(or null if not present), specifically the name, publicId, and systemId.
-          All properties default to an empty string if not present */
-      Doctype: Artifacts.Doctype | null;
-      /** Information on the size of all DOM nodes in the page and the most extreme members. */
-      DOMStats: Artifacts.DOMStats;
-      /** Relevant attributes and child properties of all <object>s, <embed>s and <applet>s in the page. */
-      EmbeddedContent: Artifacts.EmbeddedContentInfo[];
-      /** Information for font faces used in the page. */
-      Fonts: Artifacts.Font[];
-      /** Information on poorly sized font usage and the text affected by it. */
-      FontSize: Artifacts.FontSize;
-      /** All the form elements in the page and formless inputs. */
-      FormElements: Artifacts.Form[];
-      /** Screenshot of the entire page (rather than just the above the fold content). */
-      FullPageScreenshot: Artifacts.FullPageScreenshot | null;
-      /** Information about how Lighthouse artifacts were gathered. */
-      GatherContext: {gatherMode: Gatherer.GatherMode};
-      /** Information about event listeners registered on the global object. */
-      GlobalListeners: Array<Artifacts.GlobalListener>;
-      /** Whether the page ended up on an HTTPS page after attempting to load the HTTP version. */
-      HTTPRedirect: {value: boolean};
-      /** The issues surfaced in the devtools Issues panel */
-      InspectorIssues: Artifacts.InspectorIssues;
-      /** JS coverage information for code used during page load. Keyed by network URL. */
-      JsUsage: Record<string, Array<Omit<Crdp.Profiler.ScriptCoverage, 'url'>>>;
-      /** Parsed version of the page's Web App Manifest, or null if none found. */
-      Manifest: Artifacts.Manifest | null;
-      /** The URL loaded with interception */
-      MixedContent: {url: string};
-      /** Size and compression opportunity information for all the images in the page. */
-      OptimizedImages: Array<Artifacts.OptimizedImage | Artifacts.OptimizedImageError>;
-      /** HTML snippets and node paths from any password inputs that prevent pasting. */
-      PasswordInputsWithPreventedPaste: Artifacts.PasswordInputsWithPreventedPaste[];
-      /** Size info of all network records sent without compression and their size after gzipping. */
-      ResponseCompression: {requestId: string, url: string, mimeType: string, transferSize: number, resourceSize: number, gzipSize?: number}[];
-      /** Information on fetching and the content of the /robots.txt file. */
-      RobotsTxt: {status: number|null, content: string|null};
-      /** Version information for all ServiceWorkers active after the first page load. */
-      ServiceWorker: {versions: Crdp.ServiceWorker.ServiceWorkerVersion[], registrations: Crdp.ServiceWorker.ServiceWorkerRegistration[]};
-      /** Source maps of scripts executed in the page. */
-      SourceMaps: Array<Artifacts.SourceMap>;
-      /** Information on <script> and <link> tags blocking first paint. */
-      TagsBlockingFirstPaint: Artifacts.TagBlockingFirstPaint[];
-      /** Information about tap targets including their position and size. */
-      TapTargets: Artifacts.TapTarget[];
-      /** The primary log of devtools protocol activity. Used in Fraggle Rock gathering. */
-      Trace: LH.Trace;
-      /** Elements associated with metrics (ie: Largest Contentful Paint element). */
-      TraceElements: Artifacts.TraceElement[];
-    }
-
-    export type ArbitraryEqualityMap = _ArbitraryEqualityMap;
-
-    module Artifacts {
-      export type ComputedContext = Immutable<{
-        computedCache: Map<string, ArbitraryEqualityMap>;
-      }>;
-
-      export type NetworkRequest = _NetworkRequest;
-      export type TaskNode = _TaskNode;
-      export type MetaElement = LH.Artifacts['MetaElements'][0];
-
-      export interface NodeDetails {
-        lhId: string,
-        devtoolsNodePath: string,
-        selector: string,
-        boundingRect: Rect,
-        snippet: string,
-        nodeLabel: string,
-      }
-
-      export interface RuleExecutionError {
-        name: string;
-        message: string;
-      }
-
-      export interface AxeRuleResult {
-        id: string;
-        impact?: string;
-        tags: Array<string>;
-        nodes: Array<{
-          target: Array<string>;
-          failureSummary?: string;
-          node: NodeDetails;
-        }>;
-        error?: RuleExecutionError;
-      }
-
-      export interface Accessibility {
-        violations: Array<AxeRuleResult>;
-        notApplicable: Array<Pick<AxeRuleResult, 'id'>>;
-        incomplete: Array<AxeRuleResult>;
-        version: string;
-      }
-
-      export interface CSSStyleSheetInfo {
-        header: Crdp.CSS.CSSStyleSheetHeader;
-        content: string;
-      }
-
-      export interface Doctype {
-        name: string;
-        publicId: string;
-        systemId: string;
-      }
-
-      export interface DOMStats {
-        /** The total number of elements found within the page's body. */
-        totalBodyElements: number;
-        width: NodeDetails & {max: number;};
-        depth: NodeDetails & {max: number;};
-      }
-
-      export interface EmbeddedContentInfo {
-        tagName: string;
-        type: string | null;
-        src: string | null;
-        data: string | null;
-        code: string | null;
-        params: Array<{name: string; value: string}>;
-        node: LH.Artifacts.NodeDetails;
-      }
-
-      export interface IFrameElement {
-        /** The `id` attribute of the iframe. */
-        id: string,
-        /** Details for node in DOM for the iframe element */
-        node: NodeDetails,
-        /** The `src` attribute of the iframe. */
-        src: string,
-        /** The iframe's ClientRect. @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect */
-        clientRect: {
-          top: number;
-          bottom: number;
-          left: number;
-          right: number;
-          width: number;
-          height: number;
-        },
-        /** If the iframe or an ancestor of the iframe is fixed in position. */
-        isPositionFixed: boolean,
-      }
-
-      /** @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#Attributes */
-      export interface LinkElement {
-        /** The `rel` attribute of the link, normalized to lower case. @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types */
-        rel: 'alternate'|'canonical'|'dns-prefetch'|'preconnect'|'preload'|'stylesheet'|string;
-        /** The `href` attribute of the link or `null` if it was invalid in the header. */
-        href: string | null
-        /** The raw value of the `href` attribute. Only different from `href` when source is 'headers' */
-        hrefRaw: string
-        /** The `hreflang` attribute of the link */
-        hreflang: string
-        /** The `as` attribute of the link */
-        as: string
-        /** The `crossOrigin` attribute of the link */
-        crossOrigin: string | null
-        /** Where the link was found, either in the DOM or in the headers of the main document */
-        source: 'head'|'body'|'headers'
-        node: NodeDetails | null
-      }
-
-      export interface PasswordInputsWithPreventedPaste {node: NodeDetails}
-
-      export interface ScriptElement {
-        type: string | null
-        src: string | null
-        /** The `id` property of the script element; null if it had no `id` or if `source` is 'network'. */
-        id: string | null
-        async: boolean
-        defer: boolean
-        /** Details for node in DOM for the script element */
-        node: NodeDetails | null
-        /** Where the script was discovered, either in the head, the body, or network records. */
-        source: 'head'|'body'|'network'
-        /** The content of the inline script or the network record with the matching URL, null if the script had a src and no network record could be found. */
-        content: string | null
-        /** The ID of the network request that matched the URL of the src or the main document if inline, null if no request could be found. */
-        requestId: string | null
-      }
-
-      /** @see https://sourcemaps.info/spec.html#h.qz3o9nc69um5 */
-      export type RawSourceMap = {
-        /** File version and must be a positive integer. */
-        version: number
-        /** A list of original source files used by the `mappings` entry. */
-        sources: string[]
-        /** A list of symbol names used by the `mappings` entry. */
-        names?: string[]
-        /** An optional source root, useful for relocating source files on a server or removing repeated values in the `sources` entry. This value is prepended to the individual entries in the `source` field. */
-        sourceRoot?: string
-        /** An optional list of source content, useful when the `source` can’t be hosted. The contents are listed in the same order as the sources. */
-        sourcesContent?: string[]
-        /** A string with the encoded mapping data. */
-        mappings: string
-        /** An optional name of the generated code (the bundled code that was the result of this build process) that this source map is associated with. */
-        file?: string
-        /**
-         * An optional array of maps that are associated with an offset into the generated code.
-         * `map` is optional because the spec defines that either `url` or `map` must be defined.
-         * We explicitly only support `map` here.
-        */
-        sections?: Array<{offset: {line: number, column: number}, map?: RawSourceMap}>
-      }
-
-      /**
-       * Source map for a given script found at scriptUrl. If there is an error in fetching or
-       * parsing the map, errorMessage will be defined instead of map.
-       */
-      export type SourceMap = {
-        /** URL of code that source map applies to. */
-        scriptUrl: string
-        /** URL of the source map. undefined if from data URL. */
-        sourceMapUrl?: string
-        /** Source map data structure. */
-        map: RawSourceMap
-      } | {
-        /** URL of code that source map applies to. */
-        scriptUrl: string
-        /** URL of the source map. undefined if from data URL. */
-        sourceMapUrl?: string
-        /** Error that occurred during fetching or parsing of source map. */
-        errorMessage: string
-        /** No map on account of error. */
-        map?: undefined;
-      }
-
-      export interface Bundle {
-        rawMap: RawSourceMap;
-        script: ScriptElement;
-        map: TextSourceMap;
-        sizes: {
-          // TODO(cjamcl): Rename to `sources`.
-          files: Record<string, number>;
-          unmappedBytes: number;
-          totalBytes: number;
-        } | {errorMessage: string};
-      }
-
-      /** @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Attributes */
-      export interface AnchorElement {
-        rel: string
-        /** The computed href property: https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-88517319, use `rawHref` for the exact attribute value */
-        href: string
-        /** The exact value of the href attribute value, as it is in the DOM */
-        rawHref: string
-        name?: string
-        text: string
-        role: string
-        target: string
-        node: NodeDetails
-        onclick: string
-        listeners?: Array<{
-          type: Crdp.DOMDebugger.EventListener['type']
-        }>
-      }
-
-      export interface Font {
-        display: string;
-        family: string;
-        featureSettings: string;
-        stretch: string;
-        style: string;
-        unicodeRange: string;
-        variant: string;
-        weight: string;
-        src?: string[];
-      }
-
-      export interface FontSize {
-        totalTextLength: number;
-        failingTextLength: number;
-        analyzedFailingTextLength: number;
-        /** Elements that contain a text node that failed size criteria. */
-        analyzedFailingNodesData: Array<{
-          /* nodeId of the failing TextNode. */
-          nodeId: number;
-          fontSize: number;
-          textLength: number;
-          parentNode: {
-            backendNodeId: number;
-            attributes: string[];
-            nodeName: string;
-            parentNode?: {
-              backendNodeId: number;
-              attributes: string[];
-              nodeName: string;
-            };
-          };
-          cssRule?: {
-            type: 'Regular' | 'Inline' | 'Attributes';
-            range?: {startLine: number, startColumn: number};
-            parentRule?: {origin: Crdp.CSS.StyleSheetOrigin, selectors: {text: string}[]};
-            styleSheetId?: string;
-            stylesheet?: Crdp.CSS.CSSStyleSheetHeader;
-            cssProperties?: Array<Crdp.CSS.CSSProperty>;
-          }
-        }>
-      }
-
-      // TODO(bckenny): real type for parsed manifest.
-      export type Manifest = ReturnType<typeof parseManifest>;
-
-      export interface InstallabilityErrors {
-        errors: Crdp.Page.InstallabilityError[];
-      }
-
-      export interface ImageElement {
-        /** The resolved source URL of the image. Similar to `currentSrc`, but resolved for CSS images as well. */
-        src: string;
-        /** The srcset attribute value. @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset */
-        srcset: string;
-        /** The displayed width of the image, uses img.width when available falling back to clientWidth. See https://codepen.io/patrickhulce/pen/PXvQbM for examples. */
-        displayedWidth: number;
-        /** The displayed height of the image, uses img.height when available falling back to clientHeight. See https://codepen.io/patrickhulce/pen/PXvQbM for examples. */
-        displayedHeight: number;
-        /** The raw width attribute of the image element. CSS images will be set to null. */
-        attributeWidth: string | null;
-        /** The raw height attribute of the image element. CSS images will be set to null. */
-        attributeHeight: string | null;
-        /**
-         * The natural width and height of the underlying image resource, uses img.naturalHeight/img.naturalWidth. See https://codepen.io/patrickhulce/pen/PXvQbM for examples.
-         * Set to `undefined` if the data could not be collected.
-         */
-        naturalDimensions?: {
-          width: number;
-          height: number;
-        };
-        /**
-         * The width/height of the element as defined by matching CSS rules.
-         * These are distinct from the `computedStyles` properties in that they are the raw property value.
-         * e.g. `width` would be `"100vw"`, not the computed width in pixels.
-         * Set to `undefined` if the data was not collected.
-         */
-        cssEffectiveRules?: {
-          /** The width of the image as expressed by CSS rules. Set to `null` if there was no width set in CSS. */
-          width: string | null;
-          /** The height of the image as expressed by CSS rules. Set to `null` if there was no height set in CSS. */
-          height: string | null;
-          /** The aspect ratio of the image as expressed by CSS rules. Set to `null` if there was no aspect ratio set in CSS. */
-          aspectRatio: string | null;
-        };
-        /** The computed styles as determined by `getComputedStyle`. */
-        computedStyles: {
-          /** CSS `position` property. */
-          position: string;
-          /** CSS `object-fit` property. */
-          objectFit: string;
-          /** CSS `image-rendering` propertry. */
-          imageRendering: string;
-        };
-        /** The BoundingClientRect of the element. */
-        clientRect: {
-          top: number;
-          bottom: number;
-          left: number;
-          right: number;
-        };
-        /** Flags whether this element was an image via CSS background-image rather than <img> tag. */
-        isCss: boolean;
-        /** Flags whether this element was contained within a <picture> tag. */
-        isPicture: boolean;
-        /** Flags whether this element was contained within a ShadowRoot */
-        isInShadowDOM: boolean;
-        /** The MIME type of the underlying image file. */
-        mimeType?: string;
-        /** Details for node in DOM for the image element */
-        node: NodeDetails;
-        /** The loading attribute of the image. */
-        loading?: string;
-      }
-
-      export interface OptimizedImage {
-        failed: false;
-        originalSize: number;
-        jpegSize?: number;
-        webpSize?: number;
-
-        requestId: string;
-        url: string;
-        mimeType: string;
-        resourceSize: number;
-      }
-
-      export interface OptimizedImageError {
-        failed: true;
-        errMsg: string;
-
-        requestId: string;
-        url: string;
-        mimeType: string;
-        resourceSize: number;
-      }
-
-      export interface TagBlockingFirstPaint {
-        startTime: number;
-        endTime: number;
-        transferSize: number;
-        tag: {
-          tagName: 'LINK'|'SCRIPT';
-          /** The value of `HTMLLinkElement.href` or `HTMLScriptElement.src`. */
-          url: string;
-          /** A record of when changes to the `HTMLLinkElement.media` attribute occurred and if the new media type matched the page. */
-          mediaChanges?: Array<{href: string, media: string, msSinceHTMLEnd: number, matches: boolean}>;
-        };
-      }
-
-      export interface Rect {
-        width: number;
-        height: number;
-        top: number;
-        right: number;
-        bottom: number;
-        left: number;
-      }
-
-      export interface TapTarget {
-        node: NodeDetails;
-        href: string;
-        clientRects: Rect[];
-      }
-
-      export interface TraceElement {
-        traceEventType: 'largest-contentful-paint'|'layout-shift'|'animation';
-        score?: number;
-        node: NodeDetails;
-        nodeId?: number;
-        animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[];
-      }
-
-      export interface ViewportDimensions {
-        innerWidth: number;
-        innerHeight: number;
-        outerWidth: number;
-        outerHeight: number;
-        devicePixelRatio: number;
-      }
-
-      export interface InspectorIssues {
-        mixedContent: Crdp.Audits.MixedContentIssueDetails[];
-        sameSiteCookies: Crdp.Audits.SameSiteCookieIssueDetails[];
-        blockedByResponse: Crdp.Audits.BlockedByResponseIssueDetails[];
-        heavyAds: Crdp.Audits.HeavyAdIssueDetails[];
-        contentSecurityPolicy: Crdp.Audits.ContentSecurityPolicyIssueDetails[];
-      }
-
-      // Computed artifact types below.
-      export type CriticalRequestNode = {
-        [id: string]: {
-          request: Artifacts.NetworkRequest;
-          children: CriticalRequestNode;
-        }
-      }
-
-      export type ManifestValueCheckID = 'hasStartUrl'|'hasIconsAtLeast144px'|'hasIconsAtLeast512px'|'fetchesIcon'|'hasPWADisplayValue'|'hasBackgroundColor'|'hasThemeColor'|'hasShortName'|'hasName'|'shortNameLength'|'hasMaskableIcon';
-
-      export type ManifestValues = {
-        isParseFailure: false;
-        allChecks: {
-          id: ManifestValueCheckID;
-          failureText: string;
-          passing: boolean;
-        }[];
-      } | {
-        isParseFailure: true;
-        parseFailureReason: string;
-        allChecks: {
-          id: ManifestValueCheckID;
-          failureText: string;
-          passing: boolean;
-        }[];
-      }
-
-      export interface MeasureEntry {
-        // From PerformanceEntry
-        readonly duration: number;
-        readonly entryType: string;
-        readonly name: string;
-        readonly startTime: number;
-        /** Whether timing entry was collected during artifact gathering. */
-        gather?: boolean;
-      }
-
-      export interface MetricComputationDataInput {
-        devtoolsLog: DevtoolsLog;
-        trace: Trace;
-        settings: Immutable<Config.Settings>;
-        gatherContext: Artifacts['GatherContext'];
-        simulator?: LanternSimulator;
-      }
-
-      export interface MetricComputationData extends MetricComputationDataInput {
-        networkRecords: Array<Artifacts.NetworkRequest>;
-        processedTrace: ProcessedTrace;
-        processedNavigation?: ProcessedNavigation;
-      }
-
-      export interface NavigationMetricComputationData extends MetricComputationData {
-        processedNavigation: ProcessedNavigation;
-      }
-
-      export interface Metric {
-        timing: number;
-        timestamp?: number;
-      }
-
-      export interface NetworkAnalysis {
-        rtt: number;
-        additionalRttByOrigin: Map<string, number>;
-        serverResponseTimeByOrigin: Map<string, number>;
-        throughput: number;
-      }
-
-      export interface LanternMetric {
-        timing: number;
-        timestamp?: never;
-        optimisticEstimate: Gatherer.Simulation.Result
-        pessimisticEstimate: Gatherer.Simulation.Result;
-        optimisticGraph: Gatherer.Simulation.GraphNode;
-        pessimisticGraph: Gatherer.Simulation.GraphNode;
-      }
-
-      export type Speedline = speedline.Output<'speedIndex'>;
-
-      export interface TraceTimes {
-        timeOrigin: number;
-        traceEnd: number;
-      }
-
-      export interface NavigationTraceTimes {
-        timeOrigin: number;
-        firstPaint?: number;
-        firstContentfulPaint: number;
-        firstContentfulPaintAllFrames: number;
-        firstMeaningfulPaint?: number;
-        largestContentfulPaint?: number;
-        largestContentfulPaintAllFrames?: number;
-        traceEnd: number;
-        load?: number;
-        domContentLoaded?: number;
-      }
-
-      export interface ProcessedTrace {
-        /** The raw timestamps of key events, in microseconds. */
-        timestamps: TraceTimes;
-        /** The relative times from timeOrigin to key events, in milliseconds. */
-        timings: TraceTimes;
-        /** The subset of trace events from the page's process, sorted by timestamp. */
-        processEvents: Array<TraceEvent>;
-        /** The subset of trace events from the page's main thread, sorted by timestamp. */
-        mainThreadEvents: Array<TraceEvent>;
-        /** The subset of trace events from the main frame, sorted by timestamp. */
-        frameEvents: Array<TraceEvent>;
-        /** The subset of trace events from the main frame and any child frames, sorted by timestamp. */
-        frameTreeEvents: Array<TraceEvent>;
-        /** IDs for the trace's main frame, process, and thread. */
-        mainFrameIds: {pid: number, tid: number, frameId: string};
-        /** The list of frames committed in the trace. */
-        frames: Array<{id: string, url: string}>;
-        /** The trace event marking the time at which the run should consider to have begun. Typically the same as the navigationStart but might differ due to SPA navigations, client-side redirects, etc. In the FR timespan case, this event is injected by Lighthouse itself. */
-        timeOriginEvt: TraceEvent;
-      }
-
-      export interface ProcessedNavigation {
-        /** The raw timestamps of key metric events, in microseconds. */
-        timestamps: NavigationTraceTimes;
-        /** The relative times from navigationStart to key metric events, in milliseconds. */
-        timings: NavigationTraceTimes;
-        /** The trace event marking firstPaint, if it was found. */
-        firstPaintEvt?: TraceEvent;
-        /** The trace event marking firstContentfulPaint, if it was found. */
-        firstContentfulPaintEvt: TraceEvent;
-        /** The trace event marking firstContentfulPaint from all frames, if it was found. */
-        firstContentfulPaintAllFramesEvt: TraceEvent;
-        /** The trace event marking firstMeaningfulPaint, if it was found. */
-        firstMeaningfulPaintEvt?: TraceEvent;
-        /** The trace event marking largestContentfulPaint, if it was found. */
-        largestContentfulPaintEvt?: TraceEvent;
-        /** The trace event marking largestContentfulPaint from all frames, if it was found. */
-        largestContentfulPaintAllFramesEvt?: TraceEvent;
-        /** The trace event marking loadEventEnd, if it was found. */
-        loadEvt?: TraceEvent;
-        /** The trace event marking domContentLoadedEventEnd, if it was found. */
-        domContentLoadedEvt?: TraceEvent;
-        /**
-         * Whether the firstMeaningfulPaintEvt was the definitive event or a fallback to
-         * firstMeaningfulPaintCandidate events had to be attempted.
-         */
-        fmpFellBack: boolean;
-        /** Whether LCP was invalidated without a new candidate. */
-        lcpInvalidated: boolean;
-      }
-
-      /** Information on a tech stack (e.g. a JS library) used by the page. */
-      export interface DetectedStack {
-        /** The identifier for how this stack was detected. */
-        detector: 'js';
-        /** The unique string ID for the stack. */
-        id: string;
-        /** The name of the stack. */
-        name: string;
-        /** The version of the stack, if it could be detected. */
-        version?: string;
-        /** The package name on NPM, if it exists. */
-        npm?: string;
-      }
-
-      export interface FullPageScreenshot {
-        screenshot: {
-          /** Base64 image data URL. */
-          data: string;
-          width: number;
-          height: number;
-        };
-        nodes: Record<string, Rect>;
-      }
-
-      export interface TimingSummary {
-        firstContentfulPaint: number | undefined;
-        firstContentfulPaintTs: number | undefined;
-        firstContentfulPaintAllFrames: number | undefined;
-        firstContentfulPaintAllFramesTs: number | undefined;
-        firstMeaningfulPaint: number | undefined;
-        firstMeaningfulPaintTs: number | undefined;
-        largestContentfulPaint: number | undefined;
-        largestContentfulPaintTs: number | undefined;
-        largestContentfulPaintAllFrames: number | undefined;
-        largestContentfulPaintAllFramesTs: number | undefined;
-        interactive: number | undefined;
-        interactiveTs: number | undefined;
-        speedIndex: number | undefined;
-        speedIndexTs: number | undefined;
-        maxPotentialFID: number | undefined;
-        cumulativeLayoutShift: number | undefined;
-        cumulativeLayoutShiftMainFrame: number | undefined;
-        totalCumulativeLayoutShift: number | undefined;
-        totalBlockingTime: number | undefined;
-        observedTimeOrigin: number;
-        observedTimeOriginTs: number;
-        observedNavigationStart: number | undefined;
-        observedNavigationStartTs: number | undefined;
-        observedCumulativeLayoutShift: number | undefined;
-        observedCumulativeLayoutShiftMainFrame: number | undefined;
-        observedTotalCumulativeLayoutShift: number | undefined;
-        observedFirstPaint: number | undefined;
-        observedFirstPaintTs: number | undefined;
-        observedFirstContentfulPaint: number | undefined;
-        observedFirstContentfulPaintTs: number | undefined;
-        observedFirstContentfulPaintAllFrames: number | undefined;
-        observedFirstContentfulPaintAllFramesTs: number | undefined;
-        observedFirstMeaningfulPaint: number | undefined;
-        observedFirstMeaningfulPaintTs: number | undefined;
-        observedLargestContentfulPaint: number | undefined;
-        observedLargestContentfulPaintTs: number | undefined;
-        observedLargestContentfulPaintAllFrames: number | undefined;
-        observedLargestContentfulPaintAllFramesTs: number | undefined;
-        observedTraceEnd: number | undefined;
-        observedTraceEndTs: number | undefined;
-        observedLoad: number | undefined;
-        observedLoadTs: number | undefined;
-        observedDomContentLoaded: number | undefined;
-        observedDomContentLoadedTs: number | undefined;
-        observedFirstVisualChange: number;
-        observedFirstVisualChangeTs: number;
-        observedLastVisualChange: number;
-        observedLastVisualChangeTs: number;
-        observedSpeedIndex: number;
-        observedSpeedIndexTs: number;
-      }
-
-      export interface Form {
-        /** If attributes is missing that means this is a formless set of elements. */
-        attributes?: {
-          id: string;
-          name: string;
-          autocomplete: string;
-        };
-        node: NodeDetails | null;
-        inputs: Array<FormInput>;
-        labels: Array<FormLabel>;
-      }
-
-      /** Attributes collected for every input element in the inputs array from the forms interface. */
-      export interface FormInput {
-        id: string;
-        name: string;
-        placeholder?: string;
-        autocomplete: {
-          property: string;
-          attribute: string | null;
-          prediction: string | null;
-        }
-        node: NodeDetails;
-      }
-
-      /** Attributes collected for every label element in the labels array from the forms interface */
-      export interface FormLabel {
-        for: string;
-        node: NodeDetails;
-      }
-
-      /** Information about an event listener registered on the global object. */
-      export interface GlobalListener {
-        /** Event listener type, limited to those events currently of interest. */
-        type: 'pagehide'|'unload'|'visibilitychange';
-        /** The DevTools protocol script identifier. */
-        scriptId: string;
-        /** Line number in the script (0-based). */
-        lineNumber: number;
-        /** Column number in the script (0-based). */
-        columnNumber: number;
-      }
-
-      /** Describes a generic console message. */
-      interface BaseConsoleMessage {
-        /**
-         * The text printed to the console, as shown on the browser console.
-         *
-         * For console API calls, all values are formatted into the text. Primitive values and
-         * function will be printed as-is while objects will be formatted as if the object were
-         * passed to String(). For example, a div will be formatted as "[object HTMLDivElement]".
-         *
-         * For exceptions the text will be the same as err.message at runtime.
-         */
-        text: string;
-        /** Time of the console log in milliseconds since epoch. */
-        timestamp: number;
-        /** The stack trace of the log/exception, if known. */
-        stackTrace?: Crdp.Runtime.StackTrace;
-        /** The URL of the log/exception, if known. */
-        url?: string;
-        /** Line number in the script (0-indexed), if known. */
-        lineNumber?: number;
-        /** Column number in the script (0-indexed), if known. */
-        columnNumber?: number;
-      }
-
-      /** Describes a console message logged by a script using the console API. */
-      interface ConsoleAPICall extends BaseConsoleMessage {
-        eventType: 'consoleAPI';
-        /** The console API invoked. Only the following console API calls are gathered. */
-        source: 'console.warn' | 'console.error';
-        /** Corresponds to the API call. */
-        level: 'warning' | 'error';
-      }
-
-      interface ConsoleException extends BaseConsoleMessage {
-        eventType: 'exception';
-        source: 'exception';
-        level: 'error';
-      }
-
-      /**
-       * Describes a report logged to the console by the browser regarding interventions,
-       * deprecations, violations, and more.
-       */
-      interface ConsoleProtocolLog extends BaseConsoleMessage {
-        source: Crdp.Log.LogEntry['source'],
-        level: Crdp.Log.LogEntry['level'],
-        eventType: 'protocolLog';
-      }
-
-      export type ConsoleMessage = ConsoleAPICall | ConsoleException | ConsoleProtocolLog;
-    }
-  }
+export interface Artifacts extends BaseArtifacts, GathererArtifacts {}
+
+export type FRArtifacts = StrictOmit<Artifacts,
+  | 'Fonts'
+  | 'HTTPRedirect'
+  | 'Manifest'
+  | 'MixedContent'
+  | keyof FRBaseArtifacts
+>;
+
+/**
+ * Artifacts always created by gathering. These artifacts are available to Lighthouse plugins.
+ * NOTE: any breaking changes here are considered breaking Lighthouse changes that must be done
+ * on a major version bump.
+ */
+export type BaseArtifacts = UniversalBaseArtifacts & ContextualBaseArtifacts & LegacyBaseArtifacts
+
+export type FRBaseArtifacts = UniversalBaseArtifacts & ContextualBaseArtifacts;
+
+/**
+ * The set of base artifacts that are available in every mode of Lighthouse operation.
+ */
+interface UniversalBaseArtifacts {
+  /** The ISO-8601 timestamp of when the test page was fetched and artifacts collected. */
+  fetchTime: string;
+  /** A set of warnings about unexpected things encountered while loading and testing the page. */
+  LighthouseRunWarnings: Array<string | IcuMessage>;
+  /** The benchmark index that indicates rough device class. */
+  BenchmarkIndex: number;
+  /** An object containing information about the testing configuration used by Lighthouse. */
+  settings: Config.Settings;
+  /** The timing instrumentation of the gather portion of a run. */
+  Timing: Artifacts.MeasureEntry[];
 }
 
-// empty export to keep file a module
-export {}
+/**
+ * The set of base artifacts whose semantics differ or may be valueless in certain Lighthouse gather modes.
+ */
+interface ContextualBaseArtifacts {
+  /** The URL initially requested and the post-redirects URL that was actually loaded. */
+  URL: {requestedUrl: string, finalUrl: string};
+  /** If loading the page failed, value is the error that caused it. Otherwise null. */
+  PageLoadError: LighthouseError | null;
+}
+
+/**
+ * The set of base artifacts that were replaced by standard gatherers in Fraggle Rock.
+ */
+interface LegacyBaseArtifacts {
+  /** Device which Chrome is running on. */
+  HostFormFactor: 'desktop'|'mobile';
+  /** The user agent string of the version of Chrome used. */
+  HostUserAgent: string;
+  /** The user agent string that Lighthouse used to load the page. Set to the empty string if unknown. */
+  NetworkUserAgent: string;
+  /** Information on detected tech stacks (e.g. JS libraries) used by the page. */
+  Stacks: Artifacts.DetectedStack[];
+  /** Parsed version of the page's Web App Manifest, or null if none found. This moved to a regular artifact in Fraggle Rock. */
+  WebAppManifest: Artifacts.Manifest | null;
+  /** Errors preventing page being installable as PWA. This moved to a regular artifact in Fraggle Rock. */
+  InstallabilityErrors: Artifacts.InstallabilityErrors;
+  /** A set of page-load traces, keyed by passName. */
+  traces: {[passName: string]: LH.Trace};
+  /** A set of DevTools debugger protocol records, keyed by passName. */
+  devtoolsLogs: {[passName: string]: LH.DevtoolsLog};
+}
+
+/**
+ * Artifacts provided by the default gatherers that are exposed to plugins with a hardended API.
+ * NOTE: any breaking changes here are considered breaking Lighthouse changes that must be done
+ * on a major version bump.
+ */
+interface PublicGathererArtifacts {
+  /** ConsoleMessages deprecation and intervention warnings, console API calls, and exceptions logged by Chrome during page load. */
+  ConsoleMessages: Artifacts.ConsoleMessage[];
+  /** All the iframe elements in the page. */
+  IFrameElements: Artifacts.IFrameElement[];
+  /** The contents of the main HTML document network resource. */
+  MainDocumentContent: string;
+  /** Information on size and loading for all the images in the page. Natural size information for `picture` and CSS images is only available if the image was one of the largest 50 images. */
+  ImageElements: Artifacts.ImageElement[];
+  /** All the link elements on the page or equivalently declared in `Link` headers. @see https://html.spec.whatwg.org/multipage/links.html */
+  LinkElements: Artifacts.LinkElement[];
+  /** The values of the <meta> elements in the head. */
+  MetaElements: Array<{name?: string, content?: string, property?: string, httpEquiv?: string, charset?: string, node: Artifacts.NodeDetails}>;
+  /** Information on all script elements in the page. Also contains the content of all requested scripts and the networkRecord requestId that contained their content. Note, HTML documents will have one entry per script tag, all with the same requestId. */
+  ScriptElements: Array<Artifacts.ScriptElement>;
+  /** The dimensions and devicePixelRatio of the loaded viewport. */
+  ViewportDimensions: Artifacts.ViewportDimensions;
+}
+
+/**
+ * Artifacts provided by the default gatherers. Augment this interface when adding additional
+ * gatherers. Changes to these artifacts are not considered a breaking Lighthouse change.
+ */
+export interface GathererArtifacts extends PublicGathererArtifacts,LegacyBaseArtifacts {
+  /** The results of running the aXe accessibility tests on the page. */
+  Accessibility: Artifacts.Accessibility;
+  /** Array of all anchors on the page. */
+  AnchorElements: Artifacts.AnchorElement[];
+  /** The value of the page's <html> manifest attribute, or null if not defined */
+  AppCacheManifest: string | null;
+  /** Array of all URLs cached in CacheStorage. */
+  CacheContents: string[];
+  /** CSS coverage information for styles used by page's final state. */
+  CSSUsage: {rules: LH.Crdp.CSS.RuleUsage[], stylesheets: Artifacts.CSSStyleSheetInfo[]};
+  /** The primary log of devtools protocol activity. Used in Fraggle Rock gathering. */
+  DevtoolsLog: LH.DevtoolsLog;
+  /** Information on the document's doctype(or null if not present), specifically the name, publicId, and systemId.
+      All properties default to an empty string if not present */
+  Doctype: Artifacts.Doctype | null;
+  /** Information on the size of all DOM nodes in the page and the most extreme members. */
+  DOMStats: Artifacts.DOMStats;
+  /** Relevant attributes and child properties of all <object>s, <embed>s and <applet>s in the page. */
+  EmbeddedContent: Artifacts.EmbeddedContentInfo[];
+  /** Information for font faces used in the page. */
+  Fonts: Artifacts.Font[];
+  /** Information on poorly sized font usage and the text affected by it. */
+  FontSize: Artifacts.FontSize;
+  /** All the form elements in the page and formless inputs. */
+  FormElements: Artifacts.Form[];
+  /** Screenshot of the entire page (rather than just the above the fold content). */
+  FullPageScreenshot: Artifacts.FullPageScreenshot | null;
+  /** Information about how Lighthouse artifacts were gathered. */
+  GatherContext: {gatherMode: Gatherer.GatherMode};
+  /** Information about event listeners registered on the global object. */
+  GlobalListeners: Array<Artifacts.GlobalListener>;
+  /** Whether the page ended up on an HTTPS page after attempting to load the HTTP version. */
+  HTTPRedirect: {value: boolean};
+  /** The issues surfaced in the devtools Issues panel */
+  InspectorIssues: Artifacts.InspectorIssues;
+  /** JS coverage information for code used during page load. Keyed by network URL. */
+  JsUsage: Record<string, Array<Omit<LH.Crdp.Profiler.ScriptCoverage, 'url'>>>;
+  /** Parsed version of the page's Web App Manifest, or null if none found. */
+  Manifest: Artifacts.Manifest | null;
+  /** The URL loaded with interception */
+  MixedContent: {url: string};
+  /** Size and compression opportunity information for all the images in the page. */
+  OptimizedImages: Array<Artifacts.OptimizedImage | Artifacts.OptimizedImageError>;
+  /** HTML snippets and node paths from any password inputs that prevent pasting. */
+  PasswordInputsWithPreventedPaste: Artifacts.PasswordInputsWithPreventedPaste[];
+  /** Size info of all network records sent without compression and their size after gzipping. */
+  ResponseCompression: {requestId: string, url: string, mimeType: string, transferSize: number, resourceSize: number, gzipSize?: number}[];
+  /** Information on fetching and the content of the /robots.txt file. */
+  RobotsTxt: {status: number|null, content: string|null};
+  /** Version information for all ServiceWorkers active after the first page load. */
+  ServiceWorker: {versions: LH.Crdp.ServiceWorker.ServiceWorkerVersion[], registrations: LH.Crdp.ServiceWorker.ServiceWorkerRegistration[]};
+  /** Source maps of scripts executed in the page. */
+  SourceMaps: Array<Artifacts.SourceMap>;
+  /** Information on <script> and <link> tags blocking first paint. */
+  TagsBlockingFirstPaint: Artifacts.TagBlockingFirstPaint[];
+  /** Information about tap targets including their position and size. */
+  TapTargets: Artifacts.TapTarget[];
+  /** The primary log of devtools protocol activity. Used in Fraggle Rock gathering. */
+  Trace: LH.Trace;
+  /** Elements associated with metrics (ie: Largest Contentful Paint element). */
+  TraceElements: Artifacts.TraceElement[];
+}
+
+declare module Artifacts {
+  type ComputedContext = Immutable<{
+    computedCache: Map<string, ArbitraryEqualityMap>;
+  }>;
+
+  type NetworkRequest = _NetworkRequest;
+  type TaskNode = _TaskNode;
+  type MetaElement = Artifacts['MetaElements'][0];
+
+  interface NodeDetails {
+    lhId: string,
+    devtoolsNodePath: string,
+    selector: string,
+    boundingRect: Rect,
+    snippet: string,
+    nodeLabel: string,
+  }
+
+  interface RuleExecutionError {
+    name: string;
+    message: string;
+  }
+
+  interface AxeRuleResult {
+    id: string;
+    impact?: string;
+    tags: Array<string>;
+    nodes: Array<{
+      target: Array<string>;
+      failureSummary?: string;
+      node: NodeDetails;
+    }>;
+    error?: RuleExecutionError;
+  }
+
+  interface Accessibility {
+    violations: Array<AxeRuleResult>;
+    notApplicable: Array<Pick<AxeRuleResult, 'id'>>;
+    incomplete: Array<AxeRuleResult>;
+    version: string;
+  }
+
+  interface CSSStyleSheetInfo {
+    header: LH.Crdp.CSS.CSSStyleSheetHeader;
+    content: string;
+  }
+
+  interface Doctype {
+    name: string;
+    publicId: string;
+    systemId: string;
+  }
+
+  interface DOMStats {
+    /** The total number of elements found within the page's body. */
+    totalBodyElements: number;
+    width: NodeDetails & {max: number;};
+    depth: NodeDetails & {max: number;};
+  }
+
+  interface EmbeddedContentInfo {
+    tagName: string;
+    type: string | null;
+    src: string | null;
+    data: string | null;
+    code: string | null;
+    params: Array<{name: string; value: string}>;
+    node: Artifacts.NodeDetails;
+  }
+
+  interface IFrameElement {
+    /** The `id` attribute of the iframe. */
+    id: string,
+    /** Details for node in DOM for the iframe element */
+    node: NodeDetails,
+    /** The `src` attribute of the iframe. */
+    src: string,
+    /** The iframe's ClientRect. @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect */
+    clientRect: {
+      top: number;
+      bottom: number;
+      left: number;
+      right: number;
+      width: number;
+      height: number;
+    },
+    /** If the iframe or an ancestor of the iframe is fixed in position. */
+    isPositionFixed: boolean,
+  }
+
+  /** @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#Attributes */
+  interface LinkElement {
+    /** The `rel` attribute of the link, normalized to lower case. @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types */
+    rel: 'alternate'|'canonical'|'dns-prefetch'|'preconnect'|'preload'|'stylesheet'|string;
+    /** The `href` attribute of the link or `null` if it was invalid in the header. */
+    href: string | null
+    /** The raw value of the `href` attribute. Only different from `href` when source is 'headers' */
+    hrefRaw: string
+    /** The `hreflang` attribute of the link */
+    hreflang: string
+    /** The `as` attribute of the link */
+    as: string
+    /** The `crossOrigin` attribute of the link */
+    crossOrigin: string | null
+    /** Where the link was found, either in the DOM or in the headers of the main document */
+    source: 'head'|'body'|'headers'
+    node: NodeDetails | null
+  }
+
+  interface PasswordInputsWithPreventedPaste {node: NodeDetails}
+
+  interface ScriptElement {
+    type: string | null
+    src: string | null
+    /** The `id` property of the script element; null if it had no `id` or if `source` is 'network'. */
+    id: string | null
+    async: boolean
+    defer: boolean
+    /** Details for node in DOM for the script element */
+    node: NodeDetails | null
+    /** Where the script was discovered, either in the head, the body, or network records. */
+    source: 'head'|'body'|'network'
+    /** The content of the inline script or the network record with the matching URL, null if the script had a src and no network record could be found. */
+    content: string | null
+    /** The ID of the network request that matched the URL of the src or the main document if inline, null if no request could be found. */
+    requestId: string | null
+  }
+
+  /** @see https://sourcemaps.info/spec.html#h.qz3o9nc69um5 */
+  type RawSourceMap = {
+    /** File version and must be a positive integer. */
+    version: number
+    /** A list of original source files used by the `mappings` entry. */
+    sources: string[]
+    /** A list of symbol names used by the `mappings` entry. */
+    names?: string[]
+    /** An optional source root, useful for relocating source files on a server or removing repeated values in the `sources` entry. This value is prepended to the individual entries in the `source` field. */
+    sourceRoot?: string
+    /** An optional list of source content, useful when the `source` can’t be hosted. The contents are listed in the same order as the sources. */
+    sourcesContent?: string[]
+    /** A string with the encoded mapping data. */
+    mappings: string
+    /** An optional name of the generated code (the bundled code that was the result of this build process) that this source map is associated with. */
+    file?: string
+    /**
+     * An optional array of maps that are associated with an offset into the generated code.
+     * `map` is optional because the spec defines that either `url` or `map` must be defined.
+     * We explicitly only support `map` here.
+    */
+    sections?: Array<{offset: {line: number, column: number}, map?: RawSourceMap}>
+  }
+
+  /**
+   * Source map for a given script found at scriptUrl. If there is an error in fetching or
+   * parsing the map, errorMessage will be defined instead of map.
+   */
+  type SourceMap = {
+    /** URL of code that source map applies to. */
+    scriptUrl: string
+    /** URL of the source map. undefined if from data URL. */
+    sourceMapUrl?: string
+    /** Source map data structure. */
+    map: RawSourceMap
+  } | {
+    /** URL of code that source map applies to. */
+    scriptUrl: string
+    /** URL of the source map. undefined if from data URL. */
+    sourceMapUrl?: string
+    /** Error that occurred during fetching or parsing of source map. */
+    errorMessage: string
+    /** No map on account of error. */
+    map?: undefined;
+  }
+
+  interface Bundle {
+    rawMap: RawSourceMap;
+    script: ScriptElement;
+    map: TextSourceMap;
+    sizes: {
+      // TODO(cjamcl): Rename to `sources`.
+      files: Record<string, number>;
+      unmappedBytes: number;
+      totalBytes: number;
+    } | {errorMessage: string};
+  }
+
+  /** @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Attributes */
+  interface AnchorElement {
+    rel: string
+    /** The computed href property: https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-88517319, use `rawHref` for the exact attribute value */
+    href: string
+    /** The exact value of the href attribute value, as it is in the DOM */
+    rawHref: string
+    name?: string
+    text: string
+    role: string
+    target: string
+    node: NodeDetails
+    onclick: string
+    listeners?: Array<{
+      type: LH.Crdp.DOMDebugger.EventListener['type']
+    }>
+  }
+
+  interface Font {
+    display: string;
+    family: string;
+    featureSettings: string;
+    stretch: string;
+    style: string;
+    unicodeRange: string;
+    variant: string;
+    weight: string;
+    src?: string[];
+  }
+
+  interface FontSize {
+    totalTextLength: number;
+    failingTextLength: number;
+    analyzedFailingTextLength: number;
+    /** Elements that contain a text node that failed size criteria. */
+    analyzedFailingNodesData: Array<{
+      /* nodeId of the failing TextNode. */
+      nodeId: number;
+      fontSize: number;
+      textLength: number;
+      parentNode: {
+        backendNodeId: number;
+        attributes: string[];
+        nodeName: string;
+        parentNode?: {
+          backendNodeId: number;
+          attributes: string[];
+          nodeName: string;
+        };
+      };
+      cssRule?: {
+        type: 'Regular' | 'Inline' | 'Attributes';
+        range?: {startLine: number, startColumn: number};
+        parentRule?: {origin: LH.Crdp.CSS.StyleSheetOrigin, selectors: {text: string}[]};
+        styleSheetId?: string;
+        stylesheet?: LH.Crdp.CSS.CSSStyleSheetHeader;
+        cssProperties?: Array<LH.Crdp.CSS.CSSProperty>;
+      }
+    }>
+  }
+
+  // TODO(bckenny): real type for parsed manifest.
+  type Manifest = ReturnType<typeof parseManifest>;
+
+  interface InstallabilityErrors {
+    errors: LH.Crdp.Page.InstallabilityError[];
+  }
+
+  interface ImageElement {
+    /** The resolved source URL of the image. Similar to `currentSrc`, but resolved for CSS images as well. */
+    src: string;
+    /** The srcset attribute value. @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset */
+    srcset: string;
+    /** The displayed width of the image, uses img.width when available falling back to clientWidth. See https://codepen.io/patrickhulce/pen/PXvQbM for examples. */
+    displayedWidth: number;
+    /** The displayed height of the image, uses img.height when available falling back to clientHeight. See https://codepen.io/patrickhulce/pen/PXvQbM for examples. */
+    displayedHeight: number;
+    /** The raw width attribute of the image element. CSS images will be set to null. */
+    attributeWidth: string | null;
+    /** The raw height attribute of the image element. CSS images will be set to null. */
+    attributeHeight: string | null;
+    /**
+     * The natural width and height of the underlying image resource, uses img.naturalHeight/img.naturalWidth. See https://codepen.io/patrickhulce/pen/PXvQbM for examples.
+     * Set to `undefined` if the data could not be collected.
+     */
+    naturalDimensions?: {
+      width: number;
+      height: number;
+    };
+    /**
+     * The width/height of the element as defined by matching CSS rules.
+     * These are distinct from the `computedStyles` properties in that they are the raw property value.
+     * e.g. `width` would be `"100vw"`, not the computed width in pixels.
+     * Set to `undefined` if the data was not collected.
+     */
+    cssEffectiveRules?: {
+      /** The width of the image as expressed by CSS rules. Set to `null` if there was no width set in CSS. */
+      width: string | null;
+      /** The height of the image as expressed by CSS rules. Set to `null` if there was no height set in CSS. */
+      height: string | null;
+      /** The aspect ratio of the image as expressed by CSS rules. Set to `null` if there was no aspect ratio set in CSS. */
+      aspectRatio: string | null;
+    };
+    /** The computed styles as determined by `getComputedStyle`. */
+    computedStyles: {
+      /** CSS `position` property. */
+      position: string;
+      /** CSS `object-fit` property. */
+      objectFit: string;
+      /** CSS `image-rendering` propertry. */
+      imageRendering: string;
+    };
+    /** The BoundingClientRect of the element. */
+    clientRect: {
+      top: number;
+      bottom: number;
+      left: number;
+      right: number;
+    };
+    /** Flags whether this element was an image via CSS background-image rather than <img> tag. */
+    isCss: boolean;
+    /** Flags whether this element was contained within a <picture> tag. */
+    isPicture: boolean;
+    /** Flags whether this element was contained within a ShadowRoot */
+    isInShadowDOM: boolean;
+    /** The MIME type of the underlying image file. */
+    mimeType?: string;
+    /** Details for node in DOM for the image element */
+    node: NodeDetails;
+    /** The loading attribute of the image. */
+    loading?: string;
+  }
+
+  interface OptimizedImage {
+    failed: false;
+    originalSize: number;
+    jpegSize?: number;
+    webpSize?: number;
+
+    requestId: string;
+    url: string;
+    mimeType: string;
+    resourceSize: number;
+  }
+
+  interface OptimizedImageError {
+    failed: true;
+    errMsg: string;
+
+    requestId: string;
+    url: string;
+    mimeType: string;
+    resourceSize: number;
+  }
+
+  interface TagBlockingFirstPaint {
+    startTime: number;
+    endTime: number;
+    transferSize: number;
+    tag: {
+      tagName: 'LINK'|'SCRIPT';
+      /** The value of `HTMLLinkElement.href` or `HTMLScriptElement.src`. */
+      url: string;
+      /** A record of when changes to the `HTMLLinkElement.media` attribute occurred and if the new media type matched the page. */
+      mediaChanges?: Array<{href: string, media: string, msSinceHTMLEnd: number, matches: boolean}>;
+    };
+  }
+
+  interface Rect {
+    width: number;
+    height: number;
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  }
+
+  interface TapTarget {
+    node: NodeDetails;
+    href: string;
+    clientRects: Rect[];
+  }
+
+  interface TraceElement {
+    traceEventType: 'largest-contentful-paint'|'layout-shift'|'animation';
+    score?: number;
+    node: NodeDetails;
+    nodeId?: number;
+    animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[];
+  }
+
+  interface ViewportDimensions {
+    innerWidth: number;
+    innerHeight: number;
+    outerWidth: number;
+    outerHeight: number;
+    devicePixelRatio: number;
+  }
+
+  interface InspectorIssues {
+    mixedContent: LH.Crdp.Audits.MixedContentIssueDetails[];
+    sameSiteCookies: LH.Crdp.Audits.SameSiteCookieIssueDetails[];
+    blockedByResponse: LH.Crdp.Audits.BlockedByResponseIssueDetails[];
+    heavyAds: LH.Crdp.Audits.HeavyAdIssueDetails[];
+    contentSecurityPolicy: LH.Crdp.Audits.ContentSecurityPolicyIssueDetails[];
+  }
+
+  // Computed artifact types below.
+  type CriticalRequestNode = {
+    [id: string]: {
+      request: Artifacts.NetworkRequest;
+      children: CriticalRequestNode;
+    }
+  }
+
+  type ManifestValueCheckID = 'hasStartUrl'|'hasIconsAtLeast144px'|'hasIconsAtLeast512px'|'fetchesIcon'|'hasPWADisplayValue'|'hasBackgroundColor'|'hasThemeColor'|'hasShortName'|'hasName'|'shortNameLength'|'hasMaskableIcon';
+
+  type ManifestValues = {
+    isParseFailure: false;
+    allChecks: {
+      id: ManifestValueCheckID;
+      failureText: string;
+      passing: boolean;
+    }[];
+  } | {
+    isParseFailure: true;
+    parseFailureReason: string;
+    allChecks: {
+      id: ManifestValueCheckID;
+      failureText: string;
+      passing: boolean;
+    }[];
+  }
+
+  interface MeasureEntry {
+    // From PerformanceEntry
+    readonly duration: number;
+    readonly entryType: string;
+    readonly name: string;
+    readonly startTime: number;
+    /** Whether timing entry was collected during artifact gathering. */
+    gather?: boolean;
+  }
+
+  interface MetricComputationDataInput {
+    devtoolsLog: LH.DevtoolsLog;
+    trace: LH.Trace;
+    settings: Immutable<Config.Settings>;
+    gatherContext: Artifacts['GatherContext'];
+    simulator?: InstanceType<typeof LanternSimulator>;
+  }
+
+  interface MetricComputationData extends MetricComputationDataInput {
+    networkRecords: Array<Artifacts.NetworkRequest>;
+    processedTrace: ProcessedTrace;
+    processedNavigation?: ProcessedNavigation;
+  }
+
+  interface NavigationMetricComputationData extends MetricComputationData {
+    processedNavigation: ProcessedNavigation;
+  }
+
+  interface Metric {
+    timing: number;
+    timestamp?: number;
+  }
+
+  interface NetworkAnalysis {
+    rtt: number;
+    additionalRttByOrigin: Map<string, number>;
+    serverResponseTimeByOrigin: Map<string, number>;
+    throughput: number;
+  }
+
+  interface LanternMetric {
+    timing: number;
+    timestamp?: never;
+    optimisticEstimate: Gatherer.Simulation.Result
+    pessimisticEstimate: Gatherer.Simulation.Result;
+    optimisticGraph: Gatherer.Simulation.GraphNode;
+    pessimisticGraph: Gatherer.Simulation.GraphNode;
+  }
+
+  type Speedline = speedline.Output<'speedIndex'>;
+
+  interface TraceTimes {
+    timeOrigin: number;
+    traceEnd: number;
+  }
+
+  interface NavigationTraceTimes {
+    timeOrigin: number;
+    firstPaint?: number;
+    firstContentfulPaint: number;
+    firstContentfulPaintAllFrames: number;
+    firstMeaningfulPaint?: number;
+    largestContentfulPaint?: number;
+    largestContentfulPaintAllFrames?: number;
+    traceEnd: number;
+    load?: number;
+    domContentLoaded?: number;
+  }
+
+  interface ProcessedTrace {
+    /** The raw timestamps of key events, in microseconds. */
+    timestamps: TraceTimes;
+    /** The relative times from timeOrigin to key events, in milliseconds. */
+    timings: TraceTimes;
+    /** The subset of trace events from the page's process, sorted by timestamp. */
+    processEvents: Array<LH.TraceEvent>;
+    /** The subset of trace events from the page's main thread, sorted by timestamp. */
+    mainThreadEvents: Array<LH.TraceEvent>;
+    /** The subset of trace events from the main frame, sorted by timestamp. */
+    frameEvents: Array<LH.TraceEvent>;
+    /** The subset of trace events from the main frame and any child frames, sorted by timestamp. */
+    frameTreeEvents: Array<LH.TraceEvent>;
+    /** IDs for the trace's main frame, process, and thread. */
+    mainFrameIds: {pid: number, tid: number, frameId: string};
+    /** The list of frames committed in the trace. */
+    frames: Array<{id: string, url: string}>;
+    /** The trace event marking the time at which the run should consider to have begun. Typically the same as the navigationStart but might differ due to SPA navigations, client-side redirects, etc. In the FR timespan case, this event is injected by Lighthouse itself. */
+    timeOriginEvt: LH.TraceEvent;
+  }
+
+  interface ProcessedNavigation {
+    /** The raw timestamps of key metric events, in microseconds. */
+    timestamps: NavigationTraceTimes;
+    /** The relative times from navigationStart to key metric events, in milliseconds. */
+    timings: NavigationTraceTimes;
+    /** The trace event marking firstPaint, if it was found. */
+    firstPaintEvt?: LH.TraceEvent;
+    /** The trace event marking firstContentfulPaint, if it was found. */
+    firstContentfulPaintEvt: LH.TraceEvent;
+    /** The trace event marking firstContentfulPaint from all frames, if it was found. */
+    firstContentfulPaintAllFramesEvt: LH.TraceEvent;
+    /** The trace event marking firstMeaningfulPaint, if it was found. */
+    firstMeaningfulPaintEvt?: LH.TraceEvent;
+    /** The trace event marking largestContentfulPaint, if it was found. */
+    largestContentfulPaintEvt?: LH.TraceEvent;
+    /** The trace event marking largestContentfulPaint from all frames, if it was found. */
+    largestContentfulPaintAllFramesEvt?: LH.TraceEvent;
+    /** The trace event marking loadEventEnd, if it was found. */
+    loadEvt?: LH.TraceEvent;
+    /** The trace event marking domContentLoadedEventEnd, if it was found. */
+    domContentLoadedEvt?: LH.TraceEvent;
+    /**
+     * Whether the firstMeaningfulPaintEvt was the definitive event or a fallback to
+     * firstMeaningfulPaintCandidate events had to be attempted.
+     */
+    fmpFellBack: boolean;
+    /** Whether LCP was invalidated without a new candidate. */
+    lcpInvalidated: boolean;
+  }
+
+  /** Information on a tech stack (e.g. a JS library) used by the page. */
+  interface DetectedStack {
+    /** The identifier for how this stack was detected. */
+    detector: 'js';
+    /** The unique string ID for the stack. */
+    id: string;
+    /** The name of the stack. */
+    name: string;
+    /** The version of the stack, if it could be detected. */
+    version?: string;
+    /** The package name on NPM, if it exists. */
+    npm?: string;
+  }
+
+  interface FullPageScreenshot {
+    screenshot: {
+      /** Base64 image data URL. */
+      data: string;
+      width: number;
+      height: number;
+    };
+    nodes: Record<string, Rect>;
+  }
+
+  interface TimingSummary {
+    firstContentfulPaint: number | undefined;
+    firstContentfulPaintTs: number | undefined;
+    firstContentfulPaintAllFrames: number | undefined;
+    firstContentfulPaintAllFramesTs: number | undefined;
+    firstMeaningfulPaint: number | undefined;
+    firstMeaningfulPaintTs: number | undefined;
+    largestContentfulPaint: number | undefined;
+    largestContentfulPaintTs: number | undefined;
+    largestContentfulPaintAllFrames: number | undefined;
+    largestContentfulPaintAllFramesTs: number | undefined;
+    interactive: number | undefined;
+    interactiveTs: number | undefined;
+    speedIndex: number | undefined;
+    speedIndexTs: number | undefined;
+    maxPotentialFID: number | undefined;
+    cumulativeLayoutShift: number | undefined;
+    cumulativeLayoutShiftMainFrame: number | undefined;
+    totalCumulativeLayoutShift: number | undefined;
+    totalBlockingTime: number | undefined;
+    observedTimeOrigin: number;
+    observedTimeOriginTs: number;
+    observedNavigationStart: number | undefined;
+    observedNavigationStartTs: number | undefined;
+    observedCumulativeLayoutShift: number | undefined;
+    observedCumulativeLayoutShiftMainFrame: number | undefined;
+    observedTotalCumulativeLayoutShift: number | undefined;
+    observedFirstPaint: number | undefined;
+    observedFirstPaintTs: number | undefined;
+    observedFirstContentfulPaint: number | undefined;
+    observedFirstContentfulPaintTs: number | undefined;
+    observedFirstContentfulPaintAllFrames: number | undefined;
+    observedFirstContentfulPaintAllFramesTs: number | undefined;
+    observedFirstMeaningfulPaint: number | undefined;
+    observedFirstMeaningfulPaintTs: number | undefined;
+    observedLargestContentfulPaint: number | undefined;
+    observedLargestContentfulPaintTs: number | undefined;
+    observedLargestContentfulPaintAllFrames: number | undefined;
+    observedLargestContentfulPaintAllFramesTs: number | undefined;
+    observedTraceEnd: number | undefined;
+    observedTraceEndTs: number | undefined;
+    observedLoad: number | undefined;
+    observedLoadTs: number | undefined;
+    observedDomContentLoaded: number | undefined;
+    observedDomContentLoadedTs: number | undefined;
+    observedFirstVisualChange: number;
+    observedFirstVisualChangeTs: number;
+    observedLastVisualChange: number;
+    observedLastVisualChangeTs: number;
+    observedSpeedIndex: number;
+    observedSpeedIndexTs: number;
+  }
+
+  interface Form {
+    /** If attributes is missing that means this is a formless set of elements. */
+    attributes?: {
+      id: string;
+      name: string;
+      autocomplete: string;
+    };
+    node: NodeDetails | null;
+    inputs: Array<FormInput>;
+    labels: Array<FormLabel>;
+  }
+
+  /** Attributes collected for every input element in the inputs array from the forms interface. */
+  interface FormInput {
+    id: string;
+    name: string;
+    placeholder?: string;
+    autocomplete: {
+      property: string;
+      attribute: string | null;
+      prediction: string | null;
+    }
+    node: NodeDetails;
+  }
+
+  /** Attributes collected for every label element in the labels array from the forms interface */
+  interface FormLabel {
+    for: string;
+    node: NodeDetails;
+  }
+
+  /** Information about an event listener registered on the global object. */
+  interface GlobalListener {
+    /** Event listener type, limited to those events currently of interest. */
+    type: 'pagehide'|'unload'|'visibilitychange';
+    /** The DevTools protocol script identifier. */
+    scriptId: string;
+    /** Line number in the script (0-based). */
+    lineNumber: number;
+    /** Column number in the script (0-based). */
+    columnNumber: number;
+  }
+
+  /** Describes a generic console message. */
+  interface BaseConsoleMessage {
+    /**
+     * The text printed to the console, as shown on the browser console.
+     *
+     * For console API calls, all values are formatted into the text. Primitive values and
+     * function will be printed as-is while objects will be formatted as if the object were
+     * passed to String(). For example, a div will be formatted as "[object HTMLDivElement]".
+     *
+     * For exceptions the text will be the same as err.message at runtime.
+     */
+    text: string;
+    /** Time of the console log in milliseconds since epoch. */
+    timestamp: number;
+    /** The stack trace of the log/exception, if known. */
+    stackTrace?: LH.Crdp.Runtime.StackTrace;
+    /** The URL of the log/exception, if known. */
+    url?: string;
+    /** Line number in the script (0-indexed), if known. */
+    lineNumber?: number;
+    /** Column number in the script (0-indexed), if known. */
+    columnNumber?: number;
+  }
+
+  /** Describes a console message logged by a script using the console API. */
+  interface ConsoleAPICall extends BaseConsoleMessage {
+    eventType: 'consoleAPI';
+    /** The console API invoked. Only the following console API calls are gathered. */
+    source: 'console.warn' | 'console.error';
+    /** Corresponds to the API call. */
+    level: 'warning' | 'error';
+  }
+
+  interface ConsoleException extends BaseConsoleMessage {
+    eventType: 'exception';
+    source: 'exception';
+    level: 'error';
+  }
+
+  /**
+   * Describes a report logged to the console by the browser regarding interventions,
+   * deprecations, violations, and more.
+   */
+  interface ConsoleProtocolLog extends BaseConsoleMessage {
+    source: LH.Crdp.Log.LogEntry['source'],
+    level: LH.Crdp.Log.LogEntry['level'],
+    eventType: 'protocolLog';
+  }
+
+  type ConsoleMessage = ConsoleAPICall | ConsoleException | ConsoleProtocolLog;
+}

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -13,6 +13,7 @@ import _ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equalit
 
 type _TaskNode = import('../lighthouse-core/lib/tracehouse/main-thread-tasks.js').TaskNode;
 
+import Gatherer from './gatherer';
 import {IcuMessage} from './i18n';
 
 type LanternSimulator = InstanceType<typeof _LanternSimulator>;
@@ -143,7 +144,7 @@ declare global {
       /** Screenshot of the entire page (rather than just the above the fold content). */
       FullPageScreenshot: Artifacts.FullPageScreenshot | null;
       /** Information about how Lighthouse artifacts were gathered. */
-      GatherContext: {gatherMode: LH.Gatherer.GatherMode};
+      GatherContext: {gatherMode: Gatherer.GatherMode};
       /** Information about event listeners registered on the global object. */
       GlobalListeners: Array<Artifacts.GlobalListener>;
       /** Whether the page ended up on an HTTPS page after attempting to load the HTTP version. */

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -13,6 +13,7 @@ import _ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equalit
 
 type _TaskNode = import('../lighthouse-core/lib/tracehouse/main-thread-tasks.js').TaskNode;
 
+import Config from './config';
 import Gatherer from './gatherer';
 import {IcuMessage} from './i18n';
 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -13,6 +13,8 @@ import _ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equalit
 
 type _TaskNode = import('../lighthouse-core/lib/tracehouse/main-thread-tasks.js').TaskNode;
 
+import {IcuMessage} from './i18n';
+
 type LanternSimulator = InstanceType<typeof _LanternSimulator>;
 
 declare global {

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -5,6 +5,7 @@
  */
 
 import {IcuMessage} from './i18n';
+import Treemap from './treemap';
 
 type Details =
   Details.CriticalRequestChain |
@@ -113,7 +114,7 @@ declare module Details {
 
   interface TreemapData {
     type: 'treemap-data';
-    nodes: LH.Treemap.Node[];
+    nodes: Treemap.Node[];
   }
 
   /** String enum of possible types of values found within table items. */

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -6,6 +6,7 @@
 
 import {IcuMessage} from './i18n';
 import Treemap from './treemap';
+import {Artifacts} from './artifacts';
 
 type Details =
   Details.CriticalRequestChain |
@@ -82,7 +83,7 @@ declare module Details {
    * and the locations of interesting nodes.
    * Used by element screenshots renderer.
    */
-  interface FullPageScreenshot extends LH.Artifacts.FullPageScreenshot {
+  interface FullPageScreenshot extends Artifacts.FullPageScreenshot {
     type: 'full-page-screenshot';
   }
 
@@ -225,7 +226,7 @@ declare module Details {
     lhId?: string;
     path?: string;
     selector?: string;
-    boundingRect?: LH.Artifacts.Rect;
+    boundingRect?: Artifacts.Rect;
     /** An HTML snippet used to identify the node. */
     snippet?: string;
     /** A human-friendly text descriptor that's used to identify the node more quickly. */

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -4,6 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {IcuMessage} from './i18n';
+
 type Details =
   Details.CriticalRequestChain |
   Details.DebugData |
@@ -118,7 +120,7 @@ declare module Details {
   type ItemValueType = 'bytes' | 'code' | 'link' | 'ms' | 'multi' | 'node' | 'source-location' | 'numeric' | 'text' | 'thumbnail' | 'timespanMs' | 'url';
 
   /** Possible types of values found within table items. */
-  type ItemValue = string | number | boolean | DebugData | NodeValue | SourceLocationValue | LinkValue | UrlValue | CodeValue | NumericValue | LH.IcuMessage | TableSubItems;
+  type ItemValue = string | number | boolean | DebugData | NodeValue | SourceLocationValue | LinkValue | UrlValue | CodeValue | NumericValue | IcuMessage | TableSubItems;
 
   // TODO: drop TableColumnHeading, rename OpportunityColumnHeading to TableColumnHeading and
   // use that for all table-like audit details.
@@ -132,7 +134,7 @@ declare module Details {
      */
     key: string|null;
     /** Readable text label of the field. */
-    text: LH.IcuMessage | string;
+    text: IcuMessage | string;
     /**
      * The data format of the column of values being described. Usually
      * those values will be primitives rendered as this type, but the values
@@ -164,7 +166,7 @@ declare module Details {
       */
     key: string|null;
     /** Readable text label of the field. */
-    label: LH.IcuMessage | string;
+    label: IcuMessage | string;
     /**
      * The data format of the column of values being described. Usually
      * those values will be primitives rendered as this type, but the values
@@ -198,7 +200,7 @@ declare module Details {
    */
   interface CodeValue {
     type: 'code';
-    value: LH.IcuMessage | string;
+    value: IcuMessage | string;
   }
 
   /**

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -5,6 +5,7 @@
  */
 
 import AuditDetails from './audit-details';
+import Config from './config';
 import Gatherer from './gatherer';
 import {FormattedIcu, IcuMessage} from './i18n';
 
@@ -14,7 +15,7 @@ declare module Audit {
   type Context = Immutable<{
     /** audit options */
     options: Record<string, any>;
-    settings: LH.Config.Settings;
+    settings: Config.Settings;
     /**
      * Nested cache for already-computed computed artifacts. Keyed first on
      * the computed artifact's `name` property, then on input artifact(s).

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -5,6 +5,7 @@
  */
 
 import AuditDetails from './audit-details';
+import {FormattedIcu, IcuMessage} from './i18n';
 
 declare module Audit {
   export import Details = AuditDetails;
@@ -47,11 +48,11 @@ declare module Audit {
     /** The string identifier of the audit, in kebab case. */
     id: string;
     /** Short, user-visible title for the audit when successful. */
-    title: string | LH.IcuMessage;
+    title: string | IcuMessage;
     /** Short, user-visible title for the audit when failing. */
-    failureTitle?: string | LH.IcuMessage;
+    failureTitle?: string | IcuMessage;
     /** A more detailed description that describes why the audit is important and links to Lighthouse documentation on the audit; markdown links supported. */
-    description: string | LH.IcuMessage;
+    description: string | IcuMessage;
     /** A list of the members of LH.Artifacts that must be present for the audit to execute. */
     requiredArtifacts: Array<keyof LH.Artifacts>;
     /** A list of the members of LH.Artifacts that augment the audit, but aren't necessary. For internal use only with experimental-config. */
@@ -76,18 +77,18 @@ declare module Audit {
     /** The scored value of the audit, provided in the range `0-1`, or null if `scoreDisplayMode` indicates not scored. */
     score: number | null;
     /** The i18n'd string value that the audit wishes to display for its results. This value is not necessarily the string version of the `numericValue`. */
-    displayValue?: string | LH.IcuMessage;
+    displayValue?: string | IcuMessage;
     /** An explanation of why the audit failed on the test page. */
-    explanation?: string | LH.IcuMessage;
+    explanation?: string | IcuMessage;
     /** Error message from any exception thrown while running this audit. */
-    errorMessage?: string | LH.IcuMessage;
-    warnings?: Array<string | LH.IcuMessage>;
+    errorMessage?: string | IcuMessage;
+    warnings?: Array<string | IcuMessage>;
     /** Overrides scoreDisplayMode with notApplicable if set to true */
     notApplicable?: boolean;
     /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
     details?: AuditDetails;
     /** If an audit encounters unusual execution circumstances, strings can be put in this optional array to add top-level warnings to the LHR. */
-    runWarnings?: Array<LH.IcuMessage>;
+    runWarnings?: Array<IcuMessage>;
   }
 
   /** The Audit.Product type for audits that do not return a `numericValue`. */
@@ -137,7 +138,7 @@ declare module Audit {
     /** The unit of `numericValue`, used when the consumer wishes to convert numericValue to a display string. */
     numericUnit?: string;
     /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
-    details?: LH.FormattedIcu<AuditDetails>;
+    details?: FormattedIcu<AuditDetails>;
   }
 
   interface Results {

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -4,6 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality-map.js');
+import {Artifacts} from './artifacts';
 import AuditDetails from './audit-details';
 import Config from './config';
 import Gatherer from './gatherer';
@@ -21,7 +23,7 @@ declare module Audit {
      * the computed artifact's `name` property, then on input artifact(s).
      * Values are Promises resolving to the computedArtifact result.
      */
-    computedCache: Map<string, LH.ArbitraryEqualityMap>;
+    computedCache: Map<string, ArbitraryEqualityMap>;
   }>;
 
   interface ScoreOptions {
@@ -56,9 +58,9 @@ declare module Audit {
     /** A more detailed description that describes why the audit is important and links to Lighthouse documentation on the audit; markdown links supported. */
     description: string | IcuMessage;
     /** A list of the members of LH.Artifacts that must be present for the audit to execute. */
-    requiredArtifacts: Array<keyof LH.Artifacts>;
+    requiredArtifacts: Array<keyof Artifacts>;
     /** A list of the members of LH.Artifacts that augment the audit, but aren't necessary. For internal use only with experimental-config. */
-    __internalOptionalArtifacts?: Array<keyof LH.Artifacts>;
+    __internalOptionalArtifacts?: Array<keyof Artifacts>;
     /** A string identifying how the score should be interpreted for display. */
     scoreDisplayMode?: Audit.ScoreDisplayMode;
     /** A list of gather modes that this audit is applicable to. */
@@ -147,8 +149,8 @@ declare module Audit {
     [metric: string]: Result;
   }
 
-  type MultiCheckAuditP1 = Partial<Record<LH.Artifacts.ManifestValueCheckID, boolean>>;
-  type MultiCheckAuditP2 = Partial<LH.Artifacts.ManifestValues>;
+  type MultiCheckAuditP1 = Partial<Record<Artifacts.ManifestValueCheckID, boolean>>;
+  type MultiCheckAuditP2 = Partial<Artifacts.ManifestValues>;
   interface MultiCheckAuditP3 {
     failures: Array<string>;
     manifestValues?: undefined;

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -5,6 +5,7 @@
  */
 
 import AuditDetails from './audit-details';
+import Gatherer from './gatherer';
 import {FormattedIcu, IcuMessage} from './i18n';
 
 declare module Audit {
@@ -60,7 +61,7 @@ declare module Audit {
     /** A string identifying how the score should be interpreted for display. */
     scoreDisplayMode?: Audit.ScoreDisplayMode;
     /** A list of gather modes that this audit is applicable to. */
-    supportedModes?: LH.Gatherer.GatherMode[],
+    supportedModes?: Gatherer.GatherMode[],
   }
 
   interface ByteEfficiencyItem extends AuditDetails.OpportunityItem {

--- a/types/budget.d.ts
+++ b/types/budget.d.ts
@@ -4,62 +4,57 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-declare global {
-  module LH {
-    /**
-     * The performance budget interface.
-     * More info: https://github.com/GoogleChrome/budget.json
-     */
-    export interface Budget {
-      /** Budget options */
-      options?: Budget.Options;
-      /**
-       * Indicates which pages a budget applies to. Uses the robots.txt format.
-       * If it is not supplied, the budget applies to all pages.
-       * More info on robots.txt: https://developers.google.com/search/reference/robots_txt#url-matching-based-on-path-values
-       */
-      path?: string;
-      /** Budgets based on resource count. */
-      resourceCounts?: Array<Budget.ResourceBudget>;
-      /** Budgets based on resource size. */
-      resourceSizes?: Array<Budget.ResourceBudget>;
-      /** Budgets based on timing metrics. */
-      timings?: Array<Budget.TimingBudget>;
-    }
-
-    module Budget {
-      export interface ResourceBudget {
-        /** The resource type that a budget applies to. */
-        resourceType: ResourceType;
-        /** Budget for resource. Depending on context, this is either the count or size (KiB) of a resource. */
-        budget: number;
-      }
-
-      export interface TimingBudget {
-        /** The type of timing metric. */
-        metric: TimingMetric;
-        /** Budget for timing measurement, in milliseconds. */
-        budget: number;
-      }
-
-      export interface Options {
-        /**
-         * List of hostnames used to classify resources as 1st or 3rd party.
-         * Wildcards can optionally be used to match a hostname and all of its subdomains.
-         * For example e.g.: "*.news.gov.uk" matches both "news.gov.uk" and "en.news.gov.uk"
-         * If this property is not set, the root domain and all its subdomains are considered first party.
-         */
-        firstPartyHostnames?: Array<string>;
-      }
-
-      /** Supported timing metrics. */
-      export type TimingMetric = 'first-contentful-paint' | 'interactive' | 'first-meaningful-paint' | 'max-potential-fid' | 'total-blocking-time' | 'speed-index' | 'largest-contentful-paint' | 'cumulative-layout-shift';
-
-      /** Supported values for the resourceType property of a ResourceBudget. */
-      export type ResourceType = 'stylesheet' | 'image' | 'media' | 'font' | 'script' | 'document' | 'other' | 'total' | 'third-party';
-    }
-  }
+/**
+ * The performance budget interface.
+ * More info: https://github.com/GoogleChrome/budget.json
+ */
+interface Budget {
+  /** Budget options */
+  options?: Budget.Options;
+  /**
+   * Indicates which pages a budget applies to. Uses the robots.txt format.
+   * If it is not supplied, the budget applies to all pages.
+   * More info on robots.txt: https://developers.google.com/search/reference/robots_txt#url-matching-based-on-path-values
+   */
+  path?: string;
+  /** Budgets based on resource count. */
+  resourceCounts?: Array<Budget.ResourceBudget>;
+  /** Budgets based on resource size. */
+  resourceSizes?: Array<Budget.ResourceBudget>;
+  /** Budgets based on timing metrics. */
+  timings?: Array<Budget.TimingBudget>;
 }
 
-// empty export to keep file a module
-export {}
+declare module Budget {
+  interface ResourceBudget {
+    /** The resource type that a budget applies to. */
+    resourceType: ResourceType;
+    /** Budget for resource. Depending on context, this is either the count or size (KiB) of a resource. */
+    budget: number;
+  }
+
+  interface TimingBudget {
+    /** The type of timing metric. */
+    metric: TimingMetric;
+    /** Budget for timing measurement, in milliseconds. */
+    budget: number;
+  }
+
+  interface Options {
+    /**
+     * List of hostnames used to classify resources as 1st or 3rd party.
+     * Wildcards can optionally be used to match a hostname and all of its subdomains.
+     * For example e.g.: "*.news.gov.uk" matches both "news.gov.uk" and "en.news.gov.uk"
+     * If this property is not set, the root domain and all its subdomains are considered first party.
+     */
+    firstPartyHostnames?: Array<string>;
+  }
+
+  /** Supported timing metrics. */
+  type TimingMetric = 'first-contentful-paint' | 'interactive' | 'first-meaningful-paint' | 'max-potential-fid' | 'total-blocking-time' | 'speed-index' | 'largest-contentful-paint' | 'cumulative-layout-shift';
+
+  /** Supported values for the resourceType property of a ResourceBudget. */
+  type ResourceType = 'stylesheet' | 'image' | 'media' | 'font' | 'script' | 'document' | 'other' | 'total' | 'third-party';
+}
+
+export default Budget;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -6,6 +6,7 @@
  */
 
 import AuditClass = require('../lighthouse-core/audits/audit.js');
+import Gatherer from './gatherer';
 import {IcuMessage} from './i18n';
 
 interface ClassOf<T> {
@@ -62,7 +63,7 @@ declare global {
        * This information is typically set by the CLI or other channel integrations.
        */
       export interface FRContext {
-        gatherMode?: LH.Gatherer.GatherMode;
+        gatherMode?: Gatherer.GatherMode;
         configPath?: string;
         settingsOverrides?: LH.SharedFlagsSettings;
       }

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -6,6 +6,7 @@
  */
 
 import AuditClass = require('../lighthouse-core/audits/audit.js');
+import {IcuMessage} from './i18n';
 
 interface ClassOf<T> {
   new (): T;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -5,7 +5,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import AuditClass = require('../lighthouse-core/audits/audit.js');
+import Audit = require('../lighthouse-core/audits/audit.js');
 import Gatherer from './gatherer';
 import {IcuMessage} from './i18n';
 
@@ -13,233 +13,228 @@ interface ClassOf<T> {
   new (): T;
 }
 
-declare global {
-  module LH {
-    module Config {
-      /**
-       * The pre-normalization Lighthouse Config format.
-       */
-      export interface Json {
-        extends?: 'lighthouse:default' | string;
-        settings?: SharedFlagsSettings;
-        audits?: Config.AuditJson[] | null;
-        categories?: Record<string, CategoryJson> | null;
-        groups?: Record<string, Config.GroupJson> | null;
-        plugins?: Array<string>;
+declare module Config {
+  /**
+   * The pre-normalization Lighthouse Config format.
+   */
+  interface Json {
+    extends?: 'lighthouse:default' | string;
+    settings?: LH.SharedFlagsSettings;
+    audits?: Config.AuditJson[] | null;
+    categories?: Record<string, CategoryJson> | null;
+    groups?: Record<string, Config.GroupJson> | null;
+    plugins?: Array<string>;
 
-        // Fraggle Rock Only
-        artifacts?: ArtifactJson[] | null;
-        navigations?: NavigationJson[] | null;
+    // Fraggle Rock Only
+    artifacts?: ArtifactJson[] | null;
+    navigations?: NavigationJson[] | null;
 
-        // Legacy Only
-        passes?: PassJson[] | null;
-      }
+    // Legacy Only
+    passes?: PassJson[] | null;
+  }
 
-      /**
-       * The normalized and fully resolved config.
-       */
-      export interface Config {
-        settings: Settings;
-        passes: Pass[] | null;
-        audits: AuditDefn[] | null;
-        categories: Record<string, Category> | null;
-        groups: Record<string, Group> | null;
-      }
+  /**
+   * The normalized and fully resolved config.
+   */
+  interface Config {
+    settings: Settings;
+    passes: Pass[] | null;
+    audits: AuditDefn[] | null;
+    categories: Record<string, Category> | null;
+    groups: Record<string, Group> | null;
+  }
 
-      /**
-       * The normalized and fully resolved Fraggle Rock config.
-       */
-      export interface FRConfig {
-        settings: Settings;
-        artifacts: AnyArtifactDefn[] | null;
-        navigations: NavigationDefn[] | null;
-        audits: AuditDefn[] | null;
-        categories: Record<string, Category> | null;
-        groups: Record<string, Group> | null;
-      }
+  /**
+   * The normalized and fully resolved Fraggle Rock config.
+   */
+  interface FRConfig {
+    settings: Settings;
+    artifacts: AnyArtifactDefn[] | null;
+    navigations: NavigationDefn[] | null;
+    audits: AuditDefn[] | null;
+    categories: Record<string, Category> | null;
+    groups: Record<string, Group> | null;
+  }
 
-      /**
-       * Additional information about the context in which a Fraggle Rock config should be interpreted.
-       * This information is typically set by the CLI or other channel integrations.
-       */
-      export interface FRContext {
-        gatherMode?: Gatherer.GatherMode;
-        configPath?: string;
-        settingsOverrides?: LH.SharedFlagsSettings;
-      }
+  /**
+   * Additional information about the context in which a Fraggle Rock config should be interpreted.
+   * This information is typically set by the CLI or other channel integrations.
+   */
+  interface FRContext {
+    gatherMode?: Gatherer.GatherMode;
+    configPath?: string;
+    settingsOverrides?: LH.SharedFlagsSettings;
+  }
 
-      interface SharedPassNavigationJson {
-        /**
-         * Controls the behavior when the navigation fails to complete (due to server error, no FCP, etc).
-         * Fatal means Lighthouse will exit immediately and return a runtimeError / non-zero exit code.
-         * Warn means a toplevel warning will appear in the report, but the run will complete with success.
-         * Ignore means a failure is expected and no action should be taken.
-         */
-        loadFailureMode?: 'fatal'|'warn'|'ignore';
-        /** The number of milliseconds to wait after FCP until the page should be considered loaded. */
-        pauseAfterFcpMs?: number;
-        /** The number of milliseconds to wait after the load event until the page should be considered loaded. */
-        pauseAfterLoadMs?: number;
-        /** The number of milliseconds to wait between high priority network requests or 3 simulataneous requests before the page should be considered loaded. */
-        networkQuietThresholdMs?: number;
-        /** The number of milliseconds to wait between long tasks until the page should be considered loaded. */
-        cpuQuietThresholdMs?: number;
-        /** Substring patterns of network resources to block during this navigation, '*' wildcards supported though unnecessary as prefix or suffix (due to substring matching). */
-        blockedUrlPatterns?: string[];
-        /** The URL to use for the "blank" neutral page in between navigations. Defaults to `about:blank`. */
-        blankPage?: string;
-      }
+  interface SharedPassNavigationJson {
+    /**
+     * Controls the behavior when the navigation fails to complete (due to server error, no FCP, etc).
+     * Fatal means Lighthouse will exit immediately and return a runtimeError / non-zero exit code.
+     * Warn means a toplevel warning will appear in the report, but the run will complete with success.
+     * Ignore means a failure is expected and no action should be taken.
+     */
+    loadFailureMode?: 'fatal'|'warn'|'ignore';
+    /** The number of milliseconds to wait after FCP until the page should be considered loaded. */
+    pauseAfterFcpMs?: number;
+    /** The number of milliseconds to wait after the load event until the page should be considered loaded. */
+    pauseAfterLoadMs?: number;
+    /** The number of milliseconds to wait between high priority network requests or 3 simulataneous requests before the page should be considered loaded. */
+    networkQuietThresholdMs?: number;
+    /** The number of milliseconds to wait between long tasks until the page should be considered loaded. */
+    cpuQuietThresholdMs?: number;
+    /** Substring patterns of network resources to block during this navigation, '*' wildcards supported though unnecessary as prefix or suffix (due to substring matching). */
+    blockedUrlPatterns?: string[];
+    /** The URL to use for the "blank" neutral page in between navigations. Defaults to `about:blank`. */
+    blankPage?: string;
+  }
 
-      export interface PassJson extends SharedPassNavigationJson {
-        /** The identifier for the pass. Config extension will deduplicate passes with the same passName. */
-        passName: string;
-        /** Whether a trace and devtoolsLog should be recorded for the pass. */
-        recordTrace?: boolean;
-        /** Whether throttling settings should be used for the pass. */
-        useThrottling?: boolean;
-        /** The array of gatherers to run during the pass. */
-        gatherers?: GathererJson[];
-      }
+  interface PassJson extends SharedPassNavigationJson {
+    /** The identifier for the pass. Config extension will deduplicate passes with the same passName. */
+    passName: string;
+    /** Whether a trace and devtoolsLog should be recorded for the pass. */
+    recordTrace?: boolean;
+    /** Whether throttling settings should be used for the pass. */
+    useThrottling?: boolean;
+    /** The array of gatherers to run during the pass. */
+    gatherers?: GathererJson[];
+  }
 
-      export interface NavigationJson extends SharedPassNavigationJson {
-        /** The identifier for the navigation. Config extension will deduplicate navigations with the same id. */
-        id: string;
-        /** Whether throttling settings should be skipped for the pass. */
-        disableThrottling?: boolean;
-        /** Whether storage clearing (service workers, cache storage) should be skipped for the pass. A run-wide setting of `true` takes precedence over this value. */
-        disableStorageReset?: boolean;
-        /** The array of artifacts to collect during the navigation. */
-        artifacts?: Array<string>;
-      }
+  interface NavigationJson extends SharedPassNavigationJson {
+    /** The identifier for the navigation. Config extension will deduplicate navigations with the same id. */
+    id: string;
+    /** Whether throttling settings should be skipped for the pass. */
+    disableThrottling?: boolean;
+    /** Whether storage clearing (service workers, cache storage) should be skipped for the pass. A run-wide setting of `true` takes precedence over this value. */
+    disableStorageReset?: boolean;
+    /** The array of artifacts to collect during the navigation. */
+    artifacts?: Array<string>;
+  }
 
-      export interface ArtifactJson {
-        id: string;
-        gatherer: FRGathererJson;
-      }
+  interface ArtifactJson {
+    id: string;
+    gatherer: FRGathererJson;
+  }
 
-      export type GathererJson = {
-        path: string;
-        options?: {};
-      } | {
-        implementation: ClassOf<Gatherer.GathererInstance>;
-        options?: {};
-      } | {
-        instance: Gatherer.GathererInstance;
-        options?: {};
-      } | Gatherer.GathererInstance | ClassOf<Gatherer.GathererInstance> | string;
+  type GathererJson = {
+    path: string;
+    options?: {};
+  } | {
+    implementation: ClassOf<Gatherer.GathererInstance>;
+    options?: {};
+  } | {
+    instance: Gatherer.GathererInstance;
+    options?: {};
+  } | Gatherer.GathererInstance | ClassOf<Gatherer.GathererInstance> | string;
 
-      export type FRGathererJson = string | {instance: Gatherer.FRGathererInstance}
+  type FRGathererJson = string | {instance: Gatherer.FRGathererInstance}
 
-      export interface CategoryJson {
-        title: string | IcuMessage;
-        auditRefs: AuditRefJson[];
-        description?: string | IcuMessage;
-        manualDescription?: string | IcuMessage;
-      }
+  interface CategoryJson {
+    title: string | IcuMessage;
+    auditRefs: AuditRefJson[];
+    description?: string | IcuMessage;
+    manualDescription?: string | IcuMessage;
+  }
 
-      export interface GroupJson {
-        title: string | IcuMessage;
-        description?: string | IcuMessage;
-      }
+  interface GroupJson {
+    title: string | IcuMessage;
+    description?: string | IcuMessage;
+  }
 
-      export type AuditJson = {
-        path: string,
-        options?: {};
-      } | {
-        implementation: typeof AuditClass;
-        options?: {};
-      } | typeof AuditClass | string;
+  type AuditJson = {
+    path: string,
+    options?: {};
+  } | {
+    implementation: typeof Audit;
+    options?: {};
+  } | typeof Audit | string;
 
-      /**
-       * Reference to an audit member of a category and how its score should be
-       * weighted and how its results grouped with other members.
-       */
-      export interface AuditRefJson {
-        id: string;
-        weight: number;
-        group?: string;
-        acronym?: string;
-        relevantAudits?: string[];
-      }
+  /**
+   * Reference to an audit member of a category and how its score should be
+   * weighted and how its results grouped with other members.
+   */
+  interface AuditRefJson {
+    id: string;
+    weight: number;
+    group?: string;
+    acronym?: string;
+    relevantAudits?: string[];
+  }
 
-      export interface Settings extends Required<SharedFlagsSettings> {
-        throttling: Required<ThrottlingSettings>;
-        screenEmulation: ScreenEmulationSettings;
-      }
+  interface Settings extends Required<LH.SharedFlagsSettings> {
+    throttling: Required<LH.ThrottlingSettings>;
+    screenEmulation: LH.ScreenEmulationSettings;
+  }
 
-      export interface Pass extends Required<PassJson> {
-        gatherers: GathererDefn[];
-      }
+  interface Pass extends Required<PassJson> {
+    gatherers: GathererDefn[];
+  }
 
-      export interface NavigationDefn extends Omit<Required<NavigationJson>, 'artifacts'> {
-        artifacts: AnyArtifactDefn[];
-      }
+  interface NavigationDefn extends Omit<Required<NavigationJson>, 'artifacts'> {
+    artifacts: AnyArtifactDefn[];
+  }
 
-      export interface ArtifactDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
-        id: string;
-        gatherer: FRGathererDefn<TDependencies>;
-        dependencies?: TDependencies extends Gatherer.DefaultDependenciesKey ?
-          undefined :
-          Record<Exclude<TDependencies, Gatherer.DefaultDependenciesKey>, {id: string}>;
-      }
+  interface ArtifactDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
+    id: string;
+    gatherer: FRGathererDefn<TDependencies>;
+    dependencies?: TDependencies extends Gatherer.DefaultDependenciesKey ?
+      undefined :
+      Record<Exclude<TDependencies, Gatherer.DefaultDependenciesKey>, {id: string}>;
+  }
 
-      type ArtifactDefnExpander<TDependencies extends Gatherer.DependencyKey> =
-        // Lack of brackets intentional here to convert to the union of all individual dependencies.
-        TDependencies extends Gatherer.DefaultDependenciesKey ?
-          ArtifactDefn<Gatherer.DefaultDependenciesKey> :
-          ArtifactDefn<TDependencies>
-      export type AnyArtifactDefn = ArtifactDefnExpander<Gatherer.DefaultDependenciesKey>|ArtifactDefnExpander<Gatherer.DependencyKey>
+  type ArtifactDefnExpander<TDependencies extends Gatherer.DependencyKey> =
+    // Lack of brackets intentional here to convert to the union of all individual dependencies.
+    TDependencies extends Gatherer.DefaultDependenciesKey ?
+      ArtifactDefn<Gatherer.DefaultDependenciesKey> :
+      ArtifactDefn<TDependencies>
+  type AnyArtifactDefn = ArtifactDefnExpander<Gatherer.DefaultDependenciesKey>|ArtifactDefnExpander<Gatherer.DependencyKey>
 
-      export interface FRGathererDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
-        implementation?: ClassOf<Gatherer.FRGathererInstance<TDependencies>>;
-        instance: Gatherer.FRGathererInstance<TDependencies>;
-        path?: string;
-      }
+  interface FRGathererDefn<TDependencies extends Gatherer.DependencyKey = Gatherer.DependencyKey> {
+    implementation?: ClassOf<Gatherer.FRGathererInstance<TDependencies>>;
+    instance: Gatherer.FRGathererInstance<TDependencies>;
+    path?: string;
+  }
 
-      type FRGathererDefnExpander<TDependencies extends Gatherer.DependencyKey> =
-        // Lack of brackets intentional here to convert to the union of all individual dependencies.
-        TDependencies extends Gatherer.DefaultDependenciesKey ?
-          FRGathererDefn<Gatherer.DefaultDependenciesKey> :
-          FRGathererDefn<TDependencies>
-      export type AnyFRGathererDefn = FRGathererDefnExpander<Gatherer.DefaultDependenciesKey>|FRGathererDefnExpander<Gatherer.DependencyKey>
+  type FRGathererDefnExpander<TDependencies extends Gatherer.DependencyKey> =
+    // Lack of brackets intentional here to convert to the union of all individual dependencies.
+    TDependencies extends Gatherer.DefaultDependenciesKey ?
+      FRGathererDefn<Gatherer.DefaultDependenciesKey> :
+      FRGathererDefn<TDependencies>
+  type AnyFRGathererDefn = FRGathererDefnExpander<Gatherer.DefaultDependenciesKey>|FRGathererDefnExpander<Gatherer.DependencyKey>
 
-      export interface GathererDefn {
-        implementation?: ClassOf<Gatherer.GathererInstance>;
-        instance: Gatherer.GathererInstance;
-        path?: string;
-      }
+  interface GathererDefn {
+    implementation?: ClassOf<Gatherer.GathererInstance>;
+    instance: Gatherer.GathererInstance;
+    path?: string;
+  }
 
-      export interface AuditDefn {
-        implementation: typeof AuditClass;
-        path?: string;
-        options: {};
-      }
+  interface AuditDefn {
+    implementation: typeof Audit;
+    path?: string;
+    options: {};
+  }
 
-      // TODO: For now, these are unchanged from JSON and Result versions. Need to harmonize.
-      export interface AuditRef extends AuditRefJson {}
-      export interface Category extends CategoryJson {
-        auditRefs: AuditRef[];
-      }
-      export interface Group extends GroupJson {}
+  // TODO: For now, these are unchanged from JSON and Result versions. Need to harmonize.
+  interface AuditRef extends AuditRefJson {}
+  interface Category extends CategoryJson {
+    auditRefs: AuditRef[];
+  }
+  interface Group extends GroupJson {}
 
-      export interface Plugin {
-        /** Optionally provide more audits to run in addition to those specified by the base config. */
-        audits?: Array<{path: string}>;
-        /** Provide a category to display the plugin results in the report. */
-        category: LH.Config.Category;
-        /** Optionally provide more groups in addition to those specified by the base config. */
-        groups?: Record<string, LH.Config.GroupJson>;
-      }
+  interface Plugin {
+    /** Optionally provide more audits to run in addition to those specified by the base config. */
+    audits?: Array<{path: string}>;
+    /** Provide a category to display the plugin results in the report. */
+    category: Config.Category;
+    /** Optionally provide more groups in addition to those specified by the base config. */
+    groups?: Record<string, Config.GroupJson>;
+  }
 
-      export type MergeOptionsOfItems = <T extends {path?: string, options: Record<string, any>}>(items: T[]) => T[];
+  type MergeOptionsOfItems = <T extends {path?: string, options: Record<string, any>}>(items: T[]) => T[];
 
-      export type Merge = {
-        <T extends Record<string, any>, U extends Record<string, any>>(base: T|null|undefined, extension: U, overwriteArrays?: boolean): T & U;
-        <T extends Array<any>, U extends Array<any>>(base: T|null|undefined, extension: T, overwriteArrays?: boolean): T & U;
-      }
-    }
+  type Merge = {
+    <T extends Record<string, any>, U extends Record<string, any>>(base: T|null|undefined, extension: U, overwriteArrays?: boolean): T & U;
+    <T extends Array<any>, U extends Array<any>>(base: T|null|undefined, extension: T, overwriteArrays?: boolean): T & U;
   }
 }
 
-// empty export to keep file a module
-export {};
+export default Config;

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -8,6 +8,8 @@ import _Crdp from 'devtools-protocol/types/protocol';
 import _CrdpMappings from 'devtools-protocol/types/protocol-mapping';
 import {ParseSelectorToTagNames} from 'typed-query-selector/parser';
 
+import Budget from './budget';
+
 /** Merge properties of the types in union `T`. Where properties overlap, property types becomes the union of the two (or more) possible types. */
 type MergeTypes<T> = {
   [K in (T extends unknown ? keyof T : never)]: T extends Record<K, infer U> ? U : never;

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -9,6 +9,7 @@ import _CrdpMappings from 'devtools-protocol/types/protocol-mapping';
 import {ParseSelectorToTagNames} from 'typed-query-selector/parser';
 
 import Budget from './budget';
+import Protocol from './protocol';
 
 /** Merge properties of the types in union `T`. Where properties overlap, property types becomes the union of the two (or more) possible types. */
 type MergeTypes<T> = {

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -9,6 +9,7 @@ import _CrdpMappings from 'devtools-protocol/types/protocol-mapping';
 import {ParseSelectorToTagNames} from 'typed-query-selector/parser';
 
 import Budget from './budget';
+import LHResult from './lhr';
 import Protocol from './protocol';
 
 /** Merge properties of the types in union `T`. Where properties overlap, property types becomes the union of the two (or more) possible types. */
@@ -276,7 +277,7 @@ declare global {
     }
 
     export interface RunnerResult {
-      lhr: Result;
+      lhr: LHResult;
       report: string|string[];
       artifacts: Artifacts;
     }

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -8,6 +8,7 @@ import _Crdp from 'devtools-protocol/types/protocol';
 import _CrdpMappings from 'devtools-protocol/types/protocol-mapping';
 import {ParseSelectorToTagNames} from 'typed-query-selector/parser';
 
+import {Artifacts} from './artifacts';
 import Budget from './budget';
 import LHResult from './lhr';
 import Protocol from './protocol';

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -12,6 +12,7 @@ import ExecutionContext = require('../lighthouse-core/gather/driver/execution-co
 import Fetcher = require('../lighthouse-core/gather/fetcher');
 import ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality-map');
 
+import Config from './config';
 import {IcuMessage} from './i18n';
 import Protocol from './protocol';
 
@@ -49,7 +50,7 @@ declare module Gatherer {
     /** The set of available dependencies requested by the current gatherer. */
     dependencies: Pick<LH.GathererArtifacts, Exclude<TDependencies, DefaultDependenciesKey>>;
     /** The settings used for gathering. */
-    settings: LH.Config.Settings;
+    settings: Config.Settings;
   }
 
   interface PassContext {
@@ -57,8 +58,8 @@ declare module Gatherer {
     /** The url of the currently loaded page. If the main document redirects, this will be updated to keep track. */
     url: string;
     driver: Driver;
-    passConfig: LH.Config.Pass
-    settings: LH.Config.Settings;
+    passConfig: Config.Pass
+    settings: Config.Settings;
     computedCache: Map<string, ArbitraryEqualityMap>
     /** Gatherers can push to this array to add top-level warnings to the LHR. */
     LighthouseRunWarnings: Array<string | IcuMessage>;

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -15,155 +15,152 @@ import ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality
 import {IcuMessage} from './i18n';
 import Protocol from './protocol';
 
-declare global {
-  module LH.Gatherer {
-    /** The Lighthouse wrapper around a raw CDP session. */
-    export interface FRProtocolSession {
-      hasNextProtocolTimeout(): boolean;
-      getNextProtocolTimeout(): number;
-      setNextProtocolTimeout(ms: number): void;
-      on<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
-      once<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
-      addProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
-      removeProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
-      off<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
-      sendCommand<TMethod extends keyof LH.CrdpCommands>(method: TMethod, ...params: LH.CrdpCommands[TMethod]['paramsType']): Promise<LH.CrdpCommands[TMethod]['returnType']>;
+declare module Gatherer {
+  /** The Lighthouse wrapper around a raw CDP session. */
+  interface FRProtocolSession {
+    hasNextProtocolTimeout(): boolean;
+    getNextProtocolTimeout(): number;
+    setNextProtocolTimeout(ms: number): void;
+    on<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
+    once<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
+    addProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
+    removeProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
+    off<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
+    sendCommand<TMethod extends keyof LH.CrdpCommands>(method: TMethod, ...params: LH.CrdpCommands[TMethod]['paramsType']): Promise<LH.CrdpCommands[TMethod]['returnType']>;
+  }
+
+  /** The limited driver interface shared between pre and post Fraggle Rock Lighthouse. */
+  interface FRTransitionalDriver {
+    defaultSession: FRProtocolSession;
+    executionContext: ExecutionContext;
+    fetcher: Fetcher;
+  }
+
+  /** The limited context interface shared between pre and post Fraggle Rock Lighthouse. */
+  interface FRTransitionalContext<TDependencies extends DependencyKey = DefaultDependenciesKey> {
+    /** The URL of the page that is currently active. Might be `about:blank` in the before phases */
+    url: string;
+    /** The gather mode Lighthouse is currently in. */
+    gatherMode: GatherMode;
+    /** The connection to the page being analyzed. */
+    driver: FRTransitionalDriver;
+    /** The cached results of computed artifacts. */
+    computedCache: Map<string, ArbitraryEqualityMap>;
+    /** The set of available dependencies requested by the current gatherer. */
+    dependencies: Pick<LH.GathererArtifacts, Exclude<TDependencies, DefaultDependenciesKey>>;
+    /** The settings used for gathering. */
+    settings: LH.Config.Settings;
+  }
+
+  interface PassContext {
+    gatherMode: 'navigation';
+    /** The url of the currently loaded page. If the main document redirects, this will be updated to keep track. */
+    url: string;
+    driver: Driver;
+    passConfig: LH.Config.Pass
+    settings: LH.Config.Settings;
+    computedCache: Map<string, ArbitraryEqualityMap>
+    /** Gatherers can push to this array to add top-level warnings to the LHR. */
+    LighthouseRunWarnings: Array<string | IcuMessage>;
+    baseArtifacts: LH.BaseArtifacts;
+  }
+
+  interface LoadData {
+    networkRecords: Array<LH.Artifacts.NetworkRequest>;
+    devtoolsLog: LH.DevtoolsLog;
+    trace?: LH.Trace;
+  }
+
+  type PhaseResultNonPromise = void | LH.GathererArtifacts[keyof LH.GathererArtifacts];
+  type PhaseResult = PhaseResultNonPromise | Promise<PhaseResultNonPromise>
+
+  type GatherMode = 'snapshot'|'timespan'|'navigation';
+
+  type DefaultDependenciesKey = '__none__'
+  type DependencyKey = keyof LH.GathererArtifacts | DefaultDependenciesKey
+
+  interface GathererMetaNoDependencies {
+    /**
+     * Used to validate the dependency requirements of gatherers.
+     * If this property is not defined, this gatherer cannot be the dependency of another. */
+    symbol?: Symbol;
+    /** Lists the modes in which this gatherer can run. */
+    supportedModes: Array<GatherMode>;
+  }
+
+  interface GathererMetaWithDependencies<
+    TDependencies extends Exclude<DependencyKey, DefaultDependenciesKey>
+  > extends GathererMetaNoDependencies {
+    /**
+     * The set of required dependencies that this gatherer needs before it can compute its results.
+     */
+    dependencies: Record<TDependencies, Symbol>;
+  }
+
+  type GathererMeta<TDependencies extends DependencyKey = DefaultDependenciesKey> =
+    [TDependencies] extends [DefaultDependenciesKey] ?
+      GathererMetaNoDependencies :
+      GathererMetaWithDependencies<Exclude<TDependencies, DefaultDependenciesKey>>;
+
+  interface GathererInstance {
+    name: keyof LH.GathererArtifacts;
+    beforePass(context: Gatherer.PassContext): PhaseResult;
+    pass(context: Gatherer.PassContext): PhaseResult;
+    afterPass(context: Gatherer.PassContext, loadData: Gatherer.LoadData): PhaseResult;
+  }
+
+  type FRGatherPhase = keyof Omit<Gatherer.FRGathererInstance, 'name'|'meta'>
+
+  interface FRGathererInstance<TDependencies extends DependencyKey = DefaultDependenciesKey> {
+    name: keyof LH.GathererArtifacts; // temporary COMPAT measure until artifact config support is available
+    meta: GathererMeta<TDependencies>;
+    startInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
+    startSensitiveInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
+    stopSensitiveInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
+    stopInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
+    getArtifact(context: FRTransitionalContext<TDependencies>): PhaseResult;
+  }
+
+  type FRGathererInstanceExpander<TDependencies extends Gatherer.DependencyKey> =
+    // Lack of brackets intentional here to convert to the union of all individual dependencies.
+    TDependencies extends Gatherer.DefaultDependenciesKey ?
+      FRGathererInstance<Gatherer.DefaultDependenciesKey> :
+      FRGathererInstance<Exclude<TDependencies, DefaultDependenciesKey>>
+  type AnyFRGathererInstance = FRGathererInstanceExpander<Gatherer.DependencyKey>
+
+  namespace Simulation {
+    type GraphNode = import('../lighthouse-core/lib/dependency-graph/base-node').Node;
+    type GraphNetworkNode = _NetworkNode;
+    type GraphCPUNode = _CPUNode;
+    type Simulator = _Simulator;
+
+    interface MetricCoefficients {
+      intercept: number;
+      optimistic: number;
+      pessimistic: number;
     }
 
-    /** The limited driver interface shared between pre and post Fraggle Rock Lighthouse. */
-    export interface FRTransitionalDriver {
-      defaultSession: FRProtocolSession;
-      executionContext: ExecutionContext;
-      fetcher: Fetcher;
+    interface Options {
+      rtt?: number;
+      throughput?: number;
+      maximumConcurrentRequests?: number;
+      cpuSlowdownMultiplier?: number;
+      layoutTaskMultiplier?: number;
+      additionalRttByOrigin?: Map<string, number>;
+      serverResponseTimeByOrigin?: Map<string, number>;
     }
 
-    /** The limited context interface shared between pre and post Fraggle Rock Lighthouse. */
-    export interface FRTransitionalContext<TDependencies extends DependencyKey = DefaultDependenciesKey> {
-      /** The URL of the page that is currently active. Might be `about:blank` in the before phases */
-      url: string;
-      /** The gather mode Lighthouse is currently in. */
-      gatherMode: GatherMode;
-      /** The connection to the page being analyzed. */
-      driver: FRTransitionalDriver;
-      /** The cached results of computed artifacts. */
-      computedCache: Map<string, ArbitraryEqualityMap>;
-      /** The set of available dependencies requested by the current gatherer. */
-      dependencies: Pick<GathererArtifacts, Exclude<TDependencies, DefaultDependenciesKey>>;
-      /** The settings used for gathering. */
-      settings: Config.Settings;
+    interface NodeTiming {
+      startTime: number;
+      endTime: number;
+      duration: number;
     }
 
-    export interface PassContext {
-      gatherMode: 'navigation';
-      /** The url of the currently loaded page. If the main document redirects, this will be updated to keep track. */
-      url: string;
-      driver: Driver;
-      passConfig: Config.Pass
-      settings: Config.Settings;
-      computedCache: Map<string, ArbitraryEqualityMap>
-      /** Gatherers can push to this array to add top-level warnings to the LHR. */
-      LighthouseRunWarnings: Array<string | IcuMessage>;
-      baseArtifacts: BaseArtifacts;
-    }
-
-    export interface LoadData {
-      networkRecords: Array<Artifacts.NetworkRequest>;
-      devtoolsLog: DevtoolsLog;
-      trace?: Trace;
-    }
-
-    export type PhaseResultNonPromise = void | LH.GathererArtifacts[keyof LH.GathererArtifacts];
-    export type PhaseResult = PhaseResultNonPromise | Promise<PhaseResultNonPromise>
-
-    export type GatherMode = 'snapshot'|'timespan'|'navigation';
-
-    export type DefaultDependenciesKey = '__none__'
-    export type DependencyKey = keyof GathererArtifacts | DefaultDependenciesKey
-
-    interface GathererMetaNoDependencies {
-      /**
-       * Used to validate the dependency requirements of gatherers.
-       * If this property is not defined, this gatherer cannot be the dependency of another. */
-      symbol?: Symbol;
-      /** Lists the modes in which this gatherer can run. */
-      supportedModes: Array<GatherMode>;
-    }
-
-    interface GathererMetaWithDependencies<
-      TDependencies extends Exclude<DependencyKey, DefaultDependenciesKey>
-    > extends GathererMetaNoDependencies {
-      /**
-       * The set of required dependencies that this gatherer needs before it can compute its results.
-       */
-      dependencies: Record<TDependencies, Symbol>;
-    }
-
-    export type GathererMeta<TDependencies extends DependencyKey = DefaultDependenciesKey> =
-      [TDependencies] extends [DefaultDependenciesKey] ?
-        GathererMetaNoDependencies :
-        GathererMetaWithDependencies<Exclude<TDependencies, DefaultDependenciesKey>>;
-
-    export interface GathererInstance {
-      name: keyof LH.GathererArtifacts;
-      beforePass(context: LH.Gatherer.PassContext): PhaseResult;
-      pass(context: LH.Gatherer.PassContext): PhaseResult;
-      afterPass(context: LH.Gatherer.PassContext, loadData: LH.Gatherer.LoadData): PhaseResult;
-    }
-
-    export type FRGatherPhase = keyof Omit<LH.Gatherer.FRGathererInstance, 'name'|'meta'>
-
-    export interface FRGathererInstance<TDependencies extends DependencyKey = DefaultDependenciesKey> {
-      name: keyof LH.GathererArtifacts; // temporary COMPAT measure until artifact config support is available
-      meta: GathererMeta<TDependencies>;
-      startInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
-      startSensitiveInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
-      stopSensitiveInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
-      stopInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
-      getArtifact(context: FRTransitionalContext<TDependencies>): PhaseResult;
-    }
-
-    type FRGathererInstanceExpander<TDependencies extends Gatherer.DependencyKey> =
-      // Lack of brackets intentional here to convert to the union of all individual dependencies.
-      TDependencies extends Gatherer.DefaultDependenciesKey ?
-        FRGathererInstance<Gatherer.DefaultDependenciesKey> :
-        FRGathererInstance<Exclude<TDependencies, DefaultDependenciesKey>>
-    export type AnyFRGathererInstance = FRGathererInstanceExpander<Gatherer.DependencyKey>
-
-    namespace Simulation {
-      export type GraphNode = import('../lighthouse-core/lib/dependency-graph/base-node').Node;
-      export type GraphNetworkNode = _NetworkNode;
-      export type GraphCPUNode = _CPUNode;
-      export type Simulator = _Simulator;
-
-      export interface MetricCoefficients {
-        intercept: number;
-        optimistic: number;
-        pessimistic: number;
-      }
-
-      export interface Options {
-        rtt?: number;
-        throughput?: number;
-        maximumConcurrentRequests?: number;
-        cpuSlowdownMultiplier?: number;
-        layoutTaskMultiplier?: number;
-        additionalRttByOrigin?: Map<string, number>;
-        serverResponseTimeByOrigin?: Map<string, number>;
-      }
-
-      export interface NodeTiming {
-        startTime: number;
-        endTime: number;
-        duration: number;
-      }
-
-      export interface Result {
-        timeInMs: number;
-        nodeTimings: Map<GraphNode, NodeTiming>;
-      }
+    interface Result {
+      timeInMs: number;
+      nodeTimings: Map<GraphNode, NodeTiming>;
     }
   }
 }
 
-// empty export to keep file a module
-export {};
+export default Gatherer;

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -12,6 +12,7 @@ import ExecutionContext = require('../lighthouse-core/gather/driver/execution-co
 import Fetcher = require('../lighthouse-core/gather/fetcher');
 import ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality-map');
 
+import {Artifacts, BaseArtifacts, GathererArtifacts} from './artifacts';
 import Config from './config';
 import {IcuMessage} from './i18n';
 import Protocol from './protocol';
@@ -48,7 +49,7 @@ declare module Gatherer {
     /** The cached results of computed artifacts. */
     computedCache: Map<string, ArbitraryEqualityMap>;
     /** The set of available dependencies requested by the current gatherer. */
-    dependencies: Pick<LH.GathererArtifacts, Exclude<TDependencies, DefaultDependenciesKey>>;
+    dependencies: Pick<GathererArtifacts, Exclude<TDependencies, DefaultDependenciesKey>>;
     /** The settings used for gathering. */
     settings: Config.Settings;
   }
@@ -63,22 +64,22 @@ declare module Gatherer {
     computedCache: Map<string, ArbitraryEqualityMap>
     /** Gatherers can push to this array to add top-level warnings to the LHR. */
     LighthouseRunWarnings: Array<string | IcuMessage>;
-    baseArtifacts: LH.BaseArtifacts;
+    baseArtifacts: BaseArtifacts;
   }
 
   interface LoadData {
-    networkRecords: Array<LH.Artifacts.NetworkRequest>;
+    networkRecords: Array<Artifacts.NetworkRequest>;
     devtoolsLog: LH.DevtoolsLog;
     trace?: LH.Trace;
   }
 
-  type PhaseResultNonPromise = void | LH.GathererArtifacts[keyof LH.GathererArtifacts];
+  type PhaseResultNonPromise = void | GathererArtifacts[keyof GathererArtifacts];
   type PhaseResult = PhaseResultNonPromise | Promise<PhaseResultNonPromise>
 
   type GatherMode = 'snapshot'|'timespan'|'navigation';
 
   type DefaultDependenciesKey = '__none__'
-  type DependencyKey = keyof LH.GathererArtifacts | DefaultDependenciesKey
+  type DependencyKey = keyof GathererArtifacts | DefaultDependenciesKey
 
   interface GathererMetaNoDependencies {
     /**
@@ -104,7 +105,7 @@ declare module Gatherer {
       GathererMetaWithDependencies<Exclude<TDependencies, DefaultDependenciesKey>>;
 
   interface GathererInstance {
-    name: keyof LH.GathererArtifacts;
+    name: keyof GathererArtifacts;
     beforePass(context: Gatherer.PassContext): PhaseResult;
     pass(context: Gatherer.PassContext): PhaseResult;
     afterPass(context: Gatherer.PassContext, loadData: Gatherer.LoadData): PhaseResult;
@@ -113,7 +114,7 @@ declare module Gatherer {
   type FRGatherPhase = keyof Omit<Gatherer.FRGathererInstance, 'name'|'meta'>
 
   interface FRGathererInstance<TDependencies extends DependencyKey = DefaultDependenciesKey> {
-    name: keyof LH.GathererArtifacts; // temporary COMPAT measure until artifact config support is available
+    name: keyof GathererArtifacts; // temporary COMPAT measure until artifact config support is available
     meta: GathererMeta<TDependencies>;
     startInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;
     startSensitiveInstrumentation(context: FRTransitionalContext<DefaultDependenciesKey>): Promise<void>|void;

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -12,6 +12,8 @@ import ExecutionContext = require('../lighthouse-core/gather/driver/execution-co
 import Fetcher = require('../lighthouse-core/gather/fetcher');
 import ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality-map');
 
+import {IcuMessage} from './i18n';
+
 declare global {
   module LH.Gatherer {
     /** The Lighthouse wrapper around a raw CDP session. */

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -13,6 +13,7 @@ import Fetcher = require('../lighthouse-core/gather/fetcher');
 import ArbitraryEqualityMap = require('../lighthouse-core/lib/arbitrary-equality-map');
 
 import {IcuMessage} from './i18n';
+import Protocol from './protocol';
 
 declare global {
   module LH.Gatherer {
@@ -23,8 +24,8 @@ declare global {
       setNextProtocolTimeout(ms: number): void;
       on<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
       once<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
-      addProtocolMessageListener(callback: (payload: LH.Protocol.RawEventMessage) => void): void
-      removeProtocolMessageListener(callback: (payload: LH.Protocol.RawEventMessage) => void): void
+      addProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
+      removeProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
       off<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
       sendCommand<TMethod extends keyof LH.CrdpCommands>(method: TMethod, ...params: LH.CrdpCommands[TMethod]['paramsType']): Promise<LH.CrdpCommands[TMethod]['returnType']>;
     }

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -8,6 +8,7 @@ import Audit_ from './audit';
 import Budget_ from './budget';
 import * as I18n from './i18n';
 import StructuredData_ from './structured-data';
+import Treemap_ from './treemap';
 
 declare global {
   // Construct hierarchy of global types under the LH namespace.
@@ -23,5 +24,7 @@ declare global {
     export import I18NRendererStrings = I18n.I18NRendererStrings;
 
     export import StructuredData = StructuredData_;
+
+    export import Treemap = Treemap_;
   }
 }

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -5,10 +5,18 @@
  */
 
 import Audit_ from './audit';
+import * as I18n from './i18n';
 
 declare global {
   // Construct hierarchy of global types under the LH namespace.
   module LH {
     export import Audit = Audit_;
+
+    // i18n.d.ts.
+    export import IcuMessage = I18n.IcuMessage;
+    export import RawIcu = I18n.RawIcu;
+    export import FormattedIcu = I18n.FormattedIcu;
+    export import IcuMessagePaths = I18n.IcuMessagePaths;
+    export import I18NRendererStrings = I18n.I18NRendererStrings;
   }
 }

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -4,6 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import ArbitraryEqualityMap_ = require('../lighthouse-core/lib/arbitrary-equality-map.js');
+import * as Artifacts_ from './artifacts';
 import Audit_ from './audit';
 import Budget_ from './budget';
 import Config_ from './config';
@@ -19,6 +21,15 @@ import Treemap_ from './treemap';
 // Construct hierarchy of global types under the LH namespace.
 declare global {
   module LH {
+    export type ArbitraryEqualityMap = ArbitraryEqualityMap_;
+
+    // artifacts.d.ts
+    export import Artifacts = Artifacts_.Artifacts;
+    export import BaseArtifacts = Artifacts_.BaseArtifacts;
+    export import FRArtifacts = Artifacts_.FRArtifacts;
+    export import FRBaseArtifacts = Artifacts_.FRBaseArtifacts;
+    export import GathererArtifacts = Artifacts_.GathererArtifacts;
+
     export import Audit = Audit_;
     export import Budget = Budget_;
     export import Config = Config_;

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -6,6 +6,7 @@
 
 import Audit_ from './audit';
 import Budget_ from './budget';
+import Gatherer_ from './gatherer';
 import * as I18n from './i18n';
 import Protocol_ from './protocol';
 import ReportResult_ from './html-renderer';
@@ -17,6 +18,7 @@ declare global {
   module LH {
     export import Audit = Audit_;
     export import Budget = Budget_;
+    export import Gatherer = Gatherer_;
 
     // i18n.d.ts.
     export import IcuMessage = I18n.IcuMessage;

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -7,6 +7,7 @@
 import Audit_ from './audit';
 import Budget_ from './budget';
 import * as I18n from './i18n';
+import StructuredData_ from './structured-data';
 
 declare global {
   // Construct hierarchy of global types under the LH namespace.
@@ -20,5 +21,7 @@ declare global {
     export import FormattedIcu = I18n.FormattedIcu;
     export import IcuMessagePaths = I18n.IcuMessagePaths;
     export import I18NRendererStrings = I18n.I18NRendererStrings;
+
+    export import StructuredData = StructuredData_;
   }
 }

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -7,11 +7,12 @@
 import Audit_ from './audit';
 import Budget_ from './budget';
 import * as I18n from './i18n';
+import Protocol_ from './protocol';
 import StructuredData_ from './structured-data';
 import Treemap_ from './treemap';
 
+// Construct hierarchy of global types under the LH namespace.
 declare global {
-  // Construct hierarchy of global types under the LH namespace.
   module LH {
     export import Audit = Audit_;
     export import Budget = Budget_;
@@ -23,8 +24,8 @@ declare global {
     export import IcuMessagePaths = I18n.IcuMessagePaths;
     export import I18NRendererStrings = I18n.I18NRendererStrings;
 
+    export import Protocol = Protocol_;
     export import StructuredData = StructuredData_;
-
     export import Treemap = Treemap_;
   }
 }

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -8,6 +8,7 @@ import Audit_ from './audit';
 import Budget_ from './budget';
 import * as I18n from './i18n';
 import Protocol_ from './protocol';
+import ReportResult_ from './html-renderer';
 import StructuredData_ from './structured-data';
 import Treemap_ from './treemap';
 
@@ -25,6 +26,7 @@ declare global {
     export import I18NRendererStrings = I18n.I18NRendererStrings;
 
     export import Protocol = Protocol_;
+    export import ReportResult = ReportResult_;
     export import StructuredData = StructuredData_;
     export import Treemap = Treemap_;
   }

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -6,6 +6,7 @@
 
 import Audit_ from './audit';
 import Budget_ from './budget';
+import Config_ from './config';
 import Gatherer_ from './gatherer';
 import * as I18n from './i18n';
 import LHError = require('../lighthouse-core/lib/lh-error.js');
@@ -20,6 +21,7 @@ declare global {
   module LH {
     export import Audit = Audit_;
     export import Budget = Budget_;
+    export import Config = Config_;
     export import Gatherer = Gatherer_;
     export import LighthouseError = LHError;
     export import Result = LHResult;

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -5,12 +5,14 @@
  */
 
 import Audit_ from './audit';
+import Budget_ from './budget';
 import * as I18n from './i18n';
 
 declare global {
   // Construct hierarchy of global types under the LH namespace.
   module LH {
     export import Audit = Audit_;
+    export import Budget = Budget_;
 
     // i18n.d.ts.
     export import IcuMessage = I18n.IcuMessage;

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -8,6 +8,8 @@ import Audit_ from './audit';
 import Budget_ from './budget';
 import Gatherer_ from './gatherer';
 import * as I18n from './i18n';
+import LHError = require('../lighthouse-core/lib/lh-error.js');
+import LHResult from './lhr';
 import Protocol_ from './protocol';
 import ReportResult_ from './html-renderer';
 import StructuredData_ from './structured-data';
@@ -19,6 +21,8 @@ declare global {
     export import Audit = Audit_;
     export import Budget = Budget_;
     export import Gatherer = Gatherer_;
+    export import LighthouseError = LHError;
+    export import Result = LHResult;
 
     // i18n.d.ts.
     export import IcuMessage = I18n.IcuMessage;

--- a/types/html-renderer.d.ts
+++ b/types/html-renderer.d.ts
@@ -5,6 +5,7 @@
  */
 
 import Audit from './audit';
+import LHResult from './lhr';
 
 // Add needed DOM APIs not yet in tsc's lib dom.
 declare global {
@@ -20,15 +21,15 @@ declare global {
 
 // During report generation, the LHR object is transformed a bit for convenience
 // Primarily, the auditResult is added as .result onto the auditRef. We're lazy sometimes. It'll be removed in due time.
-interface ReportResult extends LH.Result {
+interface ReportResult extends LHResult {
   categories: Record<string, ReportResult.Category>;
 }
 declare module ReportResult {
-  interface Category extends LH.Result.Category {
+  interface Category extends LHResult.Category {
     auditRefs: Array<AuditRef>
   }
 
-  interface AuditRef extends LH.Result.AuditRef {
+  interface AuditRef extends LHResult.AuditRef {
     result: Audit.Result;
     stackPacks?: StackPackDescription[];
     relevantMetrics?: ReportResult.AuditRef[];

--- a/types/html-renderer.d.ts
+++ b/types/html-renderer.d.ts
@@ -4,6 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import Audit from './audit';
+
+// Add needed DOM APIs not yet in tsc's lib dom.
 declare global {
   var CompressionStream: {
     prototype: CompressionStream,
@@ -13,35 +16,32 @@ declare global {
   interface CompressionStream extends GenericTransformStream {
     readonly format: string;
   }
+}
 
-  module LH {
-    // During report generation, the LHR object is transformed a bit for convenience
-    // Primarily, the auditResult is added as .result onto the auditRef. We're lazy sometimes. It'll be removed in due time.
-    export interface ReportResult extends Result {
-      categories: Record<string, ReportResult.Category>;
-    }
-    export module ReportResult {
-      export interface Category extends Result.Category {
-        auditRefs: Array<AuditRef>
-      }
+// During report generation, the LHR object is transformed a bit for convenience
+// Primarily, the auditResult is added as .result onto the auditRef. We're lazy sometimes. It'll be removed in due time.
+interface ReportResult extends LH.Result {
+  categories: Record<string, ReportResult.Category>;
+}
+declare module ReportResult {
+  interface Category extends LH.Result.Category {
+    auditRefs: Array<AuditRef>
+  }
 
-      export interface AuditRef extends Result.AuditRef {
-        result: Audit.Result;
-        stackPacks?: StackPackDescription[];
-        relevantMetrics?: LH.ReportResult.AuditRef[];
-      }
+  interface AuditRef extends LH.Result.AuditRef {
+    result: Audit.Result;
+    stackPacks?: StackPackDescription[];
+    relevantMetrics?: ReportResult.AuditRef[];
+  }
 
-      export interface StackPackDescription {
-         /** The title of the stack pack. */
-        title: string;
-        /** A base64 data url to be used as the stack pack's icon. */
-        iconDataURL: string;
-        /** The stack-specific description for this audit. */
-        description: string;
-      }
-    }
+  interface StackPackDescription {
+      /** The title of the stack pack. */
+    title: string;
+    /** A base64 data url to be used as the stack pack's icon. */
+    iconDataURL: string;
+    /** The stack-specific description for this audit. */
+    description: string;
   }
 }
 
-// empty export to keep file a module
-export {}
+export default ReportResult;

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -6,74 +6,67 @@
 
 import {Util} from '../report/renderer/util.js';
 
-declare global {
-  module LH {
-    export type IcuMessage = {
-      // NOTE: `i18nId` rather than just `id` to make tsc typing easier (vs type branding which won't survive JSON roundtrip).
-      /** The id locating this message in the locale message json files. */
-      i18nId: string;
-      /** The dynamic values, if any, to insert into the localized string. */
-      values?: Record<string, string | number>;
-      /**
-       * A formatted version of the string, usually as found in a file's `UIStrings`
-       * entry, and used as backup if the `i18nId` doesn't refer to an existing
-       * message in the requested locale. Used when serialized and a new version of
-       * Lighthouse no longer contains the needed message (or in development and
-       * the locale files don't yet contain it).
-       */
-      formattedDefault: string,
-    };
+export type IcuMessage = {
+  // NOTE: `i18nId` rather than just `id` to make tsc typing easier (vs type branding which won't survive JSON roundtrip).
+  /** The id locating this message in the locale message json files. */
+  i18nId: string;
+  /** The dynamic values, if any, to insert into the localized string. */
+  values?: Record<string, string | number>;
+  /**
+   * A formatted version of the string, usually as found in a file's `UIStrings`
+   * entry, and used as backup if the `i18nId` doesn't refer to an existing
+   * message in the requested locale. Used when serialized and a new version of
+   * Lighthouse no longer contains the needed message (or in development and
+   * the locale files don't yet contain it).
+   */
+  formattedDefault: string,
+};
 
-    /**
-     * A helper to represent the type of an object that hasn't be localized yet.
-     * Recursively finds all `string` properties in `T` and extends them to also
-     * accept an `LH.IcuMessage`.
-     *
-     * Heavy handed and requires more type checks, so prefer explicitly setting
-     * properties to include `LH.IcuMessage` over this helper if possible.
-     */
-    type RawIcu<T> = T extends IcuMessage ? T :
-      // Check `string extends T` so LH.IcuMessage isn't added to union of string literals.
-      string extends T ? (T|IcuMessage) :
-      // Otherwise recurse into any properties and repeat.
-      {[K in keyof T]: RawIcu<T[K]>};
+/**
+ * A helper to represent the type of an object that hasn't be localized yet.
+ * Recursively finds all `string` properties in `T` and extends them to also
+ * accept an `LH.IcuMessage`.
+ *
+ * Heavy handed and requires more type checks, so prefer explicitly setting
+ * properties to include `LH.IcuMessage` over this helper if possible.
+ */
+export type RawIcu<T> = T extends IcuMessage ? T :
+  // Check `string extends T` so LH.IcuMessage isn't added to union of string literals.
+  string extends T ? (T|IcuMessage) :
+  // Otherwise recurse into any properties and repeat.
+  {[K in keyof T]: RawIcu<T[K]>};
 
-    /**
-     * A helper to represent the localization process, recursively finding all
-     * `LH.IcuMessage` properties in `T` and replacing them with `string`.
-     *
-     * Essentially undoes `LH.RawIcu<T>`, but as with that type, prefer using types
-     * with explicit `string` properties over this helper if possible.
-     */
-    type FormattedIcu<T> = T extends IcuMessage ?
-      // All LH.IcuMessages replaced with strings.
-      Exclude<T, IcuMessage> | string :
-      // Otherwise recurse into any properties and repeat.
-      {[K in keyof T]: FormattedIcu<T[K]>};
+/**
+ * A helper to represent the localization process, recursively finding all
+ * `LH.IcuMessage` properties in `T` and replacing them with `string`.
+ *
+ * Essentially undoes `LH.RawIcu<T>`, but as with that type, prefer using types
+ * with explicit `string` properties over this helper if possible.
+ */
+export type FormattedIcu<T> = T extends IcuMessage ?
+  // All LH.IcuMessages replaced with strings.
+  Exclude<T, IcuMessage> | string :
+  // Otherwise recurse into any properties and repeat.
+  {[K in keyof T]: FormattedIcu<T[K]>};
 
-    /**
-     * Info about an `LH.IcuMessage` value that was localized to a string. Value
-     * is either a
-     *  - path (`_.set()` style) into the original object where the message was replaced
-     *  - those paths and a set of values that were inserted into the localized strings.
-     */
-    type IcuMessagePath = string | {path: string, values: Record<string, string | number>};
+/**
+ * Info about an `LH.IcuMessage` value that was localized to a string. Value
+ * is either a
+ *  - path (`_.set()` style) into the original object where the message was replaced
+ *  - those paths and a set of values that were inserted into the localized strings.
+ */
+type IcuMessagePath = string | {path: string, values: Record<string, string | number>};
 
-    /**
-     * A representation of `LH.IcuMessage`s that were in an object (e.g. `LH.Result`)
-     * and have been replaced by localized strings. `LH.IcuMessagePaths` provides a
-     * mapping that can be used to change the locale of the object again.
-     * Keyed by ids from the locale message json files, values are information on
-     * how to replace the string if needed.
-     */
-    export interface IcuMessagePaths {
-      [i18nId: string]: IcuMessagePath[];
-    }
-
-    /** Localized strings for the html report renderer. */
-    export type I18NRendererStrings = typeof Util['UIStrings'];
-  }
+/**
+ * A representation of `LH.IcuMessage`s that were in an object (e.g. `LH.Result`)
+ * and have been replaced by localized strings. `LH.IcuMessagePaths` provides a
+ * mapping that can be used to change the locale of the object again.
+ * Keyed by ids from the locale message json files, values are information on
+ * how to replace the string if needed.
+ */
+export interface IcuMessagePaths {
+  [i18nId: string]: IcuMessagePath[];
 }
 
-// empty export to keep file a module
-export {}
+/** Localized strings for the html report renderer. */
+export type I18NRendererStrings = typeof Util['UIStrings'];

--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -4,121 +4,114 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import LHError = require('../lighthouse-core/lib/lh-error.js');
+import Audit from './audit';
 import {I18NRendererStrings, IcuMessagePaths} from './i18n';
 
-declare global {
-  module LH {
-    export type LighthouseError = LHError;
+/**
+ * The full output of a Lighthouse run.
+ */
+interface Result {
+  /** The URL that was supplied to Lighthouse and initially navigated to. */
+  requestedUrl: string;
+  /** The post-redirects URL that Lighthouse loaded. */
+  finalUrl: string;
+  /** The ISO-8601 timestamp of when the results were generated. */
+  fetchTime: string;
+  /** The version of Lighthouse with which these results were generated. */
+  lighthouseVersion: string;
+  /** An object containing the results of the audits, keyed by the audits' `id` identifier. */
+  audits: Record<string, Audit.Result>;
+  /** The top-level categories, their overall scores, and member audits. */
+  categories: Record<string, Result.Category>;
+  /** Descriptions of the groups referenced by CategoryMembers. */
+  categoryGroups?: Record<string, Result.ReportGroup>;
 
-    export interface Environment {
-      /** The user agent string of the version of Chrome used. */
-      hostUserAgent: string;
-      /** The user agent string that was sent over the network. */
-      networkUserAgent: string;
-      /** The benchmark index number that indicates rough device class. */
-      benchmarkIndex: number;
-      /** The version of libraries with which these results were generated. Ex: axe-core. */
-      credits: Record<string, string>,
-    }
+  /** The config settings used for these results. */
+  configSettings: LH.Config.Settings;
+  /** List of top-level warnings for this Lighthouse run. */
+  runWarnings: string[];
+  /** A top-level error message that, if present, indicates a serious enough problem that this Lighthouse result may need to be discarded. */
+  runtimeError?: {code: string, message: string};
+  /** The User-Agent string of the browser used run Lighthouse for these results. */
+  userAgent: string;
+  /** Information about the environment in which Lighthouse was run. */
+  environment: Result.Environment;
+  /** Execution timings for the Lighthouse run */
+  timing: Result.Timing;
+  /** The record of all formatted string locations in the LHR and their corresponding source values. */
+  i18n: {rendererFormattedStrings: I18NRendererStrings, icuMessagePaths?: IcuMessagePaths};
+  /** An array containing the result of all stack packs. */
+  stackPacks?: Result.StackPack[];
+}
 
-    /**
-     * The full output of a Lighthouse run.
-     */
-    export interface Result {
-      /** The URL that was supplied to Lighthouse and initially navigated to. */
-      requestedUrl: string;
-      /** The post-redirects URL that Lighthouse loaded. */
-      finalUrl: string;
-      /** The ISO-8601 timestamp of when the results were generated. */
-      fetchTime: string;
-      /** The version of Lighthouse with which these results were generated. */
-      lighthouseVersion: string;
-      /** An object containing the results of the audits, keyed by the audits' `id` identifier. */
-      audits: Record<string, Audit.Result>;
-      /** The top-level categories, their overall scores, and member audits. */
-      categories: Record<string, Result.Category>;
-      /** Descriptions of the groups referenced by CategoryMembers. */
-      categoryGroups?: Record<string, Result.ReportGroup>;
+// Result namespace
+declare module Result {
+  interface Environment {
+    /** The user agent string of the version of Chrome used. */
+    hostUserAgent: string;
+    /** The user agent string that was sent over the network. */
+    networkUserAgent: string;
+    /** The benchmark index number that indicates rough device class. */
+    benchmarkIndex: number;
+    /** The version of libraries with which these results were generated. Ex: axe-core. */
+    credits: Record<string, string>,
+  }
 
-      /** The config settings used for these results. */
-      configSettings: Config.Settings;
-      /** List of top-level warnings for this Lighthouse run. */
-      runWarnings: string[];
-      /** A top-level error message that, if present, indicates a serious enough problem that this Lighthouse result may need to be discarded. */
-      runtimeError?: {code: string, message: string};
-      /** The User-Agent string of the browser used run Lighthouse for these results. */
-      userAgent: string;
-      /** Information about the environment in which Lighthouse was run. */
-      environment: Environment;
-      /** Execution timings for the Lighthouse run */
-      timing: Result.Timing;
-      /** The record of all formatted string locations in the LHR and their corresponding source values. */
-      i18n: {rendererFormattedStrings: I18NRendererStrings, icuMessagePaths?: IcuMessagePaths};
-      /** An array containing the result of all stack packs. */
-      stackPacks?: Result.StackPack[];
-    }
+  interface Timing {
+    entries: LH.Artifacts.MeasureEntry[];
+    total: number;
+  }
 
-    // Result namespace
-    export module Result {
-      export interface Timing {
-        entries: Artifacts.MeasureEntry[];
-        total: number;
-      }
+  interface Category {
+    /** The string identifier of the category. */
+    id: string;
+    /** The human-friendly name of the category */
+    title: string;
+    /** A more detailed description of the category and its importance. */
+    description?: string;
+    /** A description for the manual audits in the category. */
+    manualDescription?: string;
+    /** The overall score of the category, the weighted average of all its audits. */
+    score: number|null;
+    /** An array of references to all the audit members of this category. */
+    auditRefs: AuditRef[];
+  }
 
-      export interface Category {
-        /** The string identifier of the category. */
-        id: string;
-        /** The human-friendly name of the category */
-        title: string;
-        /** A more detailed description of the category and its importance. */
-        description?: string;
-        /** A description for the manual audits in the category. */
-        manualDescription?: string;
-        /** The overall score of the category, the weighted average of all its audits. */
-        score: number|null;
-        /** An array of references to all the audit members of this category. */
-        auditRefs: AuditRef[];
-      }
+  interface AuditRef {
+    /** Matches the `id` of an Audit.Result. */
+    id: string;
+    /** The weight of the audit's score in the overall category score. */
+    weight: number;
+    /** Optional grouping within the category. Matches the key of a Result.Group. */
+    group?: string;
+    /** The conventional acronym for the audit/metric. */
+    acronym?: string;
+    /** Any audit IDs closely relevant to this one. */
+    relevantAudits?: string[];
+  }
 
-      export interface AuditRef {
-        /** Matches the `id` of an Audit.Result. */
-        id: string;
-        /** The weight of the audit's score in the overall category score. */
-        weight: number;
-        /** Optional grouping within the category. Matches the key of a Result.Group. */
-        group?: string;
-        /** The conventional acronym for the audit/metric. */
-        acronym?: string;
-        /** Any audit IDs closely relevant to this one. */
-        relevantAudits?: string[];
-      }
+  interface ReportGroup {
+    /** The title of the display group. */
+    title: string;
+    /** A brief description of the purpose of the display group. */
+    description?: string;
+  }
 
-      export interface ReportGroup {
-        /** The title of the display group. */
-        title: string;
-        /** A brief description of the purpose of the display group. */
-        description?: string;
-      }
-
-      /**
-       * A pack of secondary audit descriptions to be used when a page uses a
-       * specific technology stack, giving stack-specific advice for some of
-       * Lighthouse's audits.
-       */
-      export interface StackPack {
-        /** The unique string ID for this stack pack. */
-        id: string;
-        /** The title of the stack pack, to be displayed in the report. */
-        title: string;
-        /** A base64 data url to be used as the stack pack's icon. */
-        iconDataURL: string;
-        /** A set of descriptions for some of Lighthouse's audits, keyed by audit `id`. */
-        descriptions: Record<string, string>;
-      }
-    }
+  /**
+   * A pack of secondary audit descriptions to be used when a page uses a
+   * specific technology stack, giving stack-specific advice for some of
+   * Lighthouse's audits.
+   */
+  interface StackPack {
+    /** The unique string ID for this stack pack. */
+    id: string;
+    /** The title of the stack pack, to be displayed in the report. */
+    title: string;
+    /** A base64 data url to be used as the stack pack's icon. */
+    iconDataURL: string;
+    /** A set of descriptions for some of Lighthouse's audits, keyed by audit `id`. */
+    descriptions: Record<string, string>;
   }
 }
 
-// empty export to keep file a module
-export {}
+export default Result;

--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -5,6 +5,7 @@
  */
 
 import LHError = require('../lighthouse-core/lib/lh-error.js');
+import {I18NRendererStrings, IcuMessagePaths} from './i18n';
 
 declare global {
   module LH {

--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -5,6 +5,7 @@
  */
 
 import Audit from './audit';
+import Config from './config';
 import {I18NRendererStrings, IcuMessagePaths} from './i18n';
 
 /**
@@ -27,7 +28,7 @@ interface Result {
   categoryGroups?: Record<string, Result.ReportGroup>;
 
   /** The config settings used for these results. */
-  configSettings: LH.Config.Settings;
+  configSettings: Config.Settings;
   /** List of top-level warnings for this Lighthouse run. */
   runWarnings: string[];
   /** A top-level error message that, if present, indicates a serious enough problem that this Lighthouse result may need to be discarded. */

--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {Artifacts} from './artifacts';
 import Audit from './audit';
 import Config from './config';
 import {I18NRendererStrings, IcuMessagePaths} from './i18n';
@@ -59,7 +60,7 @@ declare module Result {
   }
 
   interface Timing {
-    entries: LH.Artifacts.MeasureEntry[];
+    entries: Artifacts.MeasureEntry[];
     total: number;
   }
 

--- a/types/protocol.d.ts
+++ b/types/protocol.d.ts
@@ -4,52 +4,50 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-declare global {
-  module LH.Protocol {
-    /**
-     * Union of raw (over the wire) message format of all possible Crdp events,
-     * of the form `{method: 'Domain.event', params: eventPayload}`.
-     */
-    export type RawEventMessage = RawEventMessageRecord[keyof RawEventMessageRecord];
+declare module Protocol {
+  /**
+   * Union of raw (over the wire) message format of all possible Crdp events,
+   * of the form `{method: 'Domain.event', params: eventPayload}`.
+   */
+  type RawEventMessage = RawEventMessageRecord[keyof RawEventMessageRecord];
 
-    /**
-     * Raw (over the wire) message format of all possible Crdp command responses.
-     */
-    export type RawCommandMessage = {
-      id: number;
-      result: CrdpCommands[keyof CrdpCommands]['returnType'];
-      error: {
-        code: number,
-        message: string
-      };
-    }
+  /**
+   * Raw (over the wire) message format of all possible Crdp command responses.
+   */
+  type RawCommandMessage = {
+    id: number;
+    result: LH.CrdpCommands[keyof LH.CrdpCommands]['returnType'];
+    error: {
+      code: number,
+      message: string
+    };
+  }
 
-    /**
-     * Raw (over the wire) message format of all possible Crdp events and command
-     * responses.
-     */
-    export type RawMessage = RawCommandMessage | RawEventMessage;
+  /**
+   * Raw (over the wire) message format of all possible Crdp events and command
+   * responses.
+   */
+  type RawMessage = RawCommandMessage | RawEventMessage;
 
-    /**
-     * A more strictly-typed EventEmitter interface that checks the association
-     * of event name and listener payload. TEventRecord should be a record mapping
-     * event names to tuples that can contain zero or more items, which will
-     * serve as the arguments to event listener callbacks.
-     * Inspired by work from https://github.com/bterlson/strict-event-emitter-types.
-     */
-    export type StrictEventEmitter<TEventRecord extends Record<keyof TEventRecord, any[]>> = {
-      on<E extends keyof TEventRecord>(event: E, listener: (...args: TEventRecord[E]) => void): void;
+  /**
+   * A more strictly-typed EventEmitter interface that checks the association
+   * of event name and listener payload. TEventRecord should be a record mapping
+   * event names to tuples that can contain zero or more items, which will
+   * serve as the arguments to event listener callbacks.
+   * Inspired by work from https://github.com/bterlson/strict-event-emitter-types.
+   */
+  type StrictEventEmitter<TEventRecord extends Record<keyof TEventRecord, any[]>> = {
+    on<E extends keyof TEventRecord>(event: E, listener: (...args: TEventRecord[E]) => void): void;
 
-      addListener<E extends keyof TEventRecord>(event: E, listener: (...args: TEventRecord[E]) => void): void;
+    addListener<E extends keyof TEventRecord>(event: E, listener: (...args: TEventRecord[E]) => void): void;
 
-      removeListener<E extends keyof TEventRecord>(event: E, listener: Function): void;
+    removeListener<E extends keyof TEventRecord>(event: E, listener: Function): void;
 
-      removeAllListeners<E extends keyof TEventRecord>(event?: E): void;
+    removeAllListeners<E extends keyof TEventRecord>(event?: E): void;
 
-      once<E extends keyof TEventRecord>(event: E, listener: (...args: TEventRecord[E]) => void): void;
+    once<E extends keyof TEventRecord>(event: E, listener: (...args: TEventRecord[E]) => void): void;
 
-      emit<E extends keyof TEventRecord>(event: E, ...request: TEventRecord[E]): void;
-    }
+    emit<E extends keyof TEventRecord>(event: E, ...request: TEventRecord[E]): void;
   }
 }
 
@@ -70,5 +68,4 @@ type RawEventMessageRecord = {
   };
 }
 
-// empty export to keep file a module
-export {}
+export default Protocol;

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {Artifacts} from './artifacts';
 import Config from './config';
 import LHResult from './lhr';
 
@@ -22,7 +23,7 @@ declare global {
 
     export type ExpectedRunnerResult = {
       lhr: ExpectedLHR,
-      artifacts?: Partial<Record<keyof LH.Artifacts|'_maxChromiumMilestone'|'_minChromiumMilestone', any>>
+      artifacts?: Partial<Record<keyof Artifacts|'_maxChromiumMilestone'|'_minChromiumMilestone', any>>
       networkRequests?: {length: number};
     }
 
@@ -47,7 +48,7 @@ declare global {
       {expectations: Smokehouse.ExpectedRunnerResult | Array<Smokehouse.ExpectedRunnerResult>}
 
     export type LighthouseRunner =
-      (url: string, configJson?: Config.Json, runnerOptions?: {isDebug?: boolean; useFraggleRock?: boolean}) => Promise<{lhr: LHResult, artifacts: LH.Artifacts, log: string}>;
+      (url: string, configJson?: Config.Json, runnerOptions?: {isDebug?: boolean; useFraggleRock?: boolean}) => Promise<{lhr: LHResult, artifacts: Artifacts, log: string}>;
 
     export interface SmokehouseOptions {
       /** If true, performs extra logging from the test runs. */

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import Config from './config';
 import LHResult from './lhr';
 
 declare global {
@@ -31,7 +32,7 @@ declare global {
       /** Expected test results. */
       expectations: ExpectedRunnerResult;
       /** An optional custom config. If none is present, uses the default Lighthouse config. */
-      config?: LH.Config.Json;
+      config?: Config.Json;
       /** If test is performance sensitive, set to true so that it won't be run parallel to other tests. */
       runSerially?: boolean;
     }
@@ -46,7 +47,7 @@ declare global {
       {expectations: Smokehouse.ExpectedRunnerResult | Array<Smokehouse.ExpectedRunnerResult>}
 
     export type LighthouseRunner =
-      (url: string, configJson?: LH.Config.Json, runnerOptions?: {isDebug?: boolean; useFraggleRock?: boolean}) => Promise<{lhr: LHResult, artifacts: LH.Artifacts, log: string}>;
+      (url: string, configJson?: Config.Json, runnerOptions?: {isDebug?: boolean; useFraggleRock?: boolean}) => Promise<{lhr: LHResult, artifacts: LH.Artifacts, log: string}>;
 
     export interface SmokehouseOptions {
       /** If true, performs extra logging from the test runs. */

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -4,65 +4,69 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
- declare module Smokehouse {
-  interface ExpectedLHR {
-    audits: Record<string, any>;
-    requestedUrl: string;
-    finalUrl: string;
-    runWarnings?: Array<string|RegExp>;
-    runtimeError?: {
-      code?: any;
-      message?: any;
-    };
-  }
+import LHResult from './lhr';
 
-  export type ExpectedRunnerResult = {
-    lhr: ExpectedLHR,
-    artifacts?: Partial<Record<keyof LH.Artifacts|'_maxChromiumMilestone'|'_minChromiumMilestone', any>>
-    networkRequests?: {length: number};
-  }
+declare global {
+  module Smokehouse {
+    interface ExpectedLHR {
+      audits: Record<string, any>;
+      requestedUrl: string;
+      finalUrl: string;
+      runWarnings?: Array<string|RegExp>;
+      runtimeError?: {
+        code?: any;
+        message?: any;
+      };
+    }
 
-  export interface TestDfn {
-    /** Identification of test. Can be used for group selection (e.g. `yarn smoke pwa` will run all tests with `id.includes('pwa')`). */
-    id: string;
-    /** Expected test results. */
-    expectations: ExpectedRunnerResult;
-    /** An optional custom config. If none is present, uses the default Lighthouse config. */
-    config?: LH.Config.Json;
-    /** If test is performance sensitive, set to true so that it won't be run parallel to other tests. */
-    runSerially?: boolean;
-  }
+    export type ExpectedRunnerResult = {
+      lhr: ExpectedLHR,
+      artifacts?: Partial<Record<keyof LH.Artifacts|'_maxChromiumMilestone'|'_minChromiumMilestone', any>>
+      networkRequests?: {length: number};
+    }
 
-  /**
-   * A TestDefn type that's compatible with the old array of `expectations` type and the current TestDefn type.
-   * COMPAT: remove when no long needed.
-   * @deprecated
-   */
-  export type BackCompatTestDefn =
-    Omit<Smokehouse.TestDfn, 'expectations'> &
-    {expectations: Smokehouse.ExpectedRunnerResult | Array<Smokehouse.ExpectedRunnerResult>}
+    export interface TestDfn {
+      /** Identification of test. Can be used for group selection (e.g. `yarn smoke pwa` will run all tests with `id.includes('pwa')`). */
+      id: string;
+      /** Expected test results. */
+      expectations: ExpectedRunnerResult;
+      /** An optional custom config. If none is present, uses the default Lighthouse config. */
+      config?: LH.Config.Json;
+      /** If test is performance sensitive, set to true so that it won't be run parallel to other tests. */
+      runSerially?: boolean;
+    }
 
-  export type LighthouseRunner =
-    (url: string, configJson?: LH.Config.Json, runnerOptions?: {isDebug?: boolean; useFraggleRock?: boolean}) => Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>;
+    /**
+     * A TestDefn type that's compatible with the old array of `expectations` type and the current TestDefn type.
+     * COMPAT: remove when no long needed.
+     * @deprecated
+     */
+    export type BackCompatTestDefn =
+      Omit<Smokehouse.TestDfn, 'expectations'> &
+      {expectations: Smokehouse.ExpectedRunnerResult | Array<Smokehouse.ExpectedRunnerResult>}
 
-  export interface SmokehouseOptions {
-    /** If true, performs extra logging from the test runs. */
-    isDebug?: boolean;
-    /** If true, uses the new Fraggle Rock runner. */
-    useFraggleRock?: boolean;
-    /** Manually set the number of jobs to run at once. `1` runs all tests serially. */
-    jobs?: number;
-    /** The number of times to retry failing tests before accepting. Defaults to 0. */
-    retries?: number;
-    /** A function that runs Lighthouse with the given options. Defaults to running Lighthouse via the CLI. */
-    lighthouseRunner?: LighthouseRunner;
-    /** A function that gets a list of URLs requested to the server since the last fetch. */
-    takeNetworkRequestUrls?: () => string[];
-  }
+    export type LighthouseRunner =
+      (url: string, configJson?: LH.Config.Json, runnerOptions?: {isDebug?: boolean; useFraggleRock?: boolean}) => Promise<{lhr: LHResult, artifacts: LH.Artifacts, log: string}>;
 
-  export interface SmokehouseLibOptions extends SmokehouseOptions {
-    urlFilterRegex?: RegExp;
-    skip?: (test: TestDfn, expectation: ExpectedRunnerResult) => string | false;
-    modify?: (test: TestDfn, expectation: ExpectedRunnerResult) => void;
+    export interface SmokehouseOptions {
+      /** If true, performs extra logging from the test runs. */
+      isDebug?: boolean;
+      /** If true, uses the new Fraggle Rock runner. */
+      useFraggleRock?: boolean;
+      /** Manually set the number of jobs to run at once. `1` runs all tests serially. */
+      jobs?: number;
+      /** The number of times to retry failing tests before accepting. Defaults to 0. */
+      retries?: number;
+      /** A function that runs Lighthouse with the given options. Defaults to running Lighthouse via the CLI. */
+      lighthouseRunner?: LighthouseRunner;
+      /** A function that gets a list of URLs requested to the server since the last fetch. */
+      takeNetworkRequestUrls?: () => string[];
+    }
+
+    export interface SmokehouseLibOptions extends SmokehouseOptions {
+      urlFilterRegex?: RegExp;
+      skip?: (test: TestDfn, expectation: ExpectedRunnerResult) => string | false;
+      modify?: (test: TestDfn, expectation: ExpectedRunnerResult) => void;
+    }
   }
 }

--- a/types/structured-data.d.ts
+++ b/types/structured-data.d.ts
@@ -4,39 +4,33 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-declare global {
-  module LH {
-    module StructuredData {
+declare module StructuredData {
+  type ValidatorType = "json" | "json-ld" | "json-ld-expand" | "schema-org";
 
-      export type ValidatorType = "json" | "json-ld" | "json-ld-expand" | "schema-org";
-    
-      export interface ValidationError {
-        message: string;
-        /** Property path in the expanded JSON-LD object */
-        path?: string;
-        validator: ValidatorType;
-        lineNumber?: number | null;
-        /** Schema.org type URIs of the invalid entity (undefined if type is invalid) */
-        validTypes?: Array<string>;
-      }
-
-      export interface ExpandedSchemaRepresentationItem {
-        [schemaRef: string]: Array<
-            string |
-            {
-              '@id'?: string;
-              '@type'?: string;
-              '@value'?: string;
-            }
-          >;
-      }
-
-      export type ExpandedSchemaRepresentation =
-        | Array<ExpandedSchemaRepresentationItem>
-        | ExpandedSchemaRepresentationItem;
-    }
+  interface ValidationError {
+    message: string;
+    /** Property path in the expanded JSON-LD object */
+    path?: string;
+    validator: ValidatorType;
+    lineNumber?: number | null;
+    /** Schema.org type URIs of the invalid entity (undefined if type is invalid) */
+    validTypes?: Array<string>;
   }
+
+  interface ExpandedSchemaRepresentationItem {
+    [schemaRef: string]: Array<
+        string |
+        {
+          '@id'?: string;
+          '@type'?: string;
+          '@value'?: string;
+        }
+      >;
+  }
+
+  type ExpandedSchemaRepresentation =
+    | Array<ExpandedSchemaRepresentationItem>
+    | ExpandedSchemaRepresentationItem;
 }
 
-// empty export to keep file a module
-export {};
+export default StructuredData;

--- a/types/treemap.d.ts
+++ b/types/treemap.d.ts
@@ -4,6 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import Audit from './audit';
+
 declare global {
   module LH.Treemap {
     interface Options {
@@ -11,7 +13,7 @@ declare global {
         requestedUrl: string;
         finalUrl: string;
         audits: {
-          'script-treemap-data': LH.Audit.Result;
+          'script-treemap-data': Audit.Result;
         };
         configSettings: {
           locale: LH.Locale;

--- a/types/treemap.d.ts
+++ b/types/treemap.d.ts
@@ -6,54 +6,51 @@
 
 import Audit from './audit';
 
-declare global {
-  module LH.Treemap {
-    interface Options {
-      lhr: {
-        requestedUrl: string;
-        finalUrl: string;
-        audits: {
-          'script-treemap-data': Audit.Result;
-        };
-        configSettings: {
-          locale: LH.Locale;
-        }
+declare module Treemap {
+  interface Options {
+    lhr: {
+      requestedUrl: string;
+      finalUrl: string;
+      audits: {
+        'script-treemap-data': Audit.Result;
+      };
+      configSettings: {
+        locale: LH.Locale;
       }
     }
+  }
 
-    type NodePath = string[];
+  type NodePath = string[];
 
-    interface Selector {
-      type: 'depthOneNode' | 'group';
-      value: string;
-    }
+  interface Selector {
+    type: 'depthOneNode' | 'group';
+    value: string;
+  }
 
-    interface Highlight {
-      path: NodePath;
-      /** If not set, will use the color based on the d1Node. */
-      color?: string;
-    }
+  interface Highlight {
+    path: NodePath;
+    /** If not set, will use the color based on the d1Node. */
+    color?: string;
+  }
 
-    interface ViewMode {
-      id: 'all' | 'unused-bytes' | 'duplicate-modules';
-      label: string;
-      subLabel: string;
-      enabled: boolean;
-      partitionBy?: 'resourceBytes' | 'unusedBytes';
-      highlights?: Highlight[];
-    }
+  interface ViewMode {
+    id: 'all' | 'unused-bytes' | 'duplicate-modules';
+    label: string;
+    subLabel: string;
+    enabled: boolean;
+    partitionBy?: 'resourceBytes' | 'unusedBytes';
+    highlights?: Highlight[];
+  }
 
-    interface Node {
-      /** Could be a url, a path component from a source map, or an arbitrary string. */
-      name: string;
-      resourceBytes: number;
-      unusedBytes?: number;
-      /** If present, this module is a duplicate. String is normalized source path. See ModuleDuplication.normalizeSource */
-      duplicatedNormalizedModuleName?: string;
-      children?: Node[];
-    }
+  interface Node {
+    /** Could be a url, a path component from a source map, or an arbitrary string. */
+    name: string;
+    resourceBytes: number;
+    unusedBytes?: number;
+    /** If present, this module is a duplicate. String is normalized source path. See ModuleDuplication.normalizeSource */
+    duplicatedNormalizedModuleName?: string;
+    children?: Node[];
   }
 }
 
-// empty export to keep file a module
-export {}
+export default Treemap;


### PR DESCRIPTION
re: #12860

in the style of #12870, converts all the rest of our core `.d.ts` files to local import/export style with a single file for exposing on the global. No changes to js files here. `externs.d.ts` is the only remaining (core) file, left for a follow up because it's messier.

No changes to `.js` files in this one. [`?w=1`](https://github.com/GoogleChrome/lighthouse/pull/12880/files?w=1) to avoid having to wade through all the indentation changes, and the individual file conversions (and their side effects) are split up by commit.