### PR TITLE
tests: replace $0 in cli-flag snapshots

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/cli-flags-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/cli-flags-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CLI flags array values do not support csv when appropriate 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],
@@ -48,7 +48,7 @@ Object {
 
 exports[`CLI flags array values support csv when appropriate 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],
@@ -100,7 +100,7 @@ Object {
 
 exports[`CLI flags extraHeaders should convert extra headers to object 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],
@@ -140,7 +140,7 @@ Object {
 
 exports[`CLI flags extraHeaders should read extra headers from file 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],
@@ -182,7 +182,7 @@ Object {
 
 exports[`CLI flags screenEmulation deviceScaleFactor parses a non-integer numeric value 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],
@@ -230,7 +230,7 @@ Object {
 
 exports[`CLI flags screenEmulation disabled parses the flag with no value as true 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],
@@ -278,7 +278,7 @@ Object {
 
 exports[`CLI flags screenEmulation mobile parses the flag with no value as true 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],
@@ -326,7 +326,7 @@ Object {
 
 exports[`CLI flags screenEmulation width parses a number value 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],
@@ -374,7 +374,7 @@ Object {
 
 exports[`CLI flags settings are accepted from a file path (inlined budgets) 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],
@@ -415,7 +415,7 @@ Object {
 
 exports[`CLI flags settings are accepted from a file path 1`] = `
 Object {
-  "$0": "node_modules/jest/bin/jest.js",
+  "$0": "__REPLACED__",
   "_": Array [
     "http://www.example.com",
   ],

--- a/lighthouse-cli/test/cli/cli-flags-test.js
+++ b/lighthouse-cli/test/cli/cli-flags-test.js
@@ -30,6 +30,9 @@ function snapshot(flags) {
         .replace(/\\/g, '/');
     }
   }
+  // Command changes depending on how test was run, so remove.
+  // @ts-expect-error - '$0' not in CliFlags type.
+  flags.$0 = '__REPLACED__';
 
   expect(flags).toMatchSnapshot();
 }


### PR DESCRIPTION
fixes #13875

The command to run tests changes depending on how you invoke jest, but is completely irrelevant to `cli-flags` parsing, so it can just be removed.