### PR TITLE
core: ensure log-normal score is always in correct range

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,7 +88,7 @@ module.exports = {
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2019,
+    ecmaVersion: 2020,
     ecmaFeatures: {
       globalReturn: true,
       jsx: false,


### PR DESCRIPTION
The numerical accuracy part of #13316, laying the foundation for the rest.

As mentioned there, currently `getLogNormalScore({p10: 200, median: 600}, 200) === 0.8999999314038525`, which is < 0.9, so wouldn't be considered passing, even though 200 is ≥ the p10 threshold and so should be passing. In practice the scores are rounded to two decimal places so this change won't be observable, but if/when we change how the scores are rounded, this will be a problem.

Also, it's just wrong and should be fixed :)

This change ensures that for raw scores (before rounding):
- if `numericValue` is ≤ the `p10` control point, then the audit score will be ≥ 0.9
- if `numericValue` is > the `p10` control point, then the audit score will be < 0.9
- if `numericValue` is ≤ the `median` control point, then the audit score will be ≥ 0.5
- if `numericValue` is > the `median` control point, then the audit score will be < 0.5

This isn't changing anything drastically, it's more or less nudging the few values that were on the wrong side of the score thresholds to the correct one. For example, for TBT (p10 200, median 600):

### Before change
| numericValue | score |  |
| --- | --- | --- |
| 200.00000000000009 | 0.8999999314038524 | |
| 200.00000000000006 | 0.8999999314038524 | |
| 200.00000000000003 | 0.8999999314038525 | |
| 200 | 0.8999999314038525 | should be ≥ 0.9 here and below |
| 199.99999999999997 | 0.8999999314038525 | |
| 199.99999999999994 | 0.8999999314038525 | |
| 199.99999999999991 | 0.8999999314038525 | |
| ... | ... | |
| 199.99993298607302 | 0.8999999999999999 | |
| 199.99993298607299 | 0.9 | finally 0.9 |
| 199.99993298607296 | 0.9 | |
| 199.99993298607293 | 0.9 | |
| 199.99993298607290 | 0.9000000000000001 | |

The TBT score finally hits 0.9 at a `numericValue` of 199.99993298607299, going above 0.9 at 199.9999329860729.

The current score hits 0.9 for TBT values less than a tenth of a microsecond faster than 200ms, so in practice this is only a change for sites _at_ a TBT of 200ms. The other metrics have changes at a similar magnitude; this is more or less correcting the raw scores of values at exactly the p10 control points.

### After change
| numericValue | score | |
| --- | --- | --- |
| 200.00000000000009 | 0.8999999314038524 | |
| 200.00000000000006 | 0.8999999314038524 | |
| 200.00000000000003 | 0.8999999314038525 | |
| 200 | 0.9 | good now here and below |
| 199.99999999999997 | 0.9 | |
| 199.99999999999994 | 0.9 | |
| 199.99999999999991 | 0.9 | |
| ... | ... | |
| 199.99993298607302 | 0.9 | |
| 199.99993298607299 | 0.9 | unchanged here and below |
| 199.99993298607296 | 0.9 | |
| 199.99993298607293 | 0.9 | |
| 199.99993298607290 | 0.9000000000000001 | |

The scores at `numericValue ≤ 200` are Math.maxed to 0.9 while the others are unaffected. Once the score goes above 0.9 (still at 199.9999329860729) it proceeds as before, so it's really just this tiny range that has its scores changed from e.g. 0.8999999314038525 to 0.9.

For those that care, the scoring function is as monotonic as it's ever been†, there's just a bigger first derivative discontinuity.

†have not verified the Abramowitz and Stegun approximation