### PR TITLE
tests(ci): shard all smoke tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -81,10 +81,6 @@ jobs:
       # e.g. if set 1 fails, continue with set 2 anyway
       fail-fast: false
     runs-on: windows-latest
-    env:
-      # The total number of shards. Set dynamically when length of *single* matrix variable is
-      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
-      SHARD_TOTAL: 2
     name: Windows smoke ${{ matrix.smoke-test-shard }}/2
 
     steps:
@@ -101,7 +97,7 @@ jobs:
 
     - name: Run smoke tests
       # Windows bots are slow, so only run enough tests to verify matching behavior.
-      run: yarn smoke --debug -j=1 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL dbw oopif offline lantern metrics
+      run: yarn smoke --debug -j=1 --retries=2 --shard=${{ matrix.smoke-test-shard }}/2 dbw oopif offline lantern metrics
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -120,7 +120,7 @@ jobs:
       # The total number of shards. Set dynamically when length of *single* matrix variable is
       # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
       SHARD_TOTAL: 3
-    name: ${{ matrix.smoke-test-shard }}/3
+    name: Fraggle Rock ${{ matrix.smoke-test-shard }}/3
 
     steps:
     - name: git clone

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -75,8 +75,17 @@ jobs:
 
   # Only run smoke tests for windows against stable chrome.
   smoke-windows:
+    strategy:
+      matrix:
+        smoke-test-shard: [1, 2]
+      # e.g. if set 1 fails, continue with set 2 anyway
+      fail-fast: false
     runs-on: windows-latest
-    name: Windows smoke
+    env:
+      # The total number of shards. Set dynamically when length of *single* matrix variable is
+      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
+      SHARD_TOTAL: 2
+    name: Windows smoke ${{ matrix.smoke-test-shard }}/2
 
     steps:
     - name: git clone
@@ -92,7 +101,7 @@ jobs:
 
     - name: Run smoke tests
       # Windows bots are slow, so only run enough tests to verify matching behavior.
-      run: yarn smoke --debug -j=1 --retries=2 dbw oopif offline lantern metrics
+      run: yarn smoke --debug -j=1 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL dbw oopif offline lantern metrics
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
@@ -105,8 +114,17 @@ jobs:
         path: .tmp/smokehouse-ci-failures/
 
   smoke-fr:
+    strategy:
+      matrix:
+        smoke-test-shard: [1, 2, 3]
+      # e.g. if set 1 fails, continue with set 2 anyway
+      fail-fast: false
     runs-on: ubuntu-latest
-    name: Fraggle Rock
+    env:
+      # The total number of shards. Set dynamically when length of *single* matrix variable is
+      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
+      SHARD_TOTAL: 3
+    name: ${{ matrix.smoke-test-shard }}/3
 
     steps:
     - name: git clone
@@ -123,7 +141,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - name: yarn smoke --fraggle-rock
-      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=1 --retries=2
+      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=1 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
@@ -136,8 +154,17 @@ jobs:
         path: .tmp/smokehouse-ci-failures/
 
   smoke-bundle:
+    strategy:
+      matrix:
+        smoke-test-shard: [1, 2, 3]
+      # e.g. if set 1 fails, continue with set 2 anyway
+      fail-fast: false
     runs-on: ubuntu-latest
-    name: Bundled Lighthouse
+    env:
+      # The total number of shards. Set dynamically when length of *single* matrix variable is
+      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
+      SHARD_TOTAL: 3
+    name: Bundled Lighthouse ${{ matrix.smoke-test-shard }}/3
 
     steps:
     - name: git clone
@@ -154,7 +181,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - name: yarn test-bundle
-      run: xvfb-run --auto-servernum yarn test-bundle
+      run: xvfb-run --auto-servernum yarn test-bundle --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
@@ -167,8 +194,17 @@ jobs:
         path: .tmp/smokehouse-ci-failures/
 
   smoke-bundle-fr:
+    strategy:
+      matrix:
+        smoke-test-shard: [1, 2, 3]
+      # e.g. if set 1 fails, continue with set 2 anyway
+      fail-fast: false
     runs-on: ubuntu-latest
-    name: Bundled Fraggle Rock
+    env:
+      # The total number of shards. Set dynamically when length of *single* matrix variable is
+      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
+      SHARD_TOTAL: 3
+    name: Bundled Fraggle Rock ${{ matrix.smoke-test-shard }}/3
 
     steps:
     - name: git clone
@@ -185,7 +221,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - name: yarn test-bundle
-      run: xvfb-run --auto-servernum yarn test-bundle --fraggle-rock
+      run: xvfb-run --auto-servernum yarn test-bundle --fraggle-rock --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -53,7 +53,7 @@ jobs:
     - run: sudo apt-get install xvfb
     - name: Run smoke tests
       run: |
-        xvfb-run --auto-servernum yarn c8 yarn smoke --debug -j=1 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
+        xvfb-run --auto-servernum yarn c8 yarn smoke --debug -j=2 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
         yarn c8 report --reporter text-lcov > smoke-coverage.lcov
 
     - name: Upload test coverage to Codecov
@@ -97,7 +97,7 @@ jobs:
 
     - name: Run smoke tests
       # Windows bots are slow, so only run enough tests to verify matching behavior.
-      run: yarn smoke --debug -j=1 --retries=2 --shard=${{ matrix.smoke-test-shard }}/2 dbw oopif offline lantern metrics
+      run: yarn smoke --debug -j=2 --retries=2 --shard=${{ matrix.smoke-test-shard }}/2 dbw oopif offline lantern metrics
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
@@ -137,7 +137,7 @@ jobs:
 
     - run: sudo apt-get install xvfb
     - name: yarn smoke --fraggle-rock
-      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=1 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
+      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=2 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code


### PR DESCRIPTION
Adds sharding to the FR, bundled and windows smoke tests. This should further reduce the headache of re-running flaky tests, and speed things up a bit.