### PR TITLE
misc(build): shim fs out of lightrider report generator bundle

### DIFF
--- a/build/build-lightrider-bundles.js
+++ b/build/build-lightrider-bundles.js
@@ -31,26 +31,21 @@ async function buildReportGenerator() {
   const bundle = await rollup({
     input: 'report/generator/report-generator.js',
     plugins: [
+      rollupPlugins.inlineFs({verbose: Boolean(process.env.DEBUG)}),
       rollupPlugins.shim({
         [`${LH_ROOT}/report/generator/flow-report-assets.js`]: 'export default {}',
+        'fs': 'export default {}',
       }),
       rollupPlugins.commonjs(),
-      rollupPlugins.inlineFs({verbose: Boolean(process.env.DEBUG)}),
     ],
   });
 
   await bundle.write({
     file: 'dist/lightrider/report-generator-bundle.js',
-    format: 'iife',
+    format: 'umd',
     name: 'ReportGenerator',
   });
   await bundle.close();
-
-  // Typically one would use `umd` to export to the window object, but for some reason rollup
-  // adds a `require('fs')` when used above, which errors in google3 build.
-  const outPath = `${LH_ROOT}/dist/lightrider/report-generator-bundle.js`;
-  fs.writeFileSync(outPath,
-    fs.readFileSync(outPath, 'utf-8') + '\nwindow.ReportGenerator = ReportGenerator;\n');
 }
 
 async function buildStaticServerBundle() {


### PR DESCRIPTION
from my too-late [comment in #14031](https://github.com/GoogleChrome/lighthouse/pull/14031/files#r891701219). We shim `fs` this way for the [standalone report umd bundle](https://github.com/GoogleChrome/lighthouse/blob/e84549bc51672958a48347d31b6476d1863c65d7/build/build-report.js#L126), can do the same thing here. Still a workaround, but a little less finicky.