### PR TITLE
report(flow): elide step name

### DIFF
--- a/flow-report/assets/styles.css
+++ b/flow-report/assets/styles.css
@@ -11,10 +11,12 @@
   --double-base-spacing: calc(var(--base-spacing) * 2);
   --gather-mode-icon-size: 16px;
   --header-adjacent-title-font-size: 14px;
+  --header-adjacent-title-width: minmax(var(--min-text-width), 1fr);
   --header-current-description-font-size: 12px;
   --header-current-title-font-size: 20px;
   --header-margin: minmax(0px, calc(var(--base-spacing) * 4));
   --half-base-spacing: calc(var(--base-spacing) / 2);
+  --min-text-width: 20ch;
   --separator-color: var(--color-gray-300);
   --sidebar-flow-step-navigation-font-size: 14px;
   --sidebar-selected-bg-color: #DDEEFF;
@@ -242,7 +244,7 @@
   max-width: var(--report-width);
   display: grid;
   grid-auto-rows: min-content;
-  grid-template-columns: min-content min-content minmax(20ch, 4fr) 1fr 1fr 1fr 1fr;
+  grid-template-columns: min-content min-content minmax(var(--min-text-width), 4fr) 1fr 1fr 1fr 1fr;
   align-items: center;
   margin: var(--base-spacing) 0px;
 }
@@ -411,7 +413,7 @@
     ".        prev-title .             current-tn    .             next-title ."
     ".        prev-title current-title current-title current-title next-title .";
   grid-template-rows: 1fr auto 1fr auto;
-  grid-template-columns: var(--header-margin) 1fr auto auto auto 1fr var(--header-margin);
+  grid-template-columns: var(--header-margin) var(--header-adjacent-title-width) auto auto auto var(--header-adjacent-title-width) var(--header-margin);
   align-items: center;
   margin: var(--double-base-spacing) 0px;
 }

--- a/flow-report/assets/styles.css
+++ b/flow-report/assets/styles.css
@@ -241,7 +241,6 @@
 
 .SummaryFlow {
   width: 100%;
-  max-width: var(--report-width);
   display: grid;
   grid-auto-rows: min-content;
   grid-template-columns: min-content min-content minmax(var(--min-text-width), 4fr) 1fr 1fr 1fr 1fr;
@@ -385,6 +384,9 @@
 .SummaryNavigationHeader__url {
   justify-content: start;
   text-align: left;
+}
+.SummaryNavigationHeader__url > a {
+  color: var(--color-gray-800);
   overflow-x: hidden;
   text-overflow: ellipsis;
 }
@@ -500,6 +502,7 @@
   align-self: start;
   overflow-x: hidden;
   text-overflow: ellipsis;
+  width: 100%;
 }
 
 .Header__current-title {

--- a/flow-report/assets/styles.css
+++ b/flow-report/assets/styles.css
@@ -378,6 +378,7 @@
   justify-content: center;
   padding: var(--half-base-spacing);
   background-color: var(--color-gray-100);
+  color: var(--color-gray-700);
   border-top: 1px solid var(--color-gray-300);
   text-align: center;
 }
@@ -386,7 +387,7 @@
   text-align: left;
 }
 .SummaryNavigationHeader__url > a {
-  color: var(--color-gray-800);
+  color: inherit;
   overflow-x: hidden;
   text-overflow: ellipsis;
 }

--- a/flow-report/assets/styles.css
+++ b/flow-report/assets/styles.css
@@ -20,6 +20,7 @@
   --sidebar-selected-bg-color: #DDEEFF;
   --sidebar-summary-font-size: 14px;
   --sidebar-title-font-size: 16px;
+  --sidebar-max-width: 400px;
   --summary-flow-step-label-font-size: 16px;
   --summary-subtitle-font-size: 16px;
   --summary-title-font-size: 32px;
@@ -104,6 +105,10 @@
 .Sidebar {
   grid-area: sidebar;
   border-right: 1px solid var(--separator-color);
+  width: min-content;
+  max-width: var(--sidebar-max-width);
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 .Sidebar a {
   color: var(--color-gray-800);
@@ -185,6 +190,8 @@
   grid-column: 2;
   margin: var(--half-base-spacing) 0px;
   justify-self: left;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 .SidebarFlowStep__label--navigation {
   font-size: var(--sidebar-flow-step-navigation-font-size);
@@ -232,10 +239,10 @@
 
 .SummaryFlow {
   width: 100%;
-  max-width: max-content;
+  max-width: var(--report-width);
   display: grid;
   grid-auto-rows: min-content;
-  grid-template-columns: min-content min-content 4fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: min-content min-content minmax(20ch, 4fr) 1fr 1fr 1fr 1fr;
   align-items: center;
   margin: var(--base-spacing) 0px;
 }
@@ -286,6 +293,9 @@
 .SummaryFlowStep__label {
   grid-column: 3;
   margin: var(--half-base-spacing);
+  width: 100%;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .SummaryFlowStep__mode {
@@ -296,6 +306,8 @@
   font-size: var(--summary-flow-step-label-font-size);
   color: var(--color-gray-800);
   text-decoration: underline;
+  width: 100%;
+  overflow-x: hidden;
 }
 
 .SummaryCategory__content {
@@ -371,6 +383,8 @@
 .SummaryNavigationHeader__url {
   justify-content: start;
   text-align: left;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .SummaryFlowStep__separator {
@@ -482,7 +496,8 @@
 .Header__next-title {
   font-size: var(--header-adjacent-title-font-size);
   align-self: start;
-  width: fit-content;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .Header__current-title {
@@ -490,6 +505,8 @@
   text-align: center;
   font-size: var(--header-current-title-font-size);
   font-weight: bold;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .Header__current-description {

--- a/flow-report/src/summary/summary.tsx
+++ b/flow-report/src/summary/summary.tsx
@@ -20,7 +20,9 @@ const SummaryNavigationHeader: FunctionComponent<{lhr: LH.Result}> = ({lhr}) => 
   return (
     <div className="SummaryNavigationHeader" data-testid="SummaryNavigationHeader">
       <FlowSegment/>
-      <div className="SummaryNavigationHeader__url">{lhr.finalUrl}</div>
+      <div className="SummaryNavigationHeader__url">
+        <a href={lhr.finalUrl}>{lhr.finalUrl}</a>
+      </div>
       <div className="SummaryNavigationHeader__category">
         {lhr.categories['performance'].title}
       </div>

--- a/flow-report/src/summary/summary.tsx
+++ b/flow-report/src/summary/summary.tsx
@@ -21,7 +21,7 @@ const SummaryNavigationHeader: FunctionComponent<{lhr: LH.Result}> = ({lhr}) => 
     <div className="SummaryNavigationHeader" data-testid="SummaryNavigationHeader">
       <FlowSegment/>
       <div className="SummaryNavigationHeader__url">
-        <a href={lhr.finalUrl}>{lhr.finalUrl}</a>
+        <a rel="noopener" target="_blank" href={lhr.finalUrl}>{lhr.finalUrl}</a>
       </div>
       <div className="SummaryNavigationHeader__category">
         {lhr.categories['performance'].title}

--- a/flow-report/test/summary/summary-test.tsx
+++ b/flow-report/test/summary/summary-test.tsx
@@ -60,6 +60,7 @@ describe('SummaryFlowStep', () => {
 
     const links = root.getAllByRole('link') as HTMLAnchorElement[];
     expect(links.map(a => a.href)).toEqual([
+      'https://www.mikescerealshack.co/',
       'file:///Users/example/report.html/#index=0',
       'file:///Users/example/report.html/#index=0&anchor=performance',
       'file:///Users/example/report.html/#index=0&anchor=accessibility',


### PR DESCRIPTION
I used a lot of `overflow-x: hidden; text-overflow: elide` to make this work. Adding a minimum text width of 20 characters in a few places prevents the text from disappearing completely.

I thought about sticking the ellipses in the url directly (I guess we still could), but I don't think it's a big deal to let CSS handle to overflow. Even if we wind up hiding the "more important" part of the url, the best option would be for the user to define their own descriptive name.

#11313