### PR TITLE
core(driver): drop /new tab creation fallback

### DIFF
--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -33,23 +33,9 @@ class CriConnection extends Connection {
    * @override
    * @return {Promise<void>}
    */
-  connect() {
-    return this._runJsonCommand('new')
-      .then(response => this._connectToSocket(/** @type {LH.DevToolsJsonTarget} */(response)))
-      .catch(_ => {
-        // COMPAT: headless didn't support `/json/new` before m59. (#970, crbug.com/699392)
-        // If no support, we fallback and reuse an existing open tab
-        log.warn('CriConnection', 'Cannot create new tab; reusing open tab.');
-        return this._runJsonCommand('list').then(tabs => {
-          if (!Array.isArray(tabs) || tabs.length === 0) {
-            return Promise.reject(new Error('Cannot create new tab, and no tabs already open.'));
-          }
-          const firstTab = tabs[0];
-          // first, we activate it to a foreground tab, then we connect
-          return this._runJsonCommand(`activate/${firstTab.id}`)
-              .then(() => this._connectToSocket(firstTab));
-        });
-      });
+  async connect() {
+    const response = await this._runJsonCommand('new');
+    this._connectToSocket(/** @type {LH.DevToolsJsonTarget} */(response));
   }
 
   /**

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -288,10 +288,9 @@ async function saveAssets(artifacts, audits, pathWithBasename) {
     fs.writeFileSync(devtoolsLogFilename, JSON.stringify(passAssets.devtoolsLog, null, 2));
     log.log('saveAssets', 'devtools log saved to disk: ' + devtoolsLogFilename);
 
-    const streamTraceFilename = `${pathWithBasename}-${index}${traceSuffix}`;
-    log.log('saveAssets', 'streaming trace file to disk: ' + streamTraceFilename);
-    await saveTrace(passAssets.traceData, streamTraceFilename);
-    log.log('saveAssets', 'trace file streamed to disk: ' + streamTraceFilename);
+    const traceFilename = `${pathWithBasename}-${index}${traceSuffix}`;
+    await saveTrace(passAssets.traceData, traceFilename);
+    log.log('saveAssets', 'trace file streamed to disk: ' + traceFilename);
   });
 
   await Promise.all(saveAll);


### PR DESCRIPTION
dropping a fallback case not needed since m59

this stuff is the wild /json endpoint API: https://chromedevtools.github.io/devtools-protocol/#endpoints

and a driveby to cleanup an extra log i noticed today