### PR TITLE
core(trace): use tracing-started event for frame tree info

### DIFF
--- a/lighthouse-core/lib/tracehouse/trace-processor.js
+++ b/lighthouse-core/lib/tracehouse/trace-processor.js
@@ -630,7 +630,7 @@ class TraceProcessor {
     }
 
     // Update known frames if FrameCommittedInBrowser events come in, typically
-    // with updated `url` (as well as pid, etc). Some traces (like timespans) may
+    // with updated `url`, as well as pid, etc. Some traces (like timespans) may
     // not have any committed frames.
     keyEvents
       .filter(/** @return {evt is FrameCommittedEvent} */ evt => {
@@ -653,18 +653,18 @@ class TraceProcessor {
     const frameEvents = keyEvents.filter(e => e.args.frame === mainFrameIds.frameId);
 
     // Filter to just events matching the main frame ID or any child frame IDs.
-    // In practice, there should always be FrameCommittedInBrowser events to define the frame tree.
-    // Unfortunately, many test traces do not include FrameCommittedInBrowser events due to minification.
-    // This ensures there is always a minimal frame tree and events so those tests don't fail.
     let frameTreeEvents = [];
     if (frameIdToRootFrameId.has(mainFrameIds.frameId)) {
       frameTreeEvents = keyEvents.filter(e => {
         return e.args.frame && frameIdToRootFrameId.get(e.args.frame) === mainFrameIds.frameId;
       });
     } else {
+      // In practice, there should always be TracingStartedInBrowser/FrameCommittedInBrowser events to
+      // define the frame tree. Unfortunately, many test traces do not that frame info due to minification.
+      // This ensures there is always a minimal frame tree and events so those tests don't fail.
       log.warn(
         'trace-of-tab',
-        'frameTreeEvents may be incomplete, make sure the trace has FrameCommittedInBrowser events'
+        'frameTreeEvents may be incomplete, make sure the trace has frame events'
       );
       frameIdToRootFrameId.set(mainFrameIds.frameId, mainFrameIds.frameId);
       frameTreeEvents = frameEvents;

--- a/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
+++ b/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
@@ -304,7 +304,6 @@ describe('Metrics: CLS', () => {
         const cat = 'loading,rail,devtools.timeline';
         trace.traceEvents.push(
           /* eslint-disable max-len */
-          {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: mainFrame, url: 'https://example.com'}}},
           {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: childFrame, parent: mainFrame, url: 'https://frame.com'}}},
           {name: 'FrameCommittedInBrowser', cat, args: {data: {frame: otherMainFrame, url: 'https://example.com'}}},
           {name: 'LayoutShift', cat, args: {frame: mainFrame, data: {had_recent_input: false, score: 1, weighted_score_delta: 1, is_main_frame: true}}},

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -7850,7 +7850,7 @@
             "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn more](https://web.dev/bootup-time/).",
             "score": 1,
             "scoreDisplayMode": "numeric",
-            "numericValue": 274.5320000000002,
+            "numericValue": 275.90400000000034,
             "numericUnit": "millisecond",
             "displayValue": "0.3 s",
             "details": {
@@ -7882,20 +7882,26 @@
               ],
               "items": [
                 {
+                  "url": "https://www.mikescerealshack.co/",
+                  "total": 298.1560000000002,
+                  "scripting": 115.99500000000005,
+                  "scriptParseCompile": 0
+                },
+                {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/framework.9d524150d48315f49e80.js",
-                  "total": 340.90100000000024,
-                  "scripting": 254.67600000000022,
+                  "total": 169.22000000000028,
+                  "scripting": 150.88400000000027,
                   "scriptParseCompile": 0
                 },
                 {
                   "url": "Unattributable",
-                  "total": 237.62699999999987,
-                  "scripting": 19.855999999999998,
+                  "total": 114.66900000000017,
+                  "scripting": 9.024999999999997,
                   "scriptParseCompile": 0
                 }
               ],
               "summary": {
-                "wastedMs": 274.5320000000002
+                "wastedMs": 275.90400000000034
               }
             }
           },
@@ -8537,12 +8543,12 @@
               ],
               "items": [
                 {
-                  "url": "https://www.mikescerealshack.co/_next/static/chunks/framework.9d524150d48315f49e80.js",
+                  "url": "https://www.mikescerealshack.co/",
                   "duration": 75.734,
                   "startTime": 1765.511
                 },
                 {
-                  "url": "https://www.mikescerealshack.co/_next/static/chunks/framework.9d524150d48315f49e80.js",
+                  "url": "https://www.mikescerealshack.co/",
                   "duration": 55.073,
                   "startTime": 11.328
                 }
@@ -10099,7 +10105,7 @@
               },
               {
                 "values": {
-                  "timeInMs": 274.5320000000002
+                  "timeInMs": 275.90400000000034
                 },
                 "path": "audits[bootup-time].displayValue"
               }

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -961,6 +961,7 @@ export interface TraceEvent {
       documentLoaderURL?: string;
       frames?: {
         frame: string;
+        url: string;
         parent?: string;
         processId?: number;
       }[];


### PR DESCRIPTION
Part of the responsiveness in timespans implementation.

We've previously relied on `FrameCommittedEvent`s to generate our knowledge of the frame tree, but for traces without navigations (like in a timespan), there typically aren't any `FrameCommittedEvent`s generated because all the frames are already around. As a result, metric events from outside of the main frame wouldn't be included.

`TracingStartedInBrowser` events also have frame tree information, but for a typical navigation the main frame URL will change (from `about:blank` to the test url) and child frames won't be known at all, so that frame tree is useless for cross-frame metrics in navigations.

This PR combines the two sources, starting with the set from `TracingStartedInBrowser` and updating as `FrameCommittedEvent`s come in (if they do). Navigationful and navigationless traces should now have their frame tree correctly figured out.

No test changes were needed for all the existing cross-frame tests, and I verified that for all existing tests the set of frames found in the trace are the same before and after this change. This PR includes a test that would fail without this change, but an upcoming PR with the responsiveness metric (edit: #13917) will add a real timespan trace that fails without this change.