### PR TITLE
tests(smoke): fix chromestatus url

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4973,7 +4973,7 @@ There were 128 PRs landed for this release. These are their stories.
   <img width="630" alt="screen shot 2017-02-09 at 23 43 49" src="https://cloud.githubusercontent.com/assets/316891/22818588/dd3994aa-ef22-11e6-8fee-7469a8866aa6.png">
 - **Report Chrome's deprecated API warnings** - #1470
 
-  Lists console warnings from Chrome if your page is using deprecated APIs or features that have [interventions](https://www.chromestatus.com/features#intervention):
+  Lists console warnings from Chrome if your page is using deprecated APIs or features that have [interventions](https://chromestatus.com/features#intervention):
 
   <img width="675" alt="screen shot 2017-02-10 at 00 05 25" src="https://cloud.githubusercontent.com/assets/316891/22818969/b317e9d6-ef24-11e6-89db-9ee596ba8539.png">
 - **Responsive image sizing** - #1497

--- a/docs/puppeteer.md
+++ b/docs/puppeteer.md
@@ -19,7 +19,7 @@ const lighthouse = require('lighthouse');
 const {URL} = require('url');
 
 (async() => {
-const url = 'https://www.chromestatus.com/features';
+const url = 'https://chromestatus.com/features';
 
 // Use Puppeteer to launch headful Chrome and don't use its default 800x600 viewport.
 const browser = await puppeteer.launch({
@@ -63,7 +63,7 @@ const util = require('util');
 
 (async() => {
 
-const URL = 'https://www.chromestatus.com/features';
+const URL = 'https://chromestatus.com/features';
 
 const opts = {
   //chromeFlags: ['--headless'],

--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -300,7 +300,7 @@ const expectations = {
         details: {
           items: {
           // Note: Originally this was 7 but M56 defaults document-level
-          // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
+          // listeners to passive. See https://chromestatus.com/features/5093566007214080
           // Note: It was 4, but {passive:false} doesn't get a warning as of M63: https://crbug.com/770208
           // Note: It was 3, but wheel events are now also passive as of field trial in M71 https://crbug.com/626196
             length: '>=1',

--- a/lighthouse-cli/test/smokehouse/test-definitions/pwa-chromestatus.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/pwa-chromestatus.js
@@ -19,8 +19,8 @@ const config = {
  */
 const expectations = {
   lhr: {
-    requestedUrl: 'https://www.chromestatus.com/features',
-    finalUrl: 'https://www.chromestatus.com/features',
+    requestedUrl: 'https://chromestatus.com/features',
+    finalUrl: 'https://chromestatus.com/features',
     audits: {
       'service-worker': {
         score: 0,


### PR DESCRIPTION
This was recently changed to be just https://chromestatus.com ([no dubs](https://www.youtube.com/watch?v=FrLequ6dUdM))