### PR TITLE
core(stack-packs): simplify i18n filename lookup

### DIFF
--- a/lighthouse-core/lib/stack-packs.js
+++ b/lighthouse-core/lib/stack-packs.js
@@ -10,18 +10,6 @@ const stackPacks = require('lighthouse-stack-packs');
 const i18n = require('./i18n/i18n.js');
 
 /**
- * Resolve a module on web and node
- * @param {string} module
- */
-function resolve(module) {
-  if (!require.resolve) {
-    return `node_modules/${module}`;
-  }
-
-  return require.resolve(module);
-}
-
-/**
  * Pairs consisting of a stack pack's ID and the set of stacks needed to be
  * detected in a page to display that pack's advice.
  * @type {Array<{packId: string, requiredStacks: Array<string>}>}
@@ -87,7 +75,7 @@ function getStackPacks(pageStacks) {
 
     // Create i18n handler to get translated strings.
     const str_ = i18n.createMessageInstanceIdFn(
-      resolve(`lighthouse-stack-packs/packs/${matchedPack.id}`),
+      `node_modules/lighthouse-stack-packs/packs/${matchedPack.id}.js`,
       matchedPack.UIStrings
     );
 


### PR DESCRIPTION
`require.resolve` just isn't necessary here–we only need to create the same values as the i18n keys (like `node_modules/lighthouse-stack-packs/packs/amp.js`).