### PR TITLE
core(font-size): fix CSS selector regex

### DIFF
--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -52,8 +52,8 @@ function computeSelectorSpecificity(selector) {
   let numTypes = 0;
 
   for (const token of tokens) {
-    const ids = token.match(/\b#[a-z0-9]+/g) || [];
-    const classes = token.match(/\b\.[a-z0-9]+/g) || [];
+    const ids = token.match(/(\b|^)#[a-z0-9_-]+/g) || [];
+    const classes = token.match(/(\b|^)\.[a-z0-9_-]+/g) || [];
     const types = token.match(/^[a-z]+/) ? [1] : [];
     numIDs += ids.length;
     numClasses += classes.length;

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -36,25 +36,28 @@ function hasFontSizeDeclaration(style) {
 
 /**
  * Computes the CSS specificity of a given selector, i.e. #id > .class > div
+ * TODO: Handle pseudo selectors (:not(), :where, :nth-child) and attribute selectors
  * LIMITATION: !important is not respected
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity
  * @see https://www.smashingmagazine.com/2010/04/css-specificity-and-inheritance/
+ * @see https://drafts.csswg.org/selectors-4/#specificity-rules
  *
  * @param {string} selector
  * @return {number}
  */
 function computeSelectorSpecificity(selector) {
-  const tokens = selector.split(' ');
+  // Remove universal selector and separator characters, then split.
+  const tokens = selector.replace(/[*\s+>~]/g, ' ').split(' ');
 
   let numIDs = 0;
   let numClasses = 0;
   let numTypes = 0;
 
   for (const token of tokens) {
-    const ids = token.match(/(\b|^)#[a-z0-9_-]+/g) || [];
-    const classes = token.match(/(\b|^)\.[a-z0-9_-]+/g) || [];
-    const types = token.match(/^[a-z]+/) ? [1] : [];
+    const ids = token.match(/(\b|^)#[a-z0-9_-]+/gi) || [];
+    const classes = token.match(/(\b|^)\.[a-z0-9_-]+/gi) || [];
+    const types = token.match(/^[a-z]+/i) ? [1] : [];
     numIDs += ids.length;
     numClasses += classes.length;
     numTypes += types.length;
@@ -182,7 +185,7 @@ class FontSize extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],
-  }
+  };
 
   /**
    * @param {LH.Gatherer.FRProtocolSession} session

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -187,11 +187,14 @@ describe('Font size gatherer', () => {
 
     it('should handle class selectors', () => {
       expect(compute('h1.foo')).toEqual(11);
+      expect(compute('.foo')).toEqual(10);
       expect(compute('h1 > p.other.yeah > span')).toEqual(23);
     });
 
     it('should handle ID selectors', () => {
       expect(compute('h1#awesome.foo')).toEqual(111);
+      expect(compute('#awesome.foo')).toEqual(110);
+      expect(compute('#awesome')).toEqual(100);
       expect(compute('h1 > p.other > span#the-text')).toEqual(113);
     });
 

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -198,6 +198,33 @@ describe('Font size gatherer', () => {
       expect(compute('h1 > p.other > span#the-text')).toEqual(113);
     });
 
+    it('should ignore the univeral selector', () => {
+      expect(compute('.foo')).toEqual(10);
+      expect(compute('* .foo')).toEqual(10);
+      expect(compute('.foo *')).toEqual(10);
+    });
+
+    // Examples https://drafts.csswg.org/selectors-3/#specificity
+    it('should handle l3 spec selectors', () => {
+      expect(compute('*')).toEqual(0);
+      expect(compute('LI')).toEqual(1);
+      expect(compute('UL LI')).toEqual(2);
+      expect(compute('UL OL+LI')).toEqual(3);
+      // expect(compute('H1 + *[REL=up]')).toEqual(11); // TODO: Handle attribute selectors
+      expect(compute('UL OL LI.red')).toEqual(13);
+      expect(compute('LI.red.level')).toEqual(21);
+      expect(compute('#x34y')).toEqual(100);
+      // expect(compute('#s12:not(FOO)')).toEqual(101); // TODO: Handle pseudo selectors
+    });
+
+    // Examples from https://drafts.csswg.org/selectors-4/#specificity-rules
+    it('should handle l4 spec selectors', () => {
+      expect(compute(':is(em, #foo)')).toEqual(100);
+      // expect(compute('.qux:where(em, #foo#bar#baz)')).toEqual(10); // TODO: Handle pseudo selectors
+      // expect(compute(':nth-child(even of li, .item)')).toEqual(20); // TODO: Handle pseudo selectors
+      // expect(compute(':not(em, strong#foo)')).toEqual(101); // TODO: Handle pseudo selectors
+    });
+
     it('should cap the craziness', () => {
       expect(compute('h1.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p')).toEqual(91);
     });


### PR DESCRIPTION
Resolves most of https://github.com/GoogleChrome/lighthouse/issues/12001.
