### PR TITLE
tests(smoke): add an option and cli flag to control test exclusion

### DIFF
--- a/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
+++ b/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
@@ -168,6 +168,11 @@ async function begin() {
         // eslint-disable-next-line max-len
         describe: 'A argument of the form "n/d", which divides the selected tests into d groups and runs the nth group. n and d must be positive integers with 1 ≤ n ≤ d.',
       },
+      'ignore-exclusions': {
+        type: 'boolean',
+        default: false,
+        describe: 'Ignore exclude parameter set on any tests.',
+      },
     })
     .wrap(y.terminalWidth())
     .argv;
@@ -194,7 +199,12 @@ async function begin() {
   const {default: rawTestDefns} = await import(url.pathToFileURL(testDefnPath).href);
   const allTestDefns = updateTestDefnFormat(rawTestDefns);
   const invertMatch = argv.invertMatch;
-  const requestedTestDefns = getDefinitionsToRun(allTestDefns, requestedTestIds, {invertMatch});
+  const filteredTestDefns = argv.ignoreExclusions ?
+    allTestDefns :
+    allTestDefns.filter(test => !test.exclude ||
+      !['*', argv.runner].some(runner => (test.exclude || []).includes(runner)));
+  const requestedTestDefns = getDefinitionsToRun(filteredTestDefns, requestedTestIds,
+    {invertMatch});
   const testDefns = getShardedDefinitions(requestedTestDefns, argv.shard);
 
   let smokehouseResult;

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -40,6 +40,8 @@ declare global {
       config?: Config.Json;
       /** If test is performance sensitive, set to true so that it won't be run parallel to other tests. */
       runSerially?: boolean;
+      /** Optional parameter to exclude this test from an array of runners. '*' excludes from all. */
+      exclude?: string[];
     }
 
     /**


### PR DESCRIPTION
Addresses #14127.

This implements an `exclude` list to the smoke test definition that should help to exclude a test from a specific runner or all runners. 

Example:
```diff
 export default {
   id: 'foo',
   expectations,
   config,
+  exclude: ['devtools', 'cli'],
 };
```

A test can be excluded from all runners by specifying `exclude: ['*']`. 

In order to temporarily ignore an exclusion for debugging, Smoke CLI now features a boolean flag `--ignore-exclusions`.

@connorjclark I chose to retain the list as a fixed structure instead of exclude being a `boolean`.

