### PR TITLE
report(flow): import preact h, Fragment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,8 +56,8 @@ module.exports = {
     'no-unused-vars': [2, {
       vars: 'all',
       args: 'after-used',
-      argsIgnorePattern: '(^reject$|^_+$)',
-      varsIgnorePattern: '(^_$)',
+      argsIgnorePattern: '^(reject|_+)$',
+      varsIgnorePattern: '^(_|h|Fragment)$',
     }],
     'space-infix-ops': 2,
     'strict': [2, 'global'],

--- a/flow-report/src/app.tsx
+++ b/flow-report/src/app.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, Fragment, FunctionComponent} from 'preact';
 import {useLayoutEffect, useMemo, useRef, useState} from 'preact/hooks';
 
 import {Sidebar} from './sidebar/sidebar';

--- a/flow-report/src/common.tsx
+++ b/flow-report/src/common.tsx
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {h, Fragment} from 'preact';
 import {FunctionComponent} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 

--- a/flow-report/src/header.tsx
+++ b/flow-report/src/header.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, Fragment, FunctionComponent} from 'preact';
 
 import {FlowStepIcon, FlowStepThumbnail} from './common';
 import {useLocalizedStrings} from './i18n/i18n';

--- a/flow-report/src/help-dialog.tsx
+++ b/flow-report/src/help-dialog.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent, JSX} from 'preact';
+import {h, FunctionComponent, JSX} from 'preact';
 
 import {useLocalizedStrings} from './i18n/i18n';
 import {CloseIcon, NavigationIcon, SnapshotIcon, TimespanIcon} from './icons';

--- a/flow-report/src/i18n/i18n.tsx
+++ b/flow-report/src/i18n/i18n.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {createContext, FunctionComponent} from 'preact';
+import {h, createContext, FunctionComponent} from 'preact';
 import {useContext, useMemo} from 'preact/hooks';
 
 import {formatMessage} from '../../../shared/localization/format';

--- a/flow-report/src/icons.tsx
+++ b/flow-report/src/icons.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 
 /* eslint-disable max-len */
 

--- a/flow-report/src/sidebar/flow.tsx
+++ b/flow-report/src/sidebar/flow.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, Fragment, FunctionComponent} from 'preact';
 
 import {FlowSegment} from '../common';
 import {classNames, useHashState, useFlowResult} from '../util';

--- a/flow-report/src/sidebar/sidebar.tsx
+++ b/flow-report/src/sidebar/sidebar.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 
 import {Util} from '../../../report/renderer/util';
 import {Separator} from '../common';

--- a/flow-report/src/summary/category.tsx
+++ b/flow-report/src/summary/category.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, Fragment, FunctionComponent} from 'preact';
 
 import {Util} from '../../../report/renderer/util';
 import {Separator} from '../common';

--- a/flow-report/src/summary/summary.tsx
+++ b/flow-report/src/summary/summary.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 import {useMemo} from 'preact/hooks';
 
 import {FlowSegment, FlowStepThumbnail, Separator} from '../common';

--- a/flow-report/src/topbar.tsx
+++ b/flow-report/src/topbar.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent, JSX} from 'preact';
+import {h, FunctionComponent, JSX} from 'preact';
 import {useState} from 'preact/hooks';
 
 import {HelpDialog} from './help-dialog';

--- a/flow-report/src/wrappers/category-score.tsx
+++ b/flow-report/src/wrappers/category-score.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 
 import {renderCategoryScore} from '../../../report/renderer/api';
 import {useExternalRenderer} from '../util';

--- a/flow-report/src/wrappers/markdown.tsx
+++ b/flow-report/src/wrappers/markdown.tsx
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {h} from 'preact';
 import {FunctionComponent} from 'preact';
 
 import {convertMarkdownCodeSnippets} from '../../../report/renderer/api';

--- a/flow-report/src/wrappers/report.tsx
+++ b/flow-report/src/wrappers/report.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 
 import {renderReport} from '../../../report/renderer/api.js';
 import {useExternalRenderer} from '../util';

--- a/flow-report/src/wrappers/styles.tsx
+++ b/flow-report/src/wrappers/styles.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 
 import {createStylesElement} from '../../../report/renderer/api';
 import {useExternalRenderer} from '../util';

--- a/flow-report/test/app-test.tsx
+++ b/flow-report/test/app-test.tsx
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {h} from 'preact';
 import {act, render} from '@testing-library/preact';
 
 import {App} from '../src/app';

--- a/flow-report/test/common-test.tsx
+++ b/flow-report/test/common-test.tsx
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {h} from 'preact';
 import {jest} from '@jest/globals';
 import {act, render} from '@testing-library/preact';
 

--- a/flow-report/test/flow-report-pptr-test.ts
+++ b/flow-report/test/flow-report-pptr-test.ts
@@ -4,13 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {jest} from '@jest/globals';
 import puppeteer, {Browser, Page} from 'puppeteer';
 
 import ReportGenerator from '../../report/generator/report-generator.js';
 import {flowResult} from './sample-flow';
-
-jest.setTimeout(35_000);
 
 describe('Lighthouse Flow Report', () => {
   console.log('\n✨ Be sure to have recently run this: yarn build-report');

--- a/flow-report/test/header-test.tsx
+++ b/flow-report/test/header-test.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 import {render} from '@testing-library/preact';
 
 import {Header} from '../src/header';

--- a/flow-report/test/sidebar/flow-test.tsx
+++ b/flow-report/test/sidebar/flow-test.tsx
@@ -5,7 +5,7 @@
  */
 
 import {render} from '@testing-library/preact';
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 
 import {SidebarFlow} from '../../src/sidebar/flow';
 import {FlowResultContext} from '../../src/util';

--- a/flow-report/test/sidebar/sidebar-test.tsx
+++ b/flow-report/test/sidebar/sidebar-test.tsx
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {h} from 'preact';
 import {render} from '@testing-library/preact';
 import {FunctionComponent} from 'preact';
 

--- a/flow-report/test/summary/category-test.tsx
+++ b/flow-report/test/summary/category-test.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 import {render} from '@testing-library/preact';
 
 import {SummaryTooltip} from '../../src/summary/category';

--- a/flow-report/test/summary/summary-test.tsx
+++ b/flow-report/test/summary/summary-test.tsx
@@ -5,7 +5,7 @@
  */
 
 import {render} from '@testing-library/preact';
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 
 import {I18nProvider} from '../../src/i18n/i18n';
 import {SummaryHeader, SummaryFlowStep} from '../../src/summary/summary';

--- a/flow-report/test/topbar-test.tsx
+++ b/flow-report/test/topbar-test.tsx
@@ -5,7 +5,7 @@
  */
 
 import {jest} from '@jest/globals';
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 import {act, render} from '@testing-library/preact';
 
 import {FlowResultContext, OptionsContext} from '../src/util';

--- a/flow-report/test/util-test.tsx
+++ b/flow-report/test/util-test.tsx
@@ -7,7 +7,7 @@
 import {jest} from '@jest/globals';
 import {render} from '@testing-library/preact';
 import {renderHook} from '@testing-library/preact-hooks';
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 import {act} from 'preact/test-utils';
 
 import {FlowResultContext, useExternalRenderer, useHashState} from '../src/util';

--- a/flow-report/test/wrappers/category-score-test.tsx
+++ b/flow-report/test/wrappers/category-score-test.tsx
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {FunctionComponent} from 'preact';
+import {h, FunctionComponent} from 'preact';
 import {render} from '@testing-library/preact';
 
 import {CategoryScore} from '../../src/wrappers/category-score';

--- a/flow-report/test/wrappers/markdown-test.tsx
+++ b/flow-report/test/wrappers/markdown-test.tsx
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {h} from 'preact';
 import {render} from '@testing-library/preact';
 
 import {Markdown} from '../../src/wrappers/markdown';


### PR DESCRIPTION
ref #14047

This is an odd PR- `h` and `Fragment` won't actually be used because we configure typescript with:

```
"jsx": "react-jsx",
"jsxImportSource": "preact",
```

which means Typescript (rollup?) injects `global.React = require('preact')` into the global scope (instead of converting jsx to use `h` and `Fragment`). However, these imports will be necessary for the future Mocha test runner, and it'd be a bit noisy to have all these files changing in the upcoming Mocha PR so I've split it out here.
