### PR TITLE
deps: update to typescript@4.4.1-rc

### DIFF
--- a/lighthouse-core/config/config-helpers.js
+++ b/lighthouse-core/config/config-helpers.js
@@ -20,12 +20,12 @@ const i18n = require('../lib/i18n/i18n.js');
  * If any items with identical `path` properties are found in the input array,
  * merge their `options` properties into the first instance and then discard any
  * other instances.
- * Until support of jsdoc templates with constraints, type in config.d.ts.
- * See https://github.com/Microsoft/TypeScript/issues/24283
- * @type {LH.Config.MergeOptionsOfItems}
+ * @template {{path?: string, options: Record<string, unknown>}} T
+ * @param {T[]} items
+ * @return T[]
  */
 const mergeOptionsOfItems = function(items) {
-  /** @type {Array<{id: string, path?: string, options?: Object<string, any>}>} */
+  /** @type {T[]} */
   const mergedItems = [];
 
   for (const item of items) {

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -205,7 +205,7 @@ function gatherTapTargets(tapTargetsSelector, className) {
 
   /** @type {{
     tapTargetElement: Element,
-    clientRects: ClientRect[]
+    clientRects: LH.Artifacts.Rect[]
   }[]} */
   const tapTargetsWithClientRects = [];
   tapTargetElements.forEach(tapTargetElement => {
@@ -238,7 +238,7 @@ function gatherTapTargets(tapTargetsSelector, className) {
 
   /** @type {{
     tapTargetElement: Element,
-    visibleClientRects: ClientRect[]
+    visibleClientRects: LH.Artifacts.Rect[]
   }[]} */
   const tapTargetsWithVisibleClientRects = [];
   // We use separate loop here to get visible client rects because that involves

--- a/lighthouse-core/lib/cdt/SDK.js
+++ b/lighthouse-core/lib/cdt/SDK.js
@@ -46,6 +46,7 @@ SDK.TextSourceMap.prototype.mappings = function() {
 };
 
 const originalReversedMappings = SDK.TextSourceMap.prototype._reversedMappings;
+/** @param {string} sourceURL */
 SDK.TextSourceMap.prototype._reversedMappings = function(sourceURL) {
   const mappings = originalReversedMappings.call(this, sourceURL);
   extendArray(mappings);

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -90,10 +90,16 @@ function computeDescription(ast, message) {
 
 /**
  * Collapses a jsdoc comment into a single line and trims whitespace.
- * @param {string=} comment
+ * @param {import('typescript').JSDoc['comment']} comment
  * @return {string}
  */
 function coerceToSingleLineAndTrim(comment = '') {
+  // The non-string types were introduced in https://github.com/microsoft/TypeScript/pull/41877
+  // Not currently used, but utility `getTextOfJSDocComment` will convert if the types switch over.
+  if (typeof comment !== 'string') {
+    throw new Error(`unsupported JSDoc comment: ${JSON.stringify(comment)}`);
+  }
+
   // Line breaks within a jsdoc comment should always be replaceable with a space.
   return comment.replace(/\n+/g, ' ').trim();
 }

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -197,11 +197,13 @@ export class LighthouseReportViewer {
   _replaceReportHtml(json) {
     // Allow users to view the runnerResult
     if ('lhr' in json) {
-      json = /** @type {LH.RunnerResult} */ (json).lhr;
+      const runnerResult = /** @type {LH.RunnerResult} */ (/** @type {unknown} */ (json));
+      json = runnerResult.lhr;
     }
     // Allow users to drop in PSI's json
     if ('lighthouseResult' in json) {
-      json = /** @type {{lighthouseResult: LH.Result}} */ (json).lighthouseResult;
+      const psiResp = /** @type {{lighthouseResult: LH.Result}} */ (/** @type {unknown} */ (json));
+      json = psiResp.lighthouseResult;
     }
 
     // Install as global for easier debugging

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "tabulator-tables": "^4.9.3",
     "terser": "^5.3.8",
     "typed-query-selector": "^2.4.0",
-    "typescript": "4.2.3",
+    "typescript": "4.3.5",
     "webtreemap-cdt": "^3.2.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -97,10 +97,9 @@
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@types/archiver": "^2.1.2",
     "@types/browserify": "^12.0.36",
-    "@types/chrome": "^0.0.60",
+    "@types/chrome": "^0.0.154",
     "@types/configstore": "^4.0.0",
     "@types/cpy": "^5.1.0",
-    "@types/css-font-loading-module": "^0.0.2",
     "@types/eslint": "^4.16.6",
     "@types/exorcist": "^0.4.5",
     "@types/gh-pages": "^2.0.0",
@@ -164,7 +163,7 @@
     "tabulator-tables": "^4.9.3",
     "terser": "^5.3.8",
     "typed-query-selector": "^2.4.0",
-    "typescript": "4.3.5",
+    "typescript": "4.4.1-rc",
     "webtreemap-cdt": "^3.2.1"
   },
   "dependencies": {

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -442,7 +442,7 @@ export class ReportUIFeatures {
           });
         }
       }
-    } catch (/** @type {Error} */ e) {
+    } catch (e) {
       this._copyAttempt = false;
       this._fireEventOn('lh-log', this._document, {cmd: 'log', msg: e.message});
     }
@@ -491,7 +491,7 @@ export class ReportUIFeatures {
         const htmlStr = this.getReportHtml();
         try {
           this._saveFile(new Blob([htmlStr], {type: 'text/html'}));
-        } catch (/** @type {Error} */ e) {
+        } catch (e) {
           this._fireEventOn('lh-log', this._document, {
             cmd: 'error', msg: 'Could not export as HTML. ' + e.message,
           });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "checkJs": true,
     "strict": true,
-    // TODO: turn this off to be fully `strict`.
+    // TODO: remove the next line to be fully `strict`.
     "useUnknownInCatchVariables": false,
     // "listFiles": true,
     // "noErrorTruncation": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "allowJs": true,
     "checkJs": true,
     "strict": true,
+    // TODO: turn this off to be fully `strict`.
+    "useUnknownInCatchVariables": false,
     // "listFiles": true,
     // "noErrorTruncation": true,
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -230,8 +230,6 @@ declare module Config {
     groups?: Record<string, Config.GroupJson>;
   }
 
-  type MergeOptionsOfItems = <T extends {path?: string, options: Record<string, any>}>(items: T[]) => T[];
-
   type Merge = {
     <T extends Record<string, any>, U extends Record<string, any>>(base: T|null|undefined, extension: U, overwriteArrays?: boolean): T & U;
     <T extends Array<any>, U extends Array<any>>(base: T|null|undefined, extension: T, overwriteArrays?: boolean): T & U;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8287,10 +8287,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 uglify-js@^3.1.4:
   version "3.4.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -868,12 +868,13 @@
     "@types/insert-module-globals" "*"
     "@types/node" "*"
 
-"@types/chrome@^0.0.60":
-  version "0.0.60"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.60.tgz#058eed1587b7aec3b83d4be905c8758ea145ba84"
-  integrity sha512-65L5afQNd7yZMW3zNsz4otId8+8wsD2UQM3iz4gnni3tiKo+UDGIbvCf91txakxB6KLTk7HTTeIbxViuIg6TMw==
+"@types/chrome@^0.0.154":
+  version "0.0.154"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.154.tgz#7992e97364f4447e961028ad07ac843d0b052c2d"
+  integrity sha512-6QmP744MeMUZUIUHED4d4L2la5dIF1e6bcrkGF4yGQTyO94ER+r++Ss165wkzA5cAGUYt8kToDa6L9xtNqVMxg==
   dependencies:
     "@types/filesystem" "*"
+    "@types/har-format" "*"
 
 "@types/configstore@*", "@types/configstore@^4.0.0":
   version "4.0.0"
@@ -899,11 +900,6 @@
   dependencies:
     "@types/cp-file" "*"
     "@types/glob" "*"
-
-"@types/css-font-loading-module@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@types/css-font-loading-module/-/css-font-loading-module-0.0.2.tgz#09f1f1772975777e37851b7b7a4389d97c210add"
-  integrity sha512-zZTq/B1ZcJMepOfBIMEwOZ/g/jpSPUJoxP8zPtPizOKE/Q89SujK1BLYZBg+4LLW3IzJGOI67dbeePy8uPUs+g==
 
 "@types/eslint@^4.16.6":
   version "4.16.6"
@@ -931,16 +927,16 @@
     "@types/through" "*"
 
 "@types/filesystem@*":
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.28.tgz#3fd7735830f2c7413cb5ac45780bc45904697b0e"
-  integrity sha1-P9dzWDDyx0E8taxFeAvEWQRpew4=
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.32.tgz#307df7cc084a2293c3c1a31151b178063e0a8edf"
+  integrity sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==
   dependencies:
     "@types/filewriter" "*"
 
 "@types/filewriter@*":
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.28.tgz#c054e8af4d9dd75db4e63abc76f885168714d4b3"
-  integrity sha1-wFTor02d11205jq8dviFFocU1LM=
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.29.tgz#a48795ecadf957f6c0d10e0c34af86c098fa5bee"
+  integrity sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==
 
 "@types/gh-pages@^2.0.0":
   version "2.0.0"
@@ -967,6 +963,11 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
+
+"@types/har-format@*":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.7.tgz#debfe36378f26c4fc2abca1df99f00a8ff94fd29"
+  integrity sha512-/TPzUG0tJn5x1TUcVLlDx2LqbE58hyOzDVAc9kf8SpOEmguHjU6bKUyfqb211AdqLOmU/SNyXvLKPNP5qTlfRw==
 
 "@types/insert-module-globals@*":
   version "7.0.0"
@@ -8287,10 +8288,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@4.4.1-rc:
+  version "4.4.1-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.1-rc.tgz#f75f17985a2329a94fd911b3ef2e619c33636fa0"
+  integrity sha512-SYdeKrJiOajqNTI+sweR70JET43Z567HFNo7DvvBof8J5/bt2cywy7VoWXqZyrsHEmQ9foraLtLr30mcfpfz9w==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
I was doing an update to 4.3.5 when the 4.4 release candidate came out. The [4.4 perf improvements](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-rc/#perf-improvements) really help with the continuing split up of tsconfigs, so it would be nice to land now.

The fixes needed in existing code are kind of random but are each a reasonable change.