### PR TITLE
deps(lodash): use individual lodash modules to reduce bundle size

### DIFF
--- a/lighthouse-cli/test/smokehouse/frontends/lib.js
+++ b/lighthouse-cli/test/smokehouse/frontends/lib.js
@@ -12,12 +12,10 @@
 
 /* eslint-disable no-console */
 
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep.js';
 
 import smokeTests from '../core-tests.js';
 import {runSmokehouse, getShardedDefinitions} from '../smokehouse.js';
-
-const {cloneDeep} = _;
 
 /**
  * @param {Smokehouse.SmokehouseLibOptions} options

--- a/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
+++ b/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
@@ -16,7 +16,7 @@ import path from 'path';
 import fs from 'fs';
 import url from 'url';
 
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep.js';
 import yargs from 'yargs';
 import * as yargsHelpers from 'yargs/helpers';
 import log from 'lighthouse-logger';
@@ -24,8 +24,6 @@ import log from 'lighthouse-logger';
 import {runSmokehouse, getShardedDefinitions} from '../smokehouse.js';
 import {updateTestDefnFormat} from './back-compat-util.js';
 import {LH_ROOT} from '../../../../root.js';
-
-const {cloneDeep} = _;
 
 const coreTestDefnsPath =
   path.join(LH_ROOT, 'lighthouse-cli/test/smokehouse/core-tests.js');

--- a/lighthouse-cli/test/smokehouse/report-assert.js
+++ b/lighthouse-cli/test/smokehouse/report-assert.js
@@ -9,13 +9,11 @@
  * against the results actually collected from Lighthouse.
  */
 
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep.js';
 import log from 'lighthouse-logger';
 
 import {LocalConsole} from './lib/local-console.js';
 import {chromiumVersionCheck} from './version-check.js';
-
-const {cloneDeep} = _;
 
 /**
  * @typedef Difference

--- a/lighthouse-core/config/config-helpers.js
+++ b/lighthouse-core/config/config-helpers.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const path = require('path');
-const {isEqual: isDeepEqual} = require('lodash');
+const isDeepEqual = require('lodash/isEqual.js');
 const constants = require('./constants.js');
 const Budget = require('./budget.js');
 const ConfigPlugin = require('./config-plugin.js');

--- a/lighthouse-core/fraggle-rock/gather/base-artifacts.js
+++ b/lighthouse-core/fraggle-rock/gather/base-artifacts.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const log = require('lighthouse-logger');
-const {isEqual} = require('lodash');
+const isDeepEqual = require('lodash/isEqual.js');
 const {
   getBrowserVersion,
   getBenchmarkIndex,
@@ -61,7 +61,7 @@ function deduplicateWarnings(warnings) {
   const unique = [];
 
   for (const warning of warnings) {
-    if (unique.some(existing => isEqual(warning, existing))) continue;
+    if (unique.some(existing => isDeepEqual(warning, existing))) continue;
     unique.push(warning);
   }
 

--- a/lighthouse-core/lib/arbitrary-equality-map.js
+++ b/lighthouse-core/lib/arbitrary-equality-map.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const {isEqual} = require('lodash');
+const isDeepEqual = require('lodash/isEqual.js');
 
 /**
  * @fileoverview This class is designed to allow maps with arbitrary equality functions.
@@ -74,7 +74,7 @@ class ArbitraryEqualityMap {
    * @return {boolean}
    */
   static deepEquals(objA, objB) {
-    return isEqual(objA, objB);
+    return isDeepEqual(objA, objB);
   }
 }
 

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const {isEqual: isDeepEqual} = require('lodash');
+const isDeepEqual = require('lodash/isEqual.js');
 const Driver = require('./gather/driver.js');
 const GatherRunner = require('./gather/gather-runner.js');
 const ReportScoring = require('./scoring.js');

--- a/shared/localization/swap-locale.js
+++ b/shared/localization/swap-locale.js
@@ -5,7 +5,8 @@
  */
 'use strict';
 
-const {set: _set, get: _get} = require('lodash');
+const _set = require('lodash/set.js');
+const _get = require('lodash/get.js');
 
 const format = require('./format.js');
 

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -10,7 +10,6 @@
     "module": "es2020",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
 
     "allowJs": true,
     "checkJs": true,

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -10,6 +10,7 @@
     "module": "es2020",
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
 
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
#13695 replaced our individual lodash packages with the whole lodash package, but we relied on treeshaking to keep the bundle small which didn't work because lodash's main module is a big IIFE.

Instead we can import individual modules. In hindsight, that's why lodash stopped publishing individual packages. Because you can just reach in and grab whatever you want.

### devtools bundle size

before: 1705114
after: 1631433
~70KB less