### PR TITLE
tests(smoke): increase windows retries

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Run smoke tests
       # Windows bots are slow, so only run enough tests to verify matching behavior.
-      run: yarn smoke --debug -j=2 --retries=3 --shard=${{ matrix.smoke-test-shard }}/2 dbw oopif offline lantern metrics
+      run: yarn smoke --debug -j=2 --retries=5 --shard=${{ matrix.smoke-test-shard }}/2 dbw oopif offline lantern metrics
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Run smoke tests
       # Windows bots are slow, so only run enough tests to verify matching behavior.
-      run: yarn smoke --debug -j=2 --retries=2 --shard=${{ matrix.smoke-test-shard }}/2 dbw oopif offline lantern metrics
+      run: yarn smoke --debug -j=2 --retries=3 --shard=${{ matrix.smoke-test-shard }}/2 dbw oopif offline lantern metrics
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code


### PR DESCRIPTION
~I went out of my way to get a windows cloudtop, and reproduced our windows smoke failures on that, but it only happened the first time. I can't repro anymore 🙃~

I can consistently repro the CI failures on the windows cloudtop.

Theoretically, a bump in the retries will do the same for CI though so let's see what happens...
