### PR TITLE
report(3p-filter): drop for/id as elements are already nested

### DIFF
--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -219,16 +219,14 @@ export class ReportUIFeatures {
         return !thirdPartyFilterAuditExclusions.includes(containingAudit.id);
       });
 
-    tablesWithUrls.forEach((tableEl, index) => {
+    tablesWithUrls.forEach((tableEl) => {
       const rowEls = getTableRows(tableEl);
       const thirdPartyRows = this._getThirdPartyRows(rowEls, this.json.finalUrl);
 
       // create input box
       const filterTemplate = this._dom.createComponent('3pFilter');
       const filterInput = this._dom.find('input', filterTemplate);
-      const id = `lh-3p-filter-label--${index}`;
 
-      filterInput.id = id;
       filterInput.addEventListener('change', e => {
         const shouldHideThirdParty = e.target instanceof HTMLInputElement && !e.target.checked;
         let even = true;
@@ -250,7 +248,6 @@ export class ReportUIFeatures {
         }
       });
 
-      this._dom.find('label', filterTemplate).setAttribute('for', id);
       this._dom.find('.lh-3p-filter-count', filterTemplate).textContent =
           `${thirdPartyRows.length}`;
       this._dom.find('.lh-3p-ui-string', filterTemplate).textContent =


### PR DESCRIPTION
see b/195747306

There's a bug that complains when you have this:

```html
<label for="foo">
  <input id="foo" type="checkbox">
</label>
```

but ... nesting PLUS for/id is redundant, so we just gotta get rid of one of them.

removing for/id doesnt affect the a11y/tabbing and generally i prefer the nesting solution, so i went with this.

the feature originally landed (in https://github.com/GoogleChrome/lighthouse/pull/6351 ) with both solutions, fwiw. i think it was just being defensive.. didnt hunt for the original reason.