### PR TITLE
core(fr): use frame url in gather context

### DIFF
--- a/lighthouse-cli/test/fixtures/redirects-self.html
+++ b/lighthouse-cli/test/fixtures/redirects-self.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+  <h1>Redirect to myself</h1>
+  <script>
+    const done = new URLSearchParams(window.location.search).has('done');
+    if (!done) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('done', '');
+      window.location.replace(url);
+    } else {
+      const url = new URL(window.location.href);
+      url.searchParams.delete('done');
+      window.history.pushState({}, '', url);
+    }
+  </script>
+</body>
+</html>

--- a/lighthouse-cli/test/smokehouse/core-tests.js
+++ b/lighthouse-cli/test/smokehouse/core-tests.js
@@ -53,6 +53,7 @@ import redirectsHistoryPushState from './test-definitions/redirects-history-push
 import redirectsMultipleServer from './test-definitions/redirects-multiple-server.js';
 import redirectsSingleClient from './test-definitions/redirects-single-client.js';
 import redirectsSingleServer from './test-definitions/redirects-single-server.js';
+import redirectsSelf from './test-definitions/redirects-self.js';
 import screenshot from './test-definitions/screenshot.js';
 import seoFailing from './test-definitions/seo-failing.js';
 import seoPassing from './test-definitions/seo-passing.js';
@@ -111,6 +112,7 @@ const smokeTests = [
   redirectsMultipleServer,
   redirectsSingleClient,
   redirectsSingleServer,
+  redirectsSelf,
   screenshot,
   seoFailing,
   seoPassing,

--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects-self.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects-self.js
@@ -1,0 +1,30 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const expectations = {
+  artifacts: {
+    MainDocumentContent: /Redirect to myself/,
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/redirects-self.html',
+    finalUrl: 'http://localhost:10200/redirects-self.html?done=',
+    audits: {
+    },
+    runWarnings: [
+      'The page may not be loading as expected because your test URL (http://localhost:10200/redirects-self.html) was redirected to http://localhost:10200/redirects-self.html?done=. Try testing the second URL directly.',
+    ],
+  },
+};
+
+export default {
+  id: 'redirects-self',
+  expectations,
+};
+

--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -210,6 +210,7 @@ async function _computeNavigationResult(
 async function _navigation(navigationContext) {
   const artifactState = getEmptyArtifactState();
   const phaseState = {
+    url: await navigationContext.driver.url(),
     gatherMode: /** @type {const} */ ('navigation'),
     driver: navigationContext.driver,
     computedCache: navigationContext.computedCache,
@@ -223,6 +224,7 @@ async function _navigation(navigationContext) {
   await collectPhaseArtifacts({phase: 'startInstrumentation', ...phaseState});
   await collectPhaseArtifacts({phase: 'startSensitiveInstrumentation', ...phaseState});
   const navigateResult = await _navigate(navigationContext);
+  phaseState.url = navigateResult.finalUrl;
   await collectPhaseArtifacts({phase: 'stopSensitiveInstrumentation', ...phaseState});
   await collectPhaseArtifacts({phase: 'stopInstrumentation', ...phaseState});
   await _cleanupNavigation(navigationContext);

--- a/lighthouse-core/fraggle-rock/gather/runner-helpers.js
+++ b/lighthouse-core/fraggle-rock/gather/runner-helpers.js
@@ -15,6 +15,7 @@
  * @property {LH.Gatherer.GatherMode} gatherMode
  * @property {Map<string, LH.ArbitraryEqualityMap>} computedCache
  * @property {LH.Config.Settings} settings
+ * @property {string} url
  */
 
 /** @typedef {Record<string, Promise<any>>} IntermediateArtifacts */
@@ -74,6 +75,7 @@ async function collectPhaseArtifacts(options) {
     gatherMode,
     computedCache,
     settings,
+    url,
   } = options;
   const priorPhase = phaseToPriorPhase[phase];
   const priorPhaseArtifacts = (priorPhase && artifactState[priorPhase]) || {};
@@ -90,7 +92,7 @@ async function collectPhaseArtifacts(options) {
         : /** @type {Dependencies} */ ({});
 
       return gatherer[phase]({
-        url: await driver.url(),
+        url,
         gatherMode,
         driver,
         baseArtifacts,

--- a/lighthouse-core/fraggle-rock/gather/snapshot-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/snapshot-runner.js
@@ -27,7 +27,7 @@ async function snapshot(options) {
 
   /** @type {Map<string, LH.ArbitraryEqualityMap>} */
   const computedCache = new Map();
-  const url = await options.page.url();
+  const url = await driver.url();
 
   const runnerOptions = {config, computedCache};
   const artifacts = await Runner.gather(
@@ -39,6 +39,7 @@ async function snapshot(options) {
       const artifactDefinitions = config.artifacts || [];
       const artifactState = getEmptyArtifactState();
       await collectPhaseArtifacts({
+        url,
         phase: 'getArtifact',
         gatherMode: 'snapshot',
         driver,

--- a/lighthouse-core/fraggle-rock/gather/timespan-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/timespan-runner.js
@@ -32,11 +32,12 @@ async function startTimespan(options) {
   /** @type {Map<string, LH.ArbitraryEqualityMap>} */
   const computedCache = new Map();
   const artifactDefinitions = config.artifacts || [];
-  const requestedUrl = await options.page.url();
+  const requestedUrl = await driver.url();
   const baseArtifacts = await getBaseArtifacts(config, driver, {gatherMode: 'timespan'});
   const artifactState = getEmptyArtifactState();
   /** @type {Omit<import('./runner-helpers.js').CollectPhaseArtifactOptions, 'phase'>} */
   const phaseOptions = {
+    url: requestedUrl,
     driver,
     artifactDefinitions,
     artifactState,
@@ -52,7 +53,9 @@ async function startTimespan(options) {
 
   return {
     async endTimespan() {
-      const finalUrl = await options.page.url();
+      const finalUrl = await driver.url();
+      phaseOptions.url = finalUrl;
+
       const runnerOptions = {config, computedCache};
       const artifacts = await Runner.gather(
         async () => {

--- a/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
+++ b/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
@@ -129,7 +129,7 @@ function createMockDriver() {
     _page: page,
     _executionContext: context,
     _session: session,
-    url: () => page.url(),
+    url: jest.fn(() => page.url()),
     defaultSession: session,
     connect: jest.fn(),
     disconnect: jest.fn(),

--- a/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/runner-helpers-test.js
@@ -132,6 +132,7 @@ describe('collectPhaseArtifacts', () => {
       it(`should run the ${phase} phase of gatherers in ${gatherMode} mode`, async () => {
         const {artifactDefinitions, gatherers} = createGathererSet();
         await helpers.collectPhaseArtifacts({
+          url: 'https://example.com',
           driver,
           artifactDefinitions,
           artifactState,
@@ -156,6 +157,7 @@ describe('collectPhaseArtifacts', () => {
   it('should gather the artifacts', async () => {
     const {artifactDefinitions} = createGathererSet();
     await helpers.collectPhaseArtifacts({
+      url: 'https://example.com',
       driver,
       artifactDefinitions,
       artifactState,
@@ -188,6 +190,7 @@ describe('collectPhaseArtifacts', () => {
     ];
 
     await helpers.collectPhaseArtifacts({
+      url: 'https://example.com',
       driver,
       artifactDefinitions,
       artifactState,
@@ -221,6 +224,7 @@ describe('collectPhaseArtifacts', () => {
 
     const {artifactDefinitions, gatherers} = createGathererSet();
     await helpers.collectPhaseArtifacts({
+      url: 'https://example.com',
       driver,
       artifactDefinitions,
       artifactState,

--- a/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/snapshot-runner-test.js
@@ -71,7 +71,7 @@ describe('Snapshot Runner', () => {
   });
 
   it('should collect base artifacts', async () => {
-    mockPage.url.mockResolvedValue('https://lighthouse.example.com/');
+    mockDriver.url.mockResolvedValue('https://lighthouse.example.com/');
 
     await snapshot({page, config});
     const artifacts = await mockRunner.gather.mock.calls[0][0]();

--- a/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/timespan-runner-test.js
@@ -90,11 +90,11 @@ describe('Timespan Runner', () => {
   });
 
   it('should collect base artifacts', async () => {
-    mockPage.url.mockResolvedValue('https://start.example.com/');
+    mockDriver.url.mockResolvedValue('https://start.example.com/');
 
     const timespan = await startTimespan({page, config});
 
-    mockPage.url.mockResolvedValue('https://end.example.com/');
+    mockDriver.url.mockResolvedValue('https://end.example.com/');
 
     await timespan.endTimespan();
     const artifacts = await mockRunner.gather.mock.calls[0][0]();


### PR DESCRIPTION
In legacy navigations `context.url` is the current frame URL and is unaffected by the history API.

However in FR navigations, `context.url` is the result of `page.url()` from Puppeteer and *is* affected by the history API. This can lead to issues in FR navigations where we try and use `context.url` to get the main document, but `context.url` is not the URL used to fetch the main document.

This PR ensures `context.url` reflects the current frame URL without considering any history API calls once we reach the `getArtifact` phase.

-----

Once we deprecate the legacy navigation runner, I think we should deprecate `context.url`. Then we can use `context.baseArtifacts.URL` to get the frame URL and `context.driver.url()` to get the URL affected by history API.