### PR TITLE
Fix typo in report-assert.js

### DIFF
--- a/lighthouse-cli/test/smokehouse/report-assert.js
+++ b/lighthouse-cli/test/smokehouse/report-assert.js
@@ -166,7 +166,7 @@ function pruneExpectations(localConsole, lhr, expected, reportOptions) {
 
   /**
    * Lazily compute the Chrome version because some reports are explicitly asserting error conditions.
-   * @returns {number}
+   * @return {number}
    */
   function getChromeVersion() {
     const userAgent = lhr.environment.hostUserAgent;


### PR DESCRIPTION
Fix typo:

returns -> return