### PR TITLE
deps(yargs-parser): upgrade to 21.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "update-notifier": "^4.1.0",
     "ws": "^7.0.0",
     "yargs": "^16.1.1",
-    "yargs-parser": "^20.2.4"
+    "yargs-parser": "^21.0.0"
   },
   "resolutions": {
     "puppeteer/**/devtools-protocol": "0.0.963043"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@types/update-notifier": "^4.1.0",
     "@types/ws": "^7.0.0",
     "@types/yargs": "^16.0.0",
-    "@types/yargs-parser": "^15.0.0",
+    "@types/yargs-parser": "^20.2.1",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
     "acorn": "^8.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,10 +1722,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/yargs-parser@*", "@types/yargs-parser@^15.0.0":
+"@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+
+"@types/yargs-parser@^20.2.1":
+  version "20.2.1"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
+  integrity sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
 
 "@types/yargs@^15.0.0":
   version "15.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8481,10 +8481,15 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.0.0, yargs-parser@^20.2.2, yargs-parser@^20.2.4:
+yargs-parser@^20.0.0, yargs-parser@^20.2.2:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
+yargs-parser@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
+  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
 
 yargs@^15.0.0:
   version "15.4.1"


### PR DESCRIPTION
https://github.com/yargs/yargs-parser/blob/main/CHANGELOG.md#2025-2021-02-13

No code changes necessary.

Updating to match what yarg's will be from #13590. Separate PR to show that tests still pass / keep other PR simpler.