### PR TITLE
clients(psi): include global reports styles in legacy psi rendering

### DIFF
--- a/report/clients/psi.js
+++ b/report/clients/psi.js
@@ -77,6 +77,7 @@ export function prepareLabData(LHResult, document) {
     reportLHR.categoryGroups,
     {environment: 'PSI', gatherMode: lhResult.gatherMode}
   );
+  perfCategoryEl.append(dom.createComponent('styles'));
 
   const scoreGaugeEl = dom.find('.lh-score__gauge', perfCategoryEl);
   scoreGaugeEl.remove();

--- a/report/test/clients/psi-test.js
+++ b/report/test/clients/psi-test.js
@@ -67,8 +67,6 @@ describe('PSI', () => {
         // Check that the report exists and has some content.
         assert.ok(result.perfCategoryEl instanceof document.defaultView.Element);
         assert.ok(result.perfCategoryEl.outerHTML.length > 50000, 'perfCategory HTML is populated');
-        assert.ok(!result.perfCategoryEl.outerHTML.includes('lh-permalink'),
-            'PSI\'s perfCategory HTML doesn\'t include a lh-permalink element');
         // Assume using default locale.
         const title = result.perfCategoryEl.querySelector('.lh-audit-group--metrics')
           .querySelector('.lh-audit-group__title').textContent;
@@ -83,7 +81,8 @@ describe('PSI', () => {
 
         assert.ok(result.perfCategoryEl instanceof document.defaultView.Element);
         assert.ok(result.perfCategoryEl.outerHTML.length > 50000, 'perfCategory HTML is populated');
-        assert.ok(!result.perfCategoryEl.outerHTML.includes('lh-permalink'),
+        // styles for .lh-permalink are ok, but not the HTML
+        assert.ok(!result.perfCategoryEl.outerHTML.includes('class="lh-permalink'),
             'PSI\'s perfCategory HTML doesn\'t include a lh-permalink element');
 
         assert.equal(typeof result.finalScreenshotDataUri, 'string');

--- a/report/test/clients/psi-test.js
+++ b/report/test/clients/psi-test.js
@@ -110,7 +110,7 @@ describe('PSI', () => {
         }, /no category groups/i);
       });
 
-      it('includes custom title and description', () => {
+      it.only('includes custom title and description', () => {
         const {perfCategoryEl} = prepareLabData(sampleResultsStr, document);
         const metricsGroupEl = perfCategoryEl.querySelector('.lh-audit-group--metrics');
 
@@ -118,6 +118,12 @@ describe('PSI', () => {
         // Replacing markdown because ".textContent" will be post-markdown.
         const expectedDescription = Util.UIStrings.lsPerformanceCategoryDescription
           .replace('[Lighthouse](https://developers.google.com/web/tools/lighthouse/)', 'Lighthouse');
+
+        // Styles should be applied. We'll confirm our chevrons are a reasonable size.
+        console.log(perfCategoryEl.getBoundingClientRect())
+        const chevEl = Array.from(perfCategoryEl.querySelectorAll('.lh-chevron')).map(e => e.clientHeight);
+        expect(chevEl.clientHeight).toEqual(0);
+        expect(chevEl.clientHeight).toBeLessThan(100);
 
         // Assume using default locale.
         const title = metricsGroupEl.querySelector('.lh-audit-group__title').textContent;

--- a/report/test/clients/psi-test.js
+++ b/report/test/clients/psi-test.js
@@ -110,7 +110,7 @@ describe('PSI', () => {
         }, /no category groups/i);
       });
 
-      it.only('includes custom title and description', () => {
+      it('includes custom title and description', () => {
         const {perfCategoryEl} = prepareLabData(sampleResultsStr, document);
         const metricsGroupEl = perfCategoryEl.querySelector('.lh-audit-group--metrics');
 
@@ -118,12 +118,6 @@ describe('PSI', () => {
         // Replacing markdown because ".textContent" will be post-markdown.
         const expectedDescription = Util.UIStrings.lsPerformanceCategoryDescription
           .replace('[Lighthouse](https://developers.google.com/web/tools/lighthouse/)', 'Lighthouse');
-
-        // Styles should be applied. We'll confirm our chevrons are a reasonable size.
-        console.log(perfCategoryEl.getBoundingClientRect())
-        const chevEl = Array.from(perfCategoryEl.querySelectorAll('.lh-chevron')).map(e => e.clientHeight);
-        expect(chevEl.clientHeight).toEqual(0);
-        expect(chevEl.clientHeight).toBeLessThan(100);
 
         // Assume using default locale.
         const title = metricsGroupEl.querySelector('.lh-audit-group__title').textContent;


### PR DESCRIPTION
this is minor followup from #13057

the faux-psi was broken https://lighthouse-orr78rw4f-googlechrome.vercel.app/sample-reports/%E2%8C%A3.psi.xl-accented 

maintaining preparelabdata is kinda terrible so we'll have to call it quits at some point.. 


also i tried writing a test, but since jsdom can't apply styles, i can't test much aside from confirming there's a style tag injected. (seems lame)