### PR TITLE
tests(smoke): use major milestone

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -432,7 +432,7 @@ const expectations = {
             // Test that the numbers for individual elements are in the ballpark.
             // Exact ordering and IDs between FR and legacy differ, so fork the expectations.
             '4-11-IMG': {
-              _minChromiumVersion: '104.0.5100.0',
+              _minChromiumVersion: '104',
               _legacyOnly: true,
               top: '650±50',
               bottom: '650±50',
@@ -443,7 +443,7 @@ const expectations = {
             },
             // Legacy runner execution context ID changed after 104.0.5100.0
             '5-11-IMG': {
-              _maxChromiumVersion: '104.0.5098.0',
+              _maxChromiumVersion: '103',
               _legacyOnly: true,
               top: '650±50',
               bottom: '650±50',

--- a/lighthouse-cli/test/smokehouse/test-definitions/screenshot.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/screenshot.js
@@ -54,13 +54,13 @@ const expectations = {
         // Note: The first number (5) in these ids comes from an executionContextId, and has the potential to change.
         // The following P is the same element as above but from a different JS context. This element
         // starts with height ~18 and grows over time. See screenshot.html.
-        '5-0-BODY': {_legacyOnly: true, ...elements.body, _maxChromiumVersion: '104.0.5098.0'},
-        '5-2-P': {_legacyOnly: true, ...elements.p, _maxChromiumVersion: '104.0.5098.0'},
-        '5-3-HTML': {_legacyOnly: true, _maxChromiumVersion: '104.0.5098.0'},
+        '5-0-BODY': {_legacyOnly: true, ...elements.body, _maxChromiumVersion: '103'},
+        '5-2-P': {_legacyOnly: true, ...elements.p, _maxChromiumVersion: '103'},
+        '5-3-HTML': {_legacyOnly: true, _maxChromiumVersion: '103'},
         // Legacy runner execution context ID changed after 104.0.5100.0
-        '4-0-BODY': {_legacyOnly: true, ...elements.body, _minChromiumVersion: '104.0.5100.0'},
-        '4-2-P': {_legacyOnly: true, ...elements.p, _minChromiumVersion: '104.0.5100.0'},
-        '4-3-HTML': {_legacyOnly: true, _minChromiumVersion: '104.0.5100.0'},
+        '4-0-BODY': {_legacyOnly: true, ...elements.body, _minChromiumVersion: '104'},
+        '4-2-P': {_legacyOnly: true, ...elements.p, _minChromiumVersion: '104'},
+        '4-3-HTML': {_legacyOnly: true, _minChromiumVersion: '104'},
 
         // Fraggle rock should contain the same elements just with different ids.
         '9-0-P': {_fraggleRockOnly: true, ...elements.p},


### PR DESCRIPTION
Should fix the CI failures on ToT

---

context: Chrome UserAgent is dropping all but major version information

<img src="https://user-images.githubusercontent.com/316891/172682631-99cc4505-6a27-4b39-a2cd-3c0324154bfd.jpg" width="500">

https://twitter.com/rowan_m/status/1528728452949594113

