### PR TITLE
core(fr): index test parity

### DIFF
--- a/lighthouse-core/fraggle-rock/config/filters.js
+++ b/lighthouse-core/fraggle-rock/config/filters.js
@@ -39,13 +39,12 @@ const filterResistantArtifactIds = ['HostUserAgent', 'HostFormFactor', 'Stacks',
  * categories.
  *
  * @param {LH.Config.FRConfig['categories']} allCategories
- * @param {string[] | undefined} onlyCategories
+ * @param {string[]} onlyCategories
  * @return {Set<string>}
  */
 function getAuditIdsInCategories(allCategories, onlyCategories) {
   if (!allCategories) return new Set();
 
-  onlyCategories = onlyCategories || Object.keys(allCategories);
   const categories = onlyCategories.map(categoryId => allCategories[categoryId]);
   const auditRefs = categories.flatMap(category => category?.auditRefs || []);
   return new Set(auditRefs.map(auditRef => auditRef.id));
@@ -288,7 +287,7 @@ function filterConfigByExplicitFilters(config, filters) {
 
   warnOnUnknownOnlyCategories(config.categories, onlyCategories);
 
-  let baseAuditIds = getAuditIdsInCategories(config.categories, undefined);
+  let baseAuditIds = new Set(config.audits?.map(audit => audit.implementation.meta.id));
   if (onlyCategories) {
     baseAuditIds = getAuditIdsInCategories(config.categories, onlyCategories);
   } else if (onlyAudits) {

--- a/lighthouse-core/fraggle-rock/gather/navigation-runner.js
+++ b/lighthouse-core/fraggle-rock/gather/navigation-runner.js
@@ -326,6 +326,7 @@ async function navigationGather(requestor, options) {
   const artifacts = await Runner.gather(
     async () => {
       let {page} = options;
+      const normalizedRequestor = isCallback ? requestor : URL.normalizeUrl(requestor);
 
       // For navigation mode, we shouldn't connect to a browser in audit mode,
       // therefore we connect to the browser in the gatherFn callback.
@@ -339,7 +340,7 @@ async function navigationGather(requestor, options) {
       const context = {
         driver,
         config,
-        requestor: isCallback ? requestor : URL.normalizeUrl(requestor),
+        requestor: normalizedRequestor,
         options: internalOptions,
       };
       const {baseArtifacts} = await _setup(context);

--- a/lighthouse-core/test/fraggle-rock/config/filters-test.js
+++ b/lighthouse-core/test/fraggle-rock/config/filters-test.js
@@ -502,7 +502,7 @@ describe('Fraggle Rock Config Filtering', () => {
       });
     });
 
-    it('should filter out audits and artifacts not in the categories by default', () => {
+    it('should keep audits not in any category by default', () => {
       config = {
         ...config,
         audits: [
@@ -524,6 +524,7 @@ describe('Fraggle Rock Config Filtering', () => {
           {implementation: TimespanAudit},
           {implementation: NavigationAudit},
           {implementation: ManualAudit},
+          {implementation: NavigationOnlyAudit},
         ],
       });
     });

--- a/lighthouse-core/test/index-test.js
+++ b/lighthouse-core/test/index-test.js
@@ -35,6 +35,147 @@ describe('Module Tests', function() {
     assert.notEqual(lighthouseTraceCategories.length, 0);
   });
 
+  describe('lighthouse', () => {
+    it('should throw an error when the first parameter is not defined', function() {
+      return lighthouse()
+        .then(() => {
+          throw new Error('Should not have resolved when first arg is not a string');
+        }, err => {
+          assert.ok(err);
+        });
+    });
+
+    it('should throw an error when the first parameter is an empty string', function() {
+      return lighthouse('')
+        .then(() => {
+          throw new Error('Should not have resolved when first arg is an empty string');
+        }, err => {
+          assert.ok(err);
+        });
+    });
+
+    it('should throw an error when the first parameter is not a string', function() {
+      return lighthouse({})
+        .then(() => {
+          throw new Error('Should not have resolved when first arg is not a string');
+        }, err => {
+          assert.ok(err);
+        });
+    });
+
+    it('should throw an error when the second parameter is not an object', function() {
+      return lighthouse('chrome://version', 'flags')
+        .then(() => {
+          throw new Error('Should not have resolved when second arg is not an object');
+        }, err => {
+          assert.ok(err);
+        });
+    });
+
+    it('should throw an error when the config is invalid', function() {
+      return lighthouse('chrome://version', {}, {})
+        .then(() => {
+          throw new Error('Should not have resolved when second arg is not an object');
+        }, err => {
+          assert.ok(err);
+        });
+    });
+
+    it('should throw an error when the config contains incorrect audits', function() {
+      return lighthouse('chrome://version', {}, {
+        passes: [{
+          gatherers: [
+            'script-elements',
+          ],
+        }],
+        audits: [
+          'fluff',
+        ],
+      })
+        .then(() => {
+          throw new Error('Should not have resolved');
+        }, err => {
+          assert.ok(err.message.includes('fluff'));
+        });
+    });
+
+    it('should throw an error when the url is invalid', async () => {
+      expect.hasAssertions();
+      try {
+        await lighthouse('i-am-not-valid', {}, {});
+      } catch (err) {
+        expect(err.friendlyMessage).toBe('The URL you have provided appears to be invalid.');
+        expect(err.code).toEqual('INVALID_URL');
+      }
+    });
+
+    it('should throw an error when the url is invalid protocol (file:///)', async () => {
+      expect.hasAssertions();
+      try {
+        await lighthouse('file:///a/fake/index.html', {}, {});
+      } catch (err) {
+        expect(err.friendlyMessage).toBe('The URL you have provided appears to be invalid.');
+        expect(err.code).toEqual('INVALID_URL');
+      }
+    });
+
+    it('should return formatted LHR when given no categories', function() {
+      const exampleUrl = 'https://www.reddit.com/r/nba';
+      return lighthouse(exampleUrl, {
+        output: 'html',
+      }, {
+        settings: {
+          auditMode: __dirname + '/fixtures/artifacts/perflog/',
+          formFactor: 'mobile',
+        },
+        artifacts: [
+          {id: 'MetaElements', gatherer: 'meta-elements'},
+        ],
+        audits: [
+          'viewport',
+        ],
+      }).then(results => {
+        assert.ok(/<html/.test(results.report), 'did not create html report');
+        assert.ok(results.artifacts.ViewportDimensions, 'did not set artifacts');
+        assert.ok(results.lhr.lighthouseVersion);
+        assert.ok(results.lhr.fetchTime);
+        assert.equal(results.lhr.finalUrl, exampleUrl);
+        assert.equal(results.lhr.requestedUrl, exampleUrl);
+        assert.equal(Object.values(results.lhr.categories).length, 0);
+        assert.ok(results.lhr.audits.viewport);
+        assert.strictEqual(results.lhr.audits.viewport.score, 0);
+        assert.ok(results.lhr.audits.viewport.explanation);
+        assert.ok(results.lhr.timing);
+        assert.ok(results.lhr.timing.entries.length > 3, 'timing entries not populated');
+      });
+    });
+
+    it('should specify the channel as node by default', async function() {
+      const exampleUrl = 'https://www.reddit.com/r/nba';
+      const results = await lighthouse(exampleUrl, {}, {
+        settings: {
+          auditMode: __dirname + '/fixtures/artifacts/perflog/',
+          formFactor: 'mobile',
+        },
+        audits: [],
+      });
+      assert.equal(results.lhr.configSettings.channel, 'node');
+    });
+
+    it('lets consumers pass in a custom channel', async function() {
+      const exampleUrl = 'https://www.reddit.com/r/nba';
+      const results = await lighthouse(exampleUrl, {}, {
+        settings: {
+          auditMode: __dirname + '/fixtures/artifacts/perflog/',
+          formFactor: 'mobile',
+          channel: 'custom',
+        },
+        audits: [],
+      });
+      assert.equal(results.lhr.configSettings.channel, 'custom');
+    });
+  });
+
   describe('legacyNavigation', () => {
     it('should throw an error when the first parameter is not defined', function() {
       return legacyNavigation()


### PR DESCRIPTION
Follow up to #13865 

I never copied some of the index tests for the new FR runner. This would have caught a few differences between the legacy runner and FR runner including #13863.

This PR brings back those tests for the FR runner.