### PR TITLE
tests: devtools repo master -> main

### DIFF
--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -21,7 +21,7 @@ then
   if [ -z "${CI:-}" ]; then
     git reset --hard
     git clean -fd
-    git pull --ff-only -f origin master
+    git pull --ff-only -f origin main
     gclient sync --delete_unversioned_trees --reset
   fi
 


### PR DESCRIPTION
`master` is now `main`, so `yarn test-devtools` currently fails if working from a clean slate. I feel like I've done that a lot recently (and the master->main rename for CDT is nothing new); perhaps they only recently deleted the master branch completely?

Other PRs are currently failing the devtools test, I think because the repo is stale and needed a cache clear. This change should also handle that.