### PR TITLE
fix(unsized-images): ignore non-network SVGs

### DIFF
--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -236,7 +236,7 @@ class URLShim extends URL {
     }
 
     if (url.protocol === 'data:') {
-      const match = url.pathname.match(/image\/(png|jpeg|svg\+xml|webp|gif|avif)(?=;)/);
+      const match = url.pathname.match(/image\/(png|jpeg|svg\+xml|webp|gif|avif)(?=;|,)/);
       if (!match) return undefined;
       return match[0];
     }

--- a/lighthouse-core/test/audits/unsized-images-test.js
+++ b/lighthouse-core/test/audits/unsized-images-test.js
@@ -78,7 +78,7 @@ describe('Sized images audit', () => {
     expect(result.score).toEqual(1);
   });
 
-  it('passes when an image is a non-network SVG', async () => {
+  it('passes when an image is a non-network SVG base64', async () => {
     const result = await runAudit({
       attributeWidth: '',
       attributeHeight: '',
@@ -87,6 +87,19 @@ describe('Sized images audit', () => {
         height: null,
       },
       src: 'data:image/svg+xml;base64,foo',
+    });
+    expect(result.score).toEqual(1);
+  });
+
+  it('passes when an image is a non-network SVG encoded', async () => {
+    const result = await runAudit({
+      attributeWidth: '',
+      attributeHeight: '',
+      cssEffectiveRules: {
+        width: null,
+        height: null,
+      },
+      src: 'data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%27200%27%20height=%27200%27/%3e',
     });
     expect(result.score).toEqual(1);
   });


### PR DESCRIPTION
**Summary**
This fixes a bug when detecting non-network SVG images.

In PR #12120, there was a fix added for inline SVG but only base64.

Since then, Next.js changed [from base64 to text data url](https://github.com/vercel/next.js/pull/33218) so it was no longer detected properly by Lighthouse.


<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
- Fixes #12116 
- Follow up to PR #12120 
- Next.js change https://github.com/vercel/next.js/pull/33218
