### PR TITLE
core(trace): add PrePaint event, renamed from UpdateLayerTree

### DIFF
--- a/lighthouse-core/lib/tracehouse/task-groups.js
+++ b/lighthouse-core/lib/tracehouse/task-groups.js
@@ -50,6 +50,7 @@ const taskGroups = {
       'UpdateLayer',
       'UpdateLayerTree',
       'CompositeLayers',
+      'PrePaint',
     ],
   },
   scriptParseCompile: {

--- a/lighthouse-core/lib/tracehouse/task-groups.js
+++ b/lighthouse-core/lib/tracehouse/task-groups.js
@@ -50,7 +50,7 @@ const taskGroups = {
       'UpdateLayer',
       'UpdateLayerTree',
       'CompositeLayers',
-      'PrePaint',
+      'PrePaint', // New name for UpdateLayerTree: https://crrev.com/c/3519012
     ],
   },
   scriptParseCompile: {


### PR DESCRIPTION
M102 will rename UpdateLayerTree to PrePaint. See https://chromium-review.googlesource.com/c/chromium/src/+/3519012

Trace data is the same.