### PR TITLE
tests(eslint): prefer eslint-disable-next-line max-len. audit current usages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,8 @@ module.exports = {
     'max-len': [2, 100, {
       ignoreComments: true,
       ignoreUrls: true,
+      ignorePattern: 'require\\(|import |\\sit\\(',
+      ignoreRegExpLiterals: true,
       tabWidth: 2,
     }],
     'no-empty': [2, {
@@ -68,6 +70,13 @@ module.exports = {
       imports: 'always-multiline',
       exports: 'always-multiline',
       functions: 'never',
+    }],
+    // Don't allow `eslint-disable-line max-len`, prefer instead `eslint-disable-next-line max-len`
+    // so that the line is made even longer.
+    'line-comment-position': [2, {
+      ignorePattern: '^(?! *eslint-disable-line max-len).*$',
+      applyDefaultIgnorePatterns: false,
+      position: 'above',
     }],
 
     // Custom lighthouse rules

--- a/build/build-sample-reports.js
+++ b/build/build-sample-reports.js
@@ -136,7 +136,8 @@ async function generateErrorLHR() {
   const artifacts = {
     fetchTime: '2019-06-26T23:56:58.381Z',
     LighthouseRunWarnings: [
-      `Something went wrong with recording the trace over your page load. Please run Lighthouse again. (NO_FCP)`, // eslint-disable-line max-len
+      // eslint-disable-next-line max-len
+      `Something went wrong with recording the trace over your page load. Please run Lighthouse again. (NO_FCP)`,
     ],
     HostFormFactor: 'desktop',
     HostUserAgent: 'Mozilla/5.0 ErrorUserAgent Chrome/66',

--- a/lighthouse-cli/sentry-prompt.js
+++ b/lighthouse-cli/sentry-prompt.js
@@ -11,10 +11,11 @@ import log from 'lighthouse-logger';
 
 const MAXIMUM_WAIT_TIME = 20 * 1000;
 
-// eslint-disable-next-line max-len
+/* eslint-disable max-len */
 const MESSAGE = `${log.reset}We're constantly trying to improve Lighthouse and its reliability.\n  ` +
   `${log.reset}Learn more: https://github.com/GoogleChrome/lighthouse/blob/master/docs/error-reporting.md \n ` +
-  ` ${log.bold}May we anonymously report runtime exceptions to improve the tool over time?${log.reset} `; // eslint-disable-line max-len
+  ` ${log.bold}May we anonymously report runtime exceptions to improve the tool over time?${log.reset} `;
+/* eslint-enable max-len */
 
 /**
  * @return {Promise<boolean>}

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -34,10 +34,8 @@ describe('CLI run', function() {
 
     beforeAll(async () => {
       const url = 'http://localhost:10200/dobetterweb/dbw_tester.html';
-      // eslint-disable-next-line max-len
       const samplev2ArtifactsPath = LH_ROOT + '/lighthouse-core/test/results/artifacts/';
 
-      // eslint-disable-next-line max-len
       const flags = getFlags([
         '--output=json',
         `--output-path=${filename}`,

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
@@ -117,7 +117,8 @@ async function internalRun(url, tmpPath, configJson, options) {
   try {
     await fs.access(outputPath);
   } catch (e) {
-    throw new ChildProcessError(`Lighthouse run failed to produce a report and exited with ${exitCode}.`, // eslint-disable-line max-len
+    // eslint-disable-next-line max-len
+    throw new ChildProcessError(`Lighthouse run failed to produce a report and exited with ${exitCode}.`,
         localConsole.getLog());
   }
 
@@ -134,7 +135,8 @@ async function internalRun(url, tmpPath, configJson, options) {
   // There should either be both an error exitCode and a lhr.runtimeError or neither.
   if (Boolean(exitCode) !== Boolean(lhr.runtimeError)) {
     const runtimeErrorCode = lhr.runtimeError && lhr.runtimeError.code;
-    throw new ChildProcessError(`Lighthouse did not exit with an error correctly, exiting with ${exitCode} but with runtimeError '${runtimeErrorCode}'`, // eslint-disable-line max-len
+    // eslint-disable-next-line max-len
+    throw new ChildProcessError(`Lighthouse did not exit with an error correctly, exiting with ${exitCode} but with runtimeError '${runtimeErrorCode}'`,
         localConsole.getLog());
   }
 

--- a/lighthouse-cli/test/smokehouse/test-definitions/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/seo/expectations.js
@@ -392,6 +392,7 @@ const status403 = {
   },
 };
 
+/* eslint-disable max-len */
 /**
  * @type {Smokehouse.ExpectedRunnerResult}
  * Expected Lighthouse audit values for a site exercising tap targets.
@@ -413,7 +414,6 @@ const tapTargets = {
             {
               'tapTarget': {
                 'type': 'node',
-                /* eslint-disable max-len */
                 'snippet': '<a data-gathered-target="zero-width-tap-target-with-overflowing-child-content" style="display: block; width: 0; white-space: nowrap">',
                 'path': '2,HTML,1,BODY,14,DIV,0,A',
                 'selector': 'body > div > a',
@@ -421,7 +421,6 @@ const tapTargets = {
               },
               'overlappingTarget': {
                 'type': 'node',
-                /* eslint-disable max-len */
                 'snippet': '<a data-gathered-target="passing-tap-target-next-to-zero-width-target" style="display: block; width: 110px; height: 100px;background: #aaa;">',
                 'path': '2,HTML,1,BODY,14,DIV,1,A',
                 'selector': 'body > div > a',
@@ -483,6 +482,7 @@ const tapTargets = {
     TapTargets: expectedGatheredTapTargets.map(({node}) => ({node})),
   },
 };
+/* eslint-enable max-len */
 
 export {
   passing,

--- a/lighthouse-core/audits/byte-efficiency/legacy-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/legacy-javascript.js
@@ -27,7 +27,6 @@ const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-an
 const UIStrings = {
   /** Title of a Lighthouse audit that tells the user about legacy polyfills and transforms used on the page. This is displayed in a list of audit titles that Lighthouse generates. */
   title: 'Avoid serving legacy JavaScript to modern browsers',
-  // eslint-disable-next-line max-len
   // TODO: web.dev article. this codelab is good starting place: https://web.dev/codelab-serve-modern-code/
   /** Description of a Lighthouse audit that tells the user about old JavaScript that is no longer needed. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Polyfills and transforms enable legacy browsers to use new JavaScript features. However, many aren\'t necessary for modern browsers. For your bundled JavaScript, adopt a modern script deployment strategy using module/nomodule feature detection to reduce the amount of code shipped to modern browsers, while retaining support for legacy browsers. [Learn More](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/)',

--- a/lighthouse-core/audits/dobetterweb/inspector-issues.js
+++ b/lighthouse-core/audits/dobetterweb/inspector-issues.js
@@ -18,15 +18,14 @@
 const Audit = require('../audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
 
+/* eslint-disable max-len */
 const UIStrings = {
   /** Title of a Lighthouse audit that provides detail on various types of problems with a website, like security or network errors. This descriptive title is shown to users when no issues were logged into the Chrome DevTools Issues panel. */
   title: 'No issues in the `Issues` panel in Chrome Devtools',
   /** Title of a Lighthouse audit that provides detail on various types of problems with a website, like security or network errors. This descriptive title is shown to users when issues are detected and logged into the Chrome DevTools Issues panel. */
   failureTitle: 'Issues were logged in the `Issues` panel in Chrome Devtools',
-  /* eslint-disable max-len */
   /** Description of a Lighthouse audit that tells the user why issues being logged to the Chrome DevTools Issues panel are a cause for concern and so should be fixed. This is displayed after a user expands the section to see more. No character length limits. */
   description: 'Issues logged to the `Issues` panel in Chrome Devtools indicate unresolved problems. They can come from network request failures, insufficient security controls, and other browser concerns. Open up the Issues panel in Chrome DevTools for more details on each issue.',
-  /* eslint-enable max-len */
   /** Table column header for the types of problems observed in a website, like security or network errors. */
   columnIssueType: 'Issue type',
   /** The type of an Issue in Chrome DevTools when a resource is blocked due to the website's cross-origin policy. */
@@ -34,6 +33,7 @@ const UIStrings = {
   /** The type of an Issue in Chrome DevTools when a site has large ads that use up a lot of the browser's resources. */
   issueTypeHeavyAds: 'Heavy resource usage by ads',
 };
+/* eslint-enable max-len */
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 

--- a/lighthouse-core/audits/valid-source-maps.js
+++ b/lighthouse-core/audits/valid-source-maps.js
@@ -120,12 +120,7 @@ class ValidSourceMaps extends Audit {
     /** @type {LH.Audit.Details.TableColumnHeading[]} */
     const headings = [
       /* eslint-disable max-len */
-      {
-        key: 'scriptUrl',
-        itemType: 'url',
-        subItemsHeading: {key: 'error'},
-        text: str_(i18n.UIStrings.columnURL),
-      },
+      {key: 'scriptUrl', itemType: 'url', subItemsHeading: {key: 'error'}, text: str_(i18n.UIStrings.columnURL)},
       {key: 'sourceMapUrl', itemType: 'url', text: str_(UIStrings.columnMapURL)},
       /* eslint-enable max-len */
     ];

--- a/lighthouse-core/computed/js-bundles.js
+++ b/lighthouse-core/computed/js-bundles.js
@@ -54,7 +54,6 @@ function computeGeneratedFileSizes(map, content) {
     let mappingLength = 0;
     if (lastColNum !== undefined) {
       if (lastColNum > line.length) {
-        // eslint-disable-next-line max-len
         const errorMessage =
           `${map.url()} mapping for last column out of bounds: ${lineNum + 1}:${lastColNum}`;
         log.error('JSBundles', errorMessage);

--- a/lighthouse-core/computed/trace-of-tab.js
+++ b/lighthouse-core/computed/trace-of-tab.js
@@ -25,6 +25,7 @@ class TraceOfTab {
   }
 }
 
-log.warn(`trace-of-tab`, `trace-of-tab is deprecated, use processed-trace / processed-navigation instead`); // eslint-disable-line max-len
+// eslint-disable-next-line max-len
+log.warn(`trace-of-tab`, `trace-of-tab is deprecated, use processed-trace / processed-navigation instead`);
 module.exports = makeComputedArtifact(TraceOfTab);
 

--- a/lighthouse-core/config/constants.js
+++ b/lighthouse-core/config/constants.js
@@ -81,9 +81,10 @@ const screenEmulationMetrics = {
   desktop: DESKTOP_EMULATION_METRICS,
 };
 
-
-const MOTOG4_USERAGENT = 'Mozilla/5.0 (Linux; Android 7.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4695.0 Mobile Safari/537.36 Chrome-Lighthouse'; // eslint-disable-line max-len
-const DESKTOP_USERAGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4695.0 Safari/537.36 Chrome-Lighthouse'; // eslint-disable-line max-len
+/* eslint-disable max-len */
+const MOTOG4_USERAGENT = 'Mozilla/5.0 (Linux; Android 7.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4695.0 Mobile Safari/537.36 Chrome-Lighthouse';
+const DESKTOP_USERAGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4695.0 Safari/537.36 Chrome-Lighthouse';
+/* eslint-enable max-len */
 
 const userAgents = {
   mobile: MOTOG4_USERAGENT,

--- a/lighthouse-core/fraggle-rock/config/config.js
+++ b/lighthouse-core/fraggle-rock/config/config.js
@@ -9,7 +9,7 @@ const path = require('path');
 const log = require('lighthouse-logger');
 const Runner = require('../../runner.js');
 const defaultConfig = require('./default-config.js');
-const {defaultNavigationConfig, nonSimulatedPassConfigOverrides} = require('../../config/constants.js'); // eslint-disable-line max-len
+const {defaultNavigationConfig, nonSimulatedPassConfigOverrides} = require('../../config/constants.js');
 const {
   isFRGathererDefn,
   throwInvalidDependencyOrder,

--- a/lighthouse-core/fraggle-rock/config/validation.js
+++ b/lighthouse-core/fraggle-rock/config/validation.js
@@ -50,7 +50,8 @@ function assertValidPluginName(configJSON, pluginName) {
   }
 
   if (configJSON.categories && configJSON.categories[pluginName]) {
-    throw new Error(`plugin name '${pluginName}' not allowed because it is the id of a category already found in config`); // eslint-disable-line max-len
+    // eslint-disable-next-line max-len
+    throw new Error(`plugin name '${pluginName}' not allowed because it is the id of a category already found in config`);
   }
 }
 

--- a/lighthouse-core/gather/driver/navigation.js
+++ b/lighthouse-core/gather/driver/navigation.js
@@ -7,7 +7,7 @@
 
 const log = require('lighthouse-logger');
 const NetworkMonitor = require('./network-monitor.js');
-const {waitForFullyLoaded, waitForFrameNavigated, waitForUserToContinue} = require('./wait-for-condition.js'); // eslint-disable-line max-len
+const {waitForFullyLoaded, waitForFrameNavigated, waitForUserToContinue} = require('./wait-for-condition.js');
 const constants = require('../../config/constants.js');
 const i18n = require('../../lib/i18n/i18n.js');
 const URL = require('../../lib/url-shim.js');

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -326,7 +326,8 @@ class ImageElements extends FRGatherer {
     }
 
     if (reachedGatheringBudget) {
-      log.warn('ImageElements', `Reached gathering budget of 5s. Skipped extra details for ${skippedCount}/${elements.length}`); // eslint-disable-line max-len
+      // eslint-disable-next-line max-len
+      log.warn('ImageElements', `Reached gathering budget of 5s. Skipped extra details for ${skippedCount}/${elements.length}`);
     }
   }
 

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -88,6 +88,7 @@ const UIStrings = {
    * */
   oldChromeDoesNotSupportFeature: 'This version of Chrome is too old to support \'{featureName}\'. Use a newer version to see full results.',
 };
+/* eslint-enable max-len */
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
@@ -199,7 +200,8 @@ class LighthouseError extends Error {
       if (possibleError.sentinel === LHERROR_SENTINEL) {
         // Include sentinel in destructuring so it doesn't end up in `properties`.
         // eslint-disable-next-line no-unused-vars
-        const {sentinel, code, stack, ...properties} = /** @type {SerializedLighthouseError} */ (possibleError);
+        const {sentinel, code, stack, ...properties} =
+          /** @type {SerializedLighthouseError} */ (possibleError);
         const errorDefinition = LighthouseError.errors[/** @type {keyof typeof ERRORS} */ (code)];
         const lhError = new LighthouseError(errorDefinition, properties);
         lhError.stack = stack;

--- a/lighthouse-core/lib/minification-estimator.js
+++ b/lighthouse-core/lib/minification-estimator.js
@@ -6,7 +6,6 @@
 'use strict';
 
 // https://www.ecma-international.org/ecma-262/9.0/index.html#sec-punctuators
-// eslint-disable-next-line max-len
 const PUNCTUATOR_REGEX = /(return|case|{|\(|\[|\.\.\.|;|,|<|>|<=|>=|==|!=|===|!==|\+|-|\*|%|\*\*|\+\+|--|<<|>>|>>>|&|\||\^|!|~|&&|\|\||\?|:|=|\+=|-=|\*=|%=|\*\*=|<<=|>>=|>>>=|&=|\|=|\^=|=>|\/|\/=|\})$/;
 const WHITESPACE_REGEX = /( |\n|\t)+$/;
 

--- a/lighthouse-core/scripts/lantern/run-on-all-assets.js
+++ b/lighthouse-core/scripts/lantern/run-on-all-assets.js
@@ -55,5 +55,5 @@ for (const site of expectations.sites) {
   }
 }
 
-// eslint-disable-next-line max-len
-fs.writeFileSync(constants.SITE_INDEX_WITH_GOLDEN_WITH_COMPUTED_PATH, JSON.stringify(expectations, null, 2));
+fs.writeFileSync(
+  constants.SITE_INDEX_WITH_GOLDEN_WITH_COMPUTED_PATH, JSON.stringify(expectations, null, 2));

--- a/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const RenderBlockingResourcesAudit = require('../../../audits/byte-efficiency/render-blocking-resources.js'); // eslint-disable-line max-len
+const RenderBlockingResourcesAudit = require('../../../audits/byte-efficiency/render-blocking-resources.js');
 
 const mobileSlow4G = require('../../../config/constants.js').throttling.mobileSlow4G;
 const NetworkNode = require('../../../lib/dependency-graph/network-node.js');

--- a/lighthouse-core/test/audits/metrics-test.js
+++ b/lighthouse-core/test/audits/metrics-test.js
@@ -15,10 +15,12 @@ const lcpTrace = require('../fixtures/traces/lcp-m78.json');
 const lcpDevtoolsLog = require('../fixtures/traces/lcp-m78.devtools.log.json');
 
 const lcpAllFramesTrace = require('../fixtures/traces/frame-metrics-m89.json');
-const lcpAllFramesDevtoolsLog = require('../fixtures/traces/frame-metrics-m89.devtools.log.json'); // eslint-disable-line max-len
+// eslint-disable-next-line max-len
+const lcpAllFramesDevtoolsLog = require('../fixtures/traces/frame-metrics-m89.devtools.log.json');
 
 const clsAllFramesTrace = require('../fixtures/traces/frame-metrics-m90.json');
-const clsAllFramesDevtoolsLog = require('../fixtures/traces/frame-metrics-m90.devtools.log.json'); // eslint-disable-line max-len
+// eslint-disable-next-line max-len
+const clsAllFramesDevtoolsLog = require('../fixtures/traces/frame-metrics-m90.devtools.log.json');
 
 const jumpyClsTrace = require('../fixtures/traces/jumpy-cls-m90.json');
 const jumpyClsDevtoolsLog = require('../fixtures/traces/jumpy-cls-m90.devtoolslog.json');

--- a/lighthouse-core/test/audits/metrics-test.js
+++ b/lighthouse-core/test/audits/metrics-test.js
@@ -15,11 +15,9 @@ const lcpTrace = require('../fixtures/traces/lcp-m78.json');
 const lcpDevtoolsLog = require('../fixtures/traces/lcp-m78.devtools.log.json');
 
 const lcpAllFramesTrace = require('../fixtures/traces/frame-metrics-m89.json');
-// eslint-disable-next-line max-len
 const lcpAllFramesDevtoolsLog = require('../fixtures/traces/frame-metrics-m89.devtools.log.json');
 
 const clsAllFramesTrace = require('../fixtures/traces/frame-metrics-m90.json');
-// eslint-disable-next-line max-len
 const clsAllFramesDevtoolsLog = require('../fixtures/traces/frame-metrics-m90.devtools.log.json');
 
 const jumpyClsTrace = require('../fixtures/traces/jumpy-cls-m90.json');

--- a/lighthouse-core/test/audits/seo/tap-targets-test.js
+++ b/lighthouse-core/test/audits/seo/tap-targets-test.js
@@ -221,7 +221,7 @@ describe('SEO: Tap targets audit', () => {
     assert.equal(auditResult.score, 0);
 
     expect(auditResult.explanation).toBeDisplayString(
-      /* eslint-disable max-len */
+      // eslint-disable-next-line max-len
       'Tap targets are too small because there\'s no viewport meta tag optimized for mobile screens');
   });
 

--- a/lighthouse-core/test/audits/unsized-images-test.js
+++ b/lighthouse-core/test/audits/unsized-images-test.js
@@ -434,8 +434,7 @@ describe('Sized images audit', () => {
       expect(result.score).toEqual(1);
     });
 
-    it('passes when an image has nonexplicit css width & height, and valid attribute width & height', // eslint-disable-line max-len
-    async () => {
+    it('passes when an image has nonexplicit css width & height, and valid attribute width & height', async () => {
       const result = await runAudit({
         attributeWidth: '100',
         attributeHeight: '100',
@@ -460,8 +459,8 @@ describe('Sized images audit', () => {
       expect(result.score).toEqual(1);
     });
 
-    it('fails when an image has invalid attribute width & height, and nonexplicit css width & height', // eslint-disable-line max-len
-    async () => {
+    // eslint-disable-next-line max-len
+    it('fails when an image has invalid attribute width & height, and nonexplicit css width & height', async () => {
       const result = await runAudit({
         attributeWidth: '-200',
         attributeHeight: '-200',

--- a/lighthouse-core/test/audits/unsized-images-test.js
+++ b/lighthouse-core/test/audits/unsized-images-test.js
@@ -459,7 +459,6 @@ describe('Sized images audit', () => {
       expect(result.score).toEqual(1);
     });
 
-    // eslint-disable-next-line max-len
     it('fails when an image has invalid attribute width & height, and nonexplicit css width & height', async () => {
       const result = await runAudit({
         attributeWidth: '-200',

--- a/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
+++ b/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const CumulativeLayoutShift = require('../../../computed/metrics/cumulative-layout-shift.js'); // eslint-disable-line max-len
+const CumulativeLayoutShift = require('../../../computed/metrics/cumulative-layout-shift.js');
 const jumpyClsTrace = require('../../fixtures/traces/jumpy-cls-m90.json');
 const oldMetricsTrace = require('../../fixtures/traces/frame-metrics-m89.json');
 const allFramesMetricsTrace = require('../../fixtures/traces/frame-metrics-m90.json');

--- a/lighthouse-core/test/computed/metrics/first-contentful-paint-all-frames-test.js
+++ b/lighthouse-core/test/computed/metrics/first-contentful-paint-all-frames-test.js
@@ -5,8 +5,8 @@
  */
 'use strict';
 
-const FirstContentfulPaintAllFrames = require('../../../computed/metrics/first-contentful-paint-all-frames.js'); // eslint-disable-line max-len
-const FirstContentfulPaint = require('../../../computed/metrics/first-contentful-paint.js'); // eslint-disable-line max-len
+const FirstContentfulPaintAllFrames = require('../../../computed/metrics/first-contentful-paint-all-frames.js');
+const FirstContentfulPaint = require('../../../computed/metrics/first-contentful-paint.js');
 const trace = require('../../fixtures/traces/frame-metrics-m89.json');
 const devtoolsLog = require('../../fixtures/traces/frame-metrics-m89.devtools.log.json');
 

--- a/lighthouse-core/test/computed/metrics/first-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/first-contentful-paint-test.js
@@ -7,7 +7,7 @@
 
 const assert = require('assert').strict;
 
-const FirstContentfulPaint = require('../../../computed/metrics/first-contentful-paint.js'); // eslint-disable-line max-len
+const FirstContentfulPaint = require('../../../computed/metrics/first-contentful-paint.js');
 const trace = require('../../fixtures/traces/progressive-app-m60.json');
 const devtoolsLog = require('../../fixtures/traces/progressive-app-m60.devtools.log.json');
 

--- a/lighthouse-core/test/computed/metrics/lantern-first-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-first-contentful-paint-test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const LanternFirstContentfulPaint = require('../../../computed/metrics/lantern-first-contentful-paint.js'); // eslint-disable-line max-len
+const LanternFirstContentfulPaint = require('../../../computed/metrics/lantern-first-contentful-paint.js');
 const assert = require('assert').strict;
 
 const trace = require('../../fixtures/traces/progressive-app-m60.json');

--- a/lighthouse-core/test/computed/metrics/lantern-largest-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-largest-contentful-paint-test.js
@@ -9,7 +9,7 @@ const assert = require('assert').strict;
 
 const trace = require('../../fixtures/traces/lcp-m78.json');
 const devtoolsLog = require('../../fixtures/traces/lcp-m78.devtools.log.json');
-const LanternLargestContentfulPaint = require('../../../computed/metrics/lantern-largest-contentful-paint.js'); // eslint-disable-line max-len
+const LanternLargestContentfulPaint = require('../../../computed/metrics/lantern-largest-contentful-paint.js');
 
 /* eslint-env jest */
 describe('Metrics: Lantern LCP', () => {

--- a/lighthouse-core/test/computed/metrics/largest-contentful-paint-all-frames-test.js
+++ b/lighthouse-core/test/computed/metrics/largest-contentful-paint-all-frames-test.js
@@ -7,7 +7,7 @@
 
 const assert = require('assert').strict;
 
-const LargestContentfulPaintAllFrames = require('../../../computed/metrics/largest-contentful-paint-all-frames.js'); // eslint-disable-line max-len
+const LargestContentfulPaintAllFrames = require('../../../computed/metrics/largest-contentful-paint-all-frames.js');
 const traceAllFrames = require('../../fixtures/traces/frame-metrics-m89.json');
 const devtoolsLogAllFrames = require('../../fixtures/traces/frame-metrics-m89.devtools.log.json');
 const traceMainFrame = require('../../fixtures/traces/lcp-m78.json');
@@ -23,7 +23,8 @@ describe('Metrics: LCP from all frames', () => {
   it('should throw for predicted value', async () => {
     const settings = {throttlingMethod: 'simulate'};
     const context = {settings, computedCache: new Map()};
-    const resultPromise = LargestContentfulPaintAllFrames.request({gatherContext, trace: traceAllFrames, devtoolsLog: devtoolsLogAllFrames, settings}, context); // eslint-disable-line max-len
+    // eslint-disable-next-line max-len
+    const resultPromise = LargestContentfulPaintAllFrames.request({gatherContext, trace: traceAllFrames, devtoolsLog: devtoolsLogAllFrames, settings}, context);
 
     // TODO: Implement lantern solution for LCP all frames.
     expect(resultPromise).rejects.toThrow();
@@ -32,7 +33,8 @@ describe('Metrics: LCP from all frames', () => {
   it('should compute an observed value', async () => {
     const settings = {throttlingMethod: 'provided'};
     const context = {settings, computedCache: new Map()};
-    const result = await LargestContentfulPaintAllFrames.request({gatherContext, trace: traceAllFrames, devtoolsLog: devtoolsLogAllFrames, settings}, context); // eslint-disable-line max-len
+    // eslint-disable-next-line max-len
+    const result = await LargestContentfulPaintAllFrames.request({gatherContext, trace: traceAllFrames, devtoolsLog: devtoolsLogAllFrames, settings}, context);
 
     assert.equal(Math.round(result.timing), 683);
     assert.equal(result.timestamp, 23466705983);

--- a/lighthouse-core/test/computed/metrics/largest-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/largest-contentful-paint-test.js
@@ -7,7 +7,7 @@
 
 const assert = require('assert').strict;
 
-const LargestContentfulPaint = require('../../../computed/metrics/largest-contentful-paint.js'); // eslint-disable-line max-len
+const LargestContentfulPaint = require('../../../computed/metrics/largest-contentful-paint.js');
 const trace = require('../../fixtures/traces/lcp-m78.json');
 const devtoolsLog = require('../../fixtures/traces/lcp-m78.devtools.log.json');
 const invalidTrace = require('../../fixtures/traces/progressive-app-m60.json');

--- a/lighthouse-core/test/computed/metrics/speed-index-test.js
+++ b/lighthouse-core/test/computed/metrics/speed-index-test.js
@@ -11,7 +11,7 @@ const SpeedIndex = require('../../../computed/metrics/speed-index.js');
 const trace = require('../../fixtures/traces/progressive-app-m60.json');
 const devtoolsLog = require('../../fixtures/traces/progressive-app-m60.devtools.log.json');
 const trace1msLayout = require('../../fixtures/traces/speedindex-1ms-layout-m84.trace.json');
-const devtoolsLog1msLayout = require('../../fixtures/traces/speedindex-1ms-layout-m84.devtoolslog.json'); // eslint-disable-line max-len
+const devtoolsLog1msLayout = require('../../fixtures/traces/speedindex-1ms-layout-m84.devtoolslog.json');
 
 /* eslint-env jest */
 

--- a/lighthouse-core/test/computed/viewport-meta-test.js
+++ b/lighthouse-core/test/computed/viewport-meta-test.js
@@ -19,7 +19,6 @@ describe('ViewportMeta computed artifact', () => {
     assert.equal(isMobileOptimized, false);
   });
 
-  /* eslint-disable-next-line max-len */
   it('is not mobile optimized when HTML contains a non-mobile friendly viewport meta tag', async () => {
     const viewport = 'maximum-scale=1';
     const {hasViewportTag, isMobileOptimized} =
@@ -44,7 +43,6 @@ describe('ViewportMeta computed artifact', () => {
     assert.equal(parserWarnings[0], 'Invalid values found: {"initial-scale":"microscopic"}');
   });
 
-  /* eslint-disable-next-line max-len */
   it('is not mobile optimized when HTML contains an invalid viewport meta tag key and value', async () => {
     const viewport = 'nonsense=true, initial-scale=microscopic';
     const {isMobileOptimized, parserWarnings} =

--- a/lighthouse-core/test/config/budget-test.js
+++ b/lighthouse-core/test/config/budget-test.js
@@ -204,7 +204,6 @@ describe('Budget', () => {
     it('throws when an invalid resource type is supplied', () => {
       budgets[0].resourceSizes[0].resourceType = 'movies';
       assert.throws(_ => Budget.initializeBudget(budgets),
-        // eslint-disable-next-line max-len
         /Invalid resource type: movies. \nValid resource types are: total, document,/);
     });
 
@@ -254,7 +253,6 @@ describe('Budget', () => {
     it('throws when an invalid metric is supplied', () => {
       budgets[0].timings[0].metric = 'medianMeaningfulPaint';
       assert.throws(_ => Budget.initializeBudget(budgets),
-        // eslint-disable-next-line max-len
         /Invalid timing metric: medianMeaningfulPaint. \nValid timing metrics are: first-contentful-paint, /);
     });
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -1097,7 +1097,7 @@ describe('Config', () => {
         },
       };
       assert.throws(() => new Config(configJson, {configPath: configFixturePath}),
-        /^Error: plugin name 'lighthouse-plugin-simple' not allowed because it is the id of a category/); // eslint-disable-line max-len
+        /^Error: plugin name 'lighthouse-plugin-simple' not allowed because it is the id of a category/);
     });
   });
 

--- a/lighthouse-core/test/fraggle-rock/gather/base-artifacts-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/base-artifacts-test.js
@@ -19,7 +19,8 @@ function getMockDriverForArtifacts() {
   const driverMock = createMockDriver();
   driverMock._executionContext.evaluate.mockResolvedValue(500);
   driverMock._session.sendCommand.mockResponse('Browser.getVersion', {
-    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36', // eslint-disable-line max-len
+    // eslint-disable-next-line max-len
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36',
     product: 'Chrome/92.0.4515.159',
   });
   return driverMock;

--- a/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
@@ -8,7 +8,7 @@
 const helpers = require('../../../fraggle-rock/gather/runner-helpers.js');
 const Gatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const {defaultSettings} = require('../../../config/constants.js');
-const {createMockDriver, createMockGathererInstance, createMockBaseArtifacts} = require('./mock-driver.js'); // eslint-disable-line max-len
+const {createMockDriver, createMockGathererInstance, createMockBaseArtifacts} = require('./mock-driver.js');
 
 /* eslint-env jest */
 

--- a/lighthouse-core/test/gather/driver/navigation-test.js
+++ b/lighthouse-core/test/gather/driver/navigation-test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const {createMockDriver, mockTargetManagerModule} = require('../../fraggle-rock/gather/mock-driver.js'); // eslint-disable-line max-len
+const {createMockDriver, mockTargetManagerModule} = require('../../fraggle-rock/gather/mock-driver.js');
 const targetManagerMock = mockTargetManagerModule();
 
 const {gotoURL, getNavigationWarnings} = require('../../../gather/driver/navigation.js');

--- a/lighthouse-core/test/gather/driver/network-monitor-test.js
+++ b/lighthouse-core/test/gather/driver/network-monitor-test.js
@@ -168,8 +168,10 @@ describe('NetworkMonitor', () => {
 
       const type = 'Navigation';
       const frame = /** @type {*} */ ({id: '1', url: 'https://page.example.com'});
-      sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame: {...frame, url: '1'}, type}}); // eslint-disable-line max-len
-      sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame: {...frame, url: '2'}, type}}); // eslint-disable-line max-len
+      // eslint-disable-next-line max-len
+      sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame: {...frame, url: '1'}, type}});
+      // eslint-disable-next-line max-len
+      sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame: {...frame, url: '2'}, type}});
       sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame, type}});
 
       expect(await monitor.getFinalNavigationUrl()).toEqual('https://page.example.com');

--- a/lighthouse-core/test/gather/gatherers/image-elements-test.js
+++ b/lighthouse-core/test/gather/gatherers/image-elements-test.js
@@ -15,7 +15,7 @@ const {
   createMockSession,
 } = require('../../fraggle-rock/gather/mock-driver.js');
 
-const devtoolsLog = /** @type {LH.DevtoolsLog} */ (require('../../fixtures/traces/lcp-m78.devtools.log.json')); // eslint-disable-line max-len
+const devtoolsLog = /** @type {LH.DevtoolsLog} */ (require('../../fixtures/traces/lcp-m78.devtools.log.json'));
 const networkRecords = NetworkRecorder.recordsFromLogs(devtoolsLog);
 
 jest.useFakeTimers();

--- a/lighthouse-core/test/gather/gatherers/link-elements-test.js
+++ b/lighthouse-core/test/gather/gatherers/link-elements-test.js
@@ -69,7 +69,7 @@ describe('Link Elements gatherer', () => {
     const result = await new LinkElements().afterPass(...getPassData({headers}));
     expect(result).toEqual([
       link({source: 'headers', rel: 'prefetch', href: 'https://example.com/', as: 'image'}),
-      link({source: 'headers', rel: 'preconnect', href: 'https://example.com/', crossOrigin: 'anonymous'}), // eslint-disable-line max-len
+      link({source: 'headers', rel: 'preconnect', href: 'https://example.com/', crossOrigin: 'anonymous'}),
       link({source: 'headers', rel: 'preload', href: 'https://example.com/style.css'}),
       link({source: 'headers', rel: 'canonical', href: 'https://example.com/', hrefRaw: '/'}),
       link({source: 'headers', rel: 'alternate', href: 'https://example.com/', hreflang: 'xx'}),

--- a/lighthouse-core/test/lib/line-number-from-jsonld-path-test.js
+++ b/lighthouse-core/test/lib/line-number-from-jsonld-path-test.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const assert = require('assert').strict;
-const getLineNumberFromJsonLDPath = require('../../lib/sd-validation/line-number-from-jsonld-path.js'); // eslint-disable-line max-len
+const getLineNumberFromJsonLDPath = require('../../lib/sd-validation/line-number-from-jsonld-path.js');
 
 /* global describe, it */
 describe('getLineNumberFromJsonLDPath', () => {

--- a/lighthouse-core/test/lib/minification-estimator-test.js
+++ b/lighthouse-core/test/lib/minification-estimator-test.js
@@ -7,7 +7,7 @@
 
 const fs = require('fs');
 const assert = require('assert').strict;
-const {computeCSSTokenLength, computeJSTokenLength} = require('../../lib/minification-estimator.js'); // eslint-disable-line max-len
+const {computeCSSTokenLength, computeJSTokenLength} = require('../../lib/minification-estimator.js');
 
 const angularJs = fs.readFileSync(require.resolve('angular/angular.js'), 'utf8');
 const courseheroFilename = `${__dirname}/../../test/fixtures/source-maps/coursehero-bundle-2.js`;

--- a/lighthouse-core/test/lib/page-functions-test.js
+++ b/lighthouse-core/test/lib/page-functions-test.js
@@ -54,8 +54,8 @@ describe('Page Functions', () => {
         __failedInBrowser: true,
         name: 'Error',
         message: errMsg,
-        // eslint-disable-next-line max-len
-        stack: expect.stringMatching(/^Error:.*wrapRuntimeEvalErrorInBrowser.*page-functions\.js:\d+:\d+/s),
+        stack: expect.stringMatching(
+          /^Error:.*wrapRuntimeEvalErrorInBrowser.*page-functions\.js:\d+:\d+/s),
       });
     });
 
@@ -65,8 +65,8 @@ describe('Page Functions', () => {
         __failedInBrowser: true,
         name: 'Error',
         message: 'unknown error',
-        // eslint-disable-next-line max-len
-        stack: expect.stringMatching(/^Error:.*wrapRuntimeEvalErrorInBrowser.*page-functions\.js:\d+:\d+/s),
+        stack: expect.stringMatching(
+          /^Error:.*wrapRuntimeEvalErrorInBrowser.*page-functions\.js:\d+:\d+/s),
       });
     });
   });

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -236,7 +236,7 @@ describe('Main Thread Tasks', () => {
         ts: baseTs + 85e3,
         dur: 15e3,
         ...xhr('urlXHR', 4, ['urlC']),
-      }, // eslint-disable-line max-len
+      },
       {ph: 'X', name: 'TaskC', ts: baseTs + 89e3, dur: 4e3},
     ];
 
@@ -283,7 +283,7 @@ describe('Main Thread Tasks', () => {
         ts: baseTs + 51e3,
         dur: 15e3,
         ...stackTrace('B', ['urlB']),
-      }, // eslint-disable-line max-len
+      },
       {ph: 'X', name: 'TaskC', pid, tid, ts: baseTs + 90e3, dur: 5e3},
       {ph: 'X', name: 'Layout', pid, tid, ts: baseTs + 90e3, dur: 4e3, ...frame('B')},
     ];

--- a/lighthouse-core/test/lib/tracehouse/trace-processor-test.js
+++ b/lighthouse-core/test/lib/tracehouse/trace-processor-test.js
@@ -592,6 +592,7 @@ Object {
       it('in a trace', () => {
         const trace = TraceProcessor.processTrace(lcpAllFramesTrace);
         const navigation = TraceProcessor.processNavigation(trace);
+        /* eslint-disable max-len */
         expect({
           // Main frame
           'mainFrameIds.frameId': trace.mainFrameIds.frameId,
@@ -604,10 +605,10 @@ Object {
           // All frames
           'firstContentfulPaintAllFramesEvt.ts': navigation.firstContentfulPaintAllFramesEvt.ts,
           'largestContentfulPaintAllFramesEvt.ts': navigation.largestContentfulPaintAllFramesEvt.ts,
-          'timestamps.firstContentfulPaintAllFrames': navigation.timestamps.firstContentfulPaintAllFrames, // eslint-disable-line max-len
-          'timestamps.largestContentfulPaintAllFrames': navigation.timestamps.largestContentfulPaintAllFrames, // eslint-disable-line max-len
+          'timestamps.firstContentfulPaintAllFrames': navigation.timestamps.firstContentfulPaintAllFrames,
+          'timestamps.largestContentfulPaintAllFrames': navigation.timestamps.largestContentfulPaintAllFrames,
           'timings.firstContentfulPaintAllFrames': navigation.timings.firstContentfulPaintAllFrames,
-          'timings.largestContentfulPaintAllFrames': navigation.timings.largestContentfulPaintAllFrames, // eslint-disable-line max-len
+          'timings.largestContentfulPaintAllFrames': navigation.timings.largestContentfulPaintAllFrames,
         }).toMatchInlineSnapshot(`
           Object {
             "firstContentfulPaintAllFramesEvt.ts": 23466705983,
@@ -625,6 +626,7 @@ Object {
             "timings.largestContentfulPaintAllFrames": 682.853,
           }
         `);
+        /* eslint-enable max-len */
       });
 
       it('finds FCP from all frames', () => {

--- a/lighthouse-core/test/scripts/i18n/bake-ctc-to-lhl-test.js
+++ b/lighthouse-core/test/scripts/i18n/bake-ctc-to-lhl-test.js
@@ -73,8 +73,8 @@ describe('Baking Placeholders', () => {
         },
       },
     };
-    // eslint-disable-next-line max-len
-    expect(() => bakery.bakePlaceholders(strings)).toThrow(/Message "Hello `World` \$MARKDOWN_SNIPPET_1\$" is missing placeholder\(s\): \$MARKDOWN_SNIPPET_1\$/);
+    expect(() => bakery.bakePlaceholders(strings)).toThrow(
+      /Message "Hello `World` \$MARKDOWN_SNIPPET_1\$" is missing placeholder\(s\): \$MARKDOWN_SNIPPET_1\$/);
   });
 
   it('throws when a placeholder is not in string', () => {

--- a/lighthouse-core/test/scripts/i18n/collect-strings-test.js
+++ b/lighthouse-core/test/scripts/i18n/collect-strings-test.js
@@ -333,7 +333,6 @@ describe('parseUIStrings', () => {
 });
 
 describe('#_lhlValidityChecks', () => {
-  /* eslint-disable max-len */
   it('errors when using non-supported custom-formatted ICU format', () => {
     const message = 'Hello World took {var, badFormat, milliseconds}.';
     expect(() => collect.convertMessageToCtc(message)).toThrow(
@@ -347,6 +346,7 @@ describe('#_lhlValidityChecks', () => {
   });
 
   it('errors when there is content outside of a select argument', () => {
+    // eslint-disable-next-line max-len
     const message = '{user_gender, select, female {They} male {They} other {They}} were trying to block the main thread';
     expect(() => collect.convertMessageToCtc(message)).toThrow(
       /Content cannot appear outside plural or select ICU messages.*were trying to block the main thread'\)$/);
@@ -359,6 +359,7 @@ describe('#_lhlValidityChecks', () => {
   });
 
   it('errors when there another argument outside of a plural argument', () => {
+    // eslint-disable-next-line max-len
     const message = '{count, plural, =1 {1 request} other {# requests}}{count, plural, =1 {1 request} other {# requests}}';
     expect(() => collect.convertMessageToCtc(message)).toThrow(
       /Content cannot appear outside plural or select ICU messages.*=1 {1 request} other {# requests}}'\)$/);
@@ -379,7 +380,6 @@ describe('#_lhlValidityChecks', () => {
     expect(() => collect.convertMessageToCtc(message, {name: 'Elbert'})).toThrow(
       /Content cannot appear outside plural or select ICU messages.*\(message: 'Ms. {name} received {count, plural, =1 {one award.} other {# awards.}}'\)$/);
   });
-  /* eslint-enable max-len */
 });
 
 describe('Convert Message to Placeholder', () => {

--- a/lighthouse-core/util-commonjs.js
+++ b/lighthouse-core/util-commonjs.js
@@ -561,6 +561,7 @@ Util.getUniqueSuffix = (() => {
   };
 })();
 
+/* eslint-disable max-len */
 /**
  * Report-renderer-specific strings.
  */
@@ -660,7 +661,7 @@ const UIStrings = {
   /** Descriptive label that this analysis only considers the initial load of the page, and no interaction beyond when the page had "fully loaded" */
   runtimeAnalysisWindow: 'Initial page load',
   /** Descriptive explanation that this analysis run was from a single pageload of a browser, whereas field data often summarizes hundreds+ of page loads */
-  runtimeSingleLoadTooltip: 'This data is taken from a single page load, as opposed to field data summarizing many sessions.', // eslint-disable-line max-len
+  runtimeSingleLoadTooltip: 'This data is taken from a single page load, as opposed to field data summarizing many sessions.',
 
   /** Descriptive explanation for environment throttling that was provided by the runtime environment instead of provided by Lighthouse throttling. */
   throttlingProvided: 'Provided by environment',
@@ -677,6 +678,8 @@ const UIStrings = {
   /** Label indicating that Lighthouse throttled the page using custom throttling settings. */
   runtimeCustom: 'Custom throttling',
 };
+/* eslint-enable max-len */
+
 Util.UIStrings = UIStrings;
 
 module.exports = {

--- a/report/renderer/util.js
+++ b/report/renderer/util.js
@@ -558,6 +558,7 @@ Util.getUniqueSuffix = (() => {
   };
 })();
 
+/* eslint-disable max-len */
 /**
  * Report-renderer-specific strings.
  */
@@ -657,7 +658,7 @@ const UIStrings = {
   /** Descriptive label that this analysis only considers the initial load of the page, and no interaction beyond when the page had "fully loaded" */
   runtimeAnalysisWindow: 'Initial page load',
   /** Descriptive explanation that this analysis run was from a single pageload of a browser, whereas field data often summarizes hundreds+ of page loads */
-  runtimeSingleLoadTooltip: 'This data is taken from a single page load, as opposed to field data summarizing many sessions.', // eslint-disable-line max-len
+  runtimeSingleLoadTooltip: 'This data is taken from a single page load, as opposed to field data summarizing many sessions.',
 
   /** Descriptive explanation for environment throttling that was provided by the runtime environment instead of provided by Lighthouse throttling. */
   throttlingProvided: 'Provided by environment',
@@ -674,6 +675,8 @@ const UIStrings = {
   /** Label indicating that Lighthouse throttled the page using custom throttling settings. */
   runtimeCustom: 'Custom throttling',
 };
+/* eslint-enable max-len */
+
 Util.UIStrings = UIStrings;
 
 export {

--- a/report/test/renderer/report-ui-features-test.js
+++ b/report/test/renderer/report-ui-features-test.js
@@ -210,7 +210,8 @@ describe('ReportUIFeatures', () => {
 
         function getUrlsInTable() {
           return dom
-            .findAll('#modern-image-formats tr:not(.lh-row--hidden) .lh-text__url a:first-child', container) // eslint-disable-line max-len
+            // eslint-disable-next-line max-len
+            .findAll('#modern-image-formats tr:not(.lh-row--hidden) .lh-text__url a:first-child', container)
             .map(el => el.textContent);
         }
 


### PR DESCRIPTION
Adds a new eslint rule (via `line-comment-position`) to enforce that `eslint-disable-line max-len` is not used, so that lines that are long aren't made even longer. SOCW (save our column widths)

Also begin ignore max-len for import/requires/it/regex.

Also deleted a few comments that weren't even over the max limit, and removed a few where readability was not damaged by reformatting the code.