### PR TITLE
core(full-page-screenshot): wait for doubleraf, network quiet

### DIFF
--- a/lighthouse-core/gather/gatherers/full-page-screenshot.js
+++ b/lighthouse-core/gather/gatherers/full-page-screenshot.js
@@ -27,7 +27,6 @@ function kebabCaseToCamelCase(str) {
 
 /* c8 ignore start */
 
-// eslint-disable-next-line no-inner-declarations
 function getObservedDeviceMetrics() {
   // Convert the Web API's kebab case (landscape-primary) to camel case (landscapePrimary).
   const screenOrientationType = kebabCaseToCamelCase(window.screen.orientation.type);
@@ -40,6 +39,12 @@ function getObservedDeviceMetrics() {
     },
     deviceScaleFactor: window.devicePixelRatio,
   };
+}
+
+function waitForDoubleRaf() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  });
 }
 
 /* c8 ignore stop */
@@ -109,13 +114,10 @@ class FullPageScreenshot extends FRGatherer {
       waitForNetworkIdleResult.promise,
     ]);
     waitForNetworkIdleResult.cancel();
+    await networkMonitor.disable();
 
     // Now that new resources are (probably) fetched, wait long enough for a layout.
-    await context.driver.executionContext.evaluate(function waitForDoubleRaf() {
-      return new Promise((resolve) => {
-        requestAnimationFrame(() => requestAnimationFrame(resolve));
-      });
-    }, {args: []});
+    await context.driver.executionContext.evaluate(waitForDoubleRaf, {args: []});
 
     const result = await session.sendCommand('Page.captureScreenshot', {
       format: 'jpeg',

--- a/lighthouse-core/test/gather/gatherers/full-page-screenshot-test.js
+++ b/lighthouse-core/test/gather/gatherers/full-page-screenshot-test.js
@@ -25,6 +25,8 @@ let screenSize;
 let screenshotData;
 let mockContext = createMockContext();
 
+jest.setTimeout(10_000);
+
 beforeEach(() => {
   contentSize = {width: 100, height: 100};
   screenSize = {dpr: 1};
@@ -61,6 +63,8 @@ beforeEach(() => {
         },
         deviceScaleFactor: screenSize.dpr,
       };
+    } else if (fn.name === 'waitForDoubleRaf') {
+      return {};
     } else {
       throw new Error(`unexpected fn ${fn.name}`);
     }


### PR DESCRIPTION
We don't give the page time to load new resources / perform a layout between changing the viewport and grabbing a screenshot. Sometimes, it would just work, but usually stuff is shifted a lot or many images are not loaded yet.

before

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/4071474/153964549-d3871765-5256-443c-9cab-6d411fd2916c.png">

after

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/4071474/153964528-5c9d8972-f41e-40cf-93c3-70712da3e4aa.png">
