### PR TITLE
report: isolate treemap type checking

### DIFF
--- a/build/build-treemap.js
+++ b/build/build-treemap.js
@@ -5,8 +5,6 @@
  */
 'use strict';
 
-/** @typedef {import('../lighthouse-core/lib/i18n/locales').LhlMessages} LhlMessages */
-
 const fs = require('fs');
 const GhPagesApp = require('./gh-pages-app.js');
 const {LH_ROOT} = require('../root.js');
@@ -21,7 +19,7 @@ function buildStrings() {
   // TODO(esmodules): use dynamic import when build/ is esm.
   const utilCode = fs.readFileSync(LH_ROOT + '/lighthouse-treemap/app/src/util.js', 'utf-8');
   const {UIStrings} = eval(utilCode.replace('export ', '') + '\nmodule.exports = TreemapUtil;');
-  const strings = /** @type {Record<LH.Locale, LhlMessages>} */ ({});
+  const strings = /** @type {Record<LH.Locale, string>} */ ({});
 
   for (const [locale, lhlMessages] of Object.entries(locales)) {
     const localizedStrings = Object.fromEntries(
@@ -31,7 +29,7 @@ function buildStrings() {
           return [];
         }
 
-        return [varName, v];
+        return [varName, v.message];
       })
     );
     strings[/** @type {LH.Locale} */ (locale)] = localizedStrings;

--- a/lighthouse-treemap/app/src/main.js
+++ b/lighthouse-treemap/app/src/main.js
@@ -5,8 +5,6 @@
  */
 'use strict';
 
-/** @typedef {import('../../../lighthouse-core/lib/i18n/locales').LhlMessages} LhlMessages */
-
 /* eslint-env browser */
 
 /* globals webtreemap strings Tabulator Cell Row */
@@ -710,20 +708,6 @@ function injectOptions(options) {
   `;
 }
 
-/**
- * @param {LhlMessages} localeMessages
- */
-function getStrings(localeMessages) {
-  const strings = /** @type {typeof TreemapUtil['UIStrings']} */ ({});
-
-  for (const varName of Object.keys(localeMessages)) {
-    const key = /** @type {keyof typeof TreemapUtil['UIStrings']} */ (varName);
-    strings[key] = localeMessages[varName].message;
-  }
-
-  return strings;
-}
-
 class LighthouseTreemap {
   static get APP_URL() {
     return `${location.origin}${location.pathname}`;
@@ -776,7 +760,7 @@ class LighthouseTreemap {
       // Set missing renderer strings to default (english) values.
       ...TreemapUtil.UIStrings,
       // `strings` is generated in build/build-treemap.js
-      ...getStrings(strings[options.lhr.configSettings.locale]),
+      ...strings[options.lhr.configSettings.locale],
     });
     TreemapUtil.i18n = i18n;
 

--- a/lighthouse-treemap/tsconfig.json
+++ b/lighthouse-treemap/tsconfig.json
@@ -1,12 +1,36 @@
 {
-  "extends": "../tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "../.tmp/tsbuildinfo/lighthouse-treemap",
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+
+    // Limit to base JS and DOM defs.
+    "lib": ["es2020", "dom", "dom.iterable"],
+    // Selectively include types from node_modules.
+    "types": ["tabulator-tables"],
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    // TODO: remove the next line to be fully `strict`.
+    "useUnknownInCatchVariables": false,
+
+    // "listFiles": true,
+    // "noErrorTruncation": true,
+    "extendedDiagnostics": true,
+  },
   "include": [
     "app/src/**/*.js",
-    "types",
-    "../types",
+    "types/**/*.d.ts",
   ],
-  "compilerOptions": {
-    "esModuleInterop": true,
-    "composite": false,
-  },
+  "references": [
+    {"path": "../types/lhr/"},
+    {"path": "../report/"},
+    {"path": "../lighthouse-viewer/"},
+  ],
 }

--- a/lighthouse-treemap/types/treemap.d.ts
+++ b/lighthouse-treemap/types/treemap.d.ts
@@ -1,10 +1,22 @@
 import {Logger as _Logger} from '../../report/renderer/logger.js';
 import {FirebaseNamespace} from '@firebase/app-types';
+import Treemap_ from '../../types/lhr/treemap';
+import * as Settings from '../../types/lhr/settings';
+import 'google.analytics';
+import LHResult from '../../types/lhr/lhr';
+import {TreemapUtil} from '../app/src/util';
 
 // Import for needed DOM type augmentation.
 import '../../report/types/augment-dom';
 
 declare global {
+  // Expose global types in LH namespace.
+  module LH {
+    export import Treemap = Treemap_;
+    export import Result = LHResult;
+    export import Locale = Settings.Locale;
+  }
+
   class WebTreeMap {
     constructor(data: any, options: WebTreeMapOptions);
     render(el: HTMLElement): void;
@@ -37,11 +49,13 @@ declare global {
   var logger: _Logger;
   var firebase: Required<FirebaseNamespace>;
   var idbKeyval: typeof import('idb-keyval');
-  var strings: Record<LH.Locale, import('../../lighthouse-core/lib/i18n/locales').LhlMessages>;
+  // `strings` is generated in build/build-treemap.js
+  var strings: Record<Settings.Locale, typeof TreemapUtil['UIStrings']>;
 
   interface Window {
     logger: _Logger;
     __treemapOptions?: LH.Treemap.Options;
+    ga: UniversalAnalytics.ga;
   }
 
   interface AddEventListenerOptions {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "dogfood-lhci": "./lighthouse-core/scripts/dogfood-lhci.sh",
     "timing-trace": "node lighthouse-core/scripts/generate-timing-trace.js",
     "changelog": "conventional-changelog --config ./build/changelog-generator/index.js --infile changelog.md --same-file",
-    "type-check": "tsc --build ./ report/ lighthouse-viewer/ flow-report/ && tsc -p lighthouse-treemap/",
+    "type-check": "tsc --build ./ report/ lighthouse-viewer/ lighthouse-treemap/ flow-report/",
     "i18n:checks": "./lighthouse-core/scripts/i18n/assert-strings-collected.sh",
     "i18n:collect-strings": "node lighthouse-core/scripts/i18n/collect-strings.js",
     "update:lantern-baseline": "node lighthouse-core/scripts/lantern/update-baseline-lantern-values.js",


### PR DESCRIPTION
Last functional piece of the `tsc --build` puzzle (tsconfig cleanup to follow).

The main change here is eliminating the reference to [`LhlMessages`](https://github.com/GoogleChrome/lighthouse/blob/f52048921427cc51e629a75a8f16d2c45407d636/lighthouse-core/lib/i18n/locales.js#L19) which brings in a ton of core files.

The type could be duplicated or moved to a shared `d.ts` file in the lhr types, but following the style of the equivalent `Util.i18n` usage in the main report, the LhlMessages format can be flattened from `Record<LH.Locale, {message: string}>` to `Record<LH.Locale, string>` in the build step that generates the strings, which actually simplifies ingestion in `treemap/app/src/main.js` where it's turning it into that format in the end anyways.