### PR TITLE
misc: prevent forks from running cron job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   publish:
+    # Prevent forks from running this job.
+    if: (github.event_name == 'schedule' && github.repository == 'GoogleChrome/lighthouse') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
I've been getting emails from failed publish jobs running in forks: https://github.com/codewithdev/lighthouse/actions/runs/2273813152

Got the `if` code from this q/a: https://github.community/t/do-not-run-cron-workflows-in-forks/17636