### PR TITLE
core(deprecations): drop compat for ConsoleMessages

### DIFF
--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -7,11 +7,7 @@
 
 /**
  * @fileoverview Audits a page to determine if it is calling deprecated APIs.
- * This is done by collecting console log messages and filtering them by ones
- * that contain deprecated API warnings sent by Chrome.
  */
-
-// TODO: when M97 is sufficiently old, drop support for console messages
 
 const Audit = require('./audit.js');
 const JsBundles = require('../computed/js-bundles.js');
@@ -48,7 +44,7 @@ class Deprecations extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      requiredArtifacts: ['ConsoleMessages', 'InspectorIssues', 'SourceMaps', 'Scripts'],
+      requiredArtifacts: ['InspectorIssues', 'SourceMaps', 'Scripts'],
     };
   }
 
@@ -58,32 +54,17 @@ class Deprecations extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static async audit(artifacts, context) {
-    const entries = artifacts.ConsoleMessages;
     const bundles = await JsBundles.request(artifacts, context);
 
-    let deprecations;
-    if (artifacts.InspectorIssues.deprecationIssue.length) {
-      deprecations = artifacts.InspectorIssues.deprecationIssue
-        .map(deprecation => {
-          const {scriptId, url, lineNumber, columnNumber} = deprecation.sourceCodeLocation;
-          const bundle = bundles.find(bundle => bundle.script.scriptId === scriptId);
-          return {
-            value: deprecation.message || '',
-            // Protocol.Audits.SourceCodeLocation.columnNumber is 1-indexed, but we use 0-indexed.
-            source: Audit.makeSourceLocation(url, lineNumber, columnNumber - 1, bundle),
-          };
-        });
-    } else {
-      // Backcompat for <M97.
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=1248484
-      deprecations = entries.filter(log => log.source === 'deprecation')
-        .map(log => {
-          return {
-            value: log.text,
-            source: Audit.makeSourceLocationFromConsoleMessage(log),
-          };
-        });
-    }
+    const deprecations = artifacts.InspectorIssues.deprecationIssue.map(deprecation => {
+      const {scriptId, url, lineNumber, columnNumber} = deprecation.sourceCodeLocation;
+      const bundle = bundles.find(bundle => bundle.script.scriptId === scriptId);
+      return {
+        value: deprecation.message || '',
+        // Protocol.Audits.SourceCodeLocation.columnNumber is 1-indexed, but we use 0-indexed.
+        source: Audit.makeSourceLocation(url, lineNumber, columnNumber - 1, bundle),
+      };
+    });
 
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [

--- a/lighthouse-core/test/audits/deprecations-test.js
+++ b/lighthouse-core/test/audits/deprecations-test.js
@@ -10,11 +10,10 @@ const assert = require('assert').strict;
 
 /* eslint-env jest */
 
-describe('ConsoleMessages deprecations audit', () => {
-  it('passes when no console messages were found', async () => {
+describe('Deprecations audit', () => {
+  it('passes when no deprecations were found', async () => {
     const context = {computedCache: new Map()};
     const auditResult = await DeprecationsAudit.audit({
-      ConsoleMessages: [],
       InspectorIssues: {deprecationIssue: []},
       SourceMaps: [],
       Scripts: [],
@@ -23,72 +22,11 @@ describe('ConsoleMessages deprecations audit', () => {
     assert.equal(auditResult.details.items.length, 0);
   });
 
-  it('handles deprecations that do not have url or line numbers', async () => {
-    const context = {computedCache: new Map()};
-    const auditResult = await DeprecationsAudit.audit({
-      ConsoleMessages: [
-        {
-          source: 'deprecation',
-          text: 'Deprecation message',
-        },
-      ],
-      InspectorIssues: {deprecationIssue: []},
-      SourceMaps: [],
-      Scripts: [],
-    }, context);
-    assert.equal(auditResult.score, 0);
-    expect(auditResult.displayValue).toBeDisplayString('1 warning found');
-    assert.equal(auditResult.details.items.length, 1);
-    assert.equal(auditResult.details.items[0].source, undefined);
-  });
-
-  it('fails when deprecation messages are found (ConsoleMessages)', async () => {
-    const URL = 'http://example.com';
-
-    const context = {computedCache: new Map()};
-    const auditResult = await DeprecationsAudit.audit({
-      ConsoleMessages: [
-        {
-          source: 'deprecation',
-          lineNumber: 123,
-          url: URL,
-          text: 'Deprecation message 123',
-        }, {
-          source: 'deprecation',
-          lineNumber: 456,
-          url: 'http://example2.com',
-          text: 'Deprecation message 456',
-        }, {
-          source: 'somethingelse',
-          lineNumber: 789,
-          url: 'http://example3.com',
-          text: 'Not a deprecation message 789',
-        },
-      ],
-      InspectorIssues: {deprecationIssue: []},
-      SourceMaps: [],
-      Scripts: [],
-    }, context);
-    assert.equal(auditResult.score, 0);
-    expect(auditResult.displayValue).toBeDisplayString('2 warnings found');
-    assert.equal(auditResult.details.items.length, 2);
-    assert.equal(auditResult.details.items[0].source.url, URL);
-    assert.equal(auditResult.details.items[0].source.line, 123);
-  });
-
   it('fails when deprecation messages are found', async () => {
     const URL = 'http://example.com';
 
     const context = {computedCache: new Map()};
     const auditResult = await DeprecationsAudit.audit({
-      ConsoleMessages: [
-        {
-          source: 'deprecation',
-          lineNumber: 456,
-          url: 'http://example2.com',
-          text: 'Ignore me b/c there are InspectorIssues',
-        },
-      ],
       InspectorIssues: {
         deprecationIssue: [
           {


### PR DESCRIPTION
This was needed for M97, but that's old enough now. I saw a failure in deprecations smoke test today (unrelated) and I noticed we can delete this now.