### PR TITLE
core(driver): guard verbose logic behind log.isVerbose check

### DIFF
--- a/lighthouse-core/gather/driver/wait-for-condition.js
+++ b/lighthouse-core/gather/driver/wait-for-condition.js
@@ -164,7 +164,8 @@ function waitForNetworkIdle(session, networkMonitor, networkQuietOptions) {
       const inflightRecords = networkMonitor.getInflightRequests();
       // If there are more than 20 inflight requests, load is still in full swing.
       // Wait until it calms down a bit to be a little less spammy.
-      if (inflightRecords.length < 20) {
+      if (log.isVerbose() && inflightRecords.length < 20 && inflightRecords.length > 0) {
+        log.verbose('waitFor', `=== Waiting on ${inflightRecords.length} requests to finish`);
         for (const record of inflightRecords) {
           log.verbose('waitFor', `Waiting on ${record.url.slice(0, 120)} to finish`);
         }

--- a/types/lighthouse-logger/index.d.ts
+++ b/types/lighthouse-logger/index.d.ts
@@ -11,6 +11,7 @@ declare module 'lighthouse-logger' {
     args?: any[];
   }
   export function setLevel(level: string): void;
+  export function isVerbose(): boolean;
   export function formatProtocol(prefix: string, data: Object, level?: string): void;
   export function log(title: string, ...args: any[]): void;
   export function warn(title: string, ...args: any[]): void;


### PR DESCRIPTION
We do _a lot_ of logging on network events when there is <20 inflight. This can be a lot of string operations that are just done for naught if the logging isn't verbose. so I added a simple check to avoid that.