### PR TITLE
core(fr): preserve traces on failed page load

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/errors/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/errors/error-expectations.js
@@ -35,9 +35,8 @@ const infiniteLoop = {
       'pageLoadError-default': {...NONEMPTY_ARRAY, _fraggleRockOnly: true},
     },
     traces: {
-      // Fraggle Rock treats traces as regular artifacts which are not collected on error.
-      '_legacyOnly': true,
-      'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY},
+      'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY, _legacyOnly: true},
+      'pageLoadError-default': {traceEvents: NONEMPTY_ARRAY, _fraggleRockOnly: true},
     },
   },
 };
@@ -69,9 +68,8 @@ const expiredSsl = {
       'pageLoadError-default': {...NONEMPTY_ARRAY, _fraggleRockOnly: true},
     },
     traces: {
-      // Fraggle Rock treats traces as regular artifacts which are not collected on error.
-      '_legacyOnly': true,
-      'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY},
+      'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY, _legacyOnly: true},
+      'pageLoadError-default': {traceEvents: NONEMPTY_ARRAY, _fraggleRockOnly: true},
     },
   },
 };

--- a/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
@@ -18,6 +18,7 @@ const {initializeConfig} = require('../../../fraggle-rock/config/config.js');
 const {defaultNavigationConfig} = require('../../../config/constants.js');
 const LighthouseError = require('../../../lib/lh-error.js');
 const DevtoolsLogGatherer = require('../../../gather/gatherers/devtools-log.js');
+const TraceGatherer = require('../../../gather/gatherers/trace.js');
 const toDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 // Establish the mocks before we require our file under test.
@@ -342,10 +343,15 @@ describe('NavigationRunner', () => {
       const devtoolsLog = toDevtoolsLog([{url: requestedUrl, failed: true}]);
       gatherers.timespan.meta.symbol = DevtoolsLogGatherer.symbol;
       gatherers.timespan.getArtifact = jest.fn().mockResolvedValue(devtoolsLog);
+      gatherers.navigation.meta.symbol = TraceGatherer.symbol;
+      gatherers.navigation.getArtifact = jest.fn().mockResolvedValue({traceEvents: []});
 
       const {artifacts, pageLoadError} = await run(navigation);
       expect(pageLoadError).toBeInstanceOf(LighthouseError);
-      expect(artifacts).toEqual({devtoolsLogs: {'pageLoadError-default': expect.any(Array)}});
+      expect(artifacts).toEqual({
+        devtoolsLogs: {'pageLoadError-default': expect.any(Array)},
+        traces: {'pageLoadError-default': {traceEvents: []}},
+      });
     });
 
     it('cleans up throttling before getArtifact', async () => {


### PR DESCRIPTION
**Summary**
Preserves traces in the artifacts when page load fails in Fraggle Rock navigation runner. This brings parity to error artifacts for FR.

**Related Issues/PRs**
ref #11313 
