### PR TITLE
core(canonical): remove cross-origin check

### DIFF
--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -38,11 +38,6 @@ const UIStrings = {
    * @example {https://example.com/} url
    */
   explanationPointsElsewhere: 'Points to another `hreflang` location ({url})',
-  /**
-   * @description Explanatory message stating that there was a failure in an audit caused by a URL pointing to a different domain.
-   * @example {https://example.com/} url
-   * */
-  explanationDifferentDomain: 'Points to a different domain ({url})',
   /** Explanatory message stating that the page's canonical URL was pointing to the domain's root URL, which is a common mistake. "points" refers to the action of the 'rel=canonical' referencing another link. "root" refers to the starting/home page of the website. "domain" refers to the registered domain name of the website. */
   explanationRoot: 'Points to the domain\'s root URL (the homepage), ' +
     'instead of an equivalent page of content',
@@ -171,15 +166,6 @@ class Canonical extends Audit {
       return {
         score: 0,
         explanation: str_(UIStrings.explanationPointsElsewhere, {url: baseURL.href}),
-      };
-    }
-
-    // bing and yahoo don't allow canonical URLs pointing to different domains, it's also
-    // a common mistake to publish a page with canonical pointing to e.g. a test domain or localhost
-    if (!URL.rootDomainsMatch(canonicalURL, baseURL)) {
-      return {
-        score: 0,
-        explanation: str_(UIStrings.explanationDifferentDomain, {url: canonicalURL.href}),
       };
     }
 

--- a/lighthouse-core/test/audits/seo/canonical-test.js
+++ b/lighthouse-core/test/audits/seo/canonical-test.js
@@ -127,26 +127,6 @@ describe('SEO: Document has valid canonical link', () => {
     });
   });
 
-  it('fails when canonical points to a different domain', () => {
-    const finalUrl = 'http://localhost.test';
-    const mainResource = {url: finalUrl};
-    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
-      URL: {finalUrl},
-      LinkElements: [
-        link({rel: 'canonical', source: 'head', href: 'https://example.com'}),
-      ],
-    };
-
-    const context = {computedCache: new Map()};
-    return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.score, 0);
-      expect(auditResult.explanation)
-        .toBeDisplayString('Points to a different domain (https://example.com/)');
-    });
-  });
-
   it('passes when canonical points to the root while current URL is also the root', async () => {
     const finalUrl = 'https://example.com/';
     const mainResource = {

--- a/shared/localization/locales/ar-XB.json
+++ b/shared/localization/locales/ar-XB.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "‏‮Multiple‬‏ ‏‮conflicting‬‏ ‏‮URLs‬‏ ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "‏‮Points‬‏ ‏‮to‬‏ ‏‮a‬‏ ‏‮different‬‏ ‏‮domain‬‏ ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "‏‮Invalid‬‏ ‏‮URL‬‏ ({url})"
   },

--- a/shared/localization/locales/ar.json
+++ b/shared/localization/locales/ar.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "تتعدّد عناوين URL المتضاربة ({urlList})."
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "يشير عنوان URL إلى نطاق مختلف ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "عنوان URL غير صالح ({url})"
   },

--- a/shared/localization/locales/bg.json
+++ b/shared/localization/locales/bg.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Множество несъвместими URL адреси ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Сочи към друг домейн ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Невалиден URL адрес ({url})"
   },

--- a/shared/localization/locales/ca.json
+++ b/shared/localization/locales/ca.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Hi ha diversos URL en conflicte ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Dirigeix a un altre domini ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL no vàlid ({url})"
   },

--- a/shared/localization/locales/cs.json
+++ b/shared/localization/locales/cs.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Několik konfliktních adres URL ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Odkazuje na jinou doménu ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Neplatná adresa URL ({url})"
   },

--- a/shared/localization/locales/da.json
+++ b/shared/localization/locales/da.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Flere webadresser ({urlList}) er modstridende"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Peger på et andet domæne ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Ugyldig webadresse ({url})"
   },

--- a/shared/localization/locales/de.json
+++ b/shared/localization/locales/de.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Mehrere in Konflikt stehende URLs ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Verweist auf eine andere Domain ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Ungültige URL ({url})"
   },

--- a/shared/localization/locales/el.json
+++ b/shared/localization/locales/el.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Πολλά URL σε διένεξη ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Παραπέμπει σε διαφορετικό τομέα ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Μη έγκυρο URL ({url})"
   },

--- a/shared/localization/locales/en-GB.json
+++ b/shared/localization/locales/en-GB.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Multiple conflicting URLs ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Points to a different domain ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Invalid URL ({url})"
   },

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1298,9 +1298,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Multiple conflicting URLs ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Points to a different domain ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Invalid URL ({url})"
   },

--- a/shared/localization/locales/en-XA.json
+++ b/shared/localization/locales/en-XA.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "[Mûļţîþļé çöñƒļîçţîñĝ ÛŔĻš (ᐅ{urlList}ᐊ) one two three four five six seven]"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "[Þöîñţš ţö å ðîƒƒéŕéñţ ðömåîñ (ᐅ{url}ᐊ) one two three four five six seven]"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "[Îñvåļîð ÛŔĻ (ᐅ{url}ᐊ) one two three four]"
   },

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1298,9 +1298,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "M̂úl̂t́îṕl̂é ĉón̂f́l̂íĉt́îńĝ ÚR̂Ĺŝ ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "P̂óîńt̂ś t̂ó â d́îf́f̂ér̂én̂t́ d̂óm̂áîń ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Îńv̂ál̂íd̂ ÚR̂Ĺ ({url})"
   },

--- a/shared/localization/locales/es-419.json
+++ b/shared/localization/locales/es-419.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Varias URL en conflicto ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Redirige al usuario a otro dominio ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL no válida ({url})"
   },

--- a/shared/localization/locales/es.json
+++ b/shared/localization/locales/es.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Varias URL en conflicto ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Dirige a un dominio diferente ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "La URL no es válida ({url})"
   },

--- a/shared/localization/locales/fi.json
+++ b/shared/localization/locales/fi.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Useita ristiriitaisia URL-osoitteita ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Viittaa toiseen verkkotunnukseen ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Virheellinen URL-osoite ({url})"
   },

--- a/shared/localization/locales/fil.json
+++ b/shared/localization/locales/fil.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Maraming URL ang hindi magkakatugma ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Tumuturo sa ibang domain ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Invalid na URL ({url})"
   },

--- a/shared/localization/locales/fr.json
+++ b/shared/localization/locales/fr.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Plusieurs URL en conflit ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "L'URL mène à un autre domaine ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL incorrecte ({url})"
   },

--- a/shared/localization/locales/he.json
+++ b/shared/localization/locales/he.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "התנגשויות בין כתובות URL מרובות ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "הכתובת מפנה לדומיין אחר ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "כתובת אתר לא חוקית ({url})"
   },

--- a/shared/localization/locales/hi.json
+++ b/shared/localization/locales/hi.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "कई कॉन्फ़्लिक्टिंग यूआरएल हैं ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "किसी दूसरे डोमेन की तरफ़ इशारा करता है ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "गलत यूआरएल ({url})"
   },

--- a/shared/localization/locales/hr.json
+++ b/shared/localization/locales/hr.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Više URL-ova u sukobu ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Usmjerava na drugu domenu ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Nevažeći URL ({url})"
   },

--- a/shared/localization/locales/hu.json
+++ b/shared/localization/locales/hu.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Több ütköző URL ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Más domainre mutat ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Érvénytelen URL ({url})"
   },

--- a/shared/localization/locales/id.json
+++ b/shared/localization/locales/id.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Ada beberapa URL yang bertentangan ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Mengarahkan ke domain yang berbeda ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL tidak valid ({url})"
   },

--- a/shared/localization/locales/it.json
+++ b/shared/localization/locales/it.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Diversi URL in conflitto ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Rimanda a un altro dominio ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL non valido ({url})"
   },

--- a/shared/localization/locales/ja.json
+++ b/shared/localization/locales/ja.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "複数の URL が競合しています（{urlList}）"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "別のドメイン（{url}）を指しています"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL（{url}）が無効です"
   },

--- a/shared/localization/locales/ko.json
+++ b/shared/localization/locales/ko.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "여러 개의 URL({urlList})이 충돌됨"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "다른 도메인({url})을 가리킵니다."
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "잘못된 URL({url})"
   },

--- a/shared/localization/locales/lt.json
+++ b/shared/localization/locales/lt.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Keli nesuderinami URL ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Nukreipia į kitą domeną ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Negaliojantis URL ({url})"
   },

--- a/shared/localization/locales/lv.json
+++ b/shared/localization/locales/lv.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Vairāki konfliktējoši URL ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Norāda uz citu domēnu ({url})."
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Nederīgs URL ({url})."
   },

--- a/shared/localization/locales/nl.json
+++ b/shared/localization/locales/nl.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Meerdere conflicterende URL's ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Wijst naar een ander domein ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Ongeldige URL ({url})"
   },

--- a/shared/localization/locales/no.json
+++ b/shared/localization/locales/no.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Flere motstridende nettadresser ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Peker til et annet domene ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Ugyldig nettadresse ({url})"
   },

--- a/shared/localization/locales/pl.json
+++ b/shared/localization/locales/pl.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Niezgodne ze sobą adresy URL ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Wskazuje inną domenę ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Nieprawidłowy URL ({url})"
   },

--- a/shared/localization/locales/pt-PT.json
+++ b/shared/localization/locales/pt-PT.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Vários URLs em conflito ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Aponta para um domínio diferente ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL inválido ({url})"
   },

--- a/shared/localization/locales/pt.json
+++ b/shared/localization/locales/pt.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Vários URLs com conflito ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Aponta para um domínio diferente ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL inválido ({url})"
   },

--- a/shared/localization/locales/ro.json
+++ b/shared/localization/locales/ro.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Mai multe adrese URL incompatibile ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Indică spre alt domeniu ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Adresă URL nevalidă ({url})"
   },

--- a/shared/localization/locales/ru.json
+++ b/shared/localization/locales/ru.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Несколько конфликтующих URL ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Указывает на другой домен ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Недопустимый URL ({url})"
   },

--- a/shared/localization/locales/sk.json
+++ b/shared/localization/locales/sk.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Viacero kolidujúcich webových adries ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Odkazuje na inú doménu ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Neplatná webová adresa ({url})"
   },

--- a/shared/localization/locales/sl.json
+++ b/shared/localization/locales/sl.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Več URL-jev v sporu ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Kaže na drugo domeno ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Neveljaven URL ({url})"
   },

--- a/shared/localization/locales/sr-Latn.json
+++ b/shared/localization/locales/sr-Latn.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Više neusaglašenih URL-ova ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Usmerava ka drugom domenu ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Nevažeći URL ({url})"
   },

--- a/shared/localization/locales/sr.json
+++ b/shared/localization/locales/sr.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Више неусаглашених URL-ова ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Усмерава ка другом домену ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Неважећи URL ({url})"
   },

--- a/shared/localization/locales/sv.json
+++ b/shared/localization/locales/sv.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Flera webbadresser som står i konflikt ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Pekar på en annan domän ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Ogiltig webbadress ({url})"
   },

--- a/shared/localization/locales/ta.json
+++ b/shared/localization/locales/ta.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "பல முரண்படும் URLகள் ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "வேறொரு டொமைனைச் சுட்டுகிறது ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "தவறான URL ({url})"
   },

--- a/shared/localization/locales/te.json
+++ b/shared/localization/locales/te.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "వైరుధ్యమైన అనేక URLలు ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "వేరొక డొమైన్ ({url})కు సూచిస్తోంది"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "చెల్లని URL ({url})"
   },

--- a/shared/localization/locales/th.json
+++ b/shared/localization/locales/th.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "URL หลายรายการขัดแย้งกัน ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "ชี้ไปที่โดเมนอื่น ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL ไม่ถูกต้อง ({url})"
   },

--- a/shared/localization/locales/tr.json
+++ b/shared/localization/locales/tr.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Birden fazla çakışan URL ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Farklı bir alan adına yönlendiriyor ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Geçersiz URL ({url})"
   },

--- a/shared/localization/locales/uk.json
+++ b/shared/localization/locales/uk.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Кілька URL-адрес конфліктують ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Указує на інший домен ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "Недійсна URL-адреса ({url})"
   },

--- a/shared/localization/locales/vi.json
+++ b/shared/localization/locales/vi.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "Nhiều URL xung đột ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "Trỏ đến một miền khác ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "URL không hợp lệ ({url})."
   },

--- a/shared/localization/locales/zh-HK.json
+++ b/shared/localization/locales/zh-HK.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "多個互相衝突的網址 ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "指向其他網域 ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "網址無效 ({url})"
   },

--- a/shared/localization/locales/zh-TW.json
+++ b/shared/localization/locales/zh-TW.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "多個衝突的網址 ({urlList})"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "指向其他網域 ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "網址無效 ({url})"
   },

--- a/shared/localization/locales/zh.json
+++ b/shared/localization/locales/zh.json
@@ -1292,9 +1292,6 @@
   "lighthouse-core/audits/seo/canonical.js | explanationConflict": {
     "message": "存在多个相互冲突的网址（{urlList}）"
   },
-  "lighthouse-core/audits/seo/canonical.js | explanationDifferentDomain": {
-    "message": "指向不同的域名 ({url})"
-  },
   "lighthouse-core/audits/seo/canonical.js | explanationInvalid": {
     "message": "网址无效 ({url})"
   },


### PR DESCRIPTION
**Summary**

This PR removes the warning regarding canonical URLs being on a different domain, as discussed in https://github.com/GoogleChrome/lighthouse/issues/12572.

This warning predates advice given before 2009 and is now no longer relevant.

**Related Documentation**

The related documentation listed below is collected from the issue linked above:

- https://www.bing.com/webmasters/help/webmaster-guidelines-30fba23a
- https://uk.help.yahoo.com/kb/SLN2213.html
- https://yoast.com/rel-canonical/#:~:text=the%20canonical%20link%20element%20was%20introduced%20by%20google%2C%20bing%2C%20and%20yahoo!%20in%20february%202009
- https://www.mattcutts.com/blog/canonical-link-tag/

**Related Issues/PRs**

Related issue: https://github.com/GoogleChrome/lighthouse/issues/12572.