### PR TITLE
font-size selector specificity: add slight improvement

### DIFF
--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -36,25 +36,28 @@ function hasFontSizeDeclaration(style) {
 
 /**
  * Computes the CSS specificity of a given selector, i.e. #id > .class > div
+ * TODO: Handle pseudo selectors (:not(), :where, :nth-child) and attribute selectors
  * LIMITATION: !important is not respected
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity
  * @see https://www.smashingmagazine.com/2010/04/css-specificity-and-inheritance/
+ * @see https://drafts.csswg.org/selectors-4/#specificity-rules
  *
  * @param {string} selector
  * @return {number}
  */
 function computeSelectorSpecificity(selector) {
-  const tokens = selector.split(' ');
+  // Remove universal selector and separator characters, then split.
+  const tokens = selector.replace(/[*\s+>~]/g, ' ').split(' ');
 
   let numIDs = 0;
   let numClasses = 0;
   let numTypes = 0;
 
   for (const token of tokens) {
-    const ids = token.match(/(\b|^)#[a-z0-9_-]+/g) || [];
-    const classes = token.match(/(\b|^)\.[a-z0-9_-]+/g) || [];
-    const types = token.match(/^[a-z]+/) ? [1] : [];
+    const ids = token.match(/(\b|^)#[a-z0-9_-]+/gi) || [];
+    const classes = token.match(/(\b|^)\.[a-z0-9_-]+/gi) || [];
+    const types = token.match(/^[a-z]+/i) ? [1] : [];
     numIDs += ids.length;
     numClasses += classes.length;
     numTypes += types.length;
@@ -182,7 +185,7 @@ class FontSize extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
     supportedModes: ['snapshot', 'navigation'],
-  }
+  };
 
   /**
    * @param {LH.Gatherer.FRProtocolSession} session

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -198,6 +198,33 @@ describe('Font size gatherer', () => {
       expect(compute('h1 > p.other > span#the-text')).toEqual(113);
     });
 
+    it('should ignore the univeral selector', () => {
+      expect(compute('.foo')).toEqual(10);
+      expect(compute('* .foo')).toEqual(10);
+      expect(compute('.foo *')).toEqual(10);
+    });
+
+    // Examples https://drafts.csswg.org/selectors-3/#specificity
+    it('should handle l3 spec selectors', () => {
+      expect(compute('*')).toEqual(0);
+      expect(compute('LI')).toEqual(1);
+      expect(compute('UL LI')).toEqual(2);
+      expect(compute('UL OL+LI')).toEqual(3);
+      // expect(compute('H1 + *[REL=up]')).toEqual(11); // TODO: Handle attribute selectors
+      expect(compute('UL OL LI.red')).toEqual(13);
+      expect(compute('LI.red.level')).toEqual(21);
+      expect(compute('#x34y')).toEqual(100);
+      // expect(compute('#s12:not(FOO)')).toEqual(101); // TODO: Handle pseudo selectors
+    });
+
+    // Examples from https://drafts.csswg.org/selectors-4/#specificity-rules
+    it('should handle l4 spec selectors', () => {
+      expect(compute(':is(em, #foo)')).toEqual(100);
+      // expect(compute('.qux:where(em, #foo#bar#baz)')).toEqual(10); // TODO: Handle pseudo selectors
+      // expect(compute(':nth-child(even of li, .item)')).toEqual(20); // TODO: Handle pseudo selectors
+      // expect(compute(':not(em, strong#foo)')).toEqual(101); // TODO: Handle pseudo selectors
+    });
+
     it('should cap the craziness', () => {
       expect(compute('h1.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p')).toEqual(91);
     });


### PR DESCRIPTION
this is a merge to #13455 

I wanted to add some tests so I pulled in some items from the spec. The regexes now handle uppercase in selectors (meh) and also correctly handles  sibling selectors etc (eg `div+span` gave an incorrect result before because of no whitespace around the `+`. now fixed).

that said, there are plenty of these test cases we still don't handle.   I don't care a lot, but someone could have fun if they wanted. there's probably some stuff to pull from in this npm module [keeganstreet/specificity](https://github.com/keeganstreet/specificity/blob/8757133ddd2ed0163f120900047ff0f92760b536/specificity.js#L22-L52), but it needs to be updated to include todays' `:is()` and `:where()` etc etc.  but IMO it's pretty small ROI

at least the extra test coverage is nice.