### PR TITLE
core(network-requests): add frame and preload debug data

### DIFF
--- a/lighthouse-cli/test/smokehouse/test-definitions/oopif-requests.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/oopif-requests.js
@@ -50,19 +50,19 @@ const expectations = {
             // We want to make sure we are finding the iframe's requests (paulirish.com) *AND*
             // the iframe's iframe's iframe's requests (youtube.com/doubleclick/etc).
             _includes: [
-              {url: 'http://localhost:10200/oopif-requests.html', finished: true, statusCode: 200, resourceType: 'Document'},
+              {url: 'http://localhost:10200/oopif-requests.html', finished: true, statusCode: 200, resourceType: 'Document', experimentalFromMainFrame: true},
 
               // Paulirish iframe and subresource
-              {url: 'https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/', finished: true, statusCode: 200, resourceType: 'Document'},
-              {url: 'https://www.paulirish.com/avatar150.jpg', finished: true, statusCode: 200, resourceType: 'Image'},
-              {url: 'https://www.googletagmanager.com/gtag/js?id=G-PGXNGYWP8E', finished: true, statusCode: 200, resourceType: 'Script'},
-              {url: /^https:\/\/fonts\.googleapis\.com\/css/, finished: true, statusCode: 200, resourceType: 'Stylesheet'},
+              {url: 'https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/', finished: true, statusCode: 200, resourceType: 'Document', experimentalFromMainFrame: undefined},
+              {url: 'https://www.paulirish.com/avatar150.jpg', finished: true, statusCode: 200, resourceType: 'Image', experimentalFromMainFrame: undefined},
+              {url: 'https://www.googletagmanager.com/gtag/js?id=G-PGXNGYWP8E', finished: true, statusCode: 200, resourceType: 'Script', experimentalFromMainFrame: undefined},
+              {url: /^https:\/\/fonts\.googleapis\.com\/css/, finished: true, statusCode: 200, resourceType: 'Stylesheet', experimentalFromMainFrame: undefined},
 
               // Youtube iframe (OOPIF) and some subresources
               // FYI: Youtube has a ServiceWorker which sometimes cancels the document request. As a result, there will sometimes be multiple requests for this file.
               {url: 'https://www.youtube.com/embed/NZelrwd_iRs', finished: true, statusCode: 200, resourceType: 'Document'},
               {url: /^https:\/\/www\.youtube\.com\/.*?player.*?css/, finished: true, statusCode: 200, resourceType: 'Stylesheet'},
-              {url: /^https:\/\/www\.youtube\.com\/.*?\/embed.js/, finished: true, statusCode: 200, resourceType: 'Script'},
+              {url: /^https:\/\/www\.youtube\.com\/.*?\/embed.js/, finished: true, statusCode: 200, resourceType: 'Script', experimentalFromMainFrame: undefined},
 
               // Disqus iframe (OOPIF)
               {url: /^https:\/\/disqus\.com\/embed\/comments\//, finished: true, statusCode: 200, resourceType: 'Document'},

--- a/lighthouse-cli/test/smokehouse/test-definitions/perf-preload.js
+++ b/lighthouse-cli/test/smokehouse/test-definitions/perf-preload.js
@@ -78,6 +78,11 @@ const expectations = {
       'network-requests': {
         details: {
           items: {
+            _includes: [
+              {url: 'http://localhost:10200/preload.html', isLinkPreload: undefined, experimentalFromMainFrame: true},
+              {url: 'http://localhost:10200/perf/level-2.js?warning&delay=500', isLinkPreload: true, experimentalFromMainFrame: true},
+              {url: 'http://localhost:10200/perf/preload_tester.js', isLinkPreload: undefined, experimentalFromMainFrame: true},
+            ],
             length: '>5',
           },
         },

--- a/lighthouse-core/audits/network-requests.js
+++ b/lighthouse-core/audits/network-requests.js
@@ -8,6 +8,7 @@
 const Audit = require('./audit.js');
 const URL = require('../lib/url-shim.js');
 const NetworkRecords = require('../computed/network-records.js');
+const MainResource = require('../computed/main-resource.js');
 
 class NetworkRequests extends Audit {
   /**
@@ -19,7 +20,7 @@ class NetworkRequests extends Audit {
       scoreDisplayMode: Audit.SCORING_MODES.INFORMATIVE,
       title: 'Network Requests',
       description: 'Lists the network requests that were made during page load.',
-      requiredArtifacts: ['devtoolsLogs'],
+      requiredArtifacts: ['devtoolsLogs', 'URL', 'GatherContext'],
     };
   }
 
@@ -28,75 +29,91 @@ class NetworkRequests extends Audit {
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Audit.Product>}
    */
-  static audit(artifacts, context) {
+  static async audit(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
-    return NetworkRecords.request(devtoolsLog, context).then(records => {
-      const earliestStartTime = records.reduce(
-        (min, record) => Math.min(min, record.startTime),
-        Infinity
-      );
+    const records = await NetworkRecords.request(devtoolsLog, context);
+    const earliestStartTime = records.reduce(
+      (min, record) => Math.min(min, record.startTime),
+      Infinity
+    );
 
-      /** @param {number} time */
-      const timeToMs = time => time < earliestStartTime || !Number.isFinite(time) ?
-        undefined : (time - earliestStartTime) * 1000;
+    // Optional mainFrameId check because the main resource is only available for
+    // navigations. TODO: https://github.com/GoogleChrome/lighthouse/issues/14157
+    // for the general solution to this.
+    /** @type {string|undefined} */
+    let mainFrameId;
+    if (artifacts.GatherContext.gatherMode === 'navigation') {
+      const mainResource = await MainResource.request({devtoolsLog, URL: artifacts.URL}, context);
+      mainFrameId = mainResource.frameId;
+    }
 
-      const results = records.map(record => {
-        const endTimeDeltaMs = record.lrStatistics?.endTimeDeltaMs;
-        const TCPMs = record.lrStatistics?.TCPMs;
-        const requestMs = record.lrStatistics?.requestMs;
-        const responseMs = record.lrStatistics?.responseMs;
+    /** @param {number} time */
+    const timeToMs = time => time < earliestStartTime || !Number.isFinite(time) ?
+      undefined : (time - earliestStartTime) * 1000;
 
-        return {
-          url: URL.elideDataURI(record.url),
-          protocol: record.protocol,
-          startTime: timeToMs(record.startTime),
-          endTime: timeToMs(record.endTime),
-          finished: record.finished,
-          transferSize: record.transferSize,
-          resourceSize: record.resourceSize,
-          statusCode: record.statusCode,
-          mimeType: record.mimeType,
-          resourceType: record.resourceType,
-          lrEndTimeDeltaMs: endTimeDeltaMs, // Only exists on Lightrider runs
-          lrTCPMs: TCPMs, // Only exists on Lightrider runs
-          lrRequestMs: requestMs, // Only exists on Lightrider runs
-          lrResponseMs: responseMs, // Only exists on Lightrider runs
-        };
-      });
-
-      // NOTE(i18n): this audit is only for debug info in the LHR and does not appear in the report.
-      /** @type {LH.Audit.Details.Table['headings']} */
-      const headings = [
-        {key: 'url', itemType: 'url', text: 'URL'},
-        {key: 'protocol', itemType: 'text', text: 'Protocol'},
-        {key: 'startTime', itemType: 'ms', granularity: 1, text: 'Start Time'},
-        {key: 'endTime', itemType: 'ms', granularity: 1, text: 'End Time'},
-        {
-          key: 'transferSize',
-          itemType: 'bytes',
-          displayUnit: 'kb',
-          granularity: 1,
-          text: 'Transfer Size',
-        },
-        {
-          key: 'resourceSize',
-          itemType: 'bytes',
-          displayUnit: 'kb',
-          granularity: 1,
-          text: 'Resource Size',
-        },
-        {key: 'statusCode', itemType: 'text', text: 'Status Code'},
-        {key: 'mimeType', itemType: 'text', text: 'MIME Type'},
-        {key: 'resourceType', itemType: 'text', text: 'Resource Type'},
-      ];
-
-      const tableDetails = Audit.makeTableDetails(headings, results);
+    const results = records.map(record => {
+      const endTimeDeltaMs = record.lrStatistics?.endTimeDeltaMs;
+      const TCPMs = record.lrStatistics?.TCPMs;
+      const requestMs = record.lrStatistics?.requestMs;
+      const responseMs = record.lrStatistics?.responseMs;
+      // Default these to undefined so omitted from JSON in the negative case.
+      const isLinkPreload = record.isLinkPreload || undefined;
+      const experimentalFromMainFrame = mainFrameId ?
+        ((record.frameId === mainFrameId) || undefined) :
+        undefined;
 
       return {
-        score: 1,
-        details: tableDetails,
+        url: URL.elideDataURI(record.url),
+        protocol: record.protocol,
+        startTime: timeToMs(record.startTime),
+        endTime: timeToMs(record.endTime),
+        finished: record.finished,
+        transferSize: record.transferSize,
+        resourceSize: record.resourceSize,
+        statusCode: record.statusCode,
+        mimeType: record.mimeType,
+        resourceType: record.resourceType,
+        isLinkPreload,
+        experimentalFromMainFrame,
+        lrEndTimeDeltaMs: endTimeDeltaMs, // Only exists on Lightrider runs
+        lrTCPMs: TCPMs, // Only exists on Lightrider runs
+        lrRequestMs: requestMs, // Only exists on Lightrider runs
+        lrResponseMs: responseMs, // Only exists on Lightrider runs
       };
     });
+
+    // NOTE(i18n): this audit is only for debug info in the LHR and does not appear in the report.
+    /** @type {LH.Audit.Details.Table['headings']} */
+    const headings = [
+      {key: 'url', itemType: 'url', text: 'URL'},
+      {key: 'protocol', itemType: 'text', text: 'Protocol'},
+      {key: 'startTime', itemType: 'ms', granularity: 1, text: 'Start Time'},
+      {key: 'endTime', itemType: 'ms', granularity: 1, text: 'End Time'},
+      {
+        key: 'transferSize',
+        itemType: 'bytes',
+        displayUnit: 'kb',
+        granularity: 1,
+        text: 'Transfer Size',
+      },
+      {
+        key: 'resourceSize',
+        itemType: 'bytes',
+        displayUnit: 'kb',
+        granularity: 1,
+        text: 'Resource Size',
+      },
+      {key: 'statusCode', itemType: 'text', text: 'Status Code'},
+      {key: 'mimeType', itemType: 'text', text: 'MIME Type'},
+      {key: 'resourceType', itemType: 'text', text: 'Resource Type'},
+    ];
+
+    const tableDetails = Audit.makeTableDetails(headings, results);
+
+    return {
+      score: 1,
+      details: tableDetails,
+    };
   }
 }
 

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -765,7 +765,8 @@
                   "resourceSize": 9302,
                   "statusCode": 200,
                   "mimeType": "text/html",
-                  "resourceType": "Document"
+                  "resourceType": "Document",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/fonts/danielbd.woff2",
@@ -777,7 +778,9 @@
                   "resourceSize": 35680,
                   "statusCode": 200,
                   "mimeType": "font/woff2",
-                  "resourceType": "Font"
+                  "resourceType": "Font",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://events.mikescerealshack.co/js/index.js",
@@ -789,7 +792,8 @@
                   "resourceSize": 1335,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/css/08dcb440d7d83b488817.css",
@@ -801,7 +805,9 @@
                   "resourceSize": 18126,
                   "statusCode": 200,
                   "mimeType": "text/css",
-                  "resourceType": "Stylesheet"
+                  "resourceType": "Stylesheet",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/main-1f8481d632114a408557.js",
@@ -813,7 +819,9 @@
                   "resourceSize": 17656,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/webpack-657a8433bac0aabd564e.js",
@@ -825,7 +833,9 @@
                   "resourceSize": 2351,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/framework.9d524150d48315f49e80.js",
@@ -837,7 +847,9 @@
                   "resourceSize": 130277,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/commons.49455e4fa8cc3f51203f.js",
@@ -849,7 +861,9 @@
                   "resourceSize": 44060,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/_app-ef508c97234d1af96c47.js",
@@ -861,7 +875,9 @@
                   "resourceSize": 1235,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/1aeab0175d4c4d823d7a78205bceb5dd9cd36d32.a629f28ec97ae6e480bf.js",
@@ -873,7 +889,9 @@
                   "resourceSize": 67673,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/index-37980adf97404e76e41a.js",
@@ -885,7 +903,9 @@
                   "resourceSize": 1856,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/logo-text.svg",
@@ -897,7 +917,8 @@
                   "resourceSize": 53947,
                   "statusCode": 200,
                   "mimeType": "image/svg+xml",
-                  "resourceType": "Image"
+                  "resourceType": "Image",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/t5QnfQSErVZVsTAuFcBWI/_buildManifest.js",
@@ -909,7 +930,8 @@
                   "resourceSize": 1545,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/t5QnfQSErVZVsTAuFcBWI/_ssgManifest.js",
@@ -921,7 +943,8 @@
                   "resourceSize": 76,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap",
@@ -933,7 +956,8 @@
                   "resourceSize": 3282,
                   "statusCode": 200,
                   "mimeType": "text/css",
-                  "resourceType": "Stylesheet"
+                  "resourceType": "Stylesheet",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://fonts.gstatic.com/s/poppins/v19/pxiEyp8kv8JHgFVrJJfecnFHGPc.woff2",
@@ -945,7 +969,8 @@
                   "resourceSize": 7884,
                   "statusCode": 200,
                   "mimeType": "font/woff2",
-                  "resourceType": "Font"
+                  "resourceType": "Font",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://fonts.gstatic.com/s/poppins/v19/pxiByp8kv8JHgFVrLCz7Z1xlFd2JQEk.woff2",
@@ -957,7 +982,8 @@
                   "resourceSize": 7816,
                   "statusCode": 200,
                   "mimeType": "font/woff2",
-                  "resourceType": "Font"
+                  "resourceType": "Font",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/1aeab0175d4c4d823d7a78205bceb5dd9cd36d32.a629f28ec97ae6e480bf.js",
@@ -969,7 +995,8 @@
                   "resourceSize": 0,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Other"
+                  "resourceType": "Other",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/9ea7d3ba8dd80c65c50028121847762825088b49.dc477066508a83415fce.js",
@@ -981,7 +1008,8 @@
                   "resourceSize": 0,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Other"
+                  "resourceType": "Other",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/scenes/%5Bseason%5D/%5Bepisode%5D/%5Bscene%5D-526fe33be891a56314a3.js",
@@ -993,7 +1021,8 @@
                   "resourceSize": 0,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Other"
+                  "resourceType": "Other",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/9ea7d3ba8dd80c65c50028121847762825088b49.dc477066508a83415fce.js",
@@ -1005,7 +1034,8 @@
                   "resourceSize": 8890,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/scenes/%5Bseason%5D/%5Bepisode%5D/%5Bscene%5D-526fe33be891a56314a3.js",
@@ -1017,7 +1047,8 @@
                   "resourceSize": 6837,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/favicon.png",
@@ -1029,7 +1060,8 @@
                   "resourceSize": 5164,
                   "statusCode": 200,
                   "mimeType": "image/png",
-                  "resourceType": "Other"
+                  "resourceType": "Other",
+                  "experimentalFromMainFrame": true
                 }
               ]
             }
@@ -14988,7 +15020,8 @@
                   "resourceSize": 9492,
                   "statusCode": 200,
                   "mimeType": "text/html",
-                  "resourceType": "Document"
+                  "resourceType": "Document",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/fonts/danielbd.woff2",
@@ -15000,7 +15033,9 @@
                   "resourceSize": 35680,
                   "statusCode": 200,
                   "mimeType": "font/woff2",
-                  "resourceType": "Font"
+                  "resourceType": "Font",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://events.mikescerealshack.co/js/index.js",
@@ -15012,7 +15047,8 @@
                   "resourceSize": 1335,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/css/08dcb440d7d83b488817.css",
@@ -15024,7 +15060,9 @@
                   "resourceSize": 18126,
                   "statusCode": 200,
                   "mimeType": "text/css",
-                  "resourceType": "Stylesheet"
+                  "resourceType": "Stylesheet",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/main-1f8481d632114a408557.js",
@@ -15036,7 +15074,9 @@
                   "resourceSize": 17656,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/webpack-657a8433bac0aabd564e.js",
@@ -15048,7 +15088,9 @@
                   "resourceSize": 2351,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/framework.9d524150d48315f49e80.js",
@@ -15060,7 +15102,9 @@
                   "resourceSize": 130277,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/commons.49455e4fa8cc3f51203f.js",
@@ -15072,7 +15116,9 @@
                   "resourceSize": 44060,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/_app-ef508c97234d1af96c47.js",
@@ -15084,7 +15130,9 @@
                   "resourceSize": 1235,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/1aeab0175d4c4d823d7a78205bceb5dd9cd36d32.a629f28ec97ae6e480bf.js",
@@ -15096,7 +15144,9 @@
                   "resourceSize": 67673,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/corrections-7a620a51252fe2c2f77b.js",
@@ -15108,7 +15158,9 @@
                   "resourceSize": 3328,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "isLinkPreload": true,
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/logo-text.svg",
@@ -15120,7 +15172,8 @@
                   "resourceSize": 53947,
                   "statusCode": 200,
                   "mimeType": "image/svg+xml",
-                  "resourceType": "Image"
+                  "resourceType": "Image",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/oscar-actually.jpg",
@@ -15132,7 +15185,8 @@
                   "resourceSize": 122114,
                   "statusCode": 200,
                   "mimeType": "image/jpeg",
-                  "resourceType": "Image"
+                  "resourceType": "Image",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/t5QnfQSErVZVsTAuFcBWI/_buildManifest.js",
@@ -15144,7 +15198,8 @@
                   "resourceSize": 1545,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/t5QnfQSErVZVsTAuFcBWI/_ssgManifest.js",
@@ -15156,7 +15211,8 @@
                   "resourceSize": 76,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap",
@@ -15168,7 +15224,8 @@
                   "resourceSize": 3282,
                   "statusCode": 200,
                   "mimeType": "text/css",
-                  "resourceType": "Stylesheet"
+                  "resourceType": "Stylesheet",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://fonts.gstatic.com/s/poppins/v19/pxiEyp8kv8JHgFVrJJfecnFHGPc.woff2",
@@ -15180,7 +15237,8 @@
                   "resourceSize": 7884,
                   "statusCode": 200,
                   "mimeType": "font/woff2",
-                  "resourceType": "Font"
+                  "resourceType": "Font",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://fonts.gstatic.com/s/poppins/v19/pxiByp8kv8JHgFVrLCz7Z1xlFd2JQEk.woff2",
@@ -15192,7 +15250,8 @@
                   "resourceSize": 7816,
                   "statusCode": 200,
                   "mimeType": "font/woff2",
-                  "resourceType": "Font"
+                  "resourceType": "Font",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/1aeab0175d4c4d823d7a78205bceb5dd9cd36d32.a629f28ec97ae6e480bf.js",
@@ -15204,7 +15263,8 @@
                   "resourceSize": 0,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Other"
+                  "resourceType": "Other",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/index-37980adf97404e76e41a.js",
@@ -15216,7 +15276,8 @@
                   "resourceSize": 0,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Other"
+                  "resourceType": "Other",
+                  "experimentalFromMainFrame": true
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/index-37980adf97404e76e41a.js",
@@ -15228,7 +15289,8 @@
                   "resourceSize": 1856,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "experimentalFromMainFrame": true
                 }
               ]
             }

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1309,7 +1309,8 @@
             "resourceSize": 17393,
             "statusCode": 200,
             "mimeType": "text/html",
-            "resourceType": "Document"
+            "resourceType": "Document",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
@@ -1321,7 +1322,8 @@
             "resourceSize": 689,
             "statusCode": 200,
             "mimeType": "text/css",
-            "resourceType": "Stylesheet"
+            "resourceType": "Stylesheet",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
@@ -1333,7 +1335,8 @@
             "resourceSize": 0,
             "statusCode": 404,
             "mimeType": "text/css",
-            "resourceType": "Stylesheet"
+            "resourceType": "Stylesheet",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200",
@@ -1345,7 +1348,8 @@
             "resourceSize": 689,
             "statusCode": 200,
             "mimeType": "text/css",
-            "resourceType": "Stylesheet"
+            "resourceType": "Stylesheet",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
@@ -1357,7 +1361,8 @@
             "resourceSize": 976,
             "statusCode": 200,
             "mimeType": "text/css",
-            "resourceType": "Stylesheet"
+            "resourceType": "Stylesheet",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped",
@@ -1369,7 +1374,8 @@
             "resourceSize": 689,
             "statusCode": 200,
             "mimeType": "text/css",
-            "resourceType": "Stylesheet"
+            "resourceType": "Stylesheet",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true",
@@ -1381,7 +1387,9 @@
             "resourceSize": 689,
             "statusCode": 200,
             "mimeType": "text/css",
-            "resourceType": "Stylesheet"
+            "resourceType": "Stylesheet",
+            "isLinkPreload": true,
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true",
@@ -1393,7 +1401,8 @@
             "resourceSize": 689,
             "statusCode": 200,
             "mimeType": "text/css",
-            "resourceType": "Stylesheet"
+            "resourceType": "Stylesheet",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
@@ -1405,7 +1414,8 @@
             "resourceSize": 824,
             "statusCode": 200,
             "mimeType": "application/javascript",
-            "resourceType": "Script"
+            "resourceType": "Script",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/empty_module.js?delay=500",
@@ -1417,7 +1427,8 @@
             "resourceSize": 0,
             "statusCode": 200,
             "mimeType": "application/javascript",
-            "resourceType": "Script"
+            "resourceType": "Script",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/empty.css",
@@ -1429,7 +1440,8 @@
             "resourceSize": 0,
             "statusCode": 200,
             "mimeType": "text/css",
-            "resourceType": "Stylesheet"
+            "resourceType": "Stylesheet",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000",
@@ -1441,7 +1453,8 @@
             "resourceSize": 0,
             "statusCode": 404,
             "mimeType": "application/javascript",
-            "resourceType": "Script"
+            "resourceType": "Script",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?iar1",
@@ -1453,7 +1466,8 @@
             "resourceSize": 24620,
             "statusCode": 200,
             "mimeType": "image/jpeg",
-            "resourceType": "Image"
+            "resourceType": "Image",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?isr1",
@@ -1465,7 +1479,8 @@
             "resourceSize": 24620,
             "statusCode": 200,
             "mimeType": "image/jpeg",
-            "resourceType": "Image"
+            "resourceType": "Image",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?isr2",
@@ -1477,7 +1492,8 @@
             "resourceSize": 24620,
             "statusCode": 200,
             "mimeType": "image/jpeg",
-            "resourceType": "Image"
+            "resourceType": "Image",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?isr3",
@@ -1489,7 +1505,8 @@
             "resourceSize": 24620,
             "statusCode": 200,
             "mimeType": "image/jpeg",
-            "resourceType": "Image"
+            "resourceType": "Image",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg",
@@ -1501,7 +1518,8 @@
             "resourceSize": 24620,
             "statusCode": 200,
             "mimeType": "image/jpeg",
-            "resourceType": "Image"
+            "resourceType": "Image",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/lighthouse-rotating.gif",
@@ -1513,7 +1531,8 @@
             "resourceSize": 934285,
             "statusCode": 200,
             "mimeType": "image/gif",
-            "resourceType": "Image"
+            "resourceType": "Image",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js",
@@ -1525,7 +1544,8 @@
             "resourceSize": 166320,
             "statusCode": 200,
             "mimeType": "application/javascript",
-            "resourceType": "Script"
+            "resourceType": "Script",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js",
@@ -1537,7 +1557,8 @@
             "resourceSize": 84245,
             "statusCode": 200,
             "mimeType": "text/javascript",
-            "resourceType": "Script"
+            "resourceType": "Script",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?iar2",
@@ -1549,7 +1570,8 @@
             "resourceSize": 24620,
             "statusCode": 200,
             "mimeType": "image/jpeg",
-            "resourceType": "Image"
+            "resourceType": "Image",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
@@ -1561,7 +1583,8 @@
             "resourceSize": 689,
             "statusCode": 200,
             "mimeType": "text/css",
-            "resourceType": "Stylesheet"
+            "resourceType": "Stylesheet",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
@@ -1573,7 +1596,8 @@
             "resourceSize": 17393,
             "statusCode": 200,
             "mimeType": "text/html",
-            "resourceType": "XHR"
+            "resourceType": "XHR",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "blob:http://localhost:10200/3f2bc9df-684b-4541-837c-1590152ef65d",
@@ -1585,7 +1609,8 @@
             "resourceSize": 4,
             "statusCode": 200,
             "mimeType": "text/plain",
-            "resourceType": "Image"
+            "resourceType": "Image",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "filesystem:http://localhost:10200/temporary/empty-0.43448333410631723.png",
@@ -1597,7 +1622,8 @@
             "resourceSize": 0,
             "statusCode": 200,
             "mimeType": "text/html",
-            "resourceType": "Image"
+            "resourceType": "Image",
+            "experimentalFromMainFrame": true
           },
           {
             "url": "http://localhost:10200/favicon.ico",
@@ -1609,7 +1635,8 @@
             "resourceSize": 34,
             "statusCode": 404,
             "mimeType": "image/vnd.microsoft.icon",
-            "resourceType": "Other"
+            "resourceType": "Other",
+            "experimentalFromMainFrame": true
           }
         ]
       }


### PR DESCRIPTION
Similar to #14155, this PR fills in some missing pieces of debugData to make it easier to analyze LCP issues in HTTP Archive data.

Adds two new optional properties to the `network-requests` hidden audit:
- `isLinkPreload`
- `experimentalFromMainFrame` (navigations only)

The second one is just if the request came from the main frame or not, but it turns out there's not really any way to do that in a `timespan` right now. We have network request frame information, but we don't have information on the main frame, and it's not even "the main frame" singular, since the frame will change if the timespan contains navigations :)

Since HTTP Archive only includes navigation runs, I decided to defer the general navigation/timespan solution to the already-in-discussion request source/target idea in #14157, and call it `experimentalFromMainFrame` so it's slightly more clear that the property might not be around in a few releases. Happy to bikeshed on the name, implementation, etc.