### PR TITLE
clients(viewer): use new firebase credentials

### DIFF
--- a/lighthouse-viewer/app/src/firebase-auth.js
+++ b/lighthouse-viewer/app/src/firebase-auth.js
@@ -24,11 +24,13 @@ export class FirebaseAuth {
     this._provider.addScope('gist');
 
     firebase.initializeApp({
-      apiKey: 'AIzaSyApMz8FHTyJNqqUtA51tik5Mro8j-2qMcM',
-      authDomain: 'lighthouse-viewer.firebaseapp.com',
-      databaseURL: 'https://lighthouse-viewer.firebaseio.com',
-      storageBucket: 'lighthouse-viewer.appspot.com',
-      messagingSenderId: '962507201498',
+      apiKey: 'AIzaSyBQEZMlX6A9B0jJ6PFGcBADbXZG9ogyCmQ',
+      authDomain: 'lighthouse-chrom-1560304954232.firebaseapp.com',
+      projectId: 'lighthouse-chrom-1560304954232',
+      storageBucket: 'lighthouse-chrom-1560304954232.appspot.com',
+      messagingSenderId: '89319782509',
+      appId: '1:89319782509:web:9ea5d8e149048c7836e764',
+      measurementId: 'G-7FMYHPW5YC',
     });
 
     /**


### PR DESCRIPTION
Fixes #12890

Credentials have been broken for awhile. We lost access to the old project, so I made a new one.

Shouldn't merge this until the Oauth app is transferred out of my name and into `googlechrome` org.