### PR TITLE
report: use postMessage to open viewer outside devtools

### DIFF
--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -500,7 +500,7 @@ export class ReportUIFeatures {
         } else {
           const windowName = 'viewer-' + ReportUIFeatures.computeWindowNameSuffix(this.json);
           const url = getAppsOrigin() + '/viewer/';
-          ReportUIFeatures.openTabWithUrlData({lhr: this.json}, url, windowName);
+          ReportUIFeatures.openTabAndSendData({lhr: this.json}, url, windowName);
         }
         break;
       }


### PR DESCRIPTION
This was using the wrong method. The intention was to use postMessage outside devtools.