### PR TITLE
tests(docs): clear problematic cache

### DIFF
--- a/docs/recipes/package.json
+++ b/docs/recipes/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "install-all": "yarn --cwd auth/ && yarn --cwd integration-test/ && yarn --cwd custom-gatherer-puppeteer/",
+    "install-all": "rm -rf /tmp/.junk && rm -f {auth,custom-gatherer-puppeteer,integration-test}/yarn.lock && yarn --cwd auth/ --cache-folder /tmp/.junk && yarn --cwd integration-test/ --cache-folder /tmp/.junk && yarn --cwd custom-gatherer-puppeteer/ --cache-folder /tmp/.junk",
     "integration-test": "yarn --cwd integration-test/ jest --config-path=docs-jest.config.js",
     "custom-gatherer-puppeteer-test": "yarn --cwd custom-gatherer-puppeteer/ test",
     "test": "yarn install-all && yarn integration-test && yarn custom-gatherer-puppeteer-test"


### PR DESCRIPTION
We noticed `yarn test-docs` was using old builds of lighthouse, which could only be resolved by running `yarn cache clear`. This PR avoids the problem by not using the global cache folder, instead this test now uses a throwaway folder. also deletes the lock files.

something about using a `.tgz` file as a dependency is caching in an unexpected way 🤷  (just clearing the lock files didn't fix the problem)