### PR TITLE
tests(config-helpers): restore process.cwd after mocking

### DIFF
--- a/lighthouse-core/test/config/config-helpers-test.js
+++ b/lighthouse-core/test/config/config-helpers-test.js
@@ -29,7 +29,7 @@ import {createCommonjsRefs} from '../../scripts/esm-utils.js';
 const {require, __dirname} = createCommonjsRefs(import.meta);
 
 const originalCwd = process.cwd;
-afterAll(async () => {
+afterAll(() => {
   process.cwd = originalCwd;
 });
 

--- a/lighthouse-core/test/config/config-helpers-test.js
+++ b/lighthouse-core/test/config/config-helpers-test.js
@@ -28,9 +28,10 @@ import {createCommonjsRefs} from '../../scripts/esm-utils.js';
 
 const {require, __dirname} = createCommonjsRefs(import.meta);
 
-jest.mock('process', () => ({
-  cwd: () => jest.fn(),
-}));
+const originalCwd = process.cwd;
+afterAll(async () => {
+  process.cwd = originalCwd;
+});
 
 describe('.mergeConfigFragment', () => {
   it('should merge properties in like Object.assign', () => {


### PR DESCRIPTION
The test overwrites `process.cwd` but never restores it.

Also, the `process` global is special, being injected into the scope of every module and not necessarily going through the require/import process (so can't be mocked with jest.mock that way unless the module under test explicitly imports it, which we don't). So I removed the usage of `jest.mock`.