### PR TITLE
core(source-maps): throw explicit error when map is missing required fields

### DIFF
--- a/lighthouse-core/gather/gatherers/source-maps.js
+++ b/lighthouse-core/gather/gatherers/source-maps.js
@@ -101,6 +101,11 @@ class SourceMaps extends FRGatherer {
       const map = isSourceMapADataUri ?
           this.parseSourceMapFromDataUrl(rawSourceMapUrl) :
           await this.fetchSourceMap(driver, rawSourceMapUrl);
+
+      if (typeof map.version !== 'number') throw new Error('Map has no numeric `version` field');
+      if (!Array.isArray(map.sources)) throw new Error('Map has no `sources` list');
+      if (typeof map.mappings !== 'string') throw new Error('Map has no `mappings` field');
+
       if (map.sections) {
         map.sections = map.sections.filter(section => section.map);
       }


### PR DESCRIPTION
Found another [one](https://sentry.io/organizations/google-lighthouse/issues/2666708562/events/dce9189eaa854297aa70e7b972256ec1/?project=174697#exception) from sentry. (btw it looks like theres only 3 actual JS errors in there. and this is 2 out of 3)

`lighthouse https://video.ebscohost.com/results?q=climate%20change -GA`

That page loads [this JS file](https://cmp.osano.com/169lTOSNzFFdw20EN/adcab978-e7bd-469a-a9fd-6fa5f686ea58/osano.js) which references [this map](https://cmp.osano.com/169lTOSNzFFdw20EN/adcab978-e7bd-469a-a9fd-6fa5f686ea58/osano.js.map), which is just a `{}`. It is missing 3 field required by the spec. 

But we werent validating these fields are present, leading to a `Cannot read properties of undefined (reading 'length')` on here:

https://github.com/GoogleChrome/lighthouse/blob/94b4f38d53694d6fdec38a12481f5dbd6a856f08/lighthouse-core/audits/valid-source-maps.js#L97

![image](https://user-images.githubusercontent.com/39191/170556370-1c3e015a-a742-4947-94b4-e83d8ba91e47.png)


This change adds the basic validation in the gatherer. As a result, we don't hit the exception. And the user gets the errorMessage in the UI: 

![image](https://user-images.githubusercontent.com/39191/170552840-d21aa9f3-618c-441b-ad78-15fb9e32206f.png)

The audit is still passing cuz it ["Only fails](https://github.com/GoogleChrome/lighthouse/blob/94b4f38d53694d6fdec38a12481f5dbd6a856f08/lighthouse-core/audits/valid-source-maps.js#L146) if `missingMapsForLargeFirstPartyFile` is true. All other errors are diagnostical."

