### PR TITLE
core(uses-long-cache-ttl): ignore `stale-while-revalidate`

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -181,6 +181,7 @@ class CacheHeaders extends Audit {
         cacheControl['must-revalidate'] ||
         cacheControl['no-cache'] ||
         cacheControl['no-store'] ||
+        cacheControl['stale-while-revalidate'] ||
         cacheControl['private'])) {
       return true;
     }

--- a/types/parse-cache-control/index.d.ts
+++ b/types/parse-cache-control/index.d.ts
@@ -12,6 +12,7 @@ declare module 'parse-cache-control' {
     'no-cache'?: boolean;
     'no-store'?: boolean;
     'private'?: boolean;
+    'stale-while-revalidate'?: boolean;
   }
 
   function ParseCacheControl(headers?: string): CacheHeaders | null;


### PR DESCRIPTION
Closes https://github.com/GoogleChrome/lighthouse/issues/13514
