### PR TITLE
core(scripts): use `startLine`/`startColumn` to determine inline scripts

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency.js
@@ -193,7 +193,7 @@ const expectations = {
             },
             {
               // /some-custom-url.js,
-              url: 'http://localhost:10200/byte-efficiency/tester.html',
+              url: 'inline: \n  function unusedFunction() {\n    // Un...',
               wastedBytes: '6700 +/- 100',
               wastedPercent: '99.6 +/- 0.1',
             },

--- a/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
@@ -8,7 +8,7 @@
 const ByteEfficiencyAudit = require('./byte-efficiency-audit.js');
 const i18n = require('../../lib/i18n/i18n.js');
 const computeTokenLength = require('../../lib/minification-estimator.js').computeJSTokenLength;
-const {getRequestForScript} = require('../../lib/script-helpers.js');
+const {getRequestForScript, isInline} = require('../../lib/script-helpers.js');
 
 const UIStrings = {
   /** Imperative title of a Lighthouse audit that tells the user to minify the page’s JS code to reduce file size. This is displayed in a list of audit titles that Lighthouse generates. */
@@ -83,7 +83,8 @@ class UnminifiedJavaScript extends ByteEfficiencyAudit {
       if (!script.content) continue;
 
       const networkRecord = getRequestForScript(networkRecords, script);
-      const displayUrl = script.name === artifacts.URL.finalUrl ?
+
+      const displayUrl = isInline(script) ?
         `inline: ${script.content.substring(0, 40)}...` :
         script.url;
       try {

--- a/lighthouse-core/lib/script-helpers.js
+++ b/lighthouse-core/lib/script-helpers.js
@@ -6,6 +6,14 @@
 'use strict';
 
 /**
+ * @param {LH.Artifacts.Script} script
+ * @return {boolean}
+ */
+function isInline(script) {
+  return Boolean(script.startLine || script.startColumn);
+}
+
+/**
  * @param {LH.Artifacts.NetworkRequest[]} networkRecords
  * @param {LH.Artifacts.Script} script
  * @return {LH.Artifacts.NetworkRequest|undefined}
@@ -18,4 +26,4 @@ function getRequestForScript(networkRecords, script) {
   return networkRequest;
 }
 
-module.exports = {getRequestForScript};
+module.exports = {getRequestForScript, isInline};

--- a/lighthouse-core/test/audits/byte-efficiency/unminified-javascript-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/unminified-javascript-test.js
@@ -84,6 +84,7 @@ describe('Page uses optimized responses', () => {
       URL: {finalUrl: 'https://www.example.com'},
       Scripts: [
         {
+          startLine: 30,
           scriptId: '123.1',
           url: 'https://www.example.com',
           content: `

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -2306,7 +2306,8 @@
               "nodes": [
                 {
                   "name": "https://www.mikescerealshack.co/",
-                  "resourceBytes": 421
+                  "resourceBytes": 421,
+                  "isInline": true
                 },
                 {
                   "name": "https://www.mikescerealshack.co/_next/static/chunks/webpack-657a8433bac0aabd564e.js",
@@ -16189,7 +16190,8 @@
               "nodes": [
                 {
                   "name": "https://www.mikescerealshack.co/corrections",
-                  "resourceBytes": 421
+                  "resourceBytes": 421,
+                  "isInline": true
                 },
                 {
                   "name": "https://events.mikescerealshack.co/js/index.js",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3232,7 +3232,8 @@
         "nodes": [
           {
             "name": "http://localhost:10200/dobetterweb/dbw_tester.html",
-            "resourceBytes": 7166
+            "resourceBytes": 7166,
+            "isInline": true
           },
           {
             "name": "http://localhost:10200/dobetterweb/dbw_tester.js",

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
     "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf ≥ 3.7.1 to compile the proto file.\" && false)",
     "build-proto-roundtrip": "mkdir -p .tmp && cross-env PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python proto/scripts/json_roundtrip_via_proto.py",
     "static-server": "node lighthouse-cli/test/fixtures/static-server.js",
-    "serve-dist": "cd dist && python -m SimpleHTTPServer",
-    "serve-gh-pages": "cd dist/gh-pages && python -m SimpleHTTPServer",
+    "serve-dist": "cd dist && python3 -m http.server",
+    "serve-gh-pages": "cd dist/gh-pages && python3 -m http.server",
     "serve-treemap": "yarn serve-gh-pages",
     "serve-viewer": "yarn serve-gh-pages",
     "flow-report": "yarn build-report --flow && node ./lighthouse-core/scripts/build-test-flow-report.js"

--- a/treemap/app/src/main.js
+++ b/treemap/app/src/main.js
@@ -74,7 +74,7 @@ class TreemapViewer {
     /** @type {WeakMap<LH.Treemap.Node, LH.Treemap.NodePath>} */
     this.nodeToPathMap = new WeakMap();
 
-    this.documentUrl = new URL(options.lhr.requestedUrl);
+    this.pageUrl = new URL(options.lhr.finalUrl);
     this.el = el;
     this.getHueForD1NodeName = TreemapUtil.stableHasher(TreemapUtil.COLOR_HUES);
 
@@ -83,8 +83,8 @@ class TreemapViewer {
     for (const node of this.depthOneNodesByGroup.scripts) {
       try {
         const url = new URL(node.name);
-        node.name = TreemapUtil.elideSameOrigin(url, this.documentUrl);
-        if (url.href === this.documentUrl.href) {
+        node.name = TreemapUtil.elideSameOrigin(url, this.pageUrl);
+        if (node.isInline) {
           node.name += ' (inline)';
         }
       } catch {}
@@ -116,8 +116,8 @@ class TreemapViewer {
 
   createHeader() {
     const urlEl = TreemapUtil.find('a.lh-header--url');
-    urlEl.textContent = this.documentUrl.toString();
-    urlEl.href = this.documentUrl.toString();
+    urlEl.textContent = this.pageUrl.toString();
+    urlEl.href = this.pageUrl.toString();
 
     this.createBundleSelector();
   }
@@ -237,7 +237,7 @@ class TreemapViewer {
   wrapNodesInNewRootNode(nodes) {
     const children = [...nodes];
     return {
-      name: this.documentUrl.toString(),
+      name: this.pageUrl.toString(),
       resourceBytes: children.reduce((acc, cur) => cur.resourceBytes + acc, 0),
       unusedBytes: children.reduce((acc, cur) => (cur.unusedBytes || 0) + acc, 0),
       children,

--- a/types/lhr/treemap.d.ts
+++ b/types/lhr/treemap.d.ts
@@ -51,6 +51,7 @@ declare module Treemap {
     /** If present, this module is a duplicate. String is normalized source path. See ModuleDuplication.normalizeSource */
     duplicatedNormalizedModuleName?: string;
     children?: Node[];
+    isInline?: boolean;
   }
 }
 


### PR DESCRIPTION
From https://github.com/GoogleChrome/lighthouse/pull/13793#discussion_r837962251

Instead of using the main doc url to find inline scripts, we can use the `startLine`/`startColumn`. This allows us to remove the dependency on the navigation url in treemap #13706.