### PR TITLE
i18n: memoize getIcuMessageFn

### DIFF
--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -166,6 +166,19 @@ function lookupLocale(locales, possibleLocales) {
 }
 
 /**
+ * Basic memoize
+ * @param {(...args: any) => any} fn
+ */
+function memoize(fn) {
+  /** @type {Record<string, any>} */
+  const cache = {};
+  return function(/** @type {any[]} */ ...args) {
+    const key = String(args[0]);
+    return (key in cache) ? cache[key] : (cache[key] = fn.call(undefined, ...args));
+  };
+}
+
+/**
  * Returns a function that generates `LH.IcuMessage` objects to localize the
  * messages in `fileStrings` and the shared `i18n.UIStrings`.
  * @param {string} filename
@@ -199,7 +212,7 @@ function createIcuMessageFn(filename, fileStrings) {
     };
   };
 
-  return getIcuMessageFn;
+  return memoize(getIcuMessageFn);
 }
 
 /**


### PR DESCRIPTION
i was running some -A runs and it felt quite slow. Turns out the createConfig times are ~500ms and most of that is in the `getIcuMessageFn` stuff.

I tried memoizing and the results are pretty excellent

```sh
node ./lighthouse-cli --quiet -A=./lighthouse-core/test/results/artifacts --config-path=./lighthouse-core/test/results/sample-config.js --output=json --output-path=./lighthouse-core/test/results/sample_v2.json; 
node -e "t = require('./lighthouse-core/test/results/sample_v2.json'); console.log(t.timing.entries.filter(e => e.name === 'lh:config').at(-1).duration)"
```

```
# this branch
436.51
160.34
157.83
161
156.81

# master
848.99
534.13
532.56
545.76
526.82
```