### PR TITLE
tests: add more smoke tests to devtools

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -87,5 +87,5 @@ jobs:
       # - Current DevTools hangs on any page with a service worker.
       #   https://github.com/GoogleChrome/lighthouse/issues/13396
       # - Various other issues that needed investigation.
-      run: yarn smoke --runner devtools --invert-match byte-efficiency byte-gzip dbw errors-infinite-loop lantern-idle-callback-short metrics-tricky-tti-late-fcp metrics-tricky-tti perf-budgets perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa-chromestatus pwa-svgomg pwa-rocks redirects-client-paint-server redirects-multiple-server redirects-single-server screenshot seo-tap-targets
+      run: yarn smoke --runner devtools --retries=2 --invert-match byte-efficiency byte-gzip dbw errors-infinite-loop lantern-idle-callback-short metrics-tricky-tti-late-fcp metrics-tricky-tti perf-budgets perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa-chromestatus pwa-svgomg pwa-rocks redirects-client-paint-server redirects-multiple-server redirects-single-server screenshot seo-tap-targets
       working-directory: ${{ github.workspace }}/lighthouse

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -87,5 +87,5 @@ jobs:
       # - Current DevTools hangs on any page with a service worker.
       #   https://github.com/GoogleChrome/lighthouse/issues/13396
       # - Various other issues that needed investigation.
-      run: yarn smoke --runner devtools --invert-match a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp offline-ready offline-sw-broken offline-sw-slow oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-client redirects-single-server screenshot seo-passing seo-tap-targets
+      run: yarn smoke --runner devtools --invert-match byte-efficiency byte-gzip dbw errors-infinite-loop lantern-idle-callback-short metrics-tricky-tti-late-fcp metrics-tricky-tti perf-budgets perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa-chromestatus pwa-svgomg pwa-rocks redirects-client-paint-server redirects-multiple-server redirects-single-server screenshot seo-tap-targets
       working-directory: ${{ github.workspace }}/lighthouse


### PR DESCRIPTION
Of the ones currently being skipped in CI, these pass locally for me:

```
a11y
errors-expired-ss
legacy-javascrip
offline-ready
offline-sw-broken
offline-sw-slow
oopif-requests
perf-diagnostics-third-party
redirects-history-push-state
redirects-single-client
seo-passing
```

Although depending on the version of Chrome in GHA, if it isn't already on 97 some of these (the offline ones, at least) will fail because of #13396.