### PR TITLE
core: save native getBoundingClientRect to avoid overrides

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -147,6 +147,11 @@
 
   // Ensure long-task collection still works when performance.now is redefined
   window.performance.now = 'right now';
+
+  // Ensure bounding rectangles still work when getBoundingClientRect is overriden.
+  window.HTMLElement.prototype.getBoundingClientRect = function() {
+    return {top: '', left: ''};
+  };
 </script>
 
 <div>

--- a/lighthouse-core/gather/driver/execution-context.js
+++ b/lighthouse-core/gather/driver/execution-context.js
@@ -215,6 +215,7 @@ class ExecutionContext {
       window.__nativePerformance = window.performance;
       window.__nativeFetch = window.fetch;
       window.__ElementMatches = window.Element.prototype.matches;
+      window.__HTMLElementBoundingClientRect = window.HTMLElement.prototype.getBoundingClientRect;
       // Ensure the native `performance.now` is not overwritable.
       const performance = window.performance;
       const performanceNow = window.performance.now;

--- a/lighthouse-core/gather/gatherers/iframe-elements.js
+++ b/lighthouse-core/gather/gatherers/iframe-elements.js
@@ -17,10 +17,13 @@ const pageFunctions = require('../../lib/page-functions.js');
  */
 /* c8 ignore start */
 function collectIFrameElements() {
+  const realBoundingClientRect = window.__HTMLElementBoundingClientRect ||
+    window.HTMLElement.prototype.getBoundingClientRect;
+
   // @ts-expect-error - put into scope via stringification
   const iFrameElements = getElementsInDocument('iframe'); // eslint-disable-line no-undef
   return iFrameElements.map(/** @param {HTMLIFrameElement} node */ (node) => {
-    const clientRect = node.getBoundingClientRect();
+    const clientRect = realBoundingClientRect.call(node);
     const {top, bottom, left, right, width, height} = clientRect;
     return {
       id: node.id,

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -19,9 +19,7 @@ const FontSize = require('./seo/font-size.js');
 /** @param {Element} element */
 /* c8 ignore start */
 function getClientRect(element) {
-  const realBoundingClientRect = window.__HTMLElementBoundingClientRect ||
-    window.HTMLElement.prototype.getBoundingClientRect;
-  const clientRect = realBoundingClientRect.call(element);
+  const clientRect = element.getBoundingClientRect();
   return {
     // Just grab the DOMRect properties we want, excluding x/y/width/height
     top: clientRect.top,

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -19,7 +19,9 @@ const FontSize = require('./seo/font-size.js');
 /** @param {Element} element */
 /* c8 ignore start */
 function getClientRect(element) {
-  const clientRect = element.getBoundingClientRect();
+  const realBoundingClientRect = window.__HTMLElementBoundingClientRect ||
+    window.HTMLElement.prototype.getBoundingClientRect;
+  const clientRect = realBoundingClientRect.call(element);
   return {
     // Just grab the DOMRect properties we want, excluding x/y/width/height
     top: clientRect.top,

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -434,8 +434,10 @@ function getNodeLabel(element) {
  * @return {LH.Artifacts.Rect}
  */
 function getBoundingClientRect(element) {
+  const realBoundingClientRect = window.__HTMLElementBoundingClientRect ||
+    window.HTMLElement.prototype.getBoundingClientRect;
   // The protocol does not serialize getters, so extract the values explicitly.
-  const rect = element.getBoundingClientRect();
+  const rect = realBoundingClientRect.call(element);
   return {
     top: Math.round(rect.top),
     bottom: Math.round(rect.bottom),

--- a/lighthouse-core/test/lib/page-functions-test.js
+++ b/lighthouse-core/test/lib/page-functions-test.js
@@ -21,7 +21,9 @@ describe('Page Functions', () => {
     global.Node = Node;
     global.HTMLElement = HTMLElement;
     global.document = document;
-    global.window = {};
+    global.window = {
+      HTMLElement, // for getBoundingClientRect fallback.
+    };
   });
 
   afterAll(() => {

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -23,6 +23,7 @@ declare global {
     __nativeFetch: typeof fetch,
     __nativeURL: typeof URL;
     __ElementMatches: Element['matches'];
+    __HTMLElementBoundingClientRect: HTMLElement['getBoundingClientRect'];
 
     /** Used for monitoring long tasks in the test page. */
     ____lastLongTask?: number;


### PR DESCRIPTION
Fixes #14001.

The issue was due to a conflict with an overridden `HTMLElement.prototype.getBoundingClientRect` present on the page in the bug report. This fix saves a reference to the native function and uses it across. 