### PR TITLE
tests: upload smoke failures for devtools

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -172,3 +172,10 @@ jobs:
       #   redirects-client-paint-server redirects-multiple-server redirects-single-server redirects-single-client
       run: yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/${{ strategy.job-total }} --retries=2 --invert-match a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-server redirects-single-client redirects-scripts screenshot seo-passing seo-tap-targets
       working-directory: ${{ github.workspace }}/lighthouse
+
+    - name: Upload failures
+      if: failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: Smokehouse (devtools smoke ${{ matrix.smoke-test-shard }}/${{ strategy.job-total }})
+        path: ${{ github.workspace }}/lighthouse/.tmp/smokehouse-ci-failures/

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -62,7 +62,7 @@ jobs:
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
 
-    - name: Upload dist
+    - name: Upload failures
       if: failure()
       uses: actions/upload-artifact@v1
       with:
@@ -93,7 +93,7 @@ jobs:
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
 
-    - name: Upload dist
+    - name: Upload failures
       if: failure()
       uses: actions/upload-artifact@v1
       with:
@@ -124,7 +124,7 @@ jobs:
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
 
-    - name: Upload dist
+    - name: Upload failures
       if: failure()
       uses: actions/upload-artifact@v1
       with:
@@ -155,7 +155,7 @@ jobs:
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
 
-    - name: Upload dist
+    - name: Upload failures
       if: failure()
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
other smokes do this, but devtools wasn't.

Also driveby renaming of those other steps, that was a copy/paste error