### PR TITLE
tests: add devtools e2e test runner

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -78,6 +78,37 @@ jobs:
           ${{ github.workspace }}/.gclient
         key: devtools-build-artifacts-${{ github.run_id }}
 
+  e2e:
+    needs: [build]
+    runs-on: macos-latest
+
+    steps:
+    - name: git clone
+      uses: actions/checkout@v2
+      with:
+        path: lighthouse
+
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
+    - name: Load build artifacts
+      id: devtools-build-artifacts
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.DEVTOOLS_PATH }}/out/Default/gen/front_end
+          ${{ env.DEVTOOLS_PATH }}/test/e2e
+          ${{ github.workspace }}/.gclient
+        key: devtools-build-artifacts-${{ github.run_id }}
+
+    - name: Download Content Shell
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/chromium-web-tests/download-content-shell.sh
+
+    - name: Run e2e tests
+      run: bash $GITHUB_WORKSPACE/lighthouse/lighthouse-core/test/devtools-tests/run-e2e-tests.sh
+
   web-tests:
     needs: [build]
     runs-on: macos-latest

--- a/lighthouse-core/scripts/roll-to-devtools.sh
+++ b/lighthouse-core/scripts/roll-to-devtools.sh
@@ -80,6 +80,12 @@ rsync -avh "$lh_webtests_dir" "$fe_webtests_dir" --exclude="OWNERS" --delete
 lh_webtests_exp_dir="third-party/chromium-webtests/webtests/platform/generic/http/tests/devtools/lighthouse/"
 fe_webtests_exp_dir="$dt_dir/test/webtests/platform/generic/http/tests/devtools/lighthouse"
 rsync -avh "$lh_webtests_exp_dir" "$fe_webtests_exp_dir" --exclude="OWNERS" --delete
+
+# copy e2e tests
+lh_e2e_dir="third-party/devtools-tests/e2e/lighthouse/"
+fe_e2e_dir="$dt_dir/test/e2e/lighthouse"
+rsync -avh "$lh_e2e_dir" "$fe_e2e_dir" --exclude="OWNERS" --exclude="BUILD.gn" --delete
+
 echo ""
 echo "Done. To run the webtests: "
 echo "    DEVTOOLS_PATH=\"$dt_dir\" yarn test-devtools"

--- a/lighthouse-core/test/devtools-tests/run-e2e-tests.sh
+++ b/lighthouse-core/test/devtools-tests/run-e2e-tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+##
+# @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+##
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export LH_ROOT="$SCRIPT_DIR/../../.."
+
+# Get newest folder
+latest_content_shell_dir_name=$(ls -t "$LH_ROOT/.tmp/chromium-web-tests/content-shells/" | head -n1)
+latest_content_shell_dir="$LH_ROOT/.tmp/chromium-web-tests/content-shells/$latest_content_shell_dir_name/out/Release"
+latest_content_shell=$(node "$LH_ROOT/third-party/download-content-shell/download-content-shell.js" --resolve-executable-path $latest_content_shell_dir)
+
+cd "$DEVTOOLS_PATH"
+
+git cl patch 3682120 || true
+
+# TODO: run tests from our codebase
+TEST_PATTERN="${1:-lighthouse/*}"
+npm run e2etest -- --chrome-binary-path="$latest_content_shell" "$TEST_PATTERN"

--- a/lighthouse-core/test/devtools-tests/setup.sh
+++ b/lighthouse-core/test/devtools-tests/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+##
+# @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+##
+
+# Setup dependencies for devtools e22 tests.
+# Set SKIP_DOWNLOADS to skip all the downloading and just export variables.
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LH_ROOT="$SCRIPT_DIR/../../.."
+TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
+
+export DEVTOOLS_PATH=${DEVTOOLS_PATH:-"$TEST_DIR/devtools/devtools-frontend"}
+
+if [ -z ${SKIP_DOWNLOADS+x} ]
+then
+  echo "========================================"
+  echo "Downloading latest content_shell and DevTools"
+  echo "To skip this step, set SKIP_DOWNLOADS=1"
+  echo "========================================"
+  echo
+
+  bash "$SCRIPT_DIR/../chromium-web-tests/download-devtools.sh"
+  bash "$SCRIPT_DIR/../chromium-web-tests/download-content-shell.sh"
+fi

--- a/lighthouse-core/test/devtools-tests/test-locally.sh
+++ b/lighthouse-core/test/devtools-tests/test-locally.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+##
+# @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+##
+
+# Runs the devtools e2e tests in third-party/devtools-tests using the latest
+# Lighthouse, DevTools, and Chrome content_shell*
+#
+# * Not exactly the latest, but close. See download-content-shell.js
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$SCRIPT_DIR/setup.sh"
+bash "$SCRIPT_DIR/../chromium-web-tests/roll-devtools.sh"
+bash "$SCRIPT_DIR/run-e2e-tests.sh" $*

--- a/third-party/devtools-tests/README.md
+++ b/third-party/devtools-tests/README.md
@@ -1,0 +1,11 @@
+# Devtools e2e Tests
+
+These tests are rolled into the Chromium DevTools Frontend codebase. They "belong" to the devtools frontend, but are truly defined in this Lighthouse repo.
+
+See `lighthouse-core/test/chromium-web-tests/README.md` for more.
+
+## Sync
+
+```sh
+rsync -ahvz --exclude='OWNERS' --exclude='BUILD.gn' ~/src/devtools/devtools-frontend/test/e2e/lighthouse/ third-party/devtools-tests/e2e/lighthouse/
+```

--- a/third-party/devtools-tests/e2e/lighthouse/generate-report_test.ts
+++ b/third-party/devtools-tests/e2e/lighthouse/generate-report_test.ts
@@ -1,0 +1,27 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import {assert} from 'chai';
+
+import {goToResource} from '../../shared/helper.js';
+import {describe, it} from '../../shared/mocha-extensions.js';
+import {isGenerateReportButtonDisabled, navigateToLighthouseTab} from '../helpers/lighthouse-helpers.js';
+
+describe('The Lighthouse Tab', async () => {
+  it('shows a button to generate a new report', async () => {
+    await navigateToLighthouseTab('empty.html');
+
+    const disabled = await isGenerateReportButtonDisabled();
+    assert.isFalse(disabled, 'The Generate Report button should not be disabled');
+  });
+
+  // Broken on non-debug runs
+  it.skip('[crbug.com/1057948] shows generate report button even when navigating to an unreachable page', async () => {
+    await navigateToLighthouseTab('empty.html');
+
+    await goToResource('network/unreachable.rawresponse');
+    const disabled = await isGenerateReportButtonDisabled();
+    assert.isTrue(disabled, 'The Generate Report button should be disabled');
+  });
+});

--- a/third-party/devtools-tests/e2e/lighthouse/indexeddb-warning_test.ts
+++ b/third-party/devtools-tests/e2e/lighthouse/indexeddb-warning_test.ts
@@ -1,0 +1,27 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import {assert} from 'chai';
+
+import {waitFor} from '../../shared/helper.js';
+import {describe, it} from '../../shared/mocha-extensions.js';
+import {navigateToLighthouseTab} from '../helpers/lighthouse-helpers.js';
+
+describe('IndexedDB warning', async function() {
+  it('displays when important data may affect performance', async () => {
+    await navigateToLighthouseTab('empty.html');
+
+    let warningElem = await waitFor('.lighthouse-warning-text.hidden');
+    const warningText1 = await warningElem.evaluate(node => node.textContent?.trim());
+    assert.strictEqual(warningText1, '');
+
+    await navigateToLighthouseTab('lighthouse/lighthouse-storage.html');
+
+    warningElem = await waitFor('.lighthouse-warning-text:not(.hidden)');
+    const expected =
+        'There may be stored data affecting loading performance in this location: IndexedDB. Audit this page in an incognito window to prevent those resources from affecting your scores.';
+    const warningText2 = await warningElem.evaluate(node => node.textContent?.trim());
+    assert.strictEqual(warningText2, expected);
+  });
+});

--- a/third-party/download-content-shell/README.md
+++ b/third-party/download-content-shell/README.md
@@ -6,3 +6,4 @@ Some minor patches on top from the Lighthouse Authors:
 
 * deleting code we don't need
 * changing output path
+* --resolve-executable-path

--- a/third-party/download-content-shell/download-content-shell.js
+++ b/third-party/download-content-shell/download-content-shell.js
@@ -34,7 +34,6 @@ function main() {
     console.log('Unable to download because of error:', error);
   }
 }
-main();
 
 function onUploadedCommitPosition(commitPosition) {
   const contentShellDirPath = path.resolve(CACHE_PATH, commitPosition, 'out', TARGET);
@@ -175,4 +174,10 @@ function getContentShellBinaryPath(dirPath) {
   if (process.platform === 'darwin') {
     return path.resolve(dirPath, 'Content Shell.app', 'Contents', 'MacOS', 'Content Shell');
   }
+}
+
+if (process.argv[2] === '--resolve-executable-path') {
+  console.log(getContentShellBinaryPath(process.argv[3]));
+} else {
+  main();
 }


### PR DESCRIPTION
Pretty much the same structure as the webtests, but simpler. Re-uses some scripts from the webtests folder. Can re-org whenever we actually delete webtests.

Waiting on this to land: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/3682120