### PR TITLE
core(image-elements): use execution context isolation

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -431,7 +431,7 @@ const expectations = {
           nodes: {
             // Test that the numbers for individual elements are in the ballpark.
             // Exact ordering and IDs between FR and legacy differ, so fork the expectations.
-            'page-0-IMG': {
+            '5-11-IMG': {
               _legacyOnly: true,
               top: '650±50',
               bottom: '650±50',
@@ -440,7 +440,7 @@ const expectations = {
               width: '120±20',
               height: '20±20',
             },
-            'page-2-IMG': {
+            '9-1-IMG': {
               _fraggleRockOnly: true,
               top: '650±50',
               bottom: '650±50',

--- a/lighthouse-cli/test/smokehouse/test-definitions/screenshot.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/screenshot.js
@@ -49,7 +49,7 @@ const expectations = {
       nodes: {
         // Gathered with no execution context isolation, shared between both FR and legacy.
         'page-0-P': {...elements.p},
-        
+
         // Legacy execution context IDs.
         // Note: The first number (5) in these ids comes from an executionContextId, and has the potential to change.
         // The following P is the same element as above but from a different JS context. This element

--- a/lighthouse-cli/test/smokehouse/test-definitions/screenshot.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/screenshot.js
@@ -48,15 +48,14 @@ const expectations = {
       },
       nodes: {
         // Gathered with no execution context isolation, shared between both FR and legacy.
-        'page-0-BODY': {...elements.body},
-        'page-1-P': {...elements.p},
-
+        'page-0-P': {...elements.p},
+        
         // Legacy execution context IDs.
         // Note: The first number (5) in these ids comes from an executionContextId, and has the potential to change.
         // The following P is the same element as above but from a different JS context. This element
         // starts with height ~18 and grows over time. See screenshot.html.
-        '5-1-P': {_legacyOnly: true, ...elements.p},
-        '5-2-BODY': {_legacyOnly: true, ...elements.body},
+        '5-0-BODY': {_legacyOnly: true, ...elements.body},
+        '5-2-P': {_legacyOnly: true, ...elements.p},
         '5-3-HTML': {_legacyOnly: true},
 
         // Fraggle rock should contain the same elements just with different ids.

--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -258,6 +258,7 @@ class ImageElements extends FRGatherer {
         driver.defaultSession.setNextProtocolTimeout(250);
         size = await driver.executionContext.evaluate(determineNaturalSize, {
           args: [url],
+          useIsolation: true,
         });
         this._naturalSizeCache.set(url, size);
       } catch (_) {
@@ -340,6 +341,7 @@ class ImageElements extends FRGatherer {
 
     const elements = await executionContext.evaluate(collectImageElementInfo, {
       args: [],
+      useIsolation: true,
       deps: [
         pageFunctions.getElementsInDocumentString,
         pageFunctions.getBoundingClientRectString,


### PR DESCRIPTION
mentioned in #14003