### PR TITLE
report(treemap): correct percentages when 0 bytes JS

### DIFF
--- a/treemap/app/src/main.js
+++ b/treemap/app/src/main.js
@@ -589,7 +589,8 @@ class TreemapViewer {
     ];
 
     if (bytes !== undefined && total !== undefined) {
-      const percentStr = TreemapUtil.i18n.formatPercent(bytes / total);
+      const percent = total === 0 ? 1 : bytes / total;
+      const percentStr = TreemapUtil.i18n.formatPercent(percent);
       let str = `${TreemapUtil.i18n.formatBytesWithBestUnit(bytes)} (${percentStr})`;
       // Only add label for bytes on the root node.
       if (node === this.currentTreemapRoot) {


### PR DESCRIPTION
when there were 0 total bytes JS on a page, treemap will take percentages of that 0 and happily show you 

`https://example.com/ · Resource Bytes: 0 B (NaN%)`

We saw it on example.com, but also noticed by at least [one user](https://twitter.com/drag137/status/1460527535813537793).

The "correct" percentage is arguable but since there's just the one entry on the page 100% seemed more reasonable than 0%, since that just leaves you wondering where the rest of the 0 bytes are :)

Testing is awkward. I could change `debug.json` to include a subnode with 0 total but it seems fiddly (would the test have to click into the subtree to trigger this path?). Add a new pptr test just for this?

fixes #13383