### PR TITLE
core(listitem): mention li can be contained by a menu

### DIFF
--- a/lighthouse-core/audits/accessibility/listitem.js
+++ b/lighthouse-core/audits/accessibility/listitem.js
@@ -15,13 +15,13 @@ const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
   /** Title of an accesibility audit that evaluates if any list item elements do not have list parent elements. This title is descriptive of the successful state and is shown to users when no user action is required. */
-  title: 'List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements',
+  title: 'List items (`<li>`) are contained within `<ul>`, `<ol>` or `<menu>` parent elements',
   /** Title of an accesibility audit that evaluates if any list item elements do not have list parent elements. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
-  failureTitle: 'List items (`<li>`) are not contained within `<ul>` ' +
-      'or `<ol>` parent elements.',
+  failureTitle: 'List items (`<li>`) are not contained within `<ul>`, ' +
+      '`<ol>` or `<menu>` parent elements.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Screen readers require list items (`<li>`) to be contained within a ' +
-      'parent `<ul>` or `<ol>` to be announced properly. ' +
+      'parent `<ul>`, `<ol>` or `<menu>` to be announced properly. ' +
       '[Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem).',
 };
 

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -2742,8 +2742,8 @@
           },
           "listitem": {
             "id": "listitem",
-            "title": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements",
-            "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem).",
+            "title": "List items (`<li>`) are contained within `<ul>`, `<ol>` or `<menu>` parent elements",
+            "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>`, `<ol>` or `<menu>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem).",
             "score": 1,
             "scoreDisplayMode": "binary",
             "details": {
@@ -11726,8 +11726,8 @@
           },
           "listitem": {
             "id": "listitem",
-            "title": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements",
-            "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem).",
+            "title": "List items (`<li>`) are contained within `<ul>`, `<ol>` or `<menu>` parent elements",
+            "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>`, `<ol>` or `<menu>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem).",
             "score": 1,
             "scoreDisplayMode": "binary",
             "details": {
@@ -16757,8 +16757,8 @@
           },
           "listitem": {
             "id": "listitem",
-            "title": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements",
-            "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem).",
+            "title": "List items (`<li>`) are contained within `<ul>`, `<ol>` or `<menu>` parent elements",
+            "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>`, `<ol>` or `<menu>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem).",
             "score": 1,
             "scoreDisplayMode": "binary",
             "details": {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -4049,8 +4049,8 @@
     },
     "listitem": {
       "id": "listitem",
-      "title": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements",
-      "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem).",
+      "title": "List items (`<li>`) are contained within `<ul>`, `<ol>` or `<menu>` parent elements",
+      "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>`, `<ol>` or `<menu>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem).",
       "score": null,
       "scoreDisplayMode": "notApplicable"
     },

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -450,13 +450,13 @@
     "message": "Lists contain only `<li>` elements and script supporting elements (`<script>` and `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem)."
+    "message": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>`, `<ol>` or `<menu>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/4.4/listitem)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "List items (`<li>`) are not contained within `<ul>` or `<ol>` parent elements."
+    "message": "List items (`<li>`) are not contained within `<ul>`, `<ol>` or `<menu>` parent elements."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements"
+    "message": "List items (`<li>`) are contained within `<ul>`, `<ol>` or `<menu>` parent elements"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
     "message": "Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://dequeuniversity.com/rules/axe/4.4/meta-refresh)."

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -450,13 +450,13 @@
     "message": "L̂íŝt́ŝ ćôńt̂áîń ôńl̂ý `<li>` êĺêḿêńt̂ś âńd̂ śĉŕîṕt̂ śûṕp̂ór̂t́îńĝ él̂ém̂én̂t́ŝ (`<script>` án̂d́ `<template>`)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | description": {
-    "message": "Ŝćr̂éêń r̂éâd́êŕŝ ŕêq́ûír̂é l̂íŝt́ ît́êḿŝ (`<li>`) t́ô b́ê ćôńt̂áîńêd́ ŵít̂h́îń â ṕâŕêńt̂ `<ul>` ór̂ `<ol>` t́ô b́ê án̂ńôún̂ćêd́ p̂ŕôṕêŕl̂ý. [L̂éâŕn̂ ḿôŕê](https://dequeuniversity.com/rules/axe/4.4/listitem)."
+    "message": "Ŝćr̂éêń r̂éâd́êŕŝ ŕêq́ûír̂é l̂íŝt́ ît́êḿŝ (`<li>`) t́ô b́ê ćôńt̂áîńêd́ ŵít̂h́îń â ṕâŕêńt̂ `<ul>`, `<ol>` ór̂ `<menu>` t́ô b́ê án̂ńôún̂ćêd́ p̂ŕôṕêŕl̂ý. [L̂éâŕn̂ ḿôŕê](https://dequeuniversity.com/rules/axe/4.4/listitem)."
   },
   "lighthouse-core/audits/accessibility/listitem.js | failureTitle": {
-    "message": "L̂íŝt́ ît́êḿŝ (`<li>`) ár̂é n̂ót̂ ćôńt̂áîńêd́ ŵít̂h́îń `<ul>` ôŕ `<ol>` p̂ár̂én̂t́ êĺêḿêńt̂ś."
+    "message": "L̂íŝt́ ît́êḿŝ (`<li>`) ár̂é n̂ót̂ ćôńt̂áîńêd́ ŵít̂h́îń `<ul>`, `<ol>` ôŕ `<menu>` p̂ár̂én̂t́ êĺêḿêńt̂ś."
   },
   "lighthouse-core/audits/accessibility/listitem.js | title": {
-    "message": "L̂íŝt́ ît́êḿŝ (`<li>`) ár̂é ĉón̂t́âín̂éd̂ ẃît́ĥín̂ `<ul>` ór̂ `<ol>` ṕâŕêńt̂ él̂ém̂én̂t́ŝ"
+    "message": "L̂íŝt́ ît́êḿŝ (`<li>`) ár̂é ĉón̂t́âín̂éd̂ ẃît́ĥín̂ `<ul>`, `<ol>` ór̂ `<menu>` ṕâŕêńt̂ él̂ém̂én̂t́ŝ"
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
     "message": "Ûśêŕŝ d́ô ńôt́ êx́p̂éĉt́ â ṕâǵê t́ô ŕêf́r̂éŝh́ âút̂óm̂át̂íĉál̂ĺŷ, án̂d́ d̂óîńĝ śô ẃîĺl̂ ḿôv́ê f́ôćûś b̂áĉḱ t̂ó t̂h́ê t́ôṕ ôf́ t̂h́ê ṕâǵê. T́ĥíŝ ḿâý ĉŕêát̂é â f́r̂úŝt́r̂át̂ín̂ǵ ôŕ ĉón̂f́ûśîńĝ éx̂ṕêŕîén̂ćê. [Ĺêár̂ń m̂ór̂é](https://dequeuniversity.com/rules/axe/4.4/meta-refresh)."

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-navigation-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-navigation-expected.txt
@@ -163,7 +163,7 @@ Auditing: `<input type="image">` elements have `[alt]` text
 Auditing: Form elements have associated labels
 Auditing: Links have a discernible name
 Auditing: Lists contain only `<li>` elements and script supporting elements (`<script>` and `<template>`).
-Auditing: List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements
+Auditing: List items (`<li>`) are contained within `<ul>`, `<ol>` or `<menu>` parent elements
 Auditing: The document does not use `<meta http-equiv="refresh">`
 Auditing: `[user-scalable="no"]` is not used in the `<meta name="viewport">` element and the `[maximum-scale]` attribute is not less than 5.
 Auditing: `<object>` elements have alternate text

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -277,7 +277,7 @@ Auditing: `<input type="image">` elements have `[alt]` text
 Auditing: Form elements have associated labels
 Auditing: Links have a discernible name
 Auditing: Lists contain only `<li>` elements and script supporting elements (`<script>` and `<template>`).
-Auditing: List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements
+Auditing: List items (`<li>`) are contained within `<ul>`, `<ol>` or `<menu>` parent elements
 Auditing: The document does not use `<meta http-equiv="refresh">`
 Auditing: `[user-scalable="no"]` is not used in the `<meta name="viewport">` element and the `[maximum-scale]` attribute is not less than 5.
 Auditing: `<object>` elements have alternate text


### PR DESCRIPTION
**Summary**
Axe-core has been updated to allow listitems to exist inside menu elements, in accordance with the HTML spec. So, this text should be updated since axe-core has been updated to 4.4.x (https://github.com/GoogleChrome/lighthouse/commit/37a1ceb4bb365fc6df470d1cc172760ae03fffa5)

Related to https://github.com/GoogleChrome/web.dev/issues/7802 and https://github.com/GoogleChrome/web.dev/pull/7803 in the web.dev repo.

Menu spec: https://html.spec.whatwg.org/multipage/grouping-content.html#the-menu-element
Menu on MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu

**Related Issues/PRs**
#13926
