### PR TITLE
core(csp-evaluator): bump package version

### DIFF
--- a/lighthouse-core/lib/csp-evaluator.js
+++ b/lighthouse-core/lib/csp-evaluator.js
@@ -28,12 +28,11 @@ const UIStrings = {
   missingScriptSrc: 'script-src directive is missing. ' +
     'This can allow the execution of unsafe scripts.',
   /** Message shown when a CSP does not have a script-src directive. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy". "object-src" and "'none'" do not need to be translated. */
-  missingObjectSrc: 'Elements controlled by object-src are considered legacy features. ' +
-    'Consider setting object-src to \'none\' to prevent the injection of ' +
-    'plugins that execute unsafe scripts.',
+  missingObjectSrc: 'Missing object-src allows the injection of plugins ' +
+    'that execute unsafe scripts. Consider setting object-src to \'none\' if you can.',
   /** Message shown when a CSP uses a domain allowlist to filter out malicious scripts. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy". "CSP", "'strict-dynamic'", "nonces", and "hashes" do not need to be translated. "allowlists" can be interpreted as "whitelist". */
   strictDynamic: 'Host allowlists can frequently be bypassed. Consider using ' +
-    '\'strict-dynamic\' in combination with CSP nonces or hashes.',
+    'CSP nonces or hashes instead, along with \'strict-dynamic\' if necessary.',
   /** Message shown when a CSP allows inline scripts to be run in the page. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy". "CSP", "'unsafe-inline'", "nonces", and "hashes" do not need to be translated. */
   unsafeInline: '\'unsafe-inline\' allows the execution of unsafe in-page scripts ' +
     'and event handlers. Consider using CSP nonces or hashes to allow scripts individually.',
@@ -76,6 +75,12 @@ const UIStrings = {
   /** Message shown when a CSP uses the deprecated disown-opener directive. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy". "disown-opener", "CSP3" and "Cross-Origin-Opener-Policy" do not need to be translated. */
   deprecatedDisownOpener: 'disown-opener is deprecated since CSP3. ' +
     'Please, use the Cross-Origin-Opener-Policy header instead.',
+  /**
+   * @description Message shown when a CSP keyword allows unsafe scripts to be run in the page. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy". "'strict-dynamic'" does not need to be translated.
+   *  @example {https:} keyword
+   */
+  unsafeKeyword: 'Avoid using {keyword} in this directive ' +
+    'if it is not a fallback for \'strict-dynamic\'.',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -91,6 +96,8 @@ const FINDING_TO_UI_STRING = {
     [Directive.OBJECT_SRC]: str_(UIStrings.missingObjectSrc),
   },
   [Type.SCRIPT_UNSAFE_INLINE]: str_(UIStrings.unsafeInline),
+  [Type.PLAIN_WILDCARD]: UIStrings.unsafeKeyword,
+  [Type.PLAIN_URL_SCHEMES]: UIStrings.unsafeKeyword,
   [Type.NONCE_LENGTH]: str_(UIStrings.nonceLength),
   [Type.NONCE_CHARSET]: str_(UIStrings.nonceCharset),
   [Type.DEPRECATED_DIRECTIVE]: {

--- a/lighthouse-core/lib/csp-evaluator.js
+++ b/lighthouse-core/lib/csp-evaluator.js
@@ -77,16 +77,16 @@ const UIStrings = {
     'Please, use the Cross-Origin-Opener-Policy header instead.',
   /**
    * @description Message shown when a CSP wildcard allows unsafe scripts to be run in the page. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy".
-   *  @example {https:} keyword
+   *  @example {*} keyword
    */
-  wildcard: 'Avoid using wildcards ({keyword}) in this directive. ' +
-    'It can allow scripts to be sourced from an unsafe domain.',
+  plainWildcards: 'Avoid using plain wildcards ({keyword}) in this directive. ' +
+    'Plain wildcards allow scripts to be sourced from an unsafe domain.',
   /**
    * @description Message shown when a CSP URL scheme allows unsafe scripts to be run in the page. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy".
    *  @example {https:} keyword
    */
   plainUrlScheme: 'Avoid using plain URL schemes ({keyword}) in this directive. ' +
-    'It can allow scripts to be sourced from an unsafe domain.',
+    'Plain URL schemes allow scripts to be sourced from an unsafe domain.',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -102,7 +102,7 @@ const FINDING_TO_UI_STRING = {
     [Directive.OBJECT_SRC]: str_(UIStrings.missingObjectSrc),
   },
   [Type.SCRIPT_UNSAFE_INLINE]: str_(UIStrings.unsafeInline),
-  [Type.PLAIN_WILDCARD]: UIStrings.wildcard,
+  [Type.PLAIN_WILDCARD]: UIStrings.plainWildcards,
   [Type.PLAIN_URL_SCHEMES]: UIStrings.plainUrlScheme,
   [Type.NONCE_LENGTH]: str_(UIStrings.nonceLength),
   [Type.NONCE_CHARSET]: str_(UIStrings.nonceCharset),

--- a/lighthouse-core/lib/csp-evaluator.js
+++ b/lighthouse-core/lib/csp-evaluator.js
@@ -76,11 +76,17 @@ const UIStrings = {
   deprecatedDisownOpener: 'disown-opener is deprecated since CSP3. ' +
     'Please, use the Cross-Origin-Opener-Policy header instead.',
   /**
-   * @description Message shown when a CSP keyword allows unsafe scripts to be run in the page. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy". "'strict-dynamic'" does not need to be translated.
+   * @description Message shown when a CSP wildcard allows unsafe scripts to be run in the page. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy".
    *  @example {https:} keyword
    */
-  unsafeKeyword: 'Avoid using {keyword} in this directive ' +
-    'if it is not a fallback for \'strict-dynamic\'.',
+  wildcard: 'Avoid using wildcards ({keyword}) in this directive. ' +
+    'It can allow scripts to be sourced from an unsafe domain.',
+  /**
+   * @description Message shown when a CSP URL scheme allows unsafe scripts to be run in the page. Shown in a table with a list of other CSP vulnerabilities and suggestions. "CSP" stands for "Content Security Policy".
+   *  @example {https:} keyword
+   */
+  plainUrlScheme: 'Avoid using plain URL schemes ({keyword}) in this directive. ' +
+    'It can allow scripts to be sourced from an unsafe domain.',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -96,8 +102,8 @@ const FINDING_TO_UI_STRING = {
     [Directive.OBJECT_SRC]: str_(UIStrings.missingObjectSrc),
   },
   [Type.SCRIPT_UNSAFE_INLINE]: str_(UIStrings.unsafeInline),
-  [Type.PLAIN_WILDCARD]: UIStrings.unsafeKeyword,
-  [Type.PLAIN_URL_SCHEMES]: UIStrings.unsafeKeyword,
+  [Type.PLAIN_WILDCARD]: UIStrings.wildcard,
+  [Type.PLAIN_URL_SCHEMES]: UIStrings.plainUrlScheme,
   [Type.NONCE_LENGTH]: str_(UIStrings.nonceLength),
   [Type.NONCE_CHARSET]: str_(UIStrings.nonceCharset),
   [Type.DEPRECATED_DIRECTIVE]: {

--- a/lighthouse-core/lib/i18n/locales/ar-XB.json
+++ b/lighthouse-core/lib/i18n/locales/ar-XB.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} ‏‮seems‬‏ ‏‮to‬‏ ‏‮be‬‏ ‏‮an‬‏ ‏‮invalid‬‏ ‏‮keyword‬‏."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "'‏‮unsafe‬‏-‏‮inline‬‏' ‏‮allows‬‏ ‏‮the‬‏ ‏‮execution‬‏ ‏‮of‬‏ ‏‮unsafe‬‏ ‏‮in‬‏-‏‮page‬‏ ‏‮scripts‬‏ ‏‮and‬‏ ‏‮event‬‏ ‏‮handlers‬‏. ‏‮Consider‬‏ ‏‮using‬‏ ‏‮CSP‬‏ ‏‮nonces‬‏ ‏‮or‬‏ ‏‮hashes‬‏ ‏‮to‬‏ ‏‮allow‬‏ ‏‮scripts‬‏ ‏‮individually‬‏."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "‏‮Consider‬‏ ‏‮adding‬‏ '‏‮unsafe‬‏-‏‮inline‬‏' (‏‮ignored‬‏ ‏‮by‬‏ ‏‮browsers‬‏ ‏‮supporting‬‏ ‏‮nonces‬‏/‏‮hashes‬‏) ‏‮to‬‏ ‏‮be‬‏ ‏‮backward‬‏ ‏‮compatible‬‏ ‏‮with‬‏ ‏‮older‬‏ ‏‮browsers‬‏."
   },

--- a/lighthouse-core/lib/i18n/locales/ar.json
+++ b/lighthouse-core/lib/i18n/locales/ar.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "الكلمة الرئيسية {keyword} غير صالحة."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "يسمح 'unsafe-inline' بتنفيذ نصوص برمجية ومعالجات أحداث غير آمنة في الصفحة. ننصحك باستخدام أرقام CSP الخاصة أو أجزائها للسماح بالنصوص البرمجية كل على حدة."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "ننصحك بإضافة الأمر التوجيهي 'unsafe-inline' (الذي تتجاهله المتصفِّحات المتوافقة مع nonces/hashes) لجعل CSP متوافقة مع أنظمة المتصفِّحات القديمة."
   },

--- a/lighthouse-core/lib/i18n/locales/bg.json
+++ b/lighthouse-core/lib/i18n/locales/bg.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Изглежда, че {keyword} е невалидна ключова дума."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "unsafe-inline позволява изпълнението на опасни скриптове в страницата и манипулатори на събитието. Обмислете дали да не използвате nonce или хешове в CSP, за да разрешавате скриптове поотделно."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Обмислете дали да не добавите unsafe-inline (пренебрегва се от браузъри, които поддържат nonce и хешове), за да се обезпечи обратна съвместимост с по-стари браузъри."
   },

--- a/lighthouse-core/lib/i18n/locales/ca.json
+++ b/lighthouse-core/lib/i18n/locales/ca.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "\"{keyword}\" sembla una paraula clau no vàlida."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "La directiva \"unsafe-inline\" permet l'execució de scripts in-page i gestors d'esdeveniments no segurs. Pots utilitzar nonces o valors resum de la CSP per permetre els scripts individualment."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Pots optar per afegir \"unsafe-inline\" (els navegadors que admeten nonces o valors resum l'ignoren) perquè sigui retrocompatible amb navegadors més antics."
   },

--- a/lighthouse-core/lib/i18n/locales/cs.json
+++ b/lighthouse-core/lib/i18n/locales/cs.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} je zřejmě neplatné klíčové slovo."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "unsafe-inline umožňuje spouštění skriptů na stránce a obslužných rutin událostí, které nejsou bezpečné. Zvažte, zda nepoužít hodnoty nonce nebo hash CSP, abyste skripty povolovali individuálně."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Zvažte, zda nepřidat unsafe-inline (ignorováno prohlížeči, které podporují hodnoty nonce/hash) z důvodu zpětné kompatibility se staršími prohlížeči."
   },

--- a/lighthouse-core/lib/i18n/locales/da.json
+++ b/lighthouse-core/lib/i18n/locales/da.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} lader til at være et ugyldigt søgeord."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "\"unsafe-inline\" tillader, at der kan køres \"unsafe in-page\"-scripts og hændelseshandlers. Overvej at bruge CSP-nonces eller -hashes til at tillade scripts på individuel basis."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Overvej at tilføje \"unsafe-inline\" (ignoreres af browsere, der understøtter nonces/hashes) for at gøre CSP'en bagudkompatibel med ældre browsere."
   },

--- a/lighthouse-core/lib/i18n/locales/de.json
+++ b/lighthouse-core/lib/i18n/locales/de.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "„{keyword}“ ist ein ungültiges Keyword."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "„unsafe-inline“ lässt die Ausführung unsicherer In-Page-Skripts und Event-Handler zu. Sie können CSP-Nonces oder -Hashes verwenden, um Skripts einzeln zuzulassen."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Sie können „unsafe-inline“ hinzufügen (wird von Browsern ignoriert, die Nonces/Hashes unterstützen), um mit älteren Browsern kompatibel zu sein."
   },

--- a/lighthouse-core/lib/i18n/locales/el.json
+++ b/lighthouse-core/lib/i18n/locales/el.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Το {keyword} φαίνεται ότι είναι μη έγκυρη λέξη-κλειδί."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Το unsafe-inline επιτρέπει την εκτέλεση μη ασφαλών σεναρίων στη σελίδα και δεικτών χειρισμού συμβάντων. Εξετάστε το ενδεχόμενο χρήσης αριθμών nonce ή κατακερματισμών CSP για να επιτρέπεται μεμονωμένα σενάρια."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Εξετάστε το ενδεχόμενο να προσθέσετε το unsafe-inline (παραβλέπεται από προγράμματα περιήγησης που υποστηρίζουν αριθμούς nonce/κατακερματισμούς) για συμβατότητα με παλαιότερα προγράμματα περιήγησης."
   },

--- a/lighthouse-core/lib/i18n/locales/en-GB.json
+++ b/lighthouse-core/lib/i18n/locales/en-GB.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} seems to be an invalid keyword."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "'unsafe-inline' allows the execution of unsafe in-page scripts and event handlers. Consider using CSP nonces or hashes to allow scripts individually."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Consider adding 'unsafe-inline' (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers."
   },

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -1722,7 +1722,7 @@
     "message": "Missing base-uri allows injected <base> tags to set the base URL for all relative URLs (e.g. scripts) to an attacker controlled domain. Consider setting base-uri to 'none' or 'self'."
   },
   "lighthouse-core/lib/csp-evaluator.js | missingObjectSrc": {
-    "message": "Elements controlled by object-src are considered legacy features. Consider setting object-src to 'none' to prevent the injection of plugins that execute unsafe scripts."
+    "message": "Missing object-src allows the injection of plugins that execute unsafe scripts. Consider setting object-src to 'none' if you can."
   },
   "lighthouse-core/lib/csp-evaluator.js | missingScriptSrc": {
     "message": "script-src directive is missing. This can allow the execution of unsafe scripts."
@@ -1743,7 +1743,7 @@
     "message": "The reporting destination is only configured via the report-to directive. This directive is only supported in Chromium-based browsers so it is recommended to also use a report-uri directive."
   },
   "lighthouse-core/lib/csp-evaluator.js | strictDynamic": {
-    "message": "Host allowlists can frequently be bypassed. Consider using 'strict-dynamic' in combination with CSP nonces or hashes."
+    "message": "Host allowlists can frequently be bypassed. Consider using CSP nonces or hashes instead, along with 'strict-dynamic' if necessary."
   },
   "lighthouse-core/lib/csp-evaluator.js | unknownDirective": {
     "message": "Unknown CSP directive."
@@ -1756,6 +1756,9 @@
   },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Consider adding 'unsafe-inline' (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers."
+  },
+  "lighthouse-core/lib/csp-evaluator.js | unsafeKeyword": {
+    "message": "Avoid using {keyword} in this directive if it is not a fallback for 'strict-dynamic'."
   },
   "lighthouse-core/lib/i18n/i18n.js | columnBlockingTime": {
     "message": "Main-Thread Blocking Time"

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -1737,7 +1737,10 @@
     "message": "Nonces should be at least 8 characters long."
   },
   "lighthouse-core/lib/csp-evaluator.js | plainUrlScheme": {
-    "message": "Avoid using plain URL schemes ({keyword}) in this directive. It can allow scripts to be sourced from an unsafe domain."
+    "message": "Avoid using plain URL schemes ({keyword}) in this directive. Plain URL schemes allow scripts to be sourced from an unsafe domain."
+  },
+  "lighthouse-core/lib/csp-evaluator.js | plainWildcards": {
+    "message": "Avoid using plain wildcards ({keyword}) in this directive. Plain wildcards allow scripts to be sourced from an unsafe domain."
   },
   "lighthouse-core/lib/csp-evaluator.js | reportingDestinationMissing": {
     "message": "No CSP configures a reporting destination. This makes it difficult to maintain the CSP over time and monitor for any breakages."
@@ -1759,9 +1762,6 @@
   },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Consider adding 'unsafe-inline' (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers."
-  },
-  "lighthouse-core/lib/csp-evaluator.js | wildcard": {
-    "message": "Avoid using wildcards ({keyword}) in this directive. It can allow scripts to be sourced from an unsafe domain."
   },
   "lighthouse-core/lib/i18n/i18n.js | columnBlockingTime": {
     "message": "Main-Thread Blocking Time"

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -1736,6 +1736,9 @@
   "lighthouse-core/lib/csp-evaluator.js | nonceLength": {
     "message": "Nonces should be at least 8 characters long."
   },
+  "lighthouse-core/lib/csp-evaluator.js | plainUrlScheme": {
+    "message": "Avoid using plain URL schemes ({keyword}) in this directive. It can allow scripts to be sourced from an unsafe domain."
+  },
   "lighthouse-core/lib/csp-evaluator.js | reportingDestinationMissing": {
     "message": "No CSP configures a reporting destination. This makes it difficult to maintain the CSP over time and monitor for any breakages."
   },
@@ -1757,8 +1760,8 @@
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Consider adding 'unsafe-inline' (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeKeyword": {
-    "message": "Avoid using {keyword} in this directive if it is not a fallback for 'strict-dynamic'."
+  "lighthouse-core/lib/csp-evaluator.js | wildcard": {
+    "message": "Avoid using wildcards ({keyword}) in this directive. It can allow scripts to be sourced from an unsafe domain."
   },
   "lighthouse-core/lib/i18n/i18n.js | columnBlockingTime": {
     "message": "Main-Thread Blocking Time"

--- a/lighthouse-core/lib/i18n/locales/en-XA.json
+++ b/lighthouse-core/lib/i18n/locales/en-XA.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "[ᐅ{keyword}ᐊ šéémš ţö бé åñ îñvåļîð ķéýŵöŕð. one two three four five six seven eight]"
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "['ûñšåƒé-îñļîñé' åļļöŵš ţĥé éxéçûţîöñ öƒ ûñšåƒé îñ-þåĝé šçŕîþţš åñð évéñţ ĥåñðļéŕš. Çöñšîðéŕ ûšîñĝ ÇŠÞ ñöñçéš öŕ ĥåšĥéš ţö åļļöŵ šçŕîþţš îñðîvîðûåļļý. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo]"
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "[Çöñšîðéŕ åððîñĝ 'ûñšåƒé-îñļîñé' (îĝñöŕéð бý бŕöŵšéŕš šûþþöŕţîñĝ ñöñçéš/ĥåšĥéš) ţö бé бåçķŵåŕð çömþåţîбļé ŵîţĥ öļðéŕ бŕöŵšéŕš. one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]"
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -1737,7 +1737,10 @@
     "message": "N̂ón̂ćêś ŝh́ôúl̂d́ b̂é ât́ l̂éâśt̂ 8 ćĥár̂áĉt́êŕŝ ĺôńĝ."
   },
   "lighthouse-core/lib/csp-evaluator.js | plainUrlScheme": {
-    "message": "Âv́ôíd̂ úŝín̂ǵ p̂ĺâín̂ ÚR̂Ĺ ŝćĥém̂éŝ ({keyword}) ín̂ t́ĥíŝ d́îŕêćt̂ív̂é. Ît́ ĉán̂ ál̂ĺôẃ ŝćr̂íp̂t́ŝ t́ô b́ê śôúr̂ćêd́ f̂ŕôḿ âń ûńŝáf̂é d̂óm̂áîń."
+    "message": "Âv́ôíd̂ úŝín̂ǵ p̂ĺâín̂ ÚR̂Ĺ ŝćĥém̂éŝ ({keyword}) ín̂ t́ĥíŝ d́îŕêćt̂ív̂é. P̂ĺâín̂ ÚR̂Ĺ ŝćĥém̂éŝ ál̂ĺôẃ ŝćr̂íp̂t́ŝ t́ô b́ê śôúr̂ćêd́ f̂ŕôḿ âń ûńŝáf̂é d̂óm̂áîń."
+  },
+  "lighthouse-core/lib/csp-evaluator.js | plainWildcards": {
+    "message": "Âv́ôíd̂ úŝín̂ǵ p̂ĺâín̂ ẃîĺd̂ćâŕd̂ś ({keyword}) îń t̂h́îś d̂ír̂éĉt́îv́ê. Ṕl̂áîń ŵíl̂d́ĉár̂d́ŝ ál̂ĺôẃ ŝćr̂íp̂t́ŝ t́ô b́ê śôúr̂ćêd́ f̂ŕôḿ âń ûńŝáf̂é d̂óm̂áîń."
   },
   "lighthouse-core/lib/csp-evaluator.js | reportingDestinationMissing": {
     "message": "N̂ó ĈŚP̂ ćôńf̂íĝúr̂éŝ á r̂ép̂ór̂t́îńĝ d́êśt̂ín̂át̂íôń. T̂h́îś m̂ák̂éŝ ít̂ d́îf́f̂íĉúl̂t́ t̂ó m̂áîńt̂áîń t̂h́ê ĆŜṔ ôv́êŕ t̂ím̂é âńd̂ ḿôńît́ôŕ f̂ór̂ án̂ý b̂ŕêák̂áĝéŝ."
@@ -1759,9 +1762,6 @@
   },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Ĉón̂śîd́êŕ âd́d̂ín̂ǵ 'ûńŝáf̂é-îńl̂ín̂é' (îǵn̂ór̂éd̂ b́ŷ b́r̂óŵśêŕŝ śûṕp̂ór̂t́îńĝ ńôńĉéŝ/h́âśĥéŝ) t́ô b́ê b́âćk̂ẃâŕd̂ ćôḿp̂át̂íb̂ĺê ẃît́ĥ ól̂d́êŕ b̂ŕôẃŝér̂ś."
-  },
-  "lighthouse-core/lib/csp-evaluator.js | wildcard": {
-    "message": "Âv́ôíd̂ úŝín̂ǵ ŵíl̂d́ĉár̂d́ŝ ({keyword}) ín̂ t́ĥíŝ d́îŕêćt̂ív̂é. Ît́ ĉán̂ ál̂ĺôẃ ŝćr̂íp̂t́ŝ t́ô b́ê śôúr̂ćêd́ f̂ŕôḿ âń ûńŝáf̂é d̂óm̂áîń."
   },
   "lighthouse-core/lib/i18n/i18n.js | columnBlockingTime": {
     "message": "M̂áîń-T̂h́r̂éâd́ B̂ĺôćk̂ín̂ǵ T̂ím̂é"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -1736,6 +1736,9 @@
   "lighthouse-core/lib/csp-evaluator.js | nonceLength": {
     "message": "N̂ón̂ćêś ŝh́ôúl̂d́ b̂é ât́ l̂éâśt̂ 8 ćĥár̂áĉt́êŕŝ ĺôńĝ."
   },
+  "lighthouse-core/lib/csp-evaluator.js | plainUrlScheme": {
+    "message": "Âv́ôíd̂ úŝín̂ǵ p̂ĺâín̂ ÚR̂Ĺ ŝćĥém̂éŝ ({keyword}) ín̂ t́ĥíŝ d́îŕêćt̂ív̂é. Ît́ ĉán̂ ál̂ĺôẃ ŝćr̂íp̂t́ŝ t́ô b́ê śôúr̂ćêd́ f̂ŕôḿ âń ûńŝáf̂é d̂óm̂áîń."
+  },
   "lighthouse-core/lib/csp-evaluator.js | reportingDestinationMissing": {
     "message": "N̂ó ĈŚP̂ ćôńf̂íĝúr̂éŝ á r̂ép̂ór̂t́îńĝ d́êśt̂ín̂át̂íôń. T̂h́îś m̂ák̂éŝ ít̂ d́îf́f̂íĉúl̂t́ t̂ó m̂áîńt̂áîń t̂h́ê ĆŜṔ ôv́êŕ t̂ím̂é âńd̂ ḿôńît́ôŕ f̂ór̂ án̂ý b̂ŕêák̂áĝéŝ."
   },
@@ -1757,8 +1760,8 @@
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Ĉón̂śîd́êŕ âd́d̂ín̂ǵ 'ûńŝáf̂é-îńl̂ín̂é' (îǵn̂ór̂éd̂ b́ŷ b́r̂óŵśêŕŝ śûṕp̂ór̂t́îńĝ ńôńĉéŝ/h́âśĥéŝ) t́ô b́ê b́âćk̂ẃâŕd̂ ćôḿp̂át̂íb̂ĺê ẃît́ĥ ól̂d́êŕ b̂ŕôẃŝér̂ś."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeKeyword": {
-    "message": "Âv́ôíd̂ úŝín̂ǵ {keyword} îń t̂h́îś d̂ír̂éĉt́îv́ê íf̂ ít̂ íŝ ńôt́ â f́âĺl̂b́âćk̂ f́ôŕ 'ŝt́r̂íĉt́-d̂ýn̂ám̂íĉ'."
+  "lighthouse-core/lib/csp-evaluator.js | wildcard": {
+    "message": "Âv́ôíd̂ úŝín̂ǵ ŵíl̂d́ĉár̂d́ŝ ({keyword}) ín̂ t́ĥíŝ d́îŕêćt̂ív̂é. Ît́ ĉán̂ ál̂ĺôẃ ŝćr̂íp̂t́ŝ t́ô b́ê śôúr̂ćêd́ f̂ŕôḿ âń ûńŝáf̂é d̂óm̂áîń."
   },
   "lighthouse-core/lib/i18n/i18n.js | columnBlockingTime": {
     "message": "M̂áîń-T̂h́r̂éâd́ B̂ĺôćk̂ín̂ǵ T̂ím̂é"

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -1722,7 +1722,7 @@
     "message": "M̂íŝśîńĝ b́âśê-úr̂í âĺl̂óŵś îńĵéĉt́êd́ <b̂áŝé> t̂áĝś t̂ó ŝét̂ t́ĥé b̂áŝé ÛŔL̂ f́ôŕ âĺl̂ ŕêĺât́îv́ê ÚR̂Ĺŝ (é.ĝ. śĉŕîṕt̂ś) t̂ó âń ât́t̂áĉḱêŕ ĉón̂t́r̂ól̂ĺêd́ d̂óm̂áîń. Ĉón̂śîd́êŕ ŝét̂t́îńĝ b́âśê-úr̂í t̂ó 'n̂ón̂é' ôŕ 'ŝél̂f́'."
   },
   "lighthouse-core/lib/csp-evaluator.js | missingObjectSrc": {
-    "message": "Êĺêḿêńt̂ś ĉón̂t́r̂ól̂ĺêd́ b̂ý ôb́ĵéĉt́-ŝŕĉ ár̂é ĉón̂śîd́êŕêd́ l̂éĝáĉý f̂éât́ûŕêś. Ĉón̂śîd́êŕ ŝét̂t́îńĝ ób̂j́êćt̂-śr̂ć t̂ó 'n̂ón̂é' t̂ó p̂ŕêv́êńt̂ t́ĥé îńĵéĉt́îón̂ óf̂ ṕl̂úĝín̂ś t̂h́ât́ êx́êćût́ê ún̂śâf́ê śĉŕîṕt̂ś."
+    "message": "M̂íŝśîńĝ ób̂j́êćt̂-śr̂ć âĺl̂óŵś t̂h́ê ín̂j́êćt̂íôń ôf́ p̂ĺûǵîńŝ t́ĥát̂ éx̂éĉút̂é ûńŝáf̂é ŝćr̂íp̂t́ŝ. Ćôńŝíd̂ér̂ śêt́t̂ín̂ǵ ôb́ĵéĉt́-ŝŕĉ t́ô 'ńôńê' íf̂ ýôú ĉán̂."
   },
   "lighthouse-core/lib/csp-evaluator.js | missingScriptSrc": {
     "message": "ŝćr̂íp̂t́-ŝŕĉ d́îŕêćt̂ív̂é îś m̂íŝśîńĝ. T́ĥíŝ ćâń âĺl̂óŵ t́ĥé êx́êćût́îón̂ óf̂ ún̂śâf́ê śĉŕîṕt̂ś."
@@ -1743,7 +1743,7 @@
     "message": "T̂h́ê ŕêṕôŕt̂ín̂ǵ d̂éŝt́îńât́îón̂ íŝ ón̂ĺŷ ćôńf̂íĝúr̂éd̂ v́îá t̂h́ê ŕêṕôŕt̂-t́ô d́îŕêćt̂ív̂é. T̂h́îś d̂ír̂éĉt́îv́ê íŝ ón̂ĺŷ śûṕp̂ór̂t́êd́ îń Ĉh́r̂óm̂íûḿ-b̂áŝéd̂ b́r̂óŵśêŕŝ śô ít̂ íŝ ŕêćôḿm̂én̂d́êd́ t̂ó âĺŝó ûśê á r̂ép̂ór̂t́-ûŕî d́îŕêćt̂ív̂é."
   },
   "lighthouse-core/lib/csp-evaluator.js | strictDynamic": {
-    "message": "Ĥóŝt́ âĺl̂óŵĺîśt̂ś ĉán̂ f́r̂éq̂úêńt̂ĺŷ b́ê b́ŷṕâśŝéd̂. Ćôńŝíd̂ér̂ úŝín̂ǵ 'ŝt́r̂íĉt́-d̂ýn̂ám̂íĉ' ín̂ ćôḿb̂ín̂át̂íôń ŵít̂h́ ĈŚP̂ ńôńĉéŝ ór̂ h́âśĥéŝ."
+    "message": "Ĥóŝt́ âĺl̂óŵĺîśt̂ś ĉán̂ f́r̂éq̂úêńt̂ĺŷ b́ê b́ŷṕâśŝéd̂. Ćôńŝíd̂ér̂ úŝín̂ǵ ĈŚP̂ ńôńĉéŝ ór̂ h́âśĥéŝ ín̂śt̂éâd́, âĺôńĝ ẃît́ĥ 'śt̂ŕîćt̂-d́ŷńâḿîć' îf́ n̂éĉéŝśâŕŷ."
   },
   "lighthouse-core/lib/csp-evaluator.js | unknownDirective": {
     "message": "Ûńk̂ńôẃn̂ ĆŜṔ d̂ír̂éĉt́îv́ê."
@@ -1756,6 +1756,9 @@
   },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Ĉón̂śîd́êŕ âd́d̂ín̂ǵ 'ûńŝáf̂é-îńl̂ín̂é' (îǵn̂ór̂éd̂ b́ŷ b́r̂óŵśêŕŝ śûṕp̂ór̂t́îńĝ ńôńĉéŝ/h́âśĥéŝ) t́ô b́ê b́âćk̂ẃâŕd̂ ćôḿp̂át̂íb̂ĺê ẃît́ĥ ól̂d́êŕ b̂ŕôẃŝér̂ś."
+  },
+  "lighthouse-core/lib/csp-evaluator.js | unsafeKeyword": {
+    "message": "Âv́ôíd̂ úŝín̂ǵ {keyword} îń t̂h́îś d̂ír̂éĉt́îv́ê íf̂ ít̂ íŝ ńôt́ â f́âĺl̂b́âćk̂ f́ôŕ 'ŝt́r̂íĉt́-d̂ýn̂ám̂íĉ'."
   },
   "lighthouse-core/lib/i18n/i18n.js | columnBlockingTime": {
     "message": "M̂áîń-T̂h́r̂éâd́ B̂ĺôćk̂ín̂ǵ T̂ím̂é"

--- a/lighthouse-core/lib/i18n/locales/es-419.json
+++ b/lighthouse-core/lib/i18n/locales/es-419.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Al parecer, {keyword} es una palabra clave no válida."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "\"unsafe-inline\" permite la ejecución de controladores de eventos y secuencias de comando no seguras de la página. Considera usar nonces o hashes de la CSP para permitir secuencias de comandos por separado."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Considera agregar la palabra clave \"unsafe-inline\" (ignorada por los navegadores que admiten nonces y hashes) para que la política sea retrocompatible con los navegadores anteriores."
   },

--- a/lighthouse-core/lib/i18n/locales/es.json
+++ b/lighthouse-core/lib/i18n/locales/es.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Parece que {keyword} no es una palabra clave válida."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "La directiva unsafe-inline permite que se ejecuten secuencias de comandos in-page y gestores de eventos que no son seguros. Puedes usar nonces o hashes de CSP para permitir secuencias de comandos individualmente."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Puedes añadir la directiva unsafe-inline (los navegadores que admiten nonces o hashes la ignoran) para que sea retrocompatible con navegadores anteriores."
   },

--- a/lighthouse-core/lib/i18n/locales/fi.json
+++ b/lighthouse-core/lib/i18n/locales/fi.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Näyttää siltä, että {keyword} on virheellinen avainsana."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "\"unsafe-inlinen\" avulla voidaan suorittaa vaarallisia sivun sisäisiä skriptejä ja tapahtumien käsittelijöitä. Harkitse skriptien salliminen yksitellen käyttämällä CSP-nonceja tai ‑hasheja."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Harkitse \"unsafe-inlinen\" (jonka nonceja/hasheja tukevat selaimet ohittavat) lisäämistä, niin voit saavuttaa taaksepäinyhteensopivuuden vanhempien selainten kanssa."
   },

--- a/lighthouse-core/lib/i18n/locales/fil.json
+++ b/lighthouse-core/lib/i18n/locales/fil.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Mukhang invalid na keyword ang {keyword}."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Nagbibigay-daan ang 'unsafe-inline' sa pagpapatupad ng mga hindi ligtas na in-page na script at tagapangasiwa ng event. Pag-isipang gumamit ng mga CSP nonce o hash para indibidwal na payagan ang mga script."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Pag-isipang magdagdag ng 'unsafe-inline' (binabalewala ng mga browser na sumusuporta sa mga nonce/hash) para maging backward compatible sa mga lumang browser."
   },

--- a/lighthouse-core/lib/i18n/locales/fr.json
+++ b/lighthouse-core/lib/i18n/locales/fr.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} semble être un mot clé non valide."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "'unsafe-inline' permet d'exécuter des gestionnaires d'événements et des scripts non sécurisés sur la page. Pensez à utiliser des nonces ou des hachages CSP pour autoriser les scripts un à un."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Pensez à ajouter la commande 'unsafe-inline' (ignorée par les navigateurs prenant en charge les nonces/hachages) pour assurer la rétrocompatibilité avec les anciens navigateurs."
   },

--- a/lighthouse-core/lib/i18n/locales/he.json
+++ b/lighthouse-core/lib/i18n/locales/he.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "נראה שמילת המפתח {keyword} אינה תקנית."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "הרכיב unsafe-inline מאפשר להפעיל בדף סקריפטים וגורמים מטפלים באירועים שאינם בטוחים. רצוי להשתמש בגיבובים או בצפנים חד-פעמיים של CSP כדי להתיר הפעלה של כל סקריפט בנפרד."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "כדאי להוסיף רכיב 'unsafe-inline' (דפדפנים שתומכים בגיבובים/צפנים חד-פעמיים יתעלמו ממנו) לצורך תאימות לאחור עם דפדפנים ישנים."
   },

--- a/lighthouse-core/lib/i18n/locales/hi.json
+++ b/lighthouse-core/lib/i18n/locales/hi.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} एक गलत/अमान्य कीवर्ड लग रहा है."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "'unsafe-inline', असुरक्षित इन-पेज स्क्रिप्ट और इवेंट हैंडलर चलाने की अनुमति देता है. एक-एक करके स्क्रिप्ट को अनुमति देने के लिए, CSP nonces या hashes इस्तेमाल करें."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "'unsafe-inline' जोड़ें, ताकि CSP पुराने ब्राउज़र के साथ काम कर सके. nonces/hashes के साथ काम करने वाले ब्राउज़र पर 'unsafe-inline' को अनदेखा किया जा सकता है."
   },

--- a/lighthouse-core/lib/i18n/locales/hr.json
+++ b/lighthouse-core/lib/i18n/locales/hr.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Čini se da {keyword} nije važeća ključna riječ."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Direktiva unsafe-inline omogućuje izvršavanje nesigurnih skripti i rukovatelja događajima unutar stranice. Savjetujemo vam da koristite CSP nonceove ili hasheve kako biste omogućavali skripte pojedinačno."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Savjetujemo vam da koristite unsafe-inline (koji ignoriraju preglednici koji podržavaju nonceove/hasheve) radi kompatibilnosti s prijašnjim verzijama preglednika."
   },

--- a/lighthouse-core/lib/i18n/locales/hu.json
+++ b/lighthouse-core/lib/i18n/locales/hu.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Úgy tűnik, hogy a(z) {keyword} érvénytelen kulcsszó."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Az „unsafe-inline” lehetővé teszi nem biztonságos oldalon belüli szkriptek és eseménykezelők végrehajtását. A szkriptek egyenként történő engedélyezése érdekében fontolja meg CSP nonce-ok vagy hashek használatát."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "A régebbi böngészőkkel való kompatibilitás érdekében használhatja az „unsafe-inline” kulcsszót (a nonce-t/hasht támogató böngészők figyelmen kívül hagyják)."
   },

--- a/lighthouse-core/lib/i18n/locales/id.json
+++ b/lighthouse-core/lib/i18n/locales/id.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Tampaknya {keyword} adalah kata kunci yang tidak valid."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "'unsafe-inline' mengizinkan eksekusi skrip dalam halaman dan pengendali peristiwa yang tidak aman. Sebaiknya gunakan nonce atau hash CSP untuk mengizinkan skrip satu per satu."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Sebaiknya tambahkan 'unsafe-inline' (diabaikan oleh browser yang mendukung nonce/hash) agar kompatibel dengan browser versi lama."
   },

--- a/lighthouse-core/lib/i18n/locales/it.json
+++ b/lighthouse-core/lib/i18n/locales/it.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} sembra essere una parola chiave non valida."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "L'istruzione \"unsafe-inline\" consente l'esecuzione di gestori di eventi e script in-page non sicuri. Potresti usare hash o nonce CSP per consentire singoli script."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Potresti aggiungere l'istruzione \"unsafe-inline\" (ignorata dai browser che supportano nonce/hash) per la compatibilità con le versioni precedenti dei browser."
   },

--- a/lighthouse-core/lib/i18n/locales/ja.json
+++ b/lighthouse-core/lib/i18n/locales/ja.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} は無効なキーワードのようです。"
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "'unsafe-inline' が指定されているため、安全でないページ内スクリプトやイベント ハンドラを実行できる状態になっています。CSP nonce または hash を使用して、スクリプトを個別に許可することを検討してください。"
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "古いブラウザとの下位互換性を保つため、'unsafe-inline' を追加することを検討してください（nonce / hash をサポートしているブラウザでは無視されます）。"
   },

--- a/lighthouse-core/lib/i18n/locales/ko.json
+++ b/lighthouse-core/lib/i18n/locales/ko.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword}은(는) 잘못된 키워드인 것 같습니다."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "'unsafe-inline'은 안전하지 않은 인페이지 스크립트 및 이벤트 핸들러의 실행을 허용합니다. CSP nonce 또는 hash를 사용해 스크립트를 개별적으로 허용하는 것이 좋습니다."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "기존 브라우저와의 하위 호환성을 위하여 'unsafe-inline(nonce/hash를 지원하는 브라우저에서 무시됨)'을 추가하는 것이 좋습니다."
   },

--- a/lighthouse-core/lib/i18n/locales/lt.json
+++ b/lighthouse-core/lib/i18n/locales/lt.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Panašu, kad „{keyword}“ yra netinkamas raktinis žodis."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Raktinis žodis „unsafe-inline“ leidžia vykdyti nesaugius puslapio scenarijus ir įvykių dorokles. Apsvarstykite galimybę naudoti CSP vertes „nonce“ arba „hash“, kad scenarijų vykdymas būtų leidžiamas atskirai."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Apsvarstykite galimybę pridėti raktinį žodį „unsafe-inline“ (nepaisoma naršyklėse, palaikančiose vertes „nonce“ / „hash“), kad būtų užtikrintas atgalinis suderinamumas su senesnėmis naršyklėmis."
   },

--- a/lighthouse-core/lib/i18n/locales/lv.json
+++ b/lighthouse-core/lib/i18n/locales/lv.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} ir nederīgs atslēgvārds."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Atslēgvārds “unsafe-inline” ļauj izpildīt nedrošus lapā ievietotus skriptus un notikumu apdarinātājus. Apsveriet iespēju atļaut skriptus pa vienam, izmantojot SDP vienreizējos kodus vai jaucējvērtības."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Lai nodrošinātu atpakaļsaderību ar vecākām pārlūkprogrammām, varat pievienot atslēgvārdu “unsafe-inline” (pārlūkprogrammās, kas atbalsta vienreizējos kodus vai jaucējvērtības, šis atslēgvārds tiks ignorēts)."
   },

--- a/lighthouse-core/lib/i18n/locales/nl.json
+++ b/lighthouse-core/lib/i18n/locales/nl.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Zo te zien is {keyword} een ongeldig zoekwoord."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Met 'unsafe-inline' kunnen onveilige scripts en gebeurtenishandlers op de pagina worden uitgevoerd. Overweeg CSP-nonces of -hashes te gebruiken om scripts afzonderlijk toe te staan."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Voor compatibiliteit met oudere browsers kun je overwegen 'unsafe-inline' toe te voegen (dit wordt genegeerd door browsers die nonces/hashes ondersteunen)."
   },

--- a/lighthouse-core/lib/i18n/locales/no.json
+++ b/lighthouse-core/lib/i18n/locales/no.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} ser ut til å være et ugyldig nøkkelord."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "«unsafe-inline» muliggjør kjøring av utrygge skript og hendelsesbehandlere på siden. Vurder å bruke CSP-engangsverdier eller -hasher for å la skript kjøre individuelt."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Vurder å legge til «unsafe-inline» (ignoreres av nettlesere som støtter engangsverdier eller hasher) for bakoverkompatibilitet med eldre nettlesere."
   },

--- a/lighthouse-core/lib/i18n/locales/pl.json
+++ b/lighthouse-core/lib/i18n/locales/pl.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} jest prawdopodobnie nieprawidłowym słowem kluczowym."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Dyrektywa „unsafe-inline” zezwala na wykonywanie niebezpiecznych skryptów na stronie i uruchamianie modułów obsługi zdarzeń. Zastanów się, czy nie użyć liczb jednorazowych lub haszy CSP, aby zezwolić osobno na poszczególne skrypty."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Zastanów się, czy nie dodać dyrektywy „unsafe-inline” (ignorowanej przez przeglądarki obsługujące liczby jednorazowe i hasze), aby uzyskać zgodność wsteczną ze starszymi przeglądarkami."
   },

--- a/lighthouse-core/lib/i18n/locales/pt-PT.json
+++ b/lighthouse-core/lib/i18n/locales/pt-PT.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} parece ser uma palavra-chave inválida."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "A diretiva \"unsafe-inline\" permite a execução de scripts inseguros na página e de controladores de eventos. Considere utilizar nonces ou hashes CSP para permitir scripts individualmente."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Considere adicionar \"unsafe-inline\" (ignorado por navegadores que suportam nonces/hashes) para ser retrocompatível com navegadores mais antigos."
   },

--- a/lighthouse-core/lib/i18n/locales/pt.json
+++ b/lighthouse-core/lib/i18n/locales/pt.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Parece que {keyword} é uma palavra-chave inválida."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "\"unsafe-inline\" permite a execução de scripts não seguros na página, além de manipuladores de eventos. Use os nonces ou hashes de CSP para permitir scripts individualmente."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Adicione \"unsafe-inline\", ignorado por navegadores compatíveis com nonces/hashes, para oferecer compatibilidade com versões anteriores dos navegadores."
   },

--- a/lighthouse-core/lib/i18n/locales/ro.json
+++ b/lighthouse-core/lib/i18n/locales/ro.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} pare un cuvânt cheie nevalid."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "unsafe-inline permite executarea de scripturi în pagină și handlere pentru evenimente nesigure. Îți recomandăm să folosești valori nonce sau hash pentru CSP pentru a accepta scripturile individual."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Îți recomandăm să adaugi opțiunea unsafe-inline (ignorată de browserele care acceptă valori nonce/hash) pentru retrocompatibilitatea cu browsere mai vechi."
   },

--- a/lighthouse-core/lib/i18n/locales/ru.json
+++ b/lighthouse-core/lib/i18n/locales/ru.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} — недопустимое ключевое слово."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Директива unsafe-inline позволяет выполнять небезопасные скрипты и обработчики событий на странице. Чтобы разрешать отдельные скрипты, используйте nonce или hash в политике CSP."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Чтобы обеспечить обратную совместимость со старыми браузерами, добавьте директиву unsafe-inline (игнорируется браузерами, которые поддерживают nonce или hash)."
   },

--- a/lighthouse-core/lib/i18n/locales/sk.json
+++ b/lighthouse-core/lib/i18n/locales/sk.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Zdá sa, že {keyword} je neplatné kľúčové slovo."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "unsafe-inline umožňuje spustenie nebezpečných stránkových skriptov a obslužných nástrojov udalostí. Odporúčame povoliť skripty individuálne pomocou iba raz použiteľných čísiel alebo hodnôt hash PZO."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Odporúčame pridať direktívu unsafe-inline (ignorovanú prehliadačmi podporujúcimi iba raz použiteľné čísla a hodnoty hash), aby boli pravidlá spätne kompatibilné so staršími prehliadačmi."
   },

--- a/lighthouse-core/lib/i18n/locales/sl.json
+++ b/lighthouse-core/lib/i18n/locales/sl.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Videti je, da je {keyword} neveljavna ključna beseda."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Element »unsafe-inline« omogoča izvajanje na strani umeščenih skriptov, ki niso varni, in rutin za obravnavo dogodkov. Razmislite o uporabi žetonov ali zgoščenih vrednosti za pravilnik CSP, s katerim bi omogočali posamezne skripte."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Razmislite o dodajanju elementa »unsafe-inline« (brskalniki, ki podpirajo žetone/zgoščene vrednosti, ga prezrejo) zaradi povratne združljivosti s starejšimi brskalniki."
   },

--- a/lighthouse-core/lib/i18n/locales/sr-Latn.json
+++ b/lighthouse-core/lib/i18n/locales/sr-Latn.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Izgleda da je {keyword} nevažeća ključna reč."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Direktiva unsafe-inline omogućava izvršavanje nebezbednih skripti i obrađivača događaja na stranici. Savetujemo vam da koristite CSP jednokratne ključeve ili heševe da biste pojedinačno dozvoljavali skripte."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Savetujemo vam da dodate direktivu unsafe-inline (koju ignorišu pregledači koji podržavaju jednokratne ključeve/hešove) radi kompatibilnosti unazad sa starijim pregledačima."
   },

--- a/lighthouse-core/lib/i18n/locales/sr.json
+++ b/lighthouse-core/lib/i18n/locales/sr.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Изгледа да је {keyword} неважећа кључна реч."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "Директива unsafe-inline омогућава извршавање небезбедних скрипти и обрађивача догађаја на страници. Саветујемо вам да користите CSP једнократне кључеве или хешеве да бисте појединачно дозвољавали скрипте."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Саветујемо вам да додате директиву unsafe-inline (коју игноришу прегледачи који подржавају једнократне кључеве/хешове) ради компатибилности уназад са старијим прегледачима."
   },

--- a/lighthouse-core/lib/i18n/locales/sv.json
+++ b/lighthouse-core/lib/i18n/locales/sv.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} verkar vara ett ogiltigt sökord."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "unsafe-inline möjliggör att osäkra skript och händelsehanterare körs på sidan. Du kan använda CSP-noncevärden eller -hashvärden om du vill godkänna skript separat."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Du kan lägga till unsafe-inline (ignoreras av webbläsare med stöd för noncevärden/hashvärden) för bakåtkompatibilitet med äldre webbläsare."
   },

--- a/lighthouse-core/lib/i18n/locales/ta.json
+++ b/lighthouse-core/lib/i18n/locales/ta.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} தவறான தேடல் குறிப்பு போல் தெரிகிறது."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "பக்கத்தில் உள்ள பாதுகாப்பற்ற ஸ்கிரிப்ட்டுகள் & ஈவண்ட் ஹேண்ட்லர்கள் இயக்கத்தை 'unsafe-inline' அனுமதிக்கிறது. ஸ்கிரிப்ட்டுகளைத் தனியாக அனுமதிக்க, CSP nonces/hashes என்பதைப் பயன்படுத்தவும்."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "பழைய உலாவிகளுடன் இணக்கமாக இருக்கும் வகையில் 'unsafe-inline' (nonces/hashes என்பதை ஆதரிக்கும் உலாவிகளால் புறக்கணிக்கப்பட்டது) என்பதைச் சேர்ப்பதைக் கருத்தில் கொள்ளவும்."
   },

--- a/lighthouse-core/lib/i18n/locales/te.json
+++ b/lighthouse-core/lib/i18n/locales/te.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} చెల్లని కీవర్డ్‌లాగా అనిపిస్తుంది."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "'unsafe-inline' సురక్షితంకాని unsafe in-page స్క్రిప్ట్‌లు, అలాగే ఈవెంట్ హ్యాండ్లర్‌ల అమలును అనుమతిస్తుంది. స్క్రిప్ట్‌లను వ్యక్తిగతంగా అనుమతించేందుకు CSP nonces లేదా hashesను ఉపయోగించడాన్ని పరిగణించండి."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "పాత బ్రౌజర్‌లతో అనుకూలంగా ఉండటానికి 'unsafe-inline' (nonces/hashes సపోర్ట్ చేసే బ్రౌజర్‌ల ద్వారా విస్మరించబడినవి) జోడించడాన్ని పరిగణించండి."
   },

--- a/lighthouse-core/lib/i18n/locales/th.json
+++ b/lighthouse-core/lib/i18n/locales/th.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "ดูเหมือนว่า {keyword} จะเป็นคีย์เวิร์ดที่ไม่ถูกต้อง"
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "\"unsafe-inline\" ทำให้รันสคริปต์ในหน้าเว็บและตัวจัดการเหตุการณ์ที่ไม่ปลอดภัยได้ ลองใช้ nonces หรือ hashes ของ CSP เพื่ออนุญาตสคริปต์แต่ละรายการ"
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "ลองเพิ่ม \"unsafe-inline\" (ซึ่งเบราว์เซอร์ที่รองรับ nonces/hashes จะไม่สนใจ) เพื่อให้เข้ากันได้กับเบราว์เซอร์เวอร์ชันเก่ากว่า"
   },

--- a/lighthouse-core/lib/i18n/locales/tr.json
+++ b/lighthouse-core/lib/i18n/locales/tr.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} geçersiz bir anahtar kelime gibi görünüyor."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "\"unsafe-inline\", güvenli olmayan sayfa içi komut dosyalarının ve etkinlik işleyicilerin yürütülmesine izin verir. Komut dosyalarına ayrı ayrı izin vermek için CSP nonce veya hash değerleri kullanmayı düşünün."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Eski tarayıcılarla geriye dönük uyumluluk sağlamak için \"unsafe-inline\" yönergesi (nonce/hash destekleyen tarayıcılar tarafından yok sayılır) eklemeyi düşünün."
   },

--- a/lighthouse-core/lib/i18n/locales/uk.json
+++ b/lighthouse-core/lib/i18n/locales/uk.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Схоже, {keyword} – це недійсне ключове слово."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "unsafe-inline дозволяє виконувати ненадійні вбудовані скрипти та застосовувати обробники подій. Щоб дозволити окремі скрипти, скористатися nonces або hashes для CSP."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Додайте команду unsafe-inline (ігнорується веб-переглядачами, що підтримують nonces/hashes) для зворотної сумісності зі старішими веб-переглядачами."
   },

--- a/lighthouse-core/lib/i18n/locales/vi.json
+++ b/lighthouse-core/lib/i18n/locales/vi.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "Có vẻ như {keyword} là một từ khóa không hợp lệ."
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "\"unsafe-inline\" cho phép thực thi nhiều trình xử lý sự kiện và tập lệnh không an toàn trong trang. Hãy cân nhắc dùng nonces hoặc hashes của CSP để cho phép thực thi từng tập lệnh."
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "Hãy cân nhắc thêm \"unsafe-inline\" (bị các trình duyệt hỗ trợ nonces/hashes bỏ qua) để tương thích ngược với những trình duyệt cũ."
   },

--- a/lighthouse-core/lib/i18n/locales/zh-HK.json
+++ b/lighthouse-core/lib/i18n/locales/zh-HK.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} 似乎是無效關鍵字。"
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "「unsafe-inline」會允許執行不安全的頁面內嵌指令碼和事件處理常式。建議使用 CSP nonce 或 hash 逐一允許指令碼。"
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "建議新增「unsafe-inline」，以便退回兼容舊版瀏覽器 (支援 nonce/hash 的瀏覽器會忽略 unsafe-inline)。"
   },

--- a/lighthouse-core/lib/i18n/locales/zh-TW.json
+++ b/lighthouse-core/lib/i18n/locales/zh-TW.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword} 似乎是無效關鍵字。"
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "「unsafe-inline」會允許執行不安全的網頁內指令碼和事件處理常式。建議使用 CSP nonce 或 hash 逐一允許指令碼。"
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "建議新增「unsafe-inline」，以便回溯相容於舊版瀏覽器 (支援 nonce/hash 的瀏覽器會忽略 unsafe-inline)。"
   },

--- a/lighthouse-core/lib/i18n/locales/zh.json
+++ b/lighthouse-core/lib/i18n/locales/zh.json
@@ -1742,9 +1742,6 @@
   "lighthouse-core/lib/csp-evaluator.js | unknownKeyword": {
     "message": "{keyword}似乎是无效关键字。"
   },
-  "lighthouse-core/lib/csp-evaluator.js | unsafeInline": {
-    "message": "“unsafe-inline”允许执行不安全的页内脚本和事件处理脚本。建议您使用 CSP nonces 或 hashes 来逐一允许各个脚本。"
-  },
   "lighthouse-core/lib/csp-evaluator.js | unsafeInlineFallback": {
     "message": "建议您添加“unsafe-inline”（会被支持 nonces/hashes 的浏览器忽略），以便向后兼容旧版浏览器。"
   },

--- a/lighthouse-core/test/audits/csp-xss-test.js
+++ b/lighthouse-core/test/audits/csp-xss-test.js
@@ -28,9 +28,8 @@ const STATIC_RESULTS = {
     severity: SEVERITY.high,
     description: {
       formattedDefault:
-        'Elements controlled by object-src are considered legacy features. ' +
-        'Consider setting object-src to \'none\' to prevent the injection of ' +
-        'plugins that execute unsafe scripts.',
+        'Missing object-src allows the injection of plugins that execute unsafe scripts. ' +
+        'Consider setting object-src to \'none\' if you can.',
     },
     directive: 'object-src',
   },
@@ -43,15 +42,6 @@ const STATIC_RESULTS = {
         'Consider setting base-uri to \'none\' or \'self\'.',
     },
     directive: 'base-uri',
-  },
-  noReportingDestination: {
-    severity: SEVERITY.medium,
-    description: {
-      formattedDefault:
-        'No CSP configures a reporting destination. ' +
-        'This makes it difficult to maintain the CSP over time and monitor for any breakages.',
-    },
-    directive: 'report-uri',
   },
   metaTag: {
     severity: SEVERITY.medium,
@@ -112,7 +102,6 @@ it('audit basic header', async () => {
       },
       STATIC_RESULTS.noObjectSrc,
       STATIC_RESULTS.noBaseUri,
-      STATIC_RESULTS.noReportingDestination,
       STATIC_RESULTS.unsafeInlineFallback,
     ]
   );
@@ -295,7 +284,6 @@ describe('constructResults', () => {
         },
       },
       STATIC_RESULTS.noObjectSrc,
-      STATIC_RESULTS.noReportingDestination,
     ]);
   });
 

--- a/lighthouse-core/test/lib/csp-evaluator-test.js
+++ b/lighthouse-core/test/lib/csp-evaluator-test.js
@@ -58,9 +58,8 @@ describe('getTranslatedDescription', () => {
     expect(translated).toHaveLength(1);
     expect(isIcuMessage(translated[0])).toBeTruthy();
     expect(translated[0]).toBeDisplayString(
-      'Elements controlled by object-src are considered legacy features. ' +
-      'Consider setting object-src to \'none\' to prevent the injection of ' +
-      'plugins that execute unsafe scripts.'
+      'Missing object-src allows the injection of plugins that execute unsafe scripts. ' +
+      'Consider setting object-src to \'none\' if you can.'
     );
   });
 
@@ -91,8 +90,36 @@ describe('getTranslatedDescription', () => {
     );
   });
 
+  it('wildcard', () => {
+    const rawCsp = `script-src 'strict-dynamic' *; object-src *`;
+    const findings = evaluateRawCspForFailures([rawCsp]);
+    const translated = findings.map(getTranslatedDescription);
+
+    expect(translated).toHaveLength(1);
+    expect(findings[0].directive).toEqual('object-src');
+    expect(isIcuMessage(translated[0])).toBeTruthy();
+    expect(translated[0]).toBeDisplayString(
+      'Avoid using * in this directive ' +
+      'if it is not a fallback for \'strict-dynamic\'.'
+    );
+  });
+
+  it('plain url scheme', () => {
+    const rawCsp = `script-src 'strict-dynamic' https:; object-src https:`;
+    const findings = evaluateRawCspForFailures([rawCsp]);
+    const translated = findings.map(getTranslatedDescription);
+
+    expect(translated).toHaveLength(1);
+    expect(findings[0].directive).toEqual('object-src');
+    expect(isIcuMessage(translated[0])).toBeTruthy();
+    expect(translated[0]).toBeDisplayString(
+      'Avoid using https: in this directive ' +
+      'if it is not a fallback for \'strict-dynamic\'.'
+    );
+  });
+
   it('strict-dynamic', () => {
-    const rawCsp = `script-src http:; object-src 'none'`;
+    const rawCsp = `script-src https://example.com; object-src 'none'`;
     const findings = evaluateRawCspForFailures([rawCsp]);
     const translated = findings.map(getTranslatedDescription);
 
@@ -100,34 +127,7 @@ describe('getTranslatedDescription', () => {
     expect(isIcuMessage(translated[0])).toBeTruthy();
     expect(translated[0]).toBeDisplayString(
       'Host allowlists can frequently be bypassed. Consider using ' +
-      '\'strict-dynamic\' in combination with CSP nonces or hashes.'
-    );
-  });
-
-  it('no reporting destination', () => {
-    const rawCsp = `script-src 'none'`;
-    const findings = evaluateRawCspForWarnings([rawCsp]);
-    const translated = findings.map(getTranslatedDescription);
-
-    expect(translated).toHaveLength(1);
-    expect(isIcuMessage(translated[0])).toBeTruthy();
-    expect(translated[0]).toBeDisplayString(
-      'No CSP configures a reporting destination. ' +
-      'This makes it difficult to maintain the CSP over time and monitor for any breakages.'
-    );
-  });
-
-  it('report-to only', () => {
-    const rawCsp = `script-src 'none'; report-to https://example.com`;
-    const findings = evaluateRawCspForWarnings([rawCsp]);
-    const translated = findings.map(getTranslatedDescription);
-
-    expect(translated).toHaveLength(1);
-    expect(isIcuMessage(translated[0])).toBeTruthy();
-    expect(translated[0]).toBeDisplayString(
-      'The reporting destination is only configured via the report-to directive. ' +
-      'This directive is only supported in Chromium-based browsers so it is ' +
-      'recommended to also use a report-uri directive.'
+      'CSP nonces or hashes instead, along with \'strict-dynamic\' if necessary.'
     );
   });
 

--- a/lighthouse-core/test/lib/csp-evaluator-test.js
+++ b/lighthouse-core/test/lib/csp-evaluator-test.js
@@ -99,8 +99,8 @@ describe('getTranslatedDescription', () => {
     expect(findings[0].directive).toEqual('object-src');
     expect(isIcuMessage(translated[0])).toBeTruthy();
     expect(translated[0]).toBeDisplayString(
-      'Avoid using wildcards (*) in this directive. ' +
-      'It can allow scripts to be sourced from an unsafe domain.'
+      'Avoid using plain wildcards (*) in this directive. ' +
+      'Plain wildcards allow scripts to be sourced from an unsafe domain.'
     );
   });
 
@@ -114,7 +114,7 @@ describe('getTranslatedDescription', () => {
     expect(isIcuMessage(translated[0])).toBeTruthy();
     expect(translated[0]).toBeDisplayString(
       'Avoid using plain URL schemes (https:) in this directive. ' +
-      'It can allow scripts to be sourced from an unsafe domain.'
+      'Plain URL schemes allow scripts to be sourced from an unsafe domain.'
     );
   });
 

--- a/lighthouse-core/test/lib/csp-evaluator-test.js
+++ b/lighthouse-core/test/lib/csp-evaluator-test.js
@@ -99,8 +99,8 @@ describe('getTranslatedDescription', () => {
     expect(findings[0].directive).toEqual('object-src');
     expect(isIcuMessage(translated[0])).toBeTruthy();
     expect(translated[0]).toBeDisplayString(
-      'Avoid using * in this directive ' +
-      'if it is not a fallback for \'strict-dynamic\'.'
+      'Avoid using wildcards (*) in this directive. ' +
+      'It can allow scripts to be sourced from an unsafe domain.'
     );
   });
 
@@ -113,8 +113,8 @@ describe('getTranslatedDescription', () => {
     expect(findings[0].directive).toEqual('object-src');
     expect(isIcuMessage(translated[0])).toBeTruthy();
     expect(translated[0]).toBeDisplayString(
-      'Avoid using https: in this directive ' +
-      'if it is not a fallback for \'strict-dynamic\'.'
+      'Avoid using plain URL schemes (https:) in this directive. ' +
+      'It can allow scripts to be sourced from an unsafe domain.'
     );
   });
 

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "axe-core": "4.2.3",
     "chrome-launcher": "^0.14.0",
     "configstore": "^5.0.1",
-    "csp_evaluator": "1.0.4",
+    "csp_evaluator": "1.1.0",
     "cssstyle": "1.2.1",
     "enquirer": "^2.3.6",
     "http-link-header": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,10 +2817,10 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-csp_evaluator@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/csp_evaluator/-/csp_evaluator-1.0.4.tgz#152deb224683020d55a9dce853266ecab6c56129"
-  integrity sha512-hs1lAKCbx/SWXYwpUWu3bS/k1CS10HRLh/7Kjh+VMW2ZZ8GmzymMGlModz+IIgh4gpn+PGuSVoJFkBPU3wGR7Q==
+csp_evaluator@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/csp_evaluator/-/csp_evaluator-1.1.0.tgz#7fb3378a08163de4caf0a5297e92a5f70ef42d21"
+  integrity sha512-TcB+ZH9wZBG314jAUpKHPl1oYbRJV+nAT2YwZ9y4fmUN0FkEJa8e/hKZoOgzLYp1Z/CJdFhbhhGIGh0XG8W54Q==
 
 cssom@0.3.x, cssom@^0.3.4, cssom@~0.3.6:
   version "0.3.8"


### PR DESCRIPTION
Resolves the issues in https://github.com/GoogleChrome/lighthouse/issues/12804#issuecomment-887805754

In addition to the updates in that comment:

- We check for wildcards and plain URL schemes (e.g. https:) in `object-src`, `script-src`, and `base-uri`. This is meant to replace our enforcement of `object-src 'none'`.
- UI strings for missing `object-src` and host allowlist have been updated.