### PR TITLE
tests: ignore .tmp directory in jest modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
     '**/shared/**/*-test.js',
     '**/build/**/*-test.js',
   ],
+  modulePathIgnorePatterns: ['<rootDir>/.tmp'],
   transform: {},
   prettierPath: null,
   projects: [


### PR DESCRIPTION
Was causing this error for me locally:

![image (8)](https://user-images.githubusercontent.com/4071474/139498595-eb8c2dea-3aaf-4ca8-849f-4707b82aa25f.png)


