### PR TITLE
core(link-text): check for meaningful unicode icons

### DIFF
--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -124,7 +124,17 @@ class LinkText extends Audit {
           return false;
         }
 
-        return BLOCKLIST.has(link.text.trim().toLowerCase());
+        const normalized = link.text.trim().toLowerCase();
+        const isJustOneCodePoint = [...normalized].length === 1;
+        const codePoint = isJustOneCodePoint && normalized.charCodeAt(0);
+        // https://www.w3schools.com/charsets/ref_utf_symbols.asp
+        const isUnicodeSymbol =
+          codePoint >= parseInt('2600', 16) && codePoint <= parseInt('26FF', 16);
+        const isFontAwesome =
+          codePoint >= parseInt('f000', 16) && codePoint <= parseInt('f2e0', 16);
+        const isMeaningfulIcon = isUnicodeSymbol || isFontAwesome;
+
+        return BLOCKLIST.has(normalized) || (isJustOneCodePoint && !isMeaningfulIcon);
       })
       .map(link => {
         return {

--- a/lighthouse-core/test/audits/seo/link-text-test.js
+++ b/lighthouse-core/test/audits/seo/link-text-test.js
@@ -10,7 +10,32 @@ const assert = require('assert').strict;
 
 /* eslint-env jest */
 
+function expectFailure(invalidLink) {
+  const artifacts = {
+    URL: {
+      finalUrl: 'https://example.com/page.html',
+    },
+    AnchorElements: [
+      {href: 'https://example.com/otherpage.html', text: 'legit link text', rel: ''},
+      invalidLink,
+      {href: 'https://example.com/otherpage.html', text: 'legit link text', rel: ''},
+    ],
+  };
+
+  const auditResult = LinkTextAudit.audit(artifacts);
+  assert.equal(auditResult.score, 0);
+  assert.equal(auditResult.details.items.length, 1);
+  assert.equal(auditResult.details.items[0].href, invalidLink.href);
+  assert.equal(auditResult.details.items[0].text, invalidLink.text);
+}
+
 describe('SEO: link text audit', () => {
+  it('fails when link with non descriptive text is found', () => {
+    expectFailure({href: 'https://example.com/otherpage.html', text: 'click here', rel: ''});
+    expectFailure({href: 'https://example.com/otherpage.html', text: '!', rel: ''});
+    expectFailure({href: 'https://example.com/otherpage.html', text: 'i', rel: ''});
+  });
+
   it('fails when link with non descriptive text is found', () => {
     const invalidLink = {href: 'https://example.com/otherpage.html', text: 'click here', rel: ''};
     const artifacts = {
@@ -116,6 +141,9 @@ describe('SEO: link text audit', () => {
         {href: 'https://example.com/otherpage.html', text: 'legit link text', rel: ''},
         {href: 'http://example.com/page.html?test=test', text: 'legit link text', rel: ''},
         {href: 'file://Users/user/Desktop/file.png', text: 'legit link text', rel: ''},
+        {href: 'file://Users/user/Desktop/file.png', text: '⛴', rel: ''},
+        {href: 'file://Users/user/Desktop/file.png', text: '⛴⛏', rel: ''},
+        {href: 'file://Users/user/Desktop/file.png', text: String.fromCodePoint(62062), rel: ''},
       ],
     };
 


### PR DESCRIPTION
ref #13026

Adds additional checks if the link text is a single unicode code point (after trimming):

* Fails if code point is not a "unicode symbol" or a font-awesome icon