### PR TITLE
core(fr): setup emulation and throttling for timespans

### DIFF
--- a/lighthouse-core/fraggle-rock/gather/timespan-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/timespan-runner.js
@@ -12,6 +12,7 @@ const {
   collectPhaseArtifacts,
   awaitArtifacts,
 } = require('./runner-helpers.js');
+const {prepareTargetForTimespanMode} = require('../../gather/driver/prepare.js');
 const {initializeConfig} = require('../config/config.js');
 const {getBaseArtifacts, finalizeArtifacts} = require('./base-artifacts.js');
 
@@ -42,6 +43,7 @@ async function startTimespan(options) {
     settings: config.settings,
   };
 
+  await prepareTargetForTimespanMode(driver, config.settings);
   await collectPhaseArtifacts({phase: 'startInstrumentation', ...phaseOptions});
   await collectPhaseArtifacts({phase: 'startSensitiveInstrumentation', ...phaseOptions});
 

--- a/lighthouse-core/test/fraggle-rock/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/api-test-pptr.js
@@ -25,8 +25,9 @@ jest.setTimeout(90_000);
  * Some audits can be notApplicable based on machine timing information.
  * Exclude these audits from applicability comparisons. */
 const FLAKY_AUDIT_IDS_APPLICABILITY = new Set([
-  'long-tasks',
-  'screenshot-thumbnails',
+  'long-tasks', // Depends on whether the longest task takes <50ms.
+  'screenshot-thumbnails', // Depends on OS whether frames happen to be generated on non-visual timespan changes.
+  'layout-shift-elements', // Depends on if the JS takes too long after input to be ignored for layout shift.
 ]);
 
 /**
@@ -156,7 +157,7 @@ describe('Fraggle Rock API', () => {
       // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
       expect(auditResults.length).toMatchInlineSnapshot(`48`);
 
-      expect(notApplicableAudits.length).toMatchInlineSnapshot(`6`);
+      expect(notApplicableAudits.length).toMatchInlineSnapshot(`5`);
       expect(notApplicableAudits.map(audit => audit.id)).not.toContain('server-response-time');
       expect(notApplicableAudits.map(audit => audit.id)).not.toContain('total-blocking-time');
 
@@ -199,7 +200,7 @@ describe('Fraggle Rock API', () => {
       const {auditResults, erroredAudits, notApplicableAudits} = getAuditsBreakdown(result.lhr);
       expect(auditResults.length).toMatchInlineSnapshot(`48`);
 
-      expect(notApplicableAudits.length).toMatchInlineSnapshot(`20`);
+      expect(notApplicableAudits.length).toMatchInlineSnapshot(`19`);
       expect(notApplicableAudits.map(audit => audit.id)).toContain('server-response-time');
       expect(notApplicableAudits.map(audit => audit.id)).not.toContain('total-blocking-time');
 

--- a/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
+++ b/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
@@ -218,6 +218,8 @@ function createMockContext() {
 function mockDriverSubmodules() {
   const navigationMock = {gotoURL: jest.fn()};
   const prepareMock = {
+    prepareThrottlingAndNetwork: jest.fn(),
+    prepareTargetForTimespanMode: jest.fn(),
     prepareTargetForNavigationMode: jest.fn(),
     prepareTargetForIndividualNavigation: jest.fn(),
   };
@@ -233,6 +235,8 @@ function mockDriverSubmodules() {
 
   function reset() {
     navigationMock.gotoURL = jest.fn().mockResolvedValue({finalUrl: 'https://example.com', warnings: [], timedOut: false});
+    prepareMock.prepareThrottlingAndNetwork = jest.fn().mockResolvedValue(undefined);
+    prepareMock.prepareTargetForTimespanMode = jest.fn().mockResolvedValue(undefined);
     prepareMock.prepareTargetForNavigationMode = jest.fn().mockResolvedValue({warnings: []});
     prepareMock.prepareTargetForIndividualNavigation = jest.fn().mockResolvedValue({warnings: []});
     storageMock.clearDataForOrigin = jest.fn();
@@ -248,6 +252,7 @@ function mockDriverSubmodules() {
    * @return {(...args: any[]) => void}
    */
   const get = (target, name) => {
+    if (!target[name]) throw new Error(`Target does not have property "${name}"`);
     return (...args) => target[name](...args);
   };
 

--- a/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
@@ -11,6 +11,7 @@ const {
   createMockDriver,
   createMockPage,
   createMockGathererInstance,
+  mockDriverSubmodules,
   mockDriverModule,
   mockRunnerModule,
 } = require('./mock-driver.js');
@@ -19,6 +20,7 @@ const {
 let mockRunnerRun = jest.fn();
 /** @type {ReturnType<typeof createMockDriver>} */
 let mockDriver;
+const mockSubmodules = mockDriverSubmodules();
 
 jest.mock('../../../runner.js', () => mockRunnerModule(() => mockRunnerRun));
 jest.mock('../../../fraggle-rock/gather/driver.js', () =>
@@ -40,6 +42,7 @@ describe('Timespan Runner', () => {
   let config;
 
   beforeEach(() => {
+    mockSubmodules.reset();
     mockPage = createMockPage();
     mockDriver = createMockDriver();
     mockRunnerRun = jest.fn();
@@ -69,6 +72,12 @@ describe('Timespan Runner', () => {
     await timespan.endTimespan();
     expect(mockDriver.connect).toHaveBeenCalled();
     expect(mockRunnerRun).toHaveBeenCalled();
+  });
+
+  it('should prepare the target', async () => {
+    const timespan = await startTimespan({page, config});
+    expect(mockSubmodules.prepareMock.prepareTargetForTimespanMode).toHaveBeenCalled();
+    await timespan.endTimespan();
   });
 
   it('should invoke startInstrumentation', async () => {

--- a/lighthouse-core/test/gather/driver/prepare-test.js
+++ b/lighthouse-core/test/gather/driver/prepare-test.js
@@ -38,9 +38,9 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-describe('.prepareNetworkForNavigation()', () => {
+describe('.prepareThrottlingAndNetwork()', () => {
   it('sets throttling appropriately', async () => {
-    await prepare.prepareNetworkForNavigation(
+    await prepare.prepareThrottlingAndNetwork(
       sessionMock.asSession(),
       {
         ...constants.defaultSettings,
@@ -53,10 +53,7 @@ describe('.prepareNetworkForNavigation()', () => {
           cpuSlowdownMultiplier: 2,
         },
       },
-      {
-        ...constants.defaultNavigationConfig,
-        url,
-      }
+      {...constants.defaultNavigationConfig}
     );
 
     expect(sessionMock.sendCommand.findInvocation('Network.emulateNetworkConditions')).toEqual({
@@ -71,7 +68,7 @@ describe('.prepareNetworkForNavigation()', () => {
   });
 
   it('disables throttling', async () => {
-    await prepare.prepareNetworkForNavigation(
+    await prepare.prepareThrottlingAndNetwork(
       sessionMock.asSession(),
       {
         ...constants.defaultSettings,
@@ -86,7 +83,6 @@ describe('.prepareNetworkForNavigation()', () => {
       },
       {
         ...constants.defaultNavigationConfig,
-        url,
         disableThrottling: true,
       }
     );
@@ -103,7 +99,7 @@ describe('.prepareNetworkForNavigation()', () => {
   });
 
   it('unsets url patterns when empty', async () => {
-    await prepare.prepareNetworkForNavigation(
+    await prepare.prepareThrottlingAndNetwork(
       sessionMock.asSession(),
       {
         ...constants.defaultSettings,
@@ -112,7 +108,6 @@ describe('.prepareNetworkForNavigation()', () => {
       {
         ...constants.defaultNavigationConfig,
         blockedUrlPatterns: [],
-        url,
       }
     );
 
@@ -122,7 +117,7 @@ describe('.prepareNetworkForNavigation()', () => {
   });
 
   it('blocks url patterns', async () => {
-    await prepare.prepareNetworkForNavigation(
+    await prepare.prepareThrottlingAndNetwork(
       sessionMock.asSession(),
       {
         ...constants.defaultSettings,
@@ -131,7 +126,6 @@ describe('.prepareNetworkForNavigation()', () => {
       {
         ...constants.defaultNavigationConfig,
         blockedUrlPatterns: ['https://b.example.com'],
-        url,
       }
     );
 
@@ -141,10 +135,10 @@ describe('.prepareNetworkForNavigation()', () => {
   });
 
   it('sets extraHeaders', async () => {
-    await prepare.prepareNetworkForNavigation(
+    await prepare.prepareThrottlingAndNetwork(
       sessionMock.asSession(),
       {...constants.defaultSettings, extraHeaders: {'Cookie': 'monster', 'x-men': 'wolverine'}},
-      {...constants.defaultNavigationConfig, url}
+      {...constants.defaultNavigationConfig}
     );
 
     expect(sessionMock.sendCommand.findInvocation('Network.setExtraHTTPHeaders')).toEqual({
@@ -336,5 +330,85 @@ describe('.prepareTargetForNavigationMode()', () => {
       accept: true,
       promptText: 'Lighthouse prompt response',
     });
+  });
+});
+
+describe('.prepareTargetForTimespanMode()', () => {
+  let driverMock = createMockDriver();
+
+  beforeEach(() => {
+    driverMock = createMockDriver();
+    sessionMock = driverMock._session;
+
+    sessionMock.sendCommand
+      .mockResponse('Network.enable')
+      .mockResponse('Network.setUserAgentOverride')
+      .mockResponse('Emulation.setDeviceMetricsOverride')
+      .mockResponse('Emulation.setTouchEmulationEnabled')
+      .mockResponse('Debugger.enable')
+      .mockResponse('Debugger.setSkipAllPauses')
+      .mockResponse('Debugger.setAsyncCallStackDepth')
+      .mockResponse('Network.emulateNetworkConditions')
+      .mockResponse('Emulation.setCPUThrottlingRate')
+      .mockResponse('Network.setBlockedURLs')
+      .mockResponse('Network.setExtraHTTPHeaders');
+  });
+
+  it('emulates the target device', async () => {
+    await prepare.prepareTargetForTimespanMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+      screenEmulation: {
+        disabled: false,
+        mobile: true,
+        deviceScaleFactor: 2,
+        width: 200,
+        height: 300,
+      },
+    });
+
+    expect(sessionMock.sendCommand.findInvocation('Emulation.setDeviceMetricsOverride')).toEqual({
+      mobile: true,
+      deviceScaleFactor: 2,
+      width: 200,
+      height: 300,
+    });
+  });
+
+  it('enables async stacks', async () => {
+    await prepare.prepareTargetForTimespanMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+    });
+
+    const invocations = sessionMock.sendCommand.mock.calls;
+    const debuggerInvocations = invocations.filter(call => call[0].startsWith('Debugger.'));
+    expect(debuggerInvocations.map(argList => argList[0])).toEqual([
+      'Debugger.enable',
+      'Debugger.setSkipAllPauses',
+      'Debugger.setAsyncCallStackDepth',
+    ]);
+  });
+
+  it('sets throttling', async () => {
+    await prepare.prepareTargetForTimespanMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+      throttlingMethod: 'devtools',
+    });
+
+    sessionMock.sendCommand.findInvocation('Network.emulateNetworkConditions');
+    sessionMock.sendCommand.findInvocation('Emulation.setCPUThrottlingRate');
+  });
+
+  it('sets network environment', async () => {
+    await prepare.prepareTargetForTimespanMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+      blockedUrlPatterns: ['.jpg'],
+      extraHeaders: {Cookie: 'name=wolverine'},
+    });
+
+    const blockedInvocation = sessionMock.sendCommand.findInvocation('Network.setBlockedURLs');
+    expect(blockedInvocation).toEqual({urls: ['.jpg']});
+
+    const headersInvocation = sessionMock.sendCommand.findInvocation('Network.setExtraHTTPHeaders');
+    expect(headersInvocation).toEqual({headers: {Cookie: 'name=wolverine'}});
   });
 });

--- a/lighthouse-core/test/gather/driver/prepare-test.js
+++ b/lighthouse-core/test/gather/driver/prepare-test.js
@@ -53,7 +53,7 @@ describe('.prepareThrottlingAndNetwork()', () => {
           cpuSlowdownMultiplier: 2,
         },
       },
-      {...constants.defaultNavigationConfig}
+      constants.defaultNavigationConfig
     );
 
     expect(sessionMock.sendCommand.findInvocation('Network.emulateNetworkConditions')).toEqual({


### PR DESCRIPTION
**Summary**
Enables device emulation and throttling in timespans by default.

**Related Issues/PRs**
ref #11313 
