### PR TITLE
tests: fix smoke shard total in CI

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -125,7 +125,7 @@ jobs:
       # e.g. if set 1 fails, continue with set 2 anyway
       fail-fast: false
     runs-on: macos-latest
-    name: DevTools smoke ${{ matrix.smoke-test-shard }}
+    name: DevTools smoke ${{ matrix.smoke-test-shard }}/${{ strategy.job-total }}
 
     steps:
     - name: git clone

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,8 +17,12 @@ jobs:
       # e.g. if set 1 fails, continue with set 2 anyway
       fail-fast: false
     runs-on: ubuntu-latest
-    # Job named e.g. "Chrome stable, batch 1".
-    name: Chrome ${{ matrix.chrome-channel }}, batch ${{ matrix.smoke-test-shard }}
+    env:
+      # The total number of shards. Set dynamically when length of *single* matrix variable is
+      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
+      SHARD_TOTAL: 3
+    # Job named e.g. "Chrome stable 1/3".
+    name: Chrome ${{ matrix.chrome-channel }} ${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
 
     steps:
     - name: git clone
@@ -49,7 +53,7 @@ jobs:
     - run: sudo apt-get install xvfb
     - name: Run smoke tests
       run: |
-        xvfb-run --auto-servernum yarn c8 yarn smoke --debug -j=1 --retries=2 --shard=${{ matrix.smoke-test-shard }}/${{ strategy.job-total }}
+        xvfb-run --auto-servernum yarn c8 yarn smoke --debug -j=1 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
         yarn c8 report --reporter text-lcov > smoke-coverage.lcov
 
     - name: Upload test coverage to Codecov

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,7 +22,7 @@ jobs:
       # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
       SHARD_TOTAL: 3
     # Job named e.g. "Chrome stable 1/3".
-    name: Chrome ${{ matrix.chrome-channel }} ${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
+    name: Chrome ${{ matrix.chrome-channel }} ${{ matrix.smoke-test-shard }}/${{env.SHARD_TOTAL}}
 
     steps:
     - name: git clone

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,7 +22,7 @@ jobs:
       # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
       SHARD_TOTAL: 3
     # Job named e.g. "Chrome stable 1/3".
-    name: Chrome ${{ matrix.chrome-channel }} ${{ matrix.smoke-test-shard }}/${{env.SHARD_TOTAL}}
+    name: Chrome ${{ matrix.chrome-channel }} ${{ matrix.smoke-test-shard }}/3
 
     steps:
     - name: git clone


### PR DESCRIPTION
#13792 relied on `${{ strategy.job-total }}` for the count of total shards, but in the smoke tests the `job-total` is 6 from 3 shards * 2 versions of chrome. So we were accidentally testing half the smoke tests (shards 1/6, 2/6, and 3/6). You had to dig into the logs to see the problem, though the three minute completion times were suspicious :)

<img width="726" alt="github actions log showing `--shard=1/6` CLI flag" src="https://user-images.githubusercontent.com/316891/162844631-952c1f3f-f4e6-4ac7-8bec-74e427bb2490.png">

Also put the shard total in the job name so it's a little more prominent (though the name is still set manually, so there's no guarantee it'll be kept in sync with what's actually running).