### PR TITLE
report: isolate viewer type checking

### DIFF
--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -197,7 +197,7 @@ export class LighthouseReportViewer {
   _replaceReportHtml(json) {
     // Allow users to view the runnerResult
     if ('lhr' in json) {
-      const runnerResult = /** @type {LH.RunnerResult} */ (/** @type {unknown} */ (json));
+      const runnerResult = /** @type {{lhr: LH.Result}} */ (/** @type {unknown} */ (json));
       json = runnerResult.lhr;
     }
     // Allow users to drop in PSI's json

--- a/lighthouse-viewer/tsconfig.json
+++ b/lighthouse-viewer/tsconfig.json
@@ -1,12 +1,35 @@
 {
-  "extends": "../tsconfig",
   "compilerOptions": {
+    "composite": true,
+    "outDir": "../.tmp/tsbuildinfo/lighthouse-viewer",
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+
+    // Limit to base JS and DOM defs.
+    "lib": ["es2020", "dom", "dom.iterable"],
+    // Don't include any types from node_modules.
+    "types": [],
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
     "esModuleInterop": true,
-    "composite": false,
+
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    // TODO: remove the next line to be fully `strict`.
+    "useUnknownInCatchVariables": false,
+
+    // "listFiles": true,
+    // "noErrorTruncation": true,
+    "extendedDiagnostics": true,
   },
   "include": [
     "app/src/**/*.js",
-    "../types/**/*.d.ts",
     "./types/*.d.ts",
+  ],
+  "references": [
+    {"path": "../types/lhr/"},
+    {"path": "../report/"}
   ],
 }

--- a/lighthouse-viewer/types/viewer.d.ts
+++ b/lighthouse-viewer/types/viewer.d.ts
@@ -7,11 +7,14 @@
 import _ReportGenerator = require('../../report/generator/report-generator.js');
 import {Logger as _Logger} from '../../report/renderer/logger.js';
 import {LighthouseReportViewer as _LighthouseReportViewer} from '../app/src/lighthouse-report-viewer.js';
+import 'google.analytics';
 import {FirebaseNamespace} from '@firebase/app-types';
-import _ReportResult from '../../report/types/report-result';
 
 // Import for needed DOM type augmentation.
 import '../../report/types/augment-dom';
+
+// Import for LH globals needed for report files.
+import '../../report/types/html-renderer';
 
 declare global {
   var ReportGenerator: typeof _ReportGenerator;
@@ -25,10 +28,5 @@ declare global {
 
     // Inserted by viewer build.
     LH_CURRENT_VERSION: string;
-  }
-  
-  // Expose global types in LH namespace.
-  module LH {
-    export import ReportResult = _ReportResult;
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "dogfood-lhci": "./lighthouse-core/scripts/dogfood-lhci.sh",
     "timing-trace": "node lighthouse-core/scripts/generate-timing-trace.js",
     "changelog": "conventional-changelog --config ./build/changelog-generator/index.js --infile changelog.md --same-file",
-    "type-check": "tsc -b . && tsc -b report/ && tsc -p lighthouse-viewer/ && tsc -p lighthouse-treemap/ && tsc -p flow-report/",
+    "type-check": "tsc --build ./ report/ lighthouse-viewer/ && tsc -p lighthouse-treemap/ && tsc -p flow-report/",
     "i18n:checks": "./lighthouse-core/scripts/i18n/assert-strings-collected.sh",
     "i18n:collect-strings": "node lighthouse-core/scripts/i18n/collect-strings.js",
     "update:lantern-baseline": "node lighthouse-core/scripts/lantern/update-baseline-lantern-values.js",

--- a/report/tsconfig.json
+++ b/report/tsconfig.json
@@ -7,7 +7,7 @@
 
     // Limit to base JS and DOM defs.
     "lib": ["es2020", "dom", "dom.iterable"],
-    // Don't include any node_module types.
+    // Don't include any types from node_modules.
     "types": [],
     "target": "es2020",
     "module": "es2020",


### PR DESCRIPTION
builds on #12946 to isolate viewer code.

Going through these files, it feels even more like viewer should move to `report/clients/viewer/` given that it's like 80% report code anyways, but we can take a look at that as part of the #12254 refactors