### PR TITLE
deps(axe-core): upgrade to 4.3.5

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/a11y/expectations.js
@@ -205,7 +205,7 @@ const expectations = {
                 'type': 'node',
                 'selector': 'body > section > div > div#aria-required-parent',
                 'snippet': '<div id="aria-required-parent" role="option">',
-                'explanation': 'Fix any of the following:\n  Required ARIA parent role not present: listbox',
+                'explanation': 'Fix any of the following:\n  Required ARIA parents role not present: group, listbox',
                 'nodeLabel': 'body > section > div > div#aria-required-parent',
               },
             },

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "webtreemap-cdt": "^3.2.1"
   },
   "dependencies": {
-    "axe-core": "4.2.3",
+    "axe-core": "4.3.5",
     "chrome-launcher": "^0.15.0",
     "configstore": "^5.0.1",
     "csp_evaluator": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,10 +2157,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.3.tgz#2a3afc332f0031b42f602f4a3de03c211ca98f72"
-  integrity sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==
+axe-core@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
+  integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
 
 babel-jest@^27.2.0:
   version "27.2.0"


### PR DESCRIPTION
Closes https://github.com/GoogleChrome/lighthouse/issues/13368
Probably closes https://github.com/GoogleChrome/lighthouse/issues/12039 as well

Looks like this was caused by https://github.com/dequelabs/axe-core/issues/2674 and fixed by https://github.com/dequelabs/axe-core/pull/3172 in https://github.com/dequelabs/axe-core/releases/tag/v4.3.4.
