### PR TITLE
misc(git3po): only install latest git3po if out of date

### DIFF
--- a/lighthouse-core/scripts/run-git3po.sh
+++ b/lighthouse-core/scripts/run-git3po.sh
@@ -11,6 +11,11 @@ cd "$DIRNAME"
 
 START_AT="$(date +%s -d '1 day ago')000"
 
-npm install -g git3po
+# Only install if the version has bumped
+installed_version=$(git3po --version)
+latest_version=$(npm info git3po version)
+if [[ "$installed_version" != "$latest_version" ]]; then
+  npm install -g git3po
+fi
 
 find git3po-rules/*.yaml -exec git3po --start-at="$START_AT" -c {} \;


### PR DESCRIPTION
`npm install` takes a while and has a bunch of side effects... so rather than invoking it (on my machine) every 5 minutes... this'll only do it when we need to. 