### PR TITLE
misc(build): remove empty devtools report resources

### DIFF
--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -27,10 +27,6 @@ function writeFile(name, content) {
 fs.rmSync(distDir, {recursive: true, force: true});
 fs.mkdirSync(distDir, {recursive: true});
 
-writeFile('report.js', '// This can be removed after the next CDT roll deletes this file');
-writeFile('standalone-template.html',
-  '<!-- This can be removed after the next CDT roll deletes this file -->');
-writeFile('report.d.ts', 'export {}');
 writeFile('report-generator.d.ts', 'export {}');
 
 async function buildReportGenerator() {


### PR DESCRIPTION
These files were removed from DevTools. `report-generator.d.ts` is still there.