### PR TITLE
deps(devtools-protocol): upgrade to 0.0.995287

### DIFF
--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -66,7 +66,6 @@ class Deprecations extends Audit {
       deprecations = artifacts.InspectorIssues.deprecationIssue
         // TODO: translate these strings.
         // see https://github.com/GoogleChrome/lighthouse/issues/13895
-        // @ts-expect-error: .type hasn't released to npm yet
         .filter(deprecation => !deprecation.type || deprecation.type === 'Untranslated')
         .map(deprecation => {
           const {scriptId, url, lineNumber, columnNumber} = deprecation.sourceCodeLocation;

--- a/lighthouse-core/test/gather/gatherers/inspector-issues-test.js
+++ b/lighthouse-core/test/gather/gatherers/inspector-issues-test.js
@@ -142,6 +142,7 @@ function mockDeprecation(text) {
       deprecationIssueDetails: {
         message: text,
         deprecationType: 'test',
+        type: 'Untranslated',
         sourceCodeLocation: {
           url: 'https://www.example.com',
           lineNumber: 10,

--- a/lighthouse-core/test/gather/gatherers/inspector-issues-test.js
+++ b/lighthouse-core/test/gather/gatherers/inspector-issues-test.js
@@ -239,6 +239,7 @@ describe('_getArtifact', () => {
           columnNumber: 10,
           lineNumber: 10,
         },
+        type: 'Untranslated',
       }],
       attributionReportingIssue: [],
       clientHintIssue: [],

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "cpy": "^8.1.2",
     "cross-env": "^7.0.2",
     "csv-validator": "^0.0.3",
-    "devtools-protocol": "0.0.975298",
+    "devtools-protocol": "0.0.995287",
     "es-main": "^1.0.2",
     "eslint": "^8.4.1",
     "eslint-config-google": "^0.14.0",
@@ -210,8 +210,8 @@
     "yargs-parser": "^21.0.0"
   },
   "resolutions": {
-    "puppeteer/**/devtools-protocol": "0.0.975298",
-    "puppeteer-core/**/devtools-protocol": "0.0.975298"
+    "puppeteer/**/devtools-protocol": "0.0.995287",
+    "puppeteer-core/**/devtools-protocol": "0.0.995287"
   },
   "repository": "GoogleChrome/lighthouse",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,10 +3189,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-devtools-protocol@0.0.901419, devtools-protocol@0.0.975298:
-  version "0.0.975298"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.975298.tgz#b134e8c98324f12bb57ad660639e73bc77649821"
-  integrity sha512-RNQxbC4gOlaojOPc47YJvwhx9LsmVBBgmCw0BoNRnC2Q83wqMuc/nJd+jeXQe0kcu+R2O6f83OmaE+gUejQQOw==
+devtools-protocol@0.0.901419, devtools-protocol@0.0.995287:
+  version "0.0.995287"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.995287.tgz#843a846cff79d0f76a74818ec2d604a4fe90c2d0"
+  integrity sha512-HvTDDBKzY5ojCNmxAF+N+kZGQsl+hPZPIaWpG0q1BMuvUHdRwL4IrGKIH+avNLzCrImi/kKYDnsmZi7jjm0xlw==
 
 diff-sequences@^27.4.0:
   version "27.4.0"


### PR DESCRIPTION
New types used for #13896 but the devtools-protocol package publish was broken. It's since been fixed.