### PR TITLE
misc(build): fix smokehouse bundle

### DIFF
--- a/build/build-lightrider-bundles.js
+++ b/build/build-lightrider-bundles.js
@@ -6,6 +6,8 @@
 'use strict';
 
 const browserify = require('browserify');
+const rollup = require('rollup');
+const rollupPlugins = require('./rollup-plugins.js');
 const fs = require('fs');
 const path = require('path');
 const bundleBuilder = require('./build-bundle.js');
@@ -52,11 +54,31 @@ function buildReportGenerator() {
     });
 }
 
+async function buildStaticServerBundle() {
+  const bundle = await rollup.rollup({
+    input: 'lighthouse-cli/test/fixtures/static-server.js',
+    plugins: [
+      rollupPlugins.shim({
+        'es-main': 'export default function() { return false; }',
+      }),
+      rollupPlugins.commonjs(),
+      rollupPlugins.nodeResolve(),
+    ],
+    external: ['mime-types', 'glob'],
+  });
+
+  await bundle.write({
+    file: 'dist/lightrider/static-server.js',
+    format: 'commonjs',
+  });
+}
+
 async function run() {
   await Promise.all([
     buildEntryPoint(),
     buildReportGenerator(),
     buildPsiReport(),
+    buildStaticServerBundle(),
   ]);
 }
 

--- a/build/build-smokehouse-bundle.js
+++ b/build/build-smokehouse-bundle.js
@@ -23,6 +23,11 @@ async function build() {
         [smokehouseCliFilename]:
           'export function runLighthouse() { throw new Error("not supported"); }',
       }),
+      // TODO(esmodules): brfs does not support es modules.
+      rollupPlugins.brfs({
+        global: true,
+        parserOpts: {ecmaVersion: 12, sourceType: 'module'},
+      }),
       rollupPlugins.commonjs(),
       rollupPlugins.nodePolyfills(),
       rollupPlugins.nodeResolve(),

--- a/build/build-smokehouse-bundle.js
+++ b/build/build-smokehouse-bundle.js
@@ -12,19 +12,20 @@ const {LH_ROOT} = require('../root.js');
 const distDir = `${LH_ROOT}/dist`;
 const bundleOutFile = `${distDir}/smokehouse-bundle.js`;
 const smokehouseLibFilename = './lighthouse-cli/test/smokehouse/frontends/lib.js';
-const smokehouseCliFilename =
-  require.resolve('../lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js');
+const smokehouseCliFilename = `${LH_ROOT}/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js`;
 
 async function build() {
   const bundle = await rollup.rollup({
     input: smokehouseLibFilename,
     context: 'globalThis',
     plugins: [
-      rollupPlugins.nodeResolve(),
-      rollupPlugins.commonjs(),
       rollupPlugins.shim({
-        [smokehouseCliFilename]: 'export default {}',
+        [smokehouseCliFilename]:
+          'export function runLighthouse() { throw new Error("not supported"); }',
       }),
+      rollupPlugins.commonjs(),
+      rollupPlugins.nodePolyfills(),
+      rollupPlugins.nodeResolve(),
     ],
   });
 

--- a/build/rollup-brfs.js
+++ b/build/rollup-brfs.js
@@ -1,0 +1,46 @@
+// @ts-nocheck
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const path = require('path');
+const {Readable} = require('stream');
+const brfs = require('@wardpeet/brfs');
+
+const EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx'];
+
+const rollupBrfs = function rollUpBrfs(options = {}) {
+  return {
+    name: 'brfs',
+    transform(code, id) {
+      const ext = path.extname(id);
+      if (!EXTENSIONS.includes(ext)) {
+        return null;
+      }
+      return new Promise((resolve, reject) => {
+        let output = '';
+        const src = new Readable();
+        src.push(code);
+        src.push(null);
+        const stream = src.pipe(brfs(id, options));
+        stream.on('data', function(data) {
+          output += data.toString();
+        });
+        stream.on('end', function() {
+          resolve({
+            code: output,
+            map: {mappings: ''},
+          });
+        });
+        stream.on('error', function(error) {
+          reject(error);
+        });
+      });
+    },
+  };
+};
+
+module.exports = rollupBrfs;

--- a/build/rollup-plugins.js
+++ b/build/rollup-plugins.js
@@ -18,7 +18,7 @@ function rollupPluginTypeCoerce(module) {
 
 const commonjs = rollupPluginTypeCoerce(require('@rollup/plugin-commonjs'));
 const {nodeResolve} = require('@rollup/plugin-node-resolve');
-const nodePolyfills = require('rollup-plugin-polyfill-node');
+const nodePolyfills = rollupPluginTypeCoerce(require('rollup-plugin-polyfill-node'));
 // @ts-expect-error: no published types.
 const shim = require('rollup-plugin-shim');
 const {terser} = require('rollup-plugin-terser');

--- a/build/rollup-plugins.js
+++ b/build/rollup-plugins.js
@@ -18,6 +18,7 @@ function rollupPluginTypeCoerce(module) {
 
 const commonjs = rollupPluginTypeCoerce(require('@rollup/plugin-commonjs'));
 const {nodeResolve} = require('@rollup/plugin-node-resolve');
+const nodePolyfills = require('rollup-plugin-polyfill-node');
 // @ts-expect-error: no published types.
 const shim = require('rollup-plugin-shim');
 const {terser} = require('rollup-plugin-terser');
@@ -26,6 +27,7 @@ const typescript = rollupPluginTypeCoerce(require('@rollup/plugin-typescript'));
 module.exports = {
   commonjs,
   nodeResolve,
+  nodePolyfills,
   shim,
   terser,
   typescript,

--- a/build/rollup-plugins.js
+++ b/build/rollup-plugins.js
@@ -16,6 +16,7 @@ function rollupPluginTypeCoerce(module) {
   return module;
 }
 
+const brfs = require('./rollup-brfs.js');
 const commonjs = rollupPluginTypeCoerce(require('@rollup/plugin-commonjs'));
 const {nodeResolve} = require('@rollup/plugin-node-resolve');
 const nodePolyfills = rollupPluginTypeCoerce(require('rollup-plugin-polyfill-node'));
@@ -25,6 +26,7 @@ const {terser} = require('rollup-plugin-terser');
 const typescript = rollupPluginTypeCoerce(require('@rollup/plugin-typescript'));
 
 module.exports = {
+  brfs,
   commonjs,
   nodeResolve,
   nodePolyfills,

--- a/lighthouse-cli/test/smokehouse/test-definitions/source-maps/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/source-maps/expectations.js
@@ -5,11 +5,12 @@
  */
 'use strict';
 
-import fs from 'fs';
-import {LH_ROOT} from '../../../../../root.js';
+const fs = require('fs');
 
+// TODO(esmodules): brfs does not support es modules, and this file needs to be bundlded,
+// so it is commonjs for now.
 const mapJson =
-  fs.readFileSync(`${LH_ROOT}/lighthouse-cli/test/fixtures/source-map/script.js.map`, 'utf-8');
+  fs.readFileSync(`${__dirname}/../../../fixtures/source-map/script.js.map`, 'utf-8');
 const map = JSON.parse(mapJson);
 
 /**
@@ -41,4 +42,4 @@ const expectations = {
   },
 };
 
-export {expectations};
+module.exports = {expectations};

--- a/lighthouse-cli/test/smokehouse/test-definitions/source-maps/package.json
+++ b/lighthouse-cli/test/smokehouse/test-definitions/source-maps/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "commonjs",
+  "//": "Preserve commonjs in this directory. Temporary file until converted to type: module"
+}

--- a/lighthouse-cli/test/smokehouse/test-definitions/source-maps/source-maps-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/source-maps/source-maps-config.js
@@ -17,4 +17,4 @@ const config = {
   },
 };
 
-export default config;
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "puppeteer": "^10.2.0",
     "rollup": "^2.50.6",
     "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-polyfill-node": "^0.7.0",
     "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "tabulator-tables": "^4.9.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build-extension-firefox": "node ./build/build-extension.js firefox",
     "build-devtools": "yarn reset-link && node ./build/build-bundle.js clients/devtools-entry.js dist/lighthouse-dt-bundle.js && node ./build/build-dt-report-resources.js",
     "build-smokehouse-bundle": "node ./build/build-smokehouse-bundle.js",
-    "build-lr": "yarn reset-link && node ./build/build-lightrider-bundles.js && rollup lighthouse-cli/test/fixtures/static-server.js -o dist/lightrider/static-server.js -f commonjs -p commonjs -p node-resolve -e mime-types,glob",
+    "build-lr": "yarn reset-link && node ./build/build-lightrider-bundles.js",
     "build-pack": "bash build/build-pack.sh",
     "build-report": "node build/build-report-components.js && yarn eslint --fix report/renderer/components.js && node build/build-report.js",
     "build-sample-reports": "yarn build-report && node build/build-sample-reports.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,6 +1225,15 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
+"@rollup/plugin-inject@^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-inject/-/plugin-inject-4.0.2.tgz#55b21bb244a07675f7fdde577db929c82fc17395"
+  integrity sha512-TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.4"
+    estree-walker "^1.0.1"
+    magic-string "^0.25.5"
+
 "@rollup/plugin-node-resolve@^13.0.4":
   version "13.0.4"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz#b10222f4145a019740acb7738402130d848660c0"
@@ -1245,7 +1254,7 @@
     "@rollup/pluginutils" "^3.1.0"
     resolve "^1.17.0"
 
-"@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.0.4", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
@@ -6594,7 +6603,7 @@ magic-string@0.25.1:
   dependencies:
     sourcemap-codec "^1.4.1"
 
-magic-string@^0.25.7:
+magic-string@^0.25.5, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -8042,6 +8051,13 @@ rollup-plugin-node-resolve@^5.2.0:
     is-module "^1.0.0"
     resolve "^1.11.1"
     rollup-pluginutils "^2.8.1"
+
+rollup-plugin-polyfill-node@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.7.0.tgz#938e13278c98a582a4f8814975ddd26f90afddcc"
+  integrity sha512-iJLZDfvxcQh3SpC0OiYlZG9ik26aRM29hiC2sARbAPXYunB8rzW8GtVaWuJgiCtX1hNAo/OaYvVXfPp15fMs7g==
+  dependencies:
+    "@rollup/plugin-inject" "^4.0.0"
 
 rollup-plugin-shim@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Some recent changes to the smokehouse bundling / cli test conversion to ES modules has resulted in a master roll of smokehouse to LR not working. This PR fixes that.