### PR TITLE
new_audit: add work-during-interaction diagnostic

### DIFF
--- a/lighthouse-core/audits/work-during-interaction.js
+++ b/lighthouse-core/audits/work-during-interaction.js
@@ -149,12 +149,8 @@ class WorkDuringInteraction extends Audit {
 
       const results = [];
       for (const [url, timingByGroupId] of executionTimings) {
-        let totalExecutionTimeForURL = 0;
-        for (const [groupId, timespanMs] of Object.entries(timingByGroupId)) {
-          if (timespanMs === 0) continue;
-          timingByGroupId[groupId] = timespanMs;
-          totalExecutionTimeForURL += timespanMs;
-        }
+        const totalExecutionTimeForURL = Object.values(timingByGroupId)
+            .reduce((total, timespanMs) => total + timespanMs);
 
         const scriptingTotal = timingByGroupId[taskGroups.scriptEvaluation.id] || 0;
         const layoutTotal = timingByGroupId[taskGroups.styleLayout.id] || 0;

--- a/lighthouse-core/audits/work-during-interaction.js
+++ b/lighthouse-core/audits/work-during-interaction.js
@@ -1,0 +1,250 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Audit = require('./audit.js');
+const ComputedResponsivenes = require('../computed/metrics/responsiveness.js');
+const ProcessedTrace = require('../computed/processed-trace.js');
+const i18n = require('../lib/i18n/i18n.js');
+const NetworkRecords = require('../computed/network-records.js');
+const MainThreadTasks = require('../lib/tracehouse/main-thread-tasks.js');
+const {taskGroups} = require('../lib/tracehouse/task-groups.js');
+const TraceProcessor = require('../lib/tracehouse/trace-processor.js');
+const {getExecutionTimingsByURL} = require('../lib/tracehouse/task-summary.js');
+const inpThresholds = require('./metrics/experimental-interaction-to-next-paint.js').defaultOptions;
+
+/** @typedef {import('../computed/metrics/responsiveness.js').EventTimingEvent} EventTimingEvent */
+/** @typedef {import('../lib/tracehouse/main-thread-tasks.js').TaskNode} TaskNode */
+
+const TASK_THRESHOLD = 1;
+
+const UIStrings = {
+  /** Title of a diagnostic audit that provides detail on the main thread work the browser did during a key user interaction. This descriptive title is shown to users when the amount is acceptable and no user action is required. */
+  title: 'Minimizes work during key interaction',
+  /** Title of a diagnostic audit that provides detail on the main thread work the browser did during a key user interaction. This imperative title is shown to users when there is a significant amount of execution time that could be reduced. */
+  failureTitle: 'Minimize work during key interaction',
+  /** Description of the work-during-interaction metric. This description is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  description: 'This is the thread-blocking work occurring during the Interaction to Next Paint measurement. [Learn more](https://web.dev/inp/).',
+  /** Label for a column in a data table; entries will be information on the time that the browser is delayed before responding to user input. Ideally fits within a ~40 character limit. */
+  inputDelay: 'Input delay',
+  /** Label for a column in a data table; entries will be information on the time taken by code processing user input that delays a response to the user. Ideally fits within a ~40 character limit. */
+  processingDelay: 'Processing delay',
+  /** Label for a column in a data table; entries will be information on the time that the browser is delayed before presenting a response to user input on screen. Ideally fits within a ~40 character limit. */
+  presentationDelay: 'Presentation delay',
+  /**
+   * @description Summary text that identifies the time the browser took to process a user interaction.
+   * @example {mousedown} interactionType
+   */
+  displayValue: `{timeInMs, number, milliseconds}\xa0ms spent on event '{interactionType}'`,
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+/**
+ * @fileoverview This metric gives a high-percentile measure of responsiveness to input.
+ */
+class WorkDuringInteraction extends Audit {
+  /**
+   * @return {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'work-during-interaction',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
+      supportedModes: ['timespan'],
+      requiredArtifacts: ['traces', 'devtoolsLogs'],
+    };
+  }
+
+  /**
+   * @param {TaskNode} task
+   * @param {TaskNode|undefined} parent
+   * @param {number} startTs
+   * @param {number} endTs
+   * @return {number}
+   */
+  static recursivelyClipTasks(task, parent, startTs, endTs) {
+    const taskEventStart = task.event.ts;
+    const taskEventEnd = task.endEvent?.ts ?? task.event.ts + Number(task.event.dur || 0);
+
+    task.startTime = Math.max(startTs, Math.min(endTs, taskEventStart)) / 1000;
+    task.endTime = Math.max(startTs, Math.min(endTs, taskEventEnd)) / 1000;
+    task.duration = task.endTime - task.startTime;
+
+    const childTime = task.children
+      .map(child => WorkDuringInteraction.recursivelyClipTasks(child, task, startTs, endTs))
+      .reduce((sum, child) => sum + child, 0);
+    task.selfTime = task.duration - childTime;
+    return task.duration;
+  }
+
+  /**
+   * Clip the tasks by the start and end points. Take the easy route and drop
+   * to duration 0 if out of bounds, since only durations are needed in the
+   * end (for now).
+   * Assumes owned tasks, so modifies in place. Can be called multiple times on
+   * the same `tasks` because always computed from original event timing.
+   * @param {Array<TaskNode>} tasks
+   * @param {number} startTs
+   * @param {number} endTs
+   */
+  static clipTasksByTs(tasks, startTs, endTs) {
+    for (const task of tasks) {
+      if (task.parent) continue;
+      WorkDuringInteraction.recursivelyClipTasks(task, undefined, startTs, endTs);
+    }
+  }
+
+  /**
+   * @param {EventTimingEvent} interactionEvent
+   */
+  static getPhaseTimes(interactionEvent) {
+    const interactionData = interactionEvent.args.data;
+    const startTs = interactionEvent.ts;
+    const navStart = startTs - interactionData.timeStamp * 1000;
+    const processingStartTs = navStart + interactionData.processingStart * 1000;
+    const processingEndTs = navStart + interactionData.processingEnd * 1000;
+    const endTs = startTs + interactionData.duration * 1000;
+    return {
+      inputDelay: {startTs, endTs: processingStartTs},
+      processingDelay: {startTs: processingStartTs, endTs: processingEndTs},
+      presentationDelay: {startTs: processingEndTs, endTs},
+    };
+  }
+
+  /**
+   * @param {EventTimingEvent} interactionEvent
+   * @param {LH.Trace} trace
+   * @param {LH.Artifacts.ProcessedTrace} processedTrace
+   * @param {Array<LH.Artifacts.NetworkRequest>} networkRecords
+   * @return {{table: LH.Audit.Details.Table, phases: Record<string, {startTs: number, endTs: number}>}}
+   */
+  static eventThreadBreakdown(interactionEvent, trace, processedTrace, networkRecords) {
+    // Limit to interactionEvent's thread.
+    // TODO(bckenny): limit to interactionEvent's navigation.
+    const threadEvents = TraceProcessor.filteredTraceSort(trace.traceEvents, evt => {
+      return evt.pid === interactionEvent.pid && evt.tid === interactionEvent.tid;
+    });
+    const traceEndTs = threadEvents.reduce((endTs, evt) => {
+      return Math.max(evt.ts + (evt.dur || 0), endTs);
+    }, 0);
+    // frames is only used for URL attribution, so can include all frames, even if OOPIF.
+    const {frames} = processedTrace;
+    const threadTasks = MainThreadTasks.getMainThreadTasks(threadEvents, frames, traceEndTs);
+
+    const phases = WorkDuringInteraction.getPhaseTimes(interactionEvent);
+
+    /** @type {LH.Audit.Details.TableItem[]} */
+    const items = [];
+    for (const [phaseName, phaseTimes] of Object.entries(phases)) {
+      // Clip tasks to start and end time.
+      WorkDuringInteraction.clipTasksByTs(threadTasks, phaseTimes.startTs, phaseTimes.endTs);
+      const executionTimings = getExecutionTimingsByURL(threadTasks, networkRecords);
+
+      const results = [];
+      for (const [url, timingByGroupId] of executionTimings) {
+        let totalExecutionTimeForURL = 0;
+        for (const [groupId, timespanMs] of Object.entries(timingByGroupId)) {
+          if (timespanMs === 0) continue;
+          timingByGroupId[groupId] = timespanMs;
+          totalExecutionTimeForURL += timespanMs;
+        }
+
+        const scriptingTotal = timingByGroupId[taskGroups.scriptEvaluation.id] || 0;
+        const layoutTotal = timingByGroupId[taskGroups.styleLayout.id] || 0;
+        const renderTotal = timingByGroupId[taskGroups.paintCompositeRender.id] || 0;
+
+        results.push({
+          url: url,
+          total: totalExecutionTimeForURL,
+          scripting: scriptingTotal,
+          layout: layoutTotal,
+          render: renderTotal,
+        });
+      }
+
+      const filteredResults = results
+        .filter(result => result.total > TASK_THRESHOLD)
+        .sort((a, b) => b.total - a.total);
+
+      items.push({
+        phase: str_(UIStrings[/** @type {keyof UIStrings} */ (phaseName)]),
+        total: (phaseTimes.endTs - phaseTimes.startTs) / 1000,
+        subItems: {
+          type: 'subitems',
+          items: filteredResults,
+        },
+      });
+    }
+
+    /** @type {LH.Audit.Details.Table['headings']} */
+    const headings = [
+      /* eslint-disable max-len */
+      {key: 'phase', itemType: 'text', subItemsHeading: {key: 'url', itemType: 'url'}, text: 'Phase'},
+      {key: 'total', itemType: 'ms', subItemsHeading: {key: 'total', granularity: 1, itemType: 'ms'}, granularity: 1, text: 'Total time'},
+      {key: null, itemType: 'ms', subItemsHeading: {key: 'scripting', granularity: 1, itemType: 'ms'}, text: 'Script evaluation'},
+      {key: null, itemType: 'ms', subItemsHeading: {key: 'layout', granularity: 1, itemType: 'ms'}, text: taskGroups.styleLayout.label},
+      {key: null, itemType: 'ms', subItemsHeading: {key: 'render', granularity: 1, itemType: 'ms'}, text: taskGroups.paintCompositeRender.label},
+      /* eslint-enable max-len */
+    ];
+
+    return {
+      table: Audit.makeTableDetails(headings, items),
+      phases,
+    };
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @param {LH.Audit.Context} context
+   * @return {Promise<LH.Audit.Product>}
+   */
+  static async audit(artifacts, context) {
+    const {settings} = context;
+    // TODO: responsiveness isn't yet supported by lantern.
+    if (settings.throttlingMethod === 'simulate') {
+      return {score: null, notApplicable: true};
+    }
+
+    const trace = artifacts.traces[WorkDuringInteraction.DEFAULT_PASS];
+    const metricData = {trace, settings};
+    const interactionEvent = await ComputedResponsivenes.request(metricData, context);
+    // If no interaction, diagnostic audit is n/a.
+    if (interactionEvent === null) {
+      return {score: null, notApplicable: true};
+    }
+
+    const devtoolsLog = artifacts.devtoolsLogs[WorkDuringInteraction.DEFAULT_PASS];
+    // Network records will usually be empty for timespans.
+    const networkRecords = await NetworkRecords.request(devtoolsLog, context);
+    const processedTrace = await ProcessedTrace.request(trace, context);
+    const {table, phases} = WorkDuringInteraction.eventThreadBreakdown(
+          interactionEvent, trace, processedTrace, networkRecords);
+
+    const duration = interactionEvent.args.data.duration;
+    const interactionType = interactionEvent.args.data.type;
+    const displayValue = str_(UIStrings.displayValue, {timeInMs: duration, interactionType});
+
+    return {
+      score: duration < inpThresholds.p10 ? 1 : 0,
+      displayValue,
+      details: {
+        ...table,
+        debugData: {
+          type: 'debugdata',
+          interactionType,
+          phases,
+        },
+      },
+    };
+  }
+}
+
+module.exports = WorkDuringInteraction;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-core/config/metrics-to-audits.js
+++ b/lighthouse-core/config/metrics-to-audits.js
@@ -48,9 +48,14 @@ const clsRelevantAudits = [
   // 'preload-fonts', // actually in BP, rather than perf
 ];
 
+const inpRelevantAudits = [
+  'work-during-interaction',
+];
+
 module.exports = {
   fcpRelevantAudits,
   lcpRelevantAudits,
   tbtRelevantAudits,
   clsRelevantAudits,
+  inpRelevantAudits,
 };

--- a/lighthouse-core/fraggle-rock/config/default-config.js
+++ b/lighthouse-core/fraggle-rock/config/default-config.js
@@ -6,19 +6,23 @@
 'use strict';
 
 const legacyDefaultConfig = require('../../config/default-config.js');
+const m2a = require('../../config/metrics-to-audits.js');
 const {deepClone} = require('../../config/config-helpers.js');
 
 /** @type {LH.Config.AuditJson[]} */
 const frAudits = [
   'byte-efficiency/uses-responsive-images-snapshot',
   'metrics/experimental-interaction-to-next-paint',
+  'work-during-interaction',
 ];
 
 /** @type {Record<string, LH.Config.AuditRefJson[]>} */
 const frCategoryAuditRefExtensions = {
   'performance': [
     {id: 'uses-responsive-images-snapshot', weight: 0},
-    {id: 'experimental-interaction-to-next-paint', weight: 0, group: 'metrics', acronym: 'INP'},
+    {id: 'experimental-interaction-to-next-paint', weight: 0, group: 'metrics', acronym: 'INP',
+      relevantAudits: m2a.inpRelevantAudits},
+    {id: 'work-during-interaction', weight: 0},
   ],
 };
 

--- a/lighthouse-core/test/audits/work-during-interaction-test.js
+++ b/lighthouse-core/test/audits/work-during-interaction-test.js
@@ -1,0 +1,220 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/* eslint-disable no-irregular-whitespace */
+
+import WorkDuringInteraction from '../../audits/work-during-interaction.js';
+import interactionTrace from '../fixtures/traces/timespan-responsiveness-m103.trace.json';
+import noInteractionTrace from '../fixtures/traces/jumpy-cls-m90.json';
+
+describe('Interaction to Next Paint', () => {
+  function getTestData() {
+    const artifacts = {
+      traces: {
+        [WorkDuringInteraction.DEFAULT_PASS]: interactionTrace,
+      },
+      devtoolsLogs: {
+        [WorkDuringInteraction.DEFAULT_PASS]: [],
+      },
+    };
+
+    const context = {
+      settings: {throttlingMethod: 'devtools'},
+      computedCache: new Map(),
+      options: WorkDuringInteraction.defaultOptions,
+    };
+
+    return {artifacts, context};
+  }
+
+  it('evaluates INP correctly', async () => {
+    const {artifacts, context} = getTestData();
+    const result = await WorkDuringInteraction.audit(artifacts, context);
+    expect(result).toMatchInlineSnapshot(`
+Object {
+  "details": Object {
+    "debugData": Object {
+      "interactionType": "mousedown",
+      "phases": Object {
+        "inputDelay": Object {
+          "endTs": 633282608296,
+          "startTs": 633282566296,
+        },
+        "presentationDelay": Object {
+          "endTs": 633282934296,
+          "startTs": 633282649296,
+        },
+        "processingDelay": Object {
+          "endTs": 633282649296,
+          "startTs": 633282608296,
+        },
+      },
+      "type": "debugdata",
+    },
+    "headings": Array [
+      Object {
+        "itemType": "text",
+        "key": "phase",
+        "subItemsHeading": Object {
+          "itemType": "url",
+          "key": "url",
+        },
+        "text": "Phase",
+      },
+      Object {
+        "granularity": 1,
+        "itemType": "ms",
+        "key": "total",
+        "subItemsHeading": Object {
+          "granularity": 1,
+          "itemType": "ms",
+          "key": "total",
+        },
+        "text": "Total time",
+      },
+      Object {
+        "itemType": "ms",
+        "key": null,
+        "subItemsHeading": Object {
+          "granularity": 1,
+          "itemType": "ms",
+          "key": "scripting",
+        },
+        "text": "Script evaluation",
+      },
+      Object {
+        "itemType": "ms",
+        "key": null,
+        "subItemsHeading": Object {
+          "granularity": 1,
+          "itemType": "ms",
+          "key": "layout",
+        },
+        "text": "Style & Layout",
+      },
+      Object {
+        "itemType": "ms",
+        "key": null,
+        "subItemsHeading": Object {
+          "granularity": 1,
+          "itemType": "ms",
+          "key": "render",
+        },
+        "text": "Rendering",
+      },
+    ],
+    "items": Array [
+      Object {
+        "phase": Object {
+          "formattedDefault": "Input delay",
+          "i18nId": "lighthouse-core/audits/work-during-interaction.js | inputDelay",
+          "values": undefined,
+        },
+        "subItems": Object {
+          "items": Array [
+            Object {
+              "layout": 0,
+              "render": 0,
+              "scripting": 39.855000019073486,
+              "total": 40.68599998950958,
+              "url": "http://localhost:10200/events.html",
+            },
+            Object {
+              "layout": 0,
+              "render": 0,
+              "scripting": 0,
+              "total": 1.3049999475479126,
+              "url": "Unattributable",
+            },
+          ],
+          "type": "subitems",
+        },
+        "total": 42,
+      },
+      Object {
+        "phase": Object {
+          "formattedDefault": "Processing delay",
+          "i18nId": "lighthouse-core/audits/work-during-interaction.js | processingDelay",
+          "values": undefined,
+        },
+        "subItems": Object {
+          "items": Array [
+            Object {
+              "layout": 0,
+              "render": 0,
+              "scripting": 40.6599999666214,
+              "total": 41,
+              "url": "http://localhost:10200/events.html",
+            },
+          ],
+          "type": "subitems",
+        },
+        "total": 41,
+      },
+      Object {
+        "phase": Object {
+          "formattedDefault": "Presentation delay",
+          "i18nId": "lighthouse-core/audits/work-during-interaction.js | presentationDelay",
+          "values": undefined,
+        },
+        "subItems": Object {
+          "items": Array [
+            Object {
+              "layout": 0,
+              "render": 0,
+              "scripting": 272.8389996290207,
+              "total": 278.7499998807907,
+              "url": "http://localhost:10200/events.html",
+            },
+            Object {
+              "layout": 0,
+              "render": 0,
+              "scripting": 0.03100001811981201,
+              "total": 2.01800000667572,
+              "url": "Unattributable",
+            },
+          ],
+          "type": "subitems",
+        },
+        "total": 285,
+      },
+    ],
+    "summary": undefined,
+    "type": "table",
+  },
+  "displayValue": Object {
+    "formattedDefault": "370 ms spent on event 'mousedown'",
+    "i18nId": "lighthouse-core/audits/work-during-interaction.js | displayValue",
+    "values": Object {
+      "interactionType": "mousedown",
+      "timeInMs": 368,
+    },
+  },
+  "score": 0,
+}
+`);
+  });
+
+  it('is not applicable if using simulated throttling', async () => {
+    const {artifacts, context} = getTestData();
+    context.settings.throttlingMethod = 'simulate';
+    const result = await WorkDuringInteraction.audit(artifacts, context);
+    expect(result).toMatchObject({
+      score: null,
+      notApplicable: true,
+    });
+  });
+
+  it('is not applicable if no interactions occurred in trace', async () => {
+    const {artifacts, context} = getTestData();
+    artifacts.traces[WorkDuringInteraction.DEFAULT_PASS] = noInteractionTrace;
+    const result = await WorkDuringInteraction.audit(artifacts, context);
+    expect(result).toMatchObject({
+      score: null,
+      notApplicable: true,
+    });
+  });
+});

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -9095,6 +9095,14 @@
             "score": null,
             "scoreDisplayMode": "error",
             "errorMessage": "This version of Chrome is too old to support 'detailed EventTiming trace events'. Use a newer version to see full results."
+          },
+          "work-during-interaction": {
+            "id": "work-during-interaction",
+            "title": "Minimizes work during key interaction",
+            "description": "This is the thread-blocking work occurring during the Interaction to Next Paint measurement. [Learn more](https://web.dev/inp/).",
+            "score": null,
+            "scoreDisplayMode": "error",
+            "errorMessage": "This version of Chrome is too old to support 'detailed EventTiming trace events'. Use a newer version to see full results."
           }
         },
         "configSettings": {
@@ -9312,7 +9320,14 @@
                 "id": "experimental-interaction-to-next-paint",
                 "weight": 0,
                 "group": "metrics",
-                "acronym": "INP"
+                "acronym": "INP",
+                "relevantAudits": [
+                  "work-during-interaction"
+                ]
+              },
+              {
+                "id": "work-during-interaction",
+                "weight": 0
               }
             ],
             "id": "performance",
@@ -9938,12 +9953,18 @@
             },
             {
               "startTime": 80,
+              "name": "lh:audit:work-during-interaction",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 81,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 81
+          "total": 82
         },
         "i18n": {
           "rendererFormattedStrings": {
@@ -10431,7 +10452,20 @@
                   "featureName": "detailed EventTiming trace events"
                 },
                 "path": "audits[experimental-interaction-to-next-paint].errorMessage"
+              },
+              {
+                "values": {
+                  "errorCode": "UNSUPPORTED_OLD_CHROME",
+                  "featureName": "detailed EventTiming trace events"
+                },
+                "path": "audits[work-during-interaction].errorMessage"
               }
+            ],
+            "lighthouse-core/audits/work-during-interaction.js | title": [
+              "audits[work-during-interaction].title"
+            ],
+            "lighthouse-core/audits/work-during-interaction.js | description": [
+              "audits[work-during-interaction].description"
             ],
             "lighthouse-core/config/default-config.js | performanceCategoryTitle": [
               "categories.performance.title"

--- a/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
+++ b/lighthouse-core/test/fraggle-rock/scenarios/api-test-pptr.js
@@ -91,7 +91,7 @@ describe('Fraggle Rock API', () => {
         notApplicableAudits,
       } = getAuditsBreakdown(lhr);
       // TODO(FR-COMPAT): This assertion can be removed when full compatibility is reached.
-      expect(auditResults.length).toMatchInlineSnapshot(`45`);
+      expect(auditResults.length).toMatchInlineSnapshot(`46`);
 
       expect(notApplicableAudits.length).toMatchInlineSnapshot(`5`);
       expect(notApplicableAudits.map(audit => audit.id)).not.toContain('total-blocking-time');
@@ -143,7 +143,7 @@ describe('Fraggle Rock API', () => {
       });
 
       const {auditResults, erroredAudits, notApplicableAudits} = getAuditsBreakdown(result.lhr);
-      expect(auditResults.length).toMatchInlineSnapshot(`45`);
+      expect(auditResults.length).toMatchInlineSnapshot(`46`);
 
       expect(notApplicableAudits.length).toMatchInlineSnapshot(`18`);
       expect(notApplicableAudits.map(audit => audit.id)).not.toContain('total-blocking-time');

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1658,6 +1658,27 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Has a `<meta name=\"viewport\">` tag with `width` or `initial-scale`"
   },
+  "lighthouse-core/audits/work-during-interaction.js | description": {
+    "message": "This is the thread-blocking work occurring during the Interaction to Next Paint measurement. [Learn more](https://web.dev/inp/)."
+  },
+  "lighthouse-core/audits/work-during-interaction.js | displayValue": {
+    "message": "{timeInMs, number, milliseconds} ms spent on event '{interactionType}'"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | failureTitle": {
+    "message": "Minimize work during key interaction"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | inputDelay": {
+    "message": "Input delay"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | presentationDelay": {
+    "message": "Presentation delay"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | processingDelay": {
+    "message": "Processing delay"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | title": {
+    "message": "Minimizes work during key interaction"
+  },
   "lighthouse-core/config/default-config.js | a11yAriaGroupDescription": {
     "message": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
   },

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1658,6 +1658,27 @@
   "lighthouse-core/audits/viewport.js | title": {
     "message": "Ĥáŝ á `<meta name=\"viewport\">` t̂áĝ ẃît́ĥ `width` ór̂ `initial-scale`"
   },
+  "lighthouse-core/audits/work-during-interaction.js | description": {
+    "message": "T̂h́îś îś t̂h́ê t́ĥŕêád̂-b́l̂óĉḱîńĝ ẃôŕk̂ óĉćûŕr̂ín̂ǵ d̂úr̂ín̂ǵ t̂h́ê Ín̂t́êŕâćt̂íôń t̂ó N̂éx̂t́ P̂áîńt̂ ḿêáŝúr̂ém̂én̂t́. [L̂éâŕn̂ ḿôŕê](https://web.dev/inp/)."
+  },
+  "lighthouse-core/audits/work-during-interaction.js | displayValue": {
+    "message": "{timeInMs, number, milliseconds} m̂ś ŝṕêńt̂ ón̂ év̂én̂t́ '{interactionType}'"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | failureTitle": {
+    "message": "M̂ín̂ím̂íẑé ŵór̂ḱ d̂úr̂ín̂ǵ k̂éŷ ín̂t́êŕâćt̂íôń"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | inputDelay": {
+    "message": "Îńp̂út̂ d́êĺâý"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | presentationDelay": {
+    "message": "P̂ŕêśêńt̂át̂íôń d̂él̂áŷ"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | processingDelay": {
+    "message": "P̂ŕôćêśŝín̂ǵ d̂él̂áŷ"
+  },
+  "lighthouse-core/audits/work-during-interaction.js | title": {
+    "message": "M̂ín̂ím̂íẑéŝ ẃôŕk̂ d́ûŕîńĝ ḱêý îńt̂ér̂áĉt́îón̂"
+  },
   "lighthouse-core/config/default-config.js | a11yAriaGroupDescription": {
     "message": "T̂h́êśê ár̂é ôṕp̂ór̂t́ûńît́îéŝ t́ô ím̂ṕr̂óv̂é t̂h́ê úŝáĝé ôf́ ÂŔÎÁ îń ŷóûŕ âṕp̂ĺîćât́îón̂ ẃĥíĉh́ m̂áŷ én̂h́âńĉé t̂h́ê éx̂ṕêŕîén̂ćê f́ôŕ ûśêŕŝ óf̂ áŝśîśt̂ív̂é t̂éĉh́n̂ól̂óĝý, l̂ík̂é â śĉŕêén̂ ŕêád̂ér̂."
   },

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-navigation-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-navigation-expected.txt
@@ -30,11 +30,11 @@ Cleaning origin data
 Cleaning browser cache
 Preparing network conditions
 Navigating to http://127.0.0.1:8000/devtools/lighthouse/resources/lighthouse-basic.html
-Computing artifact: NetworkRecords$I
+Computing artifact: NetworkRecords$J
 Get webapp installability errors
 Computing artifact: MainResource$k
 Collect stacks
-Computing artifact: ProcessedTrace$g
+Computing artifact: ProcessedTrace$h
 Computing artifact: ProcessedNavigation$7
 Get webapp manifest
 Audit phase
@@ -93,7 +93,7 @@ Auditing: Serves images with appropriate resolution
 Auditing: Fonts with `font-display: optional` are preloaded
 Auditing: Avoids deprecated APIs
 Auditing: Minimizes main-thread work
-Computing artifact: MainThreadTasks$7
+Computing artifact: MainThreadTasks$8
 Auditing: JavaScript execution time
 Auditing: Preload key requests
 Auditing: Preconnect to required origins

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -96,7 +96,7 @@ Gathering in-page: SourceMaps
 Gathering in-page: FullPageScreenshot
 Gathering trace
 Gathering devtoolsLog & network records
-Computing artifact: NetworkRecords$I
+Computing artifact: NetworkRecords$J
 Running afterPass methods
 Gathering: CSSUsage
 Gathering: JsUsage
@@ -124,7 +124,7 @@ Gathering: RobotsTxt
 Gathering: TapTargets
 Gathering: Accessibility
 Gathering: TraceElements
-Computing artifact: ProcessedTrace$g
+Computing artifact: ProcessedTrace$h
 Computing artifact: ProcessedNavigation$7
 Gathering: InspectorIssues
 Gathering: SourceMaps
@@ -146,7 +146,7 @@ Navigating to http://127.0.0.1:8000/devtools/lighthouse/resources/lighthouse-bas
 Running pass methods
 Gathering in-page: ServiceWorker
 Gathering devtoolsLog & network records
-Computing artifact: NetworkRecords$I
+Computing artifact: NetworkRecords$J
 Running afterPass methods
 Gathering: ServiceWorker
 Disconnecting from browser...
@@ -207,7 +207,7 @@ Auditing: Serves images with appropriate resolution
 Auditing: Fonts with `font-display: optional` are preloaded
 Auditing: Avoids deprecated APIs
 Auditing: Minimizes main-thread work
-Computing artifact: MainThreadTasks$7
+Computing artifact: MainThreadTasks$8
 Auditing: JavaScript execution time
 Auditing: Preload key requests
 Auditing: Preconnect to required origins


### PR DESCRIPTION
part of #13916 

Breaks down the tasks occurring during the INP event. Tests are very light, still working on them

Example report: https://lighthouse-ddszazj4j-googlechrome.vercel.app/gh-pages/viewer/?gist=0b9f538660fe83c57c94acb5b6a04be0

<img width="802" alt="Example lighthouse post showing new diagnostic audit" src="https://user-images.githubusercontent.com/316891/167522253-3c39db69-61b1-4ed2-9220-d95b6c577852.png">
