### PR TITLE
core(tracing): remove cpu_profiler.hires

### DIFF
--- a/lighthouse-core/gather/gatherers/trace.js
+++ b/lighthouse-core/gather/gatherers/trace.js
@@ -60,7 +60,6 @@ class Trace extends FRGatherer {
       // A bug introduced in M92 causes these categories to crash targets on Linux.
       // See https://github.com/GoogleChrome/lighthouse/issues/12835 for full investigation.
       // 'disabled-by-default-v8.cpu_profiler',
-      // 'disabled-by-default-v8.cpu_profiler.hires',
     ];
   }
 


### PR DESCRIPTION
The hires trace category was removed and basic `cpu_profiler` cat does the high-resolution sampling by default as of may 2020.

https://bugs.chromium.org/p/chromium/issues/detail?id=1082220