### PR TITLE
core: extract BootupTime task summary methods

### DIFF
--- a/lighthouse-core/audits/long-tasks.js
+++ b/lighthouse-core/audits/long-tasks.js
@@ -9,9 +9,9 @@ const Audit = require('./audit.js');
 const NetworkRecords = require('../computed/network-records.js');
 const i18n = require('../lib/i18n/i18n.js');
 const MainThreadTasks = require('../computed/main-thread-tasks.js');
-const BootupTime = require('./bootup-time.js');
 const PageDependencyGraph = require('../computed/page-dependency-graph.js');
 const LoadSimulator = require('../computed/load-simulator.js');
+const {getJavaScriptURLs, getAttributableURLForTask} = require('../lib/tracehouse/task-summary.js');
 
 /** We don't always have timing data for short tasks, if we're missing timing data. Treat it as though it were 0ms. */
 const DEFAULT_TIMING = {startTime: 0, endTime: 0, duration: 0};
@@ -78,7 +78,7 @@ class LongTasks extends Audit {
       }
     }
 
-    const jsURLs = BootupTime.getJavaScriptURLs(networkRecords);
+    const jsURLs = getJavaScriptURLs(networkRecords);
     // Only consider up to 20 long, top-level (no parent) tasks that have an explicit endTime
     const longtasks = tasks
       .map(t => {
@@ -91,7 +91,7 @@ class LongTasks extends Audit {
 
     // TODO(beytoven): Add start time that matches with the simulated throttling
     const results = longtasks.map(task => ({
-      url: BootupTime.getAttributableURLForTask(task, jsURLs),
+      url: getAttributableURLForTask(task, jsURLs),
       duration: task.duration,
       startTime: task.startTime,
     }));

--- a/lighthouse-core/audits/third-party-summary.js
+++ b/lighthouse-core/audits/third-party-summary.js
@@ -6,11 +6,11 @@
 'use strict';
 
 const Audit = require('./audit.js');
-const BootupTime = require('./bootup-time.js');
 const i18n = require('../lib/i18n/i18n.js');
 const thirdPartyWeb = require('../lib/third-party-web.js');
 const NetworkRecords = require('../computed/network-records.js');
 const MainThreadTasks = require('../computed/main-thread-tasks.js');
+const {getJavaScriptURLs, getAttributableURLForTask} = require('../lib/tracehouse/task-summary.js');
 
 const UIStrings = {
   /** Title of a diagnostic audit that provides details about the code on a web page that the user doesn't control (referred to as "third-party code"). This descriptive title is shown to users when the amount is acceptable and no user action is required. */
@@ -98,10 +98,10 @@ class ThirdPartySummary extends Audit {
       byURL.set(request.url, urlSummary);
     }
 
-    const jsURLs = BootupTime.getJavaScriptURLs(networkRecords);
+    const jsURLs = getJavaScriptURLs(networkRecords);
 
     for (const task of mainThreadTasks) {
-      const attributableURL = BootupTime.getAttributableURLForTask(task, jsURLs);
+      const attributableURL = getAttributableURLForTask(task, jsURLs);
 
       const urlSummary = byURL.get(attributableURL) || {...defaultSummary};
       const taskDuration = task.selfTime * cpuMultiplier;

--- a/lighthouse-core/lib/tracehouse/task-summary.js
+++ b/lighthouse-core/lib/tracehouse/task-summary.js
@@ -1,0 +1,87 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Utility functions for grouping and summarizing tasks.
+ */
+
+const NetworkRequest = require('../network-request.js');
+
+// These trace events, when not triggered by a script inside a particular task, are just general Chrome overhead.
+const BROWSER_TASK_NAMES_SET = new Set([
+  'CpuProfiler::StartProfiling',
+]);
+
+// These trace events, when not triggered by a script inside a particular task, are GC Chrome overhead.
+const BROWSER_GC_TASK_NAMES_SET = new Set([
+  'V8.GCCompactor',
+  'MajorGC',
+  'MinorGC',
+]);
+
+/**
+ * @param {LH.Artifacts.NetworkRequest[]} records
+ */
+function getJavaScriptURLs(records) {
+  /** @type {Set<string>} */
+  const urls = new Set();
+  for (const record of records) {
+    if (record.resourceType === NetworkRequest.TYPES.Script) {
+      urls.add(record.url);
+    }
+  }
+
+  return urls;
+}
+
+/**
+ * @param {LH.Artifacts.TaskNode} task
+ * @param {Set<string>} jsURLs
+ * @return {string}
+ */
+function getAttributableURLForTask(task, jsURLs) {
+  const jsURL = task.attributableURLs.find(url => jsURLs.has(url));
+  const fallbackURL = task.attributableURLs[0];
+  let attributableURL = jsURL || fallbackURL;
+  // If we can't find what URL was responsible for this execution, attribute it to the root page
+  // or Chrome depending on the type of work.
+  if (!attributableURL || attributableURL === 'about:blank') {
+    if (BROWSER_TASK_NAMES_SET.has(task.event.name)) attributableURL = 'Browser';
+    else if (BROWSER_GC_TASK_NAMES_SET.has(task.event.name)) attributableURL = 'Browser GC';
+    else attributableURL = 'Unattributable';
+  }
+
+  return attributableURL;
+}
+
+/**
+ * @param {LH.Artifacts.TaskNode[]} tasks
+ * @param {Array<LH.Artifacts.NetworkRequest>} networkRecords
+ * @return {Map<string, Record<string, number>>}
+ */
+function getExecutionTimingsByURL(tasks, networkRecords) {
+  const jsURLs = getJavaScriptURLs(networkRecords);
+
+  /** @type {Map<string, Record<string, number>>} */
+  const result = new Map();
+
+  for (const task of tasks) {
+    const attributableURL = getAttributableURLForTask(task, jsURLs);
+    const timingByGroupId = result.get(attributableURL) || {};
+    const originalTime = timingByGroupId[task.group.id] || 0;
+    timingByGroupId[task.group.id] = originalTime + task.selfTime;
+    result.set(attributableURL, timingByGroupId);
+  }
+
+  return result;
+}
+
+module.exports = {
+  getJavaScriptURLs,
+  getAttributableURLForTask,
+  getExecutionTimingsByURL,
+};

--- a/lighthouse-core/test/lib/tracehouse/task-summary-test.js
+++ b/lighthouse-core/test/lib/tracehouse/task-summary-test.js
@@ -34,10 +34,10 @@ describe('Task Summaries', () => {
     it('returns the script URLs from a set of network records', () => {
       const records = NetworkRecorder.recordsFromLogs(ampDevtoolsLog);
       const urls = getJavaScriptURLs(records);
-      expect(urls.size).toEqual(13);
       for (const url of urls) {
         expect(url).toMatch(/^https:\/\/cdn.ampproject.org.*js$/);
       }
+      expect(urls.size).toEqual(13);
     });
   });
 

--- a/lighthouse-core/test/lib/tracehouse/task-summary-test.js
+++ b/lighthouse-core/test/lib/tracehouse/task-summary-test.js
@@ -1,0 +1,152 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/* eslint-env jest */
+
+import {
+  getJavaScriptURLs,
+  getAttributableURLForTask,
+  getExecutionTimingsByURL,
+} from '../../../lib/tracehouse/task-summary.js';
+import NetworkRecorder from '../../../lib/network-recorder.js';
+import MainThreadTasks from '../../../lib/tracehouse/main-thread-tasks.js';
+import ampTrace from '../../fixtures/traces/amp-m86.trace.json';
+import ampDevtoolsLog from '../../fixtures/traces/amp-m86.devtoolslog.json';
+import TraceProcessor from '../../../lib/tracehouse/trace-processor.js';
+import networkRecordsToDevtoolsLog from '../../network-records-to-devtools-log.js';
+import {taskGroups} from '../../../lib/tracehouse/task-groups.js';
+
+function getTasks(trace) {
+  const {mainThreadEvents, frames, timestamps} = TraceProcessor.processTrace(trace);
+  return MainThreadTasks.getMainThreadTasks(mainThreadEvents, frames, timestamps.traceEnd);
+}
+
+describe('Task Summaries', () => {
+  describe('getJavaScriptURLs', () => {
+    it('returns no URLs for no records', () => {
+      const urls = getJavaScriptURLs([]);
+      expect(urls).toEqual(new Set());
+    });
+
+    it('returns the script URLs from a set of network records', () => {
+      const records = NetworkRecorder.recordsFromLogs(ampDevtoolsLog);
+      const urls = getJavaScriptURLs(records);
+      expect(urls.size).toEqual(13);
+      for (const url of urls) {
+        expect(url).toMatch(/^https:\/\/cdn.ampproject.org.*js$/);
+      }
+    });
+  });
+
+  describe('getAttributableURLForTask', () => {
+    const networkRecords = NetworkRecorder.recordsFromLogs(ampDevtoolsLog);
+    const jsUrls = getJavaScriptURLs(networkRecords);
+    const tasks = getTasks(ampTrace);
+    // The exact task doesn't matter.
+    const attributableTask = tasks.find(task => task.attributableURLs.length > 1);
+    const clonableTask = {...attributableTask, parent: undefined, children: []};
+    const knownJsUrl = 'https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js';
+
+    it('gets an attributable URL', () => {
+      const url = getAttributableURLForTask(attributableTask, jsUrls);
+      expect(url).toEqual(knownJsUrl);
+    });
+
+    it('uses a script URL even if not the first attributable URL', () => {
+      const clonedTask = JSON.parse(JSON.stringify(clonableTask));
+      clonedTask.attributableURLs = [
+        'https://something.com',
+        'https://something.com/scripty.js',
+        knownJsUrl,
+      ];
+      const url = getAttributableURLForTask(clonedTask, jsUrls);
+      expect(url).toEqual(knownJsUrl);
+    });
+
+    it('falls back to the first attributable URL if none of the script URLs are known', () => {
+      const clonedTask = JSON.parse(JSON.stringify(clonableTask));
+      clonedTask.attributableURLs = [
+        'https://something.com/page.html',
+        'https://something.com/scripty.js',
+        'https://example.com/another-script.js',
+      ];
+      const url = getAttributableURLForTask(clonedTask, jsUrls);
+      expect(url).toEqual('https://something.com/page.html');
+    });
+
+    it('falls back to more specific browser tasks if no attributable URLs', () => {
+      const clonedTask = JSON.parse(JSON.stringify(clonableTask));
+      clonedTask.attributableURLs = [];
+      clonedTask.event.name = 'CpuProfiler::StartProfiling';
+      const url = getAttributableURLForTask(clonedTask, jsUrls);
+      expect(url).toEqual('Browser');
+    });
+
+    it('falls back to more specific browser tasks if no attributable URLs', () => {
+      const clonedTask = JSON.parse(JSON.stringify(clonableTask));
+      clonedTask.attributableURLs = [];
+      clonedTask.event.name = 'V8.GCCompactor';
+      const url = getAttributableURLForTask(clonedTask, jsUrls);
+      expect(url).toEqual('Browser GC');
+    });
+
+    it('falls back to "Unattributable" for a generic task if no attributable URLs', () => {
+      const clonedTask = JSON.parse(JSON.stringify(clonableTask));
+      clonedTask.attributableURLs = [];
+      const url = getAttributableURLForTask(clonedTask, jsUrls);
+      expect(url).toEqual('Unattributable');
+    });
+
+    it('falls back to "Unattributable" for a generic task if attributed to about:blank', () => {
+      const clonedTask = JSON.parse(JSON.stringify(clonableTask));
+      clonedTask.attributableURLs = ['about:blank'];
+      const url = getAttributableURLForTask(clonedTask, jsUrls);
+      expect(url).toEqual('Unattributable');
+    });
+  });
+
+  describe('getExecutionTimingsByURL', () => {
+    const devtoolsLog = networkRecordsToDevtoolsLog([
+      {url: 'https://example.com'},
+      {url: 'https://example.com/script.js'},
+    ]);
+    const networkRecords = NetworkRecorder.recordsFromLogs(devtoolsLog);
+    const tasks = [{
+      attributableURLs: [
+        'https://example.com/script.js',
+      ],
+      selfTime: 2,
+      group: taskGroups.styleLayout,
+    }, {
+      attributableURLs: [
+        'https://example.com',
+        'https://someother.com/unknown-script.js',
+      ],
+      selfTime: 3,
+      group: taskGroups.paintCompositeRender,
+    }, {
+      attributableURLs: [],
+      selfTime: 5,
+      group: taskGroups.scriptEvaluation,
+      event: {name: 'MajorGC'},
+    }, {
+      attributableURLs: [],
+      selfTime: 7,
+      group: taskGroups.garbageCollection,
+      event: {name: 'RunTask'},
+    }];
+
+    it('summarizes tasks', () => {
+      const timings = getExecutionTimingsByURL(tasks, networkRecords);
+      expect(timings).toEqual(new Map([
+        ['https://example.com/script.js', {styleLayout: 2}],
+        ['https://example.com', {paintCompositeRender: 3}],
+        ['Browser GC', {scriptEvaluation: 5}],
+        ['Unattributable', {garbageCollection: 7}],
+      ]));
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,6 +99,7 @@
     "lighthouse-core/test/lib/timing-trace-saver-test.js",
     "lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js",
     "lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js",
+    "lighthouse-core/test/lib/tracehouse/task-summary-test.js",
     "lighthouse-core/test/lib/tracehouse/trace-processor-test.js",
     "lighthouse-core/test/lib/traces/pwmetrics-events-test.js",
     "lighthouse-core/test/lib/url-shim-test.js",


### PR DESCRIPTION
part of #13916

The responsiveness debugging audit will be the fourth audit using these functions, so it's just about time we spin them off into their own file.

They're not quite `main-thread-task` functions, nor are they just about `task-groups`, so a new file seemed appropriate. I'm not attached to their new location, however, so I'm happy to bikeshed.