### PR TITLE
clients(viewer): add body styles

### DIFF
--- a/lighthouse-viewer/app/styles/viewer.css
+++ b/lighthouse-viewer/app/styles/viewer.css
@@ -8,6 +8,13 @@
   box-sizing: border-box;
 }
 
+body {
+  font-family: Roboto, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  line-height: 24px;
+  margin: 0;
+}
+
 :root {
   --lh-background-color: #304ffe;
 }


### PR DESCRIPTION
#13057 removed direct usage of the report styles, which the viewer relied on a bit for styling its initial view

![image](https://user-images.githubusercontent.com/4071474/135364010-ccb118a1-4888-4b56-bc93-1251ce9aad82.png)

->

![image](https://user-images.githubusercontent.com/4071474/135364047-20aef328-08df-428e-810f-dec9b77303ae.png)
