### PR TITLE
i18n: reduce unnecessary message formats

### DIFF
--- a/shared/localization/format.js
+++ b/shared/localization/format.js
@@ -100,7 +100,7 @@ function collectAllCustomElementsFromICU(icuElements, seenElementsById = new Map
  * @param {string} lhlMessage Used for clear error logging.
  * @return {Record<string, string | number>}
  */
-function _preformatValues(messageFormatter, values, lhlMessage) {
+function _preformatValues(messageFormatter, values = {}, lhlMessage) {
   const elementMap = collectAllCustomElementsFromICU(messageFormatter.getAst().elements);
   const argumentElements = [...elementMap.values()];
 
@@ -165,11 +165,15 @@ function _preformatValues(messageFormatter, values, lhlMessage) {
  * is assumed to already be in the given locale.
  * If you need to localize a messagem `getFormatted` is probably what you want.
  * @param {string} message
- * @param {Record<string, string | number>} values
+ * @param {Record<string, string | number>|undefined} values
  * @param {LH.Locale} locale
  * @return {string}
  */
-function formatMessage(message, values = {}, locale) {
+function formatMessage(message, values, locale) {
+  // Parsing and formatting can be slow. Don't attempt if the string can't
+  // contain ICU placeholders, in which case formatting is already complete.
+  if (!message.includes('{') && values === undefined) return message;
+
   // When using accented english, force the use of a different locale for number formatting.
   const localeForMessageFormat = (locale === 'en-XA' || locale === 'en-XL') ? 'de-DE' : locale;
 

--- a/shared/test/localization/format-test.js
+++ b/shared/test/localization/format-test.js
@@ -400,6 +400,14 @@ describe('format', () => {
         .toThrow(`Provided value "sirNotAppearingInThisString" does not match any placeholder in ICU message "Hello {timeInMs, number, seconds} World"`);
     });
 
+    it('throws an error if a value is provided for a message with no placeholders', () => {
+      expect(_ => str_(UIStrings.helloWorld, {
+        extraCreditValue: 100,
+      }))
+        // eslint-disable-next-line max-len
+        .toThrow(`Provided value "extraCreditValue" does not match any placeholder in ICU message "Hello World"`);
+    });
+
     it('formats correctly with NaN and Infinity numeric values', () => {
       const helloInfinityStr = str_(UIStrings.helloBytesWorld, {in: Infinity});
       expect(helloInfinityStr).toBeDisplayString('Hello ∞ World');


### PR DESCRIPTION
alternate approach to memoization in #14026

Memoization needs to be on the `icuMessageFn` _and_ the ICU replacement values, since messages with different replacements are going to end up different as different strings in the end. One way to avoid the extra arg bookkeeping work would be to memoize only strings with no replacements, which is most of the strings (especially during config generation, where it's mostly checking audit `title`, `failureTitle`, `description`, etc.

The root performance problem is that [`IntlMessageFormat` is relatively slow, and we call it a lot](https://github.com/GoogleChrome/lighthouse/blob/c245084f364c60273541cc19e2b289ab09cae280/shared/localization/format.js#L178). If you look at a profile, it's spending almost all its time parsing each message (which to be fair, is apparently much faster in more recent `intl-messageformat` versions and I'm the one who has [resisted updating](https://github.com/GoogleChrome/lighthouse/pull/13834#pullrequestreview-935776341)).

Since ICU placeholders have to occur inside `{}`, and most of our strings don't have any replacements, this PR instead adds a simple filter that just checks if the message has a `{` in it before attempting to parse it. This will catch all messages with placeholders (letting in false positives with escaped `{` in them, but I don't believe we have any right now?). The result is equivalent to the "memoize only strings with no replacements" mentioned above.

This is slightly less efficient than memoizing the whole thing, but almost all formatted strings have no placeholders, and of those that do, only a fraction will have repeated placeholder replacements that would get a cache hit.

75 out of 880 messages (8.5%) in `en-US.json` have ICU placeholders in them, but almost all of those are things like `displayValue`s and the like, which are used rarely. In a real run using the command in #14026 

```sh
node ./lighthouse-cli --quiet -A=./lighthouse-core/test/results/artifacts --config-path=./lighthouse-core/test/results/sample-config.js --output=json --output-path=./lighthouse-core/test/results/sample_v2.json
```

of the 16,608 messages that pass through `getIcuMessageFn`, 42 (0.25%) need a replacement, so it's probably not worth the extra effort for them.

