### PR TITLE
core(errors-in-console): remove url property from items

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -200,27 +200,27 @@ const expectations = {
             0: {
               source: 'exception',
               description: /^Error: A distinctive error\s+at http:\/\/localhost:10200\/dobetterweb\/dbw_tester.html:\d+:\d+$/,
-              url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+              sourceLocation: {url: 'http://localhost:10200/dobetterweb/dbw_tester.html'},
             },
             1: {
               source: 'console.error',
               description: 'Error! Error!',
-              url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+              sourceLocation: {url: 'http://localhost:10200/dobetterweb/dbw_tester.html'},
             },
             2: {
               source: 'network',
               description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-              url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
+              sourceLocation: {url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200'},
             },
             3: {
               source: 'network',
               description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-              url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
+              sourceLocation: {url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000'},
             },
             4: {
               source: 'network',
               description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
-              url: 'http://localhost:10200/favicon.ico',
+              sourceLocation: {url: 'http://localhost:10200/favicon.ico'},
             },
             // In legacy Lighthouse this audit will have additional duplicate failures which are a mistake.
             // Fraggle Rock ordering of gatherer `stopInstrumentation` and `getArtifact` fixes the re-request issue.

--- a/lighthouse-core/audits/errors-in-console.js
+++ b/lighthouse-core/audits/errors-in-console.js
@@ -88,8 +88,6 @@ class ErrorLogs extends Audit {
         return {
           source: item.source,
           description: item.text,
-          // TODO: remove for v8 (url is covered in sourceLocation)
-          url: item.url,
           sourceLocation: Audit.makeSourceLocationFromConsoleMessage(item),
         };
       });

--- a/lighthouse-core/test/audits/errors-in-console-test.js
+++ b/lighthouse-core/test/audits/errors-in-console-test.js
@@ -69,14 +69,16 @@ describe('ConsoleMessages error logs audit', () => {
 
     assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 3);
-    assert.equal(auditResult.details.items[0].url, 'http://www.example.com/favicon.ico');
+    assert.equal(
+      auditResult.details.items[0].sourceLocation.url, 'http://www.example.com/favicon.ico');
     assert.equal(auditResult.details.items[0].description,
       'The server responded with a status of 404 (Not Found)');
-    assert.equal(auditResult.details.items[1].url,
+    assert.equal(auditResult.details.items[1].sourceLocation.url,
       'http://example.com/fancybox.js');
     assert.equal(auditResult.details.items[1].description,
       'TypeError: Cannot read property \'msie\' of undefined');
-    assert.equal(auditResult.details.items[2].url, 'http://www.example.com/wsconnect.ws');
+    assert.equal(
+      auditResult.details.items[2].sourceLocation.url, 'http://www.example.com/wsconnect.ws');
     assert.equal(auditResult.details.items[2].description,
       'WebSocket connection failed: Unexpected response code: 500');
   });
@@ -91,8 +93,8 @@ describe('ConsoleMessages error logs audit', () => {
     }, {options: {}});
     assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 1);
-    // url is undefined
-    assert.strictEqual(auditResult.details.items[0].url, undefined);
+    // sourceLocation is undefined
+    assert.strictEqual(auditResult.details.items[0].sourceLocation, undefined);
     // text is undefined
     assert.strictEqual(auditResult.details.items[0].description, undefined);
   });
@@ -119,7 +121,8 @@ describe('ConsoleMessages error logs audit', () => {
     }, {options: {}});
     assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 1);
-    assert.strictEqual(auditResult.details.items[0].url, 'http://example.com/fancybox.js');
+    assert.strictEqual(
+      auditResult.details.items[0].sourceLocation.url, 'http://example.com/fancybox.js');
     assert.strictEqual(auditResult.details.items[0].description,
       'TypeError: Cannot read property \'msie\' of undefined');
   });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -238,7 +238,6 @@
           {
             "source": "exception",
             "description": "Error: A distinctive error\n    at http://localhost:10200/dobetterweb/dbw_tester.html:56:54",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "sourceLocation": {
               "type": "source-location",
               "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
@@ -250,7 +249,6 @@
           {
             "source": "exception",
             "description": "Error: An ignored error\n    at http://localhost:10200/dobetterweb/dbw_tester.html:59:38",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "sourceLocation": {
               "type": "source-location",
               "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
@@ -262,7 +260,6 @@
           {
             "source": "console.error",
             "description": "Error! Error!",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "sourceLocation": {
               "type": "source-location",
               "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
@@ -274,7 +271,6 @@
           {
             "source": "network",
             "description": "Failed to load resource: the server responded with a status of 404 (Not Found)",
-            "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
             "sourceLocation": {
               "type": "source-location",
               "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
@@ -286,7 +282,6 @@
           {
             "source": "network",
             "description": "Failed to load resource: the server responded with a status of 404 (Not Found)",
-            "url": "http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000",
             "sourceLocation": {
               "type": "source-location",
               "url": "http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000",
@@ -298,7 +293,6 @@
           {
             "source": "network",
             "description": "Failed to load resource: the server responded with a status of 404 (Not Found)",
-            "url": "http://localhost:10200/favicon.ico",
             "sourceLocation": {
               "type": "source-location",
               "url": "http://localhost:10200/favicon.ico",
@@ -310,7 +304,6 @@
           {
             "source": "network",
             "description": "Failed to load resource: the server responded with a status of 404 (Not Found)",
-            "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
             "sourceLocation": {
               "type": "source-location",
               "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",


### PR DESCRIPTION
`url` is redundant info, exists in sourceLocation.