### PR TITLE
tests(smoke): fix ToT node id failures

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -431,7 +431,19 @@ const expectations = {
           nodes: {
             // Test that the numbers for individual elements are in the ballpark.
             // Exact ordering and IDs between FR and legacy differ, so fork the expectations.
+            '4-11-IMG': {
+              _minChromiumVersion: '104.0.5100.0',
+              _legacyOnly: true,
+              top: '650±50',
+              bottom: '650±50',
+              left: '10±10',
+              right: '120±20',
+              width: '120±20',
+              height: '20±20',
+            },
+            // Legacy runner execution context ID changed after 104.0.5100.0
             '5-11-IMG': {
+              _maxChromiumVersion: '104.0.5098.0',
               _legacyOnly: true,
               top: '650±50',
               bottom: '650±50',

--- a/lighthouse-cli/test/smokehouse/test-definitions/screenshot.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/screenshot.js
@@ -54,9 +54,13 @@ const expectations = {
         // Note: The first number (5) in these ids comes from an executionContextId, and has the potential to change.
         // The following P is the same element as above but from a different JS context. This element
         // starts with height ~18 and grows over time. See screenshot.html.
-        '5-0-BODY': {_legacyOnly: true, ...elements.body},
-        '5-2-P': {_legacyOnly: true, ...elements.p},
-        '5-3-HTML': {_legacyOnly: true},
+        '5-0-BODY': {_legacyOnly: true, ...elements.body, _maxChromiumVersion: '104.0.5098.0'},
+        '5-2-P': {_legacyOnly: true, ...elements.p, _maxChromiumVersion: '104.0.5098.0'},
+        '5-3-HTML': {_legacyOnly: true, _maxChromiumVersion: '104.0.5098.0'},
+        // Legacy runner execution context ID changed after 104.0.5100.0
+        '4-0-BODY': {_legacyOnly: true, ...elements.body, _minChromiumVersion: '104.0.5100.0'},
+        '4-2-P': {_legacyOnly: true, ...elements.p, _minChromiumVersion: '104.0.5100.0'},
+        '4-3-HTML': {_legacyOnly: true, _minChromiumVersion: '104.0.5100.0'},
 
         // Fraggle rock should contain the same elements just with different ids.
         '9-0-P': {_fraggleRockOnly: true, ...elements.p},


### PR DESCRIPTION
This started in either 104.0.5100.0 or 104.0.5099.0
