### PR TITLE
clients(viewer): import report generator async

### DIFF
--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -5,38 +5,14 @@
  */
 'use strict';
 
-const rollup = require('rollup');
 const rollupPlugins = require('./rollup-plugins.js');
 const GhPagesApp = require('./gh-pages-app.js');
 const {LH_ROOT} = require('../root.js');
-
-async function buildReportGenerator() {
-  const bundle = await rollup.rollup({
-    input: 'report/generator/report-generator.js',
-    plugins: [
-      rollupPlugins.shim({
-        [`${LH_ROOT}/report/generator/flow-report-assets.js`]: 'export default {}',
-      }),
-      rollupPlugins.commonjs(),
-      rollupPlugins.nodeResolve(),
-      rollupPlugins.inlineFs({verbose: Boolean(process.env.DEBUG)}),
-    ],
-  });
-
-  const result = await bundle.generate({
-    format: 'umd',
-    name: 'ReportGenerator',
-  });
-  await bundle.close();
-  return result.output[0].code;
-}
 
 /**
  * Build viewer, optionally deploying to gh-pages if `--deploy` flag was set.
  */
 async function run() {
-  const reportGeneratorJs = await buildReportGenerator();
-
   const app = new GhPagesApp({
     name: 'viewer',
     appDir: `${LH_ROOT}/viewer/app`,
@@ -46,7 +22,6 @@ async function run() {
       {path: '../../flow-report/assets/styles.css'},
     ],
     javascripts: [
-      reportGeneratorJs,
       {path: require.resolve('pako/dist/pako_inflate.js')},
       {path: 'src/main.js', rollup: true, rollupPlugins: [
         rollupPlugins.shim({

--- a/flow-report/src/topbar.tsx
+++ b/flow-report/src/topbar.tsx
@@ -87,8 +87,8 @@ export const Topbar: FunctionComponent<{onMenuClick: JSX.MouseEventHandler<HTMLB
       {
         getReportHtml &&
           <TopbarButton
-            onClick={() => {
-              const htmlStr = getReportHtml(flowResult);
+            onClick={async () => {
+              const htmlStr = await getReportHtml(flowResult);
               saveHtml(flowResult, htmlStr);
             }}
             label="Button that saves the report as HTML"

--- a/flow-report/test/topbar-test.tsx
+++ b/flow-report/test/topbar-test.tsx
@@ -52,7 +52,9 @@ it('save button opens save dialog for HTML file', async () => {
   const root = render(<Topbar onMenuClick={() => {}}/>, {wrapper});
 
   const saveButton = root.getByText('Save');
-  saveButton.click();
+  await act(() => {
+    saveButton.click();
+  });
 
   expect(mockSaveFile).toHaveBeenCalledWith(
     expect.any(Blob),

--- a/flow-report/types/flow-report.d.ts
+++ b/flow-report/types/flow-report.d.ts
@@ -21,7 +21,7 @@ declare global {
   module LH {
     export type ConfigSettings = Settings.ConfigSettings;
     export interface FlowReportOptions {
-      getReportHtml?: (flowResult: FlowResult_) => Promise<string>;
+      getReportHtml?: (flowResult: FlowResult_) => Promise<string>|string;
       saveAsGist?: (flowResult: FlowResult_) => void;
     }
 

--- a/flow-report/types/flow-report.d.ts
+++ b/flow-report/types/flow-report.d.ts
@@ -21,7 +21,7 @@ declare global {
   module LH {
     export type ConfigSettings = Settings.ConfigSettings;
     export interface FlowReportOptions {
-      getReportHtml?: (flowResult: FlowResult_) => string;
+      getReportHtml?: (flowResult: FlowResult_) => Promise<string>;
       saveAsGist?: (flowResult: FlowResult_) => void;
     }
 

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -148,9 +148,9 @@ export class ReportUIFeatures {
 
   /**
    * Returns the html that recreates this report.
-   * @return {string}
+   * @return {Promise<string>}
    */
-  getReportHtml() {
+  async getReportHtml() {
     if (this._topbar) {
       this._topbar.resetUIState();
     }

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -148,9 +148,9 @@ export class ReportUIFeatures {
 
   /**
    * Returns the html that recreates this report.
-   * @return {Promise<string>}
+   * @return {Promise<string>|string}
    */
-  async getReportHtml() {
+  getReportHtml() {
     if (this._topbar) {
       this._topbar.resetUIState();
     }

--- a/report/renderer/topbar-features.js
+++ b/report/renderer/topbar-features.js
@@ -60,7 +60,7 @@ export class TopbarFeatures {
    * Handler for tool button.
    * @param {Event} e
    */
-  onDropDownMenuClick(e) {
+  async onDropDownMenuClick(e) {
     e.preventDefault();
 
     const el = /** @type {?Element} */ (e.target);
@@ -87,7 +87,7 @@ export class TopbarFeatures {
         break;
       }
       case 'save-html': {
-        const htmlStr = this._reportUIFeatures.getReportHtml();
+        const htmlStr = await this._reportUIFeatures.getReportHtml();
         try {
           this._reportUIFeatures._saveFile(new Blob([htmlStr], {type: 'text/html'}));
         } catch (e) {

--- a/viewer/app/src/lighthouse-report-viewer.js
+++ b/viewer/app/src/lighthouse-report-viewer.js
@@ -255,9 +255,13 @@ export class LighthouseReportViewer {
    * @param {(json: LH.Result|LH.FlowResult) => void} [saveGistCallback]
    */
   _renderFlowResult(json, rootEl, saveGistCallback) {
-    // TODO: Add save HTML functionality with ReportGenerator loaded async.
     renderFlowReport(json, rootEl, {
       saveAsGist: saveGistCallback,
+      getReportHtml: async () => {
+        const {default: ReportGenerator} =
+          await import('../../../report/generator/report-generator.js');
+        return ReportGenerator.generateFlowReportHtml(json);
+      },
     });
     // Install as global for easier debugging.
     window.__LIGHTHOUSE_FLOW_JSON__ = json;

--- a/viewer/app/src/viewer-ui-features.js
+++ b/viewer/app/src/viewer-ui-features.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* global ReportGenerator */
+/* global */
 
 /** @typedef {import('../../../report/renderer/dom').DOM} DOM */
 /** @typedef {import('../../../shared/localization/locales').LhlMessages} LhlMessages */
@@ -55,10 +55,12 @@ export class ViewerUIFeatures extends ReportUIFeatures {
 
   /**
    * Uses ReportGenerator to create the html that recreates this report.
-   * @return {string}
+   * @return {Promise<string>}
    * @override
    */
-  getReportHtml() {
+  async getReportHtml() {
+    const {default: ReportGenerator} =
+      await import('../../../report/generator/report-generator.js');
     return ReportGenerator.generateReportHtml(this.json);
   }
 


### PR DESCRIPTION
Reduces initial bundle size for viewer. Should double the size of the report generator code because we are including the flow report assets now.

Enables viewer to save flow reports as HTML.

Closes https://github.com/GoogleChrome/lighthouse/issues/13423