### PR TITLE
tests(ci): temporarily use a fixed version of ToT Chromium

### DIFF
--- a/lighthouse-core/scripts/download-chrome.sh
+++ b/lighthouse-core/scripts/download-chrome.sh
@@ -10,10 +10,14 @@
 
 set -euo pipefail
 
+# Hardcode 19 August 2021 URLs to download until
+# https://github.com/GoogleChrome/lighthouse/issues/12942 is resolved.
 if [ "$OSTYPE" == "msys" ]; then
-  url="https://download-chromium.appspot.com/dl/Win?type=snapshots"
+  # url="https://download-chromium.appspot.com/dl/Win?type=snapshots"
+  url="https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win/refs_heads_main-913406/chrome-win.zip"
 else
-  url="https://download-chromium.appspot.com/dl/Linux_x64?type=snapshots"
+  # url="https://download-chromium.appspot.com/dl/Linux_x64?type=snapshots"
+  url="https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/refs_heads_main-913453/chrome-linux.zip"
 fi
 
 if [ -e "$CHROME_PATH" ]; then


### PR DESCRIPTION
Unblocks CI until the underlying issue of #12942 is fixed

Hopefully we won't have to do this for long.