### PR TITLE
cli: always return correct version

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -12,6 +12,7 @@ import fs from 'fs';
 import yargs from 'yargs';
 import * as yargsHelpers from 'yargs/helpers';
 
+import {LH_ROOT} from '../root.js';
 import {isObjectOfUnknownValues} from '../lighthouse-core/lib/type-verifiers.js';
 
 /**
@@ -26,6 +27,7 @@ function getFlags(manualArgv, options = {}) {
     yargs(yargsHelpers.hideBin(process.argv));
 
   let parser = y.help('help')
+      .version(JSON.parse(fs.readFileSync(`${LH_ROOT}/package.json`, 'utf-8')).version)
       .showHelpOnFail(false, 'Specify --help for available options')
 
       .usage('lighthouse <url> <options>')


### PR DESCRIPTION
**Summary**
For some reason in our published bundle, version doesn't work. To repro...

```
docker run -it --user root --entrypoint /bin/bash node:14-buster
$ npm install -g lighthouse
$ lighthouse --version
unknown
```

Sadly this doesn't actually repro within our repo, so testing is rough, but manually applying this patch to an install in the docker container had the intended effect.

**Related Issues/PRs**
fixes https://github.com/GoogleChrome/lighthouse/issues/13129
