### PR TITLE
report: render notApplicable metrics with double dash

### DIFF
--- a/report/renderer/performance-category-renderer.js
+++ b/report/renderer/performance-category-renderer.js
@@ -46,6 +46,8 @@ export class PerformanceCategoryRenderer extends CategoryRenderer {
       valueEl.textContent = 'Error!';
       const tooltip = this.dom.createChildOf(descriptionEl, 'span');
       tooltip.textContent = audit.result.errorMessage || 'Report error: no metric information';
+    } else if (audit.result.scoreDisplayMode === 'notApplicable') {
+      valueEl.textContent = '--';
     }
 
     return element;

--- a/report/test/renderer/performance-category-renderer-test.js
+++ b/report/test/renderer/performance-category-renderer-test.js
@@ -77,6 +77,26 @@ describe('PerfCategoryRenderer', () => {
     );
   });
 
+  it('renders notApplicable metrics with n/a text', () => {
+    const perfWithNaMetric = JSON.parse(JSON.stringify(category));
+    const tbt = perfWithNaMetric.auditRefs.find(audit => audit.id === 'total-blocking-time');
+    assert(tbt);
+    const {id, title, description} = tbt.result;
+    tbt.result = {
+      id,
+      title,
+      description,
+      scoreDisplayMode: 'notApplicable',
+      score: null,
+    };
+
+    const perfDom = renderer.render(perfWithNaMetric, sampleResults.categoryGroups);
+    const tbtElement = perfDom.querySelector('.lh-metric#total-blocking-time');
+    assert(tbtElement);
+    assert.equal(tbtElement.querySelector('.lh-metric__title').textContent, 'Total Blocking Time');
+    assert.equal(tbtElement.querySelector('.lh-metric__value').textContent, '--');
+  });
+
   it('does not render metrics section if no metric group audits', () => {
     // Remove metrics from category
     const newCategory = JSON.parse(JSON.stringify(category));


### PR DESCRIPTION
part of #13916

@adamraine convinced me in that issue that we should just use `scoreDisplayMode` `notApplicable` to allow metrics to declare themselves not-applicable, but (unlike all other audits) still be displayed in the report. This allows for "optional" metrics like responsiveness to correctly appear in timespan reports, even if there were no interactions in that timespan.

I still think there's a chance we won't want to eliminate the only way audits can dynamically remove themselves from the report, but that chance seems very slim since we've never done this with a metric before in the four years since metric rendering was changed much, and I think we'll still be able to change our minds without really breaking backwards/forwards compatibility with report rendering.

All that said: how should this look? Almost everything was already working so this PR is just adding some placeholder text. It's pretty weak right now, open to ideas :)

<img width="813" alt="lighthouse report metrics with '--' in the place of the missing 'Interaction to next paint' value" src="https://user-images.githubusercontent.com/316891/167490308-3faf7ff0-590e-4c6e-86f8-019d7112c03d.png">

- better styling to offset it slightly?
- @paulirish had proposed having custom text there (e.g. "No interactions in timespan" or something for INP), which _is_ possible, since `notApplicable` audits can still have their `displayValue` set and could set their own string there. Would that be better? Would need to make sure the string (and translations) fit.