### PR TITLE
core(network-request): identify filesystem resources as non-network

### DIFF
--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -480,7 +480,9 @@ class NetworkRequest {
    */
   static isNonNetworkRequest(record) {
     // The 'protocol' field in devtools a string more like a `scheme`
-    return URL.isNonNetworkProtocol(record.protocol);
+    return URL.isNonNetworkProtocol(record.protocol) ||
+      // But `protocol` can fail to be populated if the request fails, so fallback to scheme.
+      URL.isNonNetworkProtocol(record.parsedURL.scheme);
   }
 
   /**

--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -20,7 +20,7 @@ const allowedProtocols = [
 const SECURE_SCHEMES = ['data', 'https', 'wss', 'blob', 'chrome', 'chrome-extension', 'about',
   'filesystem'];
 const SECURE_LOCALHOST_DOMAINS = ['localhost', '127.0.0.1'];
-const NON_NETWORK_SCHEMES = ['blob', 'data', 'intent'];
+const NON_NETWORK_SCHEMES = ['blob', 'data', 'intent', 'file'];
 
 /**
  * There is fancy URL rewriting logic for the chrome://settings page that we need to work around.

--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -20,7 +20,13 @@ const allowedProtocols = [
 const SECURE_SCHEMES = ['data', 'https', 'wss', 'blob', 'chrome', 'chrome-extension', 'about',
   'filesystem'];
 const SECURE_LOCALHOST_DOMAINS = ['localhost', '127.0.0.1'];
-const NON_NETWORK_SCHEMES = ['blob', 'data', 'intent', 'file'];
+const NON_NETWORK_SCHEMES = [
+  'blob', // @see https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL
+  'data', // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+  'intent', // @see https://developer.chrome.com/docs/multidevice/android/intents/
+  'file', // @see https://en.wikipedia.org/wiki/File_URI_scheme
+  'filesystem', // @see https://developer.mozilla.org/en-US/docs/Web/API/FileSystem
+];
 
 /**
  * There is fancy URL rewriting logic for the chrome://settings page that we need to work around.

--- a/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
@@ -97,13 +97,14 @@ describe('Render blocking resources audit', () => {
 
     beforeEach(() => {
       requestId = 1;
+      const scheme = 'http';
       const protocol = 'http';
       record = props => {
-        const parsedURL = {host: 'example.com', securityOrigin: 'http://example.com'};
+        const parsedURL = {host: 'example.com', scheme, securityOrigin: 'http://example.com'};
         return Object.assign({parsedURL, requestId: requestId++}, props, {protocol});
       };
       recordSlow = props => {
-        const parsedURL = {host: 'slow.com', securityOrigin: 'http://slow.com'};
+        const parsedURL = {host: 'slow.com', scheme, securityOrigin: 'http://slow.com'};
         return Object.assign({parsedURL, requestId: requestId++}, props, {protocol});
       };
     });

--- a/lighthouse-core/test/computed/load-simulator-test.js
+++ b/lighthouse-core/test/computed/load-simulator-test.js
@@ -16,7 +16,7 @@ function createNetworkNode() {
   return new NetworkNode({
     requestId: '1',
     protocol: 'http',
-    parsedURL: {securityOrigin: 'https://pwa.rocks'},
+    parsedURL: {scheme: 'http', securityOrigin: 'https://pwa.rocks'},
   });
 }
 

--- a/lighthouse-core/test/computed/resource-summary-test.js
+++ b/lighthouse-core/test/computed/resource-summary-test.js
@@ -12,10 +12,6 @@ const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.
 /* eslint-env jest */
 
 function mockArtifacts(networkRecords) {
-  for (const record of networkRecords) {
-    record.protocol = record.url.slice(0, record.url.indexOf(':'));
-  }
-
   return {
     devtoolsLog: networkRecordsToDevtoolsLog(networkRecords),
     URL: {requestedUrl: networkRecords[0].url, finalUrl: networkRecords[0].url},
@@ -54,18 +50,12 @@ describe('Resource summary computed', () => {
   });
 
   it('sets "other" resource metrics correctly', async () => {
-    // networkRecordsToDevToolsLog errors with an 'other' resource type, so this test does not use it
-    const networkRecords = [
+    artifacts = mockArtifacts([
       {url: 'http://example.com/file.html', resourceType: 'Document', transferSize: 30},
-      {url: 'http://third-party.com/another-file.html', resourceType: 'manifest', transferSize: 50},
-    ];
+      {url: 'http://third-party.com/another-file.html', resourceType: 'Manifest', transferSize: 50},
+    ]);
+    const result = await ComputedResourceSummary.request(artifacts, context);
 
-    for (const record of networkRecords) {
-      record.protocol = record.url.slice(0, record.url.indexOf(':'));
-    }
-
-    const result = ComputedResourceSummary.summarize(
-      networkRecords, networkRecords[0].url, artifacts.budgets);
     assert.equal(result.other.count, 1);
     assert.equal(result.other.transferSize, 50);
   });

--- a/lighthouse-core/test/lib/network-request-test.js
+++ b/lighthouse-core/test/lib/network-request-test.js
@@ -346,4 +346,23 @@ describe('NetworkRequest', () => {
       })).toBe(true);
     });
   });
+
+  describe('#isNonNetworkRequest', () => {
+    const isNonNetworkRequest = NetworkRequest.isNonNetworkRequest;
+
+    it('correctly identifies non-network records', () => {
+      // data protocol
+      expect(isNonNetworkRequest({protocol: 'data'})).toBe(true);
+
+      // filesystem scheme
+      expect(isNonNetworkRequest({protocol: '', parsedURL: {scheme: 'file'}})).toBe(true);
+    });
+
+    it('correctly identifies network records', () => {
+      expect(isNonNetworkRequest({
+        protocol: 'h2',
+        parsedURL: {scheme: 'http', host: 'google.com'},
+      })).toBe(false);
+    });
+  });
 });

--- a/lighthouse-core/test/lib/url-shim-test.js
+++ b/lighthouse-core/test/lib/url-shim-test.js
@@ -330,8 +330,11 @@ describe('URL Shim', () => {
     assert.ok(URL.isNonNetworkProtocol('data'));
     assert.ok(URL.isNonNetworkProtocol('data:'));
     assert.ok(URL.isNonNetworkProtocol('intent:'));
+    assert.ok(URL.isNonNetworkProtocol('file:'));
+    assert.ok(URL.isNonNetworkProtocol('filesystem:'));
+    assert.ok(URL.isNonNetworkProtocol('filesystem'));
 
-    assert.ok(!URL.isNonNetworkProtocol('filesystem'));
+    assert.ok(!URL.isNonNetworkProtocol('https:'));
     assert.ok(!URL.isNonNetworkProtocol('http'));
     assert.ok(!URL.isNonNetworkProtocol('ws'));
   });


### PR DESCRIPTION
**Summary**
Closes three holes in our `isNonNetworkRequest` logic:

1. `file` protocol URLs were considered network requests.
2. `filesystem` protocol URLs were considered network requests. (it's [different](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemEntry/filesystem)!)
2. When requests are blocked or otherwise don't receive a response the `protocol` field is left empty and requests weren't identified as non-network.

**Related Issues/PRs**
fixes #12915
