### PR TITLE
core(runner): store gather timing on artifacts

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -172,6 +172,8 @@ class Runner {
           driverMock: options.driverMock,
         });
 
+        // Calling log.timeEnd here will retroactively update artifacts.Timing.
+        // Must end time here so this timing entry can be stored on saved artifacts.
         log.timeEnd(runnerStatus);
 
         // If `gather` is run multiple times before `audit`, the timing entries for each `gather` can pollute one another.

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -158,6 +158,11 @@ class Runner {
         // No browser required, just load the artifacts from disk.
         const path = this._getDataSavePath(settings);
         artifacts = assetSaver.loadArtifacts(path);
+        const requestedUrl = artifacts.URL.requestedUrl;
+
+        if (!requestedUrl) {
+          throw new Error('Cannot run audit mode on empty URL');
+        }
       } else {
         const runnerStatus = {msg: 'Gather phase', id: 'lh:runner:gather'};
         log.time(runnerStatus, 'verbose');

--- a/lighthouse-core/scripts/update-report-fixtures.js
+++ b/lighthouse-core/scripts/update-report-fixtures.js
@@ -37,9 +37,10 @@ async function update(artifactName) {
   let newArtifacts = assetSaver.loadArtifacts(artifactPath);
 
   // Normalize some data so it doesn't change on every update.
+  let baseTime = 0;
   for (const timing of newArtifacts.Timing) {
     // @ts-expect-error: Value actually is writeable at this point.
-    timing.startTime = 0;
+    timing.startTime = baseTime++;
     // @ts-expect-error: Value actually is writeable at this point.
     timing.duration = 1;
   }

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -215,728 +215,700 @@
     },
     {
       "startTime": 6,
-      "name": "lh:gather:getVersion",
+      "name": "lh:driver:navigate",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 7,
-      "name": "lh:gather:getBenchmarkIndex",
+      "name": "lh:gather:getVersion",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 8,
-      "name": "lh:gather:setupDriver",
+      "name": "lh:gather:getBenchmarkIndex",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 9,
-      "name": "lh:gather:runPass-defaultPass",
+      "name": "lh:gather:setupDriver",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 10,
-      "name": "lh:gather:loadBlank",
+      "name": "lh:prepare:navigationMode",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 11,
-      "name": "lh:storage:clearBrowserCaches",
+      "name": "lh:gather:runPass-defaultPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 12,
-      "name": "lh:gather:prepareNetworkForNavigation",
+      "name": "lh:gather:loadBlank",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 13,
-      "name": "lh:gather:beforePass",
+      "name": "lh:driver:navigate",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 14,
-      "name": "lh:gather:beforePass:CSSUsage",
+      "name": "lh:prepare:navigation",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 15,
-      "name": "lh:gather:beforePass:JsUsage",
+      "name": "lh:storage:clearDataForOrigin",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 16,
-      "name": "lh:gather:beforePass:ViewportDimensions",
+      "name": "lh:storage:clearBrowserCaches",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 17,
-      "name": "lh:gather:beforePass:ConsoleMessages",
+      "name": "lh:gather:prepareThrottlingAndNetwork",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 18,
-      "name": "lh:gather:beforePass:AnchorElements",
+      "name": "lh:gather:beforePass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 19,
-      "name": "lh:gather:beforePass:ImageElements",
+      "name": "lh:gather:beforePass:CSSUsage",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 20,
-      "name": "lh:gather:beforePass:LinkElements",
+      "name": "lh:gather:beforePass:JsUsage",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 21,
-      "name": "lh:gather:beforePass:MetaElements",
+      "name": "lh:gather:beforePass:ViewportDimensions",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 22,
-      "name": "lh:gather:beforePass:ScriptElements",
+      "name": "lh:gather:beforePass:ConsoleMessages",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 23,
-      "name": "lh:gather:beforePass:IFrameElements",
+      "name": "lh:gather:beforePass:AnchorElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 24,
-      "name": "lh:gather:beforePass:FormElements",
+      "name": "lh:gather:beforePass:ImageElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 25,
-      "name": "lh:gather:beforePass:MainDocumentContent",
+      "name": "lh:gather:beforePass:LinkElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 26,
-      "name": "lh:gather:beforePass:GatherContext",
+      "name": "lh:gather:beforePass:MetaElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 27,
-      "name": "lh:gather:beforePass:GlobalListeners",
+      "name": "lh:gather:beforePass:ScriptElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 28,
-      "name": "lh:gather:beforePass:Doctype",
+      "name": "lh:gather:beforePass:IFrameElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 29,
-      "name": "lh:gather:beforePass:DOMStats",
+      "name": "lh:gather:beforePass:FormElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 30,
-      "name": "lh:gather:beforePass:OptimizedImages",
+      "name": "lh:gather:beforePass:MainDocumentContent",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 31,
-      "name": "lh:gather:beforePass:PasswordInputsWithPreventedPaste",
+      "name": "lh:gather:beforePass:GlobalListeners",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 32,
-      "name": "lh:gather:beforePass:ResponseCompression",
+      "name": "lh:gather:beforePass:Doctype",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 33,
-      "name": "lh:gather:beforePass:TagsBlockingFirstPaint",
+      "name": "lh:gather:beforePass:DOMStats",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 34,
-      "name": "lh:gather:beforePass:FontSize",
+      "name": "lh:gather:beforePass:OptimizedImages",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 35,
-      "name": "lh:gather:beforePass:EmbeddedContent",
+      "name": "lh:gather:beforePass:PasswordInputsWithPreventedPaste",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 36,
-      "name": "lh:gather:beforePass:RobotsTxt",
+      "name": "lh:gather:beforePass:ResponseCompression",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 37,
-      "name": "lh:gather:beforePass:TapTargets",
+      "name": "lh:gather:beforePass:TagsBlockingFirstPaint",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 38,
-      "name": "lh:gather:beforePass:Accessibility",
+      "name": "lh:gather:beforePass:FontSize",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 39,
-      "name": "lh:gather:beforePass:TraceElements",
+      "name": "lh:gather:beforePass:EmbeddedContent",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 40,
-      "name": "lh:gather:beforePass:InspectorIssues",
+      "name": "lh:gather:beforePass:RobotsTxt",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 41,
-      "name": "lh:gather:beforePass:SourceMaps",
+      "name": "lh:gather:beforePass:TapTargets",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 42,
-      "name": "lh:gather:beforePass:FullPageScreenshot",
+      "name": "lh:gather:beforePass:Accessibility",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 43,
-      "name": "lh:gather:beginRecording",
+      "name": "lh:gather:beforePass:TraceElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 44,
-      "name": "lh:gather:loadPage-defaultPass",
+      "name": "lh:gather:beforePass:InspectorIssues",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 45,
-      "name": "lh:gather:pass",
+      "name": "lh:gather:beforePass:SourceMaps",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 46,
-      "name": "lh:gather:getTrace",
+      "name": "lh:gather:beforePass:FullPageScreenshot",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 47,
-      "name": "lh:gather:getDevtoolsLog",
+      "name": "lh:gather:beginRecording",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 48,
-      "name": "lh:computed:NetworkRecords",
+      "name": "lh:gather:loadPage-defaultPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 49,
-      "name": "lh:gather:afterPass",
+      "name": "lh:driver:navigate",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 50,
-      "name": "lh:gather:afterPass:CSSUsage",
+      "name": "lh:gather:pass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 51,
-      "name": "lh:gather:afterPass:JsUsage",
+      "name": "lh:gather:getTrace",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 52,
-      "name": "lh:gather:afterPass:ViewportDimensions",
+      "name": "lh:gather:getDevtoolsLog",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 53,
-      "name": "lh:gather:afterPass:ConsoleMessages",
+      "name": "lh:computed:NetworkRecords",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 54,
-      "name": "lh:gather:afterPass:AnchorElements",
+      "name": "lh:gather:afterPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 55,
-      "name": "lh:gather:afterPass:ImageElements",
+      "name": "lh:gather:afterPass:CSSUsage",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 56,
-      "name": "lh:gather:afterPass:LinkElements",
+      "name": "lh:gather:afterPass:JsUsage",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 57,
-      "name": "lh:gather:afterPass:MetaElements",
+      "name": "lh:gather:afterPass:ViewportDimensions",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 58,
-      "name": "lh:gather:afterPass:ScriptElements",
+      "name": "lh:gather:afterPass:ConsoleMessages",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 59,
-      "name": "lh:gather:afterPass:IFrameElements",
+      "name": "lh:gather:afterPass:AnchorElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 60,
-      "name": "lh:gather:afterPass:FormElements",
+      "name": "lh:gather:afterPass:ImageElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 61,
-      "name": "lh:gather:afterPass:MainDocumentContent",
+      "name": "lh:gather:afterPass:LinkElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 62,
-      "name": "lh:gather:afterPass:GatherContext",
+      "name": "lh:gather:afterPass:MetaElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 63,
-      "name": "lh:gather:afterPass:GlobalListeners",
+      "name": "lh:gather:afterPass:ScriptElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 64,
-      "name": "lh:gather:afterPass:Doctype",
+      "name": "lh:gather:afterPass:IFrameElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 65,
-      "name": "lh:gather:afterPass:DOMStats",
+      "name": "lh:gather:afterPass:FormElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 66,
-      "name": "lh:gather:afterPass:OptimizedImages",
+      "name": "lh:gather:afterPass:MainDocumentContent",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 67,
-      "name": "lh:gather:afterPass:PasswordInputsWithPreventedPaste",
+      "name": "lh:gather:afterPass:GlobalListeners",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 68,
-      "name": "lh:gather:afterPass:ResponseCompression",
+      "name": "lh:gather:afterPass:Doctype",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 69,
-      "name": "lh:gather:afterPass:TagsBlockingFirstPaint",
+      "name": "lh:gather:afterPass:DOMStats",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 70,
-      "name": "lh:gather:afterPass:FontSize",
+      "name": "lh:gather:afterPass:OptimizedImages",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 71,
-      "name": "lh:gather:afterPass:EmbeddedContent",
+      "name": "lh:gather:afterPass:PasswordInputsWithPreventedPaste",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 72,
-      "name": "lh:gather:afterPass:RobotsTxt",
+      "name": "lh:gather:afterPass:ResponseCompression",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 73,
-      "name": "lh:gather:getVersion",
+      "name": "lh:gather:afterPass:TagsBlockingFirstPaint",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 74,
-      "name": "lh:gather:getVersion",
+      "name": "lh:gather:afterPass:FontSize",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 75,
-      "name": "lh:gather:afterPass:TapTargets",
+      "name": "lh:gather:afterPass:EmbeddedContent",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 76,
-      "name": "lh:gather:afterPass:Accessibility",
+      "name": "lh:gather:afterPass:RobotsTxt",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 77,
-      "name": "lh:gather:afterPass:TraceElements",
+      "name": "lh:gather:getVersion",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 78,
-      "name": "lh:computed:ProcessedTrace",
+      "name": "lh:gather:getVersion",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 79,
-      "name": "lh:computed:ProcessedNavigation",
+      "name": "lh:gather:afterPass:TapTargets",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 80,
-      "name": "lh:gather:afterPass:InspectorIssues",
+      "name": "lh:gather:afterPass:Accessibility",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 81,
-      "name": "lh:gather:afterPass:SourceMaps",
+      "name": "lh:gather:afterPass:TraceElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 82,
-      "name": "lh:gather:afterPass:FullPageScreenshot",
+      "name": "lh:computed:ProcessedTrace",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 83,
-      "name": "lh:gather:populateBaseArtifacts",
+      "name": "lh:computed:ProcessedNavigation",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 84,
-      "name": "lh:gather:collectStacks",
+      "name": "lh:gather:afterPass:InspectorIssues",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 85,
-      "name": "lh:gather:runPass-offlinePass",
+      "name": "lh:gather:afterPass:SourceMaps",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 86,
-      "name": "lh:gather:loadBlank",
+      "name": "lh:gather:afterPass:FullPageScreenshot",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 87,
-      "name": "lh:gather:prepareNetworkForNavigation",
+      "name": "lh:gather:populateBaseArtifacts",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 88,
-      "name": "lh:gather:beforePass",
+      "name": "lh:gather:collectStacks",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 89,
-      "name": "lh:gather:beforePass:ServiceWorker",
+      "name": "lh:gather:runPass-offlinePass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
       "startTime": 90,
-      "name": "lh:gather:beginRecording",
-      "duration": 1,
-      "entryType": "measure",
-      "gather": true
-    },
-    {
-      "startTime": 91,
-      "name": "lh:gather:loadPage-offlinePass",
-      "duration": 1,
-      "entryType": "measure",
-      "gather": true
-    },
-    {
-      "startTime": 92,
-      "name": "lh:gather:pass",
-      "duration": 1,
-      "entryType": "measure",
-      "gather": true
-    },
-    {
-      "startTime": 93,
-      "name": "lh:gather:getDevtoolsLog",
-      "duration": 1,
-      "entryType": "measure",
-      "gather": true
-    },
-    {
-      "startTime": 94,
-      "name": "lh:computed:NetworkRecords",
-      "duration": 1,
-      "entryType": "measure",
-      "gather": true
-    },
-    {
-      "startTime": 95,
-      "name": "lh:gather:afterPass",
-      "duration": 1,
-      "entryType": "measure",
-      "gather": true
-    },
-    {
-      "startTime": 96,
-      "name": "lh:gather:afterPass:ServiceWorker",
-      "duration": 1,
-      "entryType": "measure",
-      "gather": true
-    },
-    {
-      "startTime": 97,
-      "name": "lh:gather:runPass-redirectPass",
-      "duration": 1,
-      "entryType": "measure",
-      "gather": true
-    },
-    {
-      "startTime": 98,
       "name": "lh:gather:loadBlank",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 99,
-      "name": "lh:gather:prepareNetworkForNavigation",
+      "startTime": 91,
+      "name": "lh:driver:navigate",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 100,
+      "startTime": 92,
+      "name": "lh:prepare:navigation",
+      "duration": 1,
+      "entryType": "measure",
+      "gather": true
+    },
+    {
+      "startTime": 93,
+      "name": "lh:gather:prepareThrottlingAndNetwork",
+      "duration": 1,
+      "entryType": "measure",
+      "gather": true
+    },
+    {
+      "startTime": 94,
       "name": "lh:gather:beforePass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 101,
-      "name": "lh:gather:beforePass:HTTPRedirect",
+      "startTime": 95,
+      "name": "lh:gather:beforePass:ServiceWorker",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 102,
+      "startTime": 96,
       "name": "lh:gather:beginRecording",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 103,
-      "name": "lh:gather:loadPage-redirectPass",
+      "startTime": 97,
+      "name": "lh:gather:loadPage-offlinePass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 104,
+      "startTime": 98,
+      "name": "lh:driver:navigate",
+      "duration": 1,
+      "entryType": "measure",
+      "gather": true
+    },
+    {
+      "startTime": 99,
       "name": "lh:gather:pass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 105,
+      "startTime": 100,
       "name": "lh:gather:getDevtoolsLog",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 106,
+      "startTime": 101,
       "name": "lh:computed:NetworkRecords",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 107,
+      "startTime": 102,
       "name": "lh:gather:afterPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 108,
-      "name": "lh:gather:afterPass:HTTPRedirect",
+      "startTime": 103,
+      "name": "lh:gather:afterPass:ServiceWorker",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 109,
+      "startTime": 104,
       "name": "lh:gather:disconnect",
+      "duration": 1,
+      "entryType": "measure",
+      "gather": true
+    },
+    {
+      "startTime": 105,
+      "name": "lh:storage:clearDataForOrigin",
       "duration": 1,
       "entryType": "measure",
       "gather": true

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -179,756 +179,763 @@
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 1,
       "name": "lh:config:requireGatherers",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 2,
       "name": "lh:config:requireAudits",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 3,
+      "name": "lh:runner:gather",
+      "duration": 1,
+      "entryType": "measure",
+      "gather": true
+    },
+    {
+      "startTime": 4,
       "name": "lh:init:connect",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 5,
       "name": "lh:gather:loadBlank",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 6,
       "name": "lh:gather:getVersion",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 7,
       "name": "lh:gather:getBenchmarkIndex",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 8,
       "name": "lh:gather:setupDriver",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 9,
       "name": "lh:gather:runPass-defaultPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 10,
       "name": "lh:gather:loadBlank",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 11,
       "name": "lh:storage:clearBrowserCaches",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 12,
       "name": "lh:gather:prepareNetworkForNavigation",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 13,
       "name": "lh:gather:beforePass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 14,
       "name": "lh:gather:beforePass:CSSUsage",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 15,
       "name": "lh:gather:beforePass:JsUsage",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 16,
       "name": "lh:gather:beforePass:ViewportDimensions",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 17,
       "name": "lh:gather:beforePass:ConsoleMessages",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 18,
       "name": "lh:gather:beforePass:AnchorElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 19,
       "name": "lh:gather:beforePass:ImageElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 20,
       "name": "lh:gather:beforePass:LinkElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 21,
       "name": "lh:gather:beforePass:MetaElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 22,
       "name": "lh:gather:beforePass:ScriptElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 23,
       "name": "lh:gather:beforePass:IFrameElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 24,
       "name": "lh:gather:beforePass:FormElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 25,
       "name": "lh:gather:beforePass:MainDocumentContent",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 26,
       "name": "lh:gather:beforePass:GatherContext",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 27,
       "name": "lh:gather:beforePass:GlobalListeners",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 28,
       "name": "lh:gather:beforePass:Doctype",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 29,
       "name": "lh:gather:beforePass:DOMStats",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 30,
       "name": "lh:gather:beforePass:OptimizedImages",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 31,
       "name": "lh:gather:beforePass:PasswordInputsWithPreventedPaste",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 32,
       "name": "lh:gather:beforePass:ResponseCompression",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 33,
       "name": "lh:gather:beforePass:TagsBlockingFirstPaint",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 34,
       "name": "lh:gather:beforePass:FontSize",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 35,
       "name": "lh:gather:beforePass:EmbeddedContent",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 36,
       "name": "lh:gather:beforePass:RobotsTxt",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 37,
       "name": "lh:gather:beforePass:TapTargets",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 38,
       "name": "lh:gather:beforePass:Accessibility",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 39,
       "name": "lh:gather:beforePass:TraceElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 40,
       "name": "lh:gather:beforePass:InspectorIssues",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 41,
       "name": "lh:gather:beforePass:SourceMaps",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 42,
       "name": "lh:gather:beforePass:FullPageScreenshot",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 43,
       "name": "lh:gather:beginRecording",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 44,
       "name": "lh:gather:loadPage-defaultPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 45,
       "name": "lh:gather:pass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 46,
       "name": "lh:gather:getTrace",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 47,
       "name": "lh:gather:getDevtoolsLog",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 48,
       "name": "lh:computed:NetworkRecords",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 49,
       "name": "lh:gather:afterPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 50,
       "name": "lh:gather:afterPass:CSSUsage",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 51,
       "name": "lh:gather:afterPass:JsUsage",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 52,
       "name": "lh:gather:afterPass:ViewportDimensions",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 53,
       "name": "lh:gather:afterPass:ConsoleMessages",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 54,
       "name": "lh:gather:afterPass:AnchorElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 55,
       "name": "lh:gather:afterPass:ImageElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 56,
       "name": "lh:gather:afterPass:LinkElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 57,
       "name": "lh:gather:afterPass:MetaElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 58,
       "name": "lh:gather:afterPass:ScriptElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 59,
       "name": "lh:gather:afterPass:IFrameElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 60,
       "name": "lh:gather:afterPass:FormElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 61,
       "name": "lh:gather:afterPass:MainDocumentContent",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 62,
       "name": "lh:gather:afterPass:GatherContext",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 63,
       "name": "lh:gather:afterPass:GlobalListeners",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 64,
       "name": "lh:gather:afterPass:Doctype",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 65,
       "name": "lh:gather:afterPass:DOMStats",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 66,
       "name": "lh:gather:afterPass:OptimizedImages",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 67,
       "name": "lh:gather:afterPass:PasswordInputsWithPreventedPaste",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 68,
       "name": "lh:gather:afterPass:ResponseCompression",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 69,
       "name": "lh:gather:afterPass:TagsBlockingFirstPaint",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 70,
       "name": "lh:gather:afterPass:FontSize",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 71,
       "name": "lh:gather:afterPass:EmbeddedContent",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 72,
       "name": "lh:gather:afterPass:RobotsTxt",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 73,
       "name": "lh:gather:getVersion",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 74,
       "name": "lh:gather:getVersion",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 75,
       "name": "lh:gather:afterPass:TapTargets",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 76,
       "name": "lh:gather:afterPass:Accessibility",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 77,
       "name": "lh:gather:afterPass:TraceElements",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 78,
       "name": "lh:computed:ProcessedTrace",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 79,
       "name": "lh:computed:ProcessedNavigation",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 80,
       "name": "lh:gather:afterPass:InspectorIssues",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 81,
       "name": "lh:gather:afterPass:SourceMaps",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 82,
       "name": "lh:gather:afterPass:FullPageScreenshot",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 83,
       "name": "lh:gather:populateBaseArtifacts",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 84,
       "name": "lh:gather:collectStacks",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 85,
       "name": "lh:gather:runPass-offlinePass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 86,
       "name": "lh:gather:loadBlank",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 87,
       "name": "lh:gather:prepareNetworkForNavigation",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 88,
       "name": "lh:gather:beforePass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 89,
       "name": "lh:gather:beforePass:ServiceWorker",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 90,
       "name": "lh:gather:beginRecording",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 91,
       "name": "lh:gather:loadPage-offlinePass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 92,
       "name": "lh:gather:pass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 93,
       "name": "lh:gather:getDevtoolsLog",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 94,
       "name": "lh:computed:NetworkRecords",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 95,
       "name": "lh:gather:afterPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 96,
       "name": "lh:gather:afterPass:ServiceWorker",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 97,
       "name": "lh:gather:runPass-redirectPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 98,
       "name": "lh:gather:loadBlank",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 99,
       "name": "lh:gather:prepareNetworkForNavigation",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 100,
       "name": "lh:gather:beforePass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 101,
       "name": "lh:gather:beforePass:HTTPRedirect",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 102,
       "name": "lh:gather:beginRecording",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 103,
       "name": "lh:gather:loadPage-redirectPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 104,
       "name": "lh:gather:pass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 105,
       "name": "lh:gather:getDevtoolsLog",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 106,
       "name": "lh:computed:NetworkRecords",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 107,
       "name": "lh:gather:afterPass",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 108,
       "name": "lh:gather:afterPass:HTTPRedirect",
       "duration": 1,
       "entryType": "measure",
       "gather": true
     },
     {
-      "startTime": 0,
+      "startTime": 109,
       "name": "lh:gather:disconnect",
       "duration": 1,
       "entryType": "measure",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -6846,12 +6846,6 @@
     "entries": [
       {
         "startTime": 0,
-        "name": "lh:gather:disconnect",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
         "name": "lh:init:config",
         "duration": 100,
         "entryType": "measure"
@@ -6871,6 +6865,660 @@
       {
         "startTime": 0,
         "name": "lh:runner:gather",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:init:connect",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:loadBlank",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getVersion",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getBenchmarkIndex",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:setupDriver",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:runPass-defaultPass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:loadBlank",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:storage:clearBrowserCaches",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:prepareNetworkForNavigation",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:CSSUsage",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:JsUsage",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:ViewportDimensions",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:ConsoleMessages",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:AnchorElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:ImageElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:LinkElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:MetaElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:ScriptElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:IFrameElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:FormElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:MainDocumentContent",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:GatherContext",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:GlobalListeners",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:Doctype",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:DOMStats",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:OptimizedImages",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:PasswordInputsWithPreventedPaste",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:ResponseCompression",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:TagsBlockingFirstPaint",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:FontSize",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:EmbeddedContent",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:RobotsTxt",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:TapTargets",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:Accessibility",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:TraceElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:InspectorIssues",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:SourceMaps",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:FullPageScreenshot",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beginRecording",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:loadPage-defaultPass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:pass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getTrace",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getDevtoolsLog",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:NetworkRecords",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:CSSUsage",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:JsUsage",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:ViewportDimensions",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:ConsoleMessages",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:AnchorElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:ImageElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:LinkElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:MetaElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:ScriptElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:IFrameElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:FormElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:MainDocumentContent",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:GatherContext",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:GlobalListeners",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:Doctype",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:DOMStats",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:OptimizedImages",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:PasswordInputsWithPreventedPaste",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:ResponseCompression",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:TagsBlockingFirstPaint",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:FontSize",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:EmbeddedContent",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:RobotsTxt",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getVersion",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getVersion",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:TapTargets",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:Accessibility",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:TraceElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:ProcessedTrace",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:ProcessedNavigation",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:InspectorIssues",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:SourceMaps",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:FullPageScreenshot",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:populateBaseArtifacts",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:collectStacks",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:runPass-offlinePass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:loadBlank",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:prepareNetworkForNavigation",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:ServiceWorker",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beginRecording",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:loadPage-offlinePass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:pass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getDevtoolsLog",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:NetworkRecords",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:ServiceWorker",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:runPass-redirectPass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:loadBlank",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:prepareNetworkForNavigation",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beforePass:HTTPRedirect",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:beginRecording",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:loadPage-redirectPass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:pass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getDevtoolsLog",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:NetworkRecords",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:afterPass:HTTPRedirect",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:disconnect",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:init:config",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:config:requireGatherers",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:config:requireAudits",
         "duration": 100,
         "entryType": "measure"
       },

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -6882,6 +6882,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:driver:navigate",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:gather:getVersion",
         "duration": 100,
         "entryType": "measure"
@@ -6900,6 +6906,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:prepare:navigationMode",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:gather:runPass-defaultPass",
         "duration": 100,
         "entryType": "measure"
@@ -6912,13 +6924,31 @@
       },
       {
         "startTime": 0,
+        "name": "lh:driver:navigate",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:prepare:navigation",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:storage:clearDataForOrigin",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:storage:clearBrowserCaches",
         "duration": 100,
         "entryType": "measure"
       },
       {
         "startTime": 0,
-        "name": "lh:gather:prepareNetworkForNavigation",
+        "name": "lh:gather:prepareThrottlingAndNetwork",
         "duration": 100,
         "entryType": "measure"
       },
@@ -6997,12 +7027,6 @@
       {
         "startTime": 0,
         "name": "lh:gather:beforePass:MainDocumentContent",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:beforePass:GatherContext",
         "duration": 100,
         "entryType": "measure"
       },
@@ -7116,6 +7140,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:driver:navigate",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:gather:pass",
         "duration": 100,
         "entryType": "measure"
@@ -7213,12 +7243,6 @@
       {
         "startTime": 0,
         "name": "lh:gather:afterPass:MainDocumentContent",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:afterPass:GatherContext",
         "duration": 100,
         "entryType": "measure"
       },
@@ -7368,7 +7392,19 @@
       },
       {
         "startTime": 0,
-        "name": "lh:gather:prepareNetworkForNavigation",
+        "name": "lh:driver:navigate",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:prepare:navigation",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:prepareThrottlingAndNetwork",
         "duration": 100,
         "entryType": "measure"
       },
@@ -7393,6 +7429,12 @@
       {
         "startTime": 0,
         "name": "lh:gather:loadPage-offlinePass",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:driver:navigate",
         "duration": 100,
         "entryType": "measure"
       },
@@ -7428,79 +7470,13 @@
       },
       {
         "startTime": 0,
-        "name": "lh:gather:runPass-redirectPass",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:loadBlank",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:prepareNetworkForNavigation",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:beforePass",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:beforePass:HTTPRedirect",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:beginRecording",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:loadPage-redirectPass",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:pass",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:getDevtoolsLog",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:computed:NetworkRecords",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:afterPass",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:gather:afterPass:HTTPRedirect",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
         "name": "lh:gather:disconnect",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:storage:clearDataForOrigin",
         "duration": 100,
         "entryType": "measure"
       },


### PR DESCRIPTION
Proposal to fix the timing issues in https://github.com/GoogleChrome/lighthouse/pull/13569.

- Taking a position on https://github.com/GoogleChrome/lighthouse/pull/13569#discussion_r789187162 , `lh:runner:gather` will always reflect the time spent gathering the page, and never the time to load artifacts from disk.
- There will always be a `lh:runner:gather` in `artifacts.Timing`
- Sample artifacts will have unique `startTime` for each timing entry so they aren't deduped in `Runner._getTiming`:

https://github.com/GoogleChrome/lighthouse/blob/62848fb75ff419e6da1d0c103680dc58a1e7f6d9/lighthouse-core/runner.js#L200-L202