### PR TITLE
report(build): don't build flow if only --standalone is requested

### DIFF
--- a/build/build-report.js
+++ b/build/build-report.js
@@ -116,6 +116,8 @@ if (require.main === module) {
   }
   if (process.argv.includes('--standalone')) {
     buildStandaloneReport();
+  }
+  if (process.argv.includes('--flow')) {
     buildFlowReport();
   }
   if (process.argv.includes('--esm')) {

--- a/lighthouse-core/scripts/build-test-flow-report.js
+++ b/lighthouse-core/scripts/build-test-flow-report.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const open = require('open');
 const {execFileSync} = require('child_process');
 
-execFileSync(`yarn`, ['build-report', '--standalone']);
+execFileSync(`yarn`, ['build-report', '--flow']);
 const reportGenerator = require('../../report/generator/report-generator.js');
 
 const flow = JSON.parse(fs.readFileSync(


### PR DESCRIPTION
When I'm working on the standalone report, I don't want to incur whatever wildness is going on with the tsc plugin for the flow report build.

That work for you @adamraine ?