### PR TITLE
core(fr): add support for plugins

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/core-tests.js
@@ -242,6 +242,10 @@ const smokeTests = [{
   expectations: require('./screenshot/expectations.js'),
   config: require('./screenshot/screenshot-config.js'),
 }, {
+  id: 'pubads',
+  expectations: require('./pubads/expectations.js'),
+  config: require('./pubads/pubads-config.js'),
+}, {
   id: 'csp-allow-all',
   expectations: csp.allowAll,
   config: require('./csp/csp-config.js'),

--- a/lighthouse-cli/test/smokehouse/test-definitions/pubads/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pubads/expectations.js
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+  * @type {Smokehouse.ExpectedRunnerResult}
+  */
+const expectations = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/online-only.html',
+    finalUrl: 'http://localhost:10200/online-only.html',
+    // We should receive warnings about no ads being on the page.
+    runWarnings: {length: '>0'},
+    audits: {
+      // We just want to ensure the plugin had a chance to run without error.
+      'ad-render-blocking-resources': {scoreDisplayMode: 'notApplicable'},
+    },
+  },
+};
+
+module.exports = expectations;

--- a/lighthouse-cli/test/smokehouse/test-definitions/pubads/pubads-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pubads/pubads-config.js
@@ -1,0 +1,12 @@
+/**
+ * @license Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/** @type {LH.Config.Json} */
+module.exports = {
+  extends: 'lighthouse:default',
+  plugins: ['lighthouse-plugin-publisher-ads'],
+};

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -14,13 +14,12 @@ const validation = require('./../fraggle-rock/config/validation.js');
 const log = require('lighthouse-logger');
 const path = require('path');
 const Runner = require('../runner.js');
-const ConfigPlugin = require('./config-plugin.js');
 const {
+  mergePlugins,
   mergeConfigFragment,
   resolveSettings,
   resolveAuditsToDefns,
   resolveGathererToDefn,
-  resolveModulePath,
   deepClone,
   deepCloneConfigJson,
 } = require('./config-helpers.js');
@@ -148,22 +147,6 @@ function assertValidFlags(flags) {
   }
 }
 
-/**
- * Throws if pluginName is invalid or (somehow) collides with a category in the
- * configJSON being added to.
- * @param {LH.Config.Json} configJSON
- * @param {string} pluginName
- */
-function assertValidPluginName(configJSON, pluginName) {
-  if (!pluginName.startsWith('lighthouse-plugin-')) {
-    throw new Error(`plugin name '${pluginName}' does not start with 'lighthouse-plugin-'`);
-  }
-
-  if (configJSON.categories && configJSON.categories[pluginName]) {
-    throw new Error(`plugin name '${pluginName}' not allowed because it is the id of a category already found in config`); // eslint-disable-line max-len
-  }
-}
-
 
 /**
  * @implements {LH.Config.Config}
@@ -203,7 +186,7 @@ class Config {
     const configDir = configPath ? path.dirname(configPath) : undefined;
 
     // Validate and merge in plugins (if any).
-    configJSON = Config.mergePlugins(configJSON, flags, configDir);
+    configJSON = mergePlugins(configJSON, configDir, flags);
 
     if (flags) {
       assertValidFlags(flags);
@@ -292,33 +275,6 @@ class Config {
     }
 
     return mergeConfigFragment(baseJSON, extendJSON);
-  }
-
-  /**
-   * @param {LH.Config.Json} configJSON
-   * @param {LH.Flags=} flags
-   * @param {string=} configDir
-   * @return {LH.Config.Json}
-   */
-  static mergePlugins(configJSON, flags, configDir) {
-    const configPlugins = configJSON.plugins || [];
-    const flagPlugins = (flags && flags.plugins) || [];
-    const pluginNames = new Set([...configPlugins, ...flagPlugins]);
-
-    for (const pluginName of pluginNames) {
-      assertValidPluginName(configJSON, pluginName);
-
-      // TODO: refactor and delete `global.isDevtools`.
-      const pluginPath = global.isDevtools || global.isLightrider ?
-        pluginName :
-        resolveModulePath(pluginName, configDir, 'plugin');
-      const rawPluginJson = require(pluginPath);
-      const pluginJson = ConfigPlugin.parsePlugin(rawPluginJson, pluginName);
-
-      configJSON = Config.extendConfigJSON(configJSON, pluginJson);
-    }
-
-    return configJSON;
   }
 
   /**

--- a/lighthouse-core/fraggle-rock/config/config.js
+++ b/lighthouse-core/fraggle-rock/config/config.js
@@ -24,6 +24,7 @@ const {
   resolveSettings,
   resolveAuditsToDefns,
   resolveGathererToDefn,
+  mergePlugins,
   mergeConfigFragment,
   mergeConfigFragmentArrayByKey,
 } = require('../../config/config-helpers.js');
@@ -250,7 +251,7 @@ function initializeConfig(configJSON, context) {
   let {configWorkingCopy, configDir} = resolveWorkingCopy(configJSON, context); // eslint-disable-line prefer-const
 
   configWorkingCopy = resolveExtensions(configWorkingCopy);
-
+  configWorkingCopy = mergePlugins(configWorkingCopy, configDir, context.settingsOverrides);
 
   const settings = resolveSettings(configWorkingCopy.settings || {}, context.settingsOverrides);
   overrideSettingsForGatherMode(settings, context);

--- a/lighthouse-core/fraggle-rock/config/validation.js
+++ b/lighthouse-core/fraggle-rock/config/validation.js
@@ -39,6 +39,22 @@ function isValidArtifactDependency(dependent, dependency) {
 }
 
 /**
+ * Throws if pluginName is invalid or (somehow) collides with a category in the
+ * configJSON being added to.
+ * @param {LH.Config.Json} configJSON
+ * @param {string} pluginName
+ */
+function assertValidPluginName(configJSON, pluginName) {
+  if (!pluginName.startsWith('lighthouse-plugin-')) {
+    throw new Error(`plugin name '${pluginName}' does not start with 'lighthouse-plugin-'`);
+  }
+
+  if (configJSON.categories && configJSON.categories[pluginName]) {
+    throw new Error(`plugin name '${pluginName}' not allowed because it is the id of a category already found in config`); // eslint-disable-line max-len
+  }
+}
+
+/**
  * Throws an error if the provided object does not implement the required Fraggle Rock gatherer interface.
  * @param {LH.Config.AnyFRGathererDefn} gathererDefn
  */
@@ -283,6 +299,7 @@ function throwInvalidArtifactDependency(artifactId, dependencyKey) {
 module.exports = {
   isFRGathererDefn,
   isValidArtifactDependency,
+  assertValidPluginName,
   assertValidFRGatherer,
   assertValidFRNavigations,
   assertValidAudit,

--- a/lighthouse-core/test/fraggle-rock/config/config-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/config-test.js
@@ -9,6 +9,7 @@ const BaseAudit = require('../../../audits/audit.js');
 const {nonSimulatedPassConfigOverrides} = require('../../../config/constants.js');
 const BaseGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const {initializeConfig} = require('../../../fraggle-rock/config/config.js');
+const {LH_ROOT} = require('../../../../root.js');
 
 /* eslint-env jest */
 
@@ -113,6 +114,23 @@ describe('Fraggle Rock Config', () => {
     expect(auditIds).toContain('document-title'); // from onlyCategories
     expect(auditIds).not.toContain('first-contentful-paint'); // from onlyCategories
     expect(auditIds).not.toContain('robots-txt'); // from skipAudits
+  });
+
+  it('should support plugins', () => {
+    const {config} = initializeConfig(undefined, {
+      gatherMode: 'navigation',
+      configPath: `${LH_ROOT}/lighthouse-core/test/fixtures/config-plugins/`,
+      settingsOverrides: {plugins: ['lighthouse-plugin-simple']},
+    });
+
+    expect(config).toMatchObject({
+      categories: {
+        'lighthouse-plugin-simple': {title: 'Simple'},
+      },
+      groups: {
+        'lighthouse-plugin-simple-new-group': {title: 'New Group'},
+      },
+    });
   });
 
   describe('resolveArtifactDependencies', () => {
@@ -460,6 +478,4 @@ describe('Fraggle Rock Config', () => {
     const invocation = () => initializeConfig(extensionConfig, {gatherMode: 'navigation'});
     expect(invocation).toThrow(/did not support any gather modes/);
   });
-
-  it.todo('should support plugins');
 });

--- a/lighthouse-core/test/fraggle-rock/config/validation-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/validation-test.js
@@ -62,6 +62,21 @@ describe('Fraggle Rock Config Validation', () => {
     }
   });
 
+  describe('.assertValidPluginName', () => {
+    it('should throw if plugin does not start with lighthouse-plugin', () => {
+      const invocation = () => validation.assertValidPluginName(defaultConfig, 'example');
+      expect(invocation).toThrow(/does not start with.*lighthouse-plugin/);
+    });
+
+    it('should throw if category already exists in config', () => {
+      const config = {...defaultConfig};
+      const category = {title: 'Test Plugin', auditRefs: [{id: 'viewport', weight: 1}]};
+      config.categories = {...defaultConfig.categories, 'lighthouse-plugin-test': category};
+      const invocation = () => validation.assertValidPluginName(config, 'lighthouse-plugin-test');
+      expect(invocation).toThrow(/not allowed because.*already found/);
+    });
+  });
+
   describe('.assertValidFRGatherer', () => {
     it('should throw if gatherer does not have a meta object', () => {
       const gatherer = new BaseFRGatherer();

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -64,7 +64,7 @@ declare module Config {
   interface FRContext {
     gatherMode?: Gatherer.GatherMode;
     configPath?: string;
-    settingsOverrides?: SharedFlagsSettings;
+    settingsOverrides?: SharedFlagsSettings & Pick<LH.Flags, 'plugins'>;
   }
 
   interface SharedPassNavigationJson {

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -15,7 +15,7 @@ declare global {
       requestedUrl: string;
       finalUrl: string | RegExp;
       userAgent?: string | RegExp;
-      runWarnings?: Array<string|RegExp>;
+      runWarnings?: Array<string|RegExp> | {length: string | number};
       runtimeError?: {
         code?: any;
         message?: any;


### PR DESCRIPTION
**Summary**
Adds plugin support to Fraggle Rock along with a pubads smoketest to validate that legacy, FR, and bundled modes of Lighthouse can at least process and run plugin audits (even if it does not exercise *their* correctness which requires a pubads integration).

**Related Issues/PRs**
ref #11313
