### PR TITLE
i18n: replace placeholder using replacer callback

### DIFF
--- a/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
+++ b/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
@@ -80,7 +80,7 @@ function bakePlaceholders(messages) {
         // Need a global replace due to plural ICU copying placeholders
         // (and therefore ICU vars) multiple times.
         const regex = new RegExp('\\$' + placeholder + '\\$', 'g');
-        message = message.replace(regex, content);
+        message = message.replace(regex, () => content);
       }
     }
 


### PR DESCRIPTION
from chat:

replacing strings literally in JS is actually pretty not straightforward. Worse, it will work in like 99% of cases until it doesn't. See:

```js
const replaceWith = 'Dollar: \'$\');';
console.log('REPLACE'.replace('REPLACE', replaceWith));
```

this prints Dollar: '); ... note the missing dollar sign ... because the replace function is "regex-aware" even if the first parameter is not a regex ...

only valid for $' and $`. the others ($0, $1) don't work

so you must do this:

```js
'REPLACE'.replace('REPLACE', () => replaceWith);
```


_____


After auditing all our usages of `String.prototype.replace`, I only found this one instance where it _could_ theoretically be problematic.