### PR TITLE
report(build): create UMD bundle build

### DIFF
--- a/build/build-report.js
+++ b/build/build-report.js
@@ -69,11 +69,27 @@ async function buildEsModulesBundle() {
   });
 }
 
+async function buildUmdBundle() {
+  const bundle = await rollup.rollup({
+    input: 'report/clients/bundle.js',
+    plugins: [
+      commonjs(),
+    ],
+  });
+
+  await bundle.write({
+    file: 'dist/report/bundle-umd.js',
+    format: 'umd',
+    name: 'report',
+  });
+}
+
 if (require.main === module) {
   if (process.argv[2] === '--only-standalone') {
     buildStandaloneReport();
   } else {
     buildStandaloneReport();
+    buildUmdBundle();
     buildEsModulesBundle();
   }
 }
@@ -81,5 +97,6 @@ if (require.main === module) {
 module.exports = {
   buildStandaloneReport,
   buildPsiReport,
+  buildUmdBundle,
   buildTreemapReport,
 };

--- a/build/build-report.js
+++ b/build/build-report.js
@@ -64,7 +64,7 @@ async function buildEsModulesBundle() {
   });
 
   await bundle.write({
-    file: 'dist/report/bundle.js',
+    file: 'dist/report/bundle.esm.js',
     format: 'esm',
   });
 }
@@ -78,7 +78,7 @@ async function buildUmdBundle() {
   });
 
   await bundle.write({
-    file: 'dist/report/bundle-umd.js',
+    file: 'dist/report/bundle.umd.js',
     format: 'umd',
     name: 'report',
   });

--- a/lighthouse-core/scripts/roll-to-devtools.sh
+++ b/lighthouse-core/scripts/roll-to-devtools.sh
@@ -47,12 +47,12 @@ cp -pPR "$lh_bg_js" "$fe_lh_dir/lighthouse-dt-bundle.js"
 echo -e "$check lighthouse-dt-bundle copied."
 
 # generate bundle.d.ts
-cp dist/report/bundle.esm.js dist/report/bundle.js
-npx tsc --allowJs --declaration --emitDeclarationOnly dist/report/bundle.js
+npx tsc --allowJs --declaration --emitDeclarationOnly dist/report/bundle.esm.js
 
 # copy report code $fe_lh_dir
 fe_lh_report_dir="$fe_lh_dir/report/"
-cp dist/report/bundle.js dist/report/bundle.d.ts "$fe_lh_report_dir"
+cp dist/report/bundle.esm.js "$fe_lh_report_dir/bundle.js"
+cp dist/report/bundle.esm.d.ts "$fe_lh_report_dir/bundle.d.ts"
 echo -e "$check Report code copied."
 
 # copy report generator + cached resources into $fe_lh_dir

--- a/lighthouse-core/scripts/roll-to-devtools.sh
+++ b/lighthouse-core/scripts/roll-to-devtools.sh
@@ -47,6 +47,7 @@ cp -pPR "$lh_bg_js" "$fe_lh_dir/lighthouse-dt-bundle.js"
 echo -e "$check lighthouse-dt-bundle copied."
 
 # generate bundle.d.ts
+cp dist/report/bundle.esm.js dist/report/bundle.js
 npx tsc --allowJs --declaration --emitDeclarationOnly dist/report/bundle.js
 
 # copy report code $fe_lh_dir
@@ -71,5 +72,5 @@ fe_webtests_dir="$dt_dir/test/webtests/http/tests/devtools/lighthouse"
 rsync -avh "$lh_webtests_dir" "$fe_webtests_dir" --exclude="OWNERS" --delete
 
 echo ""
-echo "Done. To run the webtests: " 
+echo "Done. To run the webtests: "
 echo "    DEVTOOLS_PATH=\"$dt_dir\" yarn test-devtools"


### PR DESCRIPTION
We need a UMD bundle build of the report for PSI. The ESM bundle doesn't fly there. 

Also note that this build-report file is being adjusted in https://github.com/GoogleChrome/lighthouse/pull/12815/files. I'm assuming this PR here will land first before 12815, and i'll rebase that one.