### PR TITLE
core(lazy-lcp): fix failureTitle in lcp-lazy-loaded

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -365,7 +365,7 @@ const expectations = {
         },
       },
       'js-libraries': {
-        score: 1,
+        scoreDisplayMode: 'informative',
         details: {
           items: [{
             name: 'jQuery',

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images-snapshot.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images-snapshot.js
@@ -17,6 +17,10 @@ const URL = require('../../lib/url-shim.js');
 const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
+  /** Descriptive title of a Lighthouse audit that checks if images match their displayed dimensions. This is displayed when the audit is passing. */
+  title: 'Images were appropriate for their displayed size',
+  /** Descriptive title of a Lighthouse audit that checks if images match their displayed dimensions. This is displayed when the audit is failing. */
+  failureTitle: 'Images were larger than their displayed size',
   /** Label for a column in a data table; entries will be the dimensions of an image as it appears on the page. */
   columnDisplayedDimensions: 'Displayed dimensions',
   /** Label for a column in a data table; entries will be the dimensions of an image from it's source file. */
@@ -35,7 +39,8 @@ class UsesResponsiveImagesSnapshot extends Audit {
   static get meta() {
     return {
       id: 'uses-responsive-images-snapshot',
-      title: UsesResponsiveImages.str_(UsesResponsiveImages.UIStrings.title),
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
       description: UsesResponsiveImages.str_(UsesResponsiveImages.UIStrings.description),
       supportedModes: ['snapshot'],
       requiredArtifacts: ['ImageElements', 'ViewportDimensions'],

--- a/lighthouse-core/audits/dobetterweb/js-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/js-libraries.js
@@ -32,6 +32,7 @@ class JsLibrariesAudit extends Audit {
     return {
       id: 'js-libraries',
       title: str_(UIStrings.title),
+      scoreDisplayMode: Audit.SCORING_MODES.INFORMATIVE,
       description: str_(UIStrings.description),
       requiredArtifacts: ['Stacks'],
     };

--- a/lighthouse-core/audits/dobetterweb/js-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/js-libraries.js
@@ -70,6 +70,10 @@ class JsLibrariesAudit extends Audit {
       }),
     };
 
+    if (!libDetails.length) {
+      return {score: null, notApplicable: true};
+    }
+
     return {
       score: 1, // Always pass for now.
       details: {

--- a/lighthouse-core/audits/dobetterweb/uses-http2.js
+++ b/lighthouse-core/audits/dobetterweb/uses-http2.js
@@ -60,6 +60,7 @@ class UsesHTTP2Audit extends Audit {
       id: 'uses-http2',
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       supportedModes: ['navigation'],
       requiredArtifacts: ['URL', 'devtoolsLogs', 'traces'],
     };

--- a/lighthouse-core/audits/lcp-lazy-loaded.js
+++ b/lighthouse-core/audits/lcp-lazy-loaded.js
@@ -27,6 +27,7 @@ class LargestContentfulPaintLazyLoaded extends Audit {
     return {
       id: 'lcp-lazy-loaded',
       title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
       supportedModes: ['navigation'],
       requiredArtifacts: ['TraceElements', 'ViewportDimensions', 'ImageElements'],

--- a/lighthouse-core/audits/oopif-iframe-test-audit.js
+++ b/lighthouse-core/audits/oopif-iframe-test-audit.js
@@ -22,6 +22,7 @@ module.exports = {
   meta: {
     id: 'oopif-iframe-test-audit',
     title: 'IFrame Elements',
+    failureTitle: 'IFrame Elements',
     description: 'Audit to force the inclusion of IFrameElements artifact',
     requiredArtifacts: ['IFrameElements'],
   },

--- a/lighthouse-core/fraggle-rock/config/validation.js
+++ b/lighthouse-core/fraggle-rock/config/validation.js
@@ -123,9 +123,10 @@ function assertValidAudit(auditDefinition) {
   }
 
   // If it'll have a ✔ or ✖ displayed alongside the result, it should have failureTitle
+  const scoreDisplayMode = implementation.meta.scoreDisplayMode || Audit.SCORING_MODES.BINARY;
   if (
     !i18n.isStringOrIcuMessage(implementation.meta.failureTitle) &&
-    implementation.meta.scoreDisplayMode === Audit.SCORING_MODES.BINARY
+    scoreDisplayMode === Audit.SCORING_MODES.BINARY
   ) {
     throw new Error(`${auditName} has no meta.failureTitle and should.`);
   }

--- a/lighthouse-core/lib/i18n/locales/en-US.json
+++ b/lighthouse-core/lib/i18n/locales/en-US.json
@@ -554,6 +554,12 @@
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images-snapshot.js | columnDisplayedDimensions": {
     "message": "Displayed dimensions"
   },
+  "lighthouse-core/audits/byte-efficiency/uses-responsive-images-snapshot.js | failureTitle": {
+    "message": "Images were larger than their displayed size"
+  },
+  "lighthouse-core/audits/byte-efficiency/uses-responsive-images-snapshot.js | title": {
+    "message": "Images were appropriate for their displayed size"
+  },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
     "message": "Serve images that are appropriately-sized to save cellular data and improve load time. [Learn more](https://web.dev/uses-responsive-images/)."
   },

--- a/lighthouse-core/lib/i18n/locales/en-XL.json
+++ b/lighthouse-core/lib/i18n/locales/en-XL.json
@@ -554,6 +554,12 @@
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images-snapshot.js | columnDisplayedDimensions": {
     "message": "D̂íŝṕl̂áŷéd̂ d́îḿêńŝíôńŝ"
   },
+  "lighthouse-core/audits/byte-efficiency/uses-responsive-images-snapshot.js | failureTitle": {
+    "message": "Îḿâǵêś ŵér̂é l̂ár̂ǵêŕ t̂h́âń t̂h́êír̂ d́îśp̂ĺâýêd́ ŝíẑé"
+  },
+  "lighthouse-core/audits/byte-efficiency/uses-responsive-images-snapshot.js | title": {
+    "message": "Îḿâǵêś ŵér̂é âṕp̂ŕôṕr̂íât́ê f́ôŕ t̂h́êír̂ d́îśp̂ĺâýêd́ ŝíẑé"
+  },
   "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": {
     "message": "Ŝér̂v́ê ím̂áĝéŝ t́ĥát̂ ár̂é âṕp̂ŕôṕr̂íât́êĺŷ-śîźêd́ t̂ó ŝáv̂é ĉél̂ĺûĺâŕ d̂át̂á âńd̂ ím̂ṕr̂óv̂é l̂óâd́ t̂ím̂é. [L̂éâŕn̂ ḿôŕê](https://web.dev/uses-responsive-images/)."
   },

--- a/lighthouse-core/test/audits/dobetterweb/js-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/js-libraries-test.js
@@ -10,13 +10,15 @@ const assert = require('assert').strict;
 
 /* eslint-env jest */
 describe('Returns detected front-end JavaScript libraries', () => {
-  it('always passes', () => {
+  it('not applicable when there are no stacks', () => {
     // no libraries
     const auditResult1 = JsLibrariesAudit.audit({
       Stacks: [],
     });
-    assert.equal(auditResult1.score, 1);
+    assert.equal(auditResult1.notApplicable, true);
+  });
 
+  it('always passes', () => {
     // duplicates. TODO: consider failing in this case
     const auditResult2 = JsLibrariesAudit.audit({
       Stacks: [

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -133,6 +133,7 @@ describe('Config', () => {
         return {
           id: 'missing-artifact-audit',
           title: 'none',
+          failureTitle: 'none',
           description: 'none',
           requiredArtifacts: [
             // Require fake artifact amidst base artifact and default artifacts.
@@ -161,6 +162,7 @@ describe('Config', () => {
         return {
           id: 'optional-artifact-audit',
           title: 'none',
+          failureTitle: 'none',
           description: 'none',
           requiredArtifacts: [
             'URL', // base artifact
@@ -192,6 +194,7 @@ describe('Config', () => {
         return {
           id: 'optional-artifact-audit',
           title: 'none',
+          failureTitle: 'none',
           description: 'none',
           requiredArtifacts: [
             'URL', // base artifact
@@ -223,6 +226,7 @@ describe('Config', () => {
         return {
           id: 'optional-artifact-audit',
           title: 'none',
+          failureTitle: 'none',
           description: 'none',
           requiredArtifacts: [
             'URL', // base artifact
@@ -254,6 +258,7 @@ describe('Config', () => {
         return {
           id: 'optional-artifact-audit',
           title: 'none',
+          failureTitle: 'none',
           description: 'none',
           requiredArtifacts: [
             'URL', // base artifact
@@ -285,6 +290,7 @@ describe('Config', () => {
         return {
           id: 'base-artifacts-audit',
           title: 'base',
+          failureTitle: 'base',
           description: 'base',
           requiredArtifacts: ['HostUserAgent', 'URL', 'Stacks', 'WebAppManifest'],
         };
@@ -443,6 +449,7 @@ describe('Config', () => {
             return {
               id: 'empty-string-description',
               title: 'title',
+              failureTitle: 'none',
               description: '',
               requiredArtifacts: [],
             };

--- a/lighthouse-core/test/fraggle-rock/config/config-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/config-test.js
@@ -325,6 +325,7 @@ describe('Fraggle Rock Config', () => {
           return {
             id: 'extra-audit',
             title: 'Extra',
+            failureTitle: 'Extra',
             description: 'Extra',
             requiredArtifacts: /** @type {*} */ (['ExtraArtifact']),
           };

--- a/lighthouse-core/test/fraggle-rock/config/validation-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/validation-test.js
@@ -20,7 +20,13 @@ let ExampleAudit = class extends BaseAudit {};
 
 beforeEach(() => {
   class ExampleAudit_ extends BaseAudit {
-    static meta = {id: 'audit', title: 'Title', description: 'Audit', requiredArtifacts: []};
+    static meta = {
+      id: 'audit',
+      title: 'Title',
+      failureTitle: 'Title',
+      description: 'Audit',
+      requiredArtifacts: [],
+    };
     static audit = BaseAudit.audit.bind(ExampleAudit_);
   }
   ExampleAudit = ExampleAudit_;
@@ -136,7 +142,16 @@ describe('Fraggle Rock Config Validation', () => {
     });
 
     it('should throw if failureTitle is missing', () => {
+      ExampleAudit.meta.failureTitle = undefined;
       ExampleAudit.meta.scoreDisplayMode = BaseAudit.SCORING_MODES.BINARY;
+      const audit = {implementation: ExampleAudit, options: {}};
+      const invocation = () => validation.assertValidAudit(audit);
+      expect(invocation).toThrow(/has no meta.failureTitle/);
+    });
+
+    it('should throw if failureTitle is missing and scoreDisplayMode is not defined', () => {
+      ExampleAudit.meta.failureTitle = undefined;
+      ExampleAudit.meta.scoreDisplayMode = undefined;
       const audit = {implementation: ExampleAudit, options: {}};
       const invocation = () => validation.assertValidAudit(audit);
       expect(invocation).toThrow(/has no meta.failureTitle/);

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -5267,8 +5267,8 @@
       "id": "js-libraries",
       "title": "Detected JavaScript libraries",
       "description": "All front-end JavaScript libraries detected on the page. [Learn more](https://web.dev/js-libraries/).",
-      "score": 1,
-      "scoreDisplayMode": "binary",
+      "score": null,
+      "scoreDisplayMode": "informative",
       "details": {
         "type": "table",
         "headings": [
@@ -5399,7 +5399,7 @@
       "title": "Use HTTP/2",
       "description": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers and multiplexing. [Learn more](https://web.dev/uses-http2/).",
       "score": 1,
-      "scoreDisplayMode": "binary",
+      "scoreDisplayMode": "numeric",
       "numericValue": 0,
       "numericUnit": "millisecond",
       "details": {

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -64,6 +64,7 @@ describe('Runner', () => {
   const basicAuditMeta = {
     id: 'test-audit',
     title: 'A test audit',
+    failureTitle: 'A test audit',
     description: 'An audit for testing',
     requiredArtifacts: [],
   };
@@ -212,6 +213,7 @@ describe('Runner', () => {
           return {
             id: 'dummy-audit',
             title: 'Dummy',
+            failureTitle: 'Dummy',
             description: 'Will fail because required artifact is an error',
             requiredArtifacts: ['WarningAndErrorGatherer'],
           };
@@ -763,6 +765,7 @@ describe('Runner', () => {
         return {
           id: 'test-audit',
           title: 'A test audit',
+          failureTitle: 'A test audit',
           description: 'An audit for testing',
           requiredArtifacts: ['RuntimeErrorGatherer'],
         };

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -479,7 +479,7 @@ interactive: flaky
 interactive-element-affordance: manual
 is-crawlable: pass
 is-on-https: pass
-js-libraries: pass
+js-libraries: informative
 label: notApplicable
 largest-contentful-paint: numeric
 largest-contentful-paint-element: informative
@@ -555,7 +555,7 @@ unused-css-rules: flaky
 unused-javascript: numeric
 use-landmarks: manual
 user-timings: flaky
-uses-http2: pass
+uses-http2: numeric
 uses-long-cache-ttl: numeric
 uses-optimized-images: flaky
 uses-passive-event-listeners: pass

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -479,7 +479,7 @@ interactive: flaky
 interactive-element-affordance: manual
 is-crawlable: pass
 is-on-https: pass
-js-libraries: informative
+js-libraries: notApplicable
 label: notApplicable
 largest-contentful-paint: numeric
 largest-contentful-paint-element: informative


### PR DESCRIPTION
**Summary**
The failureTitle was defined in this audit but not actually exported on the `meta` doh! This means the error message that the user receives is written backwards 😞  

We had validation for this to prevent such cases, but it only applied when the scoreDisplayMode was *explicit*, so this PR also fixes our validation to fail if the default scoreDisplayMode of binary is used.

**Related Issues/PRs**
Fixes https://github.com/GoogleChrome/lighthouse/issues/13048
