### PR TITLE
tests(ci): restore ToT Chromium download

### DIFF
--- a/lighthouse-core/scripts/download-chrome.sh
+++ b/lighthouse-core/scripts/download-chrome.sh
@@ -10,14 +10,10 @@
 
 set -euo pipefail
 
-# Hardcode 19 August 2021 URLs to download until
-# https://github.com/GoogleChrome/lighthouse/issues/12942 is resolved.
 if [ "$OSTYPE" == "msys" ]; then
-  # url="https://download-chromium.appspot.com/dl/Win?type=snapshots"
-  url="https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win/refs_heads_main-913406/chrome-win.zip"
+  url="https://download-chromium.appspot.com/dl/Win?type=snapshots"
 else
-  # url="https://download-chromium.appspot.com/dl/Linux_x64?type=snapshots"
-  url="https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/refs_heads_main-913453/chrome-linux.zip"
+  url="https://download-chromium.appspot.com/dl/Linux_x64?type=snapshots"
 fi
 
 if [ -e "$CHROME_PATH" ]; then


### PR DESCRIPTION
Reverts GoogleChrome/lighthouse#12943

fixes #12942

Unfortunately for the `DevTools / integration` CI check, our clever method of only downloading the content-shell once a day:

https://github.com/GoogleChrome/lighthouse/blob/0b31fe2b6c3ada48ab662ac9ae07e278f552b1c2/third-party/download-content-shell/download-content-shell.js#L74-L76

currently is looking for downloads in the broken URL revision numbers and so will fail if the cached version isn't able to be used. It'll be about 90 more Chromium changes (starting with `913920`) until we're clear of the broken revision numbers.