### PR TITLE
tests(smoke): test array `_includes` and `lhr.timing`

### DIFF
--- a/lighthouse-cli/test/smokehouse/readme.md
+++ b/lighthouse-cli/test/smokehouse/readme.md
@@ -64,11 +64,14 @@ Individual elements of an array can be asserted by using numeric properties in a
 
 However, if an array literal is used as the expectation, an extra condition is enforced that the actual array _must_ have the same length as the provided expected array.
 
+Arrays can be checked against a subset of elements using the special `_includes` property. The value of `_includes` _must_ be an array.
+
 **Examples**:
 | Actual | Expected | Result |
 | -- | -- | -- |
 | `[{url: 'http://badssl.com'}, {url: 'http://example.com'}]` | `{1: {url: 'http://example.com'}}` | ✅ PASS |
 | `[{timeInMs: 5}, {timeInMs: 15}]` | `{length: 2}` | ✅ PASS |
+| `[{timeInMs: 5}, {timeInMs: 15}]` | `{_includes: [{timeInMs: 5}]}` | ✅ PASS |
 | `[{timeInMs: 5}, {timeInMs: 15}]` | `[{timeInMs: 5}]` | ❌ FAIL |
 
 ### Special environment checks

--- a/lighthouse-cli/test/smokehouse/readme.md
+++ b/lighthouse-cli/test/smokehouse/readme.md
@@ -64,7 +64,7 @@ Individual elements of an array can be asserted by using numeric properties in a
 
 However, if an array literal is used as the expectation, an extra condition is enforced that the actual array _must_ have the same length as the provided expected array.
 
-Arrays can be checked against a subset of elements using the special `_includes` property. The value of `_includes` _must_ be an array.
+Arrays can be checked against a subset of elements using the special `_includes` property. The value of `_includes` _must_ be an array. Each assertion in `_includes` will remove the matching item from consideration for the rest.
 
 **Examples**:
 | Actual | Expected | Result |
@@ -72,6 +72,7 @@ Arrays can be checked against a subset of elements using the special `_includes`
 | `[{url: 'http://badssl.com'}, {url: 'http://example.com'}]` | `{1: {url: 'http://example.com'}}` | ✅ PASS |
 | `[{timeInMs: 5}, {timeInMs: 15}]` | `{length: 2}` | ✅ PASS |
 | `[{timeInMs: 5}, {timeInMs: 15}]` | `{_includes: [{timeInMs: 5}]}` | ✅ PASS |
+| `[{timeInMs: 5}, {timeInMs: 15}]` | `{_includes: [{timeInMs: 5}, {timeInMs: 5}]}` | ❌ FAIL |
 | `[{timeInMs: 5}, {timeInMs: 15}]` | `[{timeInMs: 5}]` | ❌ FAIL |
 
 ### Special environment checks

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -20,6 +20,9 @@ declare global {
         code?: any;
         message?: any;
       };
+      timing?: {
+        entries?: any
+      }
     }
 
     export type ExpectedRunnerResult = {


### PR DESCRIPTION
Landing the smoke test changes separate from https://github.com/GoogleChrome/lighthouse/pull/13569.
