### PR TITLE
tests: centralize running of recipe tests

### DIFF
--- a/docs/recipes/auth/package.json
+++ b/docs/recipes/auth/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "scripts": {
     "start": "node server/server.js"
   },

--- a/docs/recipes/custom-gatherer-puppeteer/test.sh
+++ b/docs/recipes/custom-gatherer-puppeteer/test.sh
@@ -3,7 +3,6 @@
 # Make sure we're in this `docs/recipes/customer-gatherer-puppeteer` directory
 cd "$(dirname "$0")"
 
-yarn
 node node_modules/.bin/lighthouse --config-path=custom-config.js https://www.example.com --output=json |
   jq '.audits["custom-audit"].score' |
   grep -q 1

--- a/docs/recipes/integration-test/docs-jest.config.js
+++ b/docs/recipes/integration-test/docs-jest.config.js
@@ -1,0 +1,14 @@
+/**
+ * @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+module.exports = {
+  testMatch: [
+    '**/*.test.js',
+  ],
+  transform: {},
+  prettierPath: null,
+};

--- a/docs/recipes/integration-test/package.json
+++ b/docs/recipes/integration-test/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "scripts": {
     "test": "jest example-lh-auth.test.js"
   },

--- a/docs/recipes/package.json
+++ b/docs/recipes/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "scripts": {
+    "install-all": "yarn --cwd auth/ && yarn --cwd integration-test/ && yarn --cwd custom-gatherer-puppeteer/",
+    "integration-test": "yarn --cwd integration-test/ jest --config-path=docs-jest.config.js",
+    "custom-gatherer-puppeteer-test": "yarn --cwd custom-gatherer-puppeteer/ test",
+    "test": "yarn install-all && yarn integration-test && yarn custom-gatherer-puppeteer-test"
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,18 +6,6 @@
 'use strict';
 
 module.exports = {
-  collectCoverage: false,
-  coverageReporters: ['none'],
-  collectCoverageFrom: [
-    '**/lighthouse-core/**/*.js',
-    '**/lighthouse-cli/**/*.js',
-    '**/report/**/*.js',
-    '**/lighthouse-viewer/**/*.js',
-  ],
-  coveragePathIgnorePatterns: [
-    '/test/',
-    '/scripts/',
-  ],
   setupFilesAfterEnv: ['./lighthouse-core/test/test-utils.js'],
   testEnvironment: 'node',
   testMatch: [
@@ -31,7 +19,6 @@ module.exports = {
     '**/lighthouse-viewer/**/*-test-pptr.js',
     '**/third-party/**/*-test.js',
     '**/clients/test/**/*-test.js',
-    '**/docs/**/*.test.js',
   ],
   transform: {},
   prettierPath: null,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test-treemap": "yarn unit-treemap && yarn jest lighthouse-treemap/test/treemap-test-pptr.js",
     "test-lantern": "bash lighthouse-core/scripts/test-lantern.sh",
     "test-legacy-javascript": "bash lighthouse-core/scripts/test-legacy-javascript.sh",
-    "test-docs": "yarn --cwd docs/recipes/auth && yarn jest docs/recipes/integration-test && yarn --cwd docs/recipes/custom-gatherer-puppeteer test",
+    "test-docs": "yarn --cwd docs/recipes/ test",
     "test-proto": "yarn compile-proto && yarn build-proto-roundtrip",
     "unit-core": "yarn jest \"lighthouse-core\"",
     "unit-cli": "yarn jest \"lighthouse-cli/\"",


### PR DESCRIPTION
kind of a prerequisite to #13148, but useful on its own.

The recipes each need their own `yarn install` run (and it turns out `integration-test` didn't have its `install` run, it was just falling back to the root `jest` and (I believe) the `yarn link`ed `lighthouse`).

As a result it doesn't really make sense to include `docs/recipes/integration-test/example-lh-auth.test.js` in the default jest tests, which ideally should work with just a `git clone ... && yarn && yarn build-all && yarn test`.

This PR breaks it out into its own separate `jest` call, and centralizes the running of the recipe tests to their own `package.json`.