### PR TITLE
core(lighthouse-logger): convert to ES modules

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -131,6 +131,9 @@ async function build(entryPath, distPath, opts = {minify: true}) {
           // This package exports to default in a way that causes Rollup to get confused,
           // resulting in MessageFormat being undefined.
           'require(\'intl-messageformat\').default': 'require(\'intl-messageformat\')',
+          // Below we replace lighthouse-logger with a local copy, which is ES modules. Need
+          // to change every require of the package to reflect this.
+          'require(\'lighthouse-logger\');': 'require(\'lighthouse-logger\').default;',
           // Rollup doesn't replace this, so let's manually change it to false.
           'require.main === module': 'false',
           // TODO: Use globalThis directly.

--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -5,11 +5,11 @@
  */
 'use strict';
 
-const process = require('process');
-const debug = require('debug');
-const marky = require('marky');
+import process from 'process';
+import debug from 'debug';
+import * as marky from 'marky';
+import {EventEmitter} from 'events';
 
-const EventEmitter = require('events').EventEmitter;
 const isWindows = process.platform === 'win32';
 
 // @ts-expect-error: process.browser is set via Rollup.
@@ -55,7 +55,7 @@ const loggersByTitle = {};
 const loggingBufferColumns = 25;
 let level_;
 
-class Log {
+export class Log {
   static _logToStdErr(title, argsArray) {
     const log = Log.loggerfn(title);
     log(...argsArray);
@@ -239,5 +239,3 @@ Log.takeTimeEntries = () => {
   return entries;
 };
 Log.getTimeEntries = () => marky.getEntries();
-
-module.exports = Log;

--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -55,7 +55,7 @@ const loggersByTitle = {};
 const loggingBufferColumns = 25;
 let level_;
 
-export class Log {
+export default class Log {
   static _logToStdErr(title, argsArray) {
     const log = Log.loggerfn(title);
     log(...argsArray);

--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "lighthouse-logger",
   "version": "1.3.0",
   "license": "Apache-2.0",


### PR DESCRIPTION
ref #12689

This is not a breaking change because only conversions to ESM inside `lighthouse-core` would be.

The only impact is that the `build-bundle` script will see this file as ESM during rollup (FYI: when bundling we use the local copy, but via Node we use the npm pacakge). I have no plans to publish a new version of the npm package, but if we did, that shouldn't be a breaking change for LH consumers either if LH used that new ESM version.