### PR TITLE
core: make main tsc compile cacheable

### DIFF
--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -70,6 +70,10 @@ lighthouse.getAuditList = Runner.getAuditList;
 lighthouse.traceCategories = require('./gather/driver.js').traceCategories;
 lighthouse.Audit = require('./audits/audit.js');
 lighthouse.Gatherer = require('./gather/gatherers/gatherer.js');
+
+// Explicit type reference (hidden by makeComputedArtifact) for d.ts export.
+// TODO(esmodules): should be a workaround for module.export and can be removed when in esm.
+/** @type {typeof import('./computed/network-records.js')} */
 lighthouse.NetworkRecords = require('./computed/network-records.js');
 
 module.exports = lighthouse;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "noEmit": true,
+    "emitDeclarationOnly": true,
     "module": "commonjs",
     "target": "ES2020",
     "allowJs": true,


### PR DESCRIPTION
The main typescript compilation (from the root `tsconfig.json`) hasn't had `emitDeclarationOnly` turned on because of compilation errors I ran into in #12914 when I initially enabled that. Not having declaration emit was ok, though, because it's a compilation root, not a dependency for any of our other tsconfigs, so it didn't need a `d.ts` emit for anything. The downside is that less of it is cacheable and more has to be re-done on each compile, even if nothing in the core files has changed.

I ran into this problem again in a different context and it turns out it's fairly simple, only a single error (I thought it was the first of many), and it even tells you exactly what you need to do to fix it.

> `Declaration emit for this file requires using private name 'NetworkRecords' from module '"lighthouse/lighthouse-core/computed/network-records"'. An explicit type annotation may unblock declaration emit.`

This allows fully caching the core compile, so if e.g. you're working on report stuff, you'll only spend ~100ms instead of 5s recompiling core files.