### PR TITLE
tests: split devtools ci into build, web-tests and smoke jobs 

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
     - name: Set $PATH
       run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
+    - run: echo DEVTOOLS_PATH $DEVTOOLS_PATH
+    - run: echo DEPOT_TOOLS_PATH $DEPOT_TOOLS_PATH
+    - run: echo PATH $PATH
 
     - name: git clone
       uses: actions/checkout@v2

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -104,6 +104,9 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: devtools-build
+        path: ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
+    # Just need this folder to exist, web-test-server.sh makes a symbolic link to it.
+    - run: mkdir -p $DEVTOOLS_PATH/test/webtests/http/tests/inspector-sources
 
     - name: Download Blink Tools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
@@ -159,6 +162,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: devtools-build
+        path: ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
     
     - name: Download Blink Tools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -112,7 +112,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: devtools-build
-        path: ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
+        path: ${{ github.workspace }}
     # Just need this folder to exist, web-test-server.sh makes a symbolic link inside it.
     - run: mkdir -p $DEVTOOLS_PATH/test/webtests/http/tests
     - run: ls $DEVTOOLS_PATH
@@ -172,7 +172,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: devtools-build
-        path: ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
+        path: ${{ github.workspace }}
     
     - name: Download Blink Tools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -52,7 +52,7 @@ jobs:
         #
         # The number is how many times this hash key was manually updated to break the cache.
         key: ${{ runner.os }}-2-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
-        # restore-keys: ${{ runner.os }}-
+        restore-keys: ${{ runner.os }}-
     - name: Set GHA_DEVTOOLS_CACHE_HIT
       if: steps.devtools-cache.outputs.cache-hit == 'true'
       run: echo "GHA_DEVTOOLS_CACHE_HIT=1" >> $GITHUB_ENV
@@ -87,22 +87,16 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - run: echo "DEVTOOLS_PATH is $DEVTOOLS_PATH"
-
-    # - name: Set $DEPOT_TOOLS_PATH
-    #   run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
     - name: Set $DEVTOOLS_PATH
       run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
     - name: Set $BLINK_TOOLS_PATH
       run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
-    # - name: Set $PATH
-    #   run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
 
     - name: git clone
       uses: actions/checkout@v2
       with:
         path: lighthouse
-    
+
     - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
@@ -113,10 +107,6 @@ jobs:
       with:
         name: devtools-build
         path: ${{ github.workspace }}
-    # Just need this folder to exist, web-test-server.sh makes a symbolic link inside it.
-    # - run: mkdir -p $DEVTOOLS_PATH/test/webtests/http/tests
-    - run: ls $DEVTOOLS_PATH
-    - run: ls $DEVTOOLS_PATH/test/webtests/http/tests/
 
     - name: Download Blink Tools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
@@ -149,14 +139,10 @@ jobs:
     name: Smoke batch ${{ matrix.smoke-test-shard }}
 
     steps:
-    # - name: Set $DEPOT_TOOLS_PATH
-    #   run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
     - name: Set $DEVTOOLS_PATH
       run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
     - name: Set $BLINK_TOOLS_PATH
       run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
-    # - name: Set $PATH
-    #   run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
 
     - name: git clone
       uses: actions/checkout@v2
@@ -182,12 +168,12 @@ jobs:
     - run: yarn --frozen-lockfile
       working-directory: ${{ github.workspace }}/lighthouse
 
-    # Run smoke tests via DevTools
     - name: Define ToT chrome path
       run: echo "CHROME_PATH=/Users/runner/chrome-mac-tot/Chromium.app/Contents/MacOS/Chromium" >> $GITHUB_ENV
     - name: Install Chrome ToT
       working-directory: /Users/runner
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/scripts/download-chrome.sh && mv chrome-mac chrome-mac-tot
+
     - run: mkdir latest-run
       working-directory: ${{ github.workspace }}/lighthouse
     - name: yarn smoke --runner devtools

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -2,8 +2,8 @@ name: DevTools
 
 on:
   push:
-    # branches: [master]
-  # pull_request: # run on all PRs, not just PRs to a particular branch
+    branches: [master]
+  pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:
   build:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -52,7 +52,7 @@ jobs:
         #
         # The number is how many times this hash key was manually updated to break the cache.
         key: ${{ runner.os }}-2-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
-        restore-keys: ${{ runner.os }}-
+        # restore-keys: ${{ runner.os }}-
     - name: Set GHA_DEVTOOLS_CACHE_HIT
       if: steps.devtools-cache.outputs.cache-hit == 'true'
       run: echo "GHA_DEVTOOLS_CACHE_HIT=1" >> $GITHUB_ENV

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -78,6 +78,7 @@ jobs:
         name: devtools-build
         path: |
           ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
+          ${{ env.DEVTOOLS_PATH }}/test/webtests/http/tests
           ${{ env.GITHUB_WORKSPACE }}/.gclient
         retention-days: 1
 
@@ -112,8 +113,8 @@ jobs:
       with:
         name: devtools-build
         path: ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
-    # Just need this folder to exist, web-test-server.sh makes a symbolic link to it.
-    - run: mkdir -p $DEVTOOLS_PATH/test/webtests/http/tests/inspector-sources
+    # Just need this folder to exist, web-test-server.sh makes a symbolic link inside it.
+    - run: mkdir -p $DEVTOOLS_PATH/test/webtests/http/tests
     - run: ls $DEVTOOLS_PATH
     - run: ls $DEVTOOLS_PATH/test/webtests/http/tests/
 

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -79,7 +79,7 @@ jobs:
         path: |
           ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
           ${{ env.DEVTOOLS_PATH }}/test/webtests/http/tests
-          ${{ github.workspace }}/lighthouse/.gclient
+          ${{ github.workspace }}/.gclient
         retention-days: 1
 
   web-tests:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: macos-latest # while macbots are much slower, linux reliably crashes running this
 
-  steps:
+    steps:
     - name: Set $DEPOT_TOOLS_PATH
       run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
     - name: Set $DEVTOOLS_PATH

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -24,6 +24,11 @@ jobs:
       with:
         path: lighthouse
 
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
     - name: Generate cache hash
       run: bash $GITHUB_WORKSPACE/lighthouse/.github/scripts/generate-devtools-hash.sh > cdt-test-hash.txt
     - name: Set week of the year
@@ -47,11 +52,6 @@ jobs:
         # The number is how many times this hash key was manually updated to break the cache.
         key: ${{ runner.os }}-2-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
 
-    - name: Use Node.js 14.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-
     - run: yarn --frozen-lockfile
       working-directory: ${{ github.workspace }}/lighthouse
 
@@ -71,10 +71,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: devtools-build
-        path: |
-          ${{ env.DEVTOOLS_PATH }}
-          ${{ env.BLINK_TOOLS_PATH }}
-          ${{ github.workspace }}/lighthouse/.tmp/chromium-web-tests/content-shells
+        path: ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
         retention-days: 1
 
   web-tests:
@@ -84,24 +81,34 @@ jobs:
     steps:
     - run: echo "DEVTOOLS_PATH is $DEVTOOLS_PATH"
 
-    - name: Set $DEPOT_TOOLS_PATH
-      run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
+    # - name: Set $DEPOT_TOOLS_PATH
+    #   run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
     - name: Set $DEVTOOLS_PATH
       run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
     - name: Set $BLINK_TOOLS_PATH
       run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
-    - name: Set $PATH
-      run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
+    # - name: Set $PATH
+    #   run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
 
     - name: git clone
       uses: actions/checkout@v2
       with:
         path: lighthouse
+    
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
 
     - name: Download artifact
       uses: actions/download-artifact@v2
       with:
         name: devtools-build
+
+    - name: Download Blink Tools
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
+    - name: Download Content Shell
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-content-shell.sh
 
     - name: Install python deps
       run: pip install six requests
@@ -129,29 +136,34 @@ jobs:
     name: Smoke batch ${{ matrix.smoke-test-shard }}
 
     steps:
-    - name: Set $DEPOT_TOOLS_PATH
-      run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
+    # - name: Set $DEPOT_TOOLS_PATH
+    #   run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
     - name: Set $DEVTOOLS_PATH
       run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
     - name: Set $BLINK_TOOLS_PATH
       run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
-    - name: Set $PATH
-      run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
+    # - name: Set $PATH
+    #   run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
 
     - name: git clone
       uses: actions/checkout@v2
       with:
         path: lighthouse
 
-    - name: Download artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: devtools-build
-
     - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
         node-version: 14.x
+
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: devtools-build
+    
+    - name: Download Blink Tools
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
+    - name: Download Content Shell
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-content-shell.sh
 
     - run: yarn --frozen-lockfile
       working-directory: ${{ github.workspace }}/lighthouse

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -37,6 +37,7 @@ jobs:
     # with the latest dependencies. Any commit to the DevTools repo touching Lighthouse
     # code will invalidate the cache sooner.
     - name: Cache depot tools, devtools, blink tools and content shell
+      id: devtools-cache
       uses: actions/cache@v2
       with:
         path: |
@@ -51,6 +52,10 @@ jobs:
         #
         # The number is how many times this hash key was manually updated to break the cache.
         key: ${{ runner.os }}-2-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
+        restore-keys: ${{ runner.os }}-
+    - name: Set GHA_DEVTOOLS_CACHE_HIT
+      if: steps.devtools-cache.outputs.cache-hit == 'true'
+      run: echo "GHA_DEVTOOLS_CACHE_HIT=1" >> $GITHUB_ENV
 
     - run: yarn --frozen-lockfile
       working-directory: ${{ github.workspace }}/lighthouse

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
     - name: Set $PATH
       run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
-    - run: echo DEVTOOLS_PATH $DEVTOOLS_PATH
-    - run: echo DEPOT_TOOLS_PATH $DEPOT_TOOLS_PATH
-    - run: echo PATH $PATH
 
     - name: git clone
       uses: actions/checkout@v2

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -107,6 +107,8 @@ jobs:
         path: ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
     # Just need this folder to exist, web-test-server.sh makes a symbolic link to it.
     - run: mkdir -p $DEVTOOLS_PATH/test/webtests/http/tests/inspector-sources
+    - run: ls $DEVTOOLS_PATH
+    - run: ls $DEVTOOLS_PATH/test/webtests/http/tests/
 
     - name: Download Blink Tools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -5,17 +5,16 @@ on:
     branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
+env:
+  DEPOT_TOOLS_PATH: $GITHUB_WORKSPACE/depot-tools
+  DEVTOOLS_PATH: $GITHUB_WORKSPACE/devtools-frontend
+  BLINK_TOOLS_PATH: $GITHUB_WORKSPACE/blink_tools
+
 jobs:
   build:
     runs-on: macos-latest # while macbots are much slower, linux reliably crashes running this
 
     steps:
-    - name: Set $DEPOT_TOOLS_PATH
-      run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
-    - name: Set $DEVTOOLS_PATH
-      run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
-    - name: Set $BLINK_TOOLS_PATH
-      run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
     - name: Set $PATH
       run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
 
@@ -84,11 +83,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - name: Set $DEVTOOLS_PATH
-      run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
-    - name: Set $BLINK_TOOLS_PATH
-      run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
-
     - name: git clone
       uses: actions/checkout@v2
       with:
@@ -128,6 +122,8 @@ jobs:
     strategy:
       matrix:
         smoke-test-shard: [1, 2]
+      # e.g. if set 1 fails, continue with set 2 anyway
+      fail-fast: false
     runs-on: macos-latest
     env:
       # The total number of shards. Set dynamically when length of single matrix variable is
@@ -136,11 +132,6 @@ jobs:
     name: Smoke batch ${{ matrix.smoke-test-shard }}
 
     steps:
-    - name: Set $DEVTOOLS_PATH
-      run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
-    - name: Set $BLINK_TOOLS_PATH
-      run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
-
     - name: git clone
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -78,7 +78,7 @@ jobs:
         name: devtools-build
         path: |
           ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
-          ${{ env.DEVTOOLS_PATH }}/test/webtests/http/tests
+          ${{ env.DEVTOOLS_PATH }}/test/webtests
           ${{ github.workspace }}/.gclient
         retention-days: 1
 
@@ -114,7 +114,7 @@ jobs:
         name: devtools-build
         path: ${{ github.workspace }}
     # Just need this folder to exist, web-test-server.sh makes a symbolic link inside it.
-    - run: mkdir -p $DEVTOOLS_PATH/test/webtests/http/tests
+    # - run: mkdir -p $DEVTOOLS_PATH/test/webtests/http/tests
     - run: ls $DEVTOOLS_PATH
     - run: ls $DEVTOOLS_PATH/test/webtests/http/tests/
 

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -6,9 +6,9 @@ on:
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 env:
-  DEPOT_TOOLS_PATH: $GITHUB_WORKSPACE/depot-tools
-  DEVTOOLS_PATH: $GITHUB_WORKSPACE/devtools-frontend
-  BLINK_TOOLS_PATH: $GITHUB_WORKSPACE/blink_tools
+  DEPOT_TOOLS_PATH: ${{ github.workspace }}/depot-tools
+  DEVTOOLS_PATH: ${{ github.workspace }}/devtools-frontend
+  BLINK_TOOLS_PATH: ${{ github.workspace }}/blink_tools
 
 jobs:
   build:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -45,6 +45,7 @@ jobs:
           ${{ env.DEVTOOLS_PATH }}
           ${{ env.BLINK_TOOLS_PATH }}
           ${{ github.workspace }}/lighthouse/.tmp/chromium-web-tests/content-shells
+          ${{ github.workspace }}/.gclient
         # This hash key changes:
         # 1) every monday (so invalidates once a week)
         # 2) every commit to CDT touching files important to Lighthouse web tests
@@ -52,7 +53,7 @@ jobs:
         #
         # The number is how many times this hash key was manually updated to break the cache.
         key: ${{ runner.os }}-2-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
-        restore-keys: ${{ runner.os }}-
+        # restore-keys: ${{ runner.os }}-
     - name: Set GHA_DEVTOOLS_CACHE_HIT
       if: steps.devtools-cache.outputs.cache-hit == 'true'
       run: echo "GHA_DEVTOOLS_CACHE_HIT=1" >> $GITHUB_ENV

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -2,12 +2,129 @@ name: DevTools
 
 on:
   push:
-    branches: [master]
-  pull_request: # run on all PRs, not just PRs to a particular branch
+    # branches: [master]
+  # pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:
-  integration:
+  build:
     runs-on: macos-latest # while macbots are much slower, linux reliably crashes running this
+
+  steps:
+    - name: Set $DEPOT_TOOLS_PATH
+      run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
+    - name: Set $DEVTOOLS_PATH
+      run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
+    - name: Set $BLINK_TOOLS_PATH
+      run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
+    - name: Set $PATH
+      run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
+
+    - name: git clone
+      uses: actions/checkout@v2
+      with:
+        path: lighthouse
+
+    - name: Generate cache hash
+      run: bash $GITHUB_WORKSPACE/lighthouse/.github/scripts/generate-devtools-hash.sh > cdt-test-hash.txt
+    - name: Cache depot tools, devtools, blink tools and content shell
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ env.DEPOT_TOOLS_PATH }}
+          ${{ env.DEVTOOLS_PATH }}
+          ${{ env.BLINK_TOOLS_PATH }}
+          ${{ github.workspace }}/lighthouse/.tmp/chromium-web-tests/content-shells
+        # The number is how many times this hash key was manually updated to break the cache.
+        key: ${{ runner.os }}-2-${{ hashFiles('cdt-test-hash.txt') }}
+
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
+    - run: yarn --frozen-lockfile
+      working-directory: ${{ github.workspace }}/lighthouse
+
+    - name: Download depot tools
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-depot-tools.sh
+    - name: Download DevTools Frontend
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+    - name: Download Blink Tools
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
+    - name: Download Content Shell
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-content-shell.sh
+    
+    - name: Roll Lighthouse + build DevTools
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/roll-devtools.sh
+
+  web-tests:
+    runs-on: macos-latest
+
+    steps:
+    - run: echo "DEVTOOLS_PATH is $DEVTOOLS_PATH"
+
+    - name: Set $DEPOT_TOOLS_PATH
+      run: echo "DEPOT_TOOLS_PATH=$GITHUB_WORKSPACE/depot-tools" >> $GITHUB_ENV
+    - name: Set $DEVTOOLS_PATH
+      run: echo "DEVTOOLS_PATH=$GITHUB_WORKSPACE/devtools-frontend" >> $GITHUB_ENV
+    - name: Set $BLINK_TOOLS_PATH
+      run: echo "BLINK_TOOLS_PATH=$GITHUB_WORKSPACE/blink_tools" >> $GITHUB_ENV
+    - name: Set $PATH
+      run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
+
+    - name: git clone
+      uses: actions/checkout@v2
+      with:
+        path: lighthouse
+
+    - name: Generate cache hash
+      run: bash $GITHUB_WORKSPACE/lighthouse/.github/scripts/generate-devtools-hash.sh > cdt-test-hash.txt
+    - name: Cache depot tools, devtools, blink tools and content shell
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ env.DEPOT_TOOLS_PATH }}
+          ${{ env.DEVTOOLS_PATH }}
+          ${{ env.BLINK_TOOLS_PATH }}
+          ${{ github.workspace }}/lighthouse/.tmp/chromium-web-tests/content-shells
+        # The number is how many times this hash key was manually updated to break the cache.
+        key: ${{ runner.os }}-2-${{ hashFiles('cdt-test-hash.txt') }}
+
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
+    - run: yarn --frozen-lockfile
+      working-directory: ${{ github.workspace }}/lighthouse
+
+    - name: Download depot tools
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-depot-tools.sh
+    - name: Download DevTools Frontend
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+    - name: Download Blink Tools
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
+    - name: Download Content Shell
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-content-shell.sh
+
+    - name: Install python deps
+      run: pip install six requests
+
+    - name: Run Web Tests
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
+
+    - name: Print diff
+      if: failure()
+      run: find "$GITHUB_WORKSPACE/lighthouse/.tmp/layout-test-results/retry_3" -name '*-diff.txt' -exec cat {} \;
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: results
+        path: ${{ github.workspace }}/lighthouse/.tmp/layout-test-results
+
+  smoke:
+    runs-on: macos-latest
 
     steps:
     - name: Set $DEPOT_TOOLS_PATH
@@ -44,35 +161,9 @@ jobs:
 
     - run: yarn --frozen-lockfile
       working-directory: ${{ github.workspace }}/lighthouse
-    - run: yarn build-report
-      working-directory: ${{ github.workspace }}/lighthouse
-    - run: yarn build-devtools
-      working-directory: ${{ github.workspace }}/lighthouse
 
-    - name: Download depot tools
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-depot-tools.sh
-    - name: Download DevTools Frontend
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-devtools.sh
-    - name: Download Blink Tools
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
-    - name: Download Content Shell
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-content-shell.sh
-
-    - name: Install python deps
-      run: pip install six requests
-
-    - name: Run Web Tests
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
-
-    - name: Print diff
-      if: failure()
-      run: find "$GITHUB_WORKSPACE/lighthouse/.tmp/layout-test-results/retry_3" -name '*-diff.txt' -exec cat {} \;
-    - name: Upload results
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: results
-        path: ${{ github.workspace }}/lighthouse/.tmp/layout-test-results
+    # - name: Run Web Tests
+    #   run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
     
     # Run smoke tests via DevTools
     - name: Define ToT chrome path

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -67,6 +67,16 @@ jobs:
     - name: Roll Lighthouse + build DevTools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/roll-devtools.sh
 
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: devtools-build
+        path: |
+          ${{ env.DEVTOOLS_PATH }}
+          ${{ env.BLINK_TOOLS_PATH }}
+          ${{ github.workspace }}/lighthouse/.tmp/chromium-web-tests/content-shells
+        retention-days: 1
+
   web-tests:
     needs: [build]
     runs-on: macos-latest
@@ -88,18 +98,10 @@ jobs:
       with:
         path: lighthouse
 
-    - name: Generate cache hash
-      run: bash $GITHUB_WORKSPACE/lighthouse/.github/scripts/generate-devtools-hash.sh > cdt-test-hash.txt
-    - name: Cache depot tools, devtools, blink tools and content shell
-      uses: actions/cache@v2
+    - name: Download artifact
+      uses: actions/download-artifact@v2
       with:
-        path: |
-          ${{ env.DEPOT_TOOLS_PATH }}
-          ${{ env.DEVTOOLS_PATH }}
-          ${{ env.BLINK_TOOLS_PATH }}
-          ${{ github.workspace }}/lighthouse/.tmp/chromium-web-tests/content-shells
-        # The number is how many times this hash key was manually updated to break the cache.
-        key: ${{ runner.os }}-2-${{ hashFiles('cdt-test-hash.txt') }}
+        name: devtools-build
 
     - name: Install python deps
       run: pip install six requests
@@ -141,18 +143,10 @@ jobs:
       with:
         path: lighthouse
 
-    - name: Generate cache hash
-      run: bash $GITHUB_WORKSPACE/lighthouse/.github/scripts/generate-devtools-hash.sh > cdt-test-hash.txt
-    - name: Cache depot tools, devtools, blink tools and content shell
-      uses: actions/cache@v2
+    - name: Download artifact
+      uses: actions/download-artifact@v2
       with:
-        path: |
-          ${{ env.DEPOT_TOOLS_PATH }}
-          ${{ env.DEVTOOLS_PATH }}
-          ${{ env.BLINK_TOOLS_PATH }}
-          ${{ github.workspace }}/lighthouse/.tmp/chromium-web-tests/content-shells
-        # The number is how many times this hash key was manually updated to break the cache.
-        key: ${{ runner.os }}-2-${{ hashFiles('cdt-test-hash.txt') }}
+        name: devtools-build
 
     - name: Use Node.js 14.x
       uses: actions/setup-node@v1

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -79,7 +79,7 @@ jobs:
         path: |
           ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
           ${{ env.DEVTOOLS_PATH }}/test/webtests/http/tests
-          ${{ env.GITHUB_WORKSPACE }}/.gclient
+          ${{ github.workspace }}/lighthouse/.gclient
         retention-days: 1
 
   web-tests:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -53,7 +53,7 @@ jobs:
         #
         # The number is how many times this hash key was manually updated to break the cache.
         key: ${{ runner.os }}-2-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
-        # restore-keys: ${{ runner.os }}-
+        restore-keys: ${{ runner.os }}-
     - name: Set GHA_DEVTOOLS_CACHE_HIT
       if: steps.devtools-cache.outputs.cache-hit == 'true'
       run: echo "GHA_DEVTOOLS_CACHE_HIT=1" >> $GITHUB_ENV
@@ -65,10 +65,6 @@ jobs:
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-depot-tools.sh
     - name: Download DevTools Frontend
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-devtools.sh
-    - name: Download Blink Tools
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
-    - name: Download Content Shell
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-content-shell.sh
 
     - name: Roll Lighthouse + build DevTools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/roll-devtools.sh

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -52,7 +52,7 @@ jobs:
         #
         # The number is how many times this hash key was manually updated to break the cache.
         key: ${{ runner.os }}-2-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
-        # restore-keys: ${{ runner.os }}-
+        restore-keys: ${{ runner.os }}-
     - name: Set GHA_DEVTOOLS_CACHE_HIT
       if: steps.devtools-cache.outputs.cache-hit == 'true'
       run: echo "GHA_DEVTOOLS_CACHE_HIT=1" >> $GITHUB_ENV
@@ -78,7 +78,7 @@ jobs:
         name: devtools-build
         path: |
           ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
-          ${{ env.DEVTOOLS_PATH }}/../.gclient
+          ${{ env.GITHUB_WORKSPACE }}/.gclient
         retention-days: 1
 
   web-tests:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -58,6 +58,7 @@ jobs:
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/roll-devtools.sh
 
   web-tests:
+    needs: [build]
     runs-on: macos-latest
 
     steps:
@@ -124,6 +125,7 @@ jobs:
         path: ${{ github.workspace }}/lighthouse/.tmp/layout-test-results
 
   smoke:
+    needs: [build]
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -96,17 +96,8 @@ jobs:
       with:
         node-version: 14.x
 
-    - run: yarn --frozen-lockfile
-      working-directory: ${{ github.workspace }}/lighthouse
-
-    - name: Download depot tools
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-depot-tools.sh
-    - name: Download DevTools Frontend
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-devtools.sh
-    - name: Download Blink Tools
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh
-    - name: Download Content Shell
-      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-content-shell.sh
+    # - run: yarn --frozen-lockfile
+    #   working-directory: ${{ github.workspace }}/lighthouse
 
     - name: Install python deps
       run: pip install six requests
@@ -126,7 +117,15 @@ jobs:
 
   smoke:
     needs: [build]
+    strategy:
+      matrix:
+        smoke-test-shard: [1, 2]
     runs-on: macos-latest
+    env:
+      # The total number of shards. Set dynamically when length of single matrix variable is
+      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
+      SHARD_TOTAL: 2
+    name: Smoke batch ${{ matrix.smoke-test-shard }}
 
     steps:
     - name: Set $DEPOT_TOOLS_PATH
@@ -180,5 +179,5 @@ jobs:
       # - Current DevTools hangs on any page with a service worker.
       #   https://github.com/GoogleChrome/lighthouse/issues/13396
       # - Various other issues that needed investigation.
-      run: yarn smoke --runner devtools --invert-match a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp offline-ready offline-sw-broken offline-sw-slow oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-client redirects-single-server screenshot seo-passing seo-tap-targets
+      run: yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL --retries=2 --invert-match a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp offline-ready offline-sw-broken offline-sw-slow oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-client redirects-single-server screenshot seo-passing seo-tap-targets
       working-directory: ${{ github.workspace }}/lighthouse

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -76,7 +76,9 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: devtools-build
-        path: ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
+        path: |
+          ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
+          ${{ env.DEVTOOLS_PATH }}/../.gclient
         retention-days: 1
 
   web-tests:

--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -17,10 +17,19 @@ then
   git --no-pager log -1
 
   # Update to keep current.
-  # Don't update in CI-defer to the weekly cache invalidation.
   if [ -z "${CI:-}" ]; then
+    # Locally, clean everything and update to latest code.
     git reset --hard
     git clean -fd
+    git pull --ff-only -f origin main
+    gclient sync --delete_unversioned_trees --reset
+  elif [ -z "${GHA_DEVTOOLS_CACHE_HIT:-}" ]; then
+    # For CI, just update, but only if this was a cache-miss.
+    # The only way the folder already exists _and_ there is a cache-miss is
+    # if actions/cache@v2 `restore-keys` has provided a partial environment for us.
+    # Do the same as for local, but don't clean! That would toss out all the
+    # (stale, but still useful) build artifacts.
+    git reset --hard
     git pull --ff-only -f origin main
     gclient sync --delete_unversioned_trees --reset
   fi

--- a/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
+++ b/lighthouse-core/test/chromium-web-tests/run-web-tests.sh
@@ -14,7 +14,6 @@ set -u
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export LH_ROOT="$SCRIPT_DIR/../../.."
 
-bash "$SCRIPT_DIR/roll-devtools.sh" || exit 1
 bash "$SCRIPT_DIR/web-test-server.sh" http/tests/devtools/lighthouse $*
 status=$?
 

--- a/lighthouse-core/test/chromium-web-tests/test-locally.sh
+++ b/lighthouse-core/test/chromium-web-tests/test-locally.sh
@@ -16,4 +16,5 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$SCRIPT_DIR/setup.sh"
+bash "$SCRIPT_DIR/roll-devtools.sh"
 bash "$SCRIPT_DIR/run-web-tests.sh" $*

--- a/lighthouse-core/test/chromium-web-tests/web-test-server.sh
+++ b/lighthouse-core/test/chromium-web-tests/web-test-server.sh
@@ -26,6 +26,10 @@ cleanup() {
 }
 trap 'cleanup' EXIT
 
+echo "server at"
+echo "$DEVTOOLS_PATH/test/webtests/http/tests"
+ls "$DEVTOOLS_PATH/test/webtests/http/tests"
+
 # Serve from devtools frontend webtests folder.
 (npx http-server@0.12.3 "$DEVTOOLS_PATH/test/webtests/http/tests" -p 8000 --cors > /dev/null 2>&1) &
 SERVER_PID=$!

--- a/lighthouse-core/test/chromium-web-tests/web-test-server.sh
+++ b/lighthouse-core/test/chromium-web-tests/web-test-server.sh
@@ -26,13 +26,8 @@ cleanup() {
 }
 trap 'cleanup' EXIT
 
-echo "server at"
-echo "$DEVTOOLS_PATH/test/webtests/http/tests"
-ls "$DEVTOOLS_PATH/test/webtests/http/tests"
-ls "$DEVTOOLS_PATH/test/webtests/http/tests/inspector-sources"
-
 # Serve from devtools frontend webtests folder.
-(npx http-server@0.12.3 "$DEVTOOLS_PATH/test/webtests/http/tests" -p 8000 --cors) &
+(npx http-server@0.12.3 "$DEVTOOLS_PATH/test/webtests/http/tests" -p 8000 --cors > /dev/null 2>&1) &
 SERVER_PID=$!
 
 echo "Waiting for server"

--- a/lighthouse-core/test/chromium-web-tests/web-test-server.sh
+++ b/lighthouse-core/test/chromium-web-tests/web-test-server.sh
@@ -29,9 +29,10 @@ trap 'cleanup' EXIT
 echo "server at"
 echo "$DEVTOOLS_PATH/test/webtests/http/tests"
 ls "$DEVTOOLS_PATH/test/webtests/http/tests"
+ls "$DEVTOOLS_PATH/test/webtests/http/tests/inspector-sources"
 
 # Serve from devtools frontend webtests folder.
-(npx http-server@0.12.3 "$DEVTOOLS_PATH/test/webtests/http/tests" -p 8000 --cors > /dev/null 2>&1) &
+(npx http-server@0.12.3 "$DEVTOOLS_PATH/test/webtests/http/tests" -p 8000 --cors) &
 SERVER_PID=$!
 
 echo "Waiting for server"


### PR DESCRIPTION
- adds a build job, which rolls LH + builds devtools and uploads to GHA as an artifact
- adds web-tests and sharded smoke test jobs
- uses `restore-keys` for `actions/cache` step, which should speed up build times for cache-misses

cache hit:

![image](https://user-images.githubusercontent.com/4071474/148474295-d0cf76bd-9934-4a61-a667-5d4bcbd3560a.png)

cache miss (building off latest cache):

(don't have an example here yet lol)

Building from scratch (no cache used at all):

![image](https://user-images.githubusercontent.com/4071474/148473863-8f13bacf-3770-4280-ae5a-8c28c2fbf99a.png)

