### PR TITLE
core(fr): compute timespan saving with observed throughput

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -204,13 +204,8 @@ class UnusedBytes extends Audit {
    * @param {number} wastedBytes
    * @param {Simulator} simulator
    */
-  static computeWastedMsWithThroughput(wastedBytes, simulator) {
-    const bitsPerSecond = simulator.getOptions().throughput;
-    // https://github.com/GoogleChrome/lighthouse/pull/13323#issuecomment-962031709
-    if (bitsPerSecond === 0) return 0;
-    const wastedBits = wastedBytes * 8;
-    const wastedMs = wastedBits / bitsPerSecond * 1000;
-    return wastedMs;
+  static computeWastedMsWithWastedBytes(wastedBytes, simulator) {
+    return simulator.simulateTimespan(wastedBytes);
   }
 
   /**
@@ -232,7 +227,7 @@ class UnusedBytes extends Audit {
         providedWastedBytesByUrl: result.wastedBytesByUrl,
       });
     } else {
-      wastedMs = this.computeWastedMsWithThroughput(wastedBytes, simulator);
+      wastedMs = this.computeWastedMsWithWastedBytes(wastedBytes, simulator);
     }
 
     let displayValue = result.displayValue || '';

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -201,14 +201,6 @@ class UnusedBytes extends Audit {
   }
 
   /**
-   * @param {number} wastedBytes
-   * @param {Simulator} simulator
-   */
-  static computeWastedMsWithWastedBytes(wastedBytes, simulator) {
-    return simulator.simulateTimespan(wastedBytes);
-  }
-
-  /**
    * @param {ByteEfficiencyProduct} result
    * @param {Node|null} graph
    * @param {Simulator} simulator
@@ -227,7 +219,7 @@ class UnusedBytes extends Audit {
         providedWastedBytesByUrl: result.wastedBytesByUrl,
       });
     } else {
-      wastedMs = this.computeWastedMsWithWastedBytes(wastedBytes, simulator);
+      wastedMs = simulator.computedWastedMsFromWastedBytes(wastedBytes);
     }
 
     let displayValue = result.displayValue || '';

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -219,7 +219,7 @@ class UnusedBytes extends Audit {
         providedWastedBytesByUrl: result.wastedBytesByUrl,
       });
     } else {
-      wastedMs = simulator.computedWastedMsFromWastedBytes(wastedBytes);
+      wastedMs = simulator.computeWastedMsFromWastedBytes(wastedBytes);
     }
 
     let displayValue = result.displayValue || '';

--- a/lighthouse-core/computed/load-simulator.js
+++ b/lighthouse-core/computed/load-simulator.js
@@ -24,6 +24,7 @@ class LoadSimulator {
     const options = {
       additionalRttByOrigin: networkAnalysis.additionalRttByOrigin,
       serverResponseTimeByOrigin: networkAnalysis.serverResponseTimeByOrigin,
+      observedThroughput: networkAnalysis.throughput,
     };
 
     // If we have precomputed lantern data, overwrite our observed estimates and use precomputed instead

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -493,7 +493,8 @@ class Simulator {
     const {throughput, observedThroughput} = this._options;
 
     // https://github.com/GoogleChrome/lighthouse/pull/13323#issuecomment-962031709
-    // 0 throughput means the throttling is unset. Use the observed throughput in this case.
+    // 0 throughput means the no (additional) throttling is expected.
+    // This is common for desktop + devtools throttling where throttling is additive and we don't want any additional.
     const bitsPerSecond = throughput || observedThroughput;
     if (bitsPerSecond === 0) return 0;
 

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -495,7 +495,7 @@ class Simulator {
     // https://github.com/GoogleChrome/lighthouse/pull/13323#issuecomment-962031709
     // 0 throughput means the no (additional) throttling is expected.
     // This is common for desktop + devtools throttling where throttling is additive and we don't want any additional.
-    const bitsPerSecond = throughput || observedThroughput;
+    const bitsPerSecond = throughput === 0 ? observedThroughput : throughput;
     if (bitsPerSecond === 0) return 0;
 
     const wastedBits = wastedBytes * 8;

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -489,7 +489,7 @@ class Simulator {
   /**
    * @param {number} wastedBytes
    */
-  computedWastedMsFromWastedBytes(wastedBytes) {
+  computeWastedMsFromWastedBytes(wastedBytes) {
     const {throughput, observedThroughput} = this._options;
 
     // https://github.com/GoogleChrome/lighthouse/pull/13323#issuecomment-962031709

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -489,7 +489,7 @@ class Simulator {
   /**
    * @param {number} wastedBytes
    */
-  simulateTimespan(wastedBytes) {
+  computedWastedMsFromWastedBytes(wastedBytes) {
     const {throughput, observedThroughput} = this._options;
 
     // https://github.com/GoogleChrome/lighthouse/pull/13323#issuecomment-962031709

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -486,6 +486,22 @@ class Simulator {
     };
   }
 
+  /**
+   * @param {number} wastedBytes
+   */
+  simulateTimespan(wastedBytes) {
+    const {throughput, observedThroughput} = this._options;
+
+    // https://github.com/GoogleChrome/lighthouse/pull/13323#issuecomment-962031709
+    // 0 throughput means the throttling is unset. Use the observed throughput in this case.
+    const bitsPerSecond = throughput || observedThroughput;
+    if (bitsPerSecond === 0) return 0;
+
+    const wastedBits = wastedBytes * 8;
+    const wastedMs = wastedBits / bitsPerSecond * 1000;
+    return wastedMs;
+  }
+
   /** @return {Map<string, LH.Gatherer.Simulation.Result['nodeTimings']>} */
   static get ALL_NODE_TIMINGS() {
     return ALL_SIMULATION_NODE_TIMINGS;

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -391,6 +391,6 @@ describe('Byte efficiency base audit', () => {
     };
     const settings = {throttlingMethod: 'devtools', throttling: modestThrottling};
     const result = await MockAudit.audit(artifacts, {settings, computedCache});
-    expect(result.details.overallSavingsMs).toBeCloseTo(0);
+    expect(result.details.overallSavingsMs).toBeCloseTo(575, 1);
   });
 });

--- a/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
@@ -384,4 +384,24 @@ describe('DependencyGraph/Simulator', () => {
       });
     });
   });
+
+  describe('.simulateTimespan', () => {
+    it('calculates savings using throughput', () => {
+      const simulator = new Simulator({throughput: 1000, observedThroughput: 2000});
+      const wastedMs = simulator.simulateTimespan(500);
+      expect(wastedMs).toBeCloseTo(4000);
+    });
+
+    it('falls back to observed throughput if throughput is 0', () => {
+      const simulator = new Simulator({throughput: 0, observedThroughput: 2000});
+      const wastedMs = simulator.simulateTimespan(500);
+      expect(wastedMs).toBeCloseTo(2000);
+    });
+
+    it('returns 0 if throughput and observed throughput are 0', () => {
+      const simulator = new Simulator({throughput: 0, observedThroughput: 0});
+      const wastedMs = simulator.simulateTimespan(500);
+      expect(wastedMs).toEqual(0);
+    });
+  });
 });

--- a/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
@@ -388,19 +388,19 @@ describe('DependencyGraph/Simulator', () => {
   describe('.simulateTimespan', () => {
     it('calculates savings using throughput', () => {
       const simulator = new Simulator({throughput: 1000, observedThroughput: 2000});
-      const wastedMs = simulator.simulateTimespan(500);
+      const wastedMs = simulator.computedWastedMsFromWastedBytes(500);
       expect(wastedMs).toBeCloseTo(4000);
     });
 
     it('falls back to observed throughput if throughput is 0', () => {
       const simulator = new Simulator({throughput: 0, observedThroughput: 2000});
-      const wastedMs = simulator.simulateTimespan(500);
+      const wastedMs = simulator.computedWastedMsFromWastedBytes(500);
       expect(wastedMs).toBeCloseTo(2000);
     });
 
     it('returns 0 if throughput and observed throughput are 0', () => {
       const simulator = new Simulator({throughput: 0, observedThroughput: 0});
-      const wastedMs = simulator.simulateTimespan(500);
+      const wastedMs = simulator.computedWastedMsFromWastedBytes(500);
       expect(wastedMs).toEqual(0);
     });
   });

--- a/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
@@ -388,19 +388,19 @@ describe('DependencyGraph/Simulator', () => {
   describe('.simulateTimespan', () => {
     it('calculates savings using throughput', () => {
       const simulator = new Simulator({throughput: 1000, observedThroughput: 2000});
-      const wastedMs = simulator.computedWastedMsFromWastedBytes(500);
+      const wastedMs = simulator.computeWastedMsFromWastedBytes(500);
       expect(wastedMs).toBeCloseTo(4000);
     });
 
     it('falls back to observed throughput if throughput is 0', () => {
       const simulator = new Simulator({throughput: 0, observedThroughput: 2000});
-      const wastedMs = simulator.computedWastedMsFromWastedBytes(500);
+      const wastedMs = simulator.computeWastedMsFromWastedBytes(500);
       expect(wastedMs).toBeCloseTo(2000);
     });
 
     it('returns 0 if throughput and observed throughput are 0', () => {
       const simulator = new Simulator({throughput: 0, observedThroughput: 0});
-      const wastedMs = simulator.computedWastedMsFromWastedBytes(500);
+      const wastedMs = simulator.computeWastedMsFromWastedBytes(500);
       expect(wastedMs).toEqual(0);
     });
   });

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -153,6 +153,7 @@ declare module Gatherer {
     interface Options {
       rtt?: number;
       throughput?: number;
+      observedThroughput: number;
       maximumConcurrentRequests?: number;
       cpuSlowdownMultiplier?: number;
       layoutTaskMultiplier?: number;


### PR DESCRIPTION
Followup to https://github.com/GoogleChrome/lighthouse/pull/13323

This will use the observed (real) throughput to calculate savings in timespan mode with desktop config (or any config with 0 throughput). Theoretically, any variance in the observed throughput would imply variance in performance for these cases.