### PR TITLE
core(preload-lcp-image): be specific about when to do this

### DIFF
--- a/lighthouse-core/audits/preload-lcp-image.js
+++ b/lighthouse-core/audits/preload-lcp-image.js
@@ -17,8 +17,8 @@ const UIStrings = {
   /** Title of a lighthouse audit that tells a user to preload an image in order to improve their LCP time. */
   title: 'Preload Largest Contentful Paint image',
   /** Description of a lighthouse audit that tells a user to preload an image in order to improve their LCP time.  */
-  description: 'Preload the image used by ' +
-    'the LCP element in order to improve your LCP time. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources).',
+  description: 'If the LCP element is dynamically added to the page, you should preload the ' +
+    'image in order to improve LCP. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources).',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -1741,7 +1741,7 @@
           "preload-lcp-image": {
             "id": "preload-lcp-image",
             "title": "Preload Largest Contentful Paint image",
-            "description": "Preload the image used by the LCP element in order to improve your LCP time. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources).",
+            "description": "If the LCP element is dynamically added to the page, you should preload the image in order to improve LCP. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources).",
             "score": 1,
             "scoreDisplayMode": "numeric",
             "numericValue": 0,
@@ -15643,7 +15643,7 @@
           "preload-lcp-image": {
             "id": "preload-lcp-image",
             "title": "Preload Largest Contentful Paint image",
-            "description": "Preload the image used by the LCP element in order to improve your LCP time. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources).",
+            "description": "If the LCP element is dynamically added to the page, you should preload the image in order to improve LCP. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources).",
             "score": 1,
             "scoreDisplayMode": "numeric",
             "numericValue": 0,

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2533,7 +2533,7 @@
     "preload-lcp-image": {
       "id": "preload-lcp-image",
       "title": "Preload Largest Contentful Paint image",
-      "description": "Preload the image used by the LCP element in order to improve your LCP time. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources).",
+      "description": "If the LCP element is dynamically added to the page, you should preload the image in order to improve LCP. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources).",
       "score": 1,
       "scoreDisplayMode": "numeric",
       "numericValue": 0,

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1272,7 +1272,7 @@
     "message": "Fonts with `font-display: optional` are preloaded"
   },
   "lighthouse-core/audits/preload-lcp-image.js | description": {
-    "message": "Preload the image used by the LCP element in order to improve your LCP time. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources)."
+    "message": "If the LCP element is dynamically added to the page, you should preload the image in order to improve LCP. [Learn more](https://web.dev/optimize-lcp/#preload-important-resources)."
   },
   "lighthouse-core/audits/preload-lcp-image.js | title": {
     "message": "Preload Largest Contentful Paint image"

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1272,7 +1272,7 @@
     "message": "F̂ón̂t́ŝ ẃît́ĥ `font-display: optional` ár̂é p̂ŕêĺôád̂éd̂"
   },
   "lighthouse-core/audits/preload-lcp-image.js | description": {
-    "message": "P̂ŕêĺôád̂ t́ĥé îḿâǵê úŝéd̂ b́ŷ t́ĥé L̂ĆP̂ él̂ém̂én̂t́ îń ôŕd̂ér̂ t́ô ím̂ṕr̂óv̂é ŷóûŕ L̂ĆP̂ t́îḿê. [Ĺêár̂ń m̂ór̂é](https://web.dev/optimize-lcp/#preload-important-resources)."
+    "message": "Îf́ t̂h́ê ĹĈṔ êĺêḿêńt̂ íŝ d́ŷńâḿîćâĺl̂ý âd́d̂éd̂ t́ô t́ĥé p̂áĝé, ŷóû śĥóûĺd̂ ṕr̂él̂óâd́ t̂h́ê ím̂áĝé îń ôŕd̂ér̂ t́ô ím̂ṕr̂óv̂é L̂ĆP̂. [Ĺêár̂ń m̂ór̂é](https://web.dev/optimize-lcp/#preload-important-resources)."
   },
   "lighthouse-core/audits/preload-lcp-image.js | title": {
     "message": "P̂ŕêĺôád̂ Ĺâŕĝéŝt́ Ĉón̂t́êńt̂f́ûĺ P̂áîńt̂ ím̂áĝé"


### PR DESCRIPTION
Goal is to help reduce confusion wrt future audit prioritize-lcp-image #13738 

even in isolation, this change is good because the audit explicitly ignores images that are already in the initial HTML