### PR TITLE
tests: update SVGOMG expectations

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa2-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa/pwa2-expectations.js
@@ -46,9 +46,6 @@ const svgomg = {
       },
       'apple-touch-icon': {
         score: 1,
-        warnings: [
-          /apple-touch-icon-precomposed/,
-        ],
       },
 
       // "manual" audits. Just verify in the results.


### PR DESCRIPTION
**Summary**
Our smokes have been failing because the warning on apple-touch-icon for SVGOMG is missing. The page itself was updated to fix the warning :)

![image](https://user-images.githubusercontent.com/2301202/134052931-7c6654b2-e07f-4310-b00e-cee6d851586b.png)

