### PR TITLE
core: use the main frame url for `finalUrl`

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/redirects-self.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/redirects-self.js
@@ -11,10 +11,16 @@
 const expectations = {
   artifacts: {
     MainDocumentContent: /Redirect to myself/,
+    URL: {
+      initialUrl: 'about:blank',
+      requestedUrl: 'http://localhost:10200/redirects-self.html',
+      mainDocumentUrl: 'http://localhost:10200/redirects-self.html?done=',
+      finalUrl: 'http://localhost:10200/redirects-self.html',
+    },
   },
   lhr: {
     requestedUrl: 'http://localhost:10200/redirects-self.html',
-    finalUrl: 'http://localhost:10200/redirects-self.html?done=',
+    finalUrl: 'http://localhost:10200/redirects-self.html',
     audits: {
     },
     runWarnings: [

--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -235,7 +235,7 @@ async function _navigation(navigationContext) {
       initialUrl,
       requestedUrl: navigateResult.requestedUrl,
       mainDocumentUrl: navigateResult.mainDocumentUrl,
-      finalUrl: navigateResult.mainDocumentUrl,
+      finalUrl: await navigationContext.driver.url(),
     };
   }
   phaseState.url = navigateResult.mainDocumentUrl;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -82,8 +82,8 @@ class GatherRunner {
       passContext.url = mainDocumentUrl;
       const {URL} = passContext.baseArtifacts;
       if (!URL.finalUrl || !URL.mainDocumentUrl) {
-        URL.finalUrl = mainDocumentUrl;
         URL.mainDocumentUrl = mainDocumentUrl;
+        URL.finalUrl = await passContext.driver.url();
       }
       if (passContext.passConfig.loadFailureMode === 'fatal') {
         passContext.LighthouseRunWarnings.push(...warnings);

--- a/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/navigation-runner-test.js
@@ -102,7 +102,9 @@ describe('NavigationRunner', () => {
     baseArtifacts.URL = {initialUrl: '', finalUrl: ''};
 
     mockDriver = createMockDriver();
-    mockDriver.url.mockReturnValue('about:blank');
+    mockDriver.url
+      .mockReturnValueOnce('about:blank')
+      .mockImplementationOnce(() => requestedUrl);
     driver = mockDriver.asDriver();
 
     mocks.reset();

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -124,6 +124,8 @@ beforeEach(() => {
   driver = new EmulationDriver(connectionStub);
   resetDefaultMockResponses();
 
+  fakeDriver.url = jest.fn().mockResolvedValue('about:blank');
+
   const emulation = require('../../lib/emulation.js');
   emulation.emulate = jest.fn();
   emulation.throttle = jest.fn();
@@ -153,6 +155,8 @@ describe('GatherRunner', function() {
     const driver = {};
     const gotoURL = jest.requireMock('../../gather/driver/navigation.js').gotoURL;
     gotoURL.mockResolvedValue({mainDocumentUrl: url2, warnings: []});
+    driver.url = jest.fn()
+      .mockResolvedValueOnce(url2);
 
     const passContext = {
       url: url1,
@@ -166,6 +170,7 @@ describe('GatherRunner', function() {
           finalUrl: url1,
         },
       },
+      driver,
     };
 
     return GatherRunner.loadPage(driver, passContext).then(_ => {
@@ -228,6 +233,9 @@ describe('GatherRunner', function() {
     const mainDocumentUrl = 'https://example.com/interstitial';
     const gotoURL = jest.requireMock('../../gather/driver/navigation.js').gotoURL;
     gotoURL.mockResolvedValue({mainDocumentUrl, timedOut: false, warnings: []});
+    fakeDriver.url = jest.fn()
+      .mockResolvedValueOnce('about:blank')
+      .mockResolvedValueOnce(mainDocumentUrl);
     const config = makeConfig({passes: [{passName: 'defaultPass'}]});
     const options = {
       requestedUrl,

--- a/treemap/app/debug.json
+++ b/treemap/app/debug.json
@@ -8740,7 +8740,7 @@
           "type": "treemap-data",
           "nodes": [
             {
-              "name": "https://www.coursehero.com/ (inline)",
+              "name": "https://www.coursehero.com/",
               "resourceBytes": 66329,
               "unusedBytes": 25502,
               "children": [

--- a/treemap/app/src/main.js
+++ b/treemap/app/src/main.js
@@ -84,7 +84,12 @@ class TreemapViewer {
       try {
         const url = new URL(node.name);
         node.name = TreemapUtil.elideSameOrigin(url, this.documentUrl);
-        if (url.href === this.documentUrl.href) {
+        const isInlineHtmlNode =
+          node.children?.every(child => child.name.startsWith('(inline)')) ||
+          // Backport for treemap data that does not add the "(inline)" prefix to each inline script.
+          // This is pre-10.0 when the `finalUrl` represented the main document url.
+          url.href === this.documentUrl.href;
+        if (isInlineHtmlNode) {
           node.name += ' (inline)';
         }
       } catch {}

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -200,11 +200,7 @@ declare module Artifacts {
      * Will be `undefined` in timespan/snapshot.
      */
     mainDocumentUrl?: string;
-    /**
-     * Will be the same as `mainDocumentUrl` in navigation mode.
-     * Wil be the URL of the main frame after Lighthouse finishes in timespan/snapshot.
-     * TODO: Use the main frame URL in navigation mode as well.
-     */
+    /** URL of the main frame after Lighthouse finishes. */
     finalUrl: string;
   }
 

--- a/types/lhr/lhr.d.ts
+++ b/types/lhr/lhr.d.ts
@@ -15,7 +15,7 @@ interface Result {
   gatherMode: Result.GatherMode;
   /** The URL that Lighthouse initially navigated to. Will be `undefined` in timespan/snapshot. */
   requestedUrl?: string;
-  /** The post-redirects URL that Lighthouse loaded. */
+  /** The URL of the page after Lighthouse finishes. */
   finalUrl: string;
   /** The ISO-8601 timestamp of when the results were generated. */
   fetchTime: string;


### PR DESCRIPTION
Step 5 of #13706

I did a pass on all usages of `finalUrl` in the report renderer and treemap. Every usage in the report renderer was either cosmetic or just looking at the origin, so we should be fine there.

In the treemap, we use the `finalUrl` to determine if a first-level node is for inline html scripts. With the changes in https://github.com/GoogleChrome/lighthouse/pull/13802#discussion_r839906758 we can determine this by looking for "(inline)" prefixes in the children, however we should keep the URL check around as a backport.