### PR TITLE
core(responsiveness): use raw trace event

### DIFF
--- a/lighthouse-core/audits/metrics/experimental-interaction-to-next-paint.js
+++ b/lighthouse-core/audits/metrics/experimental-interaction-to-next-paint.js
@@ -63,19 +63,21 @@ class ExperimentalInteractionToNextPaint extends Audit {
 
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const metricData = {trace, settings};
-    const metricResult = await ComputedResponsivenes.request(metricData, context);
+    const responsivenessEvent = await ComputedResponsivenes.request(metricData, context);
 
     // TODO: include the no-interaction state in the report instead of using n/a.
-    if (metricResult === null) {
+    if (responsivenessEvent === null) {
       return {score: null, notApplicable: true};
     }
 
+    const timing = responsivenessEvent.args.data.maxDuration;
+
     return {
       score: Audit.computeLogNormalScore({p10: context.options.p10, median: context.options.median},
-        metricResult.timing),
-      numericValue: metricResult.timing,
+        timing),
+      numericValue: timing,
       numericUnit: 'millisecond',
-      displayValue: str_(i18n.UIStrings.ms, {timeInMs: metricResult.timing}),
+      displayValue: str_(i18n.UIStrings.ms, {timeInMs: timing}),
     };
   }
 }

--- a/lighthouse-core/test/computed/metrics/responsiveness-test.js
+++ b/lighthouse-core/test/computed/metrics/responsiveness-test.js
@@ -74,8 +74,8 @@ describe('Metric: Responsiveness', () => {
       settings: {throttlingMethod: 'provided'},
     };
     const context = {computedCache: new Map()};
-    const result = await Responsiveness.request(metricInputData, context);
-    expect(result).toEqual(null);
+    const event = await Responsiveness.request(metricInputData, context);
+    expect(event).toEqual(null);
   });
 
   it('should select the 98th percentile interaction', async () => {
@@ -100,8 +100,8 @@ describe('Metric: Responsiveness', () => {
       }
 
       const context = {computedCache: new Map()};
-      const result = await Responsiveness.request(metricInputData, context);
-      assert.equal(result.timing, expectedTiming, `error at ${eventCount} events`);
+      const event = await Responsiveness.request(metricInputData, context);
+      assert.equal(event.args.data.maxDuration, expectedTiming, `error at ${eventCount} events`);
     }
   });
 
@@ -129,8 +129,8 @@ describe('Metric: Responsiveness', () => {
       settings: {throttlingMethod: 'provided'},
     };
     const context = {computedCache: new Map()};
-    const result = await Responsiveness.request(metricInputData, context);
-    expect(result).toEqual({timing: 49});
+    const event = await Responsiveness.request(metricInputData, context);
+    expect(event.args.data).toMatchObject({maxDuration: 49});
   });
 
   it('should throw on attempting with a simulated timespan', async () => {
@@ -148,8 +148,8 @@ describe('Metric: Responsiveness', () => {
       settings: {throttlingMethod: 'provided'},
     };
     const context = {computedCache: new Map()};
-    const result = await Responsiveness.request(metricInputData, context);
-    expect(result).toEqual({timing: 392});
+    const event = await Responsiveness.request(metricInputData, context);
+    expect(event.args.data).toMatchObject({maxDuration: 392});
   });
 
   it('evaluates from a real trace with no interaction events', async () => {
@@ -158,7 +158,7 @@ describe('Metric: Responsiveness', () => {
       settings: {throttlingMethod: 'provided'},
     };
     const context = {computedCache: new Map()};
-    const result = await Responsiveness.request(metricInputData, context);
-    expect(result).toEqual(null);
+    const event = await Responsiveness.request(metricInputData, context);
+    expect(event).toEqual(null);
   });
 });

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -1020,6 +1020,23 @@ export interface TraceEvent {
   };
 }
 
+declare module Trace {
+  /**
+   * Base event of a `ph: 'X'` 'complete' event. Extend with `name` and `args` as
+   * needed.
+   */
+  interface CompleteEvent {
+    ph: 'X';
+    cat: string;
+    pid: number;
+    tid: number;
+    dur: number;
+    ts: number;
+    tdur: number;
+    tts: number;
+  }
+}
+
 /**
  * A record of DevTools Debugging Protocol events.
  */


### PR DESCRIPTION
part of #13916

Rather than the responsiveness computed artifact returning just the duration, it now returns the whole trace event, which will allow the attribution audit to use all the other properties on that same event.

Functionality is unchanged.