### PR TITLE
deps: update to latest @rollup/plugin-typescript

### DIFF
--- a/build/build-report.js
+++ b/build/build-report.js
@@ -42,6 +42,12 @@ async function buildFlowReport() {
       commonjs(),
       typescript({
         tsconfig: 'flow-report/tsconfig.json',
+        // Plugin struggles with custom outDir, so revert it from tsconfig value
+        // as well as any options that require an outDir is set.
+        outDir: null,
+        composite: false,
+        emitDeclarationOnly: false,
+        declarationMap: false,
       }),
       terser(),
     ],

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@firebase/auth-types": "0.3.2",
     "@firebase/util": "0.2.1",
     "@rollup/plugin-node-resolve": "^13.0.4",
-    "@rollup/plugin-typescript": "^2.1.0",
+    "@rollup/plugin-typescript": "^8.2.5",
     "@testing-library/preact": "^2.0.1",
     "@testing-library/preact-hooks": "^1.1.0",
     "@types/archiver": "^2.1.2",
@@ -173,7 +173,7 @@
     "terser": "^5.3.8",
     "ts-jest": "^27.0.4",
     "typed-query-selector": "^2.4.0",
-    "typescript": "4.4.2",
+    "typescript": "4.4.3",
     "webtreemap-cdt": "^3.2.1"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -812,15 +812,15 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
-"@rollup/plugin-typescript@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-2.1.0.tgz#9d4e39cdd152901893285d90b7beb3e2755fb255"
-  integrity sha512-7lXKGY06aofrceVez/YnN2axttFdHSqlUBpCJ6ebzDfxwLDKMgSV5lD4ykBcdgE7aK3egxuLkD/HKyRB5L8Log==
+"@rollup/plugin-typescript@^8.2.5":
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-8.2.5.tgz#e0319761b2b5105615e5a0c371ae05bc2984b7de"
+  integrity sha512-QL/LvDol/PAGB2O0S7/+q2HpSUNodpw7z6nGn9BfoVCPOZ0r4EALrojFU29Bkoi2Hr2jgTocTejJ5GGWZfOxbQ==
   dependencies:
-    "@rollup/pluginutils" "^3.0.0"
-    resolve "^1.13.1"
+    "@rollup/pluginutils" "^3.1.0"
+    resolve "^1.17.0"
 
-"@rollup/pluginutils@^3.0.0", "@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
@@ -7401,7 +7401,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.4, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.4.0:
+resolve@^1.1.4, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.4.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -8496,10 +8496,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
-  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
+typescript@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
We previously settled on `@rollup/plugin-typescript@^2.1.0` even though that's pretty old (Jan 2020) because the latest versions were broken with our typescript setup. The rollup error messages were pretty inscrutable and not worth wading through since the old version was working fine (with the latest `tsc` as a peer dep).

https://github.com/GoogleChrome/lighthouse/pull/13072#discussion_r709639872 kind of forces our hand because we want `extends` support in tsconfig files, so we need a more recent plugin. The fix isn't so bad, it just seems like you really really can't use a custom `outDir`. The [readme gets into this a bit](https://github.com/rollup/plugins/tree/53fb18c0c2852598200c547a0b1d745d15b5b487/packages/typescript#declaration-output-with-outputfile), but that workaround didn't work for me (nor did [relocating the `outDir`](https://github.com/rollup/plugins/issues/243) to a few different places). Rather than torturing every path permutation until it worked, it's easier to just disable the custom `outDir` and any of the properties that force a custom `outDir` since we don't need any of those for the plugin's build anyways.

Also updates to typescript 4.4.3 because it has a bug fix (https://github.com/microsoft/TypeScript/pull/45642) that fixes the plugin [hanging forever](https://github.com/rollup/plugins/issues/983) with typescript 4.4.* builds. 