### PR TITLE
tests: restore use of latest node 16 in CI

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,11 +10,11 @@ jobs:
   unit:
     strategy:
       matrix:
-        node: ['12', '14', '16.8']
+        node: ['12', '14', '16']
     runs-on: ubuntu-latest
     name: node ${{ matrix.node }}
     env:
-      LATEST_NODE: '16.8'
+      LATEST_NODE: '16'
 
     steps:
     - name: git clone


### PR DESCRIPTION
reverts #13012

https://github.com/nodejs/node/issues/40030 was [fixed in 16.9.1](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#2021-09-10-version-1691-current-richardlau), so we can go back to floating against the latest Node 16.