### PR TITLE
deps(axe-core): upgrade to 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
   },
   "dependencies": {
     "@sentry/node": "^6.17.4",
-    "axe-core": "4.3.5",
+    "axe-core": "4.4.1",
     "chrome-launcher": "^0.15.0",
     "configstore": "^5.0.1",
     "csp_evaluator": "1.1.0",

--- a/report/test/renderer/__snapshots__/report-renderer-axe-test.js.snap
+++ b/report/test/renderer/__snapshots__/report-renderer-axe-test.js.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "description": "Ensures every id attribute value is unique",
     "help": "id attribute value must be unique",
-    "helpUrl": "https://dequeuniversity.com/rules/axe/4.3/duplicate-id?application=axeAPI",
+    "helpUrl": "https://dequeuniversity.com/rules/axe/4.4/duplicate-id?application=axeAPI",
     "id": "duplicate-id",
     "impact": "minor",
     "nodes": Array [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2173,10 +2173,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
-  integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
+axe-core@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
+  integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
 babel-jest@^27.2.0:
   version "27.2.0"


### PR DESCRIPTION
Closes https://github.com/GoogleChrome/lighthouse/issues/12432 because the `doc-endnote` role is now deprecated.

https://github.com/dequelabs/axe-core/releases