### PR TITLE
core(tsc): add base tsconfig for config inheritance

### DIFF
--- a/flow-report/tsconfig.json
+++ b/flow-report/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "outDir": "../.tmp/tsbuildinfo/flow-report",
 
-    // Project has real tsc output (and declaration was interfering with build).
-    // see https://github.com/GoogleChrome/lighthouse/pull/12929
-    "emitDeclarationOnly": false,
-
     // Limit to base JS and DOM defs.
     "lib": ["es2020", "dom", "dom.iterable"],
     // Selectively include types from node_modules/.

--- a/flow-report/tsconfig.json
+++ b/flow-report/tsconfig.json
@@ -1,39 +1,27 @@
 {
+  "extends": "../tsconfig-base.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "../.tmp/tsbuildinfo/flow-report",
+
+    // Project has real tsc output (and declaration was interfering with build).
+    // see https://github.com/GoogleChrome/lighthouse/pull/12929
     "emitDeclarationOnly": false,
-    "declarationMap": true,
 
     // Limit to base JS and DOM defs.
     "lib": ["es2020", "dom", "dom.iterable"],
-    // Selectively include types from node_modules.
+    // Selectively include types from node_modules/.
     "types": ["node", "jest"],
-    "target": "es2020",
-    "module": "es2020",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-
-    "allowJs": true,
-    "checkJs": true,
-    "strict": true,
-    // TODO: remove the next line to be fully `strict`.
-    "useUnknownInCatchVariables": false,
-
-    // "listFiles": true,
-    // "noErrorTruncation": true,
-    "extendedDiagnostics": true,
 
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
   },
+  "references": [
+    {"path": "../types/lhr/"},
+    {"path": "../report"},
+  ],
   "include": [
     "**/*.ts",
     "**/*.tsx",
     "./types",
-  ],
-  "references": [
-    {"path": "../types/lhr/"},
-    {"path": "../report"},
   ],
 }

--- a/lighthouse-treemap/tsconfig.json
+++ b/lighthouse-treemap/tsconfig.json
@@ -1,36 +1,20 @@
 {
+  "extends": "../tsconfig-base.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "../.tmp/tsbuildinfo/lighthouse-treemap",
-    "emitDeclarationOnly": true,
-    "declarationMap": true,
 
     // Limit to base JS and DOM defs.
     "lib": ["es2020", "dom", "dom.iterable"],
-    // Selectively include types from node_modules.
+    // Selectively include types from node_modules/.
     "types": ["tabulator-tables"],
-    "target": "es2020",
-    "module": "es2020",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-
-    "allowJs": true,
-    "checkJs": true,
-    "strict": true,
-    // TODO: remove the next line to be fully `strict`.
-    "useUnknownInCatchVariables": false,
-
-    // "listFiles": true,
-    // "noErrorTruncation": true,
-    "extendedDiagnostics": true,
   },
-  "include": [
-    "app/src/**/*.js",
-    "types/**/*.d.ts",
-  ],
   "references": [
     {"path": "../types/lhr/"},
     {"path": "../report/"},
     {"path": "../lighthouse-viewer/"},
+  ],
+  "include": [
+    "app/src/**/*.js",
+    "types/**/*.d.ts",
   ],
 }

--- a/lighthouse-viewer/tsconfig.json
+++ b/lighthouse-viewer/tsconfig.json
@@ -1,35 +1,19 @@
 {
+  "extends": "../tsconfig-base.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "../.tmp/tsbuildinfo/lighthouse-viewer",
-    "emitDeclarationOnly": true,
-    "declarationMap": true,
 
     // Limit to base JS and DOM defs.
     "lib": ["es2020", "dom", "dom.iterable"],
-    // Don't include any types from node_modules.
+    // Don't include any types from node_modules/.
     "types": [],
-    "target": "es2020",
-    "module": "es2020",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-
-    "allowJs": true,
-    "checkJs": true,
-    "strict": true,
-    // TODO: remove the next line to be fully `strict`.
-    "useUnknownInCatchVariables": false,
-
-    // "listFiles": true,
-    // "noErrorTruncation": true,
-    "extendedDiagnostics": true,
   },
-  "include": [
-    "app/src/**/*.js",
-    "./types/*.d.ts",
-  ],
   "references": [
     {"path": "../types/lhr/"},
     {"path": "../report/"}
+  ],
+  "include": [
+    "app/src/**/*.js",
+    "./types/*.d.ts",
   ],
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "dogfood-lhci": "./lighthouse-core/scripts/dogfood-lhci.sh",
     "timing-trace": "node lighthouse-core/scripts/generate-timing-trace.js",
     "changelog": "conventional-changelog --config ./build/changelog-generator/index.js --infile changelog.md --same-file",
-    "type-check": "tsc --build ./ report/ lighthouse-viewer/ lighthouse-treemap/ flow-report/",
+    "type-check": "tsc --build ./tsconfig-base.json",
     "i18n:checks": "./lighthouse-core/scripts/i18n/assert-strings-collected.sh",
     "i18n:collect-strings": "node lighthouse-core/scripts/i18n/collect-strings.js",
     "update:lantern-baseline": "node lighthouse-core/scripts/lantern/update-baseline-lantern-values.js",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "dogfood-lhci": "./lighthouse-core/scripts/dogfood-lhci.sh",
     "timing-trace": "node lighthouse-core/scripts/generate-timing-trace.js",
     "changelog": "conventional-changelog --config ./build/changelog-generator/index.js --infile changelog.md --same-file",
-    "type-check": "tsc --build ./tsconfig-base.json",
+    "type-check": "tsc --build ./tsconfig-all.json",
     "i18n:checks": "./lighthouse-core/scripts/i18n/assert-strings-collected.sh",
     "i18n:collect-strings": "node lighthouse-core/scripts/i18n/collect-strings.js",
     "update:lantern-baseline": "node lighthouse-core/scripts/lantern/update-baseline-lantern-values.js",

--- a/report/generator/tsconfig.json
+++ b/report/generator/tsconfig.json
@@ -1,23 +1,12 @@
 {
+  "extends": "../../tsconfig-base.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "../../.tmp/tsbuildinfo/report/generator",
-    "emitDeclarationOnly": true,
-    "declarationMap": true,
 
-    "target": "ES2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
-
-    "allowJs": true,
-    "checkJs": true,
-    "strict": true,
-    // TODO: remove the next line to be fully `strict`.
-    "useUnknownInCatchVariables": false,
-
-    // "listFiles": true,
-    // "noErrorTruncation": true,
-    "extendedDiagnostics": true,
+    // Limit defs to base JS and DOM (for URL: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34960).
+    "lib": ["es2020", "dom"],
+    // Only include `@types/node` from node_modules/.
+    "types": ["node"],
   },
   "references": [
     {"path": "../../types/lhr/"},

--- a/report/tsconfig.json
+++ b/report/tsconfig.json
@@ -1,35 +1,20 @@
 {
+  "extends": "../tsconfig-base.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "../.tmp/tsbuildinfo/report",
-    "emitDeclarationOnly": true,
-    "declarationMap": true,
 
     // Limit to base JS and DOM defs.
     "lib": ["es2020", "dom", "dom.iterable"],
-    // Don't include any types from node_modules.
+    // Don't include any types from node_modules/.
     "types": [],
-    "target": "es2020",
-    "module": "es2020",
-    "moduleResolution": "node",
-
-    "allowJs": true,
-    "checkJs": true,
-    "strict": true,
-    // TODO: remove the next line to be fully `strict`.
-    "useUnknownInCatchVariables": false,
-
-    // "listFiles": true,
-    // "noErrorTruncation": true,
-    "extendedDiagnostics": true,
   },
-  "include": [
-    "**/*.js",
-    "types/**/*.d.ts",
-  ],
   "references": [
     {"path": "../types/lhr/"},
     {"path": "./generator/"}
+  ],
+  "include": [
+    "**/*.js",
+    "types/**/*.d.ts",
   ],
   "exclude": [
     "generator/**/*.js",

--- a/tsconfig-all.json
+++ b/tsconfig-all.json
@@ -1,0 +1,15 @@
+// Compilation entry point for all tsc projects within Lighthouse.
+
+{
+  "references": [
+    {"path": "./"},
+    {"path": "./types/lhr/"},
+    {"path": "./report/"},
+    {"path": "./report/generator/"},
+    {"path": "./lighthouse-viewer/"},
+    {"path": "./lighthouse-treemap/"},
+    {"path": "./flow-report/"},
+  ],
+  "files": [],
+  "include": [],
+}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,0 +1,38 @@
+// Base compiler options and all compilation entry points.
+
+{
+  "compilerOptions": {
+    "composite": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    // TODO: remove the next line to be fully `strict`.
+    "useUnknownInCatchVariables": false,
+
+    // "listFiles": true,
+    // "noErrorTruncation": true,
+    "extendedDiagnostics": true,
+  },
+  // `references` is not inherited by extending tsconfigs. This is a list of all
+  // project references so `tsc --build tsconfig-base.json` can type check all files.
+  "references": [
+    {"path": "./"},
+    {"path": "./types/lhr/"},
+    {"path": "./report/"},
+    {"path": "./report/generator/"},
+    {"path": "./lighthouse-viewer/"},
+    {"path": "./lighthouse-treemap/"},
+    {"path": "./flow-report/"},
+  ],
+  "files": [],
+  "include": [],
+  "exclude": [],
+}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,4 +1,4 @@
-// Base compiler options and all compilation entry points.
+// Base compiler options for all tsconfig files.
 
 {
   "compilerOptions": {
@@ -21,18 +21,4 @@
     // "noErrorTruncation": true,
     "extendedDiagnostics": true,
   },
-  // `references` is not inherited by extending tsconfigs. This is a list of all
-  // project references so `tsc --build tsconfig-base.json` can type check all files.
-  "references": [
-    {"path": "./"},
-    {"path": "./types/lhr/"},
-    {"path": "./report/"},
-    {"path": "./report/generator/"},
-    {"path": "./lighthouse-viewer/"},
-    {"path": "./lighthouse-treemap/"},
-    {"path": "./flow-report/"},
-  ],
-  "files": [],
-  "include": [],
-  "exclude": [],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,16 @@
 {
+  "extends": "./tsconfig-base.json",
   "compilerOptions": {
-    "emitDeclarationOnly": true,
-    "module": "commonjs",
-    "target": "ES2020",
-    "allowJs": true,
-    "checkJs": true,
-    "strict": true,
-    // TODO: remove the next line to be fully `strict`.
-    "useUnknownInCatchVariables": false,
-    // "listFiles": true,
-    // "noErrorTruncation": true,
-
-    "resolveJsonModule": true,
-    "diagnostics": true,
-    "composite": true,
     "outDir": ".tmp/tsbuildinfo/",
-    "esModuleInterop": true,
+
+    // TODO(esmodules): included to support require('file.json'). Remove on the switch to ES Modules.
+    "resolveJsonModule": true,
   },
+  "references": [
+    {"path": "./types/lhr/"},
+    {"path": "./report/"},
+    {"path": "./report/generator/"},
+  ],
   "include": [
     "root.js",
     "lighthouse-cli/**/*.js",
@@ -35,11 +29,6 @@
     "lighthouse-core/test/fixtures/traces/lcp-m78.devtools.log.json",
     "third-party/snyk/snapshot.json",
     "lighthouse-core/audits/byte-efficiency/polyfill-graph-data.json",
-  ],
-  "references": [
-    {"path": "./types/lhr/"},
-    {"path": "./report/"},
-    {"path": "./report/generator/"},
   ],
   "exclude": [
     "lighthouse-core/test/audits/**/*.js",

--- a/types/lhr/tsconfig.json
+++ b/types/lhr/tsconfig.json
@@ -1,22 +1,12 @@
 {
+  "extends": "../../tsconfig-base.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-
-    "strict": true,
-    "extendedDiagnostics": true,
-
-    // We only need the base JS definitions, no libs in node_modules, no DOM, etc.
-    "lib": ["esnext"],
-    "types": [],
-
-    // "listFiles": true,
-    // "noErrorTruncation": true,
-
-    "composite": true,
     "outDir": "../../.tmp/tsbuildinfo/types/lhr",
+
+    // We only need the base JS definitions, no DOM, etc.
+    "lib": ["esnext"],
+    // Don't include any types from node_modules/.
+    "types": [],
   },
   "include": [
     "*.d.ts",


### PR DESCRIPTION
Extracts the shared tsconfiguration into a `tsconfig-base.json` file and has all tsconfig files extend from it. `tsconfig-base.json` also serves as a compilation entry point, so `yarn tsc --build tsconfig-base.json` compiles all the sub-(tsc-)projects.

Final PR to #12870, #12880, #12888, #12909, #12914, #12940, #12940, #12946, #12951, #12952, #12953, #12999, and #13069 sequence :)

#12860 listed some starting goals, but to summarize the point of all this:
- made single declaration points for [global `LH.*` types](https://github.com/GoogleChrome/lighthouse/blob/cb00325d735353437144c78f26c714cc76b9f590/types/global-lh.d.ts) so they'd stop [stomping](https://github.com/GoogleChrome/lighthouse/issues/12860#stomping) on each other
- clustered code so we'd stop duplicating compilation of files (like report renderer code compiled 4x since referenced from core test files, viewer, treemap, and flow-report) and simplify node vs DOM types
- extract an LHR type independent of implementation code, hopefully for use somewhere
- we can now emit `d.ts`files for our whole code base, in theory allowing easier import elsewhere (but I'm not sure we care about that anymore). Not suitable for publishing, though.
- reduce `type-check` time with incremental compilation!

(all numbers from my laptop, means over five runs)
Before all this (ebb0b004f1b26a62c156cfb8dd29ca2ecdb8d985):
```
> yarn type-check
Done in 28.11s 
```
This was _every_ time you run `yarn type-check`.

After this commit with cleared compilation cache (`rm -r .tmp/tsbuildinfo`):
```
> yarn type-check
Done in 24.98s
```
Not doing multiple compiles of some files saves a bunch of time, but emitting `d.ts` and `tsbuildinfo` files for most of our code steals back a good bunch of it. `flow-report/` was also added in the meantime. Small win.

But! If you've made no js/type changes and are just idly double checking everything is still good:
```
> yarn type-check
Done in 0.43s
```

Incremental also works within projects. e.g. a change to `gather-runner.js` only invalidates part of the core compilation and none of the report:
```
> yarn type-check
Done in 5.62s
```

And if you're working just in `flow-report` today, adding a new function to `util.ts`:
```
> yarn type-check
Done in 2.08s
```

Not going to win any `esbuild` awards yet, but much better :)