### PR TITLE
wip: tests: define all trace fixtures in common module

### DIFF
--- a/lighthouse-core/test/audits/bootup-time-test.js
+++ b/lighthouse-core/test/audits/bootup-time-test.js
@@ -10,17 +10,16 @@
 import BootupTime from '../../audits/bootup-time.js';
 
 import {strict as assert} from 'assert';
-import acceptableTrace from '../fixtures/traces/progressive-app-m60.json';
-import acceptableDevtoolsLogs from '../fixtures/traces/progressive-app-m60.devtools.log.json';
 import errorTrace from '../fixtures/traces/no_fmp_event.json';
+import {pwa} from '../fixtures/fixtures.js';
 
 describe('Performance: bootup-time audit', () => {
   const auditOptions = Object.assign({}, BootupTime.defaultOptions, {thresholdInMs: 10});
 
   it('should compute the correct BootupTime values', () => {
     const artifacts = Object.assign({
-      traces: {[BootupTime.DEFAULT_PASS]: acceptableTrace},
-      devtoolsLogs: {[BootupTime.DEFAULT_PASS]: acceptableDevtoolsLogs},
+      traces: {[BootupTime.DEFAULT_PASS]: pwa.trace},
+      devtoolsLogs: {[BootupTime.DEFAULT_PASS]: pwa.devtoolsLog},
     });
     const computedCache = new Map();
 
@@ -74,8 +73,8 @@ Array [
 
   it('should compute the correct values when simulated', async () => {
     const artifacts = Object.assign({
-      traces: {defaultPass: acceptableTrace},
-      devtoolsLogs: {defaultPass: acceptableDevtoolsLogs},
+      traces: {defaultPass: pwa.trace},
+      devtoolsLogs: {defaultPass: pwa.devtoolsLog},
     });
 
     const options = auditOptions;

--- a/lighthouse-core/test/audits/diagnostics-test.js
+++ b/lighthouse-core/test/audits/diagnostics-test.js
@@ -6,16 +6,15 @@
 'use strict';
 
 import Diagnostics from '../../audits/diagnostics.js';
-import acceptableTrace from '../fixtures/traces/progressive-app-m60.json';
-import acceptableDevToolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
+import {pwa} from '../fixtures/fixtures.js';
 
 /* eslint-env jest */
 
 describe('Diagnostics audit', () => {
   it('should work', async () => {
     const artifacts = {
-      traces: {defaultPass: acceptableTrace},
-      devtoolsLogs: {defaultPass: acceptableDevToolsLog},
+      traces: {defaultPass: pwa.trace},
+      devtoolsLogs: {defaultPass: pwa.devtoolsLog},
       URL: {
         mainDocumentUrl: 'https://pwa.rocks/',
       },

--- a/lighthouse-core/test/computed/metrics/lantern-interactive-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-interactive-test.js
@@ -7,11 +7,7 @@
 
 import LanternInteractive from '../../../computed/metrics/lantern-interactive.js';
 import {strict as assert} from 'assert';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import iframeTrace from '../../fixtures/traces/iframe-m79.trace.json';
-import iframeDevtoolsLog from '../../fixtures/traces/iframe-m79.devtoolslog.json';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {iframe, pwa} from '../../fixtures/fixtures.js';
 
 /* eslint-env jest */
 
@@ -21,7 +17,7 @@ describe('Metrics: Lantern TTI', () => {
   it('should compute predicted value', async () => {
     const settings = {};
     const context = {settings, computedCache: new Map()};
-    const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
+    const {trace, devtoolsLog, URL} = pwa.devtoolsLog;
     const result = await LanternInteractive.request({trace, devtoolsLog, gatherContext,
       settings, URL}, context);
 
@@ -39,10 +35,10 @@ describe('Metrics: Lantern TTI', () => {
   it('should compute predicted value on iframes with substantial layout', async () => {
     const settings = {};
     const context = {settings, computedCache: new Map()};
-    const URL = getURLArtifactFromDevtoolsLog(iframeDevtoolsLog);
+    const {trace, devtoolsLog, URL} = iframe.devtoolsLog;
     const result = await LanternInteractive.request({
-      trace: iframeTrace,
-      devtoolsLog: iframeDevtoolsLog,
+      trace,
+      devtoolsLog,
       gatherContext,
       settings,
       URL,

--- a/lighthouse-core/test/fixtures/fixtures.js
+++ b/lighthouse-core/test/fixtures/fixtures.js
@@ -1,0 +1,22 @@
+'use strict';
+
+import pwaTrace from './traces/progressive-app-m60.json';
+import pwaDevtoolsLog from './traces/progressive-app-m60.devtools.log.json';
+import iframeTrace from './traces/iframe-m79.trace.json';
+import iframeDevtoolsLog from './traces/iframe-m79.devtoolslog.json';
+import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+
+/**
+ * @param {any} trace
+ * @param {any} devtoolsLog
+ */
+function fixture(trace, devtoolsLog) {
+  return {
+    trace: /** @type {LH.Trace} */ (trace),
+    devtoolsLog: /** @type {LH.DevtoolsLog} */ (devtoolsLog),
+    URL: getURLArtifactFromDevtoolsLog(devtoolsLog),
+  };
+}
+
+export const pwa = fixture(pwaTrace, pwaDevtoolsLog);
+export const iframe = fixture(iframeTrace, iframeDevtoolsLog);


### PR DESCRIPTION
it's pretty annoying to get the right relative path for a fixture in order to import it. if this were a named export we could autocomplete it, but we don't have that. We could get some autocomplete wins + reduce some complexity in tests if we define an exported constant for every trace fixture.