### PR TITLE
tests: clean devtools repo in CI

### DIFF
--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -30,6 +30,7 @@ then
     # Do the same as for local, but don't clean! That would toss out all the
     # (stale, but still useful) build artifacts.
     git reset --hard
+    git clean -d -n
     git pull --ff-only -f origin main
     gclient sync --delete_unversioned_trees --reset
   fi

--- a/lighthouse-core/test/chromium-web-tests/download-devtools.sh
+++ b/lighthouse-core/test/chromium-web-tests/download-devtools.sh
@@ -24,13 +24,11 @@ then
     git pull --ff-only -f origin main
     gclient sync --delete_unversioned_trees --reset
   elif [ -z "${GHA_DEVTOOLS_CACHE_HIT:-}" ]; then
-    # For CI, just update, but only if this was a cache-miss.
+    # For CI, only run if this was a cache-miss.
     # The only way the folder already exists _and_ there is a cache-miss is
     # if actions/cache@v2 `restore-keys` has provided a partial environment for us.
-    # Do the same as for local, but don't clean! That would toss out all the
-    # (stale, but still useful) build artifacts.
     git reset --hard
-    git clean -d -n
+    git clean -fd
     git pull --ff-only -f origin main
     gclient sync --delete_unversioned_trees --reset
   fi


### PR DESCRIPTION
Fixes the merge issue we were getting in devtools CI build step.

there was an issue with landing a new test file in devtools repo first

<img width="779" alt="image" src="https://user-images.githubusercontent.com/4071474/159082150-94e0244b-36ce-42e2-8de5-91214e653068.png">

https://github.com/GoogleChrome/lighthouse/runs/5591661464?check_suite_focus=true#step:11:52

