### PR TITLE
core(network-monitor): resolve server redirects

### DIFF
--- a/lighthouse-core/gather/driver/network-monitor.js
+++ b/lighthouse-core/gather/driver/network-monitor.js
@@ -143,8 +143,21 @@ class NetworkMonitor {
     const mainFrameNavigations = frameNavigations.filter(frame => frame.id === mainFrameId);
     if (!mainFrameNavigations.length) log.warn('NetworkMonitor', 'No detected navigations');
 
+    // The requested URL is the initiator request for the first frame navigation.
+    /** @type {string|undefined} */
+    let requestedUrl = mainFrameNavigations[0]?.url;
+    if (this._networkRecorder) {
+      const records = this._networkRecorder.getRawRecords();
+
+      let initialUrlRequest = records.find(record => record.url === requestedUrl);
+      while (initialUrlRequest?.redirectSource) {
+        initialUrlRequest = initialUrlRequest.redirectSource;
+        requestedUrl = initialUrlRequest.url;
+      }
+    }
+
     return {
-      requestedUrl: mainFrameNavigations[0]?.url,
+      requestedUrl,
       finalUrl: mainFrameNavigations[mainFrameNavigations.length - 1]?.url,
     };
   }

--- a/lighthouse-core/test/fixtures/fraggle-rock/navigation-basic/links-to-index.html
+++ b/lighthouse-core/test/fixtures/fraggle-rock/navigation-basic/links-to-index.html
@@ -13,7 +13,7 @@
 <body>
   This page links to the normal fraggle rock index page.
 
-  <a href="index.html">Link to index</a>
+  <a href="/?redirect=/index.html">Link to index</a>
 </body>
 </html>
 

--- a/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
@@ -177,7 +177,7 @@ describe('Fraggle Rock API', () => {
       expect(requestor).toHaveBeenCalled();
 
       const {lhr} = result;
-      expect(lhr.requestedUrl).toEqual(`${serverBaseUrl}/index.html`);
+      expect(lhr.requestedUrl).toEqual(`${serverBaseUrl}/?redirect=/index.html`);
       expect(lhr.finalUrl).toEqual(`${serverBaseUrl}/index.html`);
 
       const {auditResults, failedAudits, erroredAudits} = getAuditsBreakdown(lhr);
@@ -193,7 +193,10 @@ describe('Fraggle Rock API', () => {
       expect(lhr.audits).toHaveProperty('total-byte-weight');
       const details = lhr.audits['total-byte-weight'].details;
       if (!details || details.type !== 'table') throw new Error('Unexpected byte weight details');
-      expect(details.items).toMatchObject([{url: `${serverBaseUrl}/index.html`}]);
+      expect(details.items).toMatchObject([
+        {url: `${serverBaseUrl}/index.html`},
+        {url: `${serverBaseUrl}/?redirect=/index.html`},
+      ]);
 
       // Check that performance metrics were computed.
       expect(lhr.audits).toHaveProperty('first-contentful-paint');

--- a/lighthouse-core/test/gather/driver/network-monitor-test.js
+++ b/lighthouse-core/test/gather/driver/network-monitor-test.js
@@ -199,7 +199,7 @@ describe('NetworkMonitor', () => {
 
       expect(await monitor.getNavigationUrls()).toEqual({
         requestedUrl: 'https://example.com',
-        finalUrl: 'https://page.example.com',
+        mainDocumentUrl: 'https://page.example.com',
       });
     });
 

--- a/lighthouse-core/test/gather/driver/network-monitor-test.js
+++ b/lighthouse-core/test/gather/driver/network-monitor-test.js
@@ -157,7 +157,7 @@ describe('NetworkMonitor', () => {
     });
   });
 
-  describe('.getFinalNavigationUrl()', () => {
+  describe('.getNavigationUrls()', () => {
     it('should handle the empty case', async () => {
       expect(await monitor.getNavigationUrls()).toEqual({});
     });
@@ -169,6 +169,31 @@ describe('NetworkMonitor', () => {
       const type = 'Navigation';
       const frame = /** @type {*} */ ({id: '1', url: 'https://page.example.com'});
       sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame: {...frame, url: 'https://example.com'}, type}}); // eslint-disable-line max-len
+      sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame: {...frame, url: 'https://intermediate.example.com'}, type}}); // eslint-disable-line max-len
+      sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame, type}});
+
+      expect(await monitor.getNavigationUrls()).toEqual({
+        requestedUrl: 'https://example.com',
+        finalUrl: 'https://page.example.com',
+      });
+    });
+
+    it('should handle server redirects', async () => {
+      sendCommandMock.mockResponse('Page.getResourceTree', {frameTree: {frame: {id: '1'}}});
+      await monitor.enable();
+
+      // One server redirect followed by a client redirect
+      const devtoolsLog = networkRecordsToDevtoolsLog([
+        {requestId: '1', startTime: 100, url: 'https://example.com', priority: 'VeryHigh'},
+        {requestId: '1:redirect', startTime: 200, url: 'https://intermediate.example.com', priority: 'VeryHigh'},
+        {requestId: '2', startTime: 300, url: 'https://page.example.com', priority: 'VeryHigh'},
+      ]);
+      for (const event of devtoolsLog) {
+        sessionMock.dispatch(event);
+      }
+
+      const type = 'Navigation';
+      const frame = /** @type {*} */ ({id: '1', url: 'https://page.example.com'});
       sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame: {...frame, url: 'https://intermediate.example.com'}, type}}); // eslint-disable-line max-len
       sessionMock.dispatch({method: 'Page.frameNavigated', params: {frame, type}});
 


### PR DESCRIPTION
This should only affect user-triggered redirects where we backfill `requestedUrl`. I noticed that `Page.frameNavigated` events are not emitted for server redirects, so we must climb the redirect chain to get the initiator request for the navigation.
