### PR TITLE
report(fr): animate timespan thumbnail

### DIFF
--- a/flow-report/src/util.ts
+++ b/flow-report/src/util.ts
@@ -50,6 +50,20 @@ export function getScreenshot(reportResult: LH.ReportResult) {
   return fullPageScreenshot || null;
 }
 
+export function getFilmstripFrames(
+  reportResult: LH.ReportResult
+): Array<{data: string}> | undefined {
+  const filmstripAudit = reportResult.audits['screenshot-thumbnails'];
+  if (!filmstripAudit) return undefined;
+
+  const frameItems =
+    filmstripAudit.details &&
+    filmstripAudit.details.type === 'filmstrip' &&
+    filmstripAudit.details.items;
+
+  return frameItems || undefined;
+}
+
 export function getModeDescription(mode: LH.Result.GatherMode, strings: UIStringsType) {
   switch (mode) {
     case 'navigation': return strings.navigationDescription;


### PR DESCRIPTION
**Summary**
Use an animated thumbnail for the timespan using the frames from the filmstrip audit details.

![animation of thumbnail](http://g.recordit.co/XPsrolXhSw.gif)

Although simplistic and a JS-based animation, it has minimal main-thread impact because the thumbnails are so small.
![image](https://user-images.githubusercontent.com/2301202/136242086-c901f8ac-4e57-43d2-b1d4-8af955d570b1.png)

**Related Issues/PRs**
ref #11313 
