### PR TITLE
core(driver): fix legacy runner hanging oopifs in some cases

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -308,6 +308,9 @@ class Driver {
     // If the iframe is in the same process as its embedding document, that means they
     // share the same target.
 
+    // A target won't acknowledge/respond to protocol methods (or, at least for Network.enable)
+    // until it is resumed. But also we're paranoid about sending Network.enable _slightly_ too late,
+    // so we issue that method first. Therefore, we don't await on this serially, but await all at once.
     await Promise.all([
       // Events from subtargets will be stringified and sent back on `Target.receivedMessageFromTarget`.
       // We want to receive information about network requests from iframes, so enable the Network domain.

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -304,20 +304,20 @@ class Driver {
       return;
     }
 
-    // Events from subtargets will be stringified and sent back on `Target.receivedMessageFromTarget`.
-    // We want to receive information about network requests from iframes, so enable the Network domain.
-    await this.sendCommandToSession('Network.enable', event.sessionId);
-
-    // We also want to receive information about subtargets of subtargets, so make sure we autoattach recursively.
-    await this.sendCommandToSession('Target.setAutoAttach', event.sessionId, {
-      autoAttach: true,
-      flatten: true,
-      // Pause targets on startup so we don't miss anything
-      waitForDebuggerOnStart: true,
-    });
-
-    // We suspended the target when we auto-attached, so make sure it goes back to being normal.
-    await this.sendCommandToSession('Runtime.runIfWaitingForDebugger', event.sessionId);
+    await Promise.all([
+      // Events from subtargets will be stringified and sent back on `Target.receivedMessageFromTarget`.
+      // We want to receive information about network requests from iframes, so enable the Network domain.
+      this.sendCommandToSession('Network.enable', event.sessionId),
+      // We also want to receive information about subtargets of subtargets, so make sure we autoattach recursively.
+      this.sendCommandToSession('Target.setAutoAttach', event.sessionId, {
+        autoAttach: true,
+        flatten: true,
+        // Pause targets on startup so we don't miss anything
+        waitForDebuggerOnStart: true,
+      }),
+      // We suspended the target when we auto-attached, so make sure it goes back to being normal.
+      this.sendCommandToSession('Runtime.runIfWaitingForDebugger', event.sessionId),
+    ]);
   }
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -304,6 +304,10 @@ class Driver {
       return;
     }
 
+    // Note: This is only reached for _out of process_ iframes (OOPIFs).
+    // If the iframe is in the same process as its embedding document, that means they
+    // share the same target.
+
     await Promise.all([
       // Events from subtargets will be stringified and sent back on `Target.receivedMessageFromTarget`.
       // We want to receive information about network requests from iframes, so enable the Network domain.


### PR DESCRIPTION
While investigating #13861, I noticed that the legacy runner takes a long time on the oopif-scripts.html smoke fixture. This is because the OOPIF target _hangs forever_, and is never loaded. This was made clear when the second iframe on the test page never rendered any content.

Turns out, we can't do `Network.enable` and await its response if the target is paused.

It _seems_ like the `iframe` specific part of `_handleTargetAttached`  may have always been busted? It's also possible that Chrome CDP internals changed underneath us.

I also added a clarifying comment in `_handleTargetAttached` noting that all that logic is only for OOPIFs.