### PR TITLE
docs: correct the Node.js version base

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "smokehouse": "./lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js"
   },
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=12.20.0 && 12.* || >=14.13 && 14.* || >=15"
   },
   "scripts": {
     "build-all": "npm-run-posix-or-windows build-all:task",

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The Chrome extension was available prior to Lighthouse being available in Chrome
 
 The Node CLI provides the most flexibility in how Lighthouse runs can be configured and reported. Users who want more advanced usage, or want to run Lighthouse in an automated fashion should use the Node CLI.
 
-_Lighthouse requires Node 12 LTS (12.x) or later._
+_Lighthouse requires Node 14 LTS (14.13) or later._
 
 **Installation**:
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The Chrome extension was available prior to Lighthouse being available in Chrome
 
 The Node CLI provides the most flexibility in how Lighthouse runs can be configured and reported. Users who want more advanced usage, or want to run Lighthouse in an automated fashion should use the Node CLI.
 
-_Lighthouse requires Node 14 LTS (14.13) or later._
+_Lighthouse requires Node 12 LTS (12.20) or later._
 
 **Installation**:
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

The PR(#13045) converts cli to use esm which also uses named exports for commonjs, this commit just corrects the description in README.

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->

- #13045
