### PR TITLE
core(responsiveness): add better INP fallback for old Chrome versions

### DIFF
--- a/lighthouse-core/audits/metrics/experimental-interaction-to-next-paint.js
+++ b/lighthouse-core/audits/metrics/experimental-interaction-to-next-paint.js
@@ -70,7 +70,9 @@ class ExperimentalInteractionToNextPaint extends Audit {
       return {score: null, notApplicable: true};
     }
 
-    const timing = interactionEvent.args.data.duration;
+    // TODO: remove workaround once 103.0.5052.0 is sufficiently released.
+    const timing = interactionEvent.name === 'FallbackTiming' ?
+        interactionEvent.duration : interactionEvent.args.data.duration;
 
     return {
       score: Audit.computeLogNormalScore({p10: context.options.p10, median: context.options.median},

--- a/lighthouse-core/audits/work-during-interaction.js
+++ b/lighthouse-core/audits/work-during-interaction.js
@@ -15,6 +15,7 @@ const {taskGroups} = require('../lib/tracehouse/task-groups.js');
 const TraceProcessor = require('../lib/tracehouse/trace-processor.js');
 const {getExecutionTimingsByURL} = require('../lib/tracehouse/task-summary.js');
 const inpThresholds = require('./metrics/experimental-interaction-to-next-paint.js').defaultOptions;
+const LHError = require('../lib/lh-error.js');
 
 /** @typedef {import('../computed/metrics/responsiveness.js').EventTimingEvent} EventTimingEvent */
 /** @typedef {import('../lib/tracehouse/main-thread-tasks.js').TaskNode} TaskNode */
@@ -214,6 +215,13 @@ class WorkDuringInteraction extends Audit {
     // If no interaction, diagnostic audit is n/a.
     if (interactionEvent === null) {
       return {score: null, notApplicable: true};
+    }
+    // TODO: remove workaround once 103.0.5052.0 is sufficiently released.
+    if (interactionEvent.name === 'FallbackTiming') {
+      throw new LHError(
+        LHError.errors.UNSUPPORTED_OLD_CHROME,
+        {featureName: 'detailed EventTiming trace events'}
+      );
     }
 
     const devtoolsLog = artifacts.devtoolsLogs[WorkDuringInteraction.DEFAULT_PASS];

--- a/lighthouse-core/test/audits/metrics/experimental-interaction-to-next-paint-test.js
+++ b/lighthouse-core/test/audits/metrics/experimental-interaction-to-next-paint-test.js
@@ -37,6 +37,26 @@ describe('Interaction to Next Paint', () => {
     });
   });
 
+  it('falls back Responsiveness timing if no m103 EventTiming events', async () => {
+    const {artifacts, context} = getTestData();
+    const clonedTrace = JSON.parse(JSON.stringify(artifacts.traces.defaultPass));
+    for (let i = 0; i < clonedTrace.traceEvents.length; i++) {
+      if (clonedTrace.traceEvents[i].name !== 'EventTiming') continue;
+      clonedTrace.traceEvents[i].args = {};
+    }
+    artifacts.traces.defaultPass = clonedTrace;
+
+    const result = await ExperimentalInteractionToNextPaint.audit(artifacts, context);
+    // Conveniently, the matching responsiveness event has slightly different
+    // duration than the matching interaction event so can be tested against.
+    expect(result).toEqual({
+      score: 0.67,
+      numericValue: 364,
+      numericUnit: 'millisecond',
+      displayValue: expect.toBeDisplayString('360 ms'),
+    });
+  });
+
   it('is not applicable if using simulated throttling', async () => {
     const {artifacts, context} = getTestData();
     context.settings.throttlingMethod = 'simulate';

--- a/lighthouse-core/test/audits/work-during-interaction-test.js
+++ b/lighthouse-core/test/audits/work-during-interaction-test.js
@@ -198,6 +198,19 @@ Object {
 `);
   });
 
+  it('evaluates INP correctly', async () => {
+    const {artifacts, context} = getTestData();
+    const clonedTrace = JSON.parse(JSON.stringify(artifacts.traces.defaultPass));
+    for (let i = 0; i < clonedTrace.traceEvents.length; i++) {
+      if (clonedTrace.traceEvents[i].name !== 'EventTiming') continue;
+      clonedTrace.traceEvents[i].args = {};
+    }
+    artifacts.traces.defaultPass = clonedTrace;
+
+    await expect(WorkDuringInteraction.audit(artifacts, context))
+      .rejects.toThrow('UNSUPPORTED_OLD_CHROME');
+  });
+
   it('is not applicable if using simulated throttling', async () => {
     const {artifacts, context} = getTestData();
     context.settings.throttlingMethod = 'simulate';

--- a/lighthouse-core/test/computed/metrics/responsiveness-test.js
+++ b/lighthouse-core/test/computed/metrics/responsiveness-test.js
@@ -235,7 +235,7 @@ describe('Metric: Responsiveness', () => {
       .rejects.toThrow(`unexpected responsiveness interactionType 'brainWave'`);
   });
 
-  it('throws an OLD_CHROME error if provided with the old trace event format', async () => {
+  it('returns a fallback timing event if provided with the old trace event format', async () => {
     const interactionEvents = [{
       ts: 500,
       maxDuration: 200,
@@ -250,8 +250,11 @@ describe('Metric: Responsiveness', () => {
       trace,
       settings: {throttlingMethod: 'provided'},
     };
-    await expect(Responsiveness.request(metricInputData, {computedCache: new Map()}))
-      .rejects.toThrow('UNSUPPORTED_OLD_CHROME');
+    const event = await Responsiveness.request(metricInputData, {computedCache: new Map()});
+    expect(event).toEqual({
+      name: 'FallbackTiming',
+      duration: 200,
+    });
   });
 
   it('only finds interaction events from the same frame as the responsiveness event', async () => {

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -9092,9 +9092,11 @@
             "id": "experimental-interaction-to-next-paint",
             "title": "Interaction to Next Paint",
             "description": "Interaction to Next Paint measures page responsiveness, how long it takes the page to visibly respond to user input. [Learn more](https://web.dev/inp/).",
-            "score": null,
-            "scoreDisplayMode": "error",
-            "errorMessage": "This version of Chrome is too old to support 'detailed EventTiming trace events'. Use a newer version to see full results."
+            "score": 1,
+            "scoreDisplayMode": "numeric",
+            "numericValue": 60,
+            "numericUnit": "millisecond",
+            "displayValue": "60 ms"
           },
           "work-during-interaction": {
             "id": "work-during-interaction",
@@ -10052,6 +10054,12 @@
                   "timeInMs": 539.765
                 },
                 "path": "audits[network-server-latency].displayValue"
+              },
+              {
+                "values": {
+                  "timeInMs": 60
+                },
+                "path": "audits[experimental-interaction-to-next-paint].displayValue"
               }
             ],
             "lighthouse-core/lib/i18n/i18n.js | cumulativeLayoutShiftMetric": [
@@ -10445,14 +10453,13 @@
             "lighthouse-core/audits/metrics/experimental-interaction-to-next-paint.js | description": [
               "audits[experimental-interaction-to-next-paint].description"
             ],
+            "lighthouse-core/audits/work-during-interaction.js | title": [
+              "audits[work-during-interaction].title"
+            ],
+            "lighthouse-core/audits/work-during-interaction.js | description": [
+              "audits[work-during-interaction].description"
+            ],
             "lighthouse-core/lib/lh-error.js | oldChromeDoesNotSupportFeature": [
-              {
-                "values": {
-                  "errorCode": "UNSUPPORTED_OLD_CHROME",
-                  "featureName": "detailed EventTiming trace events"
-                },
-                "path": "audits[experimental-interaction-to-next-paint].errorMessage"
-              },
               {
                 "values": {
                   "errorCode": "UNSUPPORTED_OLD_CHROME",
@@ -10460,12 +10467,6 @@
                 },
                 "path": "audits[work-during-interaction].errorMessage"
               }
-            ],
-            "lighthouse-core/audits/work-during-interaction.js | title": [
-              "audits[work-during-interaction].title"
-            ],
-            "lighthouse-core/audits/work-during-interaction.js | description": [
-              "audits[work-during-interaction].description"
             ],
             "lighthouse-core/config/default-config.js | performanceCategoryTitle": [
               "categories.performance.title"


### PR DESCRIPTION
part of #13916 

This change makes INP not error in Chrome < 103.0.5052.0, since it needs just the latency duration, not the rest of the new timing information. It's fine to assume that this audit will land in a DevTools after that version, but puppeteer user flows could easily run on older versions than that.

The work-during-interaction audit will still error, however, since it requires the new timing information.