### PR TITLE
core(trace-processor): ignore `navigationStart` with falsy document url

### DIFF
--- a/lighthouse-core/lib/tracehouse/trace-processor.js
+++ b/lighthouse-core/lib/tracehouse/trace-processor.js
@@ -85,8 +85,9 @@ class TraceProcessor {
    */
   static _isNavigationStartOfInterest(event) {
     return event.name === 'navigationStart' &&
-      (!event.args.data || !event.args.data.documentLoaderURL ||
-        ACCEPTABLE_NAVIGATION_URL_REGEX.test(event.args.data.documentLoaderURL));
+      event.args.data &&
+      event.args.data.documentLoaderURL &&
+      ACCEPTABLE_NAVIGATION_URL_REGEX.test(event.args.data.documentLoaderURL);
   }
 
   /**

--- a/lighthouse-core/lib/tracehouse/trace-processor.js
+++ b/lighthouse-core/lib/tracehouse/trace-processor.js
@@ -87,8 +87,8 @@ class TraceProcessor {
   static _isNavigationStartOfInterest(event) {
     if (event.name !== 'navigationStart') return false;
     // COMPAT: support pre-m67 test traces before `args.data` added to all navStart events.
-    // TODO: remove next line when old test traces (progressive-app-m60.json) are updated.
-    if (!event.args.data) return true;
+    // TODO: remove next line when old test traces (e.g. progressive-app-m60.json) are updated.
+    if (event.args.data?.documentLoaderURL === undefined) return true;
     if (!event.args.data?.documentLoaderURL) return false;
     return ACCEPTABLE_NAVIGATION_URL_REGEX.test(event.args.data.documentLoaderURL);
   }

--- a/lighthouse-core/lib/tracehouse/trace-processor.js
+++ b/lighthouse-core/lib/tracehouse/trace-processor.js
@@ -82,12 +82,12 @@ class TraceProcessor {
    * Returns true if the event is a navigation start event of a document whose URL seems valid.
    *
    * @param {LH.TraceEvent} event
+   * @return {boolean}
    */
   static _isNavigationStartOfInterest(event) {
-    return event.name === 'navigationStart' &&
-      event.args.data &&
-      event.args.data.documentLoaderURL &&
-      ACCEPTABLE_NAVIGATION_URL_REGEX.test(event.args.data.documentLoaderURL);
+    if (event.name !== 'navigationStart') return false;
+    if (!event.args.data?.documentLoaderURL) return false;
+    return ACCEPTABLE_NAVIGATION_URL_REGEX.test(event.args.data.documentLoaderURL);
   }
 
   /**

--- a/lighthouse-core/lib/tracehouse/trace-processor.js
+++ b/lighthouse-core/lib/tracehouse/trace-processor.js
@@ -466,8 +466,9 @@ class TraceProcessor {
     // If we can't find either TracingStarted event, then we'll fallback to the first navStart that
     // looks like it was loading the main frame with a real URL. Because the schema for this event
     // has changed across Chrome versions, we'll be extra defensive about finding this case.
-    const navStartEvt = events.find(e => Boolean(e.name === 'navigationStart' &&
-      e.args?.data?.isLoadingMainFrame && e.args.data.documentLoaderURL));
+    const navStartEvt = events.find(e =>
+      this._isNavigationStartOfInterest(e) && e.args.data?.isLoadingMainFrame
+    );
     // Find the first resource that was requested and make sure it agrees on the id.
     const firstResourceSendEvt = events.find(e => e.name === 'ResourceSendRequest');
     // We know that these properties exist if we found the events, but TSC doesn't.

--- a/lighthouse-core/lib/tracehouse/trace-processor.js
+++ b/lighthouse-core/lib/tracehouse/trace-processor.js
@@ -86,6 +86,9 @@ class TraceProcessor {
    */
   static _isNavigationStartOfInterest(event) {
     if (event.name !== 'navigationStart') return false;
+    // COMPAT: support pre-m67 test traces before `args.data` added to all navStart events.
+    // TODO: remove next line when old test traces (progressive-app-m60.json) are updated.
+    if (!event.args.data) return true;
     if (!event.args.data?.documentLoaderURL) return false;
     return ACCEPTABLE_NAVIGATION_URL_REGEX.test(event.args.data.documentLoaderURL);
   }

--- a/lighthouse-core/test/create-test-trace.js
+++ b/lighthouse-core/test/create-test-trace.js
@@ -81,7 +81,7 @@ function createTestTrace(options) {
     cat: 'blink.user_timing',
     args: {
       frame: rootFrame,
-      data: {documentLoaderURL: ''},
+      data: {documentLoaderURL: 'https://example.com/'},
     },
   }, {
     name: 'TracingStartedInBrowser',


### PR DESCRIPTION
Based on the description for https://github.com/GoogleChrome/lighthouse/pull/5917, it seems like we should be ignoring nav starts with falsy document url but the condition doesn't do that.

This fixed the third item in #13847 for me locally.

~Will land after #13844~