### PR TITLE
core: use a specific arg instead of rest args

### DIFF
--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -53,13 +53,10 @@ class Connection {
    * @template {keyof LH.CrdpCommands} C
    * @param {C} method
    * @param {string|undefined} sessionId
-   * @param {LH.CrdpCommands[C]['paramsType']} paramArgs,
+   * @param {LH.CrdpCommands[C]['paramsType']} params
    * @return {Promise<LH.CrdpCommands[C]['returnType']>}
    */
-  sendCommand(method, sessionId, ...paramArgs) {
-    // Reify params since we need it as a property so can't just spread again.
-    const params = paramArgs.length ? paramArgs[0] : undefined;
-
+  sendCommand(method, sessionId, params) {
     log.formatProtocol('method => browser', {method, params}, 'verbose');
     const id = ++this._lastCommandId;
     const message = JSON.stringify({id, sessionId, method, params});

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -330,7 +330,7 @@ class Driver {
    * @param {LH.CrdpCommands[C]['paramsType']} params
    * @return {Promise<LH.CrdpCommands[C]['returnType']>}
    */
-  sendCommandToSession(method, sessionId, ...params) {
+  sendCommandToSession(method, sessionId, params) {
     const timeout = this._nextProtocolTimeout;
     this._nextProtocolTimeout = DEFAULT_PROTOCOL_TIMEOUT;
 
@@ -344,7 +344,7 @@ class Driver {
     });
 
     return Promise.race([
-      this._innerSendCommand(method, sessionId, ...params),
+      this._innerSendCommand(method, sessionId, params),
       timeoutPromise,
     ]).finally(() => {
       asyncTimeout && clearTimeout(asyncTimeout);
@@ -352,14 +352,14 @@ class Driver {
   }
 
   /**
-   * Alias for 'sendCommandToSession(method, undefined, ...params)'
+   * Alias for 'sendCommandToSession(method, undefined, params)'
    * @template {keyof LH.CrdpCommands} C
    * @param {C} method
    * @param {LH.CrdpCommands[C]['paramsType']} params
    * @return {Promise<LH.CrdpCommands[C]['returnType']>}
    */
-  sendCommand(method, ...params) {
-    return this.sendCommandToSession(method, undefined, ...params);
+  sendCommand(method, params) {
+    return this.sendCommandToSession(method, undefined, params);
   }
 
   /**
@@ -371,7 +371,7 @@ class Driver {
    * @param {LH.CrdpCommands[C]['paramsType']} params
    * @return {Promise<LH.CrdpCommands[C]['returnType']>}
    */
-  _innerSendCommand(method, sessionId, ...params) {
+  _innerSendCommand(method, sessionId, params) {
     const domainCommand = /^(\w+)\.(enable|disable)$/.exec(method);
     if (domainCommand) {
       const enable = domainCommand[2] === 'enable';
@@ -379,7 +379,7 @@ class Driver {
         return Promise.resolve();
       }
     }
-    return this._connection.sendCommand(method, sessionId, ...params);
+    return this._connection.sendCommand(method, sessionId, params);
   }
 
   /**


### PR DESCRIPTION
**Summary**

This PR is an improvement for the function `sendCommand()`,  it uses only the first element of the old `paramArgs`, then we could directly use a specific parameter instead of that.

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
No
