### PR TITLE
WIP: increase usage of `MainResource` computed artifact

### DIFF
--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
@@ -79,6 +79,7 @@ async function internalRun(url, tmpPath, configJson, options) {
     `-G=${artifactsDirectory}`,
     `-A=${artifactsDirectory}`,
     '--port=0',
+    '--quiet',
   ];
 
   if (useFraggleRock) {

--- a/lighthouse-core/audits/byte-efficiency/duplicated-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/duplicated-javascript.js
@@ -11,7 +11,6 @@
 
 const ByteEfficiencyAudit = require('./byte-efficiency-audit.js');
 const ModuleDuplication = require('../../computed/module-duplication.js');
-const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-analyzer.js');
 const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
@@ -48,8 +47,7 @@ class DuplicatedJavascript extends ByteEfficiencyAudit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
-      requiredArtifacts: ['devtoolsLogs', 'traces', 'SourceMaps', 'Scripts',
-        'GatherContext', 'URL'],
+      requiredArtifacts: ['devtoolsLogs', 'traces', 'SourceMaps', 'Scripts', 'GatherContext'],
     };
   }
 
@@ -130,7 +128,6 @@ class DuplicatedJavascript extends ByteEfficiencyAudit {
       context.options?.ignoreThresholdInBytes || IGNORE_THRESHOLD_IN_BYTES;
     const duplication =
       await DuplicatedJavascript._getDuplicationGroupedByNodeModules(artifacts, context);
-    const mainDocumentRecord = NetworkAnalyzer.findOptionalMainDocument(networkRecords);
 
     /** @type {Map<string, number>} */
     const transferRatioByUrl = new Map();
@@ -164,9 +161,7 @@ class DuplicatedJavascript extends ByteEfficiencyAudit {
         /** @type {number|undefined} */
         let transferRatio = transferRatioByUrl.get(url);
         if (transferRatio === undefined) {
-          const networkRecord = url === artifacts.URL.finalUrl ?
-            mainDocumentRecord :
-            networkRecords.find(n => n.url === url);
+          const networkRecord = networkRecords.find(n => n.url === url);
 
           if (!script || script.length === undefined) {
             // This should never happen because we found the wasted bytes from bundles, which required contents in a ScriptElement.

--- a/lighthouse-core/audits/byte-efficiency/legacy-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/legacy-javascript.js
@@ -22,7 +22,6 @@ const ByteEfficiencyAudit = require('./byte-efficiency-audit.js');
 const JsBundles = require('../../computed/js-bundles.js');
 const i18n = require('../../lib/i18n/i18n.js');
 const thirdPartyWeb = require('../../lib/third-party-web.js');
-const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-analyzer.js');
 
 const UIStrings = {
   /** Title of a Lighthouse audit that tells the user about legacy polyfills and transforms used on the page. This is displayed in a list of audit titles that Lighthouse generates. */
@@ -372,16 +371,13 @@ class LegacyJavascript extends ByteEfficiencyAudit {
     let transferRatio = transferRatioByUrl.get(url);
     if (transferRatio !== undefined) return transferRatio;
 
-    const mainDocumentRecord = NetworkAnalyzer.findOptionalMainDocument(networkRecords);
     const script = artifacts.Scripts.find(script => script.url === url);
-    const networkRecord = url === artifacts.URL.finalUrl ?
-      mainDocumentRecord :
-      networkRecords.find(n => n.url === script?.url);
 
     if (!script || script.content === null) {
       // Can't find content, so just use 1.
       transferRatio = 1;
     } else {
+      const networkRecord = networkRecords.find(n => n.url === script.url);
       const contentLength = script.length || 0;
       const transferSize =
         ByteEfficiencyAudit.estimateTransferSize(networkRecord, contentLength, 'Script');

--- a/lighthouse-core/audits/csp-xss.js
+++ b/lighthouse-core/audits/csp-xss.js
@@ -47,7 +47,8 @@ class CspXss extends Audit {
       scoreDisplayMode: Audit.SCORING_MODES.INFORMATIVE,
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
-      requiredArtifacts: ['devtoolsLogs', 'MetaElements', 'URL'],
+      requiredArtifacts: ['devtoolsLogs', 'MetaElements'],
+      supportedModes: ['navigation'],
     };
   }
 
@@ -58,7 +59,7 @@ class CspXss extends Audit {
    */
   static async getRawCsps(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
-    const mainResource = await MainResource.request({devtoolsLog, URL: artifacts.URL}, context);
+    const mainResource = await MainResource.request({devtoolsLog}, context);
 
     const cspMetaTags = artifacts.MetaElements
       .filter(m => {

--- a/lighthouse-core/audits/diagnostics.js
+++ b/lighthouse-core/audits/diagnostics.js
@@ -9,7 +9,7 @@ const Audit = require('./audit.js');
 const MainThreadTasksComputed = require('../computed/main-thread-tasks.js');
 const NetworkRecordsComputed = require('../computed/network-records.js');
 const NetworkAnalysisComputed = require('../computed/network-analysis.js');
-const NetworkAnalyzer = require('../lib/dependency-graph/simulator/network-analyzer.js');
+const MainResource = require('../computed/main-resource.js');
 
 class Diagnostics extends Audit {
   /**
@@ -37,9 +37,10 @@ class Diagnostics extends Audit {
     const tasks = await MainThreadTasksComputed.request(trace, context);
     const records = await NetworkRecordsComputed.request(devtoolsLog, context);
     const analysis = await NetworkAnalysisComputed.request(devtoolsLog, context);
+    const mainResource = await MainResource.request({devtoolsLog}, context);
 
     const toplevelTasks = tasks.filter(t => !t.parent);
-    const mainDocumentTransferSize = NetworkAnalyzer.findMainDocument(records).transferSize;
+    const mainDocumentTransferSize = mainResource.transferSize;
     const totalByteWeight = records.reduce((sum, r) => sum + (r.transferSize || 0), 0);
     const totalTaskTime = toplevelTasks.reduce((sum, t) => sum + (t.duration || 0), 0);
     const maxRtt = Math.max(...analysis.additionalRttByOrigin.values()) + analysis.rtt;

--- a/lighthouse-core/audits/dobetterweb/charset.js
+++ b/lighthouse-core/audits/dobetterweb/charset.js
@@ -45,7 +45,7 @@ class CharsetDefined extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      requiredArtifacts: ['MainDocumentContent', 'URL', 'devtoolsLogs', 'MetaElements'],
+      requiredArtifacts: ['MainDocumentContent', 'devtoolsLogs', 'MetaElements'],
     };
   }
 
@@ -56,7 +56,7 @@ class CharsetDefined extends Audit {
    */
   static async audit(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
-    const mainResource = await MainResource.request({devtoolsLog, URL: artifacts.URL}, context);
+    const mainResource = await MainResource.request({devtoolsLog}, context);
     let isCharsetSet = false;
     // Check the http header 'content-type' to see if charset is defined there
     if (mainResource.responseHeaders) {

--- a/lighthouse-core/audits/performance-budget.js
+++ b/lighthouse-core/audits/performance-budget.js
@@ -123,7 +123,7 @@ class ResourceBudget extends Audit {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const data = {devtoolsLog, URL: artifacts.URL, budgets: context.settings.budgets};
     const summary = await ResourceSummary.request(data, context);
-    const mainResource = await MainResource.request({URL: artifacts.URL, devtoolsLog}, context);
+    const mainResource = await MainResource.request({devtoolsLog}, context);
     const budget = Budget.getMatchingBudget(context.settings.budgets, mainResource.url);
 
     if (!budget) {

--- a/lighthouse-core/audits/preload-lcp-image.js
+++ b/lighthouse-core/audits/preload-lcp-image.js
@@ -33,7 +33,7 @@ class PreloadLCPImageAudit extends Audit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       supportedModes: ['navigation'],
-      requiredArtifacts: ['traces', 'devtoolsLogs', 'GatherContext', 'URL', 'TraceElements',
+      requiredArtifacts: ['traces', 'devtoolsLogs', 'GatherContext', 'TraceElements',
         'ImageElements'],
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
     };
@@ -202,13 +202,12 @@ class PreloadLCPImageAudit extends Audit {
     const gatherContext = artifacts.GatherContext;
     const trace = artifacts.traces[PreloadLCPImageAudit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[PreloadLCPImageAudit.DEFAULT_PASS];
-    const URL = artifacts.URL;
     const metricData = {trace, devtoolsLog, gatherContext, settings: context.settings};
     const lcpElement = artifacts.TraceElements
       .find(element => element.traceEventType === 'largest-contentful-paint');
 
     const [mainResource, lanternLCP, simulator] = await Promise.all([
-      MainResource.request({devtoolsLog, URL}, context),
+      MainResource.request({devtoolsLog}, context),
       LanternLCP.request(metricData, context),
       LoadSimulator.request({devtoolsLog, settings: context.settings}, context),
     ]);

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -92,7 +92,6 @@ class Redirects extends Audit {
     const processedTrace = await ProcessedTrace.request(trace, context);
     const networkRecords = await NetworkRecords.request(devtoolsLog, context);
     const mainResource = await MainResource.request({devtoolsLog}, context);
-    console.log(mainResource.url);
 
     const metricComputationData = {trace, devtoolsLog, gatherContext, settings};
     const metricResult = await LanternInteractive.request(metricComputationData, context);

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -92,6 +92,7 @@ class Redirects extends Audit {
     const processedTrace = await ProcessedTrace.request(trace, context);
     const networkRecords = await NetworkRecords.request(devtoolsLog, context);
     const mainResource = await MainResource.request({devtoolsLog}, context);
+    console.log(mainResource.url);
 
     const metricComputationData = {trace, devtoolsLog, gatherContext, settings};
     const metricResult = await LanternInteractive.request(metricComputationData, context);

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -33,7 +33,7 @@ class Redirects extends Audit {
       description: str_(UIStrings.description),
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       supportedModes: ['navigation'],
-      requiredArtifacts: ['URL', 'GatherContext', 'devtoolsLogs', 'traces'],
+      requiredArtifacts: ['GatherContext', 'devtoolsLogs', 'traces'],
     };
   }
 
@@ -91,7 +91,7 @@ class Redirects extends Audit {
 
     const processedTrace = await ProcessedTrace.request(trace, context);
     const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-    const mainResource = await MainResource.request({URL: artifacts.URL, devtoolsLog}, context);
+    const mainResource = await MainResource.request({devtoolsLog}, context);
 
     const metricComputationData = {trace, devtoolsLog, gatherContext, settings};
     const metricResult = await LanternInteractive.request(metricComputationData, context);

--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -64,7 +64,7 @@ class Canonical extends Audit {
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
       supportedModes: ['navigation'],
-      requiredArtifacts: ['LinkElements', 'URL', 'devtoolsLogs'],
+      requiredArtifacts: ['LinkElements', 'devtoolsLogs'],
     };
   }
 
@@ -190,7 +190,7 @@ class Canonical extends Audit {
   static async audit(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
 
-    const mainResource = await MainResource.request({devtoolsLog, URL: artifacts.URL}, context);
+    const mainResource = await MainResource.request({devtoolsLog}, context);
     const baseURL = new URL(mainResource.url);
     const canonicalURLData = Canonical.collectCanonicalURLs(artifacts.LinkElements);
 

--- a/lighthouse-core/audits/seo/http-status-code.js
+++ b/lighthouse-core/audits/seo/http-status-code.js
@@ -6,11 +6,10 @@
 'use strict';
 
 const Audit = require('../audit.js');
-const NetworkRecords = require('../../computed/network-records.js');
 const HTTP_UNSUCCESSFUL_CODE_LOW = 400;
 const HTTP_UNSUCCESSFUL_CODE_HIGH = 599;
 const i18n = require('../../lib/i18n/i18n.js');
-const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-analyzer.js');
+const MainResource = require('../../computed/main-resource.js');
 
 const UIStrings = {
   /** Title of a Lighthouse audit that provides detail on the HTTP status code a page responds with. This descriptive title is shown when the page has responded with a valid HTTP status code. */
@@ -34,7 +33,7 @@ class HTTPStatusCode extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      requiredArtifacts: ['devtoolsLogs', 'URL', 'GatherContext'],
+      requiredArtifacts: ['devtoolsLogs'],
       supportedModes: ['navigation'],
     };
   }
@@ -46,9 +45,7 @@ class HTTPStatusCode extends Audit {
    */
   static async audit(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
-    const URL = artifacts.URL;
-    const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-    const mainResource = NetworkAnalyzer.findMainDocument(networkRecords, URL.finalUrl);
+    const mainResource = await MainResource.request({devtoolsLog}, context);
 
     const statusCode = mainResource.statusCode;
 

--- a/lighthouse-core/audits/seo/is-crawlable.js
+++ b/lighthouse-core/audits/seo/is-crawlable.js
@@ -82,7 +82,7 @@ class IsCrawlable extends Audit {
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
       supportedModes: ['navigation'],
-      requiredArtifacts: ['MetaElements', 'RobotsTxt', 'URL', 'devtoolsLogs'],
+      requiredArtifacts: ['MetaElements', 'RobotsTxt', 'devtoolsLogs'],
     };
   }
 
@@ -95,7 +95,7 @@ class IsCrawlable extends Audit {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const metaRobots = artifacts.MetaElements.find(meta => meta.name === 'robots');
 
-    return MainResource.request({devtoolsLog, URL: artifacts.URL}, context)
+    return MainResource.request({devtoolsLog}, context)
       .then(mainResource => {
         /** @type {LH.Audit.Details.Table['items']} */
         const blockingDirectives = [];

--- a/lighthouse-core/audits/server-response-time.js
+++ b/lighthouse-core/audits/server-response-time.js
@@ -8,8 +8,6 @@
 const Audit = require('./audit.js');
 const i18n = require('../lib/i18n/i18n.js');
 const MainResource = require('../computed/main-resource.js');
-const NetworkRecords = require('../computed/network-records.js');
-const NetworkAnalyzer = require('../lib/dependency-graph/simulator/network-analyzer.js');
 
 const UIStrings = {
   /** Title of a diagnostic audit that provides detail on how long it took from starting a request to when the server started responding. This descriptive title is shown to users when the amount is acceptable and no user action is required. */
@@ -39,8 +37,8 @@ class ServerResponseTime extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      supportedModes: ['timespan', 'navigation'],
-      requiredArtifacts: ['devtoolsLogs', 'URL', 'GatherContext'],
+      supportedModes: ['navigation'],
+      requiredArtifacts: ['devtoolsLogs'],
     };
   }
 
@@ -60,21 +58,7 @@ class ServerResponseTime extends Audit {
   static async audit(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
 
-    /** @type {LH.Artifacts.NetworkRequest} */
-    let mainResource;
-    if (artifacts.GatherContext.gatherMode === 'timespan') {
-      const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-      const optionalMainResource = NetworkAnalyzer.findOptionalMainDocument(
-        networkRecords,
-        artifacts.URL.finalUrl
-      );
-      if (!optionalMainResource) {
-        return {score: null, notApplicable: true};
-      }
-      mainResource = optionalMainResource;
-    } else {
-      mainResource = await MainResource.request({devtoolsLog, URL: artifacts.URL}, context);
-    }
+    const mainResource = await MainResource.request({devtoolsLog}, context);
 
     const responseTime = ServerResponseTime.calculateResponseTime(mainResource);
     const passed = responseTime < TOO_SLOW_THRESHOLD_MS;

--- a/lighthouse-core/audits/third-party-facades.js
+++ b/lighthouse-core/audits/third-party-facades.js
@@ -86,7 +86,7 @@ class ThirdPartyFacades extends Audit {
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
       supportedModes: ['navigation'],
-      requiredArtifacts: ['traces', 'devtoolsLogs', 'URL'],
+      requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
   }
 
@@ -151,7 +151,7 @@ class ThirdPartyFacades extends Audit {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-    const mainResource = await MainResource.request({devtoolsLog, URL: artifacts.URL}, context);
+    const mainResource = await MainResource.request({devtoolsLog}, context);
     const mainEntity = thirdPartyWeb.getEntity(mainResource.url);
     const tasks = await MainThreadTasks.request(trace, context);
     const multiplier = settings.throttlingMethod === 'simulate' ?

--- a/lighthouse-core/audits/timing-budget.js
+++ b/lighthouse-core/audits/timing-budget.js
@@ -37,7 +37,7 @@ class TimingBudget extends Audit {
       description: str_(UIStrings.description),
       scoreDisplayMode: Audit.SCORING_MODES.INFORMATIVE,
       supportedModes: ['navigation'],
-      requiredArtifacts: ['devtoolsLogs', 'traces', 'URL', 'GatherContext'],
+      requiredArtifacts: ['devtoolsLogs', 'traces', 'GatherContext'],
     };
   }
 
@@ -140,7 +140,7 @@ class TimingBudget extends Audit {
     const gatherContext = artifacts.GatherContext;
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
-    const mainResource = await MainResource.request({URL: artifacts.URL, devtoolsLog}, context);
+    const mainResource = await MainResource.request({devtoolsLog}, context);
     const data = {trace, devtoolsLog, gatherContext, settings: context.settings};
     const summary = (await TimingSummary.request(data, context)).metrics;
     const budget = Budget.getMatchingBudget(context.settings.budgets, mainResource.url);

--- a/lighthouse-core/audits/uses-rel-preconnect.js
+++ b/lighthouse-core/audits/uses-rel-preconnect.js
@@ -64,7 +64,7 @@ class UsesRelPreconnectAudit extends Audit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       supportedModes: ['navigation'],
-      requiredArtifacts: ['traces', 'devtoolsLogs', 'URL', 'LinkElements'],
+      requiredArtifacts: ['traces', 'devtoolsLogs', 'LinkElements'],
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
     };
   }
@@ -120,7 +120,7 @@ class UsesRelPreconnectAudit extends Audit {
     const [networkRecords, mainResource, loadSimulator, processedNavigation, pageGraph] =
       await Promise.all([
         NetworkRecords.request(devtoolsLog, context),
-        MainResource.request({devtoolsLog, URL: artifacts.URL}, context),
+        MainResource.request({devtoolsLog}, context),
         LoadSimulator.request({devtoolsLog, settings}, context),
         ProcessedNavigation.request(processedTrace, context),
         PageDependencyGraph.request({trace, devtoolsLog}, context),

--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -43,7 +43,7 @@ class UsesRelPreloadAudit extends Audit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       supportedModes: ['navigation'],
-      requiredArtifacts: ['devtoolsLogs', 'traces', 'URL'],
+      requiredArtifacts: ['devtoolsLogs', 'traces'],
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
     };
   }
@@ -212,11 +212,10 @@ class UsesRelPreloadAudit extends Audit {
   static async audit_(artifacts, context) {
     const trace = artifacts.traces[UsesRelPreloadAudit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[UsesRelPreloadAudit.DEFAULT_PASS];
-    const URL = artifacts.URL;
     const simulatorOptions = {devtoolsLog, settings: context.settings};
 
     const [mainResource, graph, simulator] = await Promise.all([
-      MainResource.request({devtoolsLog, URL}, context),
+      MainResource.request({devtoolsLog}, context),
       PageDependencyGraph.request({trace, devtoolsLog}, context),
       LoadSimulator.request(simulatorOptions, context),
     ]);

--- a/lighthouse-core/computed/critical-request-chains.js
+++ b/lighthouse-core/computed/critical-request-chains.js
@@ -129,10 +129,7 @@ class CriticalRequestChains {
    * @return {Promise<LH.Artifacts.CriticalRequestNode>}
    */
   static async compute_(data, context) {
-    const mainResource = await MainResource.request({
-      URL: data.URL,
-      devtoolsLog: data.devtoolsLog,
-    }, context);
+    const mainResource = await MainResource.request({devtoolsLog: data.devtoolsLog}, context);
 
     const graph = await PageDependencyGraph.request({
       trace: data.trace,

--- a/lighthouse-core/computed/main-resource.js
+++ b/lighthouse-core/computed/main-resource.js
@@ -27,6 +27,7 @@ class MainResource {
       if (event.method !== 'Page.frameNavigated' || event.params.frame.parentId) continue;
       // Intentionally exclude the URL fragment when looking for the network request.
       mainDocumentUrl = event.params.frame.url;
+      break;
     }
 
     if (!mainDocumentUrl) {

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const INITIAL_CWD = 14 * 1024;
-const NetworkRequest = require('../../network-request.js');
 const URL = require('../../url-shim.js');
 
 // Assume that 40% of TTFB was server response time by default for static assets
@@ -434,35 +433,16 @@ class NetworkAnalyzer {
 
   /**
    * @param {Array<LH.Artifacts.NetworkRequest>} records
-   * @param {string} [finalURL]
+   * @param {string} mainDocumentUrl
    * @return {LH.Artifacts.NetworkRequest}
    */
-  static findMainDocument(records, finalURL) {
-    const mainDocument = NetworkAnalyzer.findOptionalMainDocument(records, finalURL);
-    if (!mainDocument) throw new Error('Unable to identify the main resource');
-    return mainDocument;
-  }
-
-  /**
-   * @param {Array<LH.Artifacts.NetworkRequest>} records
-   * @param {string} [finalURL]
-   * @return {LH.Artifacts.NetworkRequest|undefined}
-   */
-  static findOptionalMainDocument(records, finalURL) {
-    // Try to find an exact match with the final URL first if we have one
-    if (finalURL) {
-      // equalWithExcludedFragments is expensive, so check that the finalUrl starts with the request first
-      const mainResource = records.find(request => finalURL.startsWith(request.url) &&
-        URL.equalWithExcludedFragments(request.url, finalURL));
-      if (mainResource) return mainResource;
-      // TODO: beacon !mainResource to Sentry, https://github.com/GoogleChrome/lighthouse/issues/7041
-    }
-
-    const documentRequests = records.filter(record => record.resourceType ===
-        NetworkRequest.TYPES.Document);
-    if (!documentRequests.length) return undefined;
-    // The main document is the earliest document request, using position in networkRecords array to break ties.
-    return documentRequests.reduce((min, r) => (r.startTime < min.startTime ? r : min));
+  static findMainDocument(records, mainDocumentUrl) {
+    // equalWithExcludedFragments is expensive, so check that the finalUrl starts with the request first
+    // TODO: beacon !mainResource to Sentry, https://github.com/GoogleChrome/lighthouse/issues/7041
+    const mainResource = records.find(request => mainDocumentUrl.startsWith(request.url) &&
+      URL.equalWithExcludedFragments(request.url, mainDocumentUrl));
+    if (!mainResource) throw new Error('Unable to identify the main resource');
+    return mainResource;
   }
 
   /**


### PR DESCRIPTION
The primary goal of this PR is to decrease our usage of `URL` in audits and computed artifacts to make the transition in https://github.com/GoogleChrome/lighthouse/issues/13706 easier. Much of the time, we are using `URL.finalUrl` to get the main document record either with `NetworkAnalyser.findMainDocument`, `NetworkAnalyser.findOptionalMainDocument`, or the `MainResource` computed artifact.

Opening this PR as a WIP to test some assumptions:
- I think we can actually get the main document URL by just looking at `Page.frameNavigated` events in the devtools log, so `MainResource` doesn't actually need `URL` as a dependency.
- Almost every usage of `NetworkAnalyser.findMainDocument` can be replaced with a request to `MainResource`
- Every call to `NetworkAnalyser.findOptionalMainDocument` either isn't needed or doesn't make sense, this PR removes that function completely.
