### PR TITLE
tests(smoke): disable `oopif-requests`

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -47,7 +47,7 @@ jobs:
 
     # Disabled to fix CI while we investigate what the bug is.
     #   perf-diagnostics-third-party, oopif-requests
-    - run: xvfb-run --auto-servernum bash $GITHUB_WORKSPACE/lighthouse-core/scripts/release/package-test.sh --fraggle-rock --invert-match perf-diagnostics-third-party, oopif-requests
+    - run: xvfb-run --auto-servernum bash $GITHUB_WORKSPACE/lighthouse-core/scripts/release/package-test.sh --fraggle-rock --invert-match perf-diagnostics-third-party oopif-requests
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -46,8 +46,8 @@ jobs:
     - run: sudo apt-get install xvfb
 
     # Disabled to fix CI while we investigate what the bug is.
-    #   perf-diagnostics-third-party
-    - run: xvfb-run --auto-servernum bash $GITHUB_WORKSPACE/lighthouse-core/scripts/release/package-test.sh --fraggle-rock --invert-match perf-diagnostics-third-party
+    #   perf-diagnostics-third-party, oopif-requests
+    - run: xvfb-run --auto-servernum bash $GITHUB_WORKSPACE/lighthouse-core/scripts/release/package-test.sh --fraggle-rock --invert-match perf-diagnostics-third-party, oopif-requests
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -138,8 +138,8 @@ jobs:
     - run: sudo apt-get install xvfb
     - name: yarn smoke --fraggle-rock
       # Disabled to fix CI while we investigate what the bug is.
-      #   perf-diagnostics-third-party
-      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=2 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL --invert-match perf-diagnostics-third-party
+      #   perf-diagnostics-third-party, oopif-requests
+      run: xvfb-run --auto-servernum yarn smoke --debug --fraggle-rock -j=2 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL --invert-match perf-diagnostics-third-party oopif-requests
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
@@ -220,8 +220,8 @@ jobs:
     - run: sudo apt-get install xvfb
     - name: yarn test-bundle
       # Disabled to fix CI while we investigate what the bug is.
-      #   perf-diagnostics-third-party
-      run: xvfb-run --auto-servernum yarn test-bundle --fraggle-rock --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL --invert-match perf-diagnostics-third-party
+      #   perf-diagnostics-third-party, oopif-requests
+      run: xvfb-run --auto-servernum yarn test-bundle --fraggle-rock --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL --invert-match perf-diagnostics-third-party oopif-requests
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/issues/14099

https://github.com/GoogleChrome/lighthouse/pull/14100 made the test more specific which is good, but it also made the test fail more often. This is probably our the same underlying issue as `perf-diagnostics-third-party` so I think we should disable (on FR only) until a CDP solution lands.