### PR TITLE
misc: add report bundles to nightly build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: yarn --frozen-lockfile
 
+      # Build report bundles needed for publishing.
+      - run: yarn build-report
+
       - name: Publish to npm
         run: |
           npm whoami


### PR DESCRIPTION
reported in https://github.com/GoogleChrome/lighthouse/issues/13216#issuecomment-944666126

`lighthouse@next` fails on trying to require these files, which is done unconditionally in `Runner`, so it's been broken for a while :/