### PR TITLE
core(doctype): fix mistaken text saying name must be lowercase

### DIFF
--- a/lighthouse-core/audits/dobetterweb/doctype.js
+++ b/lighthouse-core/audits/dobetterweb/doctype.js
@@ -24,7 +24,7 @@ const UIStrings = {
   /** Explanatory message stating that the systemId field is not empty. */
   explanationSystemId: 'Expected systemId to be an empty string',
   /** Explanatory message stating that the doctype is set, but is not "html" and is therefore invalid. */
-  explanationBadDoctype: 'Doctype name must be the lowercase string `html`',
+  explanationBadDoctype: 'Doctype name must be the string `html`',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -74,9 +74,8 @@ class Doctype extends Audit {
       };
     }
 
-    /* Note that the value for name is case sensitive,
-       and must be the string `html`. For details see:
-       https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode */
+    /* Note that the casing of this property is normalized to be lowercase.
+       see: https://html.spec.whatwg.org/#doctype-name-state */
     if (doctypeName === 'html') {
       return {
         score: 1,

--- a/lighthouse-core/audits/dobetterweb/doctype.js
+++ b/lighthouse-core/audits/dobetterweb/doctype.js
@@ -56,7 +56,7 @@ class Doctype extends Audit {
     }
 
     // only set constants once we know there is a doctype
-    const doctypeName = artifacts.Doctype.name.trim();
+    const doctypeName = artifacts.Doctype.name;
     const doctypePublicId = artifacts.Doctype.publicId;
     const doctypeSystemId = artifacts.Doctype.systemId;
 

--- a/lighthouse-core/test/audits/dobetterweb/doctype-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/doctype-test.js
@@ -19,7 +19,7 @@ describe('DOBETTERWEB: doctype audit', () => {
     expect(auditResult.explanation).toBeDisplayString('Document must contain a doctype');
   });
 
-  it('fails when the value of the name attribute is a value other then lowercase "html"', () => {
+  it('fails when the value of the name attribute is a value other than "html"', () => {
     const auditResult = Audit.audit({
       Doctype: {
         name: 'xml',
@@ -29,20 +29,7 @@ describe('DOBETTERWEB: doctype audit', () => {
     });
     assert.equal(auditResult.score, 0);
     expect(auditResult.explanation).toBeDisplayString(
-      'Doctype name must be the lowercase string `html`');
-  });
-
-  it('fails when the value of the name attribute is not the lowercase string "html"', () => {
-    const auditResult = Audit.audit({
-      Doctype: {
-        name: 'HTML',
-        publicId: '',
-        systemId: '',
-      },
-    });
-    assert.equal(auditResult.score, 0);
-    expect(auditResult.explanation).toBeDisplayString(
-      'Doctype name must be the lowercase string `html`');
+      'Doctype name must be the string `html`');
   });
 
   it('fails when the publicId attribute is not an empty string', () => {

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -777,7 +777,7 @@
     "message": "Specifying a doctype prevents the browser from switching to quirks-mode. [Learn more](https://web.dev/doctype/)."
   },
   "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
-    "message": "Doctype name must be the lowercase string `html`"
+    "message": "Doctype name must be the string `html`"
   },
   "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
     "message": "Document must contain a doctype"

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -777,7 +777,7 @@
     "message": "Ŝṕêćîf́ŷín̂ǵ â d́ôćt̂ýp̂é p̂ŕêv́êńt̂ś t̂h́ê b́r̂óŵśêŕ f̂ŕôḿ ŝẃît́ĉh́îńĝ t́ô q́ûír̂ḱŝ-ḿôd́ê. [Ĺêár̂ń m̂ór̂é](https://web.dev/doctype/)."
   },
   "lighthouse-core/audits/dobetterweb/doctype.js | explanationBadDoctype": {
-    "message": "D̂óĉt́ŷṕê ńâḿê ḿûśt̂ b́ê t́ĥé l̂óŵér̂ćâśê śt̂ŕîńĝ `html`"
+    "message": "D̂óĉt́ŷṕê ńâḿê ḿûśt̂ b́ê t́ĥé ŝt́r̂ín̂ǵ `html`"
   },
   "lighthouse-core/audits/dobetterweb/doctype.js | explanationNoDoctype": {
     "message": "D̂óĉúm̂én̂t́ m̂úŝt́ ĉón̂t́âín̂ á d̂óĉt́ŷṕê"


### PR DESCRIPTION
The standard specifies that this property is normalized to a lowercased string. https://html.spec.whatwg.org/#doctype-name-state

<img width="581" alt="image" src="https://user-images.githubusercontent.com/4071474/164351930-657c2a53-891a-436e-9870-cc307d201f39.png">
