### PR TITLE
clients(viewer): ga event for flow-report

### DIFF
--- a/viewer/app/src/lighthouse-report-viewer.js
+++ b/viewer/app/src/lighthouse-report-viewer.js
@@ -290,8 +290,10 @@ export class LighthouseReportViewer {
     try {
       if (this._isFlowReport(json)) {
         this._renderFlowResult(json, rootEl, saveGistCallback);
+        window.ga('send', 'event', 'report', 'flow-report');
       } else {
         this._renderLhr(json, rootEl, saveGistCallback);
+        window.ga('send', 'event', 'report', 'report');
       }
 
       // Only clear query string if current report isn't from a gist or PSI.


### PR DESCRIPTION
I wanted to look up how often (if at all...) flow reports are used in the viewer, but we don't have the data.