### PR TITLE
tests: dedupe some CI job names

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -125,11 +125,7 @@ jobs:
       # e.g. if set 1 fails, continue with set 2 anyway
       fail-fast: false
     runs-on: macos-latest
-    env:
-      # The total number of shards. Set dynamically when length of single matrix variable is
-      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
-      SHARD_TOTAL: 2
-    name: Smoke batch ${{ matrix.smoke-test-shard }}
+    name: Smoke DevTools ${{ matrix.smoke-test-shard }}
 
     steps:
     - name: git clone
@@ -169,5 +165,5 @@ jobs:
       # - Current DevTools hangs on any page with a service worker.
       #   https://github.com/GoogleChrome/lighthouse/issues/13396
       # - Various other issues that needed investigation.
-      run: yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL --retries=2 --invert-match a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp offline-ready offline-sw-broken offline-sw-slow oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-client redirects-single-server screenshot seo-passing seo-tap-targets
+      run: yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/${{ strategy.job-total }} --retries=2 --invert-match a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp offline-ready offline-sw-broken offline-sw-slow oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-client redirects-single-server screenshot seo-passing seo-tap-targets
       working-directory: ${{ github.workspace }}/lighthouse

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -125,7 +125,7 @@ jobs:
       # e.g. if set 1 fails, continue with set 2 anyway
       fail-fast: false
     runs-on: macos-latest
-    name: Smoke DevTools ${{ matrix.smoke-test-shard }}
+    name: DevTools smoke ${{ matrix.smoke-test-shard }}
 
     steps:
     - name: git clone

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -76,7 +76,7 @@ jobs:
   # Only run smoke tests for windows against stable chrome.
   smoke-windows:
     runs-on: windows-latest
-    name: Windows
+    name: Windows smoke
 
     steps:
     - name: git clone

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -70,7 +70,7 @@ jobs:
   # For windows, just test the potentially platform-specific code.
   unit-windows:
     runs-on: windows-latest
-    name: Windows
+    name: Windows unit
 
     steps:
     - name: git clone


### PR DESCRIPTION
Small job name tweaks. Github actions in status checks are prefaced by their workflow name (e.g. `DevTools / web-tests`) but annoyingly are not prefaced in other contexts (so you get only `web-tests`). This is fine for some things, but I already got confused by the new "Smoke batch 1" and "Smoke batch 2" introduced in #13546.

<img width="457" alt="List of passed status checks with confusing overlapping names" src="https://user-images.githubusercontent.com/316891/148617277-6217d892-ae69-4da9-a9c4-11947807ca0f.png">

This renames them to "Smoke DevTools 1" and "Smoke DevTools 2", which will end up with a redundant "DevTools / Smoke DevTools 1" in some contexts, but I couldn't think of another good way to dedupe when it's on its own.
Also renames "Windows" to "Windows smoke" and "Windows unit".

The Github UI choices are kind of unfortunate. Things are still somewhat confusing, but at least differentiated. Super happy to bikeshed :)