### PR TITLE
core(build): add LH_ROOT support to inline-fs

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -62,7 +62,7 @@ async function browserifyFile(entryPath, distPath) {
       file: require.resolve('./banner.txt'),
     })
     // Transform `fs.readFileSync`, etc into inline strings.
-    .transform(inlineFs({verbose: Boolean(process.env.DEBUG)}))
+    .transform(inlineFs({verbose: DEBUG}))
     // Strip everything out of package.json includes except for the version.
     .transform('package-json-versionify');
 

--- a/build/plugins/inline-fs.js
+++ b/build/plugins/inline-fs.js
@@ -14,6 +14,8 @@ const MagicString = require('magic-string').default;
 const resolve = require('resolve');
 const terser = require('terser');
 
+const {LH_ROOT} = require('../../root.js');
+
 // ESTree provides much better types for AST nodes. See https://github.com/acornjs/acorn/issues/946
 /** @typedef {import('estree').Node} Node */
 /** @typedef {import('estree').SimpleCallExpression} SimpleCallExpression */
@@ -280,6 +282,9 @@ function collapseToStringLiteral(node, filepath) {
         return path.dirname(filepath);
       } else if (node.name === '__filename') {
         return filepath;
+      } else if (node.name === 'LH_ROOT') {
+        // Note: hardcoded for LH. Could be be set via inline-fs options instead.
+        return LH_ROOT;
       }
       throw new AstError(`unsupported identifier '${node.name}'`, node);
     }

--- a/build/test/plugins/inline-fs-test.js
+++ b/build/test/plugins/inline-fs-test.js
@@ -241,6 +241,18 @@ describe('inline-fs', () => {
       });
     });
 
+    it('substitutes Lighthouse-specific LH_ROOT', async () => {
+      fs.writeFileSync(tmpPath, 'lh_root text content');
+
+      const constructedPath = '`${LH_ROOT}/.tmp/inline-fs/test.txt`';
+      const content = `const myRootRelativeContent = fs.readFileSync(${constructedPath}, 'utf8');`;
+      const result = await inlineFs(content, filepath);
+      expect(result).toEqual({
+        code: `const myRootRelativeContent = "lh_root text content";`,
+        warnings: [],
+      });
+    });
+
     describe('fs.readFileSync', () => {
       it('inlines content with quotes', async () => {
         fs.writeFileSync(tmpPath, `"quoted", and an unbalanced quote: "`);

--- a/lighthouse-cli/test/smokehouse/test-definitions/source-maps/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/source-maps/expectations.js
@@ -5,12 +5,11 @@
  */
 'use strict';
 
-const fs = require('fs');
+import fs from 'fs';
+import {LH_ROOT} from '../../../../../root.js';
 
-// TODO(esmodules): brfs does not support es modules, and this file needs to be bundlded,
-// so it is commonjs for now.
 const mapJson =
-  fs.readFileSync(`${__dirname}/../../../fixtures/source-map/script.js.map`, 'utf-8');
+  fs.readFileSync(`${LH_ROOT}/lighthouse-cli/test/fixtures/source-map/script.js.map`, 'utf-8');
 const map = JSON.parse(mapJson);
 
 /**
@@ -42,4 +41,4 @@ const expectations = {
   },
 };
 
-module.exports = {expectations};
+export {expectations};

--- a/lighthouse-cli/test/smokehouse/test-definitions/source-maps/package.json
+++ b/lighthouse-cli/test/smokehouse/test-definitions/source-maps/package.json
@@ -1,4 +1,0 @@
-{
-  "type": "commonjs",
-  "//": "Preserve commonjs in this directory. Temporary file until converted to type: module"
-}

--- a/lighthouse-cli/test/smokehouse/test-definitions/source-maps/source-maps-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/source-maps/source-maps-config.js
@@ -17,4 +17,4 @@ const config = {
   },
 };
 
-module.exports = config;
+export default config;

--- a/shared/localization/format.js
+++ b/shared/localization/format.js
@@ -17,7 +17,7 @@ const DEFAULT_LOCALE = 'en-US';
 
 /**
  * The locale tags for the localized messages available to Lighthouse on disk.
- * When bundled, these will be inlined by brfs.
+ * When bundled, these will be inlined by `inline-fs`.
  * These locales are considered the "canonical" locales. We support other locales which
  * are simply aliases to one of these. ex: es-AR (alias) -> es-419 (canonical)
  */


### PR DESCRIPTION
part of #13231

lets inline-fs replace `LH_ROOT` with the value of `LH_ROOT`. I expected this PR to have more but the locale replacement stuff had to move to #13275

Support is hardcoded into inline-fs rather than plumbing through options because it's only one custom thing and we've never really needed anything else out of `brfs`. If the number of identifiers (or whatever) needing to be replaced grows in the future we can always add it later (just say no to magic bundler syntax though :).

Next I was planning on adding source map and watch file support, but I believe #12771 should be good to go after this PR @connorjclark?