### PR TITLE
clients: use minimal 'url' polyfil instead of url-shim

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -142,7 +142,6 @@ async function build(entryPath, distPath, opts = {minify: true}) {
         entries: {
           'debug': require.resolve('debug/src/browser.js'),
           'lighthouse-logger': require.resolve('../lighthouse-logger/index.js'),
-          'url': require.resolve('../lighthouse-core/lib/url-shim.js'),
         },
       }),
       rollupPlugins.shim({
@@ -152,6 +151,12 @@ async function build(entryPath, distPath, opts = {minify: true}) {
           import Audit from '${require.resolve('../lighthouse-core/audits/audit.js')}';
           export {Audit};
         `,
+        // Most node 'url' polyfills don't include the WHATWG `URL` property, but
+        // that's all that's needed, so make a mini-polyfill.
+        // @see https://github.com/GoogleChrome/lighthouse/issues/5273
+        // TODO: remove when not needed for pubads (https://github.com/googleads/publisher-ads-lighthouse-plugin/pull/325)
+        // and robots-parser (https://github.com/samclarke/robots-parser/pull/23)
+        'url': 'export const URL = globalThis.URL;',
       }),
       rollupPlugins.json(),
       rollupPlugins.inlineFs({verbose: false}),

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "resolve": "^1.20.0",
     "rollup": "^2.52.7",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-polyfill-node": "^0.7.0",
+    "rollup-plugin-polyfill-node": "^0.8.0",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-terser": "^7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7150,10 +7150,10 @@ rollup-plugin-node-resolve@^5.2.0:
     resolve "^1.11.1"
     rollup-pluginutils "^2.8.1"
 
-rollup-plugin-polyfill-node@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.7.0.tgz#938e13278c98a582a4f8814975ddd26f90afddcc"
-  integrity sha512-iJLZDfvxcQh3SpC0OiYlZG9ik26aRM29hiC2sARbAPXYunB8rzW8GtVaWuJgiCtX1hNAo/OaYvVXfPp15fMs7g==
+rollup-plugin-polyfill-node@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.8.0.tgz#859c070822f5e38d221e5b4238cb34aa894c2b19"
+  integrity sha512-C4UeKedOmOBkB3FgR+z/v9kzRwV1Q/H8xWs1u1+CNe4XOV6hINfOrcO+TredKxYvopCmr+WKUSNsFUnD1RLHgQ==
   dependencies:
     "@rollup/plugin-inject" "^4.0.0"
 


### PR DESCRIPTION
Long ago (#5293) we substituted `url-shim` for the Node `url` module because `robots-parser` needed `require('url').URL` to give the WHATWG `URL` but the browserify polyfill for `'url'` didn't have `URL` on it. In the meantime, the pubads plugin also started relying on that behavior, importing URL the same way. For some reason, the most popular rollup `'url'` polyfills _still_ don't have `URL` on them, so we've still been shoving `url-shim` in there.

However, there are other things on `url-shim`, and this [can cause issues](https://github.com/GoogleChrome/lighthouse/pull/13519#issuecomment-1006961952) :)

We really only need the slimmest of polyfills for `'url'`, since only the `URL` property is needed, so this PR replaces it with one tiny version.

I also opened PRs in https://github.com/googleads/publisher-ads-lighthouse-plugin/pull/325 and https://github.com/samclarke/robots-parser/pull/23 to switch them both to the global `URL`, so we can remove this shim altogether when those land and are published.