### PR TITLE
core(js-usage): ignore __puppeteer_evaluation_script__

### DIFF
--- a/core/gather/gatherers/js-usage.js
+++ b/core/gather/gatherers/js-usage.js
@@ -59,6 +59,7 @@ class JsUsage extends FRGatherer {
         continue;
       }
 
+      // Scripts run via puppeteer's evaluate interface will have this url.
       if (scriptUsage.url === '__puppeteer_evaluation_script__') {
         continue;
       }

--- a/core/gather/gatherers/js-usage.js
+++ b/core/gather/gatherers/js-usage.js
@@ -59,6 +59,10 @@ class JsUsage extends FRGatherer {
         continue;
       }
 
+      if (scriptUsage.url === '__puppeteer_evaluation_script__') {
+        continue;
+      }
+
       usageByScriptId[scriptUsage.scriptId] = scriptUsage;
     }
 


### PR DESCRIPTION
Noticed this in JSUsage when using FR.