### PR TITLE
core(fr): parity on Stacks and FullPageSnapshot gatherers

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -106,7 +106,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - name: yarn smoke --fraggle-rock
-      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=1 --retries=2 a11y lantern seo-passing seo-failing csp metrics perf-debug
+      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=1 --retries=2 a11y lantern seo-passing seo-failing csp metrics perf-debug dbw
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -11,6 +11,10 @@
  */
 const expectations = {
   networkRequests: {
+    // Number of network requests differs between Fraggle Rock and legacy modes because
+    // FR has fewer passes, preserve this check in legacy mode only.
+    _legacyOnly: true,
+
     // 50 requests made for normal page testing.
     // 6 extra requests made because stylesheets are evicted from the cache by the time DT opens.
     // 3 extra requests made to /dobetterweb/clock.appcache
@@ -191,43 +195,40 @@ const expectations = {
       'errors-in-console': {
         score: 0,
         details: {
-          items: [
-            {
+          items: {
+            0: {
               source: 'other',
               description: 'Application Cache Error event: Manifest fetch failed (404) http://localhost:10200/dobetterweb/clock.appcache',
               url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
             },
-            {
+            1: {
               source: 'exception',
               description: /^Error: A distinctive error\s+at http:\/\/localhost:10200\/dobetterweb\/dbw_tester.html:\d+:\d+$/,
               url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
             },
-            {
+            2: {
               source: 'console.error',
               description: 'Error! Error!',
               url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
             },
-            {
+            3: {
               source: 'network',
               description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
               url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
             },
-            {
+            4: {
               source: 'network',
               description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
               url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
             },
-            {
+            5: {
               source: 'network',
               description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
               url: 'http://localhost:10200/favicon.ico',
             },
-            {
-              source: 'network',
-              description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-              url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-            },
-          ],
+            // In legacy Lighthouse this audit will have additional duplicate failures which are a mistake.
+            // Fraggle Rock ordering of gatherer `stopInstrumentation` and `getArtifact` fixes the re-request issue.
+          },
         },
       },
       'is-on-https': {
@@ -418,8 +419,19 @@ const expectations = {
             data: /^data:image\/jpeg;.{500,}/,
           },
           nodes: {
+            // Test that the numbers for individual elements are in the ballpark.
+            // Exact ordering and IDs between FR and legacy differ, so fork the expectations.
             'page-0-IMG': {
-              // Test that these are numbers and in the ballpark.
+              _legacyOnly: true,
+              top: '650±50',
+              bottom: '650±50',
+              left: '10±10',
+              right: '120±20',
+              width: '120±20',
+              height: '20±20',
+            },
+            'page-2-IMG': {
+              _fraggleRockOnly: true,
               top: '650±50',
               bottom: '650±50',
               left: '10±10',

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -12,13 +12,13 @@
 const expectations = {
   networkRequests: {
     // Number of network requests differs between Fraggle Rock and legacy modes because
-    // FR has fewer passes, preserve this check in legacy mode only.
-    _legacyOnly: true,
+    // FR has fewer passes, preserve this check moving forward.
+    _fraggleRockOnly: true,
 
-    // 50 requests made for normal page testing.
+    // 22 requests made for a single navigation.
     // 6 extra requests made because stylesheets are evicted from the cache by the time DT opens.
-    // 3 extra requests made to /dobetterweb/clock.appcache
-    length: 59,
+    // 1 request made to /dobetterweb/clock.appcache
+    length: 29,
   },
   artifacts: {
     HostFormFactor: 'desktop',

--- a/lighthouse-core/fraggle-rock/config/default-config.js
+++ b/lighthouse-core/fraggle-rock/config/default-config.js
@@ -158,7 +158,6 @@ const defaultConfig = {
         artifacts.EmbeddedContent,
         artifacts.FontSize,
         artifacts.FormElements,
-        artifacts.FullPageScreenshot,
         artifacts.GatherContext,
         artifacts.GlobalListeners,
         artifacts.IFrameElements,
@@ -187,6 +186,9 @@ const defaultConfig = {
         // Compat artifacts come last.
         artifacts.devtoolsLogs,
         artifacts.traces,
+
+        // FullPageScreenshot comes at the very end so all other node analysis is captured.
+        artifacts.FullPageScreenshot,
       ],
     },
   ],

--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -22,6 +22,8 @@
 
 /** @typedef {LH.Gatherer.FRTransitionalContext<LH.Gatherer.DependencyKey>['dependencies']} Dependencies */
 
+const log = require('lighthouse-logger');
+
 /**
  *
  * @param {{id: string}} dependency
@@ -75,6 +77,8 @@ async function collectPhaseArtifacts(options) {
   const priorPhaseArtifacts = (priorPhase && artifactState[priorPhase]) || {};
 
   for (const artifactDefn of artifactDefinitions) {
+    const logLevel = phase === 'getArtifact' ? 'log' : 'verbose';
+    log[logLevel](`artifacts:${phase}`, artifactDefn.id);
     const gatherer = artifactDefn.gatherer.instance;
 
     const priorArtifactPromise = priorPhaseArtifacts[artifactDefn.id] || Promise.resolve();

--- a/lighthouse-core/gather/gatherers/stacks.js
+++ b/lighthouse-core/gather/gatherers/stacks.js
@@ -120,7 +120,7 @@ class Stacks extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} context
    * @return {Promise<LH.Artifacts['Stacks']>}
    */
-  async snapshot(context) {
+  async getArtifact(context) {
     return Stacks.collectStacks(context.driver.executionContext);
   }
 }

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -24,7 +24,7 @@ declare global {
     export type ExpectedRunnerResult = {
       lhr: ExpectedLHR,
       artifacts?: Partial<Record<keyof Artifacts|'_maxChromiumMilestone'|'_minChromiumMilestone', any>>
-      networkRequests?: {length: number};
+      networkRequests?: {length: number, _legacyOnly?: boolean};
     }
 
     export interface TestDfn {

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -24,7 +24,7 @@ declare global {
     export type ExpectedRunnerResult = {
       lhr: ExpectedLHR,
       artifacts?: Partial<Record<keyof Artifacts|'_maxChromiumMilestone'|'_minChromiumMilestone', any>>
-      networkRequests?: {length: number, _legacyOnly?: boolean};
+      networkRequests?: {length: number, _legacyOnly?: boolean, _fraggleRockOnly?: boolean};
     }
 
     export interface TestDfn {


### PR DESCRIPTION
**Summary**
Achieves parity with legacy runner on Stacks gatherer and FullPageSnapshot gatherer (the two necessary to match results on the dobetterweb smoketest). This also adds the ability to target assertions to the legacy or FR runner in smoketests to account for irreconcilable differences like fewer passes and extra contexts that change the ID of certain artifacts.

**Related Issues/PRs**
ref #12861 #11313 
