### PR TITLE
core: append sourceURL comment to eval code

### DIFF
--- a/lighthouse-core/gather/driver/execution-context.js
+++ b/lighthouse-core/gather/driver/execution-context.js
@@ -97,7 +97,8 @@ class ExecutionContext {
             .catch(${pageFunctions.wrapRuntimeEvalErrorInBrowserString})
             .then(resolve);
         });
-      }())`,
+      }())
+      //# sourceURL=lighthouse-eval.js`,
       includeCommandLineAPI: true,
       awaitPromise: true,
       returnByValue: true,

--- a/lighthouse-core/gather/gatherers/js-usage.js
+++ b/lighthouse-core/gather/gatherers/js-usage.js
@@ -81,11 +81,9 @@ class JsUsage extends FRGatherer {
 
     for (const scriptUsage of this._scriptUsages) {
       // If `url` is blank, that means the script was anonymous (eval, new Function, onload, ...).
-      // Or, it's because it was code Lighthouse over the protocol via `Runtime.evaluate`.
-      // We currently don't consider coverage of anonymous scripts, and we definitely don't want
-      // coverage of code Lighthouse ran to inspect the page, so we ignore this ScriptCoverage if
-      // url is blank.
-      if (scriptUsage.url === '') {
+      if (scriptUsage.url === '' || scriptUsage.url === 'lighthouse-eval.js') {
+        // We currently don't consider coverage of anonymous scripts, and we definitely don't want
+        // coverage of code Lighthouse ran to inspect the page, so we ignore this ScriptCoverage.
         continue;
       }
 

--- a/lighthouse-core/gather/gatherers/scripts.js
+++ b/lighthouse-core/gather/gatherers/scripts.js
@@ -29,6 +29,22 @@ async function runInSeriesOrParallel(values, promiseMapper, runInSeries) {
 }
 
 /**
+ * Returns true if the script was created via our own calls
+ * to Runtime.evaluate.
+ * @param {LH.Crdp.Debugger.ScriptParsedEvent} script
+ */
+function isLighthouseRuntimeEvaluateScript(script) {
+  // Scripts created by Runtime.evaluate that run on the main session/frame
+  // result in an empty string for the embedderName.
+  if (!script.embedderName) return true;
+
+  // Otherwise, when running our own code inside other frames, the embedderName
+  // is set to the frame's url. In that case, we rely on the special sourceURL that
+  // we set.
+  return script.hasSourceURL && script.url === 'lighthouse-eval.js';
+}
+
+/**
  * @fileoverview Gets JavaScript file contents.
  */
 class Scripts extends FRGatherer {
@@ -68,8 +84,9 @@ class Scripts extends FRGatherer {
     // it also blocks scripts from the same origin but that happen to run in a different process,
     // like a worker.
     if (event.method === 'Debugger.scriptParsed' && !sessionId) {
-      // Events without an embedderName (read: a url) are for JS that we ran over the protocol.
-      if (event.params.embedderName) this._scriptParsedEvents.push(event.params);
+      if (!isLighthouseRuntimeEvaluateScript(event.params)) {
+        this._scriptParsedEvents.push(event.params);
+      }
     }
   }
 


### PR DESCRIPTION
This allows us to more correctly ignore scripts that we created via the Runtime.evaluate method. The current assumption (that all those scripts would have a blank embedderName) does not hold when considering iframes.