### PR TITLE
core(legacy-javascript): remove Object.getOwnPropertyNames signal

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/legacy-javascript/expectations.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/legacy-javascript/expectations.js
@@ -46,7 +46,6 @@ const expectations = {
                   {signal: 'Object.entries'},
                   {signal: 'Object.freeze'},
                   {signal: 'Object.getOwnPropertyDescriptors'},
-                  {signal: 'Object.getOwnPropertyNames'},
                   {signal: 'Object.getPrototypeOf'},
                   {signal: 'Object.isExtensible'},
                   {signal: 'Object.isFrozen'},

--- a/lighthouse-core/audits/byte-efficiency/legacy-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/legacy-javascript.js
@@ -192,7 +192,6 @@ class LegacyJavascript extends ByteEfficiencyAudit {
       ['Object.defineProperties', 'es6.object.define-properties'],
       ['Object.defineProperty', 'es6.object.define-property'],
       ['Object.freeze', 'es6.object.freeze'],
-      ['Object.getOwnPropertyNames', 'es6.object.get-own-property-names'],
       ['Object.getPrototypeOf', 'es6.object.get-prototype-of'],
       ['Object.isExtensible', 'es6.object.is-extensible'],
       ['Object.isFrozen', 'es6.object.is-frozen'],

--- a/lighthouse-core/scripts/legacy-javascript/run.js
+++ b/lighthouse-core/scripts/legacy-javascript/run.js
@@ -239,7 +239,7 @@ async function main() {
     });
   }
 
-  for (const coreJsVersion of ['2.6.12', '3.9.1']) {
+  for (const coreJsVersion of ['2.6.12', '3.19.1']) {
     const major = coreJsVersion.split('.')[0];
     removeCoreJs();
     installCoreJs(coreJsVersion);

--- a/lighthouse-core/scripts/legacy-javascript/summary-signals-nomaps.json
+++ b/lighthouse-core/scripts/legacy-javascript/summary-signals-nomaps.json
@@ -1,5 +1,5 @@
 {
-  "totalSignals": 265,
+  "totalSignals": 262,
   "variantsMissingSignals": [
     "core-js-2-only-polyfill/es6-array-filter",
     "core-js-2-only-polyfill/es6-array-map",
@@ -9,7 +9,6 @@
     "core-js-2-only-polyfill/es6-date-to-string",
     "core-js-2-only-polyfill/es6-function-name",
     "core-js-2-only-polyfill/es6-object-freeze",
-    "core-js-2-only-polyfill/es6-object-get-own-property-names",
     "core-js-2-only-polyfill/es6-object-get-prototype-of",
     "core-js-2-only-polyfill/es6-object-is-extensible",
     "core-js-2-only-polyfill/es6-object-is-frozen",
@@ -32,7 +31,7 @@
     },
     {
       "name": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
-      "signals": "Array.prototype.fill, Array.prototype.filter, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.prototype.includes, Array.isArray, Array.prototype.map, Array.of, Array.prototype.reduceRight, Array.prototype.reduce, Array.prototype.some, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.entries, Object.freeze, Object.getOwnPropertyDescriptors, Object.getOwnPropertyNames, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Object.setPrototypeOf, Object.values, Reflect.apply, Reflect.construct, Reflect.defineProperty, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat"
+      "signals": "Array.prototype.fill, Array.prototype.filter, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.prototype.includes, Array.isArray, Array.prototype.map, Array.of, Array.prototype.reduceRight, Array.prototype.reduce, Array.prototype.some, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.entries, Object.freeze, Object.getOwnPropertyDescriptors, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Object.setPrototypeOf, Object.values, Reflect.apply, Reflect.construct, Reflect.defineProperty, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat"
     },
     {
       "name": "core-js-2-only-polyfill/es6-array-fill",
@@ -124,10 +123,6 @@
     },
     {
       "name": "core-js-2-only-polyfill/es6-object-freeze",
-      "signals": ""
-    },
-    {
-      "name": "core-js-2-only-polyfill/es6-object-get-own-property-names",
       "signals": ""
     },
     {
@@ -359,10 +354,6 @@
       "signals": "Object.getOwnPropertyDescriptors"
     },
     {
-      "name": "core-js-3-only-polyfill/es-object-get-own-property-names",
-      "signals": "Object.getOwnPropertyNames"
-    },
-    {
       "name": "core-js-3-only-polyfill/es-object-get-prototype-of",
       "signals": "Object.getPrototypeOf"
     },
@@ -464,7 +455,7 @@
     },
     {
       "name": "core-js-3-preset-env-esmodules/false",
-      "signals": "Array.prototype.fill, Array.prototype.filter, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.prototype.includes, Array.isArray, Array.prototype.map, Array.of, Array.prototype.reduceRight, Array.prototype.reduce, Array.prototype.some, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.entries, Object.freeze, Object.getOwnPropertyDescriptors, Object.getOwnPropertyNames, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Object.setPrototypeOf, Object.values, Reflect.apply, Reflect.construct, Reflect.defineProperty, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, @babel/plugin-transform-classes, @babel/plugin-transform-regenerator, @babel/plugin-transform-spread"
+      "signals": "Array.prototype.fill, Array.prototype.filter, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.prototype.includes, Array.isArray, Array.prototype.map, Array.of, Array.prototype.reduceRight, Array.prototype.reduce, Array.prototype.some, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.entries, Object.freeze, Object.getOwnPropertyDescriptors, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Object.setPrototypeOf, Object.values, Reflect.apply, Reflect.construct, Reflect.defineProperty, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, @babel/plugin-transform-classes, @babel/plugin-transform-regenerator, @babel/plugin-transform-spread"
     },
     {
       "name": "core-js-3-preset-env-esmodules/true",

--- a/lighthouse-core/scripts/legacy-javascript/summary-signals.json
+++ b/lighthouse-core/scripts/legacy-javascript/summary-signals.json
@@ -1,5 +1,5 @@
 {
-  "totalSignals": 322,
+  "totalSignals": 316,
   "variantsMissingSignals": [
     "core-js-2-preset-env-esmodules/true",
     "core-js-2-preset-env-esmodules/true-and-bugfixes",
@@ -9,11 +9,11 @@
   "variants": [
     {
       "name": "all-legacy-polyfills/all-legacy-polyfills-core-js-2",
-      "signals": "Array.prototype.fill, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.isArray, Array.of, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.setPrototypeOf, Reflect.apply, Reflect.construct, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, Array.prototype.includes, Object.entries, Object.getOwnPropertyDescriptors, Object.values, Array.prototype.filter, Array.prototype.map, Array.prototype.reduce, Array.prototype.reduceRight, Array.prototype.some, Date.prototype.toString, Function.prototype.name, Object.freeze, Object.getOwnPropertyNames, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Reflect.defineProperty"
+      "signals": "Array.prototype.fill, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.isArray, Array.of, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.setPrototypeOf, Reflect.apply, Reflect.construct, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, Array.prototype.includes, Object.entries, Object.getOwnPropertyDescriptors, Object.values, Array.prototype.filter, Array.prototype.map, Array.prototype.reduce, Array.prototype.reduceRight, Array.prototype.some, Date.prototype.toString, Function.prototype.name, Object.freeze, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Reflect.defineProperty"
     },
     {
       "name": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
-      "signals": "Array.prototype.fill, Array.prototype.filter, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.prototype.includes, Array.isArray, Array.prototype.map, Array.of, Array.prototype.reduceRight, Array.prototype.reduce, Array.prototype.some, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.entries, Object.freeze, Object.getOwnPropertyDescriptors, Object.getOwnPropertyNames, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Object.setPrototypeOf, Object.values, Reflect.apply, Reflect.construct, Reflect.defineProperty, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, Date.prototype.toString, Function.prototype.name"
+      "signals": "Array.prototype.fill, Array.prototype.filter, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.prototype.includes, Array.isArray, Array.prototype.map, Array.of, Array.prototype.reduceRight, Array.prototype.reduce, Array.prototype.some, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.entries, Object.freeze, Object.getOwnPropertyDescriptors, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Object.setPrototypeOf, Object.values, Reflect.apply, Reflect.construct, Reflect.defineProperty, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, Date.prototype.toString, Function.prototype.name"
     },
     {
       "name": "core-js-2-only-polyfill/es6-array-fill",
@@ -106,10 +106,6 @@
     {
       "name": "core-js-2-only-polyfill/es6-object-freeze",
       "signals": "Object.freeze"
-    },
-    {
-      "name": "core-js-2-only-polyfill/es6-object-get-own-property-names",
-      "signals": "Object.getOwnPropertyNames"
     },
     {
       "name": "core-js-2-only-polyfill/es6-object-get-prototype-of",
@@ -225,7 +221,7 @@
     },
     {
       "name": "core-js-2-preset-env-esmodules/false",
-      "signals": "Array.prototype.fill, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.isArray, Array.of, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.setPrototypeOf, Reflect.apply, Reflect.construct, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, Array.prototype.includes, Object.entries, Object.getOwnPropertyDescriptors, Object.values, @babel/plugin-transform-classes, @babel/plugin-transform-regenerator, @babel/plugin-transform-spread, Array.prototype.filter, Array.prototype.map, Array.prototype.reduce, Array.prototype.reduceRight, Array.prototype.some, Date.prototype.toString, Function.prototype.name, Object.freeze, Object.getOwnPropertyNames, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Reflect.defineProperty"
+      "signals": "Array.prototype.fill, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.isArray, Array.of, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.setPrototypeOf, Reflect.apply, Reflect.construct, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, Array.prototype.includes, Object.entries, Object.getOwnPropertyDescriptors, Object.values, @babel/plugin-transform-classes, @babel/plugin-transform-regenerator, @babel/plugin-transform-spread, Array.prototype.filter, Array.prototype.map, Array.prototype.reduce, Array.prototype.reduceRight, Array.prototype.some, Date.prototype.toString, Function.prototype.name, Object.freeze, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Reflect.defineProperty"
     },
     {
       "name": "core-js-2-preset-env-esmodules/true",
@@ -340,10 +336,6 @@
       "signals": "Object.getOwnPropertyDescriptors"
     },
     {
-      "name": "core-js-3-only-polyfill/es-object-get-own-property-names",
-      "signals": "Object.getOwnPropertyNames"
-    },
-    {
       "name": "core-js-3-only-polyfill/es-object-get-prototype-of",
       "signals": "Object.getPrototypeOf"
     },
@@ -445,7 +437,7 @@
     },
     {
       "name": "core-js-3-preset-env-esmodules/false",
-      "signals": "Array.prototype.fill, Array.prototype.filter, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.prototype.includes, Array.isArray, Array.prototype.map, Array.of, Array.prototype.reduceRight, Array.prototype.reduce, Array.prototype.some, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.entries, Object.freeze, Object.getOwnPropertyDescriptors, Object.getOwnPropertyNames, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Object.setPrototypeOf, Object.values, Reflect.apply, Reflect.construct, Reflect.defineProperty, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, @babel/plugin-transform-classes, @babel/plugin-transform-regenerator, @babel/plugin-transform-spread, Date.prototype.toString, Function.prototype.name"
+      "signals": "Array.prototype.fill, Array.prototype.filter, Array.prototype.findIndex, Array.prototype.find, Array.prototype.forEach, Array.from, Array.prototype.includes, Array.isArray, Array.prototype.map, Array.of, Array.prototype.reduceRight, Array.prototype.reduce, Array.prototype.some, Date.now, Date.prototype.toISOString, Date.prototype.toJSON, Number.isInteger, Number.isSafeInteger, Number.parseInt, Object.defineProperties, Object.defineProperty, Object.entries, Object.freeze, Object.getOwnPropertyDescriptors, Object.getPrototypeOf, Object.isExtensible, Object.isFrozen, Object.isSealed, Object.keys, Object.preventExtensions, Object.seal, Object.setPrototypeOf, Object.values, Reflect.apply, Reflect.construct, Reflect.defineProperty, Reflect.deleteProperty, Reflect.getOwnPropertyDescriptor, Reflect.getPrototypeOf, Reflect.get, Reflect.has, Reflect.isExtensible, Reflect.ownKeys, Reflect.preventExtensions, Reflect.setPrototypeOf, String.prototype.codePointAt, String.fromCodePoint, String.raw, String.prototype.repeat, @babel/plugin-transform-classes, @babel/plugin-transform-regenerator, @babel/plugin-transform-spread, Date.prototype.toString, Function.prototype.name"
     },
     {
       "name": "core-js-3-preset-env-esmodules/true",

--- a/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
+++ b/lighthouse-core/scripts/legacy-javascript/summary-sizes.txt
@@ -1,12 +1,11 @@
 all-legacy-polyfills
-  84149        all-legacy-polyfills-core-js-3/main.bundle.min.js
-  55778        all-legacy-polyfills-core-js-2/main.bundle.min.js
+  103989       all-legacy-polyfills-core-js-3/main.bundle.min.js
+   54891       all-legacy-polyfills-core-js-2/main.bundle.min.js
 
 core-js-2-only-polyfill
   14974        es6-reflect-construct/main.bundle.min.js
   12832        es7-object-get-own-property-descriptors/main.bundle.min.js
   12278        es6-array-from/main.bundle.min.js
-  11669        es6-object-get-own-property-names/main.bundle.min.js
   11506        es6-array-find-index/main.bundle.min.js
   11479        es6-array-find/main.bundle.min.js
   11389        es7-object-entries/main.bundle.min.js
@@ -62,63 +61,62 @@ core-js-2-preset-env-esmodules
    63536       true-and-bugfixes/main.bundle.min.js
 
 core-js-3-only-polyfill
-  30090        es-array-find-index/main.bundle.min.js
-  30024        es-array-find/main.bundle.min.js
-  29184        es-array-from/main.bundle.min.js
-  27345        es-array-fill/main.bundle.min.js
-  26687        es-array-filter/main.bundle.min.js
-  26663        es-array-map/main.bundle.min.js
-  26579        es-array-includes/main.bundle.min.js
-  26563        es-array-for-each/main.bundle.min.js
-  26342        es-array-some/main.bundle.min.js
-  25662        es-reflect-construct/main.bundle.min.js
-  23119        es-array-reduce-right/main.bundle.min.js
-  23081        es-array-reduce/main.bundle.min.js
-  22464        es-date-to-iso-string/main.bundle.min.js
-  21968        es-object-prevent-extensions/main.bundle.min.js
-  21906        es-reflect-get/main.bundle.min.js
-  21867        es-object-freeze/main.bundle.min.js
-  21849        es-object-seal/main.bundle.min.js
-  21606        es-object-get-prototype-of/main.bundle.min.js
-  21456        es-reflect-get-prototype-of/main.bundle.min.js
-  21329        es-object-get-own-property-descriptors/main.bundle.min.js
-  21288        es-number-parse-int/main.bundle.min.js
-  21214        es-reflect-set-prototype-of/main.bundle.min.js
-  21073        es-object-entries/main.bundle.min.js
-  21070        es-object-define-properties/main.bundle.min.js
-  21066        es-object-values/main.bundle.min.js
-  20913        es-array-of/main.bundle.min.js
-  20909        es-object-get-own-property-names/main.bundle.min.js
-  20856        es-object-set-prototype-of/main.bundle.min.js
-  20811        es-string-code-point-at/main.bundle.min.js
-  20726        es-object-keys/main.bundle.min.js
-  20668        es-reflect-apply/main.bundle.min.js
-  20649        es-reflect-define-property/main.bundle.min.js
-  20567        es-date-to-json/main.bundle.min.js
-  20518        es-reflect-prevent-extensions/main.bundle.min.js
-  20458        es-string-from-code-point/main.bundle.min.js
-  20415        es-string-repeat/main.bundle.min.js
-  20320        es-reflect-get-own-property-descriptor/main.bundle.min.js
-  20303        es-string-raw/main.bundle.min.js
-  20250        es-reflect-delete-property/main.bundle.min.js
-  20246        es-number-is-safe-integer/main.bundle.min.js
-  20208        es-object-is-extensible/main.bundle.min.js
-  20172        es-object-is-sealed/main.bundle.min.js
-  20172        es-object-is-frozen/main.bundle.min.js
-  20137        es-number-is-integer/main.bundle.min.js
-  20105        es-object-define-property/main.bundle.min.js
-  20094        es-array-is-array/main.bundle.min.js
-  20058        es-reflect-is-extensible/main.bundle.min.js
-  19900        es-reflect-own-keys/main.bundle.min.js
-  19869        es-reflect-has/main.bundle.min.js
-  19840        es-date-now/main.bundle.min.js
-  10658        es-date-to-string/main.bundle.min.js
-   4515        es-function-name/main.bundle.min.js
+  40653        es-array-find-index/main.bundle.min.js
+  40587        es-array-find/main.bundle.min.js
+  40016        es-reflect-construct/main.bundle.min.js
+  39609        es-array-from/main.bundle.min.js
+  37047        es-array-filter/main.bundle.min.js
+  37023        es-array-map/main.bundle.min.js
+  36920        es-array-for-each/main.bundle.min.js
+  36702        es-array-some/main.bundle.min.js
+  35250        es-date-to-iso-string/main.bundle.min.js
+  35116        es-object-prevent-extensions/main.bundle.min.js
+  35015        es-object-freeze/main.bundle.min.js
+  34997        es-object-seal/main.bundle.min.js
+  34914        es-array-fill/main.bundle.min.js
+  34354        es-array-includes/main.bundle.min.js
+  33898        es-array-of/main.bundle.min.js
+  33619        es-number-parse-int/main.bundle.min.js
+  32875        es-string-code-point-at/main.bundle.min.js
+  32421        es-reflect-get/main.bundle.min.js
+  32407        es-string-raw/main.bundle.min.js
+  32346        es-string-repeat/main.bundle.min.js
+  32234        es-array-reduce-right/main.bundle.min.js
+  32204        es-array-reduce/main.bundle.min.js
+  31727        es-object-get-prototype-of/main.bundle.min.js
+  31596        es-reflect-set-prototype-of/main.bundle.min.js
+  31577        es-reflect-get-prototype-of/main.bundle.min.js
+  31447        es-object-get-own-property-descriptors/main.bundle.min.js
+  31370        es-object-entries/main.bundle.min.js
+  31363        es-object-values/main.bundle.min.js
+  31310        es-object-define-properties/main.bundle.min.js
+  31238        es-object-set-prototype-of/main.bundle.min.js
+  31216        es-reflect-is-extensible/main.bundle.min.js
+  31119        es-object-is-extensible/main.bundle.min.js
+  30860        es-object-is-sealed/main.bundle.min.js
+  30860        es-object-is-frozen/main.bundle.min.js
+  30780        es-string-from-code-point/main.bundle.min.js
+  30772        es-reflect-apply/main.bundle.min.js
+  30762        es-reflect-define-property/main.bundle.min.js
+  30626        es-reflect-prevent-extensions/main.bundle.min.js
+  30592        es-object-keys/main.bundle.min.js
+  30441        es-date-to-json/main.bundle.min.js
+  30428        es-reflect-get-own-property-descriptor/main.bundle.min.js
+  30402        es-number-is-safe-integer/main.bundle.min.js
+  30358        es-reflect-delete-property/main.bundle.min.js
+  30293        es-number-is-integer/main.bundle.min.js
+  30213        es-object-define-property/main.bundle.min.js
+  30212        es-array-is-array/main.bundle.min.js
+  30184        es-date-now/main.bundle.min.js
+  30008        es-reflect-own-keys/main.bundle.min.js
+  29977        es-reflect-has/main.bundle.min.js
+  20464        es-date-to-string/main.bundle.min.js
+  14848        es-function-name/main.bundle.min.js
 
 core-js-3-preset-env-esmodules
-  408753       false/main.bundle.min.js
-  304901       true/main.bundle.min.js
-  304220       true-and-bugfixes/main.bundle.min.js
+  469455       false/main.bundle.min.js
+  357263       true/main.bundle.min.js
+  356582       true-and-bugfixes/main.bundle.min.js
 
 only-plugin
   1787         -babel-plugin-transform-spread/main.bundle.min.js


### PR DESCRIPTION
I bumped `core-js` in the verification tool from `3.9.1` to `3.19.1`, which revealed that we must remove the signal for `Object.getOwnPropertyNames` as `esmodules: true` now includes it.