### PR TITLE
report: sort audits by weight

### DIFF
--- a/report/renderer/util.js
+++ b/report/renderer/util.js
@@ -138,6 +138,10 @@ export class Util {
           });
         }
       });
+
+      category.auditRefs.sort((a, b) => {
+        return b.weight - a.weight;
+      });
     }
 
     return clone;


### PR DESCRIPTION
Sort auditRefs by weight to influence render order in report.

Maybe useful diff in auditRefs order: https://www.diffchecker.com/NmdJHTbN

ref #12996