### PR TITLE
deps: bump `devtools-protocol` and inspector issues

### DIFF
--- a/lighthouse-core/gather/gatherers/inspector-issues.js
+++ b/lighthouse-core/gather/gatherers/inspector-issues.js
@@ -75,14 +75,11 @@ class InspectorIssues extends FRGatherer {
       sameSiteCookieIssue: [],
       sharedArrayBufferIssue: [],
       twaQualityEnforcement: [],
-      wasmCrossOriginModuleSharingIssue: [],
     };
     const keys = /** @type {Array<keyof LH.Artifacts['InspectorIssues']>} */(Object.keys(artifact));
     for (const key of keys) {
-      // The wasmCrossOriginModuleSharingIssue key doesn't follow the pattern of the rest. See
-      // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/devtools_protocol/browser_protocol.pdl;l=811;drc=9c10bf258928b5d169ba6a449f8f33958f7947ea
-      /** @type {`${key}Details` | `wasmCrossOriginModuleSharingIssue`} */
-      const detailsKey = (key === 'wasmCrossOriginModuleSharingIssue' ? `${key}` : `${key}Details`);
+      /** @type {`${key}Details`} */
+      const detailsKey = `${key}Details`;
       const allDetails = this._issues.map(issue => issue.details[detailsKey]);
       for (const detail of allDetails) {
         if (!detail) {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "cpy": "^8.1.2",
     "cross-env": "^7.0.2",
     "csv-validator": "^0.0.3",
-    "devtools-protocol": "0.0.957544",
+    "devtools-protocol": "0.0.963043",
     "es-main": "^1.0.2",
     "eslint": "^8.4.1",
     "eslint-config-google": "^0.14.0",

--- a/third-party/chromium-synchronization/inspector-issueAdded-types-test.js
+++ b/third-party/chromium-synchronization/inspector-issueAdded-types-test.js
@@ -49,7 +49,6 @@ Array [
   "sameSiteCookieIssueDetails",
   "sharedArrayBufferIssueDetails",
   "twaQualityEnforcementDetails",
-  "wasmCrossOriginModuleSharingIssue",
 ]
 `);
   });

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -568,7 +568,6 @@ declare module Artifacts {
     sameSiteCookieIssue: LH.Crdp.Audits.SameSiteCookieIssueDetails[];
     sharedArrayBufferIssue: LH.Crdp.Audits.SharedArrayBufferIssueDetails[];
     twaQualityEnforcement: LH.Crdp.Audits.TrustedWebActivityIssueDetails[];
-    wasmCrossOriginModuleSharingIssue: LH.Crdp.Audits.WasmCrossOriginModuleSharingIssueDetails[];
   }
 
   // Computed artifact types below.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,6 +3245,11 @@ devtools-protocol@0.0.901419, devtools-protocol@0.0.957544:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.957544.tgz#2e05d8ce73bb63a9c96abd40a86cd6e467e24693"
   integrity sha512-Fs5II73fwKnh+raJ+u/d/YSN/HfWcW6aERnYWeELzO04yuYt78iItsM9bK10Z0hIDVTVgA40cMK8Lk59SBYDEg==
 
+devtools-protocol@0.0.963043:
+  version "0.0.963043"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.963043.tgz#03a35b7df8bf5ee64b4c1f4f23ef5e8bd9293efb"
+  integrity sha512-yROi8O/R6ORwt1oIe5CnXWGZUL1FbbFdjl7hA73STeIeX0jpowZqZsgDBU6wQ3Vr+4M8vByq/dJLcgwZGke4Tw==
+
 diff-sequences@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"


### PR DESCRIPTION
Fixes our CI notifier and updates inspector issues.
