### PR TITLE
deps: update to typescript 4.5

### DIFF
--- a/build/build-report-components.js
+++ b/build/build-report-components.js
@@ -128,7 +128,7 @@ function compileTemplate(tmpEl) {
         continue;
       }
 
-      if (!(childNode instanceof /** @type {typeof Element} */ (window.Element))) {
+      if (!(childNode instanceof window.Element)) {
         throw new Error(`Expected ${childNode} to be an element`);
       }
       process(childNode);

--- a/clients/extension/scripts/popup.js
+++ b/clients/extension/scripts/popup.js
@@ -179,8 +179,7 @@ async function initPopup() {
 
   // Generate checkboxes from saved settings.
   generateOptionsList(settings);
-  const selectedDeviceEl = /** @type {HTMLInputElement} */ (
-    find(`.options__device input[value="${settings.device}"]`));
+  const selectedDeviceEl = find(`.options__device input[value="${settings.device}"]`);
   selectedDeviceEl.checked = true;
 
   generateReportButton.addEventListener('click', () => {

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -225,7 +225,7 @@ function getFlags(manualArgv, options = {}) {
       .options({
         'output': {
           type: 'array',
-          default: /** @type {['html']} */ (['html']),
+          default: /** @type {const} */ (['html']),
           coerce: coerceOutput,
           describe: 'Reporter for the results, supports multiple values. choices: "json", "html", "csv"',
         },
@@ -309,9 +309,9 @@ function getFlags(manualArgv, options = {}) {
       })
 
       // Choices added outside of `options()` and cast so tsc picks them up.
-      .choices('form-factor', /** @type {['mobile', 'desktop']} */ (['mobile', 'desktop']))
-      .choices('throttling-method', /** @type {['devtools', 'provided', 'simulate']} */ (['devtools', 'provided', 'simulate']))
-      .choices('preset', /** @type {['perf', 'experimental', 'desktop']} */ (['perf', 'experimental', 'desktop']))
+      .choices('form-factor', /** @type {const} */ (['mobile', 'desktop']))
+      .choices('throttling-method', /** @type {const} */ (['devtools', 'provided', 'simulate']))
+      .choices('preset', /** @type {const} */ (['perf', 'experimental', 'desktop']))
 
       .check(argv => {
         // Lighthouse doesn't need a URL if...

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects/redirects-config.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects/redirects-config.js
@@ -20,7 +20,7 @@ const config = {
       'redirects',
     ],
     // Use provided throttling method to test usage of correct navStart.
-    throttlingMethod: /** @type {'provided'} */ ('provided'),
+    throttlingMethod: /** @type {const} */ ('provided'),
   },
 };
 

--- a/lighthouse-core/audits/dobetterweb/js-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/js-libraries.js
@@ -61,7 +61,7 @@ class JsLibrariesAudit extends Audit {
     const details = Audit.makeTableDetails(headings, libDetails, {});
 
     const debugData = {
-      type: /** @type {'debugdata'} */ ('debugdata'),
+      type: /** @type {const} */ ('debugdata'),
       stacks: artifacts.Stacks.map(stack => {
         return {
           id: stack.id,

--- a/lighthouse-core/audits/seo/is-crawlable.js
+++ b/lighthouse-core/audits/seo/is-crawlable.js
@@ -126,9 +126,9 @@ class IsCrawlable extends Audit {
             const line = robotsTxt.getMatchingLineNumber(mainResource.url) || 1;
             blockingDirectives.push({
               source: {
-                type: /** @type {'source-location'} */ ('source-location'),
+                type: /** @type {const} */ ('source-location'),
                 url: robotsFileUrl.href,
-                urlProvider: /** @type {'network'} */ ('network'),
+                urlProvider: /** @type {const} */ ('network'),
                 line: line - 1,
                 column: 0,
               },

--- a/lighthouse-core/audits/third-party-summary.js
+++ b/lighthouse-core/audits/third-party-summary.js
@@ -216,12 +216,12 @@ class ThirdPartySummary extends Audit {
         return {
           ...stats,
           entity: {
-            type: /** @type {'link'} */ ('link'),
+            type: /** @type {const} */ ('link'),
             text: entity.name,
             url: entity.homepage || '',
           },
           subItems: {
-            type: /** @type {'subitems'} */ ('subitems'),
+            type: /** @type {const} */ ('subitems'),
             items: ThirdPartySummary.makeSubItems(entity, summaries, stats),
           },
         };

--- a/lighthouse-core/audits/valid-source-maps.js
+++ b/lighthouse-core/audits/valid-source-maps.js
@@ -110,7 +110,7 @@ class ValidSourceMaps extends Audit {
           scriptUrl: scriptElement.src,
           sourceMapUrl: sourceMap && sourceMap.sourceMapUrl,
           subItems: {
-            type: /** @type {'subitems'} */ ('subitems'),
+            type: /** @type {const} */ ('subitems'),
             items: errors,
           },
         });

--- a/lighthouse-core/computed/js-bundles.js
+++ b/lighthouse-core/computed/js-bundles.js
@@ -98,9 +98,7 @@ class JSBundles {
 
       const compiledUrl = SourceMap.scriptUrl || 'compiled.js';
       const mapUrl = SourceMap.sourceMapUrl || 'compiled.js.map';
-      // Hack: CDT expects undefined properties to be explicit.
-      const rawMapForCdt = /** @type {any} */ (rawMap);
-      const map = new SDK.TextSourceMap(compiledUrl, mapUrl, rawMapForCdt);
+      const map = new SDK.TextSourceMap(compiledUrl, mapUrl, rawMap);
 
       const content = scriptElement && scriptElement.content ? scriptElement.content : '';
       const sizes = computeGeneratedFileSizes(map, content);

--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -142,8 +142,8 @@ async function _collectDebugData(navigationContext, phaseState) {
 /**
  * @param {NavigationContext} navigationContext
  * @param {PhaseState} phaseState
- * @param {UnPromise<ReturnType<typeof _setupNavigation>>} setupResult
- * @param {UnPromise<ReturnType<typeof _navigate>>} navigateResult
+ * @param {Awaited<ReturnType<typeof _setupNavigation>>} setupResult
+ * @param {Awaited<ReturnType<typeof _navigate>>} navigateResult
  * @return {Promise<{finalUrl: string, artifacts: Partial<LH.GathererArtifacts>, warnings: Array<LH.IcuMessage>, pageLoadError: LH.LighthouseError | undefined}>}
  */
 async function _computeNavigationResult(

--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -195,7 +195,7 @@ async function _computeNavigationResult(
 async function _navigation(navigationContext) {
   const artifactState = getEmptyArtifactState();
   const phaseState = {
-    gatherMode: /** @type {'navigation'} */ ('navigation'),
+    gatherMode: /** @type {const} */ ('navigation'),
     driver: navigationContext.driver,
     computedCache: navigationContext.computedCache,
     artifactDefinitions: navigationContext.navigation.artifacts,

--- a/lighthouse-core/gather/driver/execution-context.js
+++ b/lighthouse-core/gather/driver/execution-context.js
@@ -166,7 +166,7 @@ class ExecutionContext {
    * @param {{args: T, useIsolation?: boolean, deps?: Array<Function|string>}} options `args` should
    *   match the args of `mainFn`, and can be any serializable value. `deps` are functions that must be
    *   defined for `mainFn` to work.
-   * @return {FlattenedPromise<R>}
+   * @return {Promise<Awaited<R>>}
    */
   evaluate(mainFn, options) {
     const argsSerialized = ExecutionContext.serializeArguments(options.args);

--- a/lighthouse-core/gather/gatherers/full-page-screenshot.js
+++ b/lighthouse-core/gather/gatherers/full-page-screenshot.js
@@ -16,19 +16,19 @@ const pageFunctions = require('../../lib/page-functions.js');
 const FULL_PAGE_SCREENSHOT_QUALITY = 30;
 
 /**
- * @param {string} str
+ * @template {string} S
+ * @param {S} str
  */
-function snakeCaseToCamelCase(str) {
-  return str.replace(/(-\w)/g, m => m[1].toUpperCase());
+function kebabCaseToCamelCase(str) {
+  return /** @type {KebabToCamelCase<S>} */ (str.replace(/(-\w)/g, m => m[1].toUpperCase()));
 }
 
 /* c8 ignore start */
 
 // eslint-disable-next-line no-inner-declarations
 function getObservedDeviceMetrics() {
-  // Convert the Web API's snake case (landscape-primary) to camel case (landscapePrimary).
-  const screenOrientationType = /** @type {LH.Crdp.Emulation.ScreenOrientationType} */ (
-    snakeCaseToCamelCase(window.screen.orientation.type));
+  // Convert the Web API's kebab case (landscape-primary) to camel case (landscapePrimary).
+  const screenOrientationType = kebabCaseToCamelCase(window.screen.orientation.type);
   return {
     width: document.documentElement.clientWidth,
     height: document.documentElement.clientHeight,
@@ -168,7 +168,7 @@ class FullPageScreenshot extends FRGatherer {
       observedDeviceMetrics = await executionContext.evaluate(getObservedDeviceMetrics, {
         args: [],
         useIsolation: true,
-        deps: [snakeCaseToCamelCase],
+        deps: [kebabCaseToCamelCase],
       });
     }
 

--- a/lighthouse-core/scripts/legacy-javascript/run.js
+++ b/lighthouse-core/scripts/legacy-javascript/run.js
@@ -136,7 +136,7 @@ function getLegacyJavascriptResults(code, map, {sourceMaps}) {
   const documentUrl = 'http://localhost/index.html'; // These URLs don't matter.
   const scriptUrl = 'https://localhost/main.bundle.min.js';
   const networkRecords = [
-    {url: documentUrl, requestId: '1000.1', resourceType: /** @type {'Document'} */ ('Document')},
+    {url: documentUrl, requestId: '1000.1', resourceType: /** @type {const} */ ('Document')},
     {url: scriptUrl, requestId: '1000.2'},
   ];
   const devtoolsLogs = networkRecordsToDevtoolsLog(networkRecords);

--- a/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
@@ -461,7 +461,7 @@ describe('NavigationRunner', () => {
   describe('navigation', () => {
     it('should initialize config', async () => {
       const settingsOverrides = {
-        formFactor: /** @type {'desktop'} */ ('desktop'),
+        formFactor: /** @type {const} */ ('desktop'),
         maxWaitForLoad: 1234,
         screenEmulation: {mobile: false},
       };

--- a/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
@@ -92,7 +92,7 @@ describe('Snapshot Runner', () => {
 
   it('should use configContext', async () => {
     const settingsOverrides = {
-      formFactor: /** @type {'desktop'} */ ('desktop'),
+      formFactor: /** @type {const} */ ('desktop'),
       maxWaitForLoad: 1234,
       screenEmulation: {mobile: false},
     };

--- a/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
@@ -109,7 +109,7 @@ describe('Timespan Runner', () => {
 
   it('should use configContext', async () => {
     const settingsOverrides = {
-      formFactor: /** @type {'desktop'} */ ('desktop'),
+      formFactor: /** @type {const} */ ('desktop'),
       maxWaitForLoad: 1234,
       screenEmulation: {mobile: false},
     };

--- a/lighthouse-core/test/gather/driver/navigation-test.js
+++ b/lighthouse-core/test/gather/driver/navigation-test.js
@@ -66,8 +66,8 @@ describe('.gotoURL', () => {
       securityOrigin: '',
       mimeType: 'text/html',
       domainAndRegistry: '',
-      secureContextType: /** @type {'Secure'} */ ('Secure'),
-      crossOriginIsolatedContextType: /** @type {'Isolated'} */ ('Isolated'),
+      secureContextType: /** @type {const} */ ('Secure'),
+      crossOriginIsolatedContextType: /** @type {const} */ ('Isolated'),
       gatedAPIFeatures: [],
     };
     navigate({...baseFrame, url: 'http://example.com'});

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -411,7 +411,7 @@ describe('GatherRunner', function() {
   it('prepares target for navigation', async () => {
     const passConfig = {
       passName: 'default',
-      loadFailureMode: /** @type {'ignore'} */ ('ignore'),
+      loadFailureMode: /** @type {const} */ ('ignore'),
       recordTrace: true,
       useThrottling: true,
       gatherers: [],

--- a/lighthouse-core/test/lib/navigation-error-test.js
+++ b/lighthouse-core/test/lib/navigation-error-test.js
@@ -15,11 +15,11 @@ const {
 } = require('../../lib/navigation-error.js');
 const NetworkRequest = require('../../lib/network-request.js');
 
-const LoadFailureMode = {
-  fatal: /** @type {'fatal'} */ ('fatal'),
-  ignore: /** @type {'ignore'} */ ('ignore'),
-  warn: /** @type {'warn'} */ ('warn'),
-};
+const LoadFailureMode = /** @type {const} */ ({
+  fatal: 'fatal',
+  ignore: 'ignore',
+  warn: 'warn',
+});
 
 describe('#getNetworkError', () => {
   /**

--- a/package.json
+++ b/package.json
@@ -181,8 +181,8 @@
     "tabulator-tables": "^4.9.3",
     "terser": "^5.3.8",
     "ts-jest": "^27.0.4",
-    "typed-query-selector": "^2.4.0",
-    "typescript": "4.4.3",
+    "typed-query-selector": "^2.6.1",
+    "typescript": "^4.5.2",
     "wait-for-expect": "^3.0.2",
     "webtreemap-cdt": "^3.2.1"
   },

--- a/report/renderer/swap-locale-feature.js
+++ b/report/renderer/swap-locale-feature.js
@@ -53,13 +53,9 @@ export class SwapLocaleFeature {
       optionEl.value = locale;
       if (locale === currentLocale) optionEl.selected = true;
 
-      // @ts-expect-error: waiting for typescript 4.5. Might need to add "ES2020.Intl"
-      // to tsconfig libs.
       // https://github.com/microsoft/TypeScript/pull/44022#issuecomment-915087098
       if (window.Intl && Intl.DisplayNames) {
-        // @ts-expect-error
         const currentLocaleDisplay = new Intl.DisplayNames([currentLocale], {type: 'language'});
-        // @ts-expect-error
         const optionLocaleDisplay = new Intl.DisplayNames([locale], {type: 'language'});
 
         const optionLocaleName = optionLocaleDisplay.of(locale);

--- a/report/renderer/swap-locale-feature.js
+++ b/report/renderer/swap-locale-feature.js
@@ -53,7 +53,6 @@ export class SwapLocaleFeature {
       optionEl.value = locale;
       if (locale === currentLocale) optionEl.selected = true;
 
-      // https://github.com/microsoft/TypeScript/pull/44022#issuecomment-915087098
       if (window.Intl && Intl.DisplayNames) {
         const currentLocaleDisplay = new Intl.DisplayNames([currentLocale], {type: 'language'});
         const optionLocaleDisplay = new Intl.DisplayNames([locale], {type: 'language'});

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -87,10 +87,6 @@ declare global {
   type FirstParamType<T extends (arg1: any, ...args: any[]) => any> =
     T extends (arg1: infer P, ...args: any[]) => any ? P : never;
 
-  type FlattenedPromise<A> = Promise<A extends Promise<infer X> ? X : A>;
-
-  type UnPromise<T> = T extends Promise<infer U> ? U : T
-
   /**
    * If `S` is a kebab-style string `S`, convert to camelCase.
    */

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -92,27 +92,12 @@ declare global {
   type UnPromise<T> = T extends Promise<infer U> ? U : T
 
   /**
-   * Split string `S` on delimiter `D`.
-   * From https://github.com/microsoft/TypeScript/pull/40336#issue-476562046
+   * If `S` is a kebab-style string `S`, convert to camelCase.
    */
-  type Split<S extends string, D extends string> =
-    string extends S ? string[] :
-    S extends '' ? [] :
-    S extends `${infer T}${D}${infer U}` ? [T, ...Split<U, D>] :
-    [S];
-
-  /**
-  * Join an array of strings using camelCase capitalization rules.
-  */
-  type StringsToCamelCase<T extends unknown[]> =
-    T extends [] ? '' :
-    T extends [string, ...infer U] ? `${T[0]}${Capitalize<StringsToCamelCase<U>>}` :
-    string;
-
-  /**
-  * If `S` is a kebab-style string `S`, convert to camelCase.
-  */
-  type KebabToCamelCase<S> = S extends string ? StringsToCamelCase<Split<S, '-'>> : S;
+  type KebabToCamelCase<S> =
+    S extends `${infer T}-${infer U}` ?
+    `${T}${Capitalize<KebabToCamelCase<U>>}` :
+    S
 
   /** Returns T with any kebab-style property names rewritten as camelCase. */
   type CamelCasify<T> = {

--- a/viewer/app/src/github-api.js
+++ b/viewer/app/src/github-api.js
@@ -111,7 +111,8 @@ export class GithubApi {
           }
 
           if (!resp.ok) {
-            if (resp.status === 304) {
+            // Should only be 304 if cachedGist exists and etag was sent, but double check.
+            if (resp.status === 304 && cachedGist) {
               return Promise.resolve(cachedGist);
             } else if (resp.status === 404) {
               // Delete the entry from IDB if it no longer exists on the server.
@@ -151,7 +152,6 @@ export class GithubApi {
       // not return a 304 and so will be overwritten.
       return idbKeyval.set(id, response).then(_ => {
         logger.hide();
-        // @ts-expect-error - TODO(bckenny): tsc unable to flatten promise chain here
         return response.content;
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8851,10 +8851,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typed-query-selector@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/typed-query-selector/-/typed-query-selector-2.4.0.tgz#5b07b099e92c910602f55c26cdb7115618d96b6c"
-  integrity sha512-LVsEnvOgSjMNCPX/6zi9rhpjnTlBfnLsTta+FFJywBdQom0k5yhNraru79HFtU1Q4ncUDtRhfMMHLnbZ10NCLQ==
+typed-query-selector@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typed-query-selector/-/typed-query-selector-2.6.1.tgz#73b6f591974129669df59d90f0bec4216e68a434"
+  integrity sha512-nzzcDrI0nncM5XTNyqeG7MrcXTx8lelUtNlTP+NvpnOfRzApyr+ZW4H/FoOaPfzmjn++Tf0ZxXpBN7Q3FN3ERw==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -8868,10 +8868,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
The biggest thing for us is that `as const` [now has an equivalent in jsdoc](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#jsdoc-const-and-type-arg-defaults): `/** @type {const} */ ('provided')`. It's not the best syntax, but pretty much exactly equivalent: `... as Type` is the typescript type assertion, `/** @type {Type} */ (...)` is the jsdoc type assertion. Ideally we can convince them to support `/** @const */` as a shorthand someday.

Other things:
- we needed a fix from typed-query-selector (https://github.com/g-plane/typed-query-selector/pull/20). Updating to get that means we also got support for `:is()` and `: where()` in our typed query selectors :)
- there were a few places where we were able to get rid of some `Promise` workarounds using the new `Awaited` type.
- some out of date `@ts-expect-error` could go
- simplified the `KebabToCamelCase` implementation