### PR TITLE
core: move network recorder and monitor to EventEmitter

### DIFF
--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -11,7 +11,7 @@ const LHError = require('../../lib/lh-error.js');
 // Controls how long to wait for a response after sending a DevTools protocol command.
 const DEFAULT_PROTOCOL_TIMEOUT = 30000;
 
-/** @typedef {new () => LH.Protocol.StrictEventEmitter<LH.CrdpEvents>} CrdpEventMessageEmitter */
+/** @typedef {LH.Protocol.StrictEventEmitterClass<LH.CrdpEvents>} CrdpEventMessageEmitter */
 const CrdpEventEmitter = /** @type {CrdpEventMessageEmitter} */ (EventEmitter);
 
 /** @implements {LH.Gatherer.FRProtocolSession} */

--- a/lighthouse-core/gather/driver/target-manager.js
+++ b/lighthouse-core/gather/driver/target-manager.js
@@ -19,8 +19,8 @@ const ProtocolSession = require('../../fraggle-rock/gather/session.js');
  */
 
 // Add protocol event types to EventEmitter.
-/** @typedef {{'protocolevent': [LH.Protocol.RawEventMessage]}} ProtocolEventRecord */
-/** @typedef {new () => LH.Protocol.StrictEventEmitter<ProtocolEventRecord>} ProtocolEventMessageEmitter */
+/** @typedef {{'protocolevent': [LH.Protocol.RawEventMessage]}} ProtocolEventMap */
+/** @typedef {LH.Protocol.StrictEventEmitterClass<ProtocolEventMap>} ProtocolEventMessageEmitter */
 const ProtocolEventEmitter = /** @type {ProtocolEventMessageEmitter} */ (EventEmitter);
 
 /**

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -9,9 +9,16 @@ const log = require('lighthouse-logger');
 const NetworkRequest = require('./network-request.js');
 const EventEmitter = require('events').EventEmitter;
 
-/** @typedef {'requeststarted'|'requestfinished'} NetworkRecorderEvent */
+/**
+ * @typedef {{
+ *   requeststarted: [NetworkRequest],
+ *   requestfinished: [NetworkRequest],
+ * }} NetworkRecorderEventMap
+ */
+/** @typedef {LH.Protocol.StrictEventEmitterClass<NetworkRecorderEventMap>} RequestEmitter */
+const RequestEventEmitter = /** @type {RequestEmitter} */ (EventEmitter);
 
-class NetworkRecorder extends EventEmitter {
+class NetworkRecorder extends RequestEventEmitter {
   /**
    * Creates an instance of NetworkRecorder.
    */
@@ -33,22 +40,6 @@ class NetworkRecorder extends EventEmitter {
    */
   getRawRecords() {
     return Array.from(this._records);
-  }
-
-  /**
-   * @param {NetworkRecorderEvent} event
-   * @param {*} listener
-   */
-  on(event, listener) {
-    return super.on(event, listener);
-  }
-
-  /**
-   * @param {NetworkRecorderEvent} event
-   * @param {*} listener
-   */
-  once(event, listener) {
-    return super.once(event, listener);
   }
 
   /**

--- a/types/protocol.d.ts
+++ b/types/protocol.d.ts
@@ -53,7 +53,7 @@ declare module Protocol {
    * serve as the arguments to event listener callbacks.
    * Inspired by work from https://github.com/bterlson/strict-event-emitter-types.
    */
-  type StrictEventEmitter<TEventRecord extends Record<keyof TEventRecord, any[]>> = {
+  type StrictEventEmitter<TEventRecord extends Record<keyof TEventRecord, unknown[]>> = {
     on<E extends keyof TEventRecord>(event: E, listener: (...args: TEventRecord[E]) => void): void;
 
     off<E extends keyof TEventRecord>(event: E, listener: Function): void;
@@ -69,6 +69,13 @@ declare module Protocol {
     emit<E extends keyof TEventRecord>(event: E, ...request: TEventRecord[E]): void;
 
     listenerCount<E extends keyof TEventRecord>(event: E): number;
+  }
+
+  /**
+   * A constructable StrictEventEmitter.
+   */
+  interface StrictEventEmitterClass<TEventRecord extends Record<keyof TEventRecord, unknown[]>> {
+    new(): StrictEventEmitter<TEventRecord>;
   }
 }
 


### PR DESCRIPTION
Part of #14078

Like with `session` in #14147, moves `NetworkRecorder` and `NetworkMonitor` from having event emitters to being event emitters.

Normally composition is 🥇, but in this case it was just requiring us to declare delegation methods to have equivalent functionality. Technically inheritance now, but functionality is disjoint, so let's just call it a mixin still :)

No functionality or test changes.