### PR TITLE
core: make targetManager accessible on driver

### DIFF
--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -21,15 +21,10 @@ class ProtocolSession {
     this._targetInfo = undefined;
     /** @type {number|undefined} */
     this._nextProtocolTimeout = undefined;
-    /** @type {WeakMap<any, any>} */
-    this._callbackMap = new WeakMap();
   }
 
-  sessionId() {
-    return this._targetInfo && this._targetInfo.type === 'iframe' ?
-      // TODO: use this._session.id() for real session id.
-      this._targetInfo.targetId :
-      undefined;
+  id() {
+    return this._cdpSession.id();
   }
 
   /** @param {LH.Crdp.Target.TargetInfo} targetInfo */
@@ -76,34 +71,6 @@ class ProtocolSession {
    */
   once(eventName, callback) {
     this._cdpSession.once(eventName, /** @type {*} */ (callback));
-  }
-
-  /**
-   * Bind to puppeteer's '*' event that fires for *any* protocol event,
-   * and wrap it with data about the protocol message instead of just the event.
-   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
-   */
-  addProtocolMessageListener(callback) {
-    /**
-     * @param {any} method
-     * @param {any} event
-     */
-    const listener = (method, event) => callback({
-      method,
-      params: event,
-      sessionId: this.sessionId(),
-    });
-    this._callbackMap.set(callback, listener);
-    this._cdpSession.on('*', /** @type {*} */ (listener));
-  }
-
-  /**
-   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
-   */
-  removeProtocolMessageListener(callback) {
-    const listener = this._callbackMap.get(callback);
-    if (!listener) return;
-    this._cdpSession.off('*', /** @type {*} */ (listener));
   }
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -96,6 +96,29 @@ class Driver {
     this.evaluate = this.executionContext.evaluate.bind(this.executionContext);
     /** @private @deprecated Only available for plugin backcompat. */
     this.evaluateAsync = this.executionContext.evaluateAsync.bind(this.executionContext);
+
+    // A shim for sufficient coverage of targetManager functionality.
+    this.targetManager = {
+      rootSession: () => {
+        return this.defaultSession;
+      },
+      /**
+       * Bind to *any* protocol event.
+       * @param {'protocolevent'} event
+       * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
+       */
+      on: (event, callback) => {
+        this._connection.on('protocolevent', callback);
+      },
+      /**
+       * Unbind to *any* protocol event.
+       * @param {'protocolevent'} event
+       * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
+       */
+      off: (event, callback) => {
+        this._connection.off('protocolevent', callback);
+      },
+    };
   }
 
   /** @deprecated - Not available on Fraggle Rock driver. */
@@ -185,22 +208,6 @@ class Driver {
     }
 
     this._eventEmitter.removeListener(eventName, cb);
-  }
-
-  /**
-   * Bind to *any* protocol event.
-   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
-   */
-  addProtocolMessageListener(callback) {
-    this._connection.on('protocolevent', callback);
-  }
-
-  /**
-   * Unbind to *any* protocol event.
-   * @param {(payload: LH.Protocol.RawEventMessage) => void} callback
-   */
-  removeProtocolMessageListener(callback) {
-    this._connection.off('protocolevent', callback);
   }
 
   /** @param {LH.Crdp.Target.TargetInfo} targetInfo */

--- a/lighthouse-core/gather/driver/navigation.js
+++ b/lighthouse-core/gather/driver/navigation.js
@@ -89,7 +89,7 @@ async function gotoURL(driver, requestor, options) {
   log.time(status);
 
   const session = driver.defaultSession;
-  const networkMonitor = new NetworkMonitor(driver.defaultSession);
+  const networkMonitor = new NetworkMonitor(driver.targetManager);
 
   // Enable the events and network monitor needed to track navigation progress.
   await networkMonitor.enable();

--- a/lighthouse-core/gather/gatherers/full-page-screenshot.js
+++ b/lighthouse-core/gather/gatherers/full-page-screenshot.js
@@ -89,7 +89,7 @@ class FullPageScreenshot extends FRGatherer {
     const height = Math.min(fullHeight, maxTextureSize);
 
     // Setup network monitor before we change the viewport.
-    const networkMonitor = new NetworkMonitor(session);
+    const networkMonitor = new NetworkMonitor(context.driver.targetManager);
     const waitForNetworkIdleResult = waitForNetworkIdle(session, networkMonitor, {
       pretendDCLAlreadyFired: true,
       networkQuietThresholdMs: 1000,

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -28,8 +28,6 @@ declare module Gatherer {
     setNextProtocolTimeout(ms: number): void;
     on<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
     once<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
-    addProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
-    removeProtocolMessageListener(callback: (payload: Protocol.RawEventMessage) => void): void
     off<TEvent extends keyof LH.CrdpEvents>(event: TEvent, callback: (...args: LH.CrdpEvents[TEvent]) => void): void;
     sendCommand<TMethod extends keyof LH.CrdpCommands>(method: TMethod, ...params: LH.CrdpCommands[TMethod]['paramsType']): Promise<LH.CrdpCommands[TMethod]['returnType']>;
     dispose(): Promise<void>;
@@ -41,6 +39,11 @@ declare module Gatherer {
     executionContext: ExecutionContext;
     fetcher: Fetcher;
     url: () => Promise<string>;
+    targetManager: {
+      rootSession(): FRProtocolSession;
+      on(event: 'protocolevent', callback: (payload: Protocol.RawEventMessage) => void): void
+      off(event: 'protocolevent', callback: (payload: Protocol.RawEventMessage) => void): void
+    };
   }
 
   /** The limited context interface shared between pre and post Fraggle Rock Lighthouse. */

--- a/types/protocol.d.ts
+++ b/types/protocol.d.ts
@@ -6,6 +6,23 @@
 
 declare module Protocol {
   /**
+   * An intermediate type, used to create a record of all possible Crdp raw event
+   * messages, keyed on method. e.g. {
+   *   'Domain.method1Name': {method: 'Domain.method1Name', params: EventPayload1},
+   *   'Domain.method2Name': {method: 'Domain.method2Name', params: EventPayload2},
+   * }
+   */
+  type RawEventMessageRecord = {
+    [K in keyof LH.CrdpEvents]: {
+      method: K,
+      // Drop [] for `undefined` (so a JS value is valid).
+      params: LH.CrdpEvents[K] extends [] ? undefined: LH.CrdpEvents[K][number]
+      // If sessionId is not set, it means the event was from the root target.
+      sessionId?: string;
+    };
+  }
+
+  /**
    * Union of raw (over the wire) message format of all possible Crdp events,
    * of the form `{method: 'Domain.event', params: eventPayload}`.
    */
@@ -51,23 +68,6 @@ declare module Protocol {
 
     emit<E extends keyof TEventRecord>(event: E, ...request: TEventRecord[E]): void;
   }
-}
-
-/**
- * An intermediate type, used to create a record of all possible Crdp raw event
- * messages, keyed on method. e.g. {
- *   'Domain.method1Name': {method: 'Domain.method1Name', params: EventPayload1},
- *   'Domain.method2Name': {method: 'Domain.method2Name', params: EventPayload2},
- * }
- */
-type RawEventMessageRecord = {
-  [K in keyof LH.CrdpEvents]: {
-    method: K,
-    // Drop [] for `undefined` (so a JS value is valid).
-    params: LH.CrdpEvents[K] extends [] ? undefined: LH.CrdpEvents[K][number]
-    // If sessionId is not set, it means the event was from the root target.
-    sessionId?: string;
-  };
 }
 
 export default Protocol;


### PR DESCRIPTION
Should help significantly with #14078. Smoke tests should all pass, but waiting on feedback before touching the unit test mocks :)

This PR elevates `TargetManager` to a top-level property on `Driver`. The intention is that TargetManager
- will be the sole place tracking and attaching to targets/sessions (including wrapping `CDPSession`s in FR `session`s), which should make the execution flow easier to understand and make future changes simpler.
- will live for as long as `Driver` does, which includes across passes. It's basically a live view of all the sessions Lighthouse knows about
- the place to subscribe to all protocol events (with the flattened `sessionId` included)

The legacy driver basically does these things already, so it was easy to expose a shim on it and keep `NetworkMonitor` (and its users) on a unified implementation. It's not pretty architecturally, but it is simple (yay) and should only be around until LH 11.

Since `TargetManager` tracks all sessions and their targetInfo, in the future it could be used for things like, "give me all the iframe sessions" so you can send commands or `evaluate()` in them easily, but nothing needs that right now and it's harder to include legacy support, so we can wait.

re: @paulirish's https://github.com/GoogleChrome/lighthouse/pull/14120#issuecomment-1154359719, AFAICT _all_ sessions now have IDs, presumably because pptr is keeping the `sessionId`-less session to itself. I'd like to verify that and move us to a place where `sessionId` is required in the all-protocol-events type:

https://github.com/GoogleChrome/lighthouse/blob/1d6ee0ef0fde4acbdae0dbbe67de7d1e5d0ac5fa/types/protocol.d.ts#L68-L69

so code will hopefully be forced to contend with it. Meanwhile in this PR, `session` drops the `sessionId` so it's like `CDPSession`. If you're subscribing to a single session's events, there's no need for a session ID. We can follow up and make the `session` event handling simpler, but I didn't want the changes in this PR interleaved with that change.