### PR TITLE
tests: use cache instead of artifacts for devtools build

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -2,9 +2,8 @@ name: DevTools
 
 on:
   push:
-    branches: [master]
-  # 1
-  # pull_request: # run on all PRs, not just PRs to a particular branch
+    # branches: [master]
+  pull_request: # run on all PRs, not just PRs to a particular branch
 
 env:
   DEPOT_TOOLS_PATH: ${{ github.workspace }}/depot-tools

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -3,7 +3,7 @@ name: DevTools
 on:
   push:
     branches: [master]
-  pull_request: # run on all PRs, not just PRs to a particular branch
+  # pull_request: # run on all PRs, not just PRs to a particular branch
 
 env:
   DEPOT_TOOLS_PATH: ${{ github.workspace }}/depot-tools
@@ -68,15 +68,16 @@ jobs:
     - name: Roll Lighthouse + build DevTools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/roll-devtools.sh
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2
+    - name: Cache build artifacts
+      id: devtools-build-artifacts
+      uses: actions/cache@v3
       with:
-        name: devtools-build
         path: |
           ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
           ${{ env.DEVTOOLS_PATH }}/test/webtests
           ${{ github.workspace }}/.gclient
-        retention-days: 1
+        key: devtools-build-artifacts-${{ github.run_id }}
+        restore-keys: devtools-build-artifacts-
 
   web-tests:
     needs: [build]
@@ -93,11 +94,18 @@ jobs:
       with:
         node-version: 14.x
 
-    - name: Download artifact
-      uses: actions/download-artifact@v2
+    - name: Cache build artifacts
+      id: devtools-build-artifacts
+      uses: actions/cache@v3
       with:
-        name: devtools-build
         path: ${{ github.workspace }}
+        key: devtools-build-artifacts-${{ github.run_id }}
+
+    # - name: Download artifact
+    #   uses: actions/download-artifact@v2
+    #   with:
+    #     name: devtools-build
+    #     path: ${{ github.workspace }}
 
     - name: Download Blink Tools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -3,6 +3,7 @@ name: DevTools
 on:
   push:
     branches: [master]
+  # 1
   # pull_request: # run on all PRs, not just PRs to a particular branch
 
 env:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -2,7 +2,7 @@ name: DevTools
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 env:
@@ -37,7 +37,7 @@ jobs:
     # code will invalidate the cache sooner.
     - name: Cache depot tools, devtools, blink tools and content shell
       id: devtools-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ env.DEPOT_TOOLS_PATH }}
@@ -77,7 +77,6 @@ jobs:
           ${{ env.DEVTOOLS_PATH }}/test/webtests
           ${{ github.workspace }}/.gclient
         key: devtools-build-artifacts-${{ github.run_id }}
-        # restore-keys: devtools-build-artifacts-
 
   web-tests:
     needs: [build]

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -77,7 +77,7 @@ jobs:
           ${{ env.DEVTOOLS_PATH }}/test/webtests
           ${{ github.workspace }}/.gclient
         key: devtools-build-artifacts-${{ github.run_id }}
-        restore-keys: devtools-build-artifacts-
+        # restore-keys: devtools-build-artifacts-
 
   web-tests:
     needs: [build]
@@ -149,11 +149,15 @@ jobs:
       with:
         node-version: 14.x
 
-    - name: Download artifact
-      uses: actions/download-artifact@v2
+    - name: Cache build artifacts
+      id: devtools-build-artifacts
+      uses: actions/cache@v3
       with:
-        name: devtools-build
-        path: ${{ github.workspace }}
+        path: |
+          ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
+          ${{ env.DEVTOOLS_PATH }}/test/webtests
+          ${{ github.workspace }}/.gclient
+        key: devtools-build-artifacts-${{ github.run_id }}
 
     - name: Download Blink Tools
       run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-blink-tools.sh

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -98,7 +98,10 @@ jobs:
       id: devtools-build-artifacts
       uses: actions/cache@v3
       with:
-        path: ${{ github.workspace }}
+        path: |
+          ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
+          ${{ env.DEVTOOLS_PATH }}/test/webtests
+          ${{ github.workspace }}/.gclient
         key: devtools-build-artifacts-${{ github.run_id }}
 
     # - name: Download artifact


### PR DESCRIPTION
Removes 8 minutes on the "upload artifact" side, and 2 minutes on the "download artifacts" side.

Not sure why the cache is sized at 15 MB but the artifact before was 90 MB... but the jobs are passing so...
Perhaps GH compresses better in cache action than for artifacts?

Thanks for the [idea](https://twitter.com/diegohaz/status/1511433132930707457) @diegohaz!