### PR TITLE
core(http-status-code): navigation only

### DIFF
--- a/lighthouse-core/audits/seo/http-status-code.js
+++ b/lighthouse-core/audits/seo/http-status-code.js
@@ -35,6 +35,7 @@ class HTTPStatusCode extends Audit {
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
       requiredArtifacts: ['devtoolsLogs', 'URL', 'GatherContext'],
+      supportedModes: ['navigation'],
     };
   }
 
@@ -47,12 +48,7 @@ class HTTPStatusCode extends Audit {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const URL = artifacts.URL;
     const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-    const mainResource = NetworkAnalyzer.findOptionalMainDocument(networkRecords, URL.finalUrl);
-
-    if (!mainResource) {
-      if (artifacts.GatherContext.gatherMode === 'timespan') return {notApplicable: true, score: 1};
-      throw new Error(`Unable to locate main resource`);
-    }
+    const mainResource = NetworkAnalyzer.findMainDocument(networkRecords, URL.finalUrl);
 
     const statusCode = mainResource.statusCode;
 

--- a/lighthouse-core/test/audits/seo/http-status-code-test.js
+++ b/lighthouse-core/test/audits/seo/http-status-code-test.js
@@ -69,17 +69,4 @@ describe('SEO: HTTP code audit', () => {
     const resultPromise = HTTPStatusCodeAudit.audit(artifacts, {computedCache: new Map()});
     await expect(resultPromise).rejects.toThrow();
   });
-
-  it('notApplicable when main resource cannot be found in timespan', async () => {
-    const finalUrl = 'https://example.com';
-
-    const artifacts = {
-      GatherContext: {gatherMode: 'timespan'},
-      devtoolsLogs: {[HTTPStatusCodeAudit.DEFAULT_PASS]: []},
-      URL: {finalUrl},
-    };
-
-    const results = await HTTPStatusCodeAudit.audit(artifacts, {computedCache: new Map()});
-    expect(results.notApplicable).toBe(true);
-  });
 });

--- a/lighthouse-core/test/fraggle-rock/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/api-test-pptr.js
@@ -130,7 +130,7 @@ describe('Fraggle Rock API', () => {
         notApplicableAudits,
       } = getAuditsBreakdown(lhr);
       // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
-      expect(auditResults.length).toMatchInlineSnapshot(`50`);
+      expect(auditResults.length).toMatchInlineSnapshot(`48`);
 
       expect(notApplicableAudits.length).toMatchInlineSnapshot(`7`);
       expect(notApplicableAudits.map(audit => audit.id)).not.toContain('server-response-time');
@@ -172,9 +172,9 @@ describe('Fraggle Rock API', () => {
       if (!result) throw new Error('Lighthouse failed to produce a result');
 
       const {auditResults, erroredAudits, notApplicableAudits} = getAuditsBreakdown(result.lhr);
-      expect(auditResults.length).toMatchInlineSnapshot(`50`);
+      expect(auditResults.length).toMatchInlineSnapshot(`48`);
 
-      expect(notApplicableAudits.length).toMatchInlineSnapshot(`22`);
+      expect(notApplicableAudits.length).toMatchInlineSnapshot(`21`);
       expect(notApplicableAudits.map(audit => audit.id)).toContain('server-response-time');
 
       // TODO(FR-COMPAT): Reduce this number by handling the error, making N/A, or removing timespan support.


### PR DESCRIPTION
It's the only (non-manual) audit in timespan SEO, and it would be N/A most of the time.