### PR TITLE
tests(ci): use BuildJet for ubuntu jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    # branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:
   # `basics` includes all non-smoke and non-unit CI
   basics:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
 
     # A few steps are duplicated across all jobs. Can be done better when this feature lands:
     #   https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations/16851
@@ -33,9 +33,9 @@ jobs:
 
     # Run pptr tests using ToT Chrome instead of stable default.
     - name: Define ToT chrome path
-      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
+      run: echo "CHROME_PATH=/home/ubuntu/chrome-linux-tot/chrome" >> $GITHUB_ENV
     - name: Install Chrome ToT
-      working-directory: /home/runner
+      working-directory: /home/ubuntu
       run: bash $GITHUB_WORKSPACE/lighthouse-core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
 
     # Run tests that require headfull Chrome.

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -2,12 +2,12 @@ name: package-test
 
 on:
   push:
-    branches: [master]
+    # branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:
   package-test:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     name: Package Test
 
     steps:

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -2,7 +2,7 @@ name: package-test
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,7 +2,7 @@ name: smoke
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,7 +2,7 @@ name: smoke
 
 on:
   push:
-    branches: [master]
+    # branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
         smoke-test-shard: [1, 2, 3]
       # e.g. if set 1 fails, continue with set 2 anyway
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     env:
       # The total number of shards. Set dynamically when length of *single* matrix variable is
       # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
@@ -38,12 +38,12 @@ jobs:
 
     - name: Define ToT chrome path
       if: matrix.chrome-channel == 'ToT'
-      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
+      run: echo "CHROME_PATH=/home/ubuntu/chrome-linux-tot/chrome" >> $GITHUB_ENV
 
     # Chrome Stable is already installed by default.
     - name: Install Chrome ToT
       if: matrix.chrome-channel == 'ToT'
-      working-directory: /home/runner
+      working-directory: /home/ubuntu
       run: bash $GITHUB_WORKSPACE/lighthouse-core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
@@ -105,7 +105,7 @@ jobs:
         path: .tmp/smokehouse-ci-failures/
 
   smoke-fr:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     name: Fraggle Rock
 
     steps:
@@ -136,7 +136,7 @@ jobs:
         path: .tmp/smokehouse-ci-failures/
 
   smoke-bundle:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     name: Bundled Lighthouse
 
     steps:
@@ -167,7 +167,7 @@ jobs:
         path: .tmp/smokehouse-ci-failures/
 
   smoke-bundle-fr:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     name: Bundled Fraggle Rock
 
     steps:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -2,7 +2,7 @@ name: unit
 
 on:
   push:
-    branches: [master]
+    # branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         node: ['14', '16', '17']
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     name: node ${{ matrix.node }}
     env:
       LATEST_NODE: '17'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -47,6 +47,7 @@ jobs:
     - run: yarn build-report
 
     # Run pptr tests using ToT Chrome instead of stable default.
+    - run: pwd
     - run: mkdir -p /home/runner
     - name: Define ToT chrome path
       run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -47,6 +47,7 @@ jobs:
     - run: yarn build-report
 
     # Run pptr tests using ToT Chrome instead of stable default.
+    - run: mkdir -p /home/runner
     - name: Define ToT chrome path
       run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
     - name: Install Chrome ToT

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -47,12 +47,10 @@ jobs:
     - run: yarn build-report
 
     # Run pptr tests using ToT Chrome instead of stable default.
-    - run: pwd
-    - run: mkdir -p /home/runner
     - name: Define ToT chrome path
-      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
+      run: echo "CHROME_PATH=/home/ubuntu/chrome-linux-tot/chrome" >> $GITHUB_ENV
     - name: Install Chrome ToT
-      working-directory: /home/runner
+      working-directory: /home/ubuntu
       run: bash $GITHUB_WORKSPACE/lighthouse-core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
 
     - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -2,7 +2,7 @@ name: unit
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:


### PR DESCRIPTION
Default github action runner for ubunutu has 7gb ram and 2 cpu cores. see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

These BuildJet runners have 4cpu and 16gb ram

I picked this tier because it matches [the price](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates) GitHub gives for their machines (although I don't know if our GoogleChrome org even pays that, I think public repos may be free? not sure).

Need to test more, but first look says maybe 2-4 minutes faster?

with buildjet https://github.com/GoogleChrome/lighthouse/actions/runs/2241966717
with github https://github.com/GoogleChrome/lighthouse/actions/runs/2241937334

Also could be we have far less problems with provisioning (github queuing our jobs)