### PR TITLE
report(build): fix building flow report with inline-fs

### DIFF
--- a/build/build-report.js
+++ b/build/build-report.js
@@ -59,6 +59,7 @@ async function buildFlowReport() {
   const bundle = await rollup.rollup({
     input: 'flow-report/standalone-flow.tsx',
     plugins: [
+      rollupPlugins.inlineFs({verbose: true}),
       rollupPlugins.replace({
         '__dirname': '""',
       }),


### PR DESCRIPTION
the change in #13275 to unguard the `fs.readdirSync` broke the flow report because it didn't have a call to `inlineFs` in the build call. This adds the plugin and fixes it.

This does add 466 bytes (the list of supported locales) to the flow report that aren't used. I assume there will be better DCE when switching to es modules and rollup will be more aggressive with tree shaking?