### PR TITLE
core(cdp): update HTTP method for /json/new call

### DIFF
--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -82,7 +82,8 @@ class CriConnection extends Connection {
    */
   _runJsonCommand(command) {
     return new Promise((resolve, reject) => {
-      const request = http.get({
+      const request = http.request({
+        method: 'PUT', // GET and POST are deprecated: https://crrev.com/c/3595822
         hostname: this.hostname,
         port: this.port,
         path: '/json/' + command,
@@ -108,6 +109,8 @@ class CriConnection extends Connection {
           reject(new Error(`Protocol JSON API error (${command}), status: ${response.statusCode}`));
         });
       });
+
+      request.end();
 
       // This error handler is critical to ensuring Lighthouse exits cleanly even when Chrome crashes.
       // See https://github.com/GoogleChrome/lighthouse/pull/8583.


### PR DESCRIPTION
Spotted this in the chrome process stderr output:

> `ERROR:devtools_http_handler.cc(636)] Using unsafe HTTP verb POST to invoke /json/new. This action will stop supporting GET and POST verbs in future versions.`

It's from a month-old CL: https://chromium-review.googlesource.com/c/chromium/src/+/3595822

from what i can tell, this only affects our non-FR launches. (aka `--legacy-navigation`)

