### PR TITLE
tests: use simpler assertion in report-renderer-axe-test.js

### DIFF
--- a/report/test/renderer/__snapshots__/report-renderer-axe-test.js.snap
+++ b/report/test/renderer/__snapshots__/report-renderer-axe-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ReportRendererAxe with aXe renders without axe violations 1`] = `
+exports[`ReportRendererAxe with aXe renders without axe violations 2`] = `
 Array [
   Object {
     "description": "Ensures every id attribute value is unique",

--- a/report/test/renderer/__snapshots__/report-renderer-axe-test.js.snap
+++ b/report/test/renderer/__snapshots__/report-renderer-axe-test.js.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportRendererAxe with aXe renders without axe violations 1`] = `
+Array [
+  Object {
+    "description": "Ensures every id attribute value is unique",
+    "help": "id attribute value must be unique",
+    "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/duplicate-id?application=axeAPI",
+    "id": "duplicate-id",
+    "impact": "minor",
+    "nodes": Array [
+      Object {
+        "all": Array [],
+        "any": Array [
+          Object {
+            "data": "viewport",
+            "id": "duplicate-id",
+            "impact": "minor",
+            "message": "Document has multiple static elements with the same id attribute: viewport",
+            "relatedNodes": Array [
+              Object {
+                "html": "<div class=\\"lh-audit lh-audit--binary lh-audit--pass\\" id=\\"viewport\\">",
+                "target": Array [
+                  "#seo > .lh-audit-group:nth-child(4) > .lh-clump--passed.lh-clump > .lh-audit--binary.lh-audit--pass.lh-audit:nth-child(2)",
+                ],
+              },
+              Object {
+                "html": "<div class=\\"lh-audit lh-audit--binary lh-audit--pass\\" id=\\"viewport\\">",
+                "target": Array [
+                  ".lh-audit-group--pwa-optimized > .lh-audit--binary.lh-audit--pass.lh-audit:nth-child(6)",
+                ],
+              },
+            ],
+          },
+        ],
+        "failureSummary": "Fix any of the following:
+  Document has multiple static elements with the same id attribute: viewport",
+        "html": "<div class=\\"lh-audit lh-audit--binary lh-audit--pass\\" id=\\"viewport\\">",
+        "impact": "minor",
+        "none": Array [],
+        "target": Array [
+          ".lh-audit--binary.lh-audit--pass.lh-audit:nth-child(20)",
+        ],
+      },
+      Object {
+        "all": Array [],
+        "any": Array [
+          Object {
+            "data": "image-alt",
+            "id": "duplicate-id",
+            "impact": "minor",
+            "message": "Document has multiple static elements with the same id attribute: image-alt",
+            "relatedNodes": Array [
+              Object {
+                "html": "<div class=\\"lh-audit lh-audit--binary lh-audit--fail\\" id=\\"image-alt\\">",
+                "target": Array [
+                  ".lh-audit-group--seo-content > .lh-audit--fail.lh-audit--binary.lh-audit:nth-child(3)",
+                ],
+              },
+            ],
+          },
+        ],
+        "failureSummary": "Fix any of the following:
+  Document has multiple static elements with the same id attribute: image-alt",
+        "html": "<div class=\\"lh-audit lh-audit--binary lh-audit--fail\\" id=\\"image-alt\\">",
+        "impact": "minor",
+        "none": Array [],
+        "target": Array [
+          ".lh-audit-group--a11y-names-labels > .lh-audit--fail.lh-audit--binary.lh-audit:nth-child(2)",
+        ],
+      },
+      Object {
+        "all": Array [],
+        "any": Array [
+          Object {
+            "data": "document-title",
+            "id": "duplicate-id",
+            "impact": "minor",
+            "message": "Document has multiple static elements with the same id attribute: document-title",
+            "relatedNodes": Array [
+              Object {
+                "html": "<div class=\\"lh-audit lh-audit--binary lh-audit--pass\\" id=\\"document-title\\">",
+                "target": Array [
+                  "#seo > .lh-audit-group:nth-child(4) > .lh-clump--passed.lh-clump > .lh-audit--binary.lh-audit--pass.lh-audit:nth-child(3)",
+                ],
+              },
+            ],
+          },
+        ],
+        "failureSummary": "Fix any of the following:
+  Document has multiple static elements with the same id attribute: document-title",
+        "html": "<div class=\\"lh-audit lh-audit--binary lh-audit--pass\\" id=\\"document-title\\">",
+        "impact": "minor",
+        "none": Array [],
+        "target": Array [
+          ".lh-audit--binary.lh-audit--pass.lh-audit:nth-child(13)",
+        ],
+      },
+    ],
+    "tags": Array [
+      "cat.parsing",
+      "wcag2a",
+      "wcag411",
+    ],
+  },
+]
+`;

--- a/report/test/renderer/report-renderer-axe-test.js
+++ b/report/test/renderer/report-renderer-axe-test.js
@@ -70,6 +70,26 @@ describe('ReportRendererAxe', () => {
         ],
       });
 
+      const axeSummary = axeResults.violations.map((v) => {
+        return {
+          id: v.id,
+          message: v.nodes.map((n) => n.failureSummary).join('\n'),
+        };
+      });
+      expect(axeSummary).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "id": "duplicate-id",
+    "message": "Fix any of the following:
+  Document has multiple static elements with the same id attribute: viewport
+Fix any of the following:
+  Document has multiple static elements with the same id attribute: image-alt
+Fix any of the following:
+  Document has multiple static elements with the same id attribute: document-title",
+  },
+]
+`);
+
       expect(axeResults.violations).toMatchSnapshot();
     },
     // This test takes 10s on fast hardware, but can take longer in CI.

--- a/report/test/renderer/report-renderer-axe-test.js
+++ b/report/test/renderer/report-renderer-axe-test.js
@@ -53,23 +53,24 @@ describe('ReportRendererAxe', () => {
       // eslint-disable-next-line no-undef
       const axeResults = await page.evaluate(config => axe.run(config), config);
 
-      expect(axeResults.violations).toMatchObject([
-        // Color contrast failure only pops up if this pptr is run headfully.
-        // There are currently 27 problematic nodes, primarily audit display text and explanations.
-        // TODO: fix these failures, regardless.
-        // {
-        //   id: 'color-contrast',
-        // },
-        {
-          id: 'duplicate-id',
-          nodes: [
-            // We use these audits in multiple categories. Makes sense.
-            {html: '<div class="lh-audit lh-audit--binary lh-audit--pass" id="viewport">'},
-            {html: '<div class="lh-audit lh-audit--binary lh-audit--fail" id="image-alt">'},
-            {html: '<div class="lh-audit lh-audit--binary lh-audit--pass" id="document-title">'},
-          ],
-        },
-      ]);
+      // Color contrast failure only pops up if this pptr is run headfully.
+      // There are currently 27 problematic nodes, primarily audit display text and explanations.
+      // TODO: fix these failures, regardless.
+      // {
+      //   id: 'color-contrast',
+      // },
+
+      expect(axeResults.violations.find(v => v.id === 'duplicate-id')).toMatchObject({
+        id: 'duplicate-id',
+        nodes: [
+          // We use these audits in multiple categories. Makes sense.
+          {html: '<div class="lh-audit lh-audit--binary lh-audit--pass" id="viewport">'},
+          {html: '<div class="lh-audit lh-audit--binary lh-audit--fail" id="image-alt">'},
+          {html: '<div class="lh-audit lh-audit--binary lh-audit--pass" id="document-title">'},
+        ],
+      });
+
+      expect(axeResults.violations).toMatchSnapshot();
     },
     // This test takes 10s on fast hardware, but can take longer in CI.
     // https://github.com/dequelabs/axe-core/tree/b573b1c1/doc/examples/jest_react#timeout-issues


### PR DESCRIPTION
When this result object changes, the delta is way too large to grok (depending on the results). This should help.