### PR TITLE
core: handle sessions inside target-manager

### DIFF
--- a/lighthouse-core/fraggle-rock/gather/driver.js
+++ b/lighthouse-core/fraggle-rock/gather/driver.js
@@ -26,8 +26,6 @@ const throwingSession = {
   off: throwNotConnectedFn,
   addProtocolMessageListener: throwNotConnectedFn,
   removeProtocolMessageListener: throwNotConnectedFn,
-  addSessionAttachedListener: throwNotConnectedFn,
-  removeSessionAttachedListener: throwNotConnectedFn,
   sendCommand: throwNotConnectedFn,
   dispose: throwNotConnectedFn,
 };

--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -27,6 +27,7 @@ class ProtocolSession {
 
   sessionId() {
     return this._targetInfo && this._targetInfo.type === 'iframe' ?
+      // TODO: use this._session.id() for real session id.
       this._targetInfo.targetId :
       undefined;
   }
@@ -75,27 +76,6 @@ class ProtocolSession {
    */
   once(eventName, callback) {
     this._cdpSession.once(eventName, /** @type {*} */ (callback));
-  }
-
-  /**
-   * Bind to the puppeteer `sessionattached` listener and return an LH ProtocolSession.
-   * @param {(session: ProtocolSession) => void} callback
-   */
-  addSessionAttachedListener(callback) {
-    /** @param {LH.Puppeteer.CDPSession} session */
-    const listener = session => callback(new ProtocolSession(session));
-    this._callbackMap.set(callback, listener);
-    this._getConnection().on('sessionattached', listener);
-  }
-
-  /**
-   * Unbind to the puppeteer `sessionattached` listener.
-   * @param {(session: ProtocolSession) => void} callback
-   */
-  removeSessionAttachedListener(callback) {
-    const listener = this._callbackMap.get(callback);
-    if (!listener) return;
-    this._getConnection().off('sessionattached', listener);
   }
 
   /**
@@ -171,12 +151,6 @@ class ProtocolSession {
   async dispose() {
     this._cdpSession.removeAllListeners();
     await this._cdpSession.detach();
-  }
-
-  _getConnection() {
-    const connection = this._cdpSession.connection();
-    if (!connection) throw new Error('Connection has been closed.');
-    return connection;
   }
 }
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -208,16 +208,6 @@ class Driver {
     // OOPIF handling in legacy driver is implicit.
   }
 
-  /** @param {(session: LH.Gatherer.FRProtocolSession) => void} callback */
-  addSessionAttachedListener(callback) { // eslint-disable-line no-unused-vars
-    // OOPIF handling in legacy driver is implicit.
-  }
-
-  /** @param {(session: LH.Gatherer.FRProtocolSession) => void} callback */
-  removeSessionAttachedListener(callback) { // eslint-disable-line no-unused-vars
-    // OOPIF handling in legacy driver is implicit.
-  }
-
   /**
    * Debounce enabling or disabling domains to prevent driver users from
    * stomping on each other. Maintains an internal count of the times a domain

--- a/lighthouse-core/gather/driver/network-monitor.js
+++ b/lighthouse-core/gather/driver/network-monitor.js
@@ -90,7 +90,10 @@ class NetworkMonitor {
     this._frameNavigations = [];
     this._sessions = new Map();
     this._networkRecorder = new NetworkRecorder();
-    this._targetManager = new TargetManager(this._session);
+    /** @type {LH.Puppeteer.CDPSession} */
+    // @ts-expect-error - temporarily reach in to get CDPSession
+    const rootCdpSession = this._session._session;
+    this._targetManager = new TargetManager(rootCdpSession);
 
     /**
      * Reemit the same network recorder events.

--- a/lighthouse-core/gather/driver/network-monitor.js
+++ b/lighthouse-core/gather/driver/network-monitor.js
@@ -92,7 +92,7 @@ class NetworkMonitor {
     this._networkRecorder = new NetworkRecorder();
     /** @type {LH.Puppeteer.CDPSession} */
     // @ts-expect-error - temporarily reach in to get CDPSession
-    const rootCdpSession = this._session._session;
+    const rootCdpSession = this._session._cdpSession;
     this._targetManager = new TargetManager(rootCdpSession);
 
     /**

--- a/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
+++ b/lighthouse-core/test/fraggle-rock/gather/mock-driver.js
@@ -33,12 +33,46 @@ function createMockSession() {
     off: fnAny(),
     addProtocolMessageListener: createMockOnFn(),
     removeProtocolMessageListener: fnAny(),
-    addSessionAttachedListener: createMockOnFn(),
-    removeSessionAttachedListener: fnAny(),
     dispose: fnAny(),
 
     /** @return {LH.Gatherer.FRProtocolSession} */
     asSession() {
+      // @ts-expect-error - We'll rely on the tests passing to know this matches.
+      return this;
+    },
+  };
+}
+
+function createMockCdpSession() {
+  const connection = createMockCdpConnection();
+
+  return {
+    send: createMockSendCommandFn({useSessionId: false}),
+    once: createMockOnceFn(),
+    on: createMockOnFn(),
+    off: fnAny(),
+    removeAllListeners: fnAny(),
+    detach: fnAny(),
+
+    connection() {
+      return connection;
+    },
+
+    /** @return {LH.Puppeteer.CDPSession} */
+    asCdpSession() {
+      // @ts-expect-error - We'll rely on the tests passing to know this matches.
+      return this;
+    },
+  };
+}
+
+function createMockCdpConnection() {
+  return {
+    on: createMockOnFn(),
+    off: fnAny(),
+
+    /** @return {LH.Puppeteer.Connection} */
+    asCdpConnection() {
       // @ts-expect-error - We'll rely on the tests passing to know this matches.
       return this;
     },
@@ -304,6 +338,7 @@ export {
   createMockDriver,
   createMockPage,
   createMockSession,
+  createMockCdpSession,
   createMockGathererInstance,
   createMockBaseArtifacts,
   createMockContext,

--- a/lighthouse-core/test/fraggle-rock/gather/session-test.js
+++ b/lighthouse-core/test/fraggle-rock/gather/session-test.js
@@ -150,44 +150,6 @@ describe('ProtocolSession', () => {
     });
   });
 
-  describe('.addSessionAttachedListener', () => {
-    it('should listen for new sessions', () => {
-      const mockOn = fnAny();
-      // @ts-expect-error - we want to use a more limited, controllable test
-      puppeteerSession = {connection: () => ({on: mockOn}), emit: fnAny()};
-      session = new ProtocolSession(puppeteerSession);
-
-      // Make sure we listen for the event.
-      const listener = fnAny();
-      session.addSessionAttachedListener(listener);
-      expect(mockOn).toHaveBeenCalledWith('sessionattached', expect.any(Function));
-
-      // Make sure we wrap the return in a ProtocolSession.
-      mockOn.mock.calls[0][1]({emit: fnAny()});
-      expect(listener).toHaveBeenCalledWith(expect.any(ProtocolSession));
-    });
-  });
-
-  describe('.removeSessionAttachedListener', () => {
-    it('should stop listening for new sessions', () => {
-      const mockOn = fnAny();
-      const mockOff = fnAny();
-      // @ts-expect-error - we want to use a more limited, controllable test
-      puppeteerSession = {connection: () => ({on: mockOn, off: mockOff}), emit: fnAny()};
-      session = new ProtocolSession(puppeteerSession);
-
-      // Make sure we listen for the event.
-      const userListener = fnAny();
-      session.addSessionAttachedListener(userListener);
-      expect(mockOn).toHaveBeenCalledWith('sessionattached', expect.any(Function));
-
-      // Make sure we unlisten the mapped function, not just the user's listener.
-      const installedListener = mockOn.mock.calls[0][1];
-      session.removeSessionAttachedListener(userListener);
-      expect(mockOff).toHaveBeenCalledWith('sessionattached', installedListener);
-    });
-  });
-
   describe('.sendCommand', () => {
     it('delegates to puppeteer', async () => {
       const send = puppeteerSession.send = fnAny().mockResolvedValue(123);

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -30,8 +30,6 @@ declare module Gatherer {
     once<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
     addProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
     removeProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
-    addSessionAttachedListener(callback: (session: FRProtocolSession) => void): void
-    removeSessionAttachedListener(callback: (session: FRProtocolSession) => void): void
     off<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
     sendCommand<TMethod extends keyof LH.CrdpCommands>(method: TMethod, ...params: LH.CrdpCommands[TMethod]['paramsType']): Promise<LH.CrdpCommands[TMethod]['returnType']>;
     dispose(): Promise<void>;


### PR DESCRIPTION
Improve understandability of `target-manager` (re: #14078) by moving the `sessionattached` listener into TargetManager itself. There's no functional change, but this means TargetManager is only in the business of creating FRSessions, not interoperating with them, which opens up further flexibility in the future.