### PR TITLE
tests(topbar): replace module mock with dependency injection

### DIFF
--- a/flow-report/src/topbar.tsx
+++ b/flow-report/src/topbar.tsx
@@ -17,8 +17,11 @@ import {saveFile} from '../../report/renderer/api';
 function saveHtml(flowResult: LH.FlowResult, htmlStr: string) {
   const blob = new Blob([htmlStr], {type: 'text/html'});
   const filename = getFlowResultFilenamePrefix(flowResult) + '.html';
-  saveFile(blob, filename);
+  saveHtml.saveFile(blob, filename);
 }
+
+// Store `saveFile` here so we can do dependency injection.
+saveHtml.saveFile = saveFile;
 
 /* eslint-disable max-len */
 const Logo: FunctionComponent = () => {
@@ -68,7 +71,7 @@ const TopbarButton: FunctionComponent<{
   );
 };
 
-export const Topbar: FunctionComponent<{onMenuClick: JSX.MouseEventHandler<HTMLButtonElement>}> =
+const Topbar: FunctionComponent<{onMenuClick: JSX.MouseEventHandler<HTMLButtonElement>}> =
 ({onMenuClick}) => {
   const flowResult = useFlowResult();
   const strings = useLocalizedStrings();
@@ -117,4 +120,9 @@ export const Topbar: FunctionComponent<{onMenuClick: JSX.MouseEventHandler<HTMLB
       }
     </div>
   );
+};
+
+export {
+  Topbar,
+  saveHtml,
 };

--- a/flow-report/test/topbar-test.tsx
+++ b/flow-report/test/topbar-test.tsx
@@ -28,7 +28,6 @@ let wrapper: FunctionComponent;
 let options: LH.FlowReportOptions;
 
 beforeEach(() => {
-  saveHtml.saveFile = defaultSaveFile;
   mockSaveFile.mockReset();
   options = {};
   wrapper = ({children}) => (
@@ -40,6 +39,10 @@ beforeEach(() => {
       </FlowResultContext.Provider>
     </OptionsContext.Provider>
   );
+});
+
+afterEach(() => {
+  saveHtml.saveFile = defaultSaveFile;
 });
 
 it('save button opens save dialog for HTML file', async () => {

--- a/flow-report/test/topbar-test.tsx
+++ b/flow-report/test/topbar-test.tsx
@@ -10,16 +10,10 @@ import {act, render} from '@testing-library/preact';
 
 import {FlowResultContext, OptionsContext} from '../src/util';
 import {I18nProvider} from '../src/i18n/i18n';
+import {Topbar, saveHtml} from '../src/topbar';
 
 const mockSaveFile = jest.fn();
-jest.unstable_mockModule('../../../report/renderer/api.js', () => ({
-  saveFile: mockSaveFile,
-}));
-
-let Topbar: typeof import('../src/topbar').Topbar;
-beforeAll(async () => {
-  Topbar = (await import('../src/topbar')).Topbar;
-});
+const defaultSaveFile = saveHtml.saveFile;
 
 const flowResult = {
   name: 'User flow',
@@ -34,6 +28,7 @@ let wrapper: FunctionComponent;
 let options: LH.FlowReportOptions;
 
 beforeEach(() => {
+  saveHtml.saveFile = defaultSaveFile;
   mockSaveFile.mockReset();
   options = {};
   wrapper = ({children}) => (
@@ -48,6 +43,7 @@ beforeEach(() => {
 });
 
 it('save button opens save dialog for HTML file', async () => {
+  saveHtml.saveFile = mockSaveFile;
   options = {getReportHtml: () => '<html></html>'};
   const root = render(<Topbar onMenuClick={() => {}}/>, {wrapper});
 


### PR DESCRIPTION
Instead of mocking a module, do dependency injection. This is necessary for #14054 because testdouble loader conflicts with the esm loader necessary for tsx files.
