### PR TITLE
deps(raven): make raven an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "preact": "^10.5.14",
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "^10.2.0",
+    "raven": "^2.2.1",
     "resolve": "^1.20.0",
     "rollup": "^2.52.7",
     "rollup-plugin-node-resolve": "^5.2.0",
@@ -204,7 +205,6 @@
     "open": "^8.4.0",
     "parse-cache-control": "1.0.1",
     "ps-list": "^8.0.0",
-    "raven": "^2.2.1",
     "robots-parser": "^3.0.0",
     "semver": "^5.3.0",
     "speedline-core": "^1.4.3",
@@ -215,6 +215,14 @@
   },
   "resolutions": {
     "puppeteer/**/devtools-protocol": "0.0.964215"
+  },
+  "peerDependencies": {
+    "raven": "^2"
+  },
+  "peerDependenciesMeta": {
+    "raven": {
+      "optional": true
+    }
   },
   "repository": "GoogleChrome/lighthouse",
   "keywords": [


### PR DESCRIPTION
**Summary**

This package has been deprecated in favor of `@sentry/node`. It just hasn’t been marked as such on npmjs.com.

It depends on deprecated packages, which yields deprecation warnings for users installing lighthouse.

It’s usage is optional in lighthouse. It’s disabled by default, and even if it’s enabled in options, the `require` statement for it is in a try-catch block.


**Related Issues/PRs**

https://docs.sentry.io/clients/javascript/
