### PR TITLE
misc: add module types declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "9.2.0",
   "description": "Automated auditing, performance metrics, and best practices for the web.",
   "main": "./lighthouse-core/index.js",
+  "types": "./types/lighthouse.js",
   "bin": {
     "lighthouse": "./lighthouse-cli/index.js",
     "chrome-debug": "./lighthouse-core/scripts/manual-chrome-launcher.js",

--- a/types/lighthouse.d.ts
+++ b/types/lighthouse.d.ts
@@ -1,0 +1,30 @@
+export = lighthouse;
+/** @typedef {import('./gather/connections/connection.js')} Connection */
+/**
+ * Run Lighthouse.
+ * @param {string=} url The URL to test. Optional if running in auditMode.
+ * @param {LH.Flags=} flags Optional settings for the Lighthouse run. If present,
+ *   they will override any settings in the config.
+ * @param {LH.Config.Json=} configJSON Configuration for the Lighthouse run. If
+ *   not present, the default config is used.
+ * @param {Connection=} userConnection
+ * @return {Promise<LH.RunnerResult|undefined>}
+ */
+declare function lighthouse(url?: string | undefined, flags?: LH.Flags, configJSON?: LH.Config.Json, userConnection?: any): Promise<LH.RunnerResult | undefined>;
+declare namespace lighthouse {
+    export { generateConfig, unknown as getAuditList, traceCategories, Audit, Gatherer, NetworkRecords, Connection };
+}
+/**
+ * Generate a Lighthouse Config.
+ * @param {LH.Config.Json=} configJson Configuration for the Lighthouse run. If
+ *   not present, the default config is used.
+ * @param {LH.Flags=} flags Optional settings for the Lighthouse run. If present,
+ *   they will override any settings in the config.
+ * @return {Config}
+ */
+declare function generateConfig(configJson?: LH.Config.Json, flags?: LH.Flags): Config;
+declare var traceCategories: any;
+declare var Audit: any;
+declare var Gatherer: any;
+declare var NetworkRecords: any;
+type Connection = any;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/master/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
Feature: Add module declaration file for better typescript support.
The types is generated using below command.
`npx /lighthouse-core/index.js --declaration --allowJs --emitDeclarationOnly --outDir types`

<!-- Describe the need for this change -->
For current version, if we create a TS project and attempt to import `lighthouse`, it will throw an error about missing module types declararion.

<!-- Link any documentation or information that would help understand this change -->
[TS doc for package.json `types` field](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)
[TS doc for generating `.d.ts` files from `.js` files](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html)

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
#1773 