### PR TITLE
tests: add FR integration scenarios

### DIFF
--- a/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
@@ -18,21 +18,7 @@ jest.setTimeout(90_000);
 describe('Fraggle Rock API', () => {
   const state = createTestState();
 
-  beforeAll(async () => {
-    await state.beforeAll();
-  });
-
-  beforeEach(async () => {
-    await state.beforeEach();
-  });
-
-  afterEach(async () => {
-    await state.afterEach();
-  });
-
-  afterAll(async () => {
-    await state.afterAll();
-  });
+  state.installSetupAndTeardownHooks();
 
   async function setupTestPage() {
     await state.page.goto(`${state.serverBaseUrl}/onclick.html`);

--- a/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
@@ -123,7 +123,7 @@ describe('Fraggle Rock API', () => {
     });
 
     it('should compute results from timespan after page load', async () => {
-      const {lighthouse, page, serverBaseUrl} = state;
+      const {page, serverBaseUrl} = state;
       await page.goto(`${serverBaseUrl}/onclick.html`);
       await page.waitForSelector('button');
 
@@ -154,7 +154,7 @@ describe('Fraggle Rock API', () => {
     });
 
     it('should compute both snapshot & timespan results', async () => {
-      const {lighthouse, page, serverBaseUrl} = state;
+      const {page, serverBaseUrl} = state;
       const result = await lighthouse.navigation({page, url: `${serverBaseUrl}/index.html`});
       if (!result) throw new Error('Lighthouse failed to produce a result');
 

--- a/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
@@ -5,117 +5,54 @@
  */
 'use strict';
 
+import {jest} from '@jest/globals';
+
+import * as lighthouse from '../../../fraggle-rock/api.js';
+import {createTestState, getAuditsBreakdown} from './pptr-test-utils.js';
+import {LH_ROOT} from '../../../../root.js';
+
 /* eslint-env jest */
-
-// TODO(esmodules): Node 14, 16 crash with `--experimental-vm-modules` if require and import
-// are used in the same test file.
-// See https://github.com/GoogleChrome/lighthouse/pull/12702#issuecomment-876832620
-// Use normal import when present file is esm.
-
-/** @type {import('path')} */
-let path;
-/** @type {import('../../fraggle-rock/api.js')} */
-let lighthouse;
-/** @type {import('puppeteer')} */
-let puppeteer;
 
 jest.setTimeout(90_000);
 
-/**
- * Some audits can be notApplicable based on machine timing information.
- * Exclude these audits from applicability comparisons. */
-const FLAKY_AUDIT_IDS_APPLICABILITY = new Set([
-  'long-tasks', // Depends on whether the longest task takes <50ms.
-  'screenshot-thumbnails', // Depends on OS whether frames happen to be generated on non-visual timespan changes.
-  'layout-shift-elements', // Depends on if the JS takes too long after input to be ignored for layout shift.
-]);
-
-/**
- * @param {LH.Result} lhr
- */
-function getAuditsBreakdown(lhr) {
-  const auditResults = Object.values(lhr.audits);
-  const irrelevantDisplayModes = new Set(['notApplicable', 'manual']);
-  const applicableAudits = auditResults.filter(
-    audit => !irrelevantDisplayModes.has(audit.scoreDisplayMode)
-  );
-
-  const notApplicableAudits = auditResults.filter(
-    audit => (
-      audit.scoreDisplayMode === 'notApplicable' &&
-      !FLAKY_AUDIT_IDS_APPLICABILITY.has(audit.id)
-    )
-  );
-
-  const informativeAudits = applicableAudits.filter(
-    audit => audit.scoreDisplayMode === 'informative'
-  );
-
-  const erroredAudits = applicableAudits.filter(
-    audit => audit.score === null && audit && !informativeAudits.includes(audit)
-  );
-
-  const failedAudits = applicableAudits.filter(audit => audit.score !== null && audit.score < 1);
-
-  return {auditResults, erroredAudits, failedAudits, notApplicableAudits};
-}
-
 describe('Fraggle Rock API', () => {
-  /** @type {InstanceType<typeof import('../../../lighthouse-cli/test/fixtures/static-server.js').Server>} */
-  let server;
-  /** @type {import('puppeteer').Browser} */
-  let browser;
-  /** @type {import('puppeteer').Page} */
-  let page;
-  /** @type {string} */
-  let serverBaseUrl;
+  const state = createTestState();
 
   beforeAll(async () => {
-    // TODO(esmodules): use normal import when present file is esm.
-    const {Server} = await import('../../../lighthouse-cli/test/fixtures/static-server.js');
-    path = await import('path');
-    lighthouse = await import('../../fraggle-rock/api.js');
-    puppeteer = (await import('puppeteer')).default;
-
-    server = new Server();
-    await server.listen(0, '127.0.0.1');
-    serverBaseUrl = `http://localhost:${server.getPort()}`;
-    browser = await puppeteer.launch({
-      headless: true,
-    });
+    await state.beforeAll();
   });
 
   beforeEach(async () => {
-    page = await browser.newPage();
+    await state.beforeEach();
   });
 
   afterEach(async () => {
-    await page.close();
+    await state.afterEach();
   });
 
   afterAll(async () => {
-    await browser.close();
-    await server.close();
+    await state.afterAll();
   });
 
   async function setupTestPage() {
-    await page.goto(`${serverBaseUrl}/onclick.html`);
+    await state.page.goto(`${state.serverBaseUrl}/onclick.html`);
     // Wait for the javascript to run.
-    await page.waitForSelector('button');
-    await page.click('button');
+    await state.page.waitForSelector('button');
+    await state.page.click('button');
     // Wait for the violations to appear (and console to be populated).
-    await page.waitForSelector('input');
+    await state.page.waitForSelector('input');
   }
 
   describe('snapshot', () => {
     beforeEach(() => {
-      server.baseDir = path.join(__dirname, '../fixtures/fraggle-rock/snapshot-basic');
+      const {server} = state;
+      server.baseDir = `${LH_ROOT}/lighthouse-core/test/fixtures/fraggle-rock/snapshot-basic`;
     });
 
     it('should compute accessibility results on the page as-is', async () => {
       await setupTestPage();
 
-      const result = await lighthouse.snapshot({page});
+      const result = await lighthouse.snapshot({page: state.page});
       if (!result) throw new Error('Lighthouse failed to produce a result');
 
       const {lhr} = result;
@@ -133,11 +70,12 @@ describe('Fraggle Rock API', () => {
 
   describe('startTimespan', () => {
     beforeEach(() => {
-      server.baseDir = path.join(__dirname, '../fixtures/fraggle-rock/snapshot-basic');
+      const {server} = state;
+      server.baseDir = `${LH_ROOT}/lighthouse-core/test/fixtures/fraggle-rock/snapshot-basic`;
     });
 
     it('should compute ConsoleMessage results across a span of time', async () => {
-      const run = await lighthouse.startTimespan({page});
+      const run = await lighthouse.startTimespan({page: state.page});
 
       await setupTestPage();
 
@@ -181,10 +119,11 @@ describe('Fraggle Rock API', () => {
       expect(lhr.audits).toHaveProperty('total-byte-weight');
       const details = lhr.audits['total-byte-weight'].details;
       if (!details || details.type !== 'table') throw new Error('Unexpected byte weight details');
-      expect(details.items).toMatchObject([{url: `${serverBaseUrl}/onclick.html`}]);
+      expect(details.items).toMatchObject([{url: `${state.serverBaseUrl}/onclick.html`}]);
     });
 
     it('should compute results from timespan after page load', async () => {
+      const {lighthouse, page, serverBaseUrl} = state;
       await page.goto(`${serverBaseUrl}/onclick.html`);
       await page.waitForSelector('button');
 
@@ -210,10 +149,12 @@ describe('Fraggle Rock API', () => {
 
   describe('navigation', () => {
     beforeEach(() => {
-      server.baseDir = path.join(__dirname, '../fixtures/fraggle-rock/navigation-basic');
+      const {server} = state;
+      server.baseDir = `${LH_ROOT}/lighthouse-core/test/fixtures/fraggle-rock/navigation-basic`;
     });
 
     it('should compute both snapshot & timespan results', async () => {
+      const {lighthouse, page, serverBaseUrl} = state;
       const result = await lighthouse.navigation({page, url: `${serverBaseUrl}/index.html`});
       if (!result) throw new Error('Lighthouse failed to produce a result');
 

--- a/lighthouse-core/test/fraggle-rock/scenarios/disconnect-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/disconnect-test-pptr.js
@@ -21,7 +21,7 @@ describe('Disconnect', () => {
 
   state.installSetupAndTeardownHooks();
 
-  beforeAll(async () => {
+  beforeAll(() => {
     state.server.baseDir = `${LH_ROOT}/lighthouse-core/test/fixtures/fraggle-rock/snapshot-basic`;
   });
 

--- a/lighthouse-core/test/fraggle-rock/scenarios/disconnect-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/disconnect-test-pptr.js
@@ -1,0 +1,86 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+import {jest} from '@jest/globals';
+
+import * as lighthouse from '../../../fraggle-rock/api.js';
+import {createTestState} from './pptr-test-utils.js';
+import {LH_ROOT} from '../../../../root.js';
+
+/* eslint-env jest */
+/* eslint-env browser */
+
+jest.setTimeout(90_000);
+
+describe('Disconnect', () => {
+  const state = createTestState();
+
+  beforeAll(async () => {
+    await state.beforeAll();
+  });
+
+  beforeEach(async () => {
+    await state.beforeEach();
+    state.server.baseDir = `${LH_ROOT}/lighthouse-core/test/fixtures/fraggle-rock/snapshot-basic`;
+  });
+
+  afterEach(async () => {
+    await state.afterEach();
+  });
+
+  afterAll(async () => {
+    await state.afterAll();
+  });
+
+  it('should reset the listeners/protocol when LH is done', async () => {
+    const pageUrl = `${state.serverBaseUrl}/onclick.html`;
+    await state.page.goto(pageUrl, {waitUntil: ['networkidle0']});
+
+    const session = await state.page.target().createCDPSession();
+    await session.send('Network.enable');
+
+    const timespan = await lighthouse.startTimespan({
+      page: state.page,
+      configContext: {
+        settingsOverrides: {blockedUrlPatterns: ['*']},
+      },
+    });
+
+    await state.page.evaluate(() => fetch(`/onclick.html`).catch(() => null));
+
+    const result = await timespan.endTimespan();
+    if (!result) throw new Error('Lighthouse failed to produce a result');
+
+    const networkDetails = result.lhr.audits['network-requests'].details;
+    if (!networkDetails || networkDetails.type !== 'table') throw new Error('Invalid details');
+    const fetchRequest = networkDetails.items[0];
+    expect(fetchRequest).toMatchObject({statusCode: -1}); // should be blocked
+
+    /** @type {Array<*>} */
+    const failedMessages = [];
+    /** @type {Array<*>} */
+    const debugMessages = [];
+    /** @param {*} request */
+    const failedListener = request => failedMessages.push(request);
+    /** @param {*} request */
+    const debugListener = request => debugMessages.push(request);
+    session.on('Network.requestWillBeSent', debugListener);
+    session.on('Network.responseReceived', debugListener);
+    session.on('Network.loadingFinished', debugListener);
+    session.on('Network.loadingFailed', failedListener);
+
+    await state.page.evaluate(() => fetch(`/onclick.html`).catch(() => null));
+
+    session.off('Network.requestWillBeSent', debugListener);
+    session.off('Network.responseReceived', debugListener);
+    session.off('Network.loadingFinished', debugListener);
+    session.off('Network.loadingFailed', failedListener);
+
+    expect(debugMessages.length).toBeGreaterThan(0); // make sure we observed the request
+    expect(failedMessages).toHaveLength(0); // should NOT be blocked (driver disconnected)
+  });
+});

--- a/lighthouse-core/test/fraggle-rock/scenarios/disconnect-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/disconnect-test-pptr.js
@@ -19,21 +19,10 @@ jest.setTimeout(90_000);
 describe('Disconnect', () => {
   const state = createTestState();
 
+  state.installSetupAndTeardownHooks();
+
   beforeAll(async () => {
-    await state.beforeAll();
-  });
-
-  beforeEach(async () => {
-    await state.beforeEach();
     state.server.baseDir = `${LH_ROOT}/lighthouse-core/test/fixtures/fraggle-rock/snapshot-basic`;
-  });
-
-  afterEach(async () => {
-    await state.afterEach();
-  });
-
-  afterAll(async () => {
-    await state.afterAll();
   });
 
   it('should reset the listeners/protocol when LH is done', async () => {

--- a/lighthouse-core/test/fraggle-rock/scenarios/package.json
+++ b/lighthouse-core/test/fraggle-rock/scenarios/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "//": "Any directory that uses `import ... from` or `export ...` must be type module. Temporary file until root package.json is type: module"
+}

--- a/lighthouse-core/test/fraggle-rock/scenarios/pptr-test-utils.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/pptr-test-utils.js
@@ -1,0 +1,83 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+import puppeteer from 'puppeteer';
+import {Server} from '../../../../lighthouse-cli/test/fixtures/static-server.js';
+
+/** @typedef {InstanceType<typeof import('../../../../lighthouse-cli/test/fixtures/static-server.js').Server>} StaticServer */
+
+export function createTestState() {
+  /** @param {string} name @return {any} */
+  const any = name => new Proxy({}, {get: () => {
+    throw new Error(`${name} used without invoking \`state.beforeAll\``);
+  }});
+
+  return {
+    browser: /** @type {import('puppeteer').Browser} */ (any('browser')),
+    page: /** @type {import('puppeteer').Page} */ (any('page')),
+    server: /** @type {StaticServer} */ (any('server')),
+    serverBaseUrl: '',
+
+    async beforeAll() {
+      this.server = new Server();
+      await this.server.listen(0, '127.0.0.1');
+      this.serverBaseUrl = `http://localhost:${this.server.getPort()}`;
+      this.browser = await puppeteer.launch({
+        headless: true,
+      });
+    },
+    async beforeEach() {
+      this.page = await this.browser.newPage();
+    },
+    async afterEach() {
+      await this.page.close();
+    },
+    async afterAll() {
+      await this.browser.close();
+      await this.server.close();
+    },
+  };
+}
+
+/**
+ * Some audits can be notApplicable based on machine timing information.
+ * Exclude these audits from applicability comparisons. */
+const FLAKY_AUDIT_IDS_APPLICABILITY = new Set([
+  'long-tasks', // Depends on whether the longest task takes <50ms.
+  'screenshot-thumbnails', // Depends on OS whether frames happen to be generated on non-visual timespan changes.
+  'layout-shift-elements', // Depends on if the JS takes too long after input to be ignored for layout shift.
+]);
+
+/**
+ * @param {LH.Result} lhr
+ */
+export function getAuditsBreakdown(lhr) {
+  const auditResults = Object.values(lhr.audits);
+  const irrelevantDisplayModes = new Set(['notApplicable', 'manual']);
+  const applicableAudits = auditResults.filter(
+    audit => !irrelevantDisplayModes.has(audit.scoreDisplayMode)
+  );
+
+  const notApplicableAudits = auditResults.filter(
+    audit => (
+      audit.scoreDisplayMode === 'notApplicable' &&
+      !FLAKY_AUDIT_IDS_APPLICABILITY.has(audit.id)
+    )
+  );
+
+  const informativeAudits = applicableAudits.filter(
+    audit => audit.scoreDisplayMode === 'informative'
+  );
+
+  const erroredAudits = applicableAudits.filter(
+    audit => audit.score === null && audit && !informativeAudits.includes(audit)
+  );
+
+  const failedAudits = applicableAudits.filter(audit => audit.score !== null && audit.score < 1);
+
+  return {auditResults, erroredAudits, failedAudits, notApplicableAudits};
+}


### PR DESCRIPTION
**Summary**
Refactors the lone puppeteer API test for Fraggle Rock to enable easily testing individual integration scenarios. Adds an example of such a scenario, disconnect integration testing (checks that blocked patterns go away after Lighthouse is done).

**Related Issues/PRs**
ref #11313 
