### PR TITLE
core(fr): timespan ensure bytes transferred

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -115,11 +115,12 @@ class UnusedBytes extends Audit {
       settings,
     };
     const networkRecords = await NetworkRecords.request(devtoolsLog, context);
+    const hasContentfulRecords = networkRecords.some(record => record.transferSize);
 
     // Requesting load simulator requires non-empty network records.
     // Timespans are not guaranteed to have any network activity.
     // There are no bytes to be saved if no bytes were downloaded, so mark N/A if empty.
-    if (!networkRecords.length && gatherContext.gatherMode === 'timespan') {
+    if (!hasContentfulRecords && gatherContext.gatherMode === 'timespan') {
       return {
         score: 1,
         notApplicable: true,


### PR DESCRIPTION
So I was playing around with FR [for fun](https://gist.github.com/adamraine/b2756637f546ab7ce9631d0f22353c9c) and I ran into an issue with byte efficiency audits.

This time, we were hitting:
https://github.com/GoogleChrome/lighthouse/blob/6c3d6090d8243bb9e7a9f5fabc46bf6d5993c430/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js#L348

The first timespan in the flow ("Open search menu") generated ~6 network requests but they all had a `transferSize` of 0 so `NetworkAnalyzer` threw this error when creating the `LoadSimulator`. The simplest solution was to ensure *some* bytes were transferred in order to make timespan BE audits applicable.

This isn't a problem in navigations, because the main resource guarantees a nonzero total transfer size.