### PR TITLE
tests(smoke): fix flaky `perf-diagnostics-third-party`

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -178,9 +178,7 @@ jobs:
       #   errors-expired-ssl errors-infinite-loop
       # Disabled because Chrome will follow the redirect first, and Lighthouse will only ever see/run the final URL.
       #   redirects-client-paint-server redirects-multiple-server redirects-single-server redirects-single-client
-      # Disabled to fix CI while we investigate what the bug is.
-      #   oopif-scripts
-      run: yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/${{ strategy.job-total }} --jobs=3 --retries=2 --invert-match oopif-scripts a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-server redirects-single-client redirects-scripts screenshot seo-passing seo-tap-targets
+      run: yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/${{ strategy.job-total }} --jobs=3 --retries=2 --invert-match a11y byte-efficiency byte-gzip dbw errors-expired-ssl errors-infinite-loop lantern-idle-callback-short legacy-javascript metrics-tricky-tti metrics-tricky-tti-late-fcp oopif-requests perf-budgets perf-diagnostics-third-party perf-fonts perf-frame-metrics perf-preload perf-trace-elements pwa redirects-client-paint-server redirects-history-push-state redirects-multiple-server redirects-single-server redirects-single-client redirects-scripts screenshot seo-passing seo-tap-targets
       working-directory: ${{ github.workspace }}/lighthouse
 
     - name: Upload failures

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,11 +2,11 @@
 
 _Some incomplete notes_
 
-![Lighthouse Architecture](https://raw.githubusercontent.com/GoogleChrome/lighthouse/master/assets/architecture.png)
+![Lighthouse Architecture](https://user-images.githubusercontent.com/6752989/168922741-d574b82c-656c-446a-bc81-43a578c75c06.png)
 
 ## Components & Terminology
 
-* **Driver** - Interfaces with [Chrome Debugging Protocol](https://developer.chrome.com/devtools/docs/debugger-protocol)  ([API viewer](https://chromedevtools.github.io/debugger-protocol-viewer/))
+* **Driver** - Interfaces with [Puppeteer](https://github.com/puppeteer/puppeteer) and [Chrome Debugging Protocol](https://developer.chrome.com/devtools/docs/debugger-protocol)  ([API viewer](https://chromedevtools.github.io/debugger-protocol-viewer/))
 * **Gatherers** - Uses Driver to collect information about the page. Minimal post-processing.  Run Lighthouse with `--gather-mode` to see the 3 primary outputs from gathering:
   1. `artifacts.json`: The output from all [gatherers](../lighthouse-core/gather/gatherers).
   2. `defaultPass.trace.json`: Most performance characteristics come from here. You can view it in the DevTools Peformance panel.
@@ -28,13 +28,13 @@ _Some incomplete notes_
 
 ```js
 // will NOT work
-driver.sendCommand('Security.enable').then(_ => {
-  driver.on('Security.securityStateChanged', state => { /* ... */ });
+driver.defaultSession.sendCommand('Security.enable').then(_ => {
+  driver.defaultSession.on('Security.securityStateChanged', state => { /* ... */ });
 })
 
 // WILL work! happy happy. :)
-driver.on('Security.securityStateChanged', state => { /* ... */ }); // event binding is synchronous
-driver.sendCommand('Security.enable');
+driver.defaultSession.on('Security.securityStateChanged', state => { /* ... */ }); // event binding is synchronous
+driver.defaultSession.sendCommand('Security.enable');
 ```
 
 * _Debugging the protocol_: Read [Better debugging of the Protocol](https://github.com/GoogleChrome/lighthouse/issues/184).
@@ -57,9 +57,9 @@ driver.sendCommand('Security.enable');
 }
 ```
 
-### Trace-of-Tab
+### Processed trace
 
-Trace-of-tab identifies trace events for key moments (navigation start, first meaningful paint, DOM content loaded, trace end, etc) and provides filtered views of just the main process and the main thread events. Because the timestamps are not necessarily interesting in isolation, trace-of-tab also calculates the times in milliseconds of key moments relative to navigation start, thus providing the typical interpretation of first meaningful paint in ms.
+The processed trace identifies trace events for key moments (navigation start, FCP, LCP, DOM content loaded, trace end, etc) and provides filtered views of just the main process and the main thread events. Because the timestamps are not necessarily interesting in isolation, the processed trace also calculates the times in milliseconds of key moments relative to navigation start, thus providing the typical interpretation of metrics in ms.
 
 ```js
 {
@@ -67,34 +67,30 @@ Trace-of-tab identifies trace events for key moments (navigation start, first me
   mainThreadEvents: [/* all trace events on the main thread */],
   timings: {
     timeOrigin: 0, // timeOrigin is always 0 ms
-    firstPaint: 150, // firstPaint time in ms after time origin
+    firstContentfulPaint: 150, // firstContentfulPaint time in ms after time origin
     /* other key moments */
     traceEnd: 16420, // traceEnd time in ms after time origin
   },
   timestamps: {
     timeOrigin: 623000000, // timeOrigin timestamp in microseconds, marks the start of the navigation of interest
-    firstPaint: 623150000, // firstPaint timestamp in microseconds
+    firstContentfulPaint: 623150000, // firstContentfulPaint timestamp in microseconds
     /* other key moments */
     traceEnd: 639420000, // traceEnd timestamp in microseconds
   },
 }
 ```
 
-### Tracing Processor
-
-Tracing processor takes the output of trace of tab and identifies the top-level main thread tasks, their durations, and corresponding impact on page responsiveness. Tracing processor also translates task timestamps to milliseconds since navigation start for easier interpretation in computed gatherers and audits.
-
 ## Audits
 
-The return value of each audit [takes this shape](https://github.com/GoogleChrome/lighthouse/blob/623b789497f6c87f85d366b4038deae5dc701c90/types/audit.d.ts#L69-L87).
+The return value of each audit [takes this shape](https://github.com/GoogleChrome/lighthouse/blob/17b7163486b69239689ed49415bdeee6f7766bfa/types/audit.d.ts#L66-L83).
 
 The `details` object is parsed in report-renderer.js. View other audits for guidance on how to structure `details`.
 
 ## Lighthouse-core internal module dependencies
 
-![image](https://user-images.githubusercontent.com/39191/86166329-786fb100-bac9-11ea-919a-d6c3b156d3a4.png)
+![image](https://user-images.githubusercontent.com/6752989/168904554-082aa9c3-46f3-448f-92b8-20ad3a02258f.png)
 
-(Generated June 30, 2020 via `madge lighthouse-core/index.js --image arch.png --layout dot --exclude="(locales\/)|(stack-packs\/packs)"`)
+(Generated May 17, 2022 via `madge lighthouse-core/index.js --image arch.png --layout dot --exclude="(locales\/)|(stack-packs\/packs)"`)
 
 ## Lantern
 

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -74,7 +74,7 @@ async function runBundledLighthouse(url, configJson, testRunnerOptions) {
 
   // Launch and connect to Chrome.
   const launchedChrome = await ChromeLauncher.launch({
-    chromeFlags: ['--disable-features=EarlyCodeCache'],
+    chromeFlags: ['--disable-features=EarlyCodeCache,EarlyBodyLoad'],
   });
   const port = launchedChrome.port;
 

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -73,7 +73,9 @@ async function runBundledLighthouse(url, configJson, testRunnerOptions) {
   const lighthouse = global.runBundledLighthouse;
 
   // Launch and connect to Chrome.
-  const launchedChrome = await ChromeLauncher.launch();
+  const launchedChrome = await ChromeLauncher.launch({
+    chromeFlags: ['--disable-features=EarlyCodeCache'],
+  });
   const port = launchedChrome.port;
 
   // Run Lighthouse.

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
@@ -79,6 +79,7 @@ async function internalRun(url, tmpPath, configJson, options) {
     `-A=${artifactsDirectory}`,
     '--port=0',
     '--quiet',
+    '--chrome-flags="--disable-features=EarlyCodeCache"',
   ];
 
   if (useFraggleRock) {

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/cli.js
@@ -79,7 +79,7 @@ async function internalRun(url, tmpPath, configJson, options) {
     `-A=${artifactsDirectory}`,
     '--port=0',
     '--quiet',
-    '--chrome-flags="--disable-features=EarlyCodeCache"',
+    '--chrome-flags="--disable-features=EarlyCodeCache,EarlyBodyLoad"',
   ];
 
   if (useFraggleRock) {

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -85,6 +85,7 @@ async function runLighthouse(url, configJson, testRunnerOptions = {}) {
   const outputDir = fs.mkdtempSync(os.tmpdir() + '/lh-smoke-cdt-runner-');
   const chromeFlags = [
     `--custom-devtools-frontend=file://${devtoolsDir}/out/Default/gen/front_end`,
+    '--disable-features=EarlyCodeCache',
   ];
   const args = [
     'run-devtools',

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -85,7 +85,7 @@ async function runLighthouse(url, configJson, testRunnerOptions = {}) {
   const outputDir = fs.mkdtempSync(os.tmpdir() + '/lh-smoke-cdt-runner-');
   const chromeFlags = [
     `--custom-devtools-frontend=file://${devtoolsDir}/out/Default/gen/front_end`,
-    '--disable-features=EarlyCodeCache',
+    '--disable-features=EarlyCodeCache,EarlyBodyLoad',
   ];
   const args = [
     'run-devtools',


### PR DESCRIPTION
🤞 won't be permanent, but can hopefully unblock CI. Should fix the flaky failures on `perf-diagnostics-third-party` ~and `oopif-scripts`~

Theory is that one or more of the features enabled by [this CL](https://chromium-review.googlesource.com/c/chromium/src/+/3555400) triggered the flakiness.

Related https://github.com/GoogleChrome/lighthouse/issues/13861