### PR TITLE
tests(smoke): use fraggle rock as the default

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -104,9 +104,9 @@ jobs:
         name: Smokehouse (windows)
         path: .tmp/smokehouse-ci-failures/
 
-  smoke-fr:
+  smoke-legacy:
     runs-on: ubuntu-latest
-    name: Fraggle Rock
+    name: Legacy Navigation
 
     steps:
     - name: git clone
@@ -122,8 +122,8 @@ jobs:
     - run: yarn reset-link
 
     - run: sudo apt-get install xvfb
-    - name: yarn smoke --fraggle-rock
-      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=1 --retries=2
+    - name: yarn smoke --legacy-navigation
+      run: xvfb-run --auto-servernum yarn smoke --debug --legacy-navigation -j=1 --retries=2
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
@@ -132,7 +132,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v1
       with:
-        name: Smokehouse (fr)
+        name: Smokehouse (legacy)
         path: .tmp/smokehouse-ci-failures/
 
   smoke-bundle:
@@ -166,9 +166,9 @@ jobs:
         name: Smokehouse (bundled)
         path: .tmp/smokehouse-ci-failures/
 
-  smoke-bundle-fr:
+  smoke-bundle-legacy:
     runs-on: ubuntu-latest
-    name: Bundled Fraggle Rock
+    name: Bundled Legacy Navigation
 
     steps:
     - name: git clone
@@ -185,7 +185,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - name: yarn test-bundle
-      run: xvfb-run --auto-servernum yarn test-bundle --fraggle-rock
+      run: xvfb-run --auto-servernum yarn test-bundle --legacy-navigation
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code

--- a/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
+++ b/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
@@ -135,10 +135,10 @@ async function begin() {
         default: false,
         describe: 'Save test artifacts and output verbose logs',
       },
-      'fraggle-rock': {
+      'legacy-navigation': {
         type: 'boolean',
         default: false,
-        describe: 'Use the new Fraggle Rock runner',
+        describe: 'Use the legacy navigation runner',
       },
       'jobs': {
         type: 'number',
@@ -216,7 +216,7 @@ async function begin() {
       jobs,
       retries,
       isDebug: argv.debug,
-      useFraggleRock: argv.fraggleRock,
+      useLegacyNavigation: argv.legacyNavigation,
       lighthouseRunner: runLighthouse,
       takeNetworkRequestUrls,
     };

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -39,7 +39,7 @@ const lighthouse = global.runBundledLighthouse;
  * Launch Chrome and do a full Lighthouse run via the Lighthouse DevTools bundle.
  * @param {string} url
  * @param {LH.Config.Json=} configJson
- * @param {{isDebug?: boolean, useFraggleRock?: boolean}=} testRunnerOptions
+ * @param {{isDebug?: boolean, useLegacyNavigation?: boolean}=} testRunnerOptions
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>}
  */
 async function runLighthouse(url, configJson, testRunnerOptions = {}) {
@@ -51,15 +51,15 @@ async function runLighthouse(url, configJson, testRunnerOptions = {}) {
     // Run Lighthouse.
     const logLevel = testRunnerOptions.isDebug ? 'info' : undefined;
     let runnerResult;
-    if (testRunnerOptions.useFraggleRock) {
+    if (testRunnerOptions.useLegacyNavigation) {
+      const connection = new ChromeProtocol(port);
+      runnerResult =
+        await lighthouse.legacyNavigation(url, {port, logLevel}, configJson, connection);
+    } else {
       // Puppeteer is not included in the bundle, we must create the page here.
       const browser = await puppeteer.connect({browserURL: `http://localhost:${port}`});
       const page = await browser.newPage();
       runnerResult = await lighthouse(url, {port, logLevel}, configJson, page);
-    } else {
-      const connection = new ChromeProtocol(port);
-      runnerResult =
-        await lighthouse.legacyNavigation(url, {port, logLevel}, configJson, connection);
     }
     if (!runnerResult) throw new Error('No runnerResult');
 

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
@@ -42,29 +42,15 @@ async function runLighthouse(url, configJson, testRunnerOptions = {}) {
 }
 
 /**
- * @param {LH.Config.Json=} configJson
- * @return {LH.Config.Json|undefined}
- */
-function convertToFraggleRockConfig(configJson) {
-  if (!configJson) return configJson;
-  if (!configJson.passes) return configJson;
-
-  return {
-    ...configJson,
-    navigations: configJson.passes.map(pass => ({...pass, id: pass.passName})),
-  };
-}
-
-/**
  * Internal runner.
  * @param {string} url
  * @param {string} tmpPath
  * @param {LH.Config.Json=} configJson
- * @param {{isDebug?: boolean, useFraggleRock?: boolean}=} options
+ * @param {{isDebug?: boolean, useLegacyNavigation?: boolean}=} options
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>}
  */
 async function internalRun(url, tmpPath, configJson, options) {
-  const {isDebug = false, useFraggleRock = false} = options || {};
+  const {isDebug = false, useLegacyNavigation = false} = options || {};
   const localConsole = new LocalConsole();
 
   const outputPath = `${tmpPath}/smokehouse.report.json`;
@@ -81,9 +67,7 @@ async function internalRun(url, tmpPath, configJson, options) {
     '--quiet',
   ];
 
-  if (useFraggleRock) {
-    configJson = convertToFraggleRockConfig(configJson);
-  } else {
+  if (useLegacyNavigation) {
     args.push('--legacy-navigation');
   }
 

--- a/lighthouse-cli/test/smokehouse/report-assert.js
+++ b/lighthouse-cli/test/smokehouse/report-assert.js
@@ -218,10 +218,10 @@ function makeComparison(name, actualResult, expectedResult) {
  * @param {LocalConsole} localConsole
  * @param {LH.Result} lhr
  * @param {Smokehouse.ExpectedRunnerResult} expected
- * @param {{runner?: string, isBundled?: boolean, useFraggleRock?: boolean}=} reportOptions
+ * @param {{runner?: string, isBundled?: boolean, useLegacyNavigation?: boolean}=} reportOptions
  */
 function pruneExpectations(localConsole, lhr, expected, reportOptions) {
-  const isFraggleRock = reportOptions?.useFraggleRock;
+  const isLegacyNavigation = reportOptions?.useLegacyNavigation;
   const isBundled = reportOptions?.isBundled;
 
   /**
@@ -277,13 +277,13 @@ function pruneExpectations(localConsole, lhr, expected, reportOptions) {
           `Actual Chromium version: ${getChromeVersionString()}`,
         ].join(' '));
         remove(key);
-      } else if (value._legacyOnly && isFraggleRock) {
+      } else if (value._legacyOnly && !isLegacyNavigation) {
         localConsole.log([
           `[${key}] marked legacy only but run is Fraggle Rock, pruning expectation:`,
           JSON.stringify(value, null, 2),
         ].join(' '));
         remove(key);
-      } else if (value._fraggleRockOnly && !isFraggleRock) {
+      } else if (value._fraggleRockOnly && isLegacyNavigation) {
         localConsole.log([
           `[${key}] marked Fraggle Rock only but run is legacy, pruning expectation:`,
           JSON.stringify(value, null, 2),
@@ -458,7 +458,7 @@ function reportAssertion(localConsole, assertion) {
  * summary. Returns count of passed and failed tests.
  * @param {{lhr: LH.Result, artifacts: LH.Artifacts, networkRequests?: string[]}} actual
  * @param {Smokehouse.ExpectedRunnerResult} expected
- * @param {{runner?: string, isDebug?: boolean, isBundled?: boolean, useFraggleRock?: boolean}=} reportOptions
+ * @param {{runner?: string, isDebug?: boolean, isBundled?: boolean, useLegacyNavigation?: boolean}=} reportOptions
  * @return {{passed: number, failed: number, log: string}}
  */
 function getAssertionReport(actual, expected, reportOptions = {}) {

--- a/lighthouse-cli/test/smokehouse/test-definitions/oopif-requests.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/oopif-requests.js
@@ -27,8 +27,8 @@ const config = {
     // to complete.
     maxWaitForLoad: 180000,
   },
-  passes: [{
-    passName: 'defaultPass',
+  navigations: [{
+    id: 'default',
     // CI machines are pretty weak which lead to many more long tasks than normal.
     // Reduce our requirement for CPU quiet.
     cpuQuietThresholdMs: 500,

--- a/lighthouse-cli/test/smokehouse/test-definitions/oopif-scripts.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/oopif-scripts.js
@@ -27,11 +27,11 @@ const config = {
     // to complete.
     maxWaitForLoad: 180000,
   },
-  passes: [
+  navigations: [
     // CI machines are pretty weak which lead to many more long tasks than normal.
     // Reduce our requirement for CPU quiet.
     {
-      passName: 'defaultPass',
+      id: 'default',
       cpuQuietThresholdMs: 500,
     },
   ],

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -52,13 +52,13 @@ declare global {
       {expectations: Smokehouse.ExpectedRunnerResult | Array<Smokehouse.ExpectedRunnerResult>}
 
     export type LighthouseRunner =
-      {runnerName?: string} & ((url: string, configJson?: Config.Json, runnerOptions?: {isDebug?: boolean; useFraggleRock?: boolean}) => Promise<{lhr: LHResult, artifacts: Artifacts, log: string}>);
+      {runnerName?: string} & ((url: string, configJson?: Config.Json, runnerOptions?: {isDebug?: boolean; useLegacyNavigation?: boolean}) => Promise<{lhr: LHResult, artifacts: Artifacts, log: string}>);
 
     export interface SmokehouseOptions {
       /** If true, performs extra logging from the test runs. */
       isDebug?: boolean;
-      /** If true, uses the new Fraggle Rock runner. */
-      useFraggleRock?: boolean;
+      /** If true, use the legacy navigation runner. */
+      useLegacyNavigation?: boolean;
       /** Manually set the number of jobs to run at once. `1` runs all tests serially. */
       jobs?: number;
       /** The number of times to retry failing tests before accepting. Defaults to 0. */


### PR DESCRIPTION
DevTools is still using the legacy navigation runner because we haven't added support for that runner yet.