### PR TITLE
tests: add temp fix for failing deprecations smoke test

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -306,6 +306,8 @@ const expectations = {
         },
       },
       'deprecations': {
+        _maxChromiumVersion: '103.0.5017.0', // TODO: deprecation strings need to be translated
+        // see https://github.com/GoogleChrome/lighthouse/issues/13895
         score: 0,
         details: {
           items: [
@@ -320,7 +322,6 @@ const expectations = {
               },
             },
             {
-              _maxChromiumVersion: '103.0.5017.0',
               value: /Synchronous XMLHttpRequest on the main thread is deprecated/,
               source: {
                 type: 'source-location',


### PR DESCRIPTION
#13895 for background

Currently blocking CI. I guess these two deprecation issues were translated at slightly different times, so now they're both untranslated, the filter introduced in #13896 is taking them both out, and the dbw test is passing with no issues.