### PR TITLE
misc(inp): switch proccessing "delay" to "time"

### DIFF
--- a/lighthouse-core/audits/work-during-interaction.js
+++ b/lighthouse-core/audits/work-during-interaction.js
@@ -32,7 +32,7 @@ const UIStrings = {
   /** Label for a column in a data table; entries will be information on the time that the browser is delayed before responding to user input. Ideally fits within a ~40 character limit. */
   inputDelay: 'Input delay',
   /** Label for a column in a data table; entries will be information on the time taken by code processing user input that delays a response to the user. Ideally fits within a ~40 character limit. */
-  processingDelay: 'Processing delay',
+  processingTime: 'Processing time',
   /** Label for a column in a data table; entries will be information on the time that the browser is delayed before presenting a response to user input on screen. Ideally fits within a ~40 character limit. */
   presentationDelay: 'Presentation delay',
   /**
@@ -116,7 +116,7 @@ class WorkDuringInteraction extends Audit {
     const endTs = startTs + interactionData.duration * 1000;
     return {
       inputDelay: {startTs, endTs: processingStartTs},
-      processingDelay: {startTs: processingStartTs, endTs: processingEndTs},
+      processingTime: {startTs: processingStartTs, endTs: processingEndTs},
       presentationDelay: {startTs: processingEndTs, endTs},
     };
   }

--- a/lighthouse-core/test/audits/work-during-interaction-test.js
+++ b/lighthouse-core/test/audits/work-during-interaction-test.js
@@ -167,8 +167,8 @@ Object {
           },
           Object {
             "phase": Object {
-              "formattedDefault": "Processing delay",
-              "i18nId": "lighthouse-core/audits/work-during-interaction.js | processingDelay",
+              "formattedDefault": "Processing time",
+              "i18nId": "lighthouse-core/audits/work-during-interaction.js | processingTime",
               "values": undefined,
             },
             "subItems": Object {
@@ -227,7 +227,7 @@ Object {
             "endTs": 633282934296,
             "startTs": 633282649296,
           },
-          "processingDelay": Object {
+          "processingTime": Object {
             "endTs": 633282649296,
             "startTs": 633282608296,
           },

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1676,8 +1676,8 @@
   "lighthouse-core/audits/work-during-interaction.js | presentationDelay": {
     "message": "Presentation delay"
   },
-  "lighthouse-core/audits/work-during-interaction.js | processingDelay": {
-    "message": "Processing delay"
+  "lighthouse-core/audits/work-during-interaction.js | processingTime": {
+    "message": "Processing time"
   },
   "lighthouse-core/audits/work-during-interaction.js | title": {
     "message": "Minimizes work during key interaction"

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1676,8 +1676,8 @@
   "lighthouse-core/audits/work-during-interaction.js | presentationDelay": {
     "message": "P̂ŕêśêńt̂át̂íôń d̂él̂áŷ"
   },
-  "lighthouse-core/audits/work-during-interaction.js | processingDelay": {
-    "message": "P̂ŕôćêśŝín̂ǵ d̂él̂áŷ"
+  "lighthouse-core/audits/work-during-interaction.js | processingTime": {
+    "message": "P̂ŕôćêśŝín̂ǵ t̂ím̂é"
   },
   "lighthouse-core/audits/work-during-interaction.js | title": {
     "message": "M̂ín̂ím̂íẑéŝ ẃôŕk̂ d́ûŕîńĝ ḱêý îńt̂ér̂áĉt́îón̂"


### PR DESCRIPTION
Apparently the middle phase of INP got switched from "processing delay" to "processing time" in the [web.dev/inp explainer](https://web.dev/inp/#:~:text=event%20handlers%20execute.-,The%20processing%20time,-%2C%20which%20is%20the), and I've been told that enough time went into discussing the change that Lighthouse should use the same nomenclature to keep things consistent :)

<img alt="a diagram of the phases of a page interaction. importantly, the middle phase is labelled 'processing time'" width="800" src="https://web-dev.imgix.net/image/jL3OLOhcWUQDnR4XjewLBx4e3PC3/Ng0j5yaGYZX9Bm3VQ70c.svg">
