### PR TITLE
core(fr): don't throw on unknown --only-categories value

### DIFF
--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const log = require('lighthouse-logger');
+
 const Audit = require('../../audits/audit.js');
 
 /** @type {Record<keyof LH.FRBaseArtifacts, string>} */
@@ -195,6 +197,24 @@ function filterCategoriesByExplicitFilters(categories, onlyCategories) {
 }
 
 /**
+ * Logs a warning if any specified onlyCategory is not a known category that can
+ * be included.
+ *
+ * @param {LH.Config.Config['categories']} allCategories
+ * @param {string[] | null} onlyCategories
+ * @return {void}
+ */
+function warnOnUnknownOnlyCategories(allCategories, onlyCategories) {
+  if (!onlyCategories) return;
+
+  for (const onlyCategoryId of onlyCategories) {
+    if (!allCategories?.[onlyCategoryId]) {
+      log.warn('config', `unrecognized category in 'onlyCategories': ${onlyCategoryId}`);
+    }
+  }
+}
+
+/**
  * Filters a categories object and their auditRefs down to the set that can be computed using
  * only the specified audits.
  *
@@ -265,6 +285,8 @@ function filterConfigByGatherMode(config, mode) {
  */
 function filterConfigByExplicitFilters(config, filters) {
   const {onlyAudits, onlyCategories, skipAudits} = filters;
+
+  warnOnUnknownOnlyCategories(config.categories, onlyCategories);
 
   let baseAuditIds = getAuditIdsInCategories(config.categories, undefined);
   if (onlyCategories) {

--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -45,7 +45,7 @@ function getAuditIdsInCategories(allCategories, onlyCategories) {
 
   onlyCategories = onlyCategories || Object.keys(allCategories);
   const categories = onlyCategories.map(categoryId => allCategories[categoryId]);
-  const auditRefs = categories.flatMap(category => category.auditRefs);
+  const auditRefs = categories.flatMap(category => category?.auditRefs || []);
   return new Set(auditRefs.map(auditRef => auditRef.id));
 }
 

--- a/lighthouse-core/test/fraggle-rock/config/filters-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/filters-test.js
@@ -457,6 +457,24 @@ describe('Fraggle Rock Config Filtering', () => {
       });
     });
 
+    it('should warn and drop unknown onlyCategories entries', () => {
+      const filtered = filters.filterConfigByExplicitFilters(config, {
+        onlyAudits: null,
+        onlyCategories: ['timespan', 'thisIsNotACategory'],
+        skipAudits: null,
+      });
+
+      if (!filtered.categories) throw new Error('Failed to keep any categories');
+      expect(Object.keys(filtered.categories)).toEqual(['timespan']);
+      expect(filtered).toMatchObject({
+        artifacts: [{id: 'Timespan'}],
+        audits: [{implementation: TimespanAudit}],
+        categories: {
+          timespan: {},
+        },
+      });
+    });
+
     it('should filter via a combination of filters', () => {
       const filtered = filters.filterConfigByExplicitFilters(config, {
         onlyCategories: ['mixed'],

--- a/lighthouse-core/test/fraggle-rock/config/filters-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/filters-test.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const log = require('lighthouse-logger');
+
 const BaseAudit = require('../../../audits/audit.js');
 const BaseGatherer = require('../../../fraggle-rock/gather/base-gatherer.js');
 const {defaultSettings, defaultNavigationConfig} = require('../../../config/constants.js');
@@ -458,11 +460,18 @@ describe('Fraggle Rock Config Filtering', () => {
     });
 
     it('should warn and drop unknown onlyCategories entries', () => {
+      /** @type {Array<unknown>} */
+      const warnings = [];
+      /** @param {unknown} evt */
+      const saveWarning = evt => warnings.push(evt);
+
+      log.events.on('warning', saveWarning);
       const filtered = filters.filterConfigByExplicitFilters(config, {
         onlyAudits: null,
         onlyCategories: ['timespan', 'thisIsNotACategory'],
         skipAudits: null,
       });
+      log.events.off('warning', saveWarning);
 
       if (!filtered.categories) throw new Error('Failed to keep any categories');
       expect(Object.keys(filtered.categories)).toEqual(['timespan']);
@@ -473,6 +482,9 @@ describe('Fraggle Rock Config Filtering', () => {
           timespan: {},
         },
       });
+      expect(warnings).toEqual(expect.arrayContaining([
+        ['config', `unrecognized category in 'onlyCategories': thisIsNotACategory`],
+      ]));
     });
 
     it('should filter via a combination of filters', () => {


### PR DESCRIPTION
Currently Lighthouse crashes when given a non-existent category for `--only-categories` in FR, either on the CLI with `--fraggle-rock` or in user-flow settings, resulting in `TypeError: Cannot read properties of undefined (reading 'auditRefs')` on [this line](https://github.com/GoogleChrome/lighthouse/blob/10c36d08bed866c79c49c6534de2b4c82a290998/lighthouse-core/fraggle-rock/config/filters.js#L48).

To repro, run  e.g. `lighthouse https://example.com --fraggle-rock --only-categories nope`.

This PR makes it so there's no effect from trying to `--only-categories` a category ID that doesn't exist, which matches classic handling of this situation. FR config handles non-existent `--only-audits` or `--skip-audits` slightly differently than `--only-categories` so already has this behavior, so nothing to fix for those.

The second commit in this PR logs a warning about this situation. Classic config does this here:

https://github.com/GoogleChrome/lighthouse/blob/10c36d08bed866c79c49c6534de2b4c82a290998/lighthouse-core/config/config.js#L373-L375

but it seems like FR config may purposefully not be logging warnings like this (there's none for non-existent `--only-audits` or `--skip-audits` entries, for instance). I wasn't sure if this was a purposeful decision or just lost in the porting process, so I left it as a separate commit to easily drop if not desired. I personally find it a useful signal that I made a typo or something, even if our logs aren't usually very visible to users.