### PR TITLE
tests: default to chrome-launcher path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-all
 
+    # Run pptr tests using ToT Chrome instead of stable default.
+    - name: Define ToT chrome path
+      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
+    - name: Install Chrome ToT
+      working-directory: /home/runner
+      run: bash $GITHUB_WORKSPACE/lighthouse-core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
+
     # Run tests that require headfull Chrome.
     - run: sudo apt-get install xvfb
     - name: yarn test-clients

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-all
 
-    - name: Define ToT chrome path
-      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
-    - name: Install Chrome ToT
-      working-directory: /home/runner
-      run: bash $GITHUB_WORKSPACE/lighthouse-core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
-
     # Run tests that require headfull Chrome.
     - run: sudo apt-get install xvfb
     - name: yarn test-clients

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -46,6 +46,13 @@ jobs:
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
 
+    # Run pptr tests using ToT Chrome instead of stable default.
+    - name: Define ToT chrome path
+      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
+    - name: Install Chrome ToT
+      working-directory: /home/runner
+      run: bash $GITHUB_WORKSPACE/lighthouse-core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
+
     - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
 
     - run: sudo apt-get install xvfb

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -46,12 +46,6 @@ jobs:
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
 
-    - name: Define ToT chrome path
-      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
-    - name: Install Chrome ToT
-      working-directory: /home/runner
-      run: bash $GITHUB_WORKSPACE/lighthouse-core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
-
     - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
 
     - run: sudo apt-get install xvfb

--- a/clients/test/extension/popup-test-pptr.js
+++ b/clients/test/extension/popup-test-pptr.js
@@ -9,6 +9,7 @@
 
 const path = require('path');
 const puppeteer = require('puppeteer-core');
+const {getChromePath} = require('chrome-launcher');
 const {DEFAULT_CATEGORIES, STORAGE_KEYS} =
   require('../../extension/scripts/settings-controller.js');
 const {LH_ROOT} = require('../../../root.js');
@@ -40,7 +41,7 @@ describe('Lighthouse chrome popup', function() {
     // start puppeteer
     browser = await puppeteer.launch({
       headless: false,
-      executablePath: process.env.CHROME_PATH,
+      executablePath: getChromePath(),
     });
 
     page = await browser.newPage();

--- a/lighthouse-core/scripts/benchmark-plus-extras.js
+++ b/lighthouse-core/scripts/benchmark-plus-extras.js
@@ -12,6 +12,7 @@
 /* global document */
 
 import puppeteer from 'puppeteer-core';
+import {getChromePath} from 'chrome-launcher';
 
 import pageFunctions from '../lib/page-functions.js';
 
@@ -73,7 +74,7 @@ async function main() {
   process.stdout.write(`Launching Chrome...\n`);
   const browser = await puppeteer.launch({
     headless: true,
-    executablePath: process.env.CHROME_PATH,
+    executablePath: getChromePath(),
   });
 
   const page = await browser.newPage();

--- a/lighthouse-core/scripts/pptr-run-devtools.js
+++ b/lighthouse-core/scripts/pptr-run-devtools.js
@@ -28,6 +28,7 @@ import {fileURLToPath} from 'url';
 import puppeteer from 'puppeteer-core';
 import yargs from 'yargs';
 import * as yargsHelpers from 'yargs/helpers';
+import {getChromePath} from 'chrome-launcher';
 
 import {parseChromeFlags} from '../../lighthouse-cli/run.js';
 
@@ -316,7 +317,7 @@ async function run() {
   }
 
   const browser = await puppeteer.launch({
-    executablePath: process.env.CHROME_PATH,
+    executablePath: getChromePath(),
     args: chromeFlags,
     devtools: true,
   });

--- a/lighthouse-core/scripts/update-flow-fixtures.js
+++ b/lighthouse-core/scripts/update-flow-fixtures.js
@@ -13,6 +13,7 @@ import open from 'open';
 import waitForExpect from 'wait-for-expect';
 import puppeteer from 'puppeteer-core';
 import yargs from 'yargs';
+import {getChromePath} from 'chrome-launcher';
 
 import {LH_ROOT} from '../../root.js';
 import api from '../fraggle-rock/api.js';
@@ -83,7 +84,7 @@ const config = {
 async function rebaselineArtifacts(artifactKeys) {
   const browser = await puppeteer.launch({
     ignoreDefaultArgs: ['--enable-automation'],
-    executablePath: process.env.CHROME_PATH,
+    executablePath: getChromePath(),
     headless: false,
   });
 

--- a/lighthouse-core/scripts/update-snapshot-sample.js
+++ b/lighthouse-core/scripts/update-snapshot-sample.js
@@ -7,6 +7,7 @@
 import fs from 'fs';
 
 import puppeteer from 'puppeteer-core';
+import {getChromePath} from 'chrome-launcher';
 
 import {LH_ROOT} from '../../root.js';
 import {snapshot} from '../fraggle-rock/api.js';
@@ -14,7 +15,7 @@ import {snapshot} from '../fraggle-rock/api.js';
 (async () => {
   const browser = await puppeteer.launch({
     ignoreDefaultArgs: ['--enable-automation'],
-    executablePath: process.env.CHROME_PATH,
+    executablePath: getChromePath(),
     headless: false,
   });
   const page = await browser.newPage();

--- a/lighthouse-core/test/fraggle-rock/scenarios/pptr-test-utils.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/pptr-test-utils.js
@@ -7,6 +7,7 @@
 
 import {beforeAll, beforeEach, afterAll, afterEach} from '@jest/globals';
 import puppeteer from 'puppeteer-core';
+import {getChromePath} from 'chrome-launcher';
 import {Server} from '../../../../lighthouse-cli/test/fixtures/static-server.js';
 
 /** @typedef {InstanceType<typeof import('../../../../lighthouse-cli/test/fixtures/static-server.js').Server>} StaticServer */
@@ -40,7 +41,7 @@ export function createTestState() {
         this.serverBaseUrl = `http://localhost:${this.server.getPort()}`;
         this.browser = await puppeteer.launch({
           headless: true,
-          executablePath: process.env.CHROME_PATH,
+          executablePath: getChromePath(),
         });
       });
 


### PR DESCRIPTION
If you don't have `CHROME_PATH` set locally, running `api-test-pptr` and `disconnect-test-pptr` fails because a Chrome can't be found for puppeteer to use. Using `chrome-launcher`'s `getChromePath()` will let a Chrome already installed on the system be used, and it still defaults to `CHROME_PATH` if it's set.