### PR TITLE
misc(build): do not include locales in devtools bundle

### DIFF
--- a/build/build-lightrider-bundles.js
+++ b/build/build-lightrider-bundles.js
@@ -40,7 +40,7 @@ function buildReportGenerator() {
   browserify(generatorFilename, {standalone: 'ReportGenerator'})
     // Transform the fs.readFile etc into inline strings.
     .transform('@wardpeet/brfs', {
-      readFileSyncTransform: minifyFileTransform,
+      readFileTransform: minifyFileTransform,
       global: true,
       parserOpts: {ecmaVersion: 12},
     })

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -20,7 +20,7 @@ async function run() {
   const generatorFilename = `${LH_ROOT}/report/report-generator.js`;
   const generatorBrowserify = browserify(generatorFilename, {standalone: 'ReportGenerator'})
     .transform('@wardpeet/brfs', {
-      readFileSyncTransform: minifyFileTransform,
+      readFileTransform: minifyFileTransform,
     });
 
   /** @type {Promise<string>} */


### PR DESCRIPTION
this also fixes brfs readFileTransform... `readFileSyncTransform` is not an option. Not sure how the PRs that I made introducing this recorded byte savings ... 😄 

fixes #12919