### PR TITLE
misc(build): prevent over optimization of computeBenchmarkIndex

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -161,6 +161,14 @@ async function build(entryPath, distPath, opts = {minify: true}) {
       }),
       rollupPlugins.nodePolyfills(),
       rollupPlugins.nodeResolve({preferBuiltins: true}),
+      // Protect the sanctity of computeBenchmarkIndex.
+      {
+        name: 'no-treeshaking-for-eval',
+        transform(code, id) {
+          if (!id.endsWith('/page-functions.js')) return;
+          return {moduleSideEffects: 'no-treeshake'};
+        },
+      },
       // Rollup sees the usages of these functions in page functions (ex: see AnchorElements)
       // and treats them as globals. Because the names are "taken" by the global, Rollup renames
       // the actual functions (getNodeDetails$1). The page functions expect a certain name, so

--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -161,14 +161,6 @@ async function build(entryPath, distPath, opts = {minify: true}) {
       }),
       rollupPlugins.nodePolyfills(),
       rollupPlugins.nodeResolve({preferBuiltins: true}),
-      // Protect the sanctity of computeBenchmarkIndex.
-      {
-        name: 'no-treeshaking',
-        transform(code, id) {
-          if (!id.endsWith('/page-functions.js')) return;
-          return {moduleSideEffects: 'no-treeshake'};
-        },
-      },
       // Rollup sees the usages of these functions in page functions (ex: see AnchorElements)
       // and treats them as globals. Because the names are "taken" by the global, Rollup renames
       // the actual functions (getNodeDetails$1). The page functions expect a certain name, so

--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -163,7 +163,7 @@ async function build(entryPath, distPath, opts = {minify: true}) {
       rollupPlugins.nodeResolve({preferBuiltins: true}),
       // Protect the sanctity of computeBenchmarkIndex.
       {
-        name: 'no-treeshaking-for-eval',
+        name: 'no-treeshaking',
         transform(code, id) {
           if (!id.endsWith('/page-functions.js')) return;
           return {moduleSideEffects: 'no-treeshake'};

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb/dbw-expectations.js
@@ -20,6 +20,7 @@ const expectations = {
     length: 28,
   },
   artifacts: {
+    BenchmarkIndex: '<10000',
     HostFormFactor: 'desktop',
     Stacks: [{
       id: 'jquery',

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -208,7 +208,7 @@ function computeBenchmarkIndex() {
 
     while (Date.now() - start < 500) {
       let s = '';
-      for (let j = 0; j < 10000; j++) s += 'a'; // eslint-disable-line no-unused-vars
+      for (let j = 0; j < 10000; j++) s += 'a';
       if (s.length === 1) throw new Error('will never happen, but prevents compiler optimizations');
 
       iterations++;

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -209,6 +209,7 @@ function computeBenchmarkIndex() {
     while (Date.now() - start < 500) {
       let s = '';
       for (let j = 0; j < 10000; j++) s += 'a'; // eslint-disable-line no-unused-vars
+      if (s.length === 1) throw new Error('will never happen, but prevents compiler optimizations');
 
       iterations++;
     }


### PR DESCRIPTION
Rollup was deleting the `for (let j = 0; j < 10000; j++) s += 'a';` line in the benchmark index function, resulting in a value of  500,000+ in bundled results.