### PR TITLE
clients(psi): expose the swapLocale types

### DIFF
--- a/build/build-report.js
+++ b/build/build-report.js
@@ -90,14 +90,8 @@ async function buildFlowReport() {
 }
 
 async function buildEsModulesBundle() {
-  const bundle = await rollup({
-    input: 'report/clients/bundle.js',
-    plugins: [
-      rollupPlugins.commonjs(),
-      // Exclude this 30kb from the devtools bundle for now.
-      // But include the type detail for bundle.esm.d.ts generation
-      rollupPlugins.shim({
-        [`${LH_ROOT}/shared/localization/i18n-module.js`]: `
+  // Include the type detail for bundle.esm.d.ts generation
+  const i18nModuleShim = `
 /**
  * Returns a new LHR with all strings changed to the new requestedLocale.
  * @param {LH.Result} lhr
@@ -123,7 +117,15 @@ function registerLocaleData(locale, lhlMessages) {
   // Stub function only included for types
 }
 export const format = {registerLocaleData};
-        `,
+`;
+
+  const bundle = await rollup({
+    input: 'report/clients/bundle.js',
+    plugins: [
+      rollupPlugins.commonjs(),
+      // Exclude this 30kb from the devtools bundle for now.
+      rollupPlugins.shim({
+        [`${LH_ROOT}/shared/localization/i18n-module.js`]: i18nModuleShim,
       }),
     ],
   });

--- a/build/build-report.js
+++ b/build/build-report.js
@@ -95,6 +95,7 @@ async function buildEsModulesBundle() {
     plugins: [
       rollupPlugins.commonjs(),
       // Exclude this 30kb from the devtools bundle for now.
+      // But include the type detail for bundle.esm.d.ts generation
       rollupPlugins.shim({
         [`${LH_ROOT}/shared/localization/i18n-module.js`]: `
 /**
@@ -104,6 +105,7 @@ async function buildEsModulesBundle() {
  * @return {{lhr: LH.Result, missingIcuMessageIds: string[]}}
  */
 export function swapLocale(lhr, requestedLocale) {
+  // Stub function only included for types
   return {
     lhr,
     missingIcuMessageIds: [],
@@ -118,7 +120,7 @@ export function swapLocale(lhr, requestedLocale) {
  * @param {Record<string, {message: string}>} lhlMessages
  */
 function registerLocaleData(locale, lhlMessages) {
-  // ...
+  // Stub function only included for types
 }
 export const format = {registerLocaleData};
         `,

--- a/build/build-report.js
+++ b/build/build-report.js
@@ -96,8 +96,32 @@ async function buildEsModulesBundle() {
       rollupPlugins.commonjs(),
       // Exclude this 30kb from the devtools bundle for now.
       rollupPlugins.shim({
-        [`${LH_ROOT}/shared/localization/i18n-module.js`]:
-            'export const swapLocale = _ => {}; export const format = _ => {};',
+        [`${LH_ROOT}/shared/localization/i18n-module.js`]: `
+/**
+ * Returns a new LHR with all strings changed to the new requestedLocale.
+ * @param {LH.Result} lhr
+ * @param {LH.Locale} requestedLocale
+ * @return {{lhr: LH.Result, missingIcuMessageIds: string[]}}
+ */
+export function swapLocale(lhr, requestedLocale) {
+  return {
+    lhr,
+    missingIcuMessageIds: []
+  };
+};
+
+/**
+ * Populate the i18n string lookup dict with locale data
+ * Used when the host environment selects the locale and serves lighthouse the intended locale file
+ * @see https://docs.google.com/document/d/1jnt3BqKB-4q3AE94UWFA0Gqspx8Sd_jivlB7gQMlmfk/edit
+ * @param {LH.Locale} locale
+ * @param {Record<string, {message: string}>} lhlMessages
+ */
+function registerLocaleData(locale, lhlMessages) {
+    LOCALE_MESSAGES[locale] = lhlMessages;
+}
+export const format = {registerLocaleData};
+        `,
       }),
     ],
   });

--- a/build/build-report.js
+++ b/build/build-report.js
@@ -106,9 +106,9 @@ async function buildEsModulesBundle() {
 export function swapLocale(lhr, requestedLocale) {
   return {
     lhr,
-    missingIcuMessageIds: []
+    missingIcuMessageIds: [],
   };
-};
+}
 
 /**
  * Populate the i18n string lookup dict with locale data
@@ -118,7 +118,7 @@ export function swapLocale(lhr, requestedLocale) {
  * @param {Record<string, {message: string}>} lhlMessages
  */
 function registerLocaleData(locale, lhlMessages) {
-    LOCALE_MESSAGES[locale] = lhlMessages;
+  // ...
 }
 export const format = {registerLocaleData};
         `,


### PR DESCRIPTION
We're in a funny situation, so here's the backstory...

1. we want the swapLocale functionality in PSI
1. our PSI integration story uses the bundle.umd.js + a .d.ts declaration file
   * we use report/bundle.esm in devtools and report/bundle.umd in PSI. because reasons.
1. the declaration file is created via `node ./node_modules/.bin/tsc --allowJs --declaration --emitDeclarationOnly ./dist/report/bundle.esm.js` <== the ESM version!
   * yes we generate types from the build that we don't use. we can't gen types from the umd one anyway
1. the esm and umd report builds are slightly different and that hasn't mattered much until recently. i shimmed swaplocale/format with `{}` for devtools to save 30kb. 
3. however for the correct type generation we need those to look reasonable
4. thus, this silly PR

------

A more reasonable solution is generating a ~lighthousereportrenderer.types.d.ts file the "right" way. `tsc` can generate quality `.d.ts` files - but its 1:1 against source files. 

There are a few projects that can consume all of those and generate a single file. 1) `dts-gen` by microsoft is at the module level and doesnt really make sense for this usecase. (probably). 2) [dts-generator](https://github.com/SitePen/dts-generator) isn't maintained and dun work. 3) [dts-bundle](https://github.com/TypeStrong/dts-bundle) is also dead. 4) [dts-bundle-generator](https://github.com/timocov/dts-bundle-generator) seems like the best one, but unfortunately it explicitly [doesnt support composite projects](https://github.com/timocov/dts-bundle-generator/issues/93). To me, situation is enough justification to justify our `sed` BS plus this unattractive solution. Ah well, I expect this situation will improve with the arch refactor + dts-bundle-generator adding support.