### PR TITLE
core(stacks): add next.js

### DIFF
--- a/lighthouse-core/lib/stack-packs.js
+++ b/lighthouse-core/lib/stack-packs.js
@@ -24,14 +24,6 @@ const stackPacksToInclude = [
     requiredStacks: ['js:drupal'],
   },
   {
-    packId: 'react',
-    requiredStacks: ['js:react'],
-  },
-  {
-    packId: 'angular',
-    requiredStacks: ['js:@angular/core'],
-  },
-  {
     packId: 'amp',
     requiredStacks: ['js:amp'],
   },
@@ -46,6 +38,18 @@ const stackPacksToInclude = [
   {
     packId: 'joomla',
     requiredStacks: ['js:joomla'],
+  },
+  {
+    packId: 'next.js',
+    requiredStacks: ['js:next'],
+  },
+  {
+    packId: 'angular',
+    requiredStacks: ['js:@angular/core'],
+  },
+  {
+    packId: 'react',
+    requiredStacks: ['js:react'],
   },
 ];
 

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -24,7 +24,10 @@ import {countTranslatedMessages} from './count-translated.js';
 import {LH_ROOT} from '../../../root.js';
 import {resolveModulePath} from '../esm-utils.js';
 
-const UISTRINGS_REGEX = /UIStrings = .*?\};\n/s;
+// Match declarations of UIStrings, terminating in either a `};\n` (very likely to always be right)
+// or `}\n\n` (allowing semicolon to be optional, but insisting on a double newline so that an
+// closing brace in the middle of the declaration does not prematurely end the pattern)
+const UISTRINGS_REGEX = /UIStrings = .*?\}(;|\n)\n/s;
 
 /** @typedef {import('./bake-ctc-to-lhl.js').CtcMessage} CtcMessage */
 /** @typedef {Required<Pick<CtcMessage, 'message'|'placeholders'>>} IncrementalCtc */
@@ -564,6 +567,7 @@ async function collectAllStringsInDir(dir) {
     if (!exportedUIStrings) {
       throw new Error('UIStrings defined in file but not exported');
     }
+    if (relativeToRootPath.includes('third')) console.log(regexMatch)
 
     // just parse the UIStrings substring to avoid ES version issues, save time, etc
     const justUIStrings = 'const ' + regexMatch[0];

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -567,7 +567,6 @@ async function collectAllStringsInDir(dir) {
     if (!exportedUIStrings) {
       throw new Error('UIStrings defined in file but not exported');
     }
-    if (relativeToRootPath.includes('third')) console.log(regexMatch)
 
     // just parse the UIStrings substring to avoid ES version issues, save time, etc
     const justUIStrings = 'const ' + regexMatch[0];

--- a/lighthouse-core/test/lib/stack-packs-test.js
+++ b/lighthouse-core/test/lib/stack-packs-test.js
@@ -29,16 +29,17 @@ describe('stack-packs lib', () => {
 // These tests summarize the contents of the lighthouse-stack-packs package.
 describe('lighthouse-stack-packs dep', () => {
   it('snapshot packs', () => {
-    expect(lighthouseStackPacksDep.map(p => p.id)).toMatchInlineSnapshot(`
+    expect(lighthouseStackPacksDep.map((p) => p.id)).toMatchInlineSnapshot(`
       Array [
-        "wordpress",
-        "drupal",
-        "react",
-        "angular",
         "amp",
-        "magento",
+        "angular",
+        "drupal",
         "joomla",
+        "magento",
+        "next.js",
         "octobercms",
+        "react",
+        "wordpress",
       ]
     `);
   });
@@ -51,22 +52,25 @@ describe('lighthouse-stack-packs dep', () => {
     expect(result).toMatchInlineSnapshot(`
       Array [
         Object {
-          "id": "wordpress",
+          "id": "amp",
           "keys": Array [
-            "unused-css-rules",
             "modern-image-formats",
             "offscreen-images",
-            "total-byte-weight",
             "render-blocking-resources",
             "unminified-css",
-            "unminified-javascript",
             "efficient-animated-content",
-            "unused-javascript",
-            "uses-long-cache-ttl",
-            "uses-optimized-images",
-            "uses-text-compression",
             "uses-responsive-images",
-            "server-response-time",
+          ],
+        },
+        Object {
+          "id": "angular",
+          "keys": Array [
+            "total-byte-weight",
+            "unminified-warning",
+            "unused-javascript",
+            "uses-responsive-images",
+            "uses-rel-preload",
+            "dom-size",
           ],
         },
         Object {
@@ -90,37 +94,22 @@ describe('lighthouse-stack-packs dep', () => {
           ],
         },
         Object {
-          "id": "react",
+          "id": "joomla",
           "keys": Array [
-            "unminified-css",
-            "unminified-javascript",
-            "unused-javascript",
-            "server-response-time",
-            "redirects",
-            "user-timings",
-            "dom-size",
-          ],
-        },
-        Object {
-          "id": "angular",
-          "keys": Array [
-            "total-byte-weight",
-            "unminified-warning",
-            "unused-javascript",
-            "uses-responsive-images",
-            "uses-rel-preload",
-            "dom-size",
-          ],
-        },
-        Object {
-          "id": "amp",
-          "keys": Array [
+            "unused-css-rules",
             "modern-image-formats",
             "offscreen-images",
+            "total-byte-weight",
             "render-blocking-resources",
             "unminified-css",
+            "unminified-javascript",
             "efficient-animated-content",
+            "unused-javascript",
+            "uses-long-cache-ttl",
+            "uses-optimized-images",
+            "uses-text-compression",
             "uses-responsive-images",
+            "server-response-time",
           ],
         },
         Object {
@@ -141,7 +130,22 @@ describe('lighthouse-stack-packs dep', () => {
           ],
         },
         Object {
-          "id": "joomla",
+          "id": "next.js",
+          "keys": Array [
+            "unused-css-rules",
+            "modern-image-formats",
+            "offscreen-images",
+            "render-blocking-resources",
+            "unused-javascript",
+            "uses-long-cache-ttl",
+            "uses-optimized-images",
+            "uses-text-compression",
+            "uses-responsive-images",
+            "user-timings",
+          ],
+        },
+        Object {
+          "id": "octobercms",
           "keys": Array [
             "unused-css-rules",
             "modern-image-formats",
@@ -160,7 +164,19 @@ describe('lighthouse-stack-packs dep', () => {
           ],
         },
         Object {
-          "id": "octobercms",
+          "id": "react",
+          "keys": Array [
+            "unminified-css",
+            "unminified-javascript",
+            "unused-javascript",
+            "server-response-time",
+            "redirects",
+            "user-timings",
+            "dom-size",
+          ],
+        },
+        Object {
+          "id": "wordpress",
           "keys": Array [
             "unused-css-rules",
             "modern-image-formats",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "jpeg-js": "^0.4.1",
     "js-library-detector": "^6.4.0",
     "lighthouse-logger": "^1.3.0",
-    "lighthouse-stack-packs": "^1.5.0",
+    "lighthouse-stack-packs": "^1.6.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -2225,6 +2225,36 @@
   "node_modules/lighthouse-stack-packs/packs/magento.js | uses-rel-preload": {
     "message": "`<link rel=preload>` tags can be added by [modifying a themes's layout](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-manage.html)."
   },
+  "node_modules/lighthouse-stack-packs/packs/next.js | modern-image-formats": {
+    "message": "Use the `Next.js` Image Optimization API to serve modern formats like `WebP` and `AVIF`. [Learn more](https://nextjs.org/docs/api-reference/next/image#acceptable-formats)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | offscreen-images": {
+    "message": "Use the `next/image` component, which defaults to `loading=\"lazy\"`. [Learn more](https://nextjs.org/docs/api-reference/next/image#loading)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | render-blocking-resources": {
+    "message": "Use the `next/script` component to defer loading of non-critical third-party scripts. [Learn more](https://nextjs.org/docs/basic-features/script)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | unused-css-rules": {
+    "message": "Consider setting up `PurgeCSS` in `Next.js` configuration to remove unused rules from stylesheets. [Learn more](https://purgecss.com/guides/next.html)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | unused-javascript": {
+    "message": "Use `Webpack Bundle Analyzer` to detect unused JavaScript code. [Learn mode](https://github.com/vercel/next.js/tree/canary/packages/next-bundle-analyzer)"
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | user-timings": {
+    "message": "Consider using `Next.js Analytics` to measure your app's real-world performance. [Learn more](https://nextjs.org/docs/advanced-features/measuring-performance)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | uses-long-cache-ttl": {
+    "message": "Configure caching for immutable assets and `Server-side Rendered` (SSR) pages. [Learn more](https://nextjs.org/docs/going-to-production#caching)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | uses-optimized-images": {
+    "message": "Use the `next/image` component instead of `<img>` to optimize images. [Learn more](https://nextjs.org/docs/basic-features/image-optimization)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | uses-responsive-images": {
+    "message": "Use the `next/image` component to set the appropriate `sizes`. [Learn more](https://nextjs.org/docs/api-reference/next/image#sizes)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | uses-text-compression": {
+    "message": "Enable compression on your Next.js server. [Learn more](https://nextjs.org/docs/api-reference/next.config.js/compression)."
+  },
   "node_modules/lighthouse-stack-packs/packs/octobercms.js | efficient-animated-content": {
     "message": "[Replace animated GIFs with video](https://web.dev/replace-gifs-with-videos/) for faster web page loads and consider using modern file formats such as [WebM](https://web.dev/replace-gifs-with-videos/#create-webm-videos) or [AV1](https://developers.google.com/web/updates/2018/09/chrome-70-media-updates#av1-decoder) to improve compression efficiency by greater than 30% over the current state-of-the-art video codec, VP9."
   },

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -2225,6 +2225,36 @@
   "node_modules/lighthouse-stack-packs/packs/magento.js | uses-rel-preload": {
     "message": "`<link rel=preload>` t̂áĝś ĉán̂ b́ê ád̂d́êd́ b̂ý [m̂ód̂íf̂ýîńĝ á t̂h́êḿêś'ŝ ĺâýôút̂](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-manage.html)."
   },
+  "node_modules/lighthouse-stack-packs/packs/next.js | modern-image-formats": {
+    "message": "Ûśê t́ĥé `Next.js` Îḿâǵê Óp̂t́îḿîźât́îón̂ ÁP̂Í t̂ó ŝér̂v́ê ḿôd́êŕn̂ f́ôŕm̂át̂ś l̂ík̂é `WebP` âńd̂ `AVIF`. [Ĺêár̂ń m̂ór̂é](https://nextjs.org/docs/api-reference/next/image#acceptable-formats)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | offscreen-images": {
+    "message": "Ûśê t́ĥé `next/image` ĉóm̂ṕôńêńt̂, ẃĥíĉh́ d̂éf̂áûĺt̂ś t̂ó `loading=\"lazy\"`. [L̂éâŕn̂ ḿôŕê](https://nextjs.org/docs/api-reference/next/image#loading)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | render-blocking-resources": {
+    "message": "Ûśê t́ĥé `next/script` ĉóm̂ṕôńêńt̂ t́ô d́êf́êŕ l̂óâd́îńĝ óf̂ ńôń-ĉŕît́îćâĺ t̂h́îŕd̂-ṕâŕt̂ý ŝćr̂íp̂t́ŝ. [Ĺêár̂ń m̂ór̂é](https://nextjs.org/docs/basic-features/script)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | unused-css-rules": {
+    "message": "Ĉón̂śîd́êŕ ŝét̂t́îńĝ úp̂ `PurgeCSS` ín̂ `Next.js` ćôńf̂íĝúr̂át̂íôń t̂ó r̂ém̂óv̂é ûńûśêd́ r̂úl̂éŝ f́r̂óm̂ śt̂ýl̂éŝh́êét̂ś. [L̂éâŕn̂ ḿôŕê](https://purgecss.com/guides/next.html)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | unused-javascript": {
+    "message": "Ûśê `Webpack Bundle Analyzer` t́ô d́êt́êćt̂ ún̂úŝéd̂ J́âv́âŚĉŕîṕt̂ ćôd́ê. [Ĺêár̂ń m̂ód̂é](https://github.com/vercel/next.js/tree/canary/packages/next-bundle-analyzer)"
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | user-timings": {
+    "message": "Ĉón̂śîd́êŕ ûśîńĝ `Next.js Analytics` t́ô ḿêáŝúr̂é ŷóûŕ âṕp̂'ś r̂éâĺ-ŵór̂ĺd̂ ṕêŕf̂ór̂ḿâńĉé. [L̂éâŕn̂ ḿôŕê](https://nextjs.org/docs/advanced-features/measuring-performance)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | uses-long-cache-ttl": {
+    "message": "Ĉón̂f́îǵûŕê ćâćĥín̂ǵ f̂ór̂ ím̂ḿût́âb́l̂é âśŝét̂ś âńd̂ `Server-side Rendered` (ŚŜŔ) p̂áĝéŝ. [Ĺêár̂ń m̂ór̂é](https://nextjs.org/docs/going-to-production#caching)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | uses-optimized-images": {
+    "message": "Ûśê t́ĥé `next/image` ĉóm̂ṕôńêńt̂ ín̂śt̂éâd́ ôf́ `<img>` t̂ó ôṕt̂ím̂íẑé îḿâǵêś. [L̂éâŕn̂ ḿôŕê](https://nextjs.org/docs/basic-features/image-optimization)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | uses-responsive-images": {
+    "message": "Ûśê t́ĥé `next/image` ĉóm̂ṕôńêńt̂ t́ô śêt́ t̂h́ê áp̂ṕr̂óp̂ŕîát̂é `sizes`. [L̂éâŕn̂ ḿôŕê](https://nextjs.org/docs/api-reference/next/image#sizes)."
+  },
+  "node_modules/lighthouse-stack-packs/packs/next.js | uses-text-compression": {
+    "message": "Êńâb́l̂é ĉóm̂ṕr̂éŝśîón̂ ón̂ ýôúr̂ Ńêx́t̂.j́ŝ śêŕv̂ér̂. [Ĺêár̂ń m̂ór̂é](https://nextjs.org/docs/api-reference/next.config.js/compression)."
+  },
   "node_modules/lighthouse-stack-packs/packs/octobercms.js | efficient-animated-content": {
     "message": "[R̂ép̂ĺâćê án̂ím̂át̂éd̂ ǴÎF́ŝ ẃît́ĥ v́îd́êó](https://web.dev/replace-gifs-with-videos/) f̂ór̂ f́âśt̂ér̂ ẃêb́ p̂áĝé l̂óâd́ŝ án̂d́ ĉón̂śîd́êŕ ûśîńĝ ḿôd́êŕn̂ f́îĺê f́ôŕm̂át̂ś ŝúĉh́ âś [Ŵéb̂Ḿ](https://web.dev/replace-gifs-with-videos/#create-webm-videos) ôŕ [ÂV́1](https://developers.google.com/web/updates/2018/09/chrome-70-media-updates#av1-decoder) t̂ó îḿp̂ŕôv́ê ćôḿp̂ŕêśŝíôń êf́f̂íĉíêńĉý b̂ý ĝŕêát̂ér̂ t́ĥán̂ 30% óv̂ér̂ t́ĥé ĉúr̂ŕêńt̂ śt̂át̂é-ôf́-t̂h́ê-ár̂t́ v̂íd̂éô ćôd́êć, V̂Ṕ9."
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5778,10 +5778,10 @@ lighthouse-plugin-publisher-ads@^1.5.4:
     intl-messageformat "^4.1.2"
     yargs "^16.1.1"
 
-lighthouse-stack-packs@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/lighthouse-stack-packs/-/lighthouse-stack-packs-1.5.0.tgz#c191f2b94db21602254baaebfb0bb90307a00ffa"
-  integrity sha512-ntVOqFsrrTQYrNf+W+sNE9GjddW+ab5QN0WrrCikjMFsUvEQ28CvT0SXcHPZXFtcsb1lMSuVaNCmEuj7oXtYGQ==
+lighthouse-stack-packs@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lighthouse-stack-packs/-/lighthouse-stack-packs-1.6.0.tgz#f7327352089f65f4ca61135956c77b9d13f6d681"
+  integrity sha512-isv4qY9YCiRis5Z3ijy14IUyAbl6AoD+Q8Co1t0GBBuQK2ZUTSK6mLgFd91MVJrhXaF3LXJRcO+JXaUFHedHhA==
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
unfortunately https://github.com/GoogleChrome/lighthouse-stack-packs/pull/66 landed without a semicolon which I had not realized was a requirement for our strings parser. I made a slight adjustment to the regex pattern to work around it.