### PR TITLE
tests: update create-test-trace utility

### DIFF
--- a/lighthouse-core/test/audits/redirects-test.js
+++ b/lighthouse-core/test/audits/redirects-test.js
@@ -107,10 +107,11 @@ const FAILING_CLIENTSIDE = [
 describe('Performance: Redirects audit', () => {
   const mockArtifacts = (networkRecords, finalUrl) => {
     const devtoolsLog = networkRecordsToDevtoolsLog(networkRecords);
+    const frameUrl = networkRecords[0].url;
 
     return {
       GatherContext: {gatherMode: 'navigation'},
-      traces: {defaultPass: createTestTrace({traceEnd: 5000})},
+      traces: {defaultPass: createTestTrace({frameUrl, traceEnd: 5000})},
       devtoolsLogs: {defaultPass: devtoolsLog},
       URL: {
         initialUrl: 'about:blank',

--- a/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
+++ b/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
@@ -298,7 +298,7 @@ describe('Metrics: CLS', () => {
 
       it('ignores layout shift data from other tabs', async () => {
         const trace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
-        const mainFrame = trace.traceEvents[0].args.frame;
+        const mainFrame = trace.traceEvents.find(e => e.name === 'navigationStart').args.frame;
         const childFrame = 'CHILDFRAME';
         const otherMainFrame = 'ANOTHERTABOPEN';
         const cat = 'loading,rail,devtools.timeline';

--- a/lighthouse-core/test/lib/tracehouse/trace-processor-test.js
+++ b/lighthouse-core/test/lib/tracehouse/trace-processor-test.js
@@ -204,7 +204,7 @@ describe('TraceProcessor', () => {
   describe('.processTrace() - frameTreeEvents', () => {
     it('frameTreeEvents excludes other frame trees', () => {
       const testTrace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
-      const mainFrame = testTrace.traceEvents[0].args.frame;
+      const mainFrame = testTrace.traceEvents.find(e => e.name === 'navigationStart').args.frame;
       const childFrame = 'CHILDFRAME';
       const otherMainFrame = 'ANOTHERTAB';
       const cat = 'loading,rail,devtools.timeline';
@@ -230,7 +230,7 @@ describe('TraceProcessor', () => {
 
     it('frameTreeEvents includes main frame events if no FrameCommittedInBrowser found', () => {
       const testTrace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
-      const mainFrame = testTrace.traceEvents[0].args.frame;
+      const mainFrame = testTrace.traceEvents.find(e => e.name === 'navigationStart').args.frame;
       const childFrame = 'CHILDFRAME';
       const otherMainFrame = 'ANOTHERTAB';
       const cat = 'loading,rail,devtools.timeline';
@@ -256,7 +256,7 @@ describe('TraceProcessor', () => {
       testTrace.traceEvents = testTrace.traceEvents
         .filter(e => e.name !== 'FrameCommittedInBrowser');
 
-      const mainFrame = testTrace.traceEvents[0].args.frame;
+      const mainFrame = testTrace.traceEvents.find(e => e.name === 'navigationStart').args.frame;
       const childFrame = 'CHILDFRAME';
       const otherMainFrame = 'ANOTHERTAB';
       const cat = 'loading,rail,devtools.timeline';
@@ -566,7 +566,7 @@ Object {
 
       it('uses latest candidate', () => {
         const testTrace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
-        const frame = testTrace.traceEvents[0].args.frame;
+        const frame = testTrace.traceEvents.find(e => e.name === 'navigationStart').args.frame;
         const args = {frame, data: {size: 50}};
         const cat = 'loading,rail,devtools.timeline';
         testTrace.traceEvents.push(
@@ -590,7 +590,7 @@ Object {
 
       it('invalidates if last event is ::Invalidate', () => {
         const testTrace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
-        const frame = testTrace.traceEvents[0].args.frame;
+        const frame = testTrace.traceEvents.find(e => e.name === 'navigationStart').args.frame;
         const args = {frame};
         const cat = 'loading,rail,devtools.timeline';
         testTrace.traceEvents.push(
@@ -659,7 +659,7 @@ Object {
 
       it('finds FCP from all frames', () => {
         const testTrace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
-        const mainFrame = testTrace.traceEvents[0].args.frame;
+        const mainFrame = testTrace.traceEvents.find(e => e.name === 'navigationStart').args.frame;
         const childFrame = 'CHILDFRAME';
         const cat = 'loading,rail,devtools.timeline';
 
@@ -682,7 +682,7 @@ Object {
 
       it('finds LCP from all frames', () => {
         const testTrace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
-        const mainFrame = testTrace.traceEvents[0].args.frame;
+        const mainFrame = testTrace.traceEvents.find(e => e.name === 'navigationStart').args.frame;
         const childFrame = 'CHILDFRAME';
         const cat = 'loading,rail,devtools.timeline';
         testTrace.traceEvents.push(


### PR DESCRIPTION
While working on #13917 I noticed `create-test-trace` has some very outdated details and wanted to fix them before it all paged out of my brain. There's a much nicer and powerful API possible here, but this PR is just some surface-level fixes to get the generated test traces closer to real traces.