### PR TITLE
clients(viewer): save flow as gist

### DIFF
--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -14,6 +14,9 @@ async function buildReportGenerator() {
   const bundle = await rollup.rollup({
     input: 'report/generator/report-generator.js',
     plugins: [
+      rollupPlugins.shim({
+        [`${LH_ROOT}/report/generator/flow-report-assets.js`]: 'export default {}',
+      }),
       rollupPlugins.commonjs(),
       rollupPlugins.nodeResolve(),
       rollupPlugins.inlineFs({verbose: Boolean(process.env.DEBUG)}),

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -14,9 +14,6 @@ async function buildReportGenerator() {
   const bundle = await rollup.rollup({
     input: 'report/generator/report-generator.js',
     plugins: [
-      rollupPlugins.shim({
-        [`${LH_ROOT}/report/generator/flow-report-assets.js`]: 'export default {}',
-      }),
       rollupPlugins.commonjs(),
       rollupPlugins.nodeResolve(),
       rollupPlugins.inlineFs({verbose: Boolean(process.env.DEBUG)}),

--- a/flow-report/api.ts
+++ b/flow-report/api.ts
@@ -8,7 +8,11 @@ import {render, h} from 'preact';
 
 import {App} from './src/app';
 
-export function renderFlowReport(flowResult: LH.FlowResult, root: HTMLElement) {
+export function renderFlowReport(
+  flowResult: LH.FlowResult,
+  root: HTMLElement,
+  options?: LH.FlowReportOptions
+) {
   root.classList.add('flow-vars', 'lh-vars', 'lh-root');
-  render(h(App, {flowResult}), root);
+  render(h(App, {flowResult, options}), root);
 }

--- a/flow-report/clients/standalone.ts
+++ b/flow-report/clients/standalone.ts
@@ -14,7 +14,9 @@ import {renderFlowReport} from '../api';
 function __initLighthouseFlowReport__() {
   const container = document.body.querySelector('main');
   if (!container) throw Error('Container element not found');
-  renderFlowReport(window.__LIGHTHOUSE_FLOW_JSON__, container);
+  renderFlowReport(window.__LIGHTHOUSE_FLOW_JSON__, container, {
+    getReportHtml: () => document.documentElement.outerHTML,
+  });
 }
 
 window.__initLighthouseFlowReport__ = __initLighthouseFlowReport__;

--- a/flow-report/src/app.tsx
+++ b/flow-report/src/app.tsx
@@ -5,11 +5,11 @@
  */
 
 import {FunctionComponent} from 'preact';
-import {useLayoutEffect, useRef, useState} from 'preact/hooks';
+import {useLayoutEffect, useMemo, useRef, useState} from 'preact/hooks';
 
 import {Sidebar} from './sidebar/sidebar';
 import {Summary} from './summary/summary';
-import {classNames, FlowResultContext, useHashState} from './util';
+import {classNames, FlowResultContext, OptionsContext, useHashState} from './util';
 import {Report} from './wrappers/report';
 import {Topbar} from './topbar';
 import {Header} from './header';
@@ -48,18 +48,24 @@ const Content: FunctionComponent = () => {
   );
 };
 
-export const App: FunctionComponent<{flowResult: LH.FlowResult}> = ({flowResult}) => {
+export const App: FunctionComponent<{
+  flowResult: LH.FlowResult,
+  options?: LH.FlowReportOptions
+}> = ({flowResult, options}) => {
   const [collapsed, setCollapsed] = useState(false);
+  const optionsValue = useMemo(() => options || {}, [options]);
   return (
-    <FlowResultContext.Provider value={flowResult}>
-      <I18nProvider>
-        <Styles/>
-        <div className={classNames('App', {'App--collapsed': collapsed})} data-testid="App">
-          <Topbar onMenuClick={() => setCollapsed(c => !c)} />
-          <Sidebar/>
-          <Content/>
-        </div>
-      </I18nProvider>
-    </FlowResultContext.Provider>
+    <OptionsContext.Provider value={optionsValue}>
+      <FlowResultContext.Provider value={flowResult}>
+        <I18nProvider>
+          <Styles/>
+          <div className={classNames('App', {'App--collapsed': collapsed})} data-testid="App">
+            <Topbar onMenuClick={() => setCollapsed(c => !c)} />
+            <Sidebar/>
+            <Content/>
+          </div>
+        </I18nProvider>
+      </FlowResultContext.Provider>
+    </OptionsContext.Provider>
   );
 };

--- a/flow-report/src/sidebar/flow.tsx
+++ b/flow-report/src/sidebar/flow.tsx
@@ -48,8 +48,6 @@ export const SidebarFlow: FunctionComponent = () => {
       {
         flowResult.steps.map((step, index) => {
           const {lhr, name} = step;
-          const url = new URL(location.href);
-          url.hash = `#index=${index}`;
           return <>
             {
               lhr.gatherMode === 'navigation' && index !== 0 ?
@@ -59,7 +57,7 @@ export const SidebarFlow: FunctionComponent = () => {
             <SidebarFlowStep
               key={lhr.fetchTime}
               mode={lhr.gatherMode}
-              href={url.href}
+              href={`#index=${index}`}
               label={name}
               isCurrent={index === (hashState && hashState.index)}
             />

--- a/flow-report/src/sidebar/sidebar.tsx
+++ b/flow-report/src/sidebar/sidebar.tsx
@@ -17,11 +17,9 @@ const SidebarSummary: FunctionComponent = () => {
   const hashState = useHashState();
   const strings = useLocalizedStrings();
 
-  const url = new URL(location.href);
-  url.hash = '#';
   return (
     <a
-      href={url.href}
+      href="#"
       className={classNames('SidebarSummary', {'Sidebar--current': hashState === null})}
       data-testid="SidebarSummary"
     >

--- a/flow-report/src/topbar.tsx
+++ b/flow-report/src/topbar.tsx
@@ -8,20 +8,15 @@ import {FunctionComponent, JSX} from 'preact';
 import {useState} from 'preact/hooks';
 
 import {HelpDialog} from './help-dialog';
-import {getFilenamePrefix} from '../../report/generator/file-namer';
+import {getFlowResultFilenamePrefix} from '../../report/generator/file-namer';
 import {useLocalizedStrings} from './i18n/i18n';
 import {HamburgerIcon, InfoIcon} from './icons';
-import {useFlowResult} from './util';
+import {useFlowResult, useOptions} from './util';
 import {saveFile} from '../../report/renderer/api';
 
-function saveHtml(flowResult: LH.FlowResult) {
-  const htmlStr = document.documentElement.outerHTML;
+function saveHtml(flowResult: LH.FlowResult, htmlStr: string) {
   const blob = new Blob([htmlStr], {type: 'text/html'});
-
-  const lhr = flowResult.steps[0].lhr;
-  const name = flowResult.name.replace(/\s/g, '-');
-  const filename = getFilenamePrefix(name, lhr.fetchTime);
-
+  const filename = getFlowResultFilenamePrefix(flowResult);
   saveFile(blob, filename);
 }
 
@@ -78,6 +73,7 @@ export const Topbar: FunctionComponent<{onMenuClick: JSX.MouseEventHandler<HTMLB
   const flowResult = useFlowResult();
   const strings = useLocalizedStrings();
   const [showHelpDialog, setShowHelpDialog] = useState(false);
+  const {getReportHtml, saveAsGist} = useOptions();
 
   return (
     <div className="Topbar">
@@ -88,10 +84,23 @@ export const Topbar: FunctionComponent<{onMenuClick: JSX.MouseEventHandler<HTMLB
         <Logo/>
       </div>
       <div className="Topbar__title">{strings.title}</div>
-      <TopbarButton
-        onClick={() => saveHtml(flowResult)}
-        label="Button that saves the report as HTML"
-      >{strings.save}</TopbarButton>
+      {
+        getReportHtml &&
+          <TopbarButton
+            onClick={() => {
+              const htmlStr = getReportHtml(flowResult);
+              saveHtml(flowResult, htmlStr);
+            }}
+            label="Button that saves the report as HTML"
+          >{strings.save}</TopbarButton>
+      }
+      {
+        saveAsGist &&
+          <TopbarButton
+            onClick={() => saveAsGist(flowResult)}
+            label="Button that saves the report to a gist"
+          >Save as Gist</TopbarButton>
+      }
       <div style={{flexGrow: 1}} />
       <TopbarButton
         onClick={() => setShowHelpDialog(previous => !previous)}

--- a/flow-report/src/util.ts
+++ b/flow-report/src/util.ts
@@ -10,6 +10,7 @@ import {useContext, useEffect, useLayoutEffect, useMemo, useRef, useState} from 
 import type {UIStringsType} from './i18n/ui-strings';
 
 const FlowResultContext = createContext<LH.FlowResult|undefined>(undefined);
+const OptionsContext = createContext<LH.FlowReportOptions>({});
 
 function getHashParam(param: string): string|null {
   const params = new URLSearchParams(location.hash.replace('#', '?'));
@@ -147,8 +148,13 @@ function useExternalRenderer<T extends Element>(
   return ref;
 }
 
+function useOptions() {
+  return useContext(OptionsContext);
+}
+
 export {
   FlowResultContext,
+  OptionsContext,
   classNames,
   getScreenDimensions,
   getFullPageScreenshot,
@@ -158,4 +164,5 @@ export {
   useHashParams,
   useHashState,
   useExternalRenderer,
+  useOptions,
 };

--- a/flow-report/test/topbar-test.tsx
+++ b/flow-report/test/topbar-test.tsx
@@ -8,7 +8,7 @@ import {jest} from '@jest/globals';
 import {FunctionComponent} from 'preact';
 import {act, render} from '@testing-library/preact';
 
-import {FlowResultContext} from '../src/util';
+import {FlowResultContext, OptionsContext} from '../src/util';
 import {I18nProvider} from '../src/i18n/i18n';
 
 const mockSaveFile = jest.fn();
@@ -31,19 +31,24 @@ const flowResult = {
 } as any;
 
 let wrapper: FunctionComponent;
+let options: LH.FlowReportOptions;
 
 beforeEach(() => {
   mockSaveFile.mockReset();
+  options = {};
   wrapper = ({children}) => (
-    <FlowResultContext.Provider value={flowResult}>
-      <I18nProvider>
-        {children}
-      </I18nProvider>
-    </FlowResultContext.Provider>
+    <OptionsContext.Provider value={options}>
+      <FlowResultContext.Provider value={flowResult}>
+        <I18nProvider>
+          {children}
+        </I18nProvider>
+      </FlowResultContext.Provider>
+    </OptionsContext.Provider>
   );
 });
 
 it('save button opens save dialog for HTML file', async () => {
+  options = {getReportHtml: () => '<html></html>'};
   const root = render(<Topbar onMenuClick={() => {}}/>, {wrapper});
 
   const saveButton = root.getByText('Save');
@@ -53,6 +58,17 @@ it('save button opens save dialog for HTML file', async () => {
     expect.any(Blob),
     'User-flow_2021-09-14_22-24-22'
   );
+});
+
+it('provides save as gist option if defined', async () => {
+  const saveAsGist = jest.fn();
+  options = {saveAsGist};
+  const root = render(<Topbar onMenuClick={() => {}}/>, {wrapper});
+
+  const saveButton = root.getByText('Save as Gist');
+  saveButton.click();
+
+  expect(saveAsGist).toHaveBeenCalledWith(flowResult);
 });
 
 it('toggles help dialog', async () => {

--- a/flow-report/types/flow-report.d.ts
+++ b/flow-report/types/flow-report.d.ts
@@ -20,6 +20,10 @@ declare global {
   // Expose global types in LH namespace.
   module LH {
     export type ConfigSettings = Settings.ConfigSettings;
+    export interface FlowReportOptions {
+      getReportHtml?: (flowResult: FlowResult_) => string;
+      saveAsGist?: (flowResult: FlowResult_) => void;
+    }
 
     export import FlowResult = FlowResult_;
   }

--- a/report/generator/file-namer.js
+++ b/report/generator/file-namer.js
@@ -43,4 +43,15 @@ function getLhrFilenamePrefix(lhr) {
   return getFilenamePrefix(hostname, lhr.fetchTime);
 }
 
-module.exports = {getLhrFilenamePrefix, getFilenamePrefix};
+/**
+ * Generate a filenamePrefix of name_YYYY-MM-DD_HH-MM-SS.
+ * @param {{name: string, steps: Array<{lhr: {fetchTime: string}}>}} flowResult
+ * @return {string}
+ */
+function getFlowResultFilenamePrefix(flowResult) {
+  const lhr = flowResult.steps[0].lhr;
+  const name = flowResult.name.replace(/\s/g, '-');
+  return getFilenamePrefix(name, lhr.fetchTime);
+}
+
+module.exports = {getLhrFilenamePrefix, getFilenamePrefix, getFlowResultFilenamePrefix};

--- a/treemap/types/treemap.d.ts
+++ b/treemap/types/treemap.d.ts
@@ -5,6 +5,7 @@ import * as Settings from '../../types/lhr/settings';
 import 'google.analytics';
 import LHResult from '../../types/lhr/lhr';
 import {TreemapUtil} from '../app/src/util';
+import FlowResult_ from '../../types/lhr/flow';
 
 // Import for needed DOM type augmentation.
 import '../../report/types/augment-dom';
@@ -15,6 +16,7 @@ declare global {
     export import Treemap = Treemap_;
     export import Result = LHResult;
     export import Locale = Settings.Locale;
+    export import FlowResult = FlowResult_;
   }
 
   class WebTreeMap {

--- a/viewer/app/src/github-api.js
+++ b/viewer/app/src/github-api.js
@@ -12,7 +12,8 @@
 import idbKeyval from 'idb-keyval';
 
 import {FirebaseAuth} from './firebase-auth.js';
-import {getLhrFilenamePrefix} from '../../../report/generator/file-namer.js';
+// eslint-disable-next-line max-len
+import {getLhrFilenamePrefix, getFlowResultFilenamePrefix} from '../../../report/generator/file-namer.js';
 
 /**
  * Wrapper around the GitHub API for reading/writing gists.
@@ -33,7 +34,7 @@ export class GithubApi {
 
   /**
    * Creates a gist under the users account.
-   * @param {LH.Result} jsonFile The gist file body.
+   * @param {LH.Result|LH.FlowResult} jsonFile The gist file body.
    * @return {Promise<string>} id of the created gist.
    */
   async createGist(jsonFile) {
@@ -46,10 +47,15 @@ export class GithubApi {
 
     try {
       const accessToken = await this._auth.getAccessToken();
-      const filename = getLhrFilenamePrefix({
-        finalUrl: jsonFile.finalUrl,
-        fetchTime: jsonFile.fetchTime,
-      });
+      let filename;
+      if ('steps' in jsonFile) {
+        filename = getFlowResultFilenamePrefix(jsonFile);
+      } else {
+        filename = getLhrFilenamePrefix({
+          finalUrl: jsonFile.finalUrl,
+          fetchTime: jsonFile.fetchTime,
+        });
+      }
       const body = {
         description: 'Lighthouse json report',
         public: false,

--- a/viewer/app/src/lighthouse-report-viewer.js
+++ b/viewer/app/src/lighthouse-report-viewer.js
@@ -16,7 +16,7 @@ import {ReportRenderer} from '../../../report/renderer/report-renderer.js';
 import {TextEncoding} from '../../../report/renderer/text-encoding.js';
 import {renderFlowReport} from '../../../flow-report/api';
 
-/* global logger ReportGenerator */
+/* global logger */
 
 /** @typedef {import('./psi-api').PSIParams} PSIParams */
 
@@ -272,11 +272,9 @@ export class LighthouseReportViewer {
    * @param {HTMLElement} rootEl
    */
   _renderFlowResult(json, rootEl) {
+    // TODO: Add save HTML functionality with ReportGenerator loaded async.
     renderFlowReport(json, rootEl, {
       saveAsGist: () => this._onSaveJson(json),
-      getReportHtml: () => {
-        return ReportGenerator.generateFlowReportHtml(json);
-      },
     });
     // Install as global for easier debugging.
     window.__LIGHTHOUSE_FLOW_JSON__ = json;

--- a/viewer/app/src/lighthouse-report-viewer.js
+++ b/viewer/app/src/lighthouse-report-viewer.js
@@ -16,7 +16,7 @@ import {ReportRenderer} from '../../../report/renderer/report-renderer.js';
 import {TextEncoding} from '../../../report/renderer/text-encoding.js';
 import {renderFlowReport} from '../../../flow-report/api';
 
-/* global logger */
+/* global logger ReportGenerator */
 
 /** @typedef {import('./psi-api').PSIParams} PSIParams */
 
@@ -272,7 +272,12 @@ export class LighthouseReportViewer {
    * @param {HTMLElement} rootEl
    */
   _renderFlowResult(json, rootEl) {
-    renderFlowReport(json, rootEl);
+    renderFlowReport(json, rootEl, {
+      saveAsGist: () => this._onSaveJson(json),
+      getReportHtml: () => {
+        return ReportGenerator.generateFlowReportHtml(json);
+      },
+    });
     // Install as global for easier debugging.
     window.__LIGHTHOUSE_FLOW_JSON__ = json;
     // eslint-disable-next-line no-console
@@ -351,7 +356,7 @@ export class LighthouseReportViewer {
 
   /**
    * Saves the current report by creating a gist on GitHub.
-   * @param {LH.Result} reportJson
+   * @param {LH.Result|LH.FlowResult} reportJson
    * @return {Promise<string|void>} id of the created gist.
    * @private
    */


### PR DESCRIPTION
Ideally want to merge into https://github.com/GoogleChrome/lighthouse/pull/13260 before landing.

Adds "Save as gist" functionality to flow report. Also fixes the flow "Save as html" in the viewer.