### PR TITLE
core(driver): do not use target manager in legacy mode

### DIFF
--- a/lighthouse-core/gather/driver/network-monitor.js
+++ b/lighthouse-core/gather/driver/network-monitor.js
@@ -106,10 +106,15 @@ class NetworkMonitor {
     this._networkRecorder.on('requestloaded', reEmit('requestloaded'));
 
     this._session.on('Page.frameNavigated', this._onFrameNavigated);
-    this._targetManager.addTargetAttachedListener(this._onTargetAttached);
-
     await this._session.sendCommand('Page.enable');
-    await this._targetManager.enable();
+
+    // Legacy driver does its own target management.
+    // @ts-expect-error
+    const isLegacyRunner = Boolean(this._session._domainEnabledCounts);
+    if (!isLegacyRunner) {
+      this._targetManager.addTargetAttachedListener(this._onTargetAttached);
+      await this._targetManager.enable();
+    }
   }
 
   /**

--- a/lighthouse-core/gather/driver/network-monitor.js
+++ b/lighthouse-core/gather/driver/network-monitor.js
@@ -111,11 +111,11 @@ class NetworkMonitor {
     // Legacy driver does its own target management.
     // @ts-expect-error
     const isLegacyRunner = Boolean(this._session._domainEnabledCounts);
-    if (!isLegacyRunner) {
+    if (isLegacyRunner) {
+      this._session.addProtocolMessageListener(this._onProtocolMessage);
+    } else {
       this._targetManager.addTargetAttachedListener(this._onTargetAttached);
       await this._targetManager.enable();
-    } else {
-      this._session.addProtocolMessageListener(this._onProtocolMessage);
     }
   }
 
@@ -130,14 +130,14 @@ class NetworkMonitor {
     // Legacy driver does its own target management.
     // @ts-expect-error
     const isLegacyRunner = Boolean(this._session._domainEnabledCounts);
-    if (!isLegacyRunner) {
+    if (isLegacyRunner) {
+      this._session.removeProtocolMessageListener(this._onProtocolMessage);
+    } else {
       this._targetManager.removeTargetAttachedListener(this._onTargetAttached);
 
       for (const session of this._sessions.values()) {
         session.removeProtocolMessageListener(this._onProtocolMessage);
       }
-    } else {
-      this._session.removeProtocolMessageListener(this._onProtocolMessage);
     }
 
     if (!isLegacyRunner) await this._targetManager.disable();

--- a/lighthouse-core/gather/driver/network-monitor.js
+++ b/lighthouse-core/gather/driver/network-monitor.js
@@ -138,9 +138,9 @@ class NetworkMonitor {
       for (const session of this._sessions.values()) {
         session.removeProtocolMessageListener(this._onProtocolMessage);
       }
-    }
 
-    if (!isLegacyRunner) await this._targetManager.disable();
+      await this._targetManager.disable();
+    }
 
     this._frameNavigations = [];
     this._networkRecorder = undefined;


### PR DESCRIPTION
Related to #14078. In the legacy driver, we are already handling targets via the [event handlers](https://github.com/GoogleChrome/lighthouse/blob/f0c2f84d5d7cfd7d558582872de9c8d7f666e9dd/lighthouse-core/gather/driver.js#L72) added in the constructor. Let's not complicate things in legacy mode by doing target management in a second place (only the NetworkMonitor is what creates a TargetManager in legacy mode).