### PR TITLE
report: extract independent report types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,8 @@
 'use strict';
 
 module.exports = {
+  // All subdirectory eslintrcs extend from this one.
+  root: true,
   // start with google standard style
   //     https://github.com/google/eslint-config-google/blob/master/index.js
   extends: ['eslint:recommended', 'google'],

--- a/clients/.eslintrc.js
+++ b/clients/.eslintrc.js
@@ -6,7 +6,6 @@
 'use strict';
 
 module.exports = {
-  extends: '../.eslintrc.js',
   env: {
     browser: true,
   },

--- a/lighthouse-core/util-commonjs.js
+++ b/lighthouse-core/util-commonjs.js
@@ -391,7 +391,7 @@ class Util {
   }
 
   /**
-   * @param {LH.Config.Settings} settings
+   * @param {LH.Result['configSettings']} settings
    * @return {!Array<{name: string, description: string}>}
    */
   static getEnvironmentDisplayValues(settings) {
@@ -414,7 +414,7 @@ class Util {
   }
 
   /**
-   * @param {LH.Config.Settings} settings
+   * @param {LH.Result['configSettings']} settings
    * @return {{deviceEmulation: string, networkThrottling: string, cpuThrottling: string}}
    */
   static getEmulationDescriptions(settings) {

--- a/lighthouse-treemap/types/treemap.d.ts
+++ b/lighthouse-treemap/types/treemap.d.ts
@@ -1,6 +1,9 @@
 import {Logger as _Logger} from '../../report/renderer/logger.js';
 import {FirebaseNamespace} from '@firebase/app-types';
 
+// Import for needed DOM type augmentation.
+import '../../report/types/augment-dom';
+
 declare global {
   class WebTreeMap {
     constructor(data: any, options: WebTreeMapOptions);
@@ -45,5 +48,3 @@ declare global {
     signal?: AbortSignal;
   }
 }
-
-export {};

--- a/lighthouse-viewer/types/viewer.d.ts
+++ b/lighthouse-viewer/types/viewer.d.ts
@@ -5,16 +5,13 @@
  */
 
 import _ReportGenerator = require('../../report/generator/report-generator.js');
-import {DOM as _DOM} from '../../report/renderer/dom.js';
-import {ReportRenderer as _ReportRenderer} from '../../report/renderer/report-renderer.js';
-import {ReportUIFeatures as _ReportUIFeatures} from '../../report/renderer/report-ui-features.js';
 import {Logger as _Logger} from '../../report/renderer/logger.js';
-import {TextEncoding as _TextEncoding} from '../../report/renderer/text-encoding.js';
 import {LighthouseReportViewer as _LighthouseReportViewer} from '../app/src/lighthouse-report-viewer.js';
-import 'google.analytics';
 import {FirebaseNamespace} from '@firebase/app-types';
-import '@firebase/auth-types';
+import _ReportResult from '../../report/types/report-result';
 
+// Import for needed DOM type augmentation.
+import '../../report/types/augment-dom';
 
 declare global {
   var ReportGenerator: typeof _ReportGenerator;
@@ -29,7 +26,9 @@ declare global {
     // Inserted by viewer build.
     LH_CURRENT_VERSION: string;
   }
+  
+  // Expose global types in LH namespace.
+  module LH {
+    export import ReportResult = _ReportResult;
+  }
 }
-
-// empty export to keep file a module
-export {}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "dogfood-lhci": "./lighthouse-core/scripts/dogfood-lhci.sh",
     "timing-trace": "node lighthouse-core/scripts/generate-timing-trace.js",
     "changelog": "conventional-changelog --config ./build/changelog-generator/index.js --infile changelog.md --same-file",
-    "type-check": "tsc -b . && tsc -p lighthouse-viewer/ && tsc -p lighthouse-treemap/ && tsc -p flow-report/",
+    "type-check": "tsc -b . && tsc -b report/ && tsc -p lighthouse-viewer/ && tsc -p lighthouse-treemap/ && tsc -p flow-report/",
     "i18n:checks": "./lighthouse-core/scripts/i18n/assert-strings-collected.sh",
     "i18n:collect-strings": "node lighthouse-core/scripts/i18n/collect-strings.js",
     "update:lantern-baseline": "node lighthouse-core/scripts/lantern/update-baseline-lantern-values.js",

--- a/report/.eslintrc.cjs
+++ b/report/.eslintrc.cjs
@@ -1,9 +1,15 @@
 /**
- * @license Copyright 2017 The Lighthouse Authors. All Rights Reserved.
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 'use strict';
+
+/**
+ * eslint does not support ESM rc files, so this must be a .cjs file.
+ * @see https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats
+ * @see https://github.com/eslint/eslint/issues/13481
+ */
 
 module.exports = {
   env: {

--- a/report/clients/psi.js
+++ b/report/clients/psi.js
@@ -24,8 +24,6 @@ import {PerformanceCategoryRenderer} from '../renderer/performance-category-rend
 import {ReportUIFeatures} from '../renderer/report-ui-features.js';
 import {Util} from '../renderer/util.js';
 
-/* global window */
-
 /** @typedef {{scoreGaugeEl: Element, perfCategoryEl: Element, finalScreenshotDataUri: string|null, scoreScaleEl: Element, installFeatures: Function}} PrepareLabDataResult */
 
 /**

--- a/report/clients/standalone.js
+++ b/report/clients/standalone.js
@@ -11,7 +11,7 @@
  * The renderer code is bundled and injected into the report HTML along with the JSON report.
  */
 
-/* global document window ga */
+/* global ga */
 
 import {DOM} from '../renderer/dom.js';
 import {Logger} from '../renderer/logger.js';

--- a/report/renderer/details-renderer.js
+++ b/report/renderer/details-renderer.js
@@ -35,7 +35,7 @@ const URL_PREFIXES = ['http://', 'https://', 'data:'];
 export class DetailsRenderer {
   /**
    * @param {DOM} dom
-   * @param {{fullPageScreenshot?: LH.Artifacts.FullPageScreenshot}} [options]
+   * @param {{fullPageScreenshot?: LH.Audit.Details.FullPageScreenshot}} [options]
    */
   constructor(dom, options = {}) {
     this._dom = dom;

--- a/report/renderer/element-screenshot-renderer.js
+++ b/report/renderer/element-screenshot-renderer.js
@@ -12,7 +12,7 @@
  */
 
 /** @typedef {import('./dom.js').DOM} DOM */
-/** @typedef {LH.Artifacts.Rect} Rect */
+/** @typedef {LH.Audit.Details.Rect} Rect */
 /** @typedef {{width: number, height: number}} Size */
 
 /**
@@ -20,13 +20,13 @@
  * @property {DOM} dom
  * @property {Element} reportEl
  * @property {Element} overlayContainerEl
- * @property {LH.Artifacts.FullPageScreenshot} fullPageScreenshot
+ * @property {LH.Audit.Details.FullPageScreenshot} fullPageScreenshot
  */
 
 import {Util} from './util.js';
 
 /**
- * @param {LH.Artifacts.FullPageScreenshot['screenshot']} screenshot
+ * @param {LH.Audit.Details.FullPageScreenshot['screenshot']} screenshot
  * @param {LH.Audit.Details.Rect} rect
  * @return {boolean}
  */
@@ -98,7 +98,7 @@ export class ElementScreenshotRenderer {
    * @param {DOM} dom
    * @param {HTMLElement} maskEl
    * @param {{left: number, top: number}} positionClip
-   * @param {LH.Artifacts.Rect} elementRect
+   * @param {Rect} elementRect
    * @param {Size} elementPreviewSize
    */
   static renderClipPathInScreenshot(dom, maskEl, positionClip, elementRect, elementPreviewSize) {
@@ -132,7 +132,7 @@ export class ElementScreenshotRenderer {
    * Allows for multiple Lighthouse reports to be rendered on the page, each with their
    * own full page screenshot.
    * @param {HTMLElement} el
-   * @param {LH.Artifacts.FullPageScreenshot['screenshot']} screenshot
+   * @param {LH.Audit.Details.FullPageScreenshot['screenshot']} screenshot
    */
   static installFullPageScreenshot(el, screenshot) {
     el.style.setProperty('--element-screenshot-url', `url(${screenshot.data})`);
@@ -195,7 +195,7 @@ export class ElementScreenshotRenderer {
   /**
    * Given the size of the element in the screenshot and the total available size of our preview container,
    * compute the factor by which we need to zoom out to view the entire element with context.
-   * @param {LH.Artifacts.Rect} elementRectSC
+   * @param {Rect} elementRectSC
    * @param {Size} renderContainerSizeDC
    * @return {number}
    */
@@ -214,8 +214,8 @@ export class ElementScreenshotRenderer {
    * Used to render both the thumbnail preview in details tables and the full-page screenshot in the lightbox.
    * Returns null if element rect is outside screenshot bounds.
    * @param {DOM} dom
-   * @param {LH.Artifacts.FullPageScreenshot['screenshot']} screenshot
-   * @param {LH.Artifacts.Rect} elementRectSC Region of screenshot to highlight.
+   * @param {LH.Audit.Details.FullPageScreenshot['screenshot']} screenshot
+   * @param {Rect} elementRectSC Region of screenshot to highlight.
    * @param {Size} maxRenderSizeDC e.g. maxThumbnailSize or maxLightboxSize.
    * @return {Element|null}
    */

--- a/report/renderer/logger.js
+++ b/report/renderer/logger.js
@@ -40,7 +40,7 @@ export class Logger {
     this.el.textContent = msg;
     this.el.classList.add('show');
     if (autoHide) {
-      this._id = setTimeout(_ => {
+      this._id = setTimeout(() => {
         this.el.classList.remove('show');
       }, 7000);
     }
@@ -61,7 +61,7 @@ export class Logger {
 
     // Rethrow to make sure it's auditable as an error, but in a setTimeout so page
     // recovers gracefully and user can try loading a report again.
-    setTimeout(_ => {
+    setTimeout(() => {
       throw new Error(msg);
     }, 0);
   }

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -705,7 +705,7 @@ export class ReportUIFeatures {
 
     // cleanup.
     this._document.body.removeChild(a);
-    setTimeout(_ => URL.revokeObjectURL(a.href), 500);
+    setTimeout(() => URL.revokeObjectURL(a.href), 500);
   }
 
   /**

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -16,8 +16,6 @@
  */
 'use strict';
 
-/* eslint-env browser */
-
 /**
  * @fileoverview Adds tools button, print, and other dynamic functionality to
  * the report.

--- a/report/renderer/text-encoding.js
+++ b/report/renderer/text-encoding.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* global btoa atob window CompressionStream Response */
+/* global CompressionStream */
 
 const btoa_ = typeof btoa !== 'undefined' ?
   btoa :

--- a/report/renderer/util.js
+++ b/report/renderer/util.js
@@ -388,7 +388,7 @@ export class Util {
   }
 
   /**
-   * @param {LH.Config.Settings} settings
+   * @param {LH.Result['configSettings']} settings
    * @return {!Array<{name: string, description: string}>}
    */
   static getEnvironmentDisplayValues(settings) {
@@ -411,7 +411,7 @@ export class Util {
   }
 
   /**
-   * @param {LH.Config.Settings} settings
+   * @param {LH.Result['configSettings']} settings
    * @return {{deviceEmulation: string, networkThrottling: string, cpuThrottling: string}}
    */
   static getEmulationDescriptions(settings) {

--- a/report/test-assets/faux-psi.js
+++ b/report/test-assets/faux-psi.js
@@ -7,8 +7,6 @@
 
 /** @fileoverview This file is a glorified call of prepareLabData. */
 
-/* global document window */
-
 /** @typedef {import('../clients/psi.js').PrepareLabDataResult} PrepareLabDataResult */
 
 (async function __initPsiReports__() {

--- a/report/test/renderer/category-renderer-test.js
+++ b/report/test/renderer/category-renderer-test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* eslint-env jest, browser */
+/* eslint-env jest */
 
 import {strict as assert} from 'assert';
 

--- a/report/test/renderer/performance-category-renderer-test.js
+++ b/report/test/renderer/performance-category-renderer-test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* eslint-env jest, browser */
+/* eslint-env jest */
 
 import {strict as assert} from 'assert';
 

--- a/report/test/renderer/pwa-category-renderer-test.js
+++ b/report/test/renderer/pwa-category-renderer-test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* eslint-env jest, browser */
+/* eslint-env jest */
 
 import {strict as assert} from 'assert';
 

--- a/report/tsconfig.json
+++ b/report/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "../.tmp/tsbuildinfo/report",
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+
+    // Limit to base JS and DOM defs.
+    "lib": ["es2020", "dom", "dom.iterable"],
+    // Include `@types/node` for use of `Buffer` in text-encoding.js.
+    "types": ["node"],
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
+
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    // TODO: remove the next line to be fully `strict`.
+    "useUnknownInCatchVariables": false,
+
+    // "listFiles": true,
+    // "noErrorTruncation": true,
+    "extendedDiagnostics": true,
+  },
+  "include": [
+    "**/*.js",
+    "types/**/*.d.ts",
+  ],
+  "references": [
+    {"path": "../types/lhr/"},
+    {"path": "./generator/"}
+  ],
+  "exclude": [
+    "generator/**/*.js",
+    // These test files require further changes before they can be type checked.
+    "test/**/*.js",
+  ],
+}

--- a/report/tsconfig.json
+++ b/report/tsconfig.json
@@ -7,8 +7,8 @@
 
     // Limit to base JS and DOM defs.
     "lib": ["es2020", "dom", "dom.iterable"],
-    // Include `@types/node` for use of `Buffer` in text-encoding.js.
-    "types": ["node"],
+    // Don't include any node_module types.
+    "types": [],
     "target": "es2020",
     "module": "es2020",
     "moduleResolution": "node",

--- a/report/types/augment-dom.d.ts
+++ b/report/types/augment-dom.d.ts
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * @fileoverview Augment global scope with needed DOM APIs that are newer or not
+ * widely supported enough to be in tsc's lib `dom`.
+ */
+
+// Import to augment querySelector/querySelectorAll with stricter type checking.
+import '../../types/query-selector';
+
+declare global {
+  var CompressionStream: {
+    prototype: CompressionStream,
+    new (format: string): CompressionStream,
+  };
+
+  interface CompressionStream extends GenericTransformStream {
+    readonly format: string;
+  }
+}

--- a/report/types/buffer.d.ts
+++ b/report/types/buffer.d.ts
@@ -1,0 +1,19 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * A minimal type for Node's `Buffer` to avoid importing all Node types for
+ * atob/btoa fallback for testing `text-encoding.js`.
+ */
+
+declare global {
+  class Buffer {
+    static from(str: string, encoding?: string): Buffer;
+    toString(encoding?: string): string;
+  }
+}
+
+export {}

--- a/report/types/html-renderer.d.ts
+++ b/report/types/html-renderer.d.ts
@@ -1,0 +1,28 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import AuditDetails from '../../types/lhr/audit-details';
+import {FormattedIcu as FormattedIcu_} from '../../types/lhr/i18n';
+import LHResult from '../../types/lhr/lhr';
+import ReportResult_ from './report-result';
+import * as Settings from '../../types/lhr/settings';
+import Treemap_ from '../../types/lhr/treemap';
+
+declare global {
+  // Expose global types in LH namespace.
+  module LH {
+    export import Result = LHResult;
+    export import ReportResult = ReportResult_;
+    export import Locale = Settings.Locale;
+    export type FormattedIcu<T> = FormattedIcu_<T>;
+
+    module Audit {
+      export import Details = AuditDetails;
+    }
+
+    export import Treemap = Treemap_;
+  }
+}

--- a/report/types/report-result.d.ts
+++ b/report/types/report-result.d.ts
@@ -4,33 +4,24 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import Audit from './audit';
-import LHResult from './lhr/lhr';
+import {Result as AuditResult}  from '../../types/lhr/audit-result';
+import LHResult from '../../types/lhr/lhr';
 
-// Add needed DOM APIs not yet in tsc's lib dom.
-declare global {
-  var CompressionStream: {
-    prototype: CompressionStream,
-    new (format: string): CompressionStream,
-  };
-
-  interface CompressionStream extends GenericTransformStream {
-    readonly format: string;
-  }
-}
-
-// During report generation, the LHR object is transformed a bit for convenience
-// Primarily, the auditResult is added as .result onto the auditRef. We're lazy sometimes. It'll be removed in due time.
+/**
+ * During report generation, the LHR object is transformed a bit for convenience
+ * Primarily, the auditResult is added as .result onto the auditRef. We're lazy sometimes. It'll be removed in due time.
+ */
 interface ReportResult extends LHResult {
   categories: Record<string, ReportResult.Category>;
 }
+
 declare module ReportResult {
   interface Category extends LHResult.Category {
     auditRefs: Array<AuditRef>
   }
 
   interface AuditRef extends LHResult.AuditRef {
-    result: Audit.Result;
+    result: AuditResult;
     stackPacks?: StackPackDescription[];
     relevantMetrics?: ReportResult.AuditRef[];
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
     "root.js",
     "lighthouse-cli/**/*.js",
     "lighthouse-core/**/*.js",
-    "report/**/*.js",
     "clients/**/*.js",
     "build/**/*.js",
     "./types/**/*.d.ts",
@@ -39,7 +38,8 @@
   ],
   "references": [
     {"path": "./types/lhr/"},
-    {"path": "./report/generator/"}
+    {"path": "./report/"},
+    {"path": "./report/generator/"},
   ],
   "exclude": [
     "lighthouse-core/test/audits/**/*.js",
@@ -50,7 +50,6 @@
     "lighthouse-core/scripts/legacy-javascript/variants",
     "lighthouse-core/test/chromium-web-tests/webtests",
     // These test files require further changes before they can be type checked.
-    "report/test/**/*.js",
     "lighthouse-core/test/config/budget-test.js",
     "lighthouse-core/test/config/config-helpers-test.js",
     "lighthouse-core/test/config/config-plugin-test.js",

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -4,29 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {ParseSelectorToTagNames} from 'typed-query-selector/parser';
-
 import {Artifacts} from './artifacts';
 import LHResult from './lhr/lhr';
 import {SharedFlagsSettings, OutputMode} from './lhr/settings';
-
-/** Merge properties of the types in union `T`. Where properties overlap, property types becomes the union of the two (or more) possible types. */
-type MergeTypes<T> = {
-  [K in (T extends unknown ? keyof T : never)]: T extends Record<K, infer U> ? U : never;
-};
-
-// Helper types for strict querySelector/querySelectorAll that includes the overlap
-// between HTML and SVG node names (<a>, <script>, etc).
-// see https://github.com/GoogleChrome/lighthouse/issues/12011
-type HtmlAndSvgElementTagNameMap = MergeTypes<HTMLElementTagNameMap|SVGElementTagNameMap> & {
-  // Fall back to Element (base of HTMLElement and SVGElement) if no specific tag name matches.
-  [id: string]: Element;
-};
-type QuerySelectorParse<I extends string> = ParseSelectorToTagNames<I> extends infer TagNames ?
-  TagNames extends Array<string> ?
-    HtmlAndSvgElementTagNameMap[TagNames[number]] :
-    Element: // Fall back for queries typed-query-selector fails to parse, e.g. `'[alt], [aria-label]'`.
-  never;
 
 declare global {
   // Augment Intl to include
@@ -55,12 +35,6 @@ declare global {
 
     // Not defined in tsc yet: https://github.com/microsoft/TypeScript/issues/40807
     requestIdleCallback(callback: (deadline: {didTimeout: boolean, timeRemaining: () => DOMHighResTimeStamp}) => void, options?: {timeout: number}): number;
-  }
-
-  // Stricter querySelector/querySelectorAll using typed-query-selector.
-  interface ParentNode {
-    querySelector<S extends string>(selector: S): QuerySelectorParse<S> | null;
-    querySelectorAll<S extends string>(selector: S): NodeListOf<QuerySelectorParse<S>>;
   }
 
   /** Make properties K in T optional. */

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -18,7 +18,6 @@ import LHError = require('../lighthouse-core/lib/lh-error.js');
 import LHResult from './lhr/lhr';
 import FlowResult_ from './lhr/flow';
 import Protocol_ from './protocol';
-import ReportResult_ from './html-renderer';
 import * as Settings from './lhr/settings';
 import StructuredData_ from './structured-data';
 import Treemap_ from './lhr/treemap';
@@ -63,7 +62,6 @@ declare global {
     export import FormattedIcu = I18n.FormattedIcu;
 
     export import Protocol = Protocol_;
-    export import ReportResult = ReportResult_;
 
     // lhr/settings.d.ts
     export import Locale = Settings.Locale;

--- a/types/query-selector.d.ts
+++ b/types/query-selector.d.ts
@@ -1,0 +1,36 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * @fileoverview Stricter querySelector/querySelectorAll using typed-query-selector.
+ */
+
+import {ParseSelectorToTagNames} from 'typed-query-selector/parser';
+
+/** Merge properties of the types in union `T`. Where properties overlap, property types becomes the union of the two (or more) possible types. */
+type MergeTypes<T> = {
+  [K in (T extends unknown ? keyof T : never)]: T extends Record<K, infer U> ? U : never;
+};
+
+// Helper types for strict querySelector/querySelectorAll that includes the overlap
+// between HTML and SVG node names (<a>, <script>, etc).
+// see https://github.com/GoogleChrome/lighthouse/issues/12011
+type HtmlAndSvgElementTagNameMap = MergeTypes<HTMLElementTagNameMap|SVGElementTagNameMap> & {
+  // Fall back to Element (base of HTMLElement and SVGElement) if no specific tag name matches.
+  [id: string]: Element;
+};
+type QuerySelectorParse<I extends string> = ParseSelectorToTagNames<I> extends infer TagNames ?
+  TagNames extends Array<string> ?
+    HtmlAndSvgElementTagNameMap[TagNames[number]] :
+    Element: // Fall back for queries typed-query-selector fails to parse, e.g. `'[alt], [aria-label]'`.
+  never;
+
+declare global {
+  interface ParentNode {
+    querySelector<S extends string>(selector: S): QuerySelectorParse<S> | null;
+    querySelectorAll<S extends string>(selector: S): NodeListOf<QuerySelectorParse<S>>;
+  }
+}


### PR DESCRIPTION
Isolates `report/` as a typescript "project" allowing it to live off in its own type world. This allows it to be browser specific and not bring in the entire lighthouse-cli/lighthouse-core/etc world just to type check the report.

Dependencies are simpler and (because of the expanded `-b` mode) more compilation caching occurs which means faster follow-up type checks (e.g. if you're working on core and haven't touched the report, the `yarn tsc -b report/` part will finish in 200ms because the cached `.tmp/tsbuildinfo` file will be newer than all the files in `report/`).

The bulk of this PR is splitting up a few more `d.ts` files for e.g. the parts of `html-renderer.d.ts` that `treemap` and `viewer` need vs the parts they don't.

I'll follow this PR with changes to make `treemap/`, `viewer/`, and `flow-report/` to do the same to them. This will be especially helpful for treemap and viewer since they recompile large parts of core due to transitive type deps. There will also probably need to be a final clean up pass to better use tsconfig inheritance and some documentation.