### PR TITLE
report(test): throw on axe error

### DIFF
--- a/report/test/renderer/report-renderer-axe-test.js
+++ b/report/test/renderer/report-renderer-axe-test.js
@@ -71,7 +71,6 @@ describe('ReportRendererAxe', () => {
       };
 
       const axeResults = await axe.run(output, config);
-      expect(axeResults).not.toBeInstanceOf(Error);
       expect(axeResults.violations).toEqual([]);
     },
     // This test takes 40s on fast hardware, and 50-60s on GHA.


### PR DESCRIPTION
something i found while working on #13123

if there is an error in the axe test... jest will report that error but then it'll sit idle until it hits the 100s timeout.
https://github.com/GoogleChrome/lighthouse/runs/3956037809#step:11:385

we want the test to fail immediately if there's a failure in there.

i swapped to async/await and verified any failures within the test throw and exit as expected.