### PR TITLE
core(script-treemap-data): correct value for size

### DIFF
--- a/lighthouse-core/audits/script-treemap-data.js
+++ b/lighthouse-core/audits/script-treemap-data.js
@@ -197,7 +197,7 @@ class ScriptTreemapDataAudit extends Audit {
 
         nodes.push({
           name,
-          resourceBytes: scriptElement.src.length,
+          resourceBytes: scriptElement.content?.length || 0,
         });
         continue;
       }

--- a/lighthouse-core/test/audits/__snapshots__/script-treemap-data-test.js.snap
+++ b/lighthouse-core/test/audits/__snapshots__/script-treemap-data-test.js.snap
@@ -5795,7 +5795,7 @@ Array [
   },
   Object {
     "name": "https://sqoosh.app/no-map-or-usage.js",
-    "resourceBytes": 37,
+    "resourceBytes": 5,
   },
 ]
 `;

--- a/lighthouse-core/test/audits/script-treemap-data-test.js
+++ b/lighthouse-core/test/audits/script-treemap-data-test.js
@@ -64,7 +64,7 @@ describe('ScriptTreemapData audit', () => {
         .toMatchInlineSnapshot(`
         Object {
           "name": "https://sqoosh.app/no-map-or-usage.js",
-          "resourceBytes": 37,
+          "resourceBytes": 5,
         }
       `);
 
@@ -79,7 +79,7 @@ describe('ScriptTreemapData audit', () => {
         }
       `);
 
-      expect(JSON.stringify(treemapData.nodes).length).toMatchInlineSnapshot(`6674`);
+      expect(JSON.stringify(treemapData.nodes).length).toMatchInlineSnapshot(`6673`);
       expect(treemapData.nodes).toMatchSnapshot();
     });
   });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3241,15 +3241,15 @@
           },
           {
             "name": "http://localhost:10200/dobetterweb/empty_module.js?delay=500",
-            "resourceBytes": 60
+            "resourceBytes": 0
           },
           {
             "name": "http://localhost:10200/dobetterweb/fake-script-wp-includes",
-            "resourceBytes": 58
+            "resourceBytes": 0
           },
           {
             "name": "http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000",
-            "resourceBytes": 60
+            "resourceBytes": 0
           },
           {
             "name": "http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js",


### PR DESCRIPTION
in practice I don't think this ever happens, not sure why coverage data would be missing for a script