### PR TITLE
tests(crq): call setExtrasFn before using the urls

### DIFF
--- a/lighthouse-core/test/computed/critical-request-chains-test.js
+++ b/lighthouse-core/test/computed/critical-request-chains-test.js
@@ -20,7 +20,7 @@ const MEDIUM = 'Medium';
 const LOW = 'Low';
 const VERY_LOW = 'VeryLow';
 
-async function createChainsFromMockRecords(prioritiesList, edges, setExtrasFn) {
+async function createChainsFromMockRecords(prioritiesList, edges, setExtrasFn, reverseRecords) {
   const networkRecords = prioritiesList.map((priority, index) => ({
     requestId: index.toString(),
     url: 'https://www.example.com/' + index,
@@ -36,6 +36,8 @@ async function createChainsFromMockRecords(prioritiesList, edges, setExtrasFn) {
     endTime: index + 1,
   }));
 
+  if (setExtrasFn) setExtrasFn(networkRecords);
+
   // add mock initiator information
   edges.forEach(edge => {
     const initiatorRequest = networkRecords[edge[0]];
@@ -45,7 +47,7 @@ async function createChainsFromMockRecords(prioritiesList, edges, setExtrasFn) {
     };
   });
 
-  if (setExtrasFn) setExtrasFn(networkRecords);
+  if (reverseRecords) networkRecords.reverse();
 
   const docUrl = networkRecords
     .find(r => r.resourceType === 'Document' && r.frameId === 1)
@@ -377,10 +379,8 @@ describe('CriticalRequestChain computed artifact', () => {
     const {networkRecords, criticalChains} = await createChainsFromMockRecords(
       [HIGH, HIGH],
       [[0, 1]],
-      networkRecords => {
-        // Reverse the records so we force nodes to be made early.
-        networkRecords.reverse();
-      }
+      undefined,
+      true // Reverse the records so we force nodes to be made early.
     );
     assert.deepEqual(criticalChains, {
       0: {


### PR DESCRIPTION
The helper function `createChainsFromMockRecords` takes a function `setExtrasFn` which modifies the network records made by default. Many tests will modify the urls, but the helper function uses the default url values when building the graph initiators (this is the old code):

<img width="476" alt="image" src="https://user-images.githubusercontent.com/4071474/165195988-69b6ace0-cafd-4676-8e83-896f56b14c1c.png">


This didn't seem to prevent any tests from working, but it was unexpected (I was debugging something by looking at the generated devtools log and found the mismatch of urls here odd).

One test did break from this, and I really don't understand it... so I opted to resolve the breakage by introducing a boolean parameter to this function to recreate the previous bad behavior.