### PR TITLE
misc: remove all FR-COMPAT todos

### DIFF
--- a/flow-report/src/summary/summary.tsx
+++ b/flow-report/src/summary/summary.tsx
@@ -68,7 +68,6 @@ export const SummaryFlowStep: FunctionComponent<{
   label: string,
   hashIndex: number,
 }> = ({lhr, label, hashIndex}) => {
-  // TODO(FR-COMPAT): Store report results globally.
   const reportResult = useMemo(() => Util.prepareReportResult(lhr), [lhr]);
 
   const screenshot = reportResult.gatherMode !== 'timespan' ? getScreenshot(reportResult) : null;
@@ -153,7 +152,6 @@ export const SummaryHeader: FunctionComponent = () => {
     }
   }
 
-  // TODO(FR-COMPAT): Pluralize UI strings.
   const subtitleCounts = [];
   if (numNavigation) subtitleCounts.push(`${numNavigation} navigation reports`);
   if (numTimespan) subtitleCounts.push(`${numTimespan} timespan reports`);

--- a/flow-report/src/util.ts
+++ b/flow-report/src/util.ts
@@ -135,7 +135,6 @@ export function useDerivedStepNames() {
     let numTimespan = 1;
     let numSnapshot = 1;
 
-    // TODO(FR-COMPAT): Override with a provided step name.
     return flowResult.lhrs.map((lhr, index) => {
       const shortUrl = shortenUrl(lhr.finalUrl);
 

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -129,7 +129,6 @@ class UnusedBytes extends Audit {
     const [result, graph, simulator] = await Promise.all([
       this.audit_(artifacts, networkRecords, context),
       // Page dependency graph is only used in navigation mode.
-      // TODO(FR-COMPAT): Use dependency graph in timespan mode.
       gatherContext.gatherMode === 'navigation' ?
         PageDependencyGraph.request({trace, devtoolsLog}, context) :
         null,
@@ -201,7 +200,6 @@ class UnusedBytes extends Audit {
   }
 
   /**
-   * TODO(FR-COMPAT): Rework opportunities to remove emphasis on `wastedMs`
    * @param {number} wastedBytes
    * @param {Simulator} simulator
    */

--- a/lighthouse-core/fraggle-rock/config/config.js
+++ b/lighthouse-core/fraggle-rock/config/config.js
@@ -134,7 +134,7 @@ function resolveArtifactsToDefns(artifacts, configDir) {
   const coreGathererList = Runner.getGathererList();
   const artifactDefns = artifacts.map(artifactJson => {
     /** @type {LH.Config.GathererJson} */
-    // @ts-expect-error FR-COMPAT - eventually move the config-helpers to support new types
+    // @ts-expect-error - remove when legacy runner path is removed.
     const gathererJson = artifactJson.gatherer;
 
     const gatherer = resolveGathererToDefn(gathererJson, coreGathererList, configDir);
@@ -251,7 +251,6 @@ function initializeConfig(configJSON, context) {
 
   configWorkingCopy = resolveExtensions(configWorkingCopy);
 
-  // TODO(FR-COMPAT): handle config plugins
 
   const settings = resolveSettings(configWorkingCopy.settings || {}, context.settingsOverrides);
   overrideSettingsForGatherMode(settings, context);

--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -242,8 +242,6 @@ async function _navigations({driver, config, requestedUrl, computedCache}) {
 async function _cleanup({requestedUrl, driver, config}) {
   const didResetStorage = !config.settings.disableStorageReset;
   if (didResetStorage) await storage.clearDataForOrigin(driver.defaultSession, requestedUrl);
-
-  // TODO(FR-COMPAT): add driver.disconnect session tracking
 }
 
 /**

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -155,7 +155,6 @@ class GatherRunner {
     const session = driver.defaultSession;
 
     // Assert no service workers are still installed, so we test that they would actually be installed for a new user.
-    // TODO(FR-COMPAT): re-evaluate the necessity of this check
     await GatherRunner.assertNoSameOriginServiceWorkerClients(session, options.requestedUrl);
 
     await prepare.prepareTargetForNavigationMode(driver, options.settings);

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -20,7 +20,6 @@ class CSSUsage extends FRGatherer {
     /** @param {LH.Crdp.CSS.StyleSheetRemovedEvent} sheet */
     this._onStylesheetRemoved = sheet => {
       // We can't fetch the content of removed stylesheets, so we ignore them completely.
-      // TODO(FR-COMPAT): Refactor use of CSSUsage artifact to not *always* rely on the content of stylesheets.
       const styleSheetId = sheet.styleSheetId;
       this._stylesheets = this._stylesheets.filter(s => s.header.styleSheetId !== styleSheetId);
     };
@@ -84,7 +83,6 @@ class CSSUsage extends FRGatherer {
     const session = context.driver.defaultSession;
     const executionContext = context.driver.executionContext;
 
-    // TODO(FR-COMPAT): Do this only for snapshot once legacy runner is deprecated.
     if (context.gatherMode !== 'timespan') {
       await this.startCSSUsageTracking(context);
 

--- a/lighthouse-core/gather/gatherers/js-usage.js
+++ b/lighthouse-core/gather/gatherers/js-usage.js
@@ -134,7 +134,6 @@ class JsUsage extends FRGatherer {
       usageByUrl[url] = scripts;
     }
 
-    // TODO(FR-COMPAT): Enable this logic for legacy and navigation or make a separate artifact for url/scriptId mappings.
     if (context.gatherMode !== 'navigation') {
       this._addMissingScriptIds(usageByUrl);
     }

--- a/lighthouse-core/gather/gatherers/trace.js
+++ b/lighthouse-core/gather/gatherers/trace.js
@@ -103,8 +103,6 @@ class Trace extends FRGatherer {
    * @param {LH.Gatherer.FRTransitionalContext} passContext
    */
   async startSensitiveInstrumentation({driver, gatherMode}) {
-    // TODO(FR-COMPAT): read additional trace categories from overall settings?
-    // TODO(FR-COMPAT): check if CSS/DOM domains have been enabled in another session and warn?
     await driver.defaultSession.sendCommand('Page.enable');
     await driver.defaultSession.sendCommand('Tracing.start', {
       categories: Trace.getDefaultTraceCategories().join(','),

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -47,7 +47,6 @@ async function emulate(session, settings) {
  * @return {Promise<void>}
  */
 async function throttle(session, settings) {
-  // TODO(FR-COMPAT): reconsider if this should be resetting anything
   if (settings.throttlingMethod !== 'devtools') return clearNetworkThrottling(session);
 
   await Promise.all([

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -132,7 +132,6 @@ class Runner {
 
       /** @type {LH.RawIcu<LH.Result>} */
       const i18nLhr = {
-        // TODO(FR-COMPAT): Make GatherContext a true base artifact.
         // If GatherContext is not collected, then we are in a non-default pass of the legacy runner.
         gatherMode: artifacts.GatherContext ? artifacts.GatherContext.gatherMode : 'navigation',
         userAgent: artifacts.HostUserAgent,

--- a/lighthouse-core/test/fraggle-rock/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/api-test-pptr.js
@@ -98,6 +98,7 @@ describe('Fraggle Rock API', () => {
       expect(accessibility.score).toBeLessThan(1);
 
       const {auditResults, erroredAudits, failedAudits} = getAuditsBreakdown(lhr);
+      // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
       expect(auditResults.length).toMatchInlineSnapshot(`80`);
 
       expect(erroredAudits).toHaveLength(0);
@@ -128,6 +129,7 @@ describe('Fraggle Rock API', () => {
         failedAudits,
         notApplicableAudits,
       } = getAuditsBreakdown(lhr);
+      // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
       expect(auditResults.length).toMatchInlineSnapshot(`48`);
 
       expect(notApplicableAudits.length).toMatchInlineSnapshot(`6`);
@@ -192,6 +194,7 @@ describe('Fraggle Rock API', () => {
 
       const {lhr} = result;
       const {auditResults, failedAudits, erroredAudits} = getAuditsBreakdown(lhr);
+      // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
       expect(auditResults.length).toMatchInlineSnapshot(`154`);
       expect(erroredAudits).toHaveLength(0);
 

--- a/lighthouse-core/test/fraggle-rock/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/api-test-pptr.js
@@ -98,7 +98,6 @@ describe('Fraggle Rock API', () => {
       expect(accessibility.score).toBeLessThan(1);
 
       const {auditResults, erroredAudits, failedAudits} = getAuditsBreakdown(lhr);
-      // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
       expect(auditResults.length).toMatchInlineSnapshot(`80`);
 
       expect(erroredAudits).toHaveLength(0);
@@ -129,7 +128,6 @@ describe('Fraggle Rock API', () => {
         failedAudits,
         notApplicableAudits,
       } = getAuditsBreakdown(lhr);
-      // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
       expect(auditResults.length).toMatchInlineSnapshot(`48`);
 
       expect(notApplicableAudits.length).toMatchInlineSnapshot(`6`);
@@ -194,7 +192,6 @@ describe('Fraggle Rock API', () => {
 
       const {lhr} = result;
       const {auditResults, failedAudits, erroredAudits} = getAuditsBreakdown(lhr);
-      // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
       expect(auditResults.length).toMatchInlineSnapshot(`154`);
       expect(erroredAudits).toHaveLength(0);
 

--- a/types/lhr/flow.d.ts
+++ b/types/lhr/flow.d.ts
@@ -8,7 +8,6 @@ import Result from './lhr';
 
 /**
  * The full output of a Lighthouse flow. Includes a series of Lighthouse runs.
- * TODO(FR-COMPAT): Add flow specific metadata (e.g. interaction steps).
  */
 export default interface FlowResult {
   /** Ordered list of lighthouse results corresponding to a navigation, timespan, or snapshot. */


### PR DESCRIPTION
**Summary**
The usage of FR-COMPAT comments morphed over time from a "heads up critical functionality is still missing" to a "here's something we want to eventually accomplish in FR." All but 1 of the existing comments were closer to the latter which I believe is better tracked as items in #11313. I've added all the relevant efforts captured by the current set of comments to that issue and feel we're close enough that future work can continue to be tracked through issues rather than the comments.

@adamraine thoughts?

**Related Issues/PRs**
ref #11313 
