### PR TITLE
tests: temporarily disable oopif-scripts smoke for devtools

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -170,7 +170,9 @@ jobs:
       #   errors-expired-ssl errors-infinite-loop
       # Disabled because Chrome will follow the redirect first, and Lighthouse will only ever see/run the final URL.
       #   redirects-client-paint-server redirects-multiple-server redirects-single-server redirects-single-client
-      run: yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/${{ strategy.job-total }} --jobs=3 --retries=2 --invert-match a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-server redirects-single-client redirects-scripts screenshot seo-passing seo-tap-targets
+      # Disabled to fix CI while we investigate what the bug is.
+      #   oopif-scripts
+      run: yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/${{ strategy.job-total }} --jobs=3 --retries=2 --invert-match oopif-scripts a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-server redirects-single-client redirects-scripts screenshot seo-passing seo-tap-targets
       working-directory: ${{ github.workspace }}/lighthouse
 
     - name: Upload failures


### PR DESCRIPTION
We need CI to work, and investigating this further is not a high priority item currently.

ref #13847  #13861