### PR TITLE
tests(smoke): realign byte ranges

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/byte-efficiency.js
@@ -187,24 +187,24 @@ const expectations = {
           items: [
             {
               url: 'http://localhost:10200/byte-efficiency/script.js',
-              wastedBytes: '46481 +/- 100',
+              wastedBytes: '46555 +/- 100',
               wastedPercent: '87 +/- 5',
             },
             {
               // /some-custom-url.js,
               url: 'inline: \n  function unusedFunction() {\n    // Un...',
-              wastedBytes: '6700 +/- 100',
+              wastedBytes: '6690 +/- 100',
               wastedPercent: '99.6 +/- 0.1',
             },
             {
               url: 'inline: \n  // Used block #1\n  // FILLER DATA JUS...',
-              wastedBytes: '6563 +/- 100',
+              wastedBytes: '6569 +/- 100',
               wastedPercent: 100,
             },
             {
               url: 'http://localhost:10200/byte-efficiency/bundle.js',
-              totalBytes: '13000 +/- 1000',
-              wastedBytes: '2350 +/- 100',
+              totalBytes: '12962 +/- 1000',
+              wastedBytes: '2349 +/- 100',
               wastedPercent: '19 +/- 5',
             },
           ],

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf-budgets.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf-budgets.js
@@ -65,13 +65,13 @@ const expectations = {
         displayValue: '10 requests • 165 KiB',
         details: {
           items: [
-            {resourceType: 'total', requestCount: 10, transferSize: '168000±1000'},
-            {resourceType: 'font', requestCount: 2, transferSize: '81000±1000'},
-            {resourceType: 'script', requestCount: 3, transferSize: '55000±1000'},
-            {resourceType: 'image', requestCount: 2, transferSize: '28000±1000'},
-            {resourceType: 'document', requestCount: 1, transferSize: '2200±150'},
-            {resourceType: 'other', requestCount: 1, transferSize: '1030±100'},
-            {resourceType: 'stylesheet', requestCount: 1, transferSize: '450±100'},
+            {resourceType: 'total', requestCount: 10, transferSize: '168521±1000'},
+            {resourceType: 'font', requestCount: 2, transferSize: '81096±1000'},
+            {resourceType: 'script', requestCount: 3, transferSize: '55170±1000'},
+            {resourceType: 'image', requestCount: 2, transferSize: '28359±1000'},
+            {resourceType: 'document', requestCount: 1, transferSize: '2283±150'},
+            {resourceType: 'other', requestCount: 1, transferSize: '1085±100'},
+            {resourceType: 'stylesheet', requestCount: 1, transferSize: '528±100'},
             {resourceType: 'media', requestCount: 0, transferSize: 0},
             {resourceType: 'third-party', requestCount: 0, transferSize: 0},
           ],
@@ -85,27 +85,27 @@ const expectations = {
             {
               resourceType: 'total',
               countOverBudget: '2 requests',
-              sizeOverBudget: '66000±1000',
+              sizeOverBudget: '66121±1000',
             },
             {
               resourceType: 'script',
               countOverBudget: '2 requests',
-              sizeOverBudget: '25000±1000',
+              sizeOverBudget: '24450±1000',
             },
             {
               resourceType: 'font',
               countOverBudget: undefined,
-              sizeOverBudget: '4000±500',
+              sizeOverBudget: '4296±500',
             },
             {
               resourceType: 'document',
               countOverBudget: '1 request',
-              sizeOverBudget: '1250±50',
+              sizeOverBudget: '1259±50',
             },
             {
               resourceType: 'stylesheet',
               countOverBudget: undefined,
-              sizeOverBudget: '450±100',
+              sizeOverBudget: '528±100',
             },
             {
               resourceType: 'image',


### PR DESCRIPTION
Values had shifted just enough for failures in LR smokerider.

(reminder: these byte values differ slightly in LR because we use a different version of node, which has different headers, and headers are counted as part of the resource size. see cl/379821904)