### PR TITLE
core(preload-lcp-image): enable audit

### DIFF
--- a/lighthouse-core/audits/preload-fonts.js
+++ b/lighthouse-core/audits/preload-fonts.js
@@ -97,9 +97,8 @@ class PreloadFontsAudit extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static async audit() {
-    // Preload advice is dangerous until https://bugs.chromium.org/p/chromium/issues/detail?id=788757
-    // has been fixed and validated. All preload audits are on hold until then.
-    // See https://github.com/GoogleChrome/lighthouse/issues/11960 for more discussion.
+    // Preload advice is on hold until https://github.com/GoogleChrome/lighthouse/issues/11960
+    // is resolved.
     return {score: 1, notApplicable: true};
   }
 }

--- a/lighthouse-core/audits/preload-lcp-image.js
+++ b/lighthouse-core/audits/preload-lcp-image.js
@@ -198,7 +198,7 @@ class PreloadLCPImageAudit extends Audit {
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Audit.Product>}
    */
-  static async audit_(artifacts, context) {
+  static async audit(artifacts, context) {
     const gatherContext = artifacts.GatherContext;
     const trace = artifacts.traces[PreloadLCPImageAudit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[PreloadLCPImageAudit.DEFAULT_PASS];
@@ -235,16 +235,6 @@ class PreloadLCPImageAudit extends Audit {
       displayValue: wastedMs ? str_(i18n.UIStrings.displayValueMsSavings, {wastedMs}) : '',
       details,
     };
-  }
-
-  /**
-   * @return {Promise<LH.Audit.Product>}
-   */
-  static async audit() {
-    // Preload advice is dangerous until https://bugs.chromium.org/p/chromium/issues/detail?id=788757
-    // has been fixed and validated. All preload audits are on hold until then.
-    // See https://github.com/GoogleChrome/lighthouse/issues/11960 for more discussion.
-    return {score: 1, notApplicable: true, details: Audit.makeOpportunityDetails([], [], 0)};
   }
 }
 

--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -257,9 +257,8 @@ class UsesRelPreloadAudit extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static async audit() {
-    // Preload advice is dangerous until https://bugs.chromium.org/p/chromium/issues/detail?id=788757
-    // has been fixed and validated. All preload audits are on hold until then.
-    // See https://github.com/GoogleChrome/lighthouse/issues/11960 for more discussion.
+    // Preload advice is on hold until https://github.com/GoogleChrome/lighthouse/issues/11960
+    // is resolved.
     return {score: 1, notApplicable: true, details: Audit.makeOpportunityDetails([], [], 0)};
   }
 }

--- a/lighthouse-core/test/audits/preload-lcp-image-test.js
+++ b/lighthouse-core/test/audits/preload-lcp-image-test.js
@@ -97,7 +97,7 @@ describe('Performance: preload-lcp audit', () => {
     const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl, imageUrl);
     artifacts.ImageElements = [];
     const context = {settings: {}, computedCache: new Map()};
-    const results = await PreloadLCPImage.audit_(artifacts, context);
+    const results = await PreloadLCPImage.audit(artifacts, context);
     expect(results.score).toEqual(1);
     expect(results.details.overallSavingsMs).toEqual(0);
     expect(results.details.items).toHaveLength(0);
@@ -108,7 +108,7 @@ describe('Performance: preload-lcp audit', () => {
     networkRecords[3].isLinkPreload = true;
     const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl, imageUrl);
     const context = {settings: {}, computedCache: new Map()};
-    const results = await PreloadLCPImage.audit_(artifacts, context);
+    const results = await PreloadLCPImage.audit(artifacts, context);
     expect(results.score).toEqual(1);
     expect(results.details.overallSavingsMs).toEqual(0);
     expect(results.details.items).toHaveLength(0);
@@ -119,7 +119,7 @@ describe('Performance: preload-lcp audit', () => {
     networkRecords[3].protocol = 'data';
     const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl, imageUrl);
     const context = {settings: {}, computedCache: new Map()};
-    const results = await PreloadLCPImage.audit_(artifacts, context);
+    const results = await PreloadLCPImage.audit(artifacts, context);
     expect(results.score).toEqual(1);
     expect(results.details.overallSavingsMs).toEqual(0);
     expect(results.details.items).toHaveLength(0);
@@ -129,7 +129,7 @@ describe('Performance: preload-lcp audit', () => {
     const networkRecords = mockNetworkRecords();
     const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl, imageUrl);
     const context = {settings: {}, computedCache: new Map()};
-    const results = await PreloadLCPImage.audit_(artifacts, context);
+    const results = await PreloadLCPImage.audit(artifacts, context);
     expect(results.numericValue).toEqual(180);
     expect(results.details.overallSavingsMs).toEqual(180);
     expect(results.details.items[0].url).toEqual(imageUrl);
@@ -141,7 +141,7 @@ describe('Performance: preload-lcp audit', () => {
     networkRecords[3].transferSize = 5 * 1000 * 1000;
     const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl, imageUrl);
     const context = {settings: {}, computedCache: new Map()};
-    const results = await PreloadLCPImage.audit_(artifacts, context);
+    const results = await PreloadLCPImage.audit(artifacts, context);
     expect(results.numericValue).toEqual(30);
     expect(results.details.overallSavingsMs).toEqual(30);
     expect(results.details.items[0].url).toEqual(imageUrl);
@@ -153,7 +153,7 @@ describe('Performance: preload-lcp audit', () => {
     networkRecords[2].transferSize = 2 * 1000 * 1000;
     const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl, imageUrl);
     const context = {settings: {}, computedCache: new Map()};
-    const results = await PreloadLCPImage.audit_(artifacts, context);
+    const results = await PreloadLCPImage.audit(artifacts, context);
     expect(results.numericValue).toEqual(30);
     expect(results.details.overallSavingsMs).toEqual(30);
     expect(results.details.items[0].url).toEqual(imageUrl);

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2534,8 +2534,11 @@
       "id": "preload-lcp-image",
       "title": "Preload Largest Contentful Paint image",
       "description": "Preload the image used by the LCP element in order to improve your LCP time. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources).",
-      "score": null,
-      "scoreDisplayMode": "notApplicable",
+      "score": 1,
+      "scoreDisplayMode": "numeric",
+      "numericValue": 0,
+      "numericUnit": "millisecond",
+      "displayValue": "",
       "details": {
         "type": "opportunity",
         "headings": [],
@@ -7375,6 +7378,12 @@
       {
         "startTime": 0,
         "name": "lh:audit:preload-lcp-image",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:LanternLargestContentfulPaint",
         "duration": 100,
         "entryType": "measure"
       },

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -504,7 +504,7 @@ password-inputs-can-be-pasted-into: pass
 performance-budget: notApplicable
 plugins: pass
 preload-fonts: notApplicable
-preload-lcp-image: notApplicable
+preload-lcp-image: numeric
 pwa-cross-browser: manual
 pwa-each-page-has-url: manual
 pwa-page-transitions: manual


### PR DESCRIPTION
disabled in #12661. The bug has since been resolved

re-enabling just this one, saving the other for when we #11960 is closed