### PR TITLE
tests: use readJson instead of imports for json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     }],
     'no-floating-decimal': 2,
     'max-len': [2, 100, {
+      ignorePattern: 'readJson\\(',
       ignoreComments: true,
       ignoreUrls: true,
       tabWidth: 2,

--- a/lighthouse-cli/test/cli/printer-test.js
+++ b/lighthouse-cli/test/cli/printer-test.js
@@ -7,8 +7,10 @@
 import {strict as assert} from 'assert';
 import fs from 'fs';
 
+import {readJson} from '../../../root.js';
 import * as Printer from '../../printer.js';
-import sampleResults from '../../../lighthouse-core/test/results/sample_v2.json';
+
+const sampleResults = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 
 describe('Printer', () => {
   it('accepts valid output paths', () => {

--- a/lighthouse-core/test/audits/bootup-time-test.js
+++ b/lighthouse-core/test/audits/bootup-time-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import BootupTime from '../../audits/bootup-time.js';
-import acceptableTrace from '../fixtures/traces/progressive-app-m60.json';
-import acceptableDevtoolsLogs from '../fixtures/traces/progressive-app-m60.devtools.log.json';
-import errorTrace from '../fixtures/traces/no_fmp_event.json';
+
+const acceptableTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const acceptableDevtoolsLogs = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const errorTrace = readJson('../fixtures/traces/no_fmp_event.json', import.meta);
 
 describe('Performance: bootup-time audit', () => {
   const auditOptions = Object.assign({}, BootupTime.defaultOptions, {thresholdInMs: 10});

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -12,11 +12,13 @@ import CPUNode from '../../../lib/dependency-graph/cpu-node.js';
 import Simulator from '../../../lib/dependency-graph/simulator/simulator.js';
 import PageDependencyGraph from '../../../computed/page-dependency-graph.js';
 import LoadSimulator from '../../../computed/load-simulator.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import traceM78 from '../../fixtures/traces/lcp-m78.json';
-import devtoolsLogM78 from '../../fixtures/traces/lcp-m78.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {readJson} from '../../../../root.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const traceM78 = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
+const devtoolsLogM78 = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 
 describe('Byte efficiency base audit', () => {
   let graph;

--- a/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
@@ -4,14 +4,16 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import DuplicatedJavascript from '../../../audits/byte-efficiency/duplicated-javascript.js';
-import trace from '../../fixtures/traces/lcp-m78.json';
-import devtoolsLog from '../../fixtures/traces/lcp-m78.devtools.log.json';
 import {
   loadSourceMapFixture,
   createScript,
   getURLArtifactFromDevtoolsLog,
 } from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 
 describe('DuplicatedJavascript computed artifact', () => {
   it('works (simple)', async () => {

--- a/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
@@ -12,11 +12,13 @@ import NetworkNode from '../../../lib/dependency-graph/network-node.js';
 import CPUNode from '../../../lib/dependency-graph/cpu-node.js';
 import Simulator from '../../../lib/dependency-graph/simulator/simulator.js';
 import NetworkRequest from '../../../lib/network-request.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import ampTrace from '../../fixtures/traces/amp-m86.trace.json';
-import ampDevtoolsLog from '../../fixtures/traces/amp-m86.devtoolslog.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {readJson} from '../../../../root.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const ampTrace = readJson('../../fixtures/traces/amp-m86.trace.json', import.meta);
+const ampDevtoolsLog = readJson('../../fixtures/traces/amp-m86.devtoolslog.json', import.meta);
 
 const mobileSlow4G = constants.throttling.mobileSlow4G;
 

--- a/lighthouse-core/test/audits/critical-request-chains-test.js
+++ b/lighthouse-core/test/audits/critical-request-chains-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import CriticalRequestChains from '../../audits/critical-request-chains.js';
-import redditDevtoolsLog from '../fixtures/artifacts/perflog/defaultPass.devtoolslog.json';
 import createTestTrace from '../create-test-trace.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
+
+const redditDevtoolsLog = readJson('../fixtures/artifacts/perflog/defaultPass.devtoolslog.json', import.meta);
 
 const FAILING_CHAIN_RECORDS = [
   {

--- a/lighthouse-core/test/audits/diagnostics-test.js
+++ b/lighthouse-core/test/audits/diagnostics-test.js
@@ -4,9 +4,11 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import Diagnostics from '../../audits/diagnostics.js';
-import acceptableTrace from '../fixtures/traces/progressive-app-m60.json';
-import acceptableDevToolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
+
+const acceptableTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const acceptableDevToolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 describe('Diagnostics audit', () => {
   it('should work', async () => {

--- a/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
@@ -4,12 +4,14 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import UsesHTTP2Audit from '../../../audits/dobetterweb/uses-http2.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
 import NetworkRecords from '../../../computed/network-records.js';
 import networkRecordsToDevtoolsLog from '../../network-records-to-devtools-log.js';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 describe('Resources are fetched over http/2', () => {
   let artifacts = {};

--- a/lighthouse-core/test/audits/final-screenshot-test.js
+++ b/lighthouse-core/test/audits/final-screenshot-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import FinalScreenshotAudit from '../../audits/final-screenshot.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 
 const noScreenshotsTrace = {traceEvents: pwaTrace.traceEvents.filter(e => e.name !== 'Screenshot')};
 

--- a/lighthouse-core/test/audits/installable-manifest-test.js
+++ b/lighthouse-core/test/audits/installable-manifest-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import InstallableManifestAudit from '../../audits/installable-manifest.js';
 import manifestParser from '../../lib/manifest-parser.js';
-import manifest from '../fixtures/manifest.json';
-import manifestDirtyJpg from '../fixtures/manifest-dirty-jpg.json';
+
+const manifest = readJson('../fixtures/manifest.json', import.meta);
+const manifestDirtyJpg = readJson('../fixtures/manifest-dirty-jpg.json', import.meta);
 
 const manifestSrc = JSON.stringify(manifest);
 const manifestDirtyJpgSrc = JSON.stringify(manifestDirtyJpg);

--- a/lighthouse-core/test/audits/main-thread-tasks-test.js
+++ b/lighthouse-core/test/audits/main-thread-tasks-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import MainThreadTasks from '../../audits/main-thread-tasks.js';
-import acceptableTrace from '../fixtures/traces/progressive-app-m60.json';
+
+const acceptableTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 
 describe('Main thread tasks audit', () => {
   it('should work', async () => {

--- a/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
+++ b/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
@@ -6,11 +6,13 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import PageExecutionTimings from '../../audits/mainthread-work-breakdown.js';
-import acceptableTrace from '../fixtures/traces/progressive-app-m60.json';
-import siteWithRedirectTrace from '../fixtures/traces/site-with-redirect.json';
-import loadTrace from '../fixtures/traces/load.json';
-import errorTrace from '../fixtures/traces/no_fmp_event.json';
+
+const acceptableTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const siteWithRedirectTrace = readJson('../fixtures/traces/site-with-redirect.json', import.meta);
+const loadTrace = readJson('../fixtures/traces/load.json', import.meta);
+const errorTrace = readJson('../fixtures/traces/no_fmp_event.json', import.meta);
 
 const options = PageExecutionTimings.defaultOptions;
 

--- a/lighthouse-core/test/audits/maskable-icon-test.js
+++ b/lighthouse-core/test/audits/maskable-icon-test.js
@@ -4,10 +4,12 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import MaskableIconAudit from '../../audits/maskable-icon.js';
 import manifestParser from '../../lib/manifest-parser.js';
-import manifest from '../fixtures/manifest.json';
-import manifestWithoutMaskable from '../fixtures/manifest-no-maskable-icon.json';
+
+const manifest = readJson('../fixtures/manifest.json', import.meta);
+const manifestWithoutMaskable = readJson('../fixtures/manifest-no-maskable-icon.json', import.meta);
 
 const manifestSrc = JSON.stringify(manifest);
 const manifestWithoutMaskableSrc = JSON.stringify(manifestWithoutMaskable);

--- a/lighthouse-core/test/audits/metrics-test.js
+++ b/lighthouse-core/test/audits/metrics-test.js
@@ -6,19 +6,21 @@
 
 import {jest} from '@jest/globals';
 
+import {readJson} from '../../../root.js';
 import MetricsAudit from '../../audits/metrics.js';
 import TTIComputed from '../../computed/metrics/interactive.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
-import lcpTrace from '../fixtures/traces/lcp-m78.json';
-import lcpDevtoolsLog from '../fixtures/traces/lcp-m78.devtools.log.json';
-import lcpAllFramesTrace from '../fixtures/traces/frame-metrics-m89.json';
-import lcpAllFramesDevtoolsLog from '../fixtures/traces/frame-metrics-m89.devtools.log.json'; // eslint-disable-line max-len
-import clsAllFramesTrace from '../fixtures/traces/frame-metrics-m90.json';
-import clsAllFramesDevtoolsLog from '../fixtures/traces/frame-metrics-m90.devtools.log.json'; // eslint-disable-line max-len
-import jumpyClsTrace from '../fixtures/traces/jumpy-cls-m90.json';
-import jumpyClsDevtoolsLog from '../fixtures/traces/jumpy-cls-m90.devtoolslog.json';
 import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const lcpTrace = readJson('../fixtures/traces/lcp-m78.json', import.meta);
+const lcpDevtoolsLog = readJson('../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
+const lcpAllFramesTrace = readJson('../fixtures/traces/frame-metrics-m89.json', import.meta);
+const lcpAllFramesDevtoolsLog = readJson('../fixtures/traces/frame-metrics-m89.devtools.log.json', import.meta);
+const clsAllFramesTrace = readJson('../fixtures/traces/frame-metrics-m90.json', import.meta);
+const clsAllFramesDevtoolsLog = readJson('../fixtures/traces/frame-metrics-m90.devtools.log.json', import.meta);
+const jumpyClsTrace = readJson('../fixtures/traces/jumpy-cls-m90.json', import.meta);
+const jumpyClsDevtoolsLog = readJson('../fixtures/traces/jumpy-cls-m90.devtoolslog.json', import.meta);
 
 describe('Performance: metrics', () => {
   it('evaluates valid input correctly', async () => {

--- a/lighthouse-core/test/audits/metrics/cumulative-layout-shift-test.js
+++ b/lighthouse-core/test/audits/metrics/cumulative-layout-shift-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import CumulativeLayoutShift from '../../../audits/metrics/cumulative-layout-shift.js';
-import jumpyClsTrace from '../../fixtures/traces/jumpy-cls-m90.json';
+
+const jumpyClsTrace = readJson('../../fixtures/traces/jumpy-cls-m90.json', import.meta);
 
 describe('Cumulative Layout Shift', () => {
   it('evaluates CLS correctly', async () => {

--- a/lighthouse-core/test/audits/metrics/experimental-interaction-to-next-paint-test.js
+++ b/lighthouse-core/test/audits/metrics/experimental-interaction-to-next-paint-test.js
@@ -4,10 +4,12 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import ExperimentalInteractionToNextPaint from
   '../../../audits/metrics/experimental-interaction-to-next-paint.js';
-import interactionTrace from '../../fixtures/traces/timespan-responsiveness-m103.trace.json';
-import noInteractionTrace from '../../fixtures/traces/jumpy-cls-m90.json';
+
+const interactionTrace = readJson('../../fixtures/traces/timespan-responsiveness-m103.trace.json', import.meta);
+const noInteractionTrace = readJson('../../fixtures/traces/jumpy-cls-m90.json', import.meta);
 
 describe('Interaction to Next Paint', () => {
   function getTestData() {

--- a/lighthouse-core/test/audits/metrics/first-contentful-paint-3g-test.js
+++ b/lighthouse-core/test/audits/metrics/first-contentful-paint-3g-test.js
@@ -4,10 +4,12 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import FCP3G from '../../../audits/metrics/first-contentful-paint-3g.js';
-import pwaTrace from '../../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const pwaTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const options = FCP3G.defaultOptions;
 

--- a/lighthouse-core/test/audits/metrics/first-contentful-paint-test.js
+++ b/lighthouse-core/test/audits/metrics/first-contentful-paint-test.js
@@ -6,12 +6,14 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import FcpAudit from '../../../audits/metrics/first-contentful-paint.js';
 import constants from '../../../config/constants.js';
-import pwaTrace from '../../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import frameTrace from '../../fixtures/traces/frame-metrics-m90.json';
-import frameDevtoolsLog from '../../fixtures/traces/frame-metrics-m90.devtools.log.json';
+
+const pwaTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const frameTrace = readJson('../../fixtures/traces/frame-metrics-m90.json', import.meta);
+const frameDevtoolsLog = readJson('../../fixtures/traces/frame-metrics-m90.devtools.log.json', import.meta);
 
 const options = FcpAudit.defaultOptions;
 

--- a/lighthouse-core/test/audits/metrics/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/metrics/first-meaningful-paint-test.js
@@ -9,9 +9,11 @@ import {strict as assert} from 'assert';
 import FMPAudit from '../../../audits/metrics/first-meaningful-paint.js';
 import Audit from '../../../audits/audit.js';
 import constants from '../../../config/constants.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLogs from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {readJson} from '../../../../root.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLogs = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 /**
  * @param {{

--- a/lighthouse-core/test/audits/metrics/interactive-test.js
+++ b/lighthouse-core/test/audits/metrics/interactive-test.js
@@ -6,12 +6,14 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import Interactive from '../../../audits/metrics/interactive.js';
 import constants from '../../../config/constants.js';
-import acceptableTrace from '../../fixtures/traces/progressive-app-m60.json';
-import acceptableDevToolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import redirectTrace from '../../fixtures/traces/site-with-redirect.json';
-import redirectDevToolsLog from '../../fixtures/traces/site-with-redirect.devtools.log.json';
+
+const acceptableTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const acceptableDevToolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const redirectTrace = readJson('../../fixtures/traces/site-with-redirect.json', import.meta);
+const redirectDevToolsLog = readJson('../../fixtures/traces/site-with-redirect.devtools.log.json', import.meta);
 
 const options = Interactive.defaultOptions;
 

--- a/lighthouse-core/test/audits/metrics/largest-contentful-paint-test.js
+++ b/lighthouse-core/test/audits/metrics/largest-contentful-paint-test.js
@@ -4,12 +4,14 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import LCPAudit from '../../../audits/metrics/largest-contentful-paint.js';
 import constants from '../../../config/constants.js';
-import trace from '../../fixtures/traces/lcp-m78.json';
-import devtoolsLog from '../../fixtures/traces/lcp-m78.devtools.log.json';
-import preLcpTrace from '../../fixtures/traces/progressive-app-m60.json';
-import preLcpDevtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
+
+const trace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
+const preLcpTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const preLcpDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const defaultOptions = LCPAudit.defaultOptions;
 

--- a/lighthouse-core/test/audits/metrics/speed-index-test.js
+++ b/lighthouse-core/test/audits/metrics/speed-index-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import Audit from '../../../audits/metrics/speed-index.js';
 import constants from '../../../config/constants.js';
-import pwaTrace from '../../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
+
+const pwaTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const options = Audit.defaultOptions;
 

--- a/lighthouse-core/test/audits/metrics/total-blocking-time-test.js
+++ b/lighthouse-core/test/audits/metrics/total-blocking-time-test.js
@@ -4,13 +4,15 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import TBTAudit from '../../../audits/metrics/total-blocking-time.js';
 import constants from '../../../config/constants.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import lcpTrace from '../../fixtures/traces/lcp-m78.json';
-import lcpDevtoolsLog from '../../fixtures/traces/lcp-m78.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const lcpTrace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
+const lcpDevtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 
 const defaultOptions = TBTAudit.defaultOptions;
 

--- a/lighthouse-core/test/audits/network-requests-test.js
+++ b/lighthouse-core/test/audits/network-requests-test.js
@@ -4,9 +4,12 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import NetworkRequests from '../../audits/network-requests.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
-import cutoffLoadDevtoolsLog from '../fixtures/traces/cutoff-load-m83.devtoolslog.json';
+
+const cutoffLoadDevtoolsLog = readJson('../fixtures/traces/cutoff-load-m83.devtoolslog.json', import.meta);
+
 describe('Network requests audit', () => {
   it('should report finished and unfinished network requests', async () => {
     const artifacts = {

--- a/lighthouse-core/test/audits/network-rtt-test.js
+++ b/lighthouse-core/test/audits/network-rtt-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import NetworkRTT from '../../audits/network-rtt.js';
-import acceptableDevToolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
+
+const acceptableDevToolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 describe('Network RTT audit', () => {
   it('should work', async () => {

--- a/lighthouse-core/test/audits/network-server-latency-test.js
+++ b/lighthouse-core/test/audits/network-server-latency-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import ServerLatency from '../../audits/network-server-latency.js';
-import acceptableDevToolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
+
+const acceptableDevToolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 describe('Network Server Latency audit', () => {
   it('should work', async () => {

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -4,10 +4,13 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import PredictivePerf from '../../audits/predictive-perf.js';
-import acceptableTrace from '../fixtures/traces/lcp-m78.json';
-import acceptableDevToolsLog from '../fixtures/traces/lcp-m78.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+
+const acceptableTrace = readJson('../fixtures/traces/lcp-m78.json', import.meta);
+const acceptableDevToolsLog = readJson('../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
+
 describe('Performance: predictive performance audit', () => {
   it('should compute the predicted values', async () => {
     const artifacts = {

--- a/lighthouse-core/test/audits/screenshot-thumbnails-test.js
+++ b/lighthouse-core/test/audits/screenshot-thumbnails-test.js
@@ -9,9 +9,10 @@ import path from 'path';
 import {strict as assert} from 'assert';
 
 import ScreenshotThumbnailsAudit from '../../audits/screenshot-thumbnails.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
-import {LH_ROOT} from '../../../root.js';
+import {LH_ROOT, readJson} from '../../../root.js';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const noScreenshotsTrace = {traceEvents: pwaTrace.traceEvents.filter(e => e.name !== 'Screenshot')};
 

--- a/lighthouse-core/test/audits/splash-screen-test.js
+++ b/lighthouse-core/test/audits/splash-screen-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import SplashScreenAudit from '../../audits/splash-screen.js';
 import manifestParser from '../../lib/manifest-parser.js';
-import manifest from '../fixtures/manifest.json';
-import manifestDirtyJpg from '../fixtures/manifest-dirty-jpg.json';
+
+const manifest = readJson('../fixtures/manifest.json', import.meta);
+const manifestDirtyJpg = readJson('../fixtures/manifest-dirty-jpg.json', import.meta);
 
 const manifestSrc = JSON.stringify(manifest);
 const manifestDirtyJpgSrc = JSON.stringify(manifestDirtyJpg);

--- a/lighthouse-core/test/audits/themed-omnibox-test.js
+++ b/lighthouse-core/test/audits/themed-omnibox-test.js
@@ -6,9 +6,11 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import ThemedOmniboxAudit from '../../audits/themed-omnibox.js';
 import manifestParser from '../../lib/manifest-parser.js';
-import manifest from '../fixtures/manifest.json';
+
+const manifest = readJson('../fixtures/manifest.json', import.meta);
 
 const manifestSrc = JSON.stringify(manifest);
 const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';

--- a/lighthouse-core/test/audits/third-party-facades-test.js
+++ b/lighthouse-core/test/audits/third-party-facades-test.js
@@ -7,12 +7,14 @@
 import ThirdPartyFacades from '../../audits/third-party-facades.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
 import createTestTrace from '../create-test-trace.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
-import videoEmbedsTrace from '../fixtures/traces/video-embeds-m84.json';
-import videoEmbedsDevtolsLog from '../fixtures/traces/video-embeds-m84.devtools.log.json';
-import noThirdPartyTrace from '../fixtures/traces/no-tracingstarted-m74.json';
 import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+import {readJson} from '../../../root.js';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const videoEmbedsTrace = readJson('../fixtures/traces/video-embeds-m84.json', import.meta);
+const videoEmbedsDevtolsLog = readJson('../fixtures/traces/video-embeds-m84.devtools.log.json', import.meta);
+const noThirdPartyTrace = readJson('../fixtures/traces/no-tracingstarted-m74.json', import.meta);
 
 function intercomProductUrl(id) {
   return `https://widget.intercom.io/widget/${id}`;

--- a/lighthouse-core/test/audits/third-party-summary-test.js
+++ b/lighthouse-core/test/audits/third-party-summary-test.js
@@ -4,11 +4,14 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import ThirdPartySummary from '../../audits/third-party-summary.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
-import noThirdPartyTrace from '../fixtures/traces/no-tracingstarted-m74.json';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const noThirdPartyTrace = readJson('../fixtures/traces/no-tracingstarted-m74.json', import.meta);
+
 describe('Third party summary', () => {
   it('surface the discovered third parties', async () => {
     const artifacts = {

--- a/lighthouse-core/test/audits/timing-budget-test.js
+++ b/lighthouse-core/test/audits/timing-budget-test.js
@@ -4,12 +4,14 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import TimingBudgetAudit from '../../audits/timing-budget.js';
-import trace from '../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
-import lcpTrace from '../fixtures/traces/lcp-m78.json';
-import lcpDevtoolsLog from '../fixtures/traces/lcp-m78.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+
+const trace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const lcpTrace = readJson('../fixtures/traces/lcp-m78.json', import.meta);
+const lcpDevtoolsLog = readJson('../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 
 describe('Performance: Timing budget audit', () => {
   let artifacts;

--- a/lighthouse-core/test/audits/user-timing-test.js
+++ b/lighthouse-core/test/audits/user-timing-test.js
@@ -6,8 +6,10 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import UserTimingsAudit from '../../audits/user-timings.js';
-import traceEvents from '../fixtures/traces/trace-user-timings.json';
+
+const traceEvents = readJson('../fixtures/traces/trace-user-timings.json', import.meta);
 
 function generateArtifactsWithTrace(trace) {
   return {

--- a/lighthouse-core/test/audits/uses-rel-preload-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preload-test.js
@@ -7,11 +7,13 @@
 import {strict as assert} from 'assert';
 
 import UsesRelPreload from '../../audits/uses-rel-preload.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
 import createTestTrace from '../create-test-trace.js';
 import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+import {readJson} from '../../../root.js';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const defaultMainResourceUrl = 'http://www.example.com/';
 const defaultMainResource = {

--- a/lighthouse-core/test/audits/work-during-interaction-test.js
+++ b/lighthouse-core/test/audits/work-during-interaction-test.js
@@ -6,9 +6,11 @@
 
 /* eslint-disable no-irregular-whitespace */
 
+import {readJson} from '../../../root.js';
 import WorkDuringInteraction from '../../audits/work-during-interaction.js';
-import interactionTrace from '../fixtures/traces/timespan-responsiveness-m103.trace.json';
-import noInteractionTrace from '../fixtures/traces/jumpy-cls-m90.json';
+
+const interactionTrace = readJson('../fixtures/traces/timespan-responsiveness-m103.trace.json', import.meta);
+const noInteractionTrace = readJson('../fixtures/traces/jumpy-cls-m90.json', import.meta);
 
 describe('Interaction to Next Paint', () => {
   function getTestData() {

--- a/lighthouse-core/test/computed/critical-request-chains-test.js
+++ b/lighthouse-core/test/computed/critical-request-chains-test.js
@@ -6,12 +6,14 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import CriticalRequestChains from '../../computed/critical-request-chains.js';
 import NetworkRequest from '../../lib/network-request.js';
 import createTestTrace from '../create-test-trace.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
 import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
-import wikipediaDevtoolsLog from '../fixtures/wikipedia-redirect.devtoolslog.json';
+
+const wikipediaDevtoolsLog = readJson('../fixtures/wikipedia-redirect.devtoolslog.json', import.meta);
 
 const HIGH = 'High';
 const VERY_HIGH = 'VeryHigh';

--- a/lighthouse-core/test/computed/load-simulator-test.js
+++ b/lighthouse-core/test/computed/load-simulator-test.js
@@ -6,9 +6,11 @@
 
 import {strict as assert} from 'assert';
 
-import devtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
+import {readJson} from '../../../root.js';
 import LoadSimulator from '../../computed/load-simulator.js';
 import NetworkNode from '../../lib/dependency-graph/network-node.js';
+
+const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 function createNetworkNode() {
   return new NetworkNode({

--- a/lighthouse-core/test/computed/main-resource-test.js
+++ b/lighthouse-core/test/computed/main-resource-test.js
@@ -6,9 +6,11 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import MainResource from '../../computed/main-resource.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
-import wikipediaDevtoolsLog from '../fixtures/wikipedia-redirect.devtoolslog.json';
+
+const wikipediaDevtoolsLog = readJson('../fixtures/wikipedia-redirect.devtoolslog.json', import.meta);
 
 describe('MainResource computed artifact', () => {
   it('returns an artifact', () => {

--- a/lighthouse-core/test/computed/main-thread-tasks-test.js
+++ b/lighthouse-core/test/computed/main-thread-tasks-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import MainThreadTasks from '../../computed/main-thread-tasks.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 
 describe('MainThreadTasksComputed', () => {
   it('computes the artifact', async () => {

--- a/lighthouse-core/test/computed/manifest-values-test.js
+++ b/lighthouse-core/test/computed/manifest-values-test.js
@@ -6,9 +6,11 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import ManifestValues from '../../computed/manifest-values.js';
 import manifestParser from '../../lib/manifest-parser.js';
-import manifest from '../fixtures/manifest.json';
+
+const manifest = readJson('../fixtures/manifest.json', import.meta);
 
 const manifestSrc = JSON.stringify(manifest);
 

--- a/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
+++ b/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
@@ -4,12 +4,14 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import CumulativeLayoutShift from '../../../computed/metrics/cumulative-layout-shift.js';
 import createTestTrace from '../../create-test-trace.js';
-import jumpyClsTrace from '../../fixtures/traces/jumpy-cls-m90.json';
-import oldMetricsTrace from '../../fixtures/traces/frame-metrics-m89.json';
-import allFramesMetricsTrace from '../../fixtures/traces/frame-metrics-m90.json';
-import preClsTrace from '../../fixtures/traces/progressive-app-m60.json';
+
+const jumpyClsTrace = readJson('../../fixtures/traces/jumpy-cls-m90.json', import.meta);
+const oldMetricsTrace = readJson('../../fixtures/traces/frame-metrics-m89.json', import.meta);
+const allFramesMetricsTrace = readJson('../../fixtures/traces/frame-metrics-m90.json', import.meta);
+const preClsTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 
 const childFrameId = 'CAF4634127666E186C9C8B35627DBF0B';
 

--- a/lighthouse-core/test/computed/metrics/first-contentful-paint-all-frames-test.js
+++ b/lighthouse-core/test/computed/metrics/first-contentful-paint-all-frames-test.js
@@ -4,10 +4,12 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import FirstContentfulPaintAllFrames from '../../../computed/metrics/first-contentful-paint-all-frames.js'; // eslint-disable-line max-len
 import FirstContentfulPaint from '../../../computed/metrics/first-contentful-paint.js'; // eslint-disable-line max-len
-import trace from '../../fixtures/traces/frame-metrics-m89.json';
-import devtoolsLog from '../../fixtures/traces/frame-metrics-m89.devtools.log.json';
+
+const trace = readJson('../../fixtures/traces/frame-metrics-m89.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/frame-metrics-m89.devtools.log.json', import.meta);
 
 describe('Metrics: FCP all frames', () => {
   const gatherContext = {gatherMode: 'navigation'};

--- a/lighthouse-core/test/computed/metrics/first-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/first-contentful-paint-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import FirstContentfulPaint from '../../../computed/metrics/first-contentful-paint.js'; // eslint-disable-line max-len
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
 

--- a/lighthouse-core/test/computed/metrics/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/first-meaningful-paint-test.js
@@ -6,14 +6,16 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import FirstMeaningfulPaint from '../../../computed/metrics/first-meaningful-paint.js';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
-import pwaTrace from '../../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import badNavStartTrace from '../../fixtures/traces/bad-nav-start-ts.json';
-import lateTracingStartedTrace from '../../fixtures/traces/tracingstarted-after-navstart.json';
-import preactTrace from '../../fixtures/traces/preactjs.com_ts_of_undefined.json';
-import noFMPtrace from '../../fixtures/traces/no_fmp_event.json';
+
+const pwaTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const badNavStartTrace = readJson('../../fixtures/traces/bad-nav-start-ts.json', import.meta);
+const lateTracingStartedTrace = readJson('../../fixtures/traces/tracingstarted-after-navstart.json', import.meta);
+const preactTrace = readJson('../../fixtures/traces/preactjs.com_ts_of_undefined.json', import.meta);
+const noFMPtrace = readJson('../../fixtures/traces/no_fmp_event.json', import.meta);
 
 describe('Metrics: FMP', () => {
   const gatherContext = {gatherMode: 'navigation'};

--- a/lighthouse-core/test/computed/metrics/interactive-test.js
+++ b/lighthouse-core/test/computed/metrics/interactive-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import Interactive from '../../../computed/metrics/interactive.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
 

--- a/lighthouse-core/test/computed/metrics/lantern-first-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-first-contentful-paint-test.js
@@ -7,11 +7,14 @@
 import {strict as assert} from 'assert';
 
 import LanternFirstContentfulPaint from '../../../computed/metrics/lantern-first-contentful-paint.js'; // eslint-disable-line max-len
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
 import networkRecordsToDevtoolsLog from '../../network-records-to-devtools-log.js';
 import createTestTrace from '../../create-test-trace.js';
+import {readJson} from '../../../../root.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+
 describe('Metrics: Lantern FCP', () => {
   const gatherContext = {gatherMode: 'navigation'};
 

--- a/lighthouse-core/test/computed/metrics/lantern-first-meaningful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-first-meaningful-paint-test.js
@@ -6,11 +6,13 @@
 
 import {strict as assert} from 'assert';
 
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
+import {readJson} from '../../../../root.js';
 import LanternFirstMeaningfulPaint from
   '../../../computed/metrics/lantern-first-meaningful-paint.js';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
 describe('Metrics: Lantern FMP', () => {

--- a/lighthouse-core/test/computed/metrics/lantern-interactive-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-interactive-test.js
@@ -6,12 +6,14 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import LanternInteractive from '../../../computed/metrics/lantern-interactive.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import iframeTrace from '../../fixtures/traces/iframe-m79.trace.json';
-import iframeDevtoolsLog from '../../fixtures/traces/iframe-m79.devtoolslog.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const iframeTrace = readJson('../../fixtures/traces/iframe-m79.trace.json', import.meta);
+const iframeDevtoolsLog = readJson('../../fixtures/traces/iframe-m79.devtoolslog.json', import.meta);
 
 describe('Metrics: Lantern TTI', () => {
   const gatherContext = {gatherMode: 'navigation'};

--- a/lighthouse-core/test/computed/metrics/lantern-largest-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-largest-contentful-paint-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
-import trace from '../../fixtures/traces/lcp-m78.json';
-import devtoolsLog from '../../fixtures/traces/lcp-m78.devtools.log.json';
+import {readJson} from '../../../../root.js';
 import LanternLargestContentfulPaint from '../../../computed/metrics/lantern-largest-contentful-paint.js'; // eslint-disable-line max-len
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 
 const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
 describe('Metrics: Lantern LCP', () => {

--- a/lighthouse-core/test/computed/metrics/lantern-speed-index-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-speed-index-test.js
@@ -7,8 +7,10 @@
 import constants from '../../../config/constants.js';
 import LanternSpeedIndex from '../../../computed/metrics/lantern-speed-index.js';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
+import {readJson} from '../../../../root.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const defaultThrottling = constants.throttling.mobileSlow4G;
 const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);

--- a/lighthouse-core/test/computed/metrics/largest-contentful-paint-all-frames-test.js
+++ b/lighthouse-core/test/computed/metrics/largest-contentful-paint-all-frames-test.js
@@ -6,13 +6,15 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import LargestContentfulPaintAllFrames from '../../../computed/metrics/largest-contentful-paint-all-frames.js'; // eslint-disable-line max-len
-import traceAllFrames from '../../fixtures/traces/frame-metrics-m89.json';
-import devtoolsLogAllFrames from '../../fixtures/traces/frame-metrics-m89.devtools.log.json';
-import traceMainFrame from '../../fixtures/traces/lcp-m78.json';
-import devtoolsLogMainFrame from '../../fixtures/traces/lcp-m78.devtools.log.json';
-import invalidTrace from '../../fixtures/traces/progressive-app-m60.json';
-import invalidDevtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
+
+const traceAllFrames = readJson('../../fixtures/traces/frame-metrics-m89.json', import.meta);
+const devtoolsLogAllFrames = readJson('../../fixtures/traces/frame-metrics-m89.devtools.log.json', import.meta);
+const traceMainFrame = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
+const devtoolsLogMainFrame = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
+const invalidTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const invalidDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 describe('Metrics: LCP from all frames', () => {
   const gatherContext = {gatherMode: 'navigation'};

--- a/lighthouse-core/test/computed/metrics/largest-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/largest-contentful-paint-test.js
@@ -6,12 +6,14 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import LargestContentfulPaint from '../../../computed/metrics/largest-contentful-paint.js'; // eslint-disable-line max-len
-import trace from '../../fixtures/traces/lcp-m78.json';
-import devtoolsLog from '../../fixtures/traces/lcp-m78.devtools.log.json';
-import invalidTrace from '../../fixtures/traces/progressive-app-m60.json';
-import invalidDevtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
+const invalidTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const invalidDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 describe('Metrics: LCP', () => {
   const gatherContext = {gatherMode: 'navigation'};

--- a/lighthouse-core/test/computed/metrics/max-potential-fid-test.js
+++ b/lighthouse-core/test/computed/metrics/max-potential-fid-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import MaxPotentialFID from '../../../computed/metrics/max-potential-fid.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
 

--- a/lighthouse-core/test/computed/metrics/responsiveness-test.js
+++ b/lighthouse-core/test/computed/metrics/responsiveness-test.js
@@ -6,10 +6,12 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import Responsiveness from '../../../computed/metrics/responsiveness.js';
 import createTestTrace from '../../create-test-trace.js';
-import interactionTrace from '../../fixtures/traces/timespan-responsiveness-m103.trace.json';
-import noInteractionTrace from '../../fixtures/traces/frame-metrics-m89.json';
+
+const interactionTrace = readJson('../../fixtures/traces/timespan-responsiveness-m103.trace.json', import.meta);
+const noInteractionTrace = readJson('../../fixtures/traces/frame-metrics-m89.json', import.meta);
 
 const childFrameId = 'CAF4634127666E186C9C8B35627DBF0B';
 

--- a/lighthouse-core/test/computed/metrics/speed-index-test.js
+++ b/lighthouse-core/test/computed/metrics/speed-index-test.js
@@ -6,12 +6,14 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import SpeedIndex from '../../../computed/metrics/speed-index.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import trace1msLayout from '../../fixtures/traces/speedindex-1ms-layout-m84.trace.json';
-import devtoolsLog1msLayout from '../../fixtures/traces/speedindex-1ms-layout-m84.devtoolslog.json'; // eslint-disable-line max-len
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const trace1msLayout = readJson('../../fixtures/traces/speedindex-1ms-layout-m84.trace.json', import.meta);
+const devtoolsLog1msLayout = readJson('../../fixtures/traces/speedindex-1ms-layout-m84.devtoolslog.json', import.meta); // eslint-disable-line max-len
 
 describe('Metrics: Speed Index', () => {
   const gatherContext = {gatherMode: 'navigation'};

--- a/lighthouse-core/test/computed/metrics/timing-summary-test.js
+++ b/lighthouse-core/test/computed/metrics/timing-summary-test.js
@@ -4,9 +4,12 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import TimingSummary from '../../../computed/metrics/timing-summary.js';
-import trace from '../../fixtures/traces/frame-metrics-m90.json';
-import devtoolsLog from '../../fixtures/traces/frame-metrics-m90.devtools.log.json';
+
+const trace = readJson('../../fixtures/traces/frame-metrics-m90.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/frame-metrics-m90.devtools.log.json', import.meta);
+
 describe('Timing summary', () => {
   it('contains the correct data', async () => {
     const gatherContext = {gatherMode: 'navigation'};

--- a/lighthouse-core/test/computed/metrics/total-blocking-time-test.js
+++ b/lighthouse-core/test/computed/metrics/total-blocking-time-test.js
@@ -5,10 +5,12 @@
  */
 
 import TotalBlockingTime from '../../../computed/metrics/total-blocking-time.js';
-import trace from '../../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../../fixtures/traces/progressive-app-m60.devtools.log.json';
 import {calculateSumOfBlockingTime} from '../../../computed/metrics/tbt-utils.js';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {readJson} from '../../../../root.js';
+
+const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
 

--- a/lighthouse-core/test/computed/network-analysis-test.js
+++ b/lighthouse-core/test/computed/network-analysis-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import NetworkAnalysis from '../../computed/network-analysis.js';
-import acceptableDevToolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
+
+const acceptableDevToolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 describe('Network analysis computed', () => {
   it('should return network analysis', async () => {

--- a/lighthouse-core/test/computed/page-dependency-graph-test.js
+++ b/lighthouse-core/test/computed/page-dependency-graph-test.js
@@ -9,11 +9,13 @@ import {strict as assert} from 'assert';
 import PageDependencyGraph from '../../computed/page-dependency-graph.js';
 import BaseNode from '../../lib/dependency-graph/base-node.js';
 import NetworkRequest from '../../lib/network-request.js';
-import sampleTrace from '../fixtures/traces/iframe-m79.trace.json';
-import sampleDevtoolsLog from '../fixtures/traces/iframe-m79.devtoolslog.json';
 import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
 import NetworkRecorder from '../../lib/network-recorder.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
+import {readJson} from '../../../root.js';
+
+const sampleTrace = readJson('../fixtures/traces/iframe-m79.trace.json', import.meta);
+const sampleDevtoolsLog = readJson('../fixtures/traces/iframe-m79.devtoolslog.json', import.meta);
 
 function createRequest(
   requestId,

--- a/lighthouse-core/test/computed/processed-navigation-test.js
+++ b/lighthouse-core/test/computed/processed-navigation-test.js
@@ -6,9 +6,11 @@
 
 import ProcessedTrace from '../../computed/processed-trace.js';
 import ProcessedNavigation from '../../computed/processed-navigation.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
-import noFCPtrace from '../fixtures/traces/airhorner_no_fcp.json';
-import noNavStartTrace from '../fixtures/traces/no_navstart_event.json';
+import {readJson} from '../../../root.js';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const noFCPtrace = readJson('../fixtures/traces/airhorner_no_fcp.json', import.meta);
+const noNavStartTrace = readJson('../fixtures/traces/no_navstart_event.json', import.meta);
 
 describe('ProcessedTrace', () => {
   it('computes the artifact', async () => {

--- a/lighthouse-core/test/computed/processed-trace-test.js
+++ b/lighthouse-core/test/computed/processed-trace-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import ProcessedTrace from '../../computed/processed-trace.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 
 describe('ProcessedTrace', () => {
   it('computes the artifact', async () => {

--- a/lighthouse-core/test/computed/screenshots-test.js
+++ b/lighthouse-core/test/computed/screenshots-test.js
@@ -6,8 +6,10 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import Screenshots from '../../computed/screenshots.js';
-import pwaTrace from '../fixtures/traces/progressive-app.json';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app.json', import.meta);
 
 describe('Screenshot computed artifact', () => {
   it('returns an artifact for a real trace', () => {

--- a/lighthouse-core/test/computed/speedline-test.js
+++ b/lighthouse-core/test/computed/speedline-test.js
@@ -6,10 +6,11 @@
 
 import {strict as assert} from 'assert';
 
-import pwaTrace from '../fixtures/traces/progressive-app.json';
-import threeFrameTrace from '../fixtures/traces/threeframes-blank_content_more.json';
 import Speedline from '../../computed/speedline.js';
 import {readJson} from '../../../root.js';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app.json', import.meta);
+const threeFrameTrace = readJson('../fixtures/traces/threeframes-blank_content_more.json', import.meta);
 
 describe('Speedline gatherer', () => {
   it('returns an error message on faulty trace data', () => {

--- a/lighthouse-core/test/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/computed/trace-of-tab-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../root.js';
 import TraceOfTab from '../../computed/trace-of-tab.js';
-import pwaTrace from '../fixtures/traces/progressive-app-m60.json';
+
+const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 
 describe('TraceOfTab', () => {
   it('computes the artifact', async () => {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -11,7 +11,6 @@ import {jest} from '@jest/globals';
 import Gatherer from '../../gather/gatherers/gatherer.js';
 // import GathererRunner_ from '../../gather/gather-runner.js';
 // import Config from '../../config/config.js';
-import unresolvedPerfLog from './../fixtures/unresolved-perflog.json';
 import LHError from '../../lib/lh-error.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
 // import Driver from '../../gather/driver.js';
@@ -26,6 +25,9 @@ import {
 } from '../test-utils.js';
 import fakeDriver from './fake-driver.js';
 import {createCommonjsRefs} from '../../scripts/esm-utils.js';
+import {readJson} from '../../../root.js';
+
+const unresolvedPerfLog = readJson('./../fixtures/unresolved-perflog.json', import.meta);
 
 const {require} = createCommonjsRefs(import.meta);
 

--- a/lighthouse-core/test/gather/gatherers/image-elements-test.js
+++ b/lighthouse-core/test/gather/gatherers/image-elements-test.js
@@ -6,14 +6,15 @@
 
 import {jest} from '@jest/globals';
 
+import {readJson} from '../../../../root.js';
 import ImageElements from '../../../gather/gatherers/image-elements.js';
 import NetworkRecorder from '../../../lib/network-recorder.js';
 import {createMockContext, createMockDriver, createMockSession} from
   '../../fraggle-rock/gather/mock-driver.js';
 import {fnAny} from '../../test-utils.js';
-import devtoolsLog from '../../fixtures/traces/lcp-m78.devtools.log.json';
 
-// @ts-expect-error
+const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
+
 const networkRecords = NetworkRecorder.recordsFromLogs(devtoolsLog);
 
 jest.useFakeTimers();
@@ -309,7 +310,6 @@ describe('FR compat', () => {
     mockContext.driver._executionContext.evaluate.mockReturnValue([mockElement()]);
 
     const artifact = await gatherer.afterPass(mockContext.asLegacyContext(), {
-      // @ts-expect-error
       devtoolsLog,
       networkRecords,
     });

--- a/lighthouse-core/test/gather/gatherers/main-document-content-test.js
+++ b/lighthouse-core/test/gather/gatherers/main-document-content-test.js
@@ -4,19 +4,19 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import MainDocumentContent from '../../../gather/gatherers/main-document-content.js';
 import NetworkRecorder from '../../../lib/network-recorder.js';
 import {createMockContext} from '../../fraggle-rock/gather/mock-driver.js';
 import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
-import devtoolsLog from '../../fixtures/traces/lcp-m78.devtools.log.json';
 
-// @ts-expect-error
+const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
+
 const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
 
 describe('FR compat', () => {
   it('uses loadData in legacy mode', async () => {
     const gatherer = new MainDocumentContent();
-    // @ts-expect-error
     const networkRecords = NetworkRecorder.recordsFromLogs(devtoolsLog);
     const mockContext = createMockContext();
     mockContext.baseArtifacts.URL = URL;
@@ -25,7 +25,6 @@ describe('FR compat', () => {
 
     const artifact = await gatherer.afterPass(
       mockContext.asLegacyContext(),
-      // @ts-expect-error
       {devtoolsLog, networkRecords}
     );
 
@@ -42,7 +41,6 @@ describe('FR compat', () => {
     /** @type {LH.Gatherer.FRTransitionalContext<'DevtoolsLog'>} */
     const context = {
       ...mockContext.asContext(),
-      // @ts-expect-error
       dependencies: {DevtoolsLog: devtoolsLog},
     };
 

--- a/lighthouse-core/test/gather/gatherers/network-user-agent-test.js
+++ b/lighthouse-core/test/gather/gatherers/network-user-agent-test.js
@@ -4,8 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {readJson} from '../../../../root.js';
 import NetworkUserAgent from '../../../gather/gatherers/network-user-agent.js';
-import devtoolsLog from '../../fixtures/traces/lcp-m78.devtools.log.json';
+
+const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 
 describe('.getNetworkUserAgent', () => {
   it('should return empty string when no network events available', async () => {
@@ -14,7 +16,6 @@ describe('.getNetworkUserAgent', () => {
   });
 
   it('should return the user agent that was used to make requests', async () => {
-    // @ts-expect-error
     const result = await NetworkUserAgent.getNetworkUserAgent(devtoolsLog);
     // eslint-disable-next-line max-len
     expect(result).toEqual('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36');

--- a/lighthouse-core/test/gather/gatherers/trace-elements-test.js
+++ b/lighthouse-core/test/gather/gatherers/trace-elements-test.js
@@ -12,7 +12,9 @@ import Connection from '../../../gather/connections/connection.js';
 import createTestTrace from '../../create-test-trace.js';
 import {createMockSendCommandFn, createMockOnFn} from '../mock-commands.js';
 import {flushAllTimersAndMicrotasks, fnAny} from '../../test-utils.js';
-import animationTrace from '../../fixtures/traces/animation.json';
+import {readJson} from '../../../../root.js';
+
+const animationTrace = readJson('../../fixtures/traces/animation.json', import.meta);
 
 jest.useFakeTimers();
 

--- a/lighthouse-core/test/index-test.js
+++ b/lighthouse-core/test/index-test.js
@@ -6,9 +6,10 @@
 
 import {strict as assert} from 'assert';
 
-import pkg from '../../package.json';
 import lighthouse from '../index.js';
-import {LH_ROOT} from '../../root.js';
+import {LH_ROOT, readJson} from '../../root.js';
+
+const pkg = readJson('package.json');
 
 const {legacyNavigation} = lighthouse;
 const TEST_DIR = `${LH_ROOT}/lighthouse-core/test`;

--- a/lighthouse-core/test/lib/arbitrary-equality-map-test.js
+++ b/lighthouse-core/test/lib/arbitrary-equality-map-test.js
@@ -6,8 +6,10 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import ArbitraryEqualityMap from '../../lib/arbitrary-equality-map.js';
-import trace from '../fixtures/traces/progressive-app-m60.json';
+
+const trace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 
 describe('ArbitraryEqualityMap', () => {
   it('creates a map', () => {

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -10,13 +10,15 @@ import fs from 'fs';
 import assetSaver from '../../lib/asset-saver.js';
 import Metrics from '../../lib/traces/pwmetrics-events.js';
 import LHError from '../../lib/lh-error.js';
-import traceEvents from '../fixtures/traces/progressive-app.json';
-import dbwTrace from '../results/artifacts/defaultPass.trace.json';
-import dbwResults from '../results/sample_v2.json';
 import Audit from '../../audits/audit.js';
 import {createCommonjsRefs} from '../../scripts/esm-utils.js';
-import fullTraceObj from '../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
+import {readJson} from '../../../root.js';
+
+const traceEvents = readJson('../fixtures/traces/progressive-app.json', import.meta);
+const dbwTrace = readJson('../results/artifacts/defaultPass.trace.json', import.meta);
+const dbwResults = readJson('../results/sample_v2.json', import.meta);
+const fullTraceObj = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 const {__dirname} = createCommonjsRefs(import.meta);
 

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -8,8 +8,10 @@ import {strict as assert} from 'assert';
 
 import NetworkAnalyzer from '../../../../lib/dependency-graph/simulator/network-analyzer.js';
 import NetworkRecords from '../../../../computed/network-records.js';
-import devtoolsLog from '../../../fixtures/traces/progressive-app-m60.devtools.log.json';
-import devtoolsLogWithRedirect from '../../../fixtures/traces/site-with-redirect.devtools.log.json';
+import {readJson} from '../../../../../root.js';
+
+const devtoolsLog = readJson('../../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const devtoolsLogWithRedirect = readJson('../../../fixtures/traces/site-with-redirect.devtools.log.json', import.meta);
 
 describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
   let recordId;

--- a/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
@@ -12,8 +12,10 @@ import Simulator from '../../../../lib/dependency-graph/simulator/simulator.js';
 import DNSCache from '../../../../lib/dependency-graph/simulator/dns-cache.js';
 import PageDependencyGraph from '../../../../computed/page-dependency-graph.js';
 import {getURLArtifactFromDevtoolsLog} from '../../../test-utils.js';
-import pwaTrace from '../../../fixtures/traces/progressive-app-m60.json';
-import pwaDevtoolsLog from '../../../fixtures/traces/progressive-app-m60.devtools.log.json';
+import {readJson} from '../../../../../root.js';
+
+const pwaTrace = readJson('../../../fixtures/traces/progressive-app-m60.json', import.meta);
+const pwaDevtoolsLog = readJson('../../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 let nextRequestId = 1;
 let nextTid = 1;

--- a/lighthouse-core/test/lib/manifest-parser-test.js
+++ b/lighthouse-core/test/lib/manifest-parser-test.js
@@ -6,8 +6,10 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import manifestParser from '../../lib/manifest-parser.js';
-import manifestStub from '../fixtures/manifest.json';
+
+const manifestStub = readJson('../fixtures/manifest.json', import.meta);
 
 const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';

--- a/lighthouse-core/test/lib/minify-devtoolslog-test.js
+++ b/lighthouse-core/test/lib/minify-devtoolslog-test.js
@@ -5,9 +5,11 @@
  */
 
 import {minifyDevtoolsLog} from '../../lib/minify-devtoolslog.js';
-import trace from '../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
 import MetricsAudit from '../../audits/metrics.js';
+import {readJson} from '../../../root.js';
+
+const trace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 describe('minify-devtoolslog', () => {
   it('has identical metrics to unminified', async () => {

--- a/lighthouse-core/test/lib/minify-trace-test.js
+++ b/lighthouse-core/test/lib/minify-trace-test.js
@@ -5,9 +5,11 @@
  */
 
 import {minifyTrace} from '../../lib/minify-trace.js';
-import trace from '../fixtures/traces/progressive-app-m60.json';
-import devtoolsLog from '../fixtures/traces/progressive-app-m60.devtools.log.json';
 import MetricsAudit from '../../audits/metrics.js';
+import {readJson} from '../../../root.js';
+
+const trace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 
 describe('minify-trace', () => {
   it('has identical metrics to unminified', async () => {

--- a/lighthouse-core/test/lib/network-recorder-test.js
+++ b/lighthouse-core/test/lib/network-recorder-test.js
@@ -6,13 +6,15 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../root.js';
 import NetworkRecorder from '../../lib/network-recorder.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
-import devtoolsLogItems from '../fixtures/artifacts/perflog/defaultPass.devtoolslog.json';
-import prefetchedScriptDevtoolsLog from '../fixtures/prefetched-script.devtoolslog.json';
-import redirectsDevtoolsLog from '../fixtures/wikipedia-redirect.devtoolslog.json';
-import redirectsScriptDevtoolsLog from '../fixtures/redirects-from-script.devtoolslog.json';
-import lrRequestDevtoolsLog from '../fixtures/lr.devtoolslog.json';
+
+const devtoolsLogItems = readJson('../fixtures/artifacts/perflog/defaultPass.devtoolslog.json', import.meta);
+const prefetchedScriptDevtoolsLog = readJson('../fixtures/prefetched-script.devtoolslog.json', import.meta);
+const redirectsDevtoolsLog = readJson('../fixtures/wikipedia-redirect.devtoolslog.json', import.meta);
+const redirectsScriptDevtoolsLog = readJson('../fixtures/redirects-from-script.devtoolslog.json', import.meta);
+const lrRequestDevtoolsLog = readJson('../fixtures/lr.devtoolslog.json', import.meta);
 
 describe('network recorder', function() {
   it('recordsFromLogs expands into records', function() {

--- a/lighthouse-core/test/lib/proto-preprocessor-test.js
+++ b/lighthouse-core/test/lib/proto-preprocessor-test.js
@@ -6,7 +6,9 @@
 
 import {getProtoRoundTrip} from '../test-utils.js';
 import {processForProto} from '../../lib/proto-preprocessor.js';
-import sampleJson from '../results/sample_v2.json';
+import {readJson} from '../../../root.js';
+
+const sampleJson = readJson('../results/sample_v2.json', import.meta);
 
 const {describeIfProtoExists, sampleResultsRoundtripStr} = getProtoRoundTrip();
 const roundTripJson = sampleResultsRoundtripStr && JSON.parse(sampleResultsRoundtripStr);

--- a/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
+++ b/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
@@ -7,8 +7,10 @@
 import CpuProfileModel from '../../../lib/tracehouse/cpu-profile-model.js';
 import TraceProcessor from '../../../lib/tracehouse/trace-processor.js';
 import MainThreadTasks from '../../../lib/tracehouse/main-thread-tasks.js';
-import profilerTrace from '../../fixtures/traces/cpu-profiler-m86.trace.json';
 import CpuProfilerModel from '../../../lib/tracehouse/cpu-profile-model.js';
+import {readJson} from '../../../../root.js';
+
+const profilerTrace = readJson('../../fixtures/traces/cpu-profiler-m86.trace.json', import.meta);
 
 describe('CPU Profiler Model', () => {
   /** @type {LH.TraceCpuProfile} */

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -9,9 +9,11 @@ import {strict as assert} from 'assert';
 import MainThreadTasks from '../../../lib/tracehouse/main-thread-tasks.js';
 import TraceProcessor from '../../../lib/tracehouse/trace-processor.js';
 import {taskGroups} from '../../../lib/tracehouse/task-groups.js';
-import pwaTrace from '../../fixtures/traces/progressive-app.json';
-import noTracingStartedTrace from '../../fixtures/traces/no-tracingstarted-m74.json';
 import TracingProcessor from '../../../lib/tracehouse/trace-processor.js';
+import {readJson} from '../../../../root.js';
+
+const pwaTrace = readJson('../../fixtures/traces/progressive-app.json', import.meta);
+const noTracingStartedTrace = readJson('../../fixtures/traces/no-tracingstarted-m74.json', import.meta);
 
 describe('Main Thread Tasks', () => {
   const pid = 1;

--- a/lighthouse-core/test/lib/tracehouse/task-summary-test.js
+++ b/lighthouse-core/test/lib/tracehouse/task-summary-test.js
@@ -11,11 +11,13 @@ import {
 } from '../../../lib/tracehouse/task-summary.js';
 import NetworkRecorder from '../../../lib/network-recorder.js';
 import MainThreadTasks from '../../../lib/tracehouse/main-thread-tasks.js';
-import ampTrace from '../../fixtures/traces/amp-m86.trace.json';
-import ampDevtoolsLog from '../../fixtures/traces/amp-m86.devtoolslog.json';
 import TraceProcessor from '../../../lib/tracehouse/trace-processor.js';
 import networkRecordsToDevtoolsLog from '../../network-records-to-devtools-log.js';
 import {taskGroups} from '../../../lib/tracehouse/task-groups.js';
+import {readJson} from '../../../../root.js';
+
+const ampTrace = readJson('../../fixtures/traces/amp-m86.trace.json', import.meta);
+const ampDevtoolsLog = readJson('../../fixtures/traces/amp-m86.devtoolslog.json', import.meta);
 
 function getTasks(trace) {
   const {mainThreadEvents, frames, timestamps} = TraceProcessor.processTrace(trace);

--- a/lighthouse-core/test/lib/tracehouse/trace-processor-test.js
+++ b/lighthouse-core/test/lib/tracehouse/trace-processor-test.js
@@ -6,21 +6,23 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import TraceProcessor from '../../../lib/tracehouse/trace-processor.js';
 import createTestTrace from '../../create-test-trace.js';
-import pwaTrace from '../../fixtures/traces/progressive-app.json';
-import badNavStartTrace from '../../fixtures/traces/bad-nav-start-ts.json';
-import lateTracingStartedTrace from '../../fixtures/traces/tracingstarted-after-navstart.json';
-import noTracingStartedTrace from '../../fixtures/traces/no-tracingstarted-m74.json';
-import preactTrace from '../../fixtures/traces/preactjs.com_ts_of_undefined.json';
-import noFMPtrace from '../../fixtures/traces/no_fmp_event.json';
-import noFCPtrace from '../../fixtures/traces/airhorner_no_fcp.json';
-import timespanTrace from '../../fixtures/traces/timespan-trace-m91.json';
-import noNavStartTrace from '../../fixtures/traces/no_navstart_event.json';
-import backgroundTabTrace from '../../fixtures/traces/backgrounded-tab-missing-paints.json';
-import lcpTrace from '../../fixtures/traces/lcp-m78.json';
-import lcpAllFramesTrace from '../../fixtures/traces/frame-metrics-m89.json';
-import startedAfterNavstartTrace from '../../fixtures/traces/tracingstarted-after-navstart.json';
+
+const pwaTrace = readJson('../../fixtures/traces/progressive-app.json', import.meta);
+const badNavStartTrace = readJson('../../fixtures/traces/bad-nav-start-ts.json', import.meta);
+const lateTracingStartedTrace = readJson('../../fixtures/traces/tracingstarted-after-navstart.json', import.meta);
+const noTracingStartedTrace = readJson('../../fixtures/traces/no-tracingstarted-m74.json', import.meta);
+const preactTrace = readJson('../../fixtures/traces/preactjs.com_ts_of_undefined.json', import.meta);
+const noFMPtrace = readJson('../../fixtures/traces/no_fmp_event.json', import.meta);
+const noFCPtrace = readJson('../../fixtures/traces/airhorner_no_fcp.json', import.meta);
+const timespanTrace = readJson('../../fixtures/traces/timespan-trace-m91.json', import.meta);
+const noNavStartTrace = readJson('../../fixtures/traces/no_navstart_event.json', import.meta);
+const backgroundTabTrace = readJson('../../fixtures/traces/backgrounded-tab-missing-paints.json', import.meta);
+const lcpTrace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
+const lcpAllFramesTrace = readJson('../../fixtures/traces/frame-metrics-m89.json', import.meta);
+const startedAfterNavstartTrace = readJson('../../fixtures/traces/tracingstarted-after-navstart.json', import.meta);
 
 describe('TraceProcessor', () => {
   describe('_riskPercentiles', () => {

--- a/lighthouse-core/test/lib/traces/pwmetrics-events-test.js
+++ b/lighthouse-core/test/lib/traces/pwmetrics-events-test.js
@@ -6,9 +6,11 @@
 
 import {strict as assert} from 'assert';
 
+import {readJson} from '../../../../root.js';
 import Metrics from '../../../lib/traces/pwmetrics-events.js';
-import dbwTrace from '../../results/artifacts/defaultPass.trace.json';
-import dbwResults from '../../results/sample_v2.json';
+
+const dbwTrace = readJson('../../results/artifacts/defaultPass.trace.json', import.meta);
+const dbwResults = readJson('../../results/sample_v2.json', import.meta);
 
 describe('metrics events class', () => {
   it('exposes metric definitions', () => {

--- a/lighthouse-core/test/network-records-to-devtools-log-test.js
+++ b/lighthouse-core/test/network-records-to-devtools-log-test.js
@@ -5,8 +5,10 @@
  */
 
 import NetworkRecorder from '../../lighthouse-core/lib/network-recorder.js';
+import {readJson} from '../../root.js';
 import networkRecordsToDevtoolsLog from './network-records-to-devtools-log.js';
-import lcpDevtoolsLog from './fixtures/traces/lcp-m78.devtools.log.json';
+
+const lcpDevtoolsLog = readJson('./fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 
 describe('networkRecordsToDevtoolsLog', () => {
   it('should generate the four messages per request', () => {

--- a/lighthouse-core/test/sample-json-test.js
+++ b/lighthouse-core/test/sample-json-test.js
@@ -4,7 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import sampleJson from './results/sample_v2.json';
+import {readJson} from '../../root.js';
+
+const sampleJson = readJson('./results/sample_v2.json', import.meta);
 
 describe('Sample JSON', () => {
   /** @type {LH.Result} */

--- a/report/test/renderer/category-renderer-test.js
+++ b/report/test/renderer/category-renderer-test.js
@@ -13,7 +13,9 @@ import {I18n} from '../../renderer/i18n.js';
 import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {CategoryRenderer} from '../../renderer/category-renderer.js';
-import sampleResultsOrig from '../../../lighthouse-core/test/results/sample_v2.json';
+import {readJson} from '../../../root.js';
+
+const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 
 describe('CategoryRenderer', () => {
   let renderer;

--- a/report/test/renderer/performance-category-renderer-test.js
+++ b/report/test/renderer/performance-category-renderer-test.js
@@ -14,7 +14,9 @@ import URL from '../../../lighthouse-core/lib/url-shim.js';
 import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {PerformanceCategoryRenderer} from '../../renderer/performance-category-renderer.js';
-import sampleResultsOrig from '../../../lighthouse-core/test/results/sample_v2.json';
+import {readJson} from '../../../root.js';
+
+const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 
 describe('PerfCategoryRenderer', () => {
   let category;

--- a/report/test/renderer/pwa-category-renderer-test.js
+++ b/report/test/renderer/pwa-category-renderer-test.js
@@ -13,7 +13,9 @@ import {I18n} from '../../renderer/i18n.js';
 import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {PwaCategoryRenderer} from '../../renderer/pwa-category-renderer.js';
-import sampleResultsOrig from '../../../lighthouse-core/test/results/sample_v2.json';
+import {readJson} from '../../../root.js';
+
+const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 
 describe('PwaCategoryRenderer', () => {
   let category;

--- a/report/test/renderer/report-renderer-axe-test.js
+++ b/report/test/renderer/report-renderer-axe-test.js
@@ -6,9 +6,11 @@
 
 import puppeteer from 'puppeteer';
 
-import sampleResults from '../../../lighthouse-core/test/results/sample_v2.json';
 import reportGenerator from '../../generator/report-generator.js';
 import axeLib from '../../../lighthouse-core/lib/axe.js';
+import {readJson} from '../../../root.js';
+
+const sampleResults = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 
 describe('ReportRendererAxe', () => {
   describe('with aXe', () => {

--- a/report/test/renderer/report-renderer-test.js
+++ b/report/test/renderer/report-renderer-test.js
@@ -15,7 +15,9 @@ import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {CategoryRenderer} from '../../renderer/category-renderer.js';
 import {ReportRenderer} from '../../renderer/report-renderer.js';
-import sampleResultsOrig from '../../../lighthouse-core/test/results/sample_v2.json';
+import {readJson} from '../../../root.js';
+
+const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 
 const TIMESTAMP_REGEX = /\d+, \d{4}.*\d+:\d+/;
 

--- a/report/test/renderer/report-ui-features-test.js
+++ b/report/test/renderer/report-ui-features-test.js
@@ -16,7 +16,9 @@ import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {ReportUIFeatures} from '../../renderer/report-ui-features.js';
 import {CategoryRenderer} from '../../renderer/category-renderer.js';
 import {ReportRenderer} from '../../renderer/report-renderer.js';
-import sampleResultsOrig from '../../../lighthouse-core/test/results/sample_v2.json';
+import {readJson} from '../../../root.js';
+
+const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 
 describe('ReportUIFeatures', () => {
   let sampleResults;

--- a/report/test/renderer/util-test.js
+++ b/report/test/renderer/util-test.js
@@ -8,7 +8,9 @@ import {strict as assert} from 'assert';
 
 import {Util} from '../../renderer/util.js';
 import {I18n} from '../../renderer/i18n.js';
-import sampleResult from '../../../lighthouse-core/test/results/sample_v2.json';
+import {readJson} from '../../../root.js';
+
+const sampleResult = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 
 describe('util helpers', () => {
   beforeEach(() => {


### PR DESCRIPTION
To prepare for using mocha instead of jest, we need to drop all the json imports (which jest supports, but mocha does not, because mocha is "just node").

I used a regex to do the bulk of the migration:

```
import (.*) from ('.*\.json')
const $1 = readJson($2, import.meta)
```

I also configured the `max-len` lint rule to ignore any line that uses `readJson`: `ignorePattern: 'readJson\\(',` 