### PR TITLE
Honor ESET Antivirus' X-Content-Encoding-Over-Network response header…

### DIFF
--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -20,7 +20,12 @@ const {fetchResponseBodyFromCache} = require('../../driver/network.js');
 const NetworkRecords = require('../../../computed/network-records.js');
 
 const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
-const compressionHeaders = ['content-encoding', 'x-original-content-encoding'];
+
+const compressionHeaders = [
+  'content-encoding',
+  'x-original-content-encoding',
+  'x-content-encoding-over-network',
+];
 const compressionTypes = ['gzip', 'br', 'deflate'];
 const binaryMimeTypes = ['image', 'audio', 'video'];
 /** @type {LH.Crdp.Network.ResourceType[]} */


### PR DESCRIPTION
… as compression header

**Summary**

Add response header X-Content-Encoding-Over-Network to the array of recognized compression headers. (This response header is present when ESET Antivirus has decompressed the response payload for scanning.)

**Related Issues/PRs**

Fixes GoogleChrome/lighthouse#13173
