### PR TITLE
misc: temporarily remove brendan from triage rotation

### DIFF
--- a/.github/workflows/issue-assigner.yml
+++ b/.github/workflows/issue-assigner.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: patrickhulce/issue-assigner@eeec7a10bd3c02f02d2284fc82a8adabdc001869
         with:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          maintainers: 'paulirish,connorjclark,adamraine,brendankenny'
+          maintainers: 'paulirish,connorjclark,adamraine'


### PR DESCRIPTION
good time to recall that its a standalone workflow and separate from git3po etc.  😀 