### PR TITLE
tests: fix single node a11y tests

### DIFF
--- a/lighthouse-core/test/audits/accessibility/aria-allowed-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-allowed-attr-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: aria-allowed-attr audit', () => {
       Accessibility: {
         violations: [{
           id: 'aria-allowed-attr',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/aria-required-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-required-attr-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: aria-required-attr audit', () => {
       Accessibility: {
         violations: [{
           id: 'aria-required-attr',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/aria-required-children-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-required-children-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: aria-required-children audit', () => {
       Accessibility: {
         violations: [{
           id: 'aria-required-children',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/aria-required-parent-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-required-parent-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: aria-required-parent audit', () => {
       Accessibility: {
         violations: [{
           id: 'aria-required-parent',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/aria-roles-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-roles-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: aria-roles audit', () => {
       Accessibility: {
         violations: [{
           id: 'aria-roles',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/aria-valid-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-valid-attr-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: aria-valid-attr audit', () => {
       Accessibility: {
         violations: [{
           id: 'aria-valid-attr',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/aria-valid-attr-value-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-valid-attr-value-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: aria-valid-attr-value audit', () => {
       Accessibility: {
         violations: [{
           id: 'aria-valid-attr-value',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/button-name-test.js
+++ b/lighthouse-core/test/audits/accessibility/button-name-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: button-name audit', () => {
       Accessibility: {
         violations: [{
           id: 'button-name',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/bypass-test.js
+++ b/lighthouse-core/test/audits/accessibility/bypass-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: bypass audit', () => {
       Accessibility: {
         violations: [{
           id: 'bypass',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/color-contrast-test.js
+++ b/lighthouse-core/test/audits/accessibility/color-contrast-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: color-contrast audit', () => {
       Accessibility: {
         violations: [{
           id: 'color-contrast',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/definition-list-test.js
+++ b/lighthouse-core/test/audits/accessibility/definition-list-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: definition-list audit', () => {
       Accessibility: {
         violations: [{
           id: 'definition-list',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/dlitem-test.js
+++ b/lighthouse-core/test/audits/accessibility/dlitem-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: dlitem audit', () => {
       Accessibility: {
         violations: [{
           id: 'dlitem',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/document-title-test.js
+++ b/lighthouse-core/test/audits/accessibility/document-title-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: document-title audit', () => {
       Accessibility: {
         violations: [{
           id: 'document-title',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/frame-title-test.js
+++ b/lighthouse-core/test/audits/accessibility/frame-title-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: frame-title audit', () => {
       Accessibility: {
         violations: [{
           id: 'frame-title',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/html-has-lang-test.js
+++ b/lighthouse-core/test/audits/accessibility/html-has-lang-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: html-has-lang audit', () => {
       Accessibility: {
         violations: [{
           id: 'html-has-lang',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/html-lang-valid-test.js
+++ b/lighthouse-core/test/audits/accessibility/html-lang-valid-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: html-lang-valid audit', () => {
       Accessibility: {
         violations: [{
           id: 'html-lang-valid',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/image-alt-test.js
+++ b/lighthouse-core/test/audits/accessibility/image-alt-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: image-alt audit', () => {
       Accessibility: {
         violations: [{
           id: 'image-alt',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/input-image-alt-test.js
+++ b/lighthouse-core/test/audits/accessibility/input-image-alt-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: input-image-alt audit', () => {
       Accessibility: {
         violations: [{
           id: 'input-image-alt',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/label-test.js
+++ b/lighthouse-core/test/audits/accessibility/label-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: label audit', () => {
       Accessibility: {
         violations: [{
           id: 'label',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/link-name-test.js
+++ b/lighthouse-core/test/audits/accessibility/link-name-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: link-name audit', () => {
       Accessibility: {
         violations: [{
           id: 'link-name',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/list-test.js
+++ b/lighthouse-core/test/audits/accessibility/list-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: list audit', () => {
       Accessibility: {
         violations: [{
           id: 'list',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/listitem-test.js
+++ b/lighthouse-core/test/audits/accessibility/listitem-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: listitem audit', () => {
       Accessibility: {
         violations: [{
           id: 'listitem',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/meta-refresh-test.js
+++ b/lighthouse-core/test/audits/accessibility/meta-refresh-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: meta-refresh audit', () => {
       Accessibility: {
         violations: [{
           id: 'meta-refresh',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/meta-viewport-test.js
+++ b/lighthouse-core/test/audits/accessibility/meta-viewport-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: meta-viewport audit', () => {
       Accessibility: {
         violations: [{
           id: 'meta-viewport',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/object-alt-test.js
+++ b/lighthouse-core/test/audits/accessibility/object-alt-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: object-alt audit', () => {
       Accessibility: {
         violations: [{
           id: 'object-alt',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/tabindex-test.js
+++ b/lighthouse-core/test/audits/accessibility/tabindex-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: tabindex audit', () => {
       Accessibility: {
         violations: [{
           id: 'tabindex',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/td-headers-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/td-headers-attr-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: td-headers-attr audit', () => {
       Accessibility: {
         violations: [{
           id: 'td-headers-attr',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/th-has-data-cells-test.js
+++ b/lighthouse-core/test/audits/accessibility/th-has-data-cells-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: th-has-data-cells audit', () => {
       Accessibility: {
         violations: [{
           id: 'th-has-data-cells',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/valid-lang-test.js
+++ b/lighthouse-core/test/audits/accessibility/valid-lang-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: valid-lang audit', () => {
       Accessibility: {
         violations: [{
           id: 'valid-lang',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },

--- a/lighthouse-core/test/audits/accessibility/video-caption-test.js
+++ b/lighthouse-core/test/audits/accessibility/video-caption-test.js
@@ -31,7 +31,7 @@ describe('Accessibility: video-caption audit', () => {
       Accessibility: {
         violations: [{
           id: 'video-caption',
-          nodes: [],
+          nodes: [{node: {}, relatedNodes: []}],
           help: 'http://example.com/',
         }],
       },


### PR DESCRIPTION
These tests accidentally regressed in #11474, making every a11y audit test file repeat the same two unit tests (zero nodes and one node). Don't know if these tests are useful, but it was quick to restore them.