### PR TITLE
core(navigation): improve url presentation in redirect warning message

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects-client-paint-server.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects-client-paint-server.js
@@ -52,7 +52,7 @@ const expectations = {
       },
     },
     runWarnings: [
-      /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+      /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to \(.*redirects-final.html \)—try testing the second URL directly./,
     ],
   },
 };

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects-history-push-state.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects-history-push-state.js
@@ -35,7 +35,7 @@ const expectations = {
     audits: {
     },
     runWarnings: [
-      /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html\?pushState. Try testing the second URL directly./,
+      /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to \(.*redirects-final.html\?pushState \)—try testing the second URL directly./,
     ],
   },
 };

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects-multiple-server.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects-multiple-server.js
@@ -48,7 +48,7 @@ const expectations = {
       },
     },
     runWarnings: [
-      /The page may not be loading as expected because your test URL \(.*online-only.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+      /The page may not be loading as expected because your test URL \(.*online-only.html.*\) was redirected to \(.*redirects-final.html \)—try testing the second URL directly./,
     ],
   },
 };

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects-single-client.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects-single-client.js
@@ -32,7 +32,7 @@ const expectations = {
     audits: {
     },
     runWarnings: [
-      /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+      /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to \(.*redirects-final.html \)—try testing the second URL directly./,
     ],
   },
 };

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects-single-server.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects-single-server.js
@@ -49,7 +49,7 @@ const expectations = {
       },
     },
     runWarnings: [
-      /The page may not be loading as expected because your test URL \(.*online-only.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,
+      /The page may not be loading as expected because your test URL \(.*online-only.html.*\) was redirected to \(.*redirects-final.html \)—try testing the second URL directly./,
     ],
   },
 };

--- a/lighthouse-core/gather/driver/navigation.js
+++ b/lighthouse-core/gather/driver/navigation.js
@@ -19,8 +19,7 @@ const UIStrings = {
    * @example {https://example.com/final/resolved/page} final
    */
   warningRedirected: 'The page may not be loading as expected because your test URL ' +
-  `({requested}) was redirected to {final}. ` +
-  'Try testing the second URL directly.',
+  `( {requested} ) was redirected to ( {final} )—try testing the second URL directly.`,
   /**
    * @description Warning that Lighthouse timed out while waiting for the page to load.
    */

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1803,7 +1803,7 @@
     "message": "The tested device appears to have a slower CPU than  Lighthouse expects. This can negatively affect your performance score. Learn more about [calibrating an appropriate CPU slowdown multiplier](https://github.com/GoogleChrome/lighthouse/blob/master/docs/throttling.md#cpu-throttling)."
   },
   "lighthouse-core/gather/driver/navigation.js | warningRedirected": {
-    "message": "The page may not be loading as expected because your test URL ({requested}) was redirected to {final}. Try testing the second URL directly."
+    "message": "The page may not be loading as expected because your test URL ( {requested} ) was redirected to ( {final} )—try testing the second URL directly."
   },
   "lighthouse-core/gather/driver/navigation.js | warningTimeout": {
     "message": "The page loaded too slowly to finish within the time limit. Results may be incomplete."

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1803,7 +1803,7 @@
     "message": "T̂h́ê t́êśt̂éd̂ d́êv́îćê áp̂ṕêár̂ś t̂ó ĥáv̂é â śl̂óŵér̂ ĆP̂Ú t̂h́âń  L̂íĝh́t̂h́ôúŝé êx́p̂éĉt́ŝ. T́ĥíŝ ćâń n̂éĝát̂ív̂él̂ý âf́f̂éĉt́ ŷóûŕ p̂ér̂f́ôŕm̂án̂ćê śĉór̂é. L̂éâŕn̂ ḿôŕê áb̂óût́ [ĉál̂íb̂ŕât́îńĝ án̂ áp̂ṕr̂óp̂ŕîát̂é ĈṔÛ śl̂óŵd́ôẃn̂ ḿûĺt̂íp̂ĺîér̂](https://github.com/GoogleChrome/lighthouse/blob/master/docs/throttling.md#cpu-throttling)."
   },
   "lighthouse-core/gather/driver/navigation.js | warningRedirected": {
-    "message": "T̂h́ê ṕâǵê ḿâý n̂ót̂ b́ê ĺôád̂ín̂ǵ âś êx́p̂éĉt́êd́ b̂éĉáûśê ýôúr̂ t́êśt̂ ÚR̂Ĺ ({requested}) ŵáŝ ŕêd́îŕêćt̂éd̂ t́ô {final}. T́r̂ý t̂éŝt́îńĝ t́ĥé ŝéĉón̂d́ ÛŔL̂ d́îŕêćt̂ĺŷ."
+    "message": "T̂h́ê ṕâǵê ḿâý n̂ót̂ b́ê ĺôád̂ín̂ǵ âś êx́p̂éĉt́êd́ b̂éĉáûśê ýôúr̂ t́êśt̂ ÚR̂Ĺ ( {requested} ) ŵáŝ ŕêd́îŕêćt̂éd̂ t́ô ( {final} )—t́r̂ý t̂éŝt́îńĝ t́ĥé ŝéĉón̂d́ ÛŔL̂ d́îŕêćt̂ĺŷ."
   },
   "lighthouse-core/gather/driver/navigation.js | warningTimeout": {
     "message": "T̂h́ê ṕâǵê ĺôád̂éd̂ t́ôó ŝĺôẃl̂ý t̂ó f̂ín̂íŝh́ ŵít̂h́îń t̂h́ê t́îḿê ĺîḿît́. R̂éŝúl̂t́ŝ ḿâý b̂é îńĉóm̂ṕl̂ét̂é."


### PR DESCRIPTION
before

> "The page may not be loading as expected because your test URL (chromestatus.com/features) was redirected to chromestatus.com/features. Try testing the second URL directly."

after 

> "The page may not be loading as expected because your test URL ( chromestatus.com/features ) was redirected to ( chromestatus.com/features )—try testing the second URL directly."

Padding the url with spaces on either side improves url detection. for example, see how the url is wrong for the old format here: 
![image](https://user-images.githubusercontent.com/4071474/145314472-f5cfc39d-0657-47d4-95c0-6270caf2c2ec.png)

