### PR TITLE
misc(build): use cross platform sed for devtools script

### DIFF
--- a/lighthouse-core/scripts/roll-to-devtools.sh
+++ b/lighthouse-core/scripts/roll-to-devtools.sh
@@ -47,10 +47,14 @@ echo -e "$check lighthouse-dt-bundle copied."
 
 # generate bundle.d.ts
 npx tsc --allowJs --declaration --emitDeclarationOnly dist/report/bundle.esm.js
+
 # Exports of report/clients/bundle.js can possibly be mistakenly overriden by tsc.
-sed -i 's/export type DOM = any;//' dist/report/bundle.esm.d.ts
-sed -i 's/export type ReportRenderer = any;//' dist/report/bundle.esm.d.ts
-sed -i 's/export type ReportUIFeatures = any;//' dist/report/bundle.esm.d.ts
+# Funky sed inplace command so we support both GNU sed and BSD sed (used by GHA devtools runner on macos)
+#     https://stackoverflow.com/a/22084103/89484
+sed -i.bak 's/export type DOM = any;//' dist/report/bundle.esm.d.ts
+sed -i.bak 's/export type ReportRenderer = any;//' dist/report/bundle.esm.d.ts
+sed -i.bak 's/export type ReportUIFeatures = any;//' dist/report/bundle.esm.d.ts
+
 
 # copy report code $fe_lh_dir
 fe_lh_report_dir="$fe_lh_dir/report/"


### PR DESCRIPTION


Running `yarn open-devtools` locally, i get an error:

> `../../front_end/panels/lighthouse/LighthousePanel.ts(266,38): error TS2339: Property 'DOM' does not exist on type 'typeof import("lighthouse/.tmp/chromium-web-tests/devtools/devtools-frontend/out/Default/gen/front_end/third_party/lighthouse/report/report")'.`


In #12933 we added a fix for this, but the sed command was invalid. 
And since the script didnt have a `euo pipefail` the script continued despite this happening:

```
+ npx tsc --allowJs --declaration --emitDeclarationOnly dist/report/bundle.esm.js
+ sed -i '' 's/export type DOM = any;//' dist/report/bundle.esm.d.ts
sed: can't read s/export type DOM = any;//: No such file or directory
```

(found all this while debugging some CI devtools failures in #13123)