### PR TITLE
tests: update deprecations smoke for M96

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -102,14 +102,6 @@
 </style>
 </template>
 
-<template id="deprecations-tmpl">
-  <style>
-    body /deep/ div {
-      color: pink; /* FAIL - deprecation warning */
-    }
-  </style>
-</template>
-
 <!-- Force FCP to be ~5s out, necessary to make sure our render-blocking audits still work -->
 <!-- even when other forces were responsible for delaying the render. -->
 <script src="./fcp-delayer.js?delay=5000"></script>
@@ -371,8 +363,6 @@ function passwordInputsCanBePastedIntoTest() {
 
 
 function deprecationsTest() {
-  stampTemplate('deprecations-tmpl', document.head);
-
   // TODO: some deprecated API messages are not currently being logged correctly.
   // See: https://crbug.com/680832
 

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -315,8 +315,10 @@ const expectations = {
         score: 0,
         details: {
           items: {
-          // Note: HTML Imports added to deprecations in m70, so 3 before, 4 after.
-            length: '>=3',
+            // <M96 - Application Cache API manifest
+            // * - window.webkitStorageInfo
+            // * - Synchronous XMLHttpRequest
+            length: '>=2',
           },
         },
       },


### PR DESCRIPTION
**Summary**
Appcache warning no longer shows up in deprecations which fails our smoke tests on ToT. Did not remove the appcache marker itself because it's part of #12614 

