### PR TITLE
report: fix category anchor links for embedded render

### DIFF
--- a/report/renderer/category-renderer.js
+++ b/report/renderer/category-renderer.js
@@ -319,7 +319,11 @@ export class CategoryRenderer {
   renderScoreGauge(category, groupDefinitions) { // eslint-disable-line no-unused-vars
     const tmpl = this.dom.createComponent('gauge');
     const wrapper = this.dom.find('a.lh-gauge__wrapper', tmpl);
-    this.dom.safelySetHref(wrapper, `#${category.id}`);
+    const url = new URL(window.location.href);
+    url.hash = category.id;
+    this.dom.safelySetHref(wrapper, url.href);
+    // wrapper.href = url.href;
+    // wrapper.addEventListener('click', () => window.location.href = category.id);
 
     if (Util.isPluginCategory(category.id)) {
       wrapper.classList.add('lh-gauge__wrapper--plugin');

--- a/report/renderer/dom.js
+++ b/report/renderer/dom.js
@@ -161,7 +161,7 @@ export class DOM {
     let parsed;
     try {
       parsed = new URL(url);
-    } catch (_) {}
+    } catch {}
 
     if (parsed && allowedProtocols.includes(parsed.protocol)) {
       elem.href = parsed.href;

--- a/report/renderer/dom.js
+++ b/report/renderer/dom.js
@@ -157,7 +157,7 @@ export class DOM {
       return;
     }
 
-    const allowedProtocols = ['https:', 'http:'];
+    const allowedProtocols = ['https:', 'http:', window.location.protocol];
     let parsed;
     try {
       parsed = new URL(url);

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -128,6 +128,7 @@ export class ReportUIFeatures {
       const containerEl = this._dom.find('.lh-container', this._document);
       const elToAddScrollListener = this._getScrollParent(containerEl);
       elToAddScrollListener.addEventListener('scroll', this._updateStickyHeaderOnScroll);
+      window.addEventListener('hashchange', this._updateStickyHeaderOnScroll);
 
       // Use ResizeObserver where available.
       // TODO: there is an issue with incorrect position numbers and, as a result, performance

--- a/report/test/renderer/category-renderer-test.js
+++ b/report/test/renderer/category-renderer-test.js
@@ -24,16 +24,18 @@ describe('CategoryRenderer', () => {
   beforeAll(() => {
     Util.i18n = new I18n('en', {...Util.UIStrings});
 
-    const {document} = new jsdom.JSDOM().window;
-    const dom = new DOM(document);
+    const {window} = new jsdom.JSDOM();
+    const dom = new DOM(window.document);
     const detailsRenderer = new DetailsRenderer(dom);
     renderer = new CategoryRenderer(dom, detailsRenderer);
+    global.window = window;
 
     sampleResults = Util.prepareReportResult(sampleResultsOrig);
   });
 
   afterAll(() => {
     Util.i18n = undefined;
+    global.window = undefined;
   });
 
   it('renders an audit', () => {

--- a/report/test/renderer/crc-details-renderer-test.js
+++ b/report/test/renderer/crc-details-renderer-test.js
@@ -74,16 +74,18 @@ describe('DetailsRenderer', () => {
   let dom;
   let detailsRenderer;
 
-  beforeAll(() => {
+  beforeEach(() => {
     Util.i18n = new I18n('en', {...Util.UIStrings});
 
-    const {document} = new jsdom.JSDOM().window;
-    dom = new DOM(document);
+    const {window} = new jsdom.JSDOM();
+    dom = new DOM(window.document);
     detailsRenderer = new DetailsRenderer(dom);
+    global.window = window;
   });
 
-  afterAll(() => {
+  afterEach(() => {
     Util.i18n = undefined;
+    global.window = undefined;
   });
 
   it('renders tree structure', () => {

--- a/report/test/renderer/details-renderer-test.js
+++ b/report/test/renderer/details-renderer-test.js
@@ -18,9 +18,10 @@ describe('DetailsRenderer', () => {
   let renderer;
 
   function createRenderer(options) {
-    const {document} = new jsdom.JSDOM().window;
-    const dom = new DOM(document);
+    const {window} = new jsdom.JSDOM();
+    const dom = new DOM(window.document);
     renderer = new DetailsRenderer(dom, options);
+    global.window = window;
   }
 
   beforeAll(() => {
@@ -30,6 +31,7 @@ describe('DetailsRenderer', () => {
 
   afterAll(() => {
     Util.i18n = undefined;
+    global.window = undefined;
   });
 
   describe('render', () => {

--- a/report/test/renderer/dom-test.js
+++ b/report/test/renderer/dom-test.js
@@ -18,12 +18,11 @@ import {I18n} from '../../renderer/i18n.js';
 describe('DOM', () => {
   /** @type {DOM} */
   let dom;
-  let window;
   let nativeCreateObjectURL;
 
   beforeAll(() => {
     Util.i18n = new I18n('en', {...Util.UIStrings});
-    window = new jsdom.JSDOM().window;
+    const {window} = new jsdom.JSDOM();
 
     // The Node version of URL.createObjectURL isn't compatible with the jsdom blob type,
     // so we stub it.
@@ -32,11 +31,14 @@ describe('DOM', () => {
 
     dom = new DOM(window.document);
     dom.setLighthouseChannel('someChannel');
+
+    global.window = window;
   });
 
   afterAll(() => {
     Util.i18n = undefined;
     URL.createObjectURL = nativeCreateObjectURL;
+    global.window = undefined;
   });
 
   describe('createElement', () => {
@@ -186,7 +188,6 @@ describe('DOM', () => {
         'filesystem:http://localhost/img.png',
         'ws://evilchat.com/',
         'wss://evilchat.com/',
-        'about:about',
         'chrome://chrome-urls/',
       ].forEach(url => {
         const a = dom.createElement('a');

--- a/report/test/renderer/performance-category-renderer-test.js
+++ b/report/test/renderer/performance-category-renderer-test.js
@@ -24,20 +24,24 @@ describe('PerfCategoryRenderer', () => {
   let sampleResults;
 
   beforeAll(() => {
-    Util.i18n = new I18n('en', {...Util.UIStrings});
-
-    const {document} = new jsdom.JSDOM().window;
-    const dom = new DOM(document);
-    const detailsRenderer = new DetailsRenderer(dom);
-    renderer = new PerformanceCategoryRenderer(dom, detailsRenderer);
-
     // TODO: don't call a LH.ReportResult `sampleResults`, which is typically always LH.Result
     sampleResults = Util.prepareReportResult(sampleResultsOrig);
     category = sampleResults.categories.performance;
   });
 
-  afterAll(() => {
+  beforeEach(() => {
+    Util.i18n = new I18n('en', {...Util.UIStrings});
+
+    const {window} = new jsdom.JSDOM();
+    const dom = new DOM(window.document);
+    const detailsRenderer = new DetailsRenderer(dom);
+    renderer = new PerformanceCategoryRenderer(dom, detailsRenderer);
+    global.window = window;
+  });
+
+  afterEach(() => {
     Util.i18n = undefined;
+    global.window = undefined;
   });
 
   it('renders the category header', () => {
@@ -298,7 +302,7 @@ describe('PerfCategoryRenderer', () => {
     let getDescriptionsAfterCheckedToggle;
 
     describe('works if there is a performance category', () => {
-      beforeAll(() => {
+      beforeEach(() => {
         container = renderer.render(category, sampleResults.categoryGroups);
         const metricsAuditGroup = container.querySelector(metricsSelector);
         toggle = metricsAuditGroup.querySelector(toggleSelector);

--- a/report/test/renderer/pwa-category-renderer-test.js
+++ b/report/test/renderer/pwa-category-renderer-test.js
@@ -23,24 +23,26 @@ describe('PwaCategoryRenderer', () => {
   let sampleResults;
 
   beforeAll(() => {
-    Util.i18n = new I18n('en', {...Util.UIStrings});
-
-    const {document} = new jsdom.JSDOM().window;
-    const dom = new DOM(document);
-    const detailsRenderer = new DetailsRenderer(dom);
-    pwaRenderer = new PwaCategoryRenderer(dom, detailsRenderer);
-
     sampleResults = Util.prepareReportResult(sampleResultsOrig);
   });
 
   beforeEach(() => {
+    Util.i18n = new I18n('en', {...Util.UIStrings});
+
     // Clone category to allow modifications.
     const pwaCategory = sampleResults.categories.pwa;
     category = JSON.parse(JSON.stringify(pwaCategory));
+
+    const {window} = new jsdom.JSDOM();
+    const dom = new DOM(window.document);
+    const detailsRenderer = new DetailsRenderer(dom);
+    pwaRenderer = new PwaCategoryRenderer(dom, detailsRenderer);
+    global.window = window;
   });
 
-  afterAll(() => {
+  afterEach(() => {
     Util.i18n = undefined;
+    global.window = undefined;
   });
 
   it('renders the regular audits', () => {

--- a/report/test/renderer/report-renderer-test.js
+++ b/report/test/renderer/report-renderer-test.js
@@ -33,7 +33,7 @@ describe('ReportRenderer', () => {
     };
 
     const {window} = new jsdom.JSDOM();
-    global.self = window;
+    global.window = global.self = window;
 
     const dom = new DOM(window.document);
     const detailsRenderer = new DetailsRenderer(dom);
@@ -44,6 +44,7 @@ describe('ReportRenderer', () => {
 
   afterAll(() => {
     global.self = undefined;
+    global.window = undefined;
     global.matchMedia = undefined;
   });
 


### PR DESCRIPTION
This link was replacing the URL with basically `window.location.pathname#...`, which is a bug when the report is not on the root of an origin. bug was made apparent in new PSI.