### PR TITLE
core: always use `MainResource` for main document

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/legacy-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/legacy-javascript.js
@@ -373,12 +373,12 @@ class LegacyJavascript extends ByteEfficiencyAudit {
     if (transferRatio !== undefined) return transferRatio;
 
     const script = artifacts.Scripts.find(script => script.url === url);
-    const networkRecord = getRequestForScript(networkRecords, script);
 
     if (!script || script.content === null) {
       // Can't find content, so just use 1.
       transferRatio = 1;
     } else {
+      const networkRecord = getRequestForScript(networkRecords, script);
       const contentLength = script.length || 0;
       const transferSize =
         ByteEfficiencyAudit.estimateTransferSize(networkRecord, contentLength, 'Script');

--- a/lighthouse-core/audits/seo/http-status-code.js
+++ b/lighthouse-core/audits/seo/http-status-code.js
@@ -6,11 +6,10 @@
 'use strict';
 
 const Audit = require('../audit.js');
-const NetworkRecords = require('../../computed/network-records.js');
 const HTTP_UNSUCCESSFUL_CODE_LOW = 400;
 const HTTP_UNSUCCESSFUL_CODE_HIGH = 599;
 const i18n = require('../../lib/i18n/i18n.js');
-const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-analyzer.js');
+const MainResource = require('../../computed/main-resource.js');
 
 const UIStrings = {
   /** Title of a Lighthouse audit that provides detail on the HTTP status code a page responds with. This descriptive title is shown when the page has responded with a valid HTTP status code. */
@@ -47,8 +46,7 @@ class HTTPStatusCode extends Audit {
   static async audit(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const URL = artifacts.URL;
-    const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-    const mainResource = NetworkAnalyzer.findMainDocument(networkRecords, URL.finalUrl);
+    const mainResource = await MainResource.request({devtoolsLog, URL}, context);
 
     const statusCode = mainResource.statusCode;
 

--- a/lighthouse-core/audits/server-response-time.js
+++ b/lighthouse-core/audits/server-response-time.js
@@ -8,8 +8,6 @@
 const Audit = require('./audit.js');
 const i18n = require('../lib/i18n/i18n.js');
 const MainResource = require('../computed/main-resource.js');
-const NetworkRecords = require('../computed/network-records.js');
-const NetworkAnalyzer = require('../lib/dependency-graph/simulator/network-analyzer.js');
 
 const UIStrings = {
   /** Title of a diagnostic audit that provides detail on how long it took from starting a request to when the server started responding. This descriptive title is shown to users when the amount is acceptable and no user action is required. */
@@ -39,7 +37,7 @@ class ServerResponseTime extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      supportedModes: ['timespan', 'navigation'],
+      supportedModes: ['navigation'],
       requiredArtifacts: ['devtoolsLogs', 'URL', 'GatherContext'],
     };
   }
@@ -61,20 +59,7 @@ class ServerResponseTime extends Audit {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
 
     /** @type {LH.Artifacts.NetworkRequest} */
-    let mainResource;
-    if (artifacts.GatherContext.gatherMode === 'timespan') {
-      const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-      const optionalMainResource = NetworkAnalyzer.findOptionalMainDocument(
-        networkRecords,
-        artifacts.URL.finalUrl
-      );
-      if (!optionalMainResource) {
-        return {score: null, notApplicable: true};
-      }
-      mainResource = optionalMainResource;
-    } else {
-      mainResource = await MainResource.request({devtoolsLog, URL: artifacts.URL}, context);
-    }
+    const mainResource = await MainResource.request({devtoolsLog, URL: artifacts.URL}, context);
 
     const responseTime = ServerResponseTime.calculateResponseTime(mainResource);
     const passed = responseTime < TOO_SLOW_THRESHOLD_MS;

--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -394,6 +394,8 @@ class PageDependencyGraph {
     const networkNodeOutput = PageDependencyGraph.getNetworkNodeOutput(networkRecords);
     const cpuNodes = PageDependencyGraph.getCPUNodes(processedTrace);
 
+    // TODO: Remove this usage of `findMainDocument`. This assumption isn't true if there was a JS redirect.
+    // ...
     // The main document request is the earliest network request *of type document*.
     // This will be different from the root request when there are server redirects.
     const mainDocumentRequest = NetworkAnalyzer.findMainDocument(networkRecords);

--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -224,6 +224,7 @@ async function _navigation(navigationContext) {
   await collectPhaseArtifacts({phase: 'startInstrumentation', ...phaseState});
   await collectPhaseArtifacts({phase: 'startSensitiveInstrumentation', ...phaseState});
   const navigateResult = await _navigate(navigationContext);
+  phaseState.baseArtifacts.URL.finalUrl = navigateResult.finalUrl;
   phaseState.url = navigateResult.finalUrl;
   await collectPhaseArtifacts({phase: 'stopSensitiveInstrumentation', ...phaseState});
   await collectPhaseArtifacts({phase: 'stopInstrumentation', ...phaseState});

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -80,6 +80,7 @@ class GatherRunner {
         ...passContext.passConfig,
       });
       passContext.url = finalUrl;
+      passContext.baseArtifacts.URL.finalUrl = finalUrl;
       if (passContext.passConfig.loadFailureMode === 'fatal') {
         passContext.LighthouseRunWarnings.push(...warnings);
       }

--- a/lighthouse-core/gather/gatherers/main-document-content.js
+++ b/lighthouse-core/gather/gatherers/main-document-content.js
@@ -6,10 +6,9 @@
 'use strict';
 
 const FRGatherer = require('../../fraggle-rock/gather/base-gatherer.js');
-const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-analyzer.js');
-const NetworkRecords = require('../../computed/network-records.js');
 const DevtoolsLog = require('./devtools-log.js');
 const {fetchResponseBodyFromCache} = require('../driver/network.js');
+const MainResource = require('../../computed/main-resource.js');
 
 /**
  * Collects the content of the main html document.
@@ -24,14 +23,16 @@ class MainDocumentContent extends FRGatherer {
   /**
    *
    * @param {LH.Gatherer.FRTransitionalContext} context
-   * @param {LH.Artifacts.NetworkRequest[]} networkRecords
+   * @param {LH.Artifacts['DevtoolsLog']} devtoolsLog
    * @return {Promise<LH.Artifacts['MainDocumentContent']>}
    */
-  async _getArtifact(context, networkRecords) {
-    const mainResource = NetworkAnalyzer.findMainDocument(networkRecords, context.url);
+  async _getArtifact(context, devtoolsLog) {
+    const mainResource =
+      await MainResource.request({devtoolsLog, URL: context.baseArtifacts.URL}, context);
     const session = context.driver.defaultSession;
     return fetchResponseBodyFromCache(session, mainResource.requestId);
   }
+
   /**
    *
    * @param {LH.Gatherer.FRTransitionalContext<'DevtoolsLog'>} context
@@ -39,8 +40,7 @@ class MainDocumentContent extends FRGatherer {
    */
   async getArtifact(context) {
     const devtoolsLog = context.dependencies.DevtoolsLog;
-    const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-    return this._getArtifact(context, networkRecords);
+    return this._getArtifact(context, devtoolsLog);
   }
 
   /**
@@ -49,7 +49,7 @@ class MainDocumentContent extends FRGatherer {
    * @return {Promise<LH.Artifacts['MainDocumentContent']>}
    */
   async afterPass(passContext, loadData) {
-    return this._getArtifact({...passContext, dependencies: {}}, loadData.networkRecords);
+    return this._getArtifact({...passContext, dependencies: {}}, loadData.devtoolsLog);
   }
 }
 


### PR DESCRIPTION
This PR aims to use the `MainResource` computed artifact universally instead of calling `NetworkMonitor.findMainDocument` directly. There are two reasons we would want to do this:

- With https://github.com/GoogleChrome/lighthouse/issues/13706, we would need to assert that the main document URL exists before every usage of `NetworkAnalyzer.findMainDocument`. If we use `MainResource` universally, we will only need to assert the main document URL exists within `MainResource`.
- `NetworkAnalyzer.findMainDocument` will return the first document request if it is not given a URL as its second parameter. This will return an incorrect network request if there was a JS redirect.