### PR TITLE
tests: clean up and add comments to cdt layout test scripts

### DIFF
--- a/lighthouse-core/scripts/build-devtools.sh
+++ b/lighthouse-core/scripts/build-devtools.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+##
+# @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+##
+
+# 1) Builds Lighthouse bundle for DevTools
+# 2) Rolls to local devtools repo. By default, this is the temporary checkout in .tmp
+# 3) Builds devtools frontend with new Lighthouse roll
+# 
+# Run `bash lighthouse-core/test/chromium-web-tests/setup.sh` first to update the temporary devtools checkout.
+# Specify `$DEVTOOLS_PATH` to use a different devtools repo.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LH_ROOT="$SCRIPT_DIR/../.."
+TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
+DEFAULT_DEVTOOLS_PATH="$TEST_DIR/devtools/devtools-frontend"
+DEVTOOLS_PATH=${DEVTOOLS_PATH:-"$DEFAULT_DEVTOOLS_PATH"}
+
+echo "DEVTOOLS_PATH: $DEVTOOLS_PATH"
+
+if [ ! -d "$DEVTOOLS_PATH" ]; then
+  echo "No devtools found at $DEVTOOLS_PATH."
+  if [ "$DEVTOOLS_PATH" = "$DEFAULT_DEVTOOLS_PATH" ]; then
+    echo "Have you run 'yarn test-devtools' yet?"
+  fi
+
+  exit 1
+fi
+
+if ! which gn ; then
+  # If the contributor doesn't have a separate depot tools in their path, use the tmp copy.
+  DEPOT_TOOLS_PATH="$TEST_DIR/depot-tools"
+  BLINK_TOOLS_PATH="$TEST_DIR/blink_tools"
+  export PATH=$DEPOT_TOOLS_PATH:$PATH
+  # Add typ to python path. The regular method assumes there is a Chromium checkout.
+  export PYTHONPATH="${PYTHONPATH:-}:$BLINK_TOOLS_PATH/latest/third_party/typ"
+fi
+
+yarn devtools "$DEVTOOLS_PATH"
+
+cd "$DEVTOOLS_PATH"
+gn gen out/Default
+gclient sync
+autoninja -C out/Default

--- a/lighthouse-core/scripts/open-devtools.sh
+++ b/lighthouse-core/scripts/open-devtools.sh
@@ -8,6 +8,11 @@ set -euo pipefail
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 ##
 
+# 1) Builds DevTools with current Lighthouse
+# 2) Opens $CHROME_PATH using new devtools frontend build, passing any additional args to Chrome.
+#
+# Specify `$DEVTOOLS_PATH` to use a different devtools repo.
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT="$SCRIPT_DIR/../.."
 TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
@@ -19,28 +24,13 @@ if [ -z "${CHROME_PATH:-}" ]; then
   exit 1
 fi
 
+if [ "$DEFAULT_DEVTOOLS_PATH" == "$DEVTOOLS_PATH" ]; then
+  bash "$LH_ROOT/lighthouse-core/test/chromium-web-tests/setup.sh"
+fi
+
 echo "CHROME_PATH: $CHROME_PATH"
-echo "DEVTOOLS_PATH: $DEVTOOLS_PATH"
 
-if [ ! -d "$DEVTOOLS_PATH" ]; then
-  echo "No devtools found at $DEVTOOLS_PATH. Have you run 'yarn test-devtools' yet?"
-  exit 1
-fi
-
-if ! which gn ; then
-  # If the contributor doesn't have a separate depot tools in their path, use the tmp copy.
-  DEPOT_TOOLS_PATH="$TEST_DIR/depot-tools"
-  BLINK_TOOLS_PATH="$TEST_DIR/blink_tools"
-  export PATH=$DEPOT_TOOLS_PATH:$PATH
-  # Add typ to python path. The regular method assumes there is a Chromium checkout.
-  export PYTHONPATH="${PYTHONPATH:-}:$BLINK_TOOLS_PATH/latest/third_party/typ"
-fi
-
-yarn devtools "$DEVTOOLS_PATH"
-
-cd "$DEVTOOLS_PATH"
-gn gen out/Default
-gclient sync
-autoninja -C out/Default
+export DEVTOOLS_PATH
+bash "$SCRIPT_DIR/build-devtools.sh"
 
 "$CHROME_PATH" --custom-devtools-frontend=file://"$DEVTOOLS_PATH"/out/Default/gen/front_end $*

--- a/lighthouse-core/scripts/open-devtools.sh
+++ b/lighthouse-core/scripts/open-devtools.sh
@@ -15,22 +15,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT="$SCRIPT_DIR/../.."
-TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
-DEFAULT_DEVTOOLS_PATH="$TEST_DIR/devtools/devtools-frontend"
-DEVTOOLS_PATH=${DEVTOOLS_PATH:-"$DEFAULT_DEVTOOLS_PATH"}
 
 if [ -z "${CHROME_PATH:-}" ]; then
   echo 'Must set $CHROME_PATH'
   exit 1
 fi
 
-if [ "$DEFAULT_DEVTOOLS_PATH" == "$DEVTOOLS_PATH" ]; then
-  bash "$LH_ROOT/lighthouse-core/test/chromium-web-tests/setup.sh"
+# If using the default .tmp devtools checkout, make sure it's up to date first.
+if [ -z "${DEVTOOLS_PATH:-}" ]; then
+  source "$LH_ROOT/lighthouse-core/test/chromium-web-tests/setup.sh"
 fi
 
 echo "CHROME_PATH: $CHROME_PATH"
 
-export DEVTOOLS_PATH
-bash "$SCRIPT_DIR/build-devtools.sh"
+bash "$LH_ROOT/lighthouse-core/scripts/build-devtools.sh"
 
 "$CHROME_PATH" --custom-devtools-frontend=file://"$DEVTOOLS_PATH"/out/Default/gen/front_end $*

--- a/lighthouse-core/scripts/pptr-run-devtools.js
+++ b/lighthouse-core/scripts/pptr-run-devtools.js
@@ -10,6 +10,14 @@
  * Make sure CHROME_PATH is set to a modern version of Chrome.
  * May work on older versions of Chrome.
  *
+ * To use with locally built DevTools and Lighthouse, run (assuming devtools at ~/src/devtools/devtools-frontend):
+ *    yarn devtools
+ *    yarn run-devtools --custom-devtools-frontend=file://$HOME/src/devtools/devtools-frontend/out/Default/gen/front_end
+ *
+ * Or with the DevTools in .tmp:
+ *   bash lighthouse-core/test/chromium-web-tests/setup.sh
+ *   yarn run-devtools --custom-devtools-frontend=file://$PWD/.tmp/chromium-web-tests/devtools/devtools-frontend/out/Default/gen/front_end
+ *
  * URL list file: yarn run-devtools < path/to/urls.txt
  * Single URL: yarn run-devtools "https://example.com"
  */
@@ -217,6 +225,10 @@ async function run() {
   }
 
   const customDevtools = argv['custom-devtools-frontend'];
+  if (customDevtools) {
+    console.log(`Using custom devtools frontend: ${customDevtools}`);
+    console.log('Make sure it has been built recently!');
+  }
 
   const browser = await puppeteer.launch({
     executablePath: process.env.CHROME_PATH,
@@ -242,6 +254,7 @@ async function run() {
     }
   }
   console.log(`${urlList.length - errorCount} / ${urlList.length} urls run successfully.`);
+  console.log(`Results saved to ${argv.o}`);
 
   await browser.close();
 

--- a/lighthouse-core/test/chromium-web-tests/README.md
+++ b/lighthouse-core/test/chromium-web-tests/README.md
@@ -7,11 +7,15 @@ This runs the Chromium webtests using the devtools integration tester.
 ## Run
 
 ```sh
-yarn build-devtools
 yarn test-devtools
 
 # Reset the results.
 yarn update:test-devtools
+
+# Run the test runner, without updating content_shell or getting the latest
+# DevTools commits like `yarn test-devtools` does.
+# This still bundles Lighthouse + rolls to DevTools before running the tests.
+SKIP_DOWNLOADS=1 yarn test-devtools
 ```
 
 ### Prerequistes

--- a/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
+++ b/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
@@ -6,6 +6,9 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 ##
 
+# Do not use directly. Requires setting up multiple environment variables first,
+# see test-locally.sh for example.
+
 set -u
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/lighthouse-core/test/chromium-web-tests/setup.sh
+++ b/lighthouse-core/test/chromium-web-tests/setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+##
+# @license Copyright 2021 The Lighthouse Authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+##
+
+# Setup dependencies for local layout test runner.
+# Set SKIP_DOWNLOADS to skip all the downloading and just export variables.
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LH_ROOT="$SCRIPT_DIR/../../.."
+TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
+
+export DEPOT_TOOLS_PATH="$TEST_DIR/depot-tools"
+export DEVTOOLS_PATH=${DEVTOOLS_PATH:-"$TEST_DIR/devtools/devtools-frontend"}
+export BLINK_TOOLS_PATH="$TEST_DIR/blink_tools"
+export PATH=$DEPOT_TOOLS_PATH:$PATH
+
+if [ -z ${SKIP_DOWNLOADS+x} ]
+then
+  echo "========================================"
+  echo "Downloading dependencies, including latest content_shell and DevTools"
+  echo "To skip this step, set SKIP_DOWNLOADS=1"
+  echo "========================================"
+  echo
+
+  bash "$SCRIPT_DIR/download-depot-tools.sh"
+  bash "$SCRIPT_DIR/download-devtools.sh"
+  bash "$SCRIPT_DIR/download-blink-tools.sh"
+  bash "$SCRIPT_DIR/download-content-shell.sh"
+fi

--- a/lighthouse-core/test/chromium-web-tests/test-locally.sh
+++ b/lighthouse-core/test/chromium-web-tests/test-locally.sh
@@ -6,24 +6,14 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 ##
 
+# Runs the layout tests in third-party/chromium-webtests using the latest
+# Lighthouse, DevTools, and Chrome content_shell*
+#
+# * Not exactly the latest, but close. See download-content-shell.js
+
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-LH_ROOT="$SCRIPT_DIR/../../.."
-TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
 
-# Setup dependencies.
-export DEPOT_TOOLS_PATH="$TEST_DIR/depot-tools"
-export DEVTOOLS_PATH=${DEVTOOLS_PATH:-"$TEST_DIR/devtools/devtools-frontend"}
-export BLINK_TOOLS_PATH="$TEST_DIR/blink_tools"
-export PATH=$DEPOT_TOOLS_PATH:$PATH
-
-set -x
-
-bash "$SCRIPT_DIR/download-depot-tools.sh"
-bash "$SCRIPT_DIR/download-devtools.sh"
-bash "$SCRIPT_DIR/download-blink-tools.sh"
-bash "$SCRIPT_DIR/download-content-shell.sh"
-
-# Run web tests.
+source "$SCRIPT_DIR/setup.sh"
 bash "$SCRIPT_DIR/run-web-tests.sh" $*


### PR DESCRIPTION
Some refactoring/documenting I wanted to do for these scripts.

* Add a lot of file-level comments
* Split out dependency setup from test-locally.sh into its own script
* Run setup.sh in `yarn open-devtools` if running against the default .tmp DevTools checkout
* Split out "roll and build devtools" from `yarn open-devtools`, should be useful for #13456
* SKIP_DOWNLOADS : Add option to skip the content_shell / CDT updates