### PR TITLE
new_audit(document compatibility check for quirks mode):  added

### DIFF
--- a/lighthouse-core/audits/dobetterweb/doctype.js
+++ b/lighthouse-core/audits/dobetterweb/doctype.js
@@ -3,28 +3,31 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-'use strict';
+"use strict";
 
-const Audit = require('../audit.js');
-const i18n = require('../../lib/i18n/i18n.js');
+const Audit = require("../audit.js");
+const i18n = require("../../lib/i18n/i18n.js");
 
 const UIStrings = {
   /** Title of a Lighthouse audit that provides detail on the doctype of a page. This descriptive title is shown to users when the pages's doctype is set to HTML. */
-  title: 'Page has the HTML doctype',
+  title: "Page has the HTML doctype",
   /** Title of a Lighthouse audit that provides detail on the doctype of a page. This descriptive title is shown to users when the page's doctype is not set to HTML. */
-  failureTitle: 'Page lacks the HTML doctype, thus triggering quirks-mode',
+  failureTitle: "Page lacks the HTML doctype, thus triggering quirks-mode",
   /** Description of a Lighthouse audit that tells the user why they should define an HTML doctype. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
-  description: 'Specifying a doctype prevents the browser ' +
-    'from switching to quirks-mode. ' +
-    '[Learn more](https://web.dev/doctype/).',
+  description:
+    "Specifying a doctype prevents the browser " +
+    "from switching to quirks-mode. " +
+    "[Learn more](https://web.dev/doctype/).",
   /** Explanatory message stating that the document has no doctype. */
-  explanationNoDoctype: 'Document must contain a doctype',
+  explanationNoDoctype: "Document must contain a doctype",
   /** Explanatory message stating that the publicId field is not empty. */
-  explanationPublicId: 'Expected publicId to be an empty string',
+  explanationPublicId: "Expected publicId to be an empty string",
   /** Explanatory message stating that the systemId field is not empty. */
-  explanationSystemId: 'Expected systemId to be an empty string',
+  explanationSystemId: "Expected systemId to be an empty string",
+  /** Explanatory message stating that the doctype statement is incorrect. */
+  explanationWrongDoctype: "Doctype statement is incorrect",
   /** Explanatory message stating that the doctype is set, but is not "html" and is therefore invalid. */
-  explanationBadDoctype: 'Doctype name must be the lowercase string `html`',
+  explanationBadDoctype: "Doctype name must be the lowercase string `html`",
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -35,11 +38,11 @@ class Doctype extends Audit {
    */
   static get meta() {
     return {
-      id: 'doctype',
+      id: "doctype",
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      requiredArtifacts: ['Doctype'],
+      requiredArtifacts: ["Doctype"],
     };
   }
 
@@ -60,24 +63,34 @@ class Doctype extends Audit {
     const doctypePublicId = artifacts.Doctype.publicId;
     const doctypeSystemId = artifacts.Doctype.systemId;
 
-    if (doctypePublicId !== '') {
+    if (doctypePublicId !== "") {
       return {
         score: 0,
         explanation: str_(UIStrings.explanationPublicId),
       };
     }
 
-    if (doctypeSystemId !== '') {
+    if (doctypeSystemId !== "") {
       return {
         score: 0,
         explanation: str_(UIStrings.explanationSystemId),
+      };
+    }
+    /* 
+      Document compatibility mode check for quirk mode
+    */
+    if (document.compatMode == "BackCompat") {
+      // means it's in quirk mode
+      return {
+        score: 0,
+        explanation: str_(UIStrings.explanationWrongDoctype),
       };
     }
 
     /* Note that the value for name is case sensitive,
        and must be the string `html`. For details see:
        https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode */
-    if (doctypeName === 'html') {
+    if (doctypeName === "html") {
       return {
         score: 1,
       };


### PR DESCRIPTION
**Summary**
<!-- What kind of change does this PR introduce? -->
**Type of PR**
Additional condition checking


<!-- Describe the need for this change -->
**Need for change**
Lighthouse overlooked compatibility check for `quirks mode` in case of incorrect doctype. I added an additional check for compatibility with an additional explanation message `explanationWrongDoctype` in UIStrings.

![Screenshot (169)](https://user-images.githubusercontent.com/54969439/130140955-ada5eb35-ee26-4b33-813e-db82fb1125a5.png)

![Screenshot (168)](https://user-images.githubusercontent.com/54969439/130140973-66a36dbc-08cf-41ed-8549-497d656df45e.png)


<!-- Link any documentation or information that would help understand this change -->
**Documentation**
I looked at this: [compatMode](https://developer.mozilla.org/en-US/docs/Web/API/Document/compatMode) MDN doc for more information about compatibility check.

**Related Issues/PRs**
PR to fix the issue no: #10030 

**And sorry for the extra changes my IDE automatically converted single quotes into double quotes**