### PR TITLE
deps: move to minimum Node 14

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -83,7 +83,7 @@ body:
     attributes:
       label: Node Version
       description: >
-        What version of node.js were you using? (Only applicable to CLI and node) (Note: the minimum Node version we support is 12.13.0)
+        What version of node.js were you using? (Only applicable to CLI and node) (Note: the minimum Node version we support is 14.15.0)
     validations:
       required: false
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
         GITHUB_CONTEXT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         GITHUB_CONTEXT_BASE_SHA: ${{ github.event.before }}
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-all

--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -31,10 +31,10 @@ jobs:
     steps:
     - name: git clone
       uses: actions/checkout@v2
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
     - run: yarn --frozen-lockfile
 
     - run: yarn jest --testMatch="**/third-party/chromium-synchronization/*-test.js"

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -35,10 +35,10 @@ jobs:
         # The number is how many times this hash key was manually updated to break the cache.
         key: ${{ runner.os }}-2-${{ hashFiles('lighthouse/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/*.js', 'lighthouse/.github/workflows/devtools.yml', 'lighthouse/lighthouse-core/test/chromium-web-tests/*', 'lighthouse/clients/devtools-entry.js', 'lighthouse/clients/devtools-report-assets.js', 'lighthouse/build/build-bundle.js', 'lighthouse/build/build-dt-report-resources.js') }}
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - run: yarn --frozen-lockfile
       working-directory: ${{ github.workspace }}/lighthouse

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
           registry-url: https://registry.npmjs.org/
       - run: yarn --frozen-lockfile
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,10 +31,10 @@ jobs:
         # Depth of at least 2 for codecov coverage diffs. See https://github.com/GoogleChrome/lighthouse/pull/12079
         fetch-depth: 2
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Define ToT chrome path
       if: matrix.chrome-channel == 'ToT'
@@ -82,10 +82,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
@@ -112,10 +112,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
@@ -143,10 +143,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,11 +10,11 @@ jobs:
   unit:
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ['14', '16', '17']
     runs-on: ubuntu-latest
     name: node ${{ matrix.node }}
     env:
-      LATEST_NODE: '16'
+      LATEST_NODE: '17'
 
     steps:
     - name: git clone
@@ -76,10 +76,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report

--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -169,8 +169,12 @@ async function minifyScript(filePath) {
     },
   });
 
-  fs.writeFileSync(filePath, result.code);
-  if (DEBUG) fs.writeFileSync(`${filePath}.map`, result.map);
+  if (result.code) {
+    fs.writeFileSync(filePath, result.code);
+  }
+  if (DEBUG && typeof result.map === 'string') {
+    fs.writeFileSync(`${filePath}.map`, result.map);
+  }
 }
 
 /**

--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -26,8 +26,7 @@ function writeFile(name, content) {
   fs.writeFileSync(`${distDir}/${name}`, content);
 }
 
-fs.mkdirSync(distDir, {recursive: true}); // Ensure dist is present, else rmdir will throw. COMPAT: when dropping Node 12, replace with fs.rm(p, {force: true})
-fs.rmdirSync(distDir, {recursive: true});
+fs.rmSync(distDir, {recursive: true, force: true});
 fs.mkdirSync(distDir, {recursive: true});
 
 writeFile('report.js', htmlReportAssets.REPORT_JAVASCRIPT);

--- a/build/build-sample-reports.js
+++ b/build/build-sample-reports.js
@@ -188,6 +188,6 @@ async function generateErrorLHR() {
   appleTouchIconAudit.scoreDisplayMode = 'binary';
   appleTouchIconAudit.score = 1;
 
-  fs.rmdirSync(TMP, {recursive: true});
+  fs.rmSync(TMP, {recursive: true, force: true});
   return errorLhr;
 }

--- a/build/gh-pages-app.js
+++ b/build/gh-pages-app.js
@@ -82,8 +82,7 @@ class GhPagesApp {
   }
 
   async build() {
-    fs.mkdirSync(this.distDir, {recursive: true}); // Ensure dist is present, else rmdir will throw. COMPAT: when dropping Node 12, replace with fs.rm(p, {force: true})
-    fs.rmdirSync(this.distDir, {recursive: true});
+    fs.rmSync(this.distDir, {recursive: true, force: true});
 
     const html = await this._compileHtml();
     safeWriteFile(`${this.distDir}/index.html`, html);

--- a/docs/headless-chrome.md
+++ b/docs/headless-chrome.md
@@ -5,8 +5,8 @@
 Setup:
 
 ```sh
-# Lighthouse requires Node 12 LTS (12.x) or later.
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - &&\
+# Lighthouse requires Node 14 LTS (14.x) or later.
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - &&\
 sudo apt-get install -y nodejs npm
 
 # get chromium (stable)
@@ -27,8 +27,8 @@ lighthouse --chrome-flags="--headless" https://github.com
 Alternatively, you can run full Chrome + xvfb instead of headless mode. These steps worked on Debian Jessie:
 
 ```sh
-# get node 12
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+# get node 14
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 sudo apt-get install -y nodejs npm
 
 # get chromium (stable) and Xvfb

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
@@ -39,7 +39,7 @@ async function runLighthouse(url, configJson, testRunnerOptions = {}) {
   const tmpPath = await fs.mkdtemp(`${tmpDir}/smokehouse-`);
   return internalRun(url, tmpPath, configJson, testRunnerOptions)
     // Wait for internalRun() before removing scratch directory.
-    .finally(() => !isDebug && fs.rmdir(tmpPath, {recursive: true}));
+    .finally(() => !isDebug && fs.rm(tmpPath, {recursive: true, force: true}));
 }
 
 /**

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -235,9 +235,9 @@ async function saveTrace(traceData, traceFilename) {
   const traceIter = traceJsonGenerator(traceData);
   const writeStream = fs.createWriteStream(traceFilename);
 
-  // TODO: Can remove Readable.from() in Node 13, promisify(pipeline) in Node 15.
+  // TODO: Can remove promisify(pipeline) in Node 15.
   // https://nodejs.org/api/stream.html#stream_stream_pipeline_streams_callback
-  return pipeline(stream.Readable.from(traceIter), writeStream);
+  return pipeline(traceIter, writeStream);
 }
 
 /**
@@ -250,7 +250,7 @@ function saveDevtoolsLog(devtoolsLog, devtoolLogFilename) {
   const logIter = arrayOfObjectsJsonGenerator(devtoolsLog);
   const writeStream = fs.createWriteStream(devtoolLogFilename);
 
-  return pipeline(stream.Readable.from(logIter), writeStream);
+  return pipeline(logIter, writeStream);
 }
 
 /**

--- a/lighthouse-core/scripts/dogfood-lhci.sh
+++ b/lighthouse-core/scripts/dogfood-lhci.sh
@@ -10,8 +10,8 @@ if [[ -z "$LHCI_CANARY_SERVER_TOKEN" ]]; then
 fi
 
 NODE_VERSION=$(node --version)
-if [[ "$NODE_VERSION" != "v12"* ]]; then
-  echo "Not running dogfood script on node versions other than 12";
+if [[ "$NODE_VERSION" != "v14"* ]]; then
+  echo "Not running dogfood script on node versions other than 14";
   exit 0;
 fi
 

--- a/lighthouse-core/scripts/gcp-collection/fleet-create-directories.js
+++ b/lighthouse-core/scripts/gcp-collection/fleet-create-directories.js
@@ -22,7 +22,7 @@ const URLS_LIST = process.argv[2]
   ? path.resolve(process.cwd(), process.argv[2])
   : path.join(LH_ROOT, 'lighthouse-core/scripts/gcp-collection/urls.txt');
 
-fs.rmdirSync(TMP_DIR, {recursive: true});
+fs.rmSync(TMP_DIR, {recursive: true, force: true});
 fs.mkdirSync(TMP_DIR);
 
 const MACHINE_BASE_INDEX = 0;

--- a/lighthouse-core/scripts/gcp-collection/gcp-setup.sh
+++ b/lighthouse-core/scripts/gcp-collection/gcp-setup.sh
@@ -17,7 +17,7 @@ echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sud
 wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 
 # Node apt-key
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 
 # Install dependencies
 sudo apt-get update

--- a/lighthouse-core/scripts/lantern/collect/gcp-setup.sh
+++ b/lighthouse-core/scripts/lantern/collect/gcp-setup.sh
@@ -11,7 +11,7 @@ echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sud
 wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 
 # Node apt-key
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 
 # Install dependencies
 sudo apt-get update

--- a/lighthouse-core/scripts/lantern/collect/golden.js
+++ b/lighthouse-core/scripts/lantern/collect/golden.js
@@ -109,7 +109,7 @@ async function main() {
   /** @type {Golden} */
   const golden = {sites: goldenSites};
 
-  fs.rmdirSync(common.goldenFolder, {recursive: true});
+  fs.rmSync(common.goldenFolder, {recursive: true, force: true});
   fs.mkdirSync(common.goldenFolder);
   saveGoldenData('site-index-plus-golden-expectations.json', JSON.stringify(golden, null, 2));
   for (const result of goldenSites) {

--- a/lighthouse-core/test/config/config-helpers-test.js
+++ b/lighthouse-core/test/config/config-helpers-test.js
@@ -23,7 +23,6 @@ const Runner = require('../../runner.js');
 const Gatherer = require('../../gather/gatherers/gatherer.js');
 const ImageElementsGatherer = require('../../gather/gatherers/image-elements.js');
 const UserTimingsAudit = require('../../audits/user-timings.js');
-const {isNode12SmallIcu} = require('../test-utils.js');
 const {LH_ROOT} = require('../../../root.js');
 
 jest.mock('process', () => ({
@@ -249,11 +248,6 @@ describe('.mergePlugins', () => {
 describe('.resolveSettings', () => {
   it('resolves the locale', () => {
     const settings = resolveSettings({locale: 'zh-CN'});
-    // COMPAT: Node 12 only has 'en-US' by default.
-    if (isNode12SmallIcu()) {
-      expect(settings.locale).toEqual('en-US');
-      return;
-    }
     expect(settings.locale).toEqual('zh');
   });
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -15,7 +15,6 @@ const Gatherer = require('../../gather/gatherers/gatherer.js');
 const Audit = require('../../audits/audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
 const format = require('../../../shared/localization/format.js');
-const {isNode12SmallIcu} = require('../test-utils.js');
 
 /* eslint-env jest */
 
@@ -837,8 +836,6 @@ describe('Config', () => {
     it('uses config setting for locale if set', () => {
       const locale = 'ar-XB';
       const config = new Config({settings: {locale}});
-      // COMPAT: Node 12 only has 'en' by default.
-      if (isNode12SmallIcu()) return;
       assert.strictEqual(config.settings.locale, locale);
     });
 
@@ -846,8 +843,6 @@ describe('Config', () => {
       const settingsLocale = 'en-XA';
       const flagsLocale = 'ar-XB';
       const config = new Config({settings: {locale: settingsLocale}}, {locale: flagsLocale});
-      // COMPAT: Node 12 only has 'en' by default.
-      if (isNode12SmallIcu()) return;
       assert.strictEqual(config.settings.locale, flagsLocale);
     });
   });

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -221,7 +221,7 @@ describe('asset-saver helper', () => {
     const outputPath = __dirname + '/json-serialization-test-data/';
 
     afterEach(() => {
-      fs.rmdirSync(outputPath, {recursive: true});
+      fs.rmSync(outputPath, {recursive: true, force: true});
     });
 
     it('round trips saved artifacts', async () => {

--- a/lighthouse-core/test/lib/i18n/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n/i18n-test.js
@@ -8,7 +8,6 @@
 const path = require('path');
 const i18n = require('../../../lib/i18n/i18n.js');
 const log = require('lighthouse-logger');
-const {isNode12SmallIcu} = require('../../test-utils.js');
 
 /* eslint-env jest */
 
@@ -50,16 +49,6 @@ describe('i18n', () => {
 
       expect(i18n.lookupLocale(invalidLocale)).toEqual('en-US');
 
-      // COMPAT: Node 12 logs an extra warning that full-icu is not available.
-      if (isNode12SmallIcu()) {
-        expect(logListener).toBeCalledTimes(2);
-        expect(logListener).toHaveBeenNthCalledWith(1, ['i18n',
-          expect.stringMatching(/Requested locale not available in this version of node/)]);
-        expect(logListener).toHaveBeenNthCalledWith(2, ['i18n',
-          `locale(s) '${invalidLocale}' not available. Falling back to default 'en-US'`]);
-        return;
-      }
-
       expect(logListener).toBeCalledTimes(1);
       expect(logListener).toBeCalledWith(['i18n',
         `locale(s) '${invalidLocale}' not available. Falling back to default 'en-US'`]);
@@ -68,12 +57,6 @@ describe('i18n', () => {
     });
 
     it('falls back to root tag prefix if specific locale not available', () => {
-      // COMPAT: Node 12 only has 'en-US' by default.
-      if (isNode12SmallIcu()) {
-        expect(i18n.lookupLocale('es-JKJK')).toEqual('en-US');
-        return;
-      }
-
       expect(i18n.lookupLocale('es-JKJK')).toEqual('es');
     });
 
@@ -87,13 +70,6 @@ describe('i18n', () => {
       });
 
       it('takes multiple locale strings and returns a possible, canonicalized one', () => {
-        // COMPAT: Node 12 only has 'en-US' by default.
-        if (isNode12SmallIcu()) {
-          expect(i18n.lookupLocale([invalidLocale, 'eN-uS', 'en-xa'], ['ar', 'es', 'en-US']))
-            .toEqual('en-US');
-          return;
-        }
-
         expect(i18n.lookupLocale([invalidLocale, 'eS', 'en-xa'], ['ar', 'es']))
             .toEqual('es');
       });

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -82,7 +82,7 @@ describe('Runner', () => {
     const resolvedPath = path.resolve(process.cwd(), artifactsPath);
 
     afterAll(() => {
-      fs.rmdirSync(resolvedPath, {recursive: true});
+      fs.rmSync(resolvedPath, {recursive: true, force: true});
     });
 
     it('-G gathers, quits, and doesn\'t run audits', () => {
@@ -441,7 +441,7 @@ describe('Runner', () => {
       assert.strictEqual(auditResult.scoreDisplayMode, 'error');
       assert.ok(auditResult.errorMessage.includes(errorMessage));
 
-      fs.rmdirSync(resolvedPath, {recursive: true});
+      fs.rmSync(resolvedPath, {recursive: true, force: true});
     });
 
     it('only passes the requested artifacts to the audit (no optional artifacts)', async () => {

--- a/lighthouse-core/test/test-utils.js
+++ b/lighthouse-core/test/test-utils.js
@@ -272,18 +272,6 @@ function makeMocksForGatherRunner() {
   }));
 }
 
-/**
- * Returns whether this is running in Node 12 with what we suspect is the default
- * `small-icu` build. Limited to Node 12 so it's not accidentally hitting this
- * path in Node 13+ in CI and we can be certain the `full-icu` path is being exercised.
- * @return {boolean}
- */
-function isNode12SmallIcu() {
-  // COMPAT: Remove when Node 12 is retired and `full-icu` is the default everywhere.
-  return process.versions.node.startsWith('12') &&
-    Intl.NumberFormat.supportedLocalesOf('es').length === 0;
-}
-
 module.exports = {
   getProtoRoundTrip,
   loadSourceMapFixture,
@@ -293,6 +281,5 @@ module.exports = {
   createDecomposedPromise,
   flushAllTimersAndMicrotasks,
   makeMocksForGatherRunner,
-  isNode12SmallIcu,
   ...mockCommands,
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "smokehouse": "./lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js"
   },
   "engines": {
-    "node": ">=12.20.0 12 || >=14.13 14  || >=15"
+    "node": ">=14.15"
   },
   "scripts": {
     "build-all": "npm-run-posix-or-windows build-all:task",

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The Chrome extension was available prior to Lighthouse being available in Chrome
 
 The Node CLI provides the most flexibility in how Lighthouse runs can be configured and reported. Users who want more advanced usage, or want to run Lighthouse in an automated fashion should use the Node CLI.
 
-_Lighthouse requires Node 12 LTS (12.20) or later._
+_Lighthouse requires Node 14 LTS (14.x) or later._
 
 **Installation**:
 
@@ -451,9 +451,9 @@ machine. Report results are never processed or beaconed to a remote server.
 
 ### How do I get localized Lighthouse results via the CLI?
 
-Starting in Lighthouse 8.0, Lighthouse relies entirely on native `Intl` support and no longer uses an `Intl` polyfill. If you're using Node 13 or later, there should be no issue because Node is now [built with `full-icu` by default](https://nodejs.medium.com/node-js-12-to-lts-and-node-js-13-is-here-e28d6a4a2bd#9514).
+Starting in Lighthouse 8.0, Lighthouse relies entirely on native `Intl` support and no longer uses an `Intl` polyfill. If you're using Node 14 or later, there should be no issue because Node is now [built with `full-icu` by default](https://nodejs.medium.com/node-js-12-to-lts-and-node-js-13-is-here-e28d6a4a2bd#9514).
 
-However, if you're using Node 12 (when `small-icu` was the default) or another `small-icu` Node build, you may see Lighthouse log messages about your locale not being available. To remedy this, you can upgrade to Node 14+ or manually install ICU data by using the [`full-icu`](https://www.npmjs.com/package/full-icu) module and the [`--icu-data-dir` node flag](https://nodejs.org/api/intl.html#intl_providing_icu_data_at_runtime) at launch.
+However, if you're using a `small-icu` Node build, you may see Lighthouse log messages about your locale not being available. To remedy this, you can upgrade to Node 14+ or manually install ICU data by using the [`full-icu`](https://www.npmjs.com/package/full-icu) module and the [`--icu-data-dir` node flag](https://nodejs.org/api/intl.html#intl_providing_icu_data_at_runtime) at launch.
 
 ### How do I author custom audits to extend Lighthouse?
 

--- a/report/test/renderer/i18n-test.js
+++ b/report/test/renderer/i18n-test.js
@@ -9,7 +9,6 @@ import {strict as assert} from 'assert';
 
 import {Util} from '../../renderer/util.js';
 import {I18n} from '../../renderer/i18n.js';
-import {isNode12SmallIcu} from '../../../lighthouse-core/test/test-utils.js';
 
 // Require i18n to make sure Intl is polyfilled in Node without full-icu for testing.
 // When Util is run in a browser, Intl will be supplied natively (IE11+).
@@ -108,9 +107,6 @@ describe('util helpers', () => {
   });
 
   it('formats numbers based on locale', () => {
-    // COMPAT: Node 12 only has 'en' by default.
-    if (isNode12SmallIcu()) return;
-
     // Requires full-icu or Intl polyfill.
     const number = 12346.858558;
 
@@ -122,9 +118,6 @@ describe('util helpers', () => {
   });
 
   it('uses decimal comma with en-XA test locale', () => {
-    // COMPAT: Node 12 only has 'en' by default.
-    if (isNode12SmallIcu()) return;
-
     // Requires full-icu or Intl polyfill.
     const number = 12346.858558;
 

--- a/shared/test/localization/format-test.js
+++ b/shared/test/localization/format-test.js
@@ -407,15 +407,7 @@ describe('format', () => {
       expect(helloInfinityStr).toBeDisplayString('Hello ∞ World');
 
       const helloNaNStr = str_(UIStrings.helloBytesWorld, {in: NaN});
-      // TODO(COMPAT): workaround can be removed after Node 13 is retired.
-      // expect(helloNaNStr).toBeDisplayString('Hello NaN World');
-
-      // Node 13/V8 7.9 and 8.0 have a bug where `({a: NaN}).a.toLocaleString() === "-NaN"`. It
-      // works correctly in Node 12 and 14, so work around it since NaN isn't essential for
-      // user-facing strings and it will eventually correct itself.
-      const formattedNaNStr = format.getFormatted(helloNaNStr, 'en-US');
-      expect(formattedNaNStr === 'Hello NaN World' || formattedNaNStr === 'Hello -NaN World')
-        .toBe(true);
+      expect(helloNaNStr).toBeDisplayString('Hello NaN World');
     });
   });
 });

--- a/shared/test/localization/swap-locale-test.js
+++ b/shared/test/localization/swap-locale-test.js
@@ -6,23 +6,11 @@
 'use strict';
 
 const swapLocale = require('../../localization/swap-locale.js');
-const {isNode12SmallIcu} = require('../../../lighthouse-core/test/test-utils.js');
 
 const lhr = require('../../../lighthouse-core/test/results/sample_v2.json');
 
 /* eslint-env jest */
 describe('swap-locale', () => {
-  // COMPAT: Node 12 only has 'en' by default. Skip these tests since they're all about swapping locales.
-  if (isNode12SmallIcu()) {
-    // Jest requires at least one test per suite.
-    it('throws if locale is not supported', () => {
-      // Even though 'pt' is requested, 'en' is all that's available.
-      expect(() => swapLocale(lhr, 'pt')).toThrow('Unsupported locale \'pt\'');
-    });
-
-    return;
-  }
-
   it('does not mutate the original lhr', () => {
     /** @type {LH.Result} */
     const lhrClone = JSON.parse(JSON.stringify(lhr));

--- a/third-party/download-content-shell/download-content-shell.js
+++ b/third-party/download-content-shell/download-content-shell.js
@@ -85,7 +85,7 @@ function deleteOldContentShells() {
   const remainingNumberOfContentShells = MAX_CONTENT_SHELLS / 2;
   const oldContentShellDirs = files.slice(remainingNumberOfContentShells);
   for (let i = 0; i < oldContentShellDirs.length; i++) {
-    utils.removeRecursive(path.resolve(CACHE_PATH, oldContentShellDirs[i]));
+    fs.rmSync(path.resolve(CACHE_PATH, oldContentShellDirs[i]), {recursive: true, force: true});
   }
   console.log(`Removed old content shells: ${oldContentShellDirs}`);
 }
@@ -126,7 +126,7 @@ function findPreviousUploadedPosition(commitPosition) {
 async function prepareContentShellDirectory(folder) {
   const contentShellPath = path.join(CACHE_PATH, folder);
   if (utils.isDir(contentShellPath)) {
-    utils.removeRecursive(contentShellPath);
+    fs.rmSync(contentShellPath, {recursive: true, force: true});
   }
   fs.mkdirSync(contentShellPath);
   return folder;

--- a/third-party/download-content-shell/utils.js
+++ b/third-party/download-content-shell/utils.js
@@ -96,29 +96,6 @@ function copyRecursive(src, dest) {
   }
 }
 
-function removeRecursive(filePath) {
-  try {
-    if (fs.existsSync(filePath)) {
-      if (isFile(filePath)) {
-        fs.unlinkSync(filePath);
-        return;
-      }
-      const files = fs.readdirSync(filePath);
-      for (let i = 0; i < files.length; i++) {
-        const childPath = path.resolve(filePath, files[i]);
-        if (isDir(childPath)) {
-          removeRecursive(childPath);
-        } else {
-          fs.unlinkSync(childPath);
-        }
-      }
-      fs.rmdirSync(filePath);
-    }
-  } catch (error) {
-    throw new Error(`Received an error: [${error}] while trying to remove: ${filePath}`);
-  }
-}
-
 function includes(sequence, target) {
   return sequence.indexOf(target) > -1;
 }
@@ -145,7 +122,6 @@ module.exports = {
   isDir,
   copy,
   copyRecursive,
-  removeRecursive,
   includes,
   shellOutput,
   parseArgs,

--- a/types/enquirer.d.ts
+++ b/types/enquirer.d.ts
@@ -4,6 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {EventEmitter} from 'events';
+
 declare module 'enquirer' {
   interface ConfirmOption {
     name: string | (() => string);
@@ -12,7 +14,7 @@ declare module 'enquirer' {
     actions?: {'ctrl': {[key: string]: string}}
   }
 
-  class Confirm extends NodeJS.EventEmitter {
+  class Confirm extends EventEmitter {
     constructor(option: ConfirmOption);
     run: () => Promise<boolean>;
     close: () => Promise<void>

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -4,9 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-declare module NodeJS {
-  interface Global {
-    isDevtools?: boolean;
-    isLightrider?: boolean;
-  }
+declare global {
+  var isDevtools: boolean | undefined;
+  var isLightrider: boolean | undefined;
 }
+
+export {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1604,20 +1604,15 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*":
-  version "12.20.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.7.tgz#1cb61fd0c85cb87e728c43107b5fd82b69bc9ef8"
-  integrity sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==
-
-"@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "16.7.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.4.tgz#68a9384694af63ceab8848e95d76d9a3519e84b6"
-  integrity sha512-25QXpDsTiDnl2rZGUenagVMwO46way8dOUdvoC3R3p+6TrbpxeJBo/v87BEG1IHI31Jhaa8lPeSHcqwxsVBeYQ==
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
+  version "16.11.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.2.tgz#31c249c136c3f9b35d4b60fb8e50e01a1f0cc9a5"
+  integrity sha512-w34LtBB0OkDTs19FQHXy4Ig/TOXI4zqvXS2Kk1PAsRKZ0I+nik7LlMYxckW0tSNGtvWmzB+mrCTbuEjuB9DVsw==
 
 "@types/node@^11.10.4":
-  version "11.15.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.9.tgz#656b2f61ebe6af278769dfc24e6ab00528a373eb"
-  integrity sha512-NcOiyA/gxMAounNa4IPm/e13kYqU48onEarMnbLzz3ynEdlxFKYFoBbMBSefAHJR77r9MCtD88J0Z2TVtNsBbw==
+  version "11.15.54"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.54.tgz#59ed60e7b0d56905a654292e8d73275034eb6283"
+  integrity sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==
 
 "@types/pako@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
part of #12614

With Node 17 out and Node 16 LTS [planned for next week](https://nodejs.org/en/about/releases/), this moves us to requiring [Node 14](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md) (now the _Maintenance_ LTS) as a minimum requirement.

The changes here are
- updating the references to Node 12 in docs and in package.json, github action scripts, etc
- removing the Node 12 small-icu workarounds introduced in #12426 since all versions of Node now supported are build with `full-icu` by default (it will [still log instructions](https://github.com/GoogleChrome/lighthouse/blob/12c32b3c559a056c511a696b0c114dbfc0e43368/lighthouse-core/lib/i18n/i18n.js#L155-L158) if it's run in a Node purposefully built as `small-icu` and a non-`en-US` locale is requested)
- updating a few "TODO: remove once updated to Node x"s, like `rmdirSync` -> `rmSync`
- three type updates necessitated by the updated `@types/node`