### PR TITLE
report: add options disableFireworks and disableDarkMode

### DIFF
--- a/flow-report/src/wrappers/report.tsx
+++ b/flow-report/src/wrappers/report.tsx
@@ -34,6 +34,7 @@ export const Report: FunctionComponent<{hashState: LH.FlowResult.HashState}> =
   const ref = useExternalRenderer<HTMLDivElement>(() => {
     return renderReport(hashState.currentLhr, {
       disableFireworks: true,
+      disableDarkMode: true,
       omitTopbar: true,
       omitGlobalStyles: true,
       onPageAnchorRendered: link => convertAnchor(link, hashState.index),

--- a/flow-report/src/wrappers/report.tsx
+++ b/flow-report/src/wrappers/report.tsx
@@ -33,7 +33,7 @@ export const Report: FunctionComponent<{hashState: LH.FlowResult.HashState}> =
 ({hashState}) => {
   const ref = useExternalRenderer<HTMLDivElement>(() => {
     return renderReport(hashState.currentLhr, {
-      disableAutoDarkModeAndFireworks: true,
+      disableFireworks: true,
       omitTopbar: true,
       omitGlobalStyles: true,
       onPageAnchorRendered: link => convertAnchor(link, hashState.index),

--- a/report/clients/standalone.js
+++ b/report/clients/standalone.js
@@ -14,9 +14,7 @@
 /* global ga */
 
 import {renderReport} from '../renderer/api.js';
-import {toggleDarkTheme} from '../renderer/features-util.js';
 import {Logger} from '../renderer/logger.js';
-import {DOM} from './bundle.js';
 
 function __initLighthouseReport__() {
   /** @type {LH.Result} */
@@ -28,12 +26,6 @@ function __initLighthouseReport__() {
       return document.documentElement.outerHTML;
     },
   });
-
-  // Fireworks look better in dark mode.
-  if (reportRootEl.querySelector('.lh-score100')) {
-    toggleDarkTheme(new DOM(document, reportRootEl), true);
-  }
-
   document.body.append(reportRootEl);
 
   document.addEventListener('lh-analytics', /** @param {Event} e */ e => {

--- a/report/clients/standalone.js
+++ b/report/clients/standalone.js
@@ -14,7 +14,9 @@
 /* global ga */
 
 import {renderReport} from '../renderer/api.js';
+import {toggleDarkTheme} from '../renderer/features-util.js';
 import {Logger} from '../renderer/logger.js';
+import {DOM} from './bundle.js';
 
 function __initLighthouseReport__() {
   /** @type {LH.Result} */
@@ -26,6 +28,12 @@ function __initLighthouseReport__() {
       return document.documentElement.outerHTML;
     },
   });
+
+  // Fireworks look better in dark mode.
+  if (reportRootEl.querySelector('.lh-score100')) {
+    toggleDarkTheme(new DOM(document, reportRootEl), true);
+  }
+
   document.body.append(reportRootEl);
 
   document.addEventListener('lh-analytics', /** @param {Event} e */ e => {

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -73,8 +73,8 @@ export class ReportUIFeatures {
     // Do not query the system preferences for DevTools - DevTools should only apply dark theme
     // if dark is selected in the settings panel.
     // TODO: set `disableDarkMode` in devtools and delete this special case.
-    const disableDarkMode = this._dom.isDevTools() || this._opts.disableDarkMode ||
-      this._opts.disableAutoDarkModeAndFireworks;
+    const disableDarkMode = this._dom.isDevTools() ||
+      this._opts.disableDarkMode || this._opts.disableAutoDarkModeAndFireworks;
     if (!disableDarkMode && window.matchMedia('(prefers-color-scheme: dark)').matches) {
       toggleDarkTheme(this._dom, true);
     }
@@ -86,9 +86,12 @@ export class ReportUIFeatures {
       const cat = lhr.categories[id];
       return cat && cat.score === 1;
     });
-    if (scoresAll100 &&
-      !(this._opts.disableFireworks || this._opts.disableAutoDarkModeAndFireworks)) {
+    const disableFireworks =
+      this._opts.disableFireworks || this._opts.disableAutoDarkModeAndFireworks;
+    if (scoresAll100 && !disableFireworks) {
       this._enableFireworks();
+      // If dark mode is allowed, force it on because it looks so much better.
+      if (!disableDarkMode) toggleDarkTheme(this._dom, true);
     }
 
     // Show the metric descriptions by default when there is an error.

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -70,12 +70,12 @@ export class ReportUIFeatures {
     this._setupThirdPartyFilter();
     this._setupElementScreenshotOverlay(this._dom.rootEl);
 
-    let turnOffTheLights = false;
     // Do not query the system preferences for DevTools - DevTools should only apply dark theme
     // if dark is selected in the settings panel.
-    const disableDarkMode = this._dom.isDevTools() || this._opts.disableAutoDarkModeAndFireworks;
+    // TODO: set `disableDarkMode` in devtools and delete this special case.
+    const disableDarkMode = this._dom.isDevTools() || this._opts.disableDarkMode;
     if (!disableDarkMode && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      turnOffTheLights = true;
+      toggleDarkTheme(this._dom, true);
     }
 
     // Fireworks!
@@ -85,13 +85,8 @@ export class ReportUIFeatures {
       const cat = lhr.categories[id];
       return cat && cat.score === 1;
     });
-    if (scoresAll100 && !this._opts.disableAutoDarkModeAndFireworks) {
-      turnOffTheLights = true;
+    if (scoresAll100 && !this._opts.disableFireworks) {
       this._enableFireworks();
-    }
-
-    if (turnOffTheLights) {
-      toggleDarkTheme(this._dom, true);
     }
 
     // Show the metric descriptions by default when there is an error.

--- a/report/renderer/report-ui-features.js
+++ b/report/renderer/report-ui-features.js
@@ -73,7 +73,8 @@ export class ReportUIFeatures {
     // Do not query the system preferences for DevTools - DevTools should only apply dark theme
     // if dark is selected in the settings panel.
     // TODO: set `disableDarkMode` in devtools and delete this special case.
-    const disableDarkMode = this._dom.isDevTools() || this._opts.disableDarkMode;
+    const disableDarkMode = this._dom.isDevTools() || this._opts.disableDarkMode ||
+      this._opts.disableAutoDarkModeAndFireworks;
     if (!disableDarkMode && window.matchMedia('(prefers-color-scheme: dark)').matches) {
       toggleDarkTheme(this._dom, true);
     }
@@ -85,7 +86,8 @@ export class ReportUIFeatures {
       const cat = lhr.categories[id];
       return cat && cat.score === 1;
     });
-    if (scoresAll100 && !this._opts.disableFireworks) {
+    if (scoresAll100 &&
+      !(this._opts.disableFireworks || this._opts.disableAutoDarkModeAndFireworks)) {
       this._enableFireworks();
     }
 

--- a/report/test-assets/faux-psi.js
+++ b/report/test-assets/faux-psi.js
@@ -46,7 +46,8 @@ async function renderLHReport() {
 
       const reportRootEl = lighthouseRenderer.renderReport(lhr, {
         omitTopbar: true,
-        disableAutoDarkModeAndFireworks: true,
+        disableFireworks: true,
+        disableDarkMode: true,
       });
       // TODO: display warnings if appropriate.
       for (const el of reportRootEl.querySelectorAll('.lh-warnings--toplevel')) {

--- a/report/types/report-renderer.d.ts
+++ b/report/types/report-renderer.d.ts
@@ -17,6 +17,11 @@ declare module Renderer {
     disableDarkMode?: boolean;
     /** Disables the fireworks animation that plays when all core categories have a 100 score. */
     disableFireworks?: boolean;
+    /**
+     * Disable dark mode and fireworks.
+     * @deprecated Use `disableDarkMode` and `disableFireworks` instead.
+     */
+    disableAutoDarkModeAndFireworks?: boolean;
 
     /** Disable the topbar UI component */
     omitTopbar?: boolean;

--- a/report/types/report-renderer.d.ts
+++ b/report/types/report-renderer.d.ts
@@ -11,9 +11,12 @@ declare module Renderer {
 
   interface Options {
     /**
-     * Don't automatically apply dark-mode to dark based on (prefers-color-scheme: dark). (DevTools and PSI don't want this.)
-     * Also, the fireworks easter-egg will want to flip to dark, so this setting will also disable chance of fireworks. */
-    disableAutoDarkModeAndFireworks?: boolean;
+     * Disables automatically applying dark mode based on `prefers-color-scheme: dark`. Dark mode can still
+     * be manually applied by assigning the class `lh-dark` to the report element.
+     */
+    disableDarkMode?: boolean;
+    /** Disables the fireworks animation that plays when all core categories have a 100 score. */
+    disableFireworks?: boolean;
 
     /** Disable the topbar UI component */
     omitTopbar?: boolean;


### PR DESCRIPTION
Deciding to use the dark theme should be left to the embedder, in case it wouldn't mesh with the site theme. We tried to do this with `disableAutoDarkModeAndFireworks` but:

* the name is ambiguous (does it disable dark mode AND fireworks, or just the auto "use dark mode" on fireworks?)
* apparently we wanted the former, but we missed part of it (#13610)
* Forces embedder to drop dark mode support if they simply don't want / can't support the fireworks

This PR:

* deprecates `disableAutoDarkModeAndFireworks`
* adds `disableDarkMode` option (embedders such as DevTools can set this and defer to the DevTools theme system to toggle the dark theme; or they can set it because the site should never be displayed in a dark theme and having just LH be dark would be jarring)
* adds `disableFireworks` option
* automatically switches to dark mode because it makes fireworks looks cool only if neither of the new options are disabled