### PR TITLE
report: remove smooth scrolling css

### DIFF
--- a/report/assets/styles.css
+++ b/report/assets/styles.css
@@ -310,7 +310,6 @@
   margin: 0;
   line-height: var(--report-line-height);
   background: var(--report-background-color);
-  scroll-behavior: smooth;
   color: var(--report-text-color);
 }
 


### PR DESCRIPTION
g3 import keeps complaining about this css rule; if no one feels strongly, simplest solution is to just get rid of this