### PR TITLE
misc(build): fix vercel deployment by adopting stricter `engines` grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "smokehouse": "./lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js"
   },
   "engines": {
-    "node": ">=12.20.0 <15"
+    "node": ">=12.20.0 12 || >=14.13 14  || >=15"
   },
   "scripts": {
     "build-all": "npm-run-posix-or-windows build-all:task",


### PR DESCRIPTION
the vercel deployments broke because of #13099 👍 
![image](https://user-images.githubusercontent.com/39191/136288845-18e38427-29ff-447a-8f00-e31d8306421d.png)


There's no formal spec for semver constraints, but the `&&` syntax seems to be a problem. https://jubianchi.github.io/semver-check doesnt like it and neither does the `semver` npm package.

![image](https://user-images.githubusercontent.com/39191/136288655-6ffe0fe5-e4c3-4755-8cf5-6edffcd34de7.png)

https://github.com/npm/node-semver#range-grammar wasn't mentioned in the grammar..

after looking at those docs for a bit i saw this example:
![image](https://user-images.githubusercontent.com/39191/136288752-be0b5ff7-b170-4a48-963e-7548daba5870.png)

so anyway... its an easy fix and the new range is parsed happily by 'semver' and vercel's thing.

![image](https://user-images.githubusercontent.com/39191/136289043-830bc77d-49f5-4b90-8f01-fbae392a47e3.png)

![image](https://user-images.githubusercontent.com/39191/136289072-1236877b-da3e-4c9d-bc02-5ff8c0188fed.png)
