### PR TITLE
core(build): add warnings to inline-fs plugin

### DIFF
--- a/build/plugins/inline-fs.js
+++ b/build/plugins/inline-fs.js
@@ -32,7 +32,7 @@ class AstError extends Error {
  * Returns `null` as code if no changes were made.
  * @param {string} code
  * @param {string} filepath
- * @return {Promise<{code: string|null, warnings?: Array<Warning>}>}
+ * @return {Promise<{code: string|null, warnings: Array<Warning>}>}
  */
 async function inlineFs(code, filepath) {
   // Approach:
@@ -48,7 +48,7 @@ async function inlineFs(code, filepath) {
   const foundIndices = [...code.matchAll(fsSearch)].map(e => e.index);
 
   // Return null for not-applicable files with as little work as possible.
-  if (foundIndices.length === 0) return {code: null};
+  if (foundIndices.length === 0) return {code: null, warnings: []};
 
   const output = new MagicString(code);
   let madeChange = false;

--- a/build/test/plugins/inline-fs-test.js
+++ b/build/test/plugins/inline-fs-test.js
@@ -30,22 +30,30 @@ describe('inline-fs', () => {
     it('returns null for content with no fs calls', async () => {
       const content = 'const val = 1;';
       const result = await inlineFs(content, filepath);
-      expect(result).toEqual({code: null});
+      expect(result).toEqual({
+        code: null,
+        warnings: [],
+      });
     });
 
     it('returns null for non-call references to fs methods', async () => {
       const content = 'const val = fs.readFileSync ? 1 : 2;';
       const result = await inlineFs(content, filepath);
-      expect(result).toEqual({code: null});
+      expect(result).toEqual({
+        code: null,
+        warnings: [],
+      });
     });
 
     it('evaluates an fs.readFileSync call and inlines the contents', async () => {
       fs.writeFileSync(tmpPath, 'template literal text content');
 
       const content = `const myTextContent = fs.readFileSync('${tmpPath}', 'utf8');`;
-      const {code, warnings} = await inlineFs(content, filepath);
-      expect(code).toBe(`const myTextContent = "template literal text content";`);
-      expect(warnings).toEqual([]);
+      const result = await inlineFs(content, filepath);
+      expect(result).toEqual({
+        code: `const myTextContent = "template literal text content";`,
+        warnings: [],
+      });
     });
 
     it('warns and skips unsupported construct but inlines subsequent fs method calls', async () => {


### PR DESCRIPTION
part of #13231

adds structured warnings to inline-fs plugin. Type is a subset of the [esbuild warning type](https://esbuild.github.io/plugins/#:~:text=resolveDir%3F%3A%20string%3B%0A%20%20warnings%3F%3A%20Message%5B%5D%3B%0A%20%20watchDirs%3F%3A%20string%5B%5D%3B%0A%20%20watchFiles%3F%3A%20string%5B%5D%3B%0A%7D-,interface%20Message,-%7B%0A%20%20text%3A%20string%3B%0A%20%20location%3A%20Location%20%7C%20null%3B%0A%20%20detail%3A%20any%3B%20//%20The), in case we ever want to move over to that :) More seriously, esbuild uses the location to do nice

```
fs.readFileSync(__filename, 'binary');
                            ^
Error: unsupported encoding
  at ...
```
logging, and we could maybe do the same if there's a nice library somewhere we could use, or we could just live with plain old `filepath:line:column` logging until we ever need something fancier.

All that's for later, though. This just keeps a list of encountered warnings.