### PR TITLE
report: layout metrics naturally 

### DIFF
--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -413,10 +413,10 @@ const defaultConfig = {
       supportedModes: ['navigation', 'timespan', 'snapshot'],
       auditRefs: [
         {id: 'first-contentful-paint', weight: 10, group: 'metrics', acronym: 'FCP', relevantAudits: m2a.fcpRelevantAudits},
-        {id: 'speed-index', weight: 10, group: 'metrics', acronym: 'SI'},
-        {id: 'largest-contentful-paint', weight: 25, group: 'metrics', acronym: 'LCP', relevantAudits: m2a.lcpRelevantAudits},
         {id: 'interactive', weight: 10, group: 'metrics', acronym: 'TTI'},
+        {id: 'speed-index', weight: 10, group: 'metrics', acronym: 'SI'},
         {id: 'total-blocking-time', weight: 30, group: 'metrics', acronym: 'TBT', relevantAudits: m2a.tbtRelevantAudits},
+        {id: 'largest-contentful-paint', weight: 25, group: 'metrics', acronym: 'LCP', relevantAudits: m2a.lcpRelevantAudits},
         {id: 'cumulative-layout-shift', weight: 15, group: 'metrics', acronym: 'CLS', relevantAudits: m2a.clsRelevantAudits},
 
         // These are our "invisible" metrics. Not displayed, but still in the LHR.

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -3826,10 +3826,33 @@
                 ]
               },
               {
+                "id": "interactive",
+                "weight": 10,
+                "group": "metrics",
+                "acronym": "TTI"
+              },
+              {
                 "id": "speed-index",
                 "weight": 10,
                 "group": "metrics",
                 "acronym": "SI"
+              },
+              {
+                "id": "total-blocking-time",
+                "weight": 30,
+                "group": "metrics",
+                "acronym": "TBT",
+                "relevantAudits": [
+                  "long-tasks",
+                  "third-party-summary",
+                  "third-party-facades",
+                  "bootup-time",
+                  "mainthread-work-breakdown",
+                  "dom-size",
+                  "duplicated-javascript",
+                  "legacy-javascript",
+                  "viewport"
+                ]
               },
               {
                 "id": "largest-contentful-paint",
@@ -3853,29 +3876,6 @@
                   "unused-javascript",
                   "efficient-animated-content",
                   "total-byte-weight"
-                ]
-              },
-              {
-                "id": "interactive",
-                "weight": 10,
-                "group": "metrics",
-                "acronym": "TTI"
-              },
-              {
-                "id": "total-blocking-time",
-                "weight": 30,
-                "group": "metrics",
-                "acronym": "TBT",
-                "relevantAudits": [
-                  "long-tasks",
-                  "third-party-summary",
-                  "third-party-facades",
-                  "bootup-time",
-                  "mainthread-work-breakdown",
-                  "dom-size",
-                  "duplicated-javascript",
-                  "legacy-javascript",
-                  "viewport"
                 ]
               },
               {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -5927,10 +5927,33 @@
           ]
         },
         {
+          "id": "interactive",
+          "weight": 10,
+          "group": "metrics",
+          "acronym": "TTI"
+        },
+        {
           "id": "speed-index",
           "weight": 10,
           "group": "metrics",
           "acronym": "SI"
+        },
+        {
+          "id": "total-blocking-time",
+          "weight": 30,
+          "group": "metrics",
+          "acronym": "TBT",
+          "relevantAudits": [
+            "long-tasks",
+            "third-party-summary",
+            "third-party-facades",
+            "bootup-time",
+            "mainthread-work-breakdown",
+            "dom-size",
+            "duplicated-javascript",
+            "legacy-javascript",
+            "viewport"
+          ]
         },
         {
           "id": "largest-contentful-paint",
@@ -5954,29 +5977,6 @@
             "unused-javascript",
             "efficient-animated-content",
             "total-byte-weight"
-          ]
-        },
-        {
-          "id": "interactive",
-          "weight": 10,
-          "group": "metrics",
-          "acronym": "TTI"
-        },
-        {
-          "id": "total-blocking-time",
-          "weight": 30,
-          "group": "metrics",
-          "acronym": "TBT",
-          "relevantAudits": [
-            "long-tasks",
-            "third-party-summary",
-            "third-party-facades",
-            "bootup-time",
-            "mainthread-work-breakdown",
-            "dom-size",
-            "duplicated-javascript",
-            "legacy-javascript",
-            "viewport"
           ]
         },
         {

--- a/report/renderer/performance-category-renderer.js
+++ b/report/renderer/performance-category-renderer.js
@@ -168,30 +168,6 @@ export class PerformanceCategoryRenderer extends CategoryRenderer {
   }
 
   /**
-   * Config order of metrics assumes they will fill the grid column by column, but CSS will order metrics row by row.
-   * This function adjusts metric order to meet the config expectation.
-   *
-   * @param {LH.ReportResult.AuditRef[]} metrics
-   */
-  _reorderMetrics(metrics) {
-    // Clone input to avoid changes.
-    metrics = [...metrics];
-
-    const halfway = Math.ceil(metrics.length / 2);
-    const col1 = metrics.slice(0, halfway).reverse();
-    const col2 = metrics.slice(halfway).reverse();
-
-    const result = [];
-    while (col1.length || col2.length) {
-      const metric1 = col1.pop();
-      const metric2 = col2.pop();
-      if (metric1) result.push(metric1);
-      if (metric2) result.push(metric2);
-    }
-    return result;
-  }
-
-  /**
    * @param {LH.ReportResult.Category} category
    * @param {Object<string, LH.Result.ReportGroup>} groups
    * @param {{gatherMode: LH.Result.GatherMode}=} options
@@ -205,8 +181,7 @@ export class PerformanceCategoryRenderer extends CategoryRenderer {
     element.appendChild(this.renderCategoryHeader(category, groups, options));
 
     // Metrics.
-    const unorderedMetrics = category.auditRefs.filter(audit => audit.group === 'metrics');
-    const metricAudits = this._reorderMetrics(unorderedMetrics);
+    const metricAudits = category.auditRefs.filter(audit => audit.group === 'metrics');
 
     if (metricAudits.length) {
       const [metricsGroupEl, metricsFooterEl] = this.renderAuditGroup(groups.metrics);

--- a/report/test/renderer/performance-category-renderer-test.js
+++ b/report/test/renderer/performance-category-renderer-test.js
@@ -371,44 +371,4 @@ Array [
       });
     });
   });
-
-  describe('_reorderMetrics', () => {
-    it('orders metrics by row', () => {
-      const metrics = [
-        {id: 'first-contentful-paint'},
-        {id: 'speed-index'},
-        {id: 'largest-contentful-paint'},
-        {id: 'interactive'},
-        {id: 'total-blocking-time'},
-        {id: 'cumulative-layout-shift'},
-      ];
-      const orderedMetrics = renderer._reorderMetrics(metrics);
-      assert.deepStrictEqual(orderedMetrics, [
-        {id: 'first-contentful-paint'},
-        {id: 'interactive'},
-        {id: 'speed-index'},
-        {id: 'total-blocking-time'},
-        {id: 'largest-contentful-paint'},
-        {id: 'cumulative-layout-shift'},
-      ]);
-    });
-
-    it('orders odd number of metrics by row', () => {
-      const metrics = [
-        {id: 'first-contentful-paint'},
-        {id: 'speed-index'},
-        {id: 'largest-contentful-paint'},
-        {id: 'interactive'},
-        {id: 'total-blocking-time'},
-      ];
-      const orderedMetrics = renderer._reorderMetrics(metrics);
-      assert.deepStrictEqual(orderedMetrics, [
-        {id: 'first-contentful-paint'},
-        {id: 'interactive'},
-        {id: 'speed-index'},
-        {id: 'total-blocking-time'},
-        {id: 'largest-contentful-paint'},
-      ]);
-    });
-  });
 });


### PR DESCRIPTION
proposing this for #13328

The order of metrics and audits in default-config has a direct effect on the visual presentation and I've manually adjusted them there previously to affect the displayed result. So I'd rather continue to control it through that means.

This is more simple than and still accomplishes the goals:

* ✅ navigation 6-metric display looks good
* ✅ navigation 6-metric display maintains existing item placement (that has been consistent for 3 years)
* ✅ timespan 2-metric display lays out side-by-side instead of vertically-stacked.


--------------

![image](https://user-images.githubusercontent.com/39191/141006648-a0d0e6fa-6dbb-45ed-9894-e419b9c17ef5.png)

--------------

![image](https://user-images.githubusercontent.com/39191/141006686-a23af210-02bf-440e-928b-b94d8c3d1e15.png)
