### PR TITLE
misc: rename LHError to LighthouseError

### DIFF
--- a/clients/lightrider/lightrider-entry.js
+++ b/clients/lightrider/lightrider-entry.js
@@ -11,7 +11,7 @@ import {Buffer} from 'buffer';
 
 import log from 'lighthouse-logger';
 import lighthouse from '../../lighthouse-core/index.js';
-import LHError from '../../lighthouse-core/lib/lh-error.js';
+import LighthouseError from '../../lighthouse-core/lib/lh-error.js';
 import preprocessor from '../../lighthouse-core/lib/proto-preprocessor.js';
 import assetSaver from '../../lighthouse-core/lib/asset-saver.js';
 
@@ -86,9 +86,9 @@ export async function runLighthouseInLR(connection, url, flags, lrOpts) {
   } catch (err) {
     // If an error ruined the entire lighthouse run, attempt to return a meaningful error.
     let runtimeError;
-    if (!(err instanceof LHError) || !err.lhrRuntimeError) {
+    if (!(err instanceof LighthouseError) || !err.lhrRuntimeError) {
       runtimeError = {
-        code: LHError.UNKNOWN_ERROR,
+        code: LighthouseError.UNKNOWN_ERROR,
         message: `Unknown error encountered with message '${err.message}'`,
       };
     } else {

--- a/clients/test/lightrider/lightrider-entry-test.js
+++ b/clients/test/lightrider/lightrider-entry-test.js
@@ -9,13 +9,13 @@ import jestMock from 'jest-mock';
 import {strict as assert} from 'assert';
 import {runLighthouseInLR} from '../../lightrider/lightrider-entry.js';
 import Runner from '../../../lighthouse-core/runner.js';
-import LHError from '../../../lighthouse-core/lib/lh-error.js';
+import LighthouseError from '../../../lighthouse-core/lib/lh-error.js';
 
 describe('lightrider-entry', () => {
   describe('#runLighthouseInLR', () => {
     it('returns a runtimeError LHR when lighthouse throws a runtimeError', async () => {
-      const connectionError = new LHError(
-        LHError.errors.FAILED_DOCUMENT_REQUEST,
+      const connectionError = new LighthouseError(
+        LighthouseError.errors.FAILED_DOCUMENT_REQUEST,
         {errorDetails: 'Bad connection req'}
       );
       assert.strictEqual(connectionError.lhrRuntimeError, true);
@@ -53,7 +53,7 @@ describe('lightrider-entry', () => {
 
       const result = await runLighthouseInLR(mockConnection, url, {output}, {});
       const parsedResult = JSON.parse(result);
-      assert.strictEqual(parsedResult.runtimeError.code, LHError.UNKNOWN_ERROR);
+      assert.strictEqual(parsedResult.runtimeError.code, LighthouseError.UNKNOWN_ERROR);
       assert.ok(parsedResult.runtimeError.message.includes(errorMsg));
     });
 

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -250,7 +250,7 @@ async function runLighthouse(url, flags, config) {
     if (runnerResult?.lhr.runtimeError) {
       const {runtimeError} = runnerResult.lhr;
       return printErrorAndExit({
-        name: 'LHError',
+        name: 'LighthouseError',
         friendlyMessage: runtimeError.message,
         code: runtimeError.code,
         message: runtimeError.message,

--- a/lighthouse-core/audits/final-screenshot.js
+++ b/lighthouse-core/audits/final-screenshot.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const Audit = require('./audit.js');
-const LHError = require('../lib/lh-error.js');
+const LighthouseError = require('../lib/lh-error.js');
 const ProcessedTrace = require('../computed/processed-trace.js');
 const Screenshots = require('../computed/screenshots.js');
 
@@ -41,7 +41,7 @@ class FinalScreenshot extends Audit {
       if (artifacts.GatherContext.gatherMode === 'timespan') return {notApplicable: true, score: 1};
 
       // If it was another mode, that's a fatal error.
-      throw new LHError(LHError.errors.NO_SCREENSHOTS);
+      throw new LighthouseError(LighthouseError.errors.NO_SCREENSHOTS);
     }
 
     return {

--- a/lighthouse-core/audits/screenshot-thumbnails.js
+++ b/lighthouse-core/audits/screenshot-thumbnails.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const Audit = require('./audit.js');
-const LHError = require('../lib/lh-error.js');
+const LighthouseError = require('../lib/lh-error.js');
 const jpeg = require('jpeg-js');
 const Speedline = require('../computed/speedline.js');
 
@@ -88,7 +88,7 @@ class ScreenshotThumbnails extends Audit {
     const timelineEnd = Math.max(maxFrameTime, minimumTimelineDuration);
 
     if (!analyzedFrames.length || !Number.isFinite(timelineEnd)) {
-      throw new LHError(LHError.errors.INVALID_SPEEDLINE);
+      throw new LighthouseError(LighthouseError.errors.INVALID_SPEEDLINE);
     }
 
     for (let i = 1; i <= NUMBER_OF_THUMBNAILS; i++) {
@@ -144,10 +144,10 @@ class ScreenshotThumbnails extends Audit {
       return await this._audit(artifacts, context);
     } catch (err) {
       const noFramesErrors = new Set([
-        LHError.errors.NO_SCREENSHOTS.code,
-        LHError.errors.SPEEDINDEX_OF_ZERO.code,
-        LHError.errors.NO_SPEEDLINE_FRAMES.code,
-        LHError.errors.INVALID_SPEEDLINE.code,
+        LighthouseError.errors.NO_SCREENSHOTS.code,
+        LighthouseError.errors.SPEEDINDEX_OF_ZERO.code,
+        LighthouseError.errors.NO_SPEEDLINE_FRAMES.code,
+        LighthouseError.errors.INVALID_SPEEDLINE.code,
       ]);
 
       // If a timespan didn't happen to contain frames, that's fine. Just mark not applicable.

--- a/lighthouse-core/audits/work-during-interaction.js
+++ b/lighthouse-core/audits/work-during-interaction.js
@@ -15,7 +15,7 @@ const {taskGroups} = require('../lib/tracehouse/task-groups.js');
 const TraceProcessor = require('../lib/tracehouse/trace-processor.js');
 const {getExecutionTimingsByURL} = require('../lib/tracehouse/task-summary.js');
 const inpThresholds = require('./metrics/experimental-interaction-to-next-paint.js').defaultOptions;
-const LHError = require('../lib/lh-error.js');
+const LighthouseError = require('../lib/lh-error.js');
 
 /** @typedef {import('../computed/metrics/responsiveness.js').EventTimingEvent} EventTimingEvent */
 /** @typedef {import('../lib/tracehouse/main-thread-tasks.js').TaskNode} TaskNode */
@@ -237,8 +237,8 @@ class WorkDuringInteraction extends Audit {
     }
     // TODO: remove workaround once 103.0.5052.0 is sufficiently released.
     if (interactionEvent.name === 'FallbackTiming') {
-      throw new LHError(
-        LHError.errors.UNSUPPORTED_OLD_CHROME,
+      throw new LighthouseError(
+        LighthouseError.errors.UNSUPPORTED_OLD_CHROME,
         {featureName: 'detailed EventTiming trace events'}
       );
     }

--- a/lighthouse-core/computed/metrics/cumulative-layout-shift.js
+++ b/lighthouse-core/computed/metrics/cumulative-layout-shift.js
@@ -7,7 +7,7 @@
 
 const makeComputedArtifact = require('../computed-artifact.js');
 const ProcessedTrace = require('../processed-trace.js');
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 
 /** @typedef {{ts: number, isMainFrame: boolean, weightedScore: number}} LayoutShiftEvent */
 
@@ -40,8 +40,8 @@ class CumulativeLayoutShift {
       // For all-frames CLS calculation, we rely on `weighted_score_delta`, which
       // was added in Chrome 90: https://crbug.com/1173139
       if (event.args.data.weighted_score_delta === undefined) {
-        throw new LHError(
-          LHError.errors.UNSUPPORTED_OLD_CHROME,
+        throw new LighthouseError(
+          LighthouseError.errors.UNSUPPORTED_OLD_CHROME,
           {featureName: 'Cumulative Layout Shift'}
         );
       }

--- a/lighthouse-core/computed/metrics/first-meaningful-paint.js
+++ b/lighthouse-core/computed/metrics/first-meaningful-paint.js
@@ -7,7 +7,7 @@
 
 const makeComputedArtifact = require('../computed-artifact.js');
 const NavigationMetric = require('./navigation-metric.js');
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 const LanternFirstMeaningfulPaint = require('./lantern-first-meaningful-paint.js');
 
 class FirstMeaningfulPaint extends NavigationMetric {
@@ -28,7 +28,7 @@ class FirstMeaningfulPaint extends NavigationMetric {
   static async computeObservedMetric(data) {
     const {processedNavigation} = data;
     if (processedNavigation.timings.firstMeaningfulPaint === undefined) {
-      throw new LHError(LHError.errors.NO_FMP);
+      throw new LighthouseError(LighthouseError.errors.NO_FMP);
     }
 
     return {

--- a/lighthouse-core/computed/metrics/interactive.js
+++ b/lighthouse-core/computed/metrics/interactive.js
@@ -11,7 +11,7 @@ const LanternInteractive = require('./lantern-interactive.js');
 
 const NetworkMonitor = require('../../gather/driver/network-monitor.js');
 const TracingProcessor = require('../../lib/tracehouse/trace-processor.js');
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 
 const REQUIRED_QUIET_WINDOW = 5000;
 const ALLOWED_CONCURRENT_REQUESTS = 2;
@@ -133,10 +133,10 @@ class Interactive extends NavigationMetric {
       }
     }
 
-    throw new LHError(
+    throw new LighthouseError(
       cpuCandidate
-        ? LHError.errors.NO_TTI_NETWORK_IDLE_PERIOD
-        : LHError.errors.NO_TTI_CPU_IDLE_PERIOD
+        ? LighthouseError.errors.NO_TTI_NETWORK_IDLE_PERIOD
+        : LighthouseError.errors.NO_TTI_CPU_IDLE_PERIOD
     );
   }
 
@@ -158,7 +158,7 @@ class Interactive extends NavigationMetric {
     const {processedTrace, processedNavigation, networkRecords} = data;
 
     if (!processedNavigation.timestamps.domContentLoaded) {
-      throw new LHError(LHError.errors.NO_DCL);
+      throw new LighthouseError(LighthouseError.errors.NO_DCL);
     }
 
     const longTasks = TracingProcessor.getMainThreadTopLevelEvents(processedTrace)

--- a/lighthouse-core/computed/metrics/lantern-first-meaningful-paint.js
+++ b/lighthouse-core/computed/metrics/lantern-first-meaningful-paint.js
@@ -7,7 +7,7 @@
 
 const makeComputedArtifact = require('../computed-artifact.js');
 const LanternMetric = require('./lantern-metric.js');
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 const LanternFirstContentfulPaint = require('./lantern-first-contentful-paint.js');
 
 /** @typedef {import('../../lib/dependency-graph/base-node.js').Node} Node */
@@ -32,7 +32,7 @@ class LanternFirstMeaningfulPaint extends LanternMetric {
   static getOptimisticGraph(dependencyGraph, processedNavigation) {
     const fmp = processedNavigation.timestamps.firstMeaningfulPaint;
     if (!fmp) {
-      throw new LHError(LHError.errors.NO_FMP);
+      throw new LighthouseError(LighthouseError.errors.NO_FMP);
     }
 
     return LanternFirstContentfulPaint.getFirstPaintBasedGraph(
@@ -52,7 +52,7 @@ class LanternFirstMeaningfulPaint extends LanternMetric {
   static getPessimisticGraph(dependencyGraph, processedNavigation) {
     const fmp = processedNavigation.timestamps.firstMeaningfulPaint;
     if (!fmp) {
-      throw new LHError(LHError.errors.NO_FMP);
+      throw new LighthouseError(LighthouseError.errors.NO_FMP);
     }
 
     return LanternFirstContentfulPaint.getFirstPaintBasedGraph(

--- a/lighthouse-core/computed/metrics/lantern-largest-contentful-paint.js
+++ b/lighthouse-core/computed/metrics/lantern-largest-contentful-paint.js
@@ -7,7 +7,7 @@
 
 const makeComputedArtifact = require('../computed-artifact.js');
 const LanternMetric = require('./lantern-metric.js');
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 const LanternFirstContentfulPaint = require('./lantern-first-contentful-paint.js');
 
 /** @typedef {import('../../lib/dependency-graph/base-node.js').Node} Node */
@@ -47,7 +47,7 @@ class LanternLargestContentfulPaint extends LanternMetric {
   static getOptimisticGraph(dependencyGraph, processedNavigation) {
     const lcp = processedNavigation.timestamps.largestContentfulPaint;
     if (!lcp) {
-      throw new LHError(LHError.errors.NO_LCP);
+      throw new LighthouseError(LighthouseError.errors.NO_LCP);
     }
 
     return LanternFirstContentfulPaint.getFirstPaintBasedGraph(
@@ -65,7 +65,7 @@ class LanternLargestContentfulPaint extends LanternMetric {
   static getPessimisticGraph(dependencyGraph, processedNavigation) {
     const lcp = processedNavigation.timestamps.largestContentfulPaint;
     if (!lcp) {
-      throw new LHError(LHError.errors.NO_LCP);
+      throw new LighthouseError(LighthouseError.errors.NO_LCP);
     }
 
     return LanternFirstContentfulPaint.getFirstPaintBasedGraph(

--- a/lighthouse-core/computed/metrics/largest-contentful-paint-all-frames.js
+++ b/lighthouse-core/computed/metrics/largest-contentful-paint-all-frames.js
@@ -11,7 +11,7 @@
 
 const makeComputedArtifact = require('../computed-artifact.js');
 const NavigationMetric = require('./navigation-metric.js');
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 
 class LargestContentfulPaintAllFrames extends NavigationMetric {
   /**
@@ -29,7 +29,7 @@ class LargestContentfulPaintAllFrames extends NavigationMetric {
   static async computeObservedMetric(data) {
     const {processedNavigation} = data;
     if (processedNavigation.timings.largestContentfulPaintAllFrames === undefined) {
-      throw new LHError(LHError.errors.NO_LCP_ALL_FRAMES);
+      throw new LighthouseError(LighthouseError.errors.NO_LCP_ALL_FRAMES);
     }
 
     return {

--- a/lighthouse-core/computed/metrics/largest-contentful-paint.js
+++ b/lighthouse-core/computed/metrics/largest-contentful-paint.js
@@ -15,7 +15,7 @@
 
 const makeComputedArtifact = require('../computed-artifact.js');
 const NavigationMetric = require('./navigation-metric.js');
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 const LanternLargestContentfulPaint = require('./lantern-largest-contentful-paint.js');
 
 class LargestContentfulPaint extends NavigationMetric {
@@ -36,7 +36,7 @@ class LargestContentfulPaint extends NavigationMetric {
   static async computeObservedMetric(data) {
     const {processedNavigation} = data;
     if (processedNavigation.timings.largestContentfulPaint === undefined) {
-      throw new LHError(LHError.errors.NO_LCP);
+      throw new LighthouseError(LighthouseError.errors.NO_LCP);
     }
 
     return {

--- a/lighthouse-core/computed/speedline.js
+++ b/lighthouse-core/computed/speedline.js
@@ -7,7 +7,7 @@
 
 const makeComputedArtifact = require('./computed-artifact.js');
 const speedline = require('speedline-core');
-const LHError = require('../lib/lh-error.js');
+const LighthouseError = require('../lib/lh-error.js');
 const ProcessedTrace = require('./processed-trace.js');
 
 class Speedline {
@@ -33,17 +33,17 @@ class Speedline {
       });
     }).catch(err => {
       if (/No screenshots found in trace/.test(err.message)) {
-        throw new LHError(LHError.errors.NO_SCREENSHOTS);
+        throw new LighthouseError(LighthouseError.errors.NO_SCREENSHOTS);
       }
 
       throw err;
     }).then(speedline => {
       if (speedline.frames.length === 0) {
-        throw new LHError(LHError.errors.NO_SPEEDLINE_FRAMES);
+        throw new LighthouseError(LighthouseError.errors.NO_SPEEDLINE_FRAMES);
       }
 
       if (speedline.speedIndex === 0) {
-        throw new LHError(LHError.errors.SPEEDINDEX_OF_ZERO);
+        throw new LighthouseError(LighthouseError.errors.SPEEDINDEX_OF_ZERO);
       }
 
       return speedline;

--- a/lighthouse-core/fraggle-rock/gather/session.js
+++ b/lighthouse-core/fraggle-rock/gather/session.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const EventEmitter = require('events').EventEmitter;
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 
 // Controls how long to wait for a response after sending a DevTools protocol command.
 const DEFAULT_PROTOCOL_TIMEOUT = 30000;
@@ -87,7 +87,8 @@ class ProtocolSession extends CrdpEventEmitter {
     const timeoutPromise = new Promise((resolve, reject) => {
       if (timeoutMs === Infinity) return;
 
-      timeout = setTimeout(reject, timeoutMs, new LHError(LHError.errors.PROTOCOL_TIMEOUT, {
+      // eslint-disable-next-line max-len
+      timeout = setTimeout(reject, timeoutMs, new LighthouseError(LighthouseError.errors.PROTOCOL_TIMEOUT, {
         protocolMethod: method,
       }));
     });

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -7,7 +7,7 @@
 
 const EventEmitter = require('events').EventEmitter;
 const log = require('lighthouse-logger');
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 
 // TODO(bckenny): CommandCallback properties should be tied by command type after
 // https://github.com/Microsoft/TypeScript/pull/22348. See driver.js TODO.
@@ -138,7 +138,7 @@ class Connection {
       callback.resolve(Promise.resolve().then(_ => {
         if (object.error) {
           log.formatProtocol('method <= browser ERR', {method: callback.method}, 'error');
-          throw LHError.fromProtocolMessage(callback.method, object.error);
+          throw LighthouseError.fromProtocolMessage(callback.method, object.error);
         }
 
         log.formatProtocol('method <= browser OK',

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -7,7 +7,7 @@
 
 const Fetcher = require('./fetcher.js');
 const ExecutionContext = require('./driver/execution-context.js');
-const LHError = require('../lib/lh-error.js');
+const LighthouseError = require('../lib/lh-error.js');
 const {fetchResponseBodyFromCache} = require('../gather/driver/network.js');
 const EventEmitter = require('events').EventEmitter;
 
@@ -343,7 +343,8 @@ class Driver {
     let asyncTimeout;
     const timeoutPromise = new Promise((resolve, reject) => {
       if (timeout === Infinity) return;
-      asyncTimeout = setTimeout(reject, timeout, new LHError(LHError.errors.PROTOCOL_TIMEOUT, {
+      // eslint-disable-next-line max-len
+      asyncTimeout = setTimeout(reject, timeout, new LighthouseError(LighthouseError.errors.PROTOCOL_TIMEOUT, {
         protocolMethod: method,
       }));
     });

--- a/lighthouse-core/gather/driver/wait-for-condition.js
+++ b/lighthouse-core/gather/driver/wait-for-condition.js
@@ -8,7 +8,7 @@
 /* global window */
 
 const log = require('lighthouse-logger');
-const LHError = require('../../lib/lh-error.js');
+const LighthouseError = require('../../lib/lh-error.js');
 const ExecutionContext = require('./execution-context.js');
 
 /** @typedef {import('./network-monitor.js')} NetworkMonitor */
@@ -75,7 +75,7 @@ function waitForFcp(session, pauseAfterFcpMs, maxWaitForFcpMs) {
   /** @type {Promise<void>} */
   const promise = new Promise((resolve, reject) => {
     const maxWaitTimeout = setTimeout(() => {
-      reject(new LHError(LHError.errors.NO_FCP));
+      reject(new LighthouseError(LighthouseError.errors.NO_FCP));
     }, maxWaitForFcpMs);
     /** @type {NodeJS.Timeout|undefined} */
     let loadTimeout;
@@ -476,7 +476,7 @@ async function waitForFullyLoaded(session, networkMonitor, options) {
         log.warn('waitFor', 'Page appears to be hung, killing JavaScript...');
         await session.sendCommand('Emulation.setScriptExecutionDisabled', {value: true});
         await session.sendCommand('Runtime.terminateExecution');
-        throw new LHError(LHError.errors.PAGE_HUNG);
+        throw new LighthouseError(LighthouseError.errors.PAGE_HUNG);
       }
 
       return {timedOut: true};

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -90,7 +90,7 @@ class GatherRunner {
         passContext.LighthouseRunWarnings.push(...warnings);
       }
     } catch (err) {
-      // If it's one of our loading-based LHErrors, we'll treat it as a page load error.
+      // If it's one of our loading-based LighthouseErrors, we'll treat it as a page load error.
       if (err.code === 'NO_FCP' || err.code === 'PAGE_HUNG') {
         return {navigationError: err};
       }

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -48,7 +48,7 @@ function loadArtifacts(basePath) {
     throw new Error('No saved artifacts found at ' + basePath);
   }
 
-  // load artifacts.json using a reviver to deserialize any LHErrors in artifacts.
+  // load artifacts.json using a reviver to deserialize any LighthouseErrors in artifacts.
   const artifactsStr = fs.readFileSync(path.join(basePath, artifactsFilename), 'utf8');
   /** @type {LH.Artifacts} */
   const artifacts = JSON.parse(artifactsStr, LighthouseError.parseReviver);
@@ -128,7 +128,7 @@ async function saveArtifacts(artifacts, basePath) {
     await saveDevtoolsLog(devtoolsLog, `${basePath}/${passName}${devtoolsLogSuffix}`);
   }
 
-  // save everything else, using a replacer to serialize LHErrors in the artifacts.
+  // save everything else, using a replacer to serialize LighthouseErrors in the artifacts.
   const restArtifactsString = JSON.stringify(restArtifacts, stringifyReplacer, 2) + '\n';
   fs.writeFileSync(`${basePath}/${artifactsFilename}`, restArtifactsString, 'utf8');
   log.log('Artifacts saved to disk in folder:', basePath);

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -15,7 +15,7 @@ const lanternTraceSaver = require('./lantern-trace-saver.js');
 const Metrics = require('./traces/pwmetrics-events.js');
 const NetworkAnalysisComputed = require('../computed/network-analysis.js');
 const LoadSimulatorComputed = require('../computed/load-simulator.js');
-const LHError = require('../lib/lh-error.js');
+const LighthouseError = require('../lib/lh-error.js');
 // TODO(esmodules): Rollup does not support `promisfy` or `stream.pipeline`. Bundled files
 // don't need anything in this file except for `stringifyReplacer`, so a check for
 // truthiness before using is enough.
@@ -51,7 +51,7 @@ function loadArtifacts(basePath) {
   // load artifacts.json using a reviver to deserialize any LHErrors in artifacts.
   const artifactsStr = fs.readFileSync(path.join(basePath, artifactsFilename), 'utf8');
   /** @type {LH.Artifacts} */
-  const artifacts = JSON.parse(artifactsStr, LHError.parseReviver);
+  const artifacts = JSON.parse(artifactsStr, LighthouseError.parseReviver);
 
   const filenames = fs.readdirSync(basePath);
 
@@ -87,9 +87,9 @@ function loadArtifacts(basePath) {
  * @param {any} value
  */
 function stringifyReplacer(key, value) {
-  // Currently only handle LHError and other Error types.
+  // Currently only handle LighthouseError and other Error types.
   if (value instanceof Error) {
-    return LHError.stringifyReplacer(value);
+    return LighthouseError.stringifyReplacer(value);
   }
 
   return value;

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -114,7 +114,7 @@ class LighthouseError extends Error {
    */
   constructor(errorDefinition, properties) {
     super(errorDefinition.code);
-    this.name = 'LHError';
+    this.name = 'LighthouseError';
     this.code = errorDefinition.code;
     // Add additional properties to be ICU replacements in the error string.
     // `code` is always added as `errorCode` so callers don't need to specify the code multiple times.
@@ -182,12 +182,12 @@ class LighthouseError extends Error {
       };
     }
 
-    throw new Error('Invalid value for LHError stringification');
+    throw new Error('Invalid value for LighthouseError stringification');
   }
 
   /**
    * A JSON.parse reviver. If any value passed in is a serialized Error or
-   * LHError, the error is recreated as the original object. Otherwise, the
+   * LighthouseError, the error is recreated as the original object. Otherwise, the
    * value is passed through unchanged.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Using_the_reviver_parameter
    * @param {string} key

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -148,7 +148,7 @@ class LighthouseError extends Error {
   }
 
   /**
-   * A JSON.stringify replacer to serialize LHErrors and (as a fallback) Errors.
+   * A JSON.stringify replacer to serialize LighthouseErrors and (as a fallback) Errors.
    * Returns a simplified version of the error object that can be reconstituted
    * as a copy of the original error at parse time.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter
@@ -169,7 +169,7 @@ class LighthouseError extends Error {
       };
     }
 
-    // Unexpected errors won't be LHErrors, but we want them serialized as well.
+    // Unexpected errors won't be LighthouseErrors, but we want them serialized as well.
     if (err instanceof Error) {
       const {message, stack} = err;
       // @ts-expect-error - code can be helpful for e.g. node errors, so preserve it if it's present.

--- a/lighthouse-core/lib/lh-trace-processor.js
+++ b/lighthouse-core/lib/lh-trace-processor.js
@@ -5,17 +5,17 @@
  */
 'use strict';
 
-const LHError = require('../lib/lh-error.js');
+const LighthouseError = require('../lib/lh-error.js');
 const TraceProcessor = require('../lib/tracehouse/trace-processor.js');
 
-// TraceProcessor throws generic errors, but we'd like our special localized and code-specific LHError
+// TraceProcessor throws generic errors, but we'd like our special localized and code-specific LighthouseError
 // objects to be thrown instead.
 class LHTraceProcessor extends TraceProcessor {
   /**
    * @return {Error}
    */
   static createNoNavstartError() {
-    return new LHError(LHError.errors.NO_NAVSTART);
+    return new LighthouseError(LighthouseError.errors.NO_NAVSTART);
   }
 
   /**
@@ -25,21 +25,21 @@ class LHTraceProcessor extends TraceProcessor {
    * @return {Error}
    */
   static createNoResourceSendRequestError() {
-    return new LHError(LHError.errors.NO_RESOURCE_REQUEST);
+    return new LighthouseError(LighthouseError.errors.NO_RESOURCE_REQUEST);
   }
 
   /**
    * @return {Error}
    */
   static createNoTracingStartedError() {
-    return new LHError(LHError.errors.NO_TRACING_STARTED);
+    return new LighthouseError(LighthouseError.errors.NO_TRACING_STARTED);
   }
 
   /**
    * @return {Error}
    */
   static createNoFirstContentfulPaintError() {
-    return new LHError(LHError.errors.NO_FCP);
+    return new LighthouseError(LighthouseError.errors.NO_FCP);
   }
 }
 

--- a/lighthouse-core/lib/navigation-error.js
+++ b/lighthouse-core/lib/navigation-error.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const LHError = require('./lh-error.js');
+const LighthouseError = require('./lh-error.js');
 const NetworkAnalyzer = require('./dependency-graph/simulator/network-analyzer.js');
 const NetworkRequest = require('./network-request.js');
 const i18n = require('./i18n/i18n.js');
@@ -32,7 +32,7 @@ const XHTML_MIME_TYPE = 'application/xhtml+xml';
  */
 function getNetworkError(mainRecord) {
   if (!mainRecord) {
-    return new LHError(LHError.errors.NO_DOCUMENT_REQUEST);
+    return new LighthouseError(LighthouseError.errors.NO_DOCUMENT_REQUEST);
   } else if (mainRecord.failed) {
     const netErr = mainRecord.localizedFailDescription;
     // Match all resolution and DNS failures
@@ -42,12 +42,13 @@ function getNetworkError(mainRecord) {
       netErr === 'net::ERR_NAME_RESOLUTION_FAILED' ||
       netErr.startsWith('net::ERR_DNS_')
     ) {
-      return new LHError(LHError.errors.DNS_FAILURE);
+      return new LighthouseError(LighthouseError.errors.DNS_FAILURE);
     } else {
-      return new LHError(LHError.errors.FAILED_DOCUMENT_REQUEST, {errorDetails: netErr});
+      return new LighthouseError(
+        LighthouseError.errors.FAILED_DOCUMENT_REQUEST, {errorDetails: netErr});
     }
   } else if (mainRecord.hasErrorStatusCode()) {
-    return new LHError(LHError.errors.ERRORED_DOCUMENT_REQUEST, {
+    return new LighthouseError(LighthouseError.errors.ERRORED_DOCUMENT_REQUEST, {
       statusCode: `${mainRecord.statusCode}`,
     });
   }
@@ -76,13 +77,13 @@ function getInterstitialError(mainRecord, networkRecords) {
 
   // If a request failed with the `net::ERR_CERT_*` collection of errors, then it's a security issue.
   if (mainRecord.localizedFailDescription.startsWith('net::ERR_CERT')) {
-    return new LHError(LHError.errors.INSECURE_DOCUMENT_REQUEST, {
+    return new LighthouseError(LighthouseError.errors.INSECURE_DOCUMENT_REQUEST, {
       securityMessages: mainRecord.localizedFailDescription,
     });
   }
 
   // If we made it this far, it's a generic Chrome interstitial error.
-  return new LHError(LHError.errors.CHROME_INTERSTITIAL_ERROR);
+  return new LighthouseError(LighthouseError.errors.CHROME_INTERSTITIAL_ERROR);
 }
 
 /**
@@ -98,7 +99,7 @@ function getNonHtmlError(finalRecord) {
   // mimeType is determined by the browser, we assume Chrome is determining mimeType correctly,
   // independently of 'Content-Type' response headers, and always sending mimeType if well-formed.
   if (finalRecord.mimeType !== HTML_MIME_TYPE && finalRecord.mimeType !== XHTML_MIME_TYPE) {
-    return new LHError(LHError.errors.NOT_HTML, {
+    return new LighthouseError(LighthouseError.errors.NOT_HTML, {
       mimeType: finalRecord.mimeType,
     });
   }

--- a/lighthouse-core/lib/sentry.js
+++ b/lighthouse-core/lib/sentry.js
@@ -108,14 +108,14 @@ function init(opts) {
       const sampledErrorMatch = SAMPLED_ERRORS.find(sample => sample.pattern.test(err.message));
       if (sampledErrorMatch && sampledErrorMatch.rate <= Math.random()) return;
 
-      // @ts-expect-error - properties added to protocol method LHErrors.
+      // @ts-expect-error - properties added to protocol method LighthouseErrors.
       if (err.protocolMethod) {
         // Protocol errors all share same stack trace, so add more to fingerprint
-        // @ts-expect-error - properties added to protocol method LHErrors.
+        // @ts-expect-error - properties added to protocol method LighthouseErrors.
         opts.fingerprint = ['{{ default }}', err.protocolMethod, err.protocolError];
 
         opts.tags = opts.tags || {};
-        // @ts-expect-error - properties added to protocol method LHErrors.
+        // @ts-expect-error - properties added to protocol method LighthouseErrors.
         opts.tags.protocolMethod = err.protocolMethod;
       }
 

--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -10,7 +10,7 @@
  */
 
 const {Util} = require('../util-commonjs.js');
-const LHError = require('../lib/lh-error.js');
+const LighthouseError = require('../lib/lh-error.js');
 
 /** @typedef {import('./network-request.js')} NetworkRequest */
 
@@ -260,7 +260,7 @@ class URLShim extends URL {
       // Use canonicalized URL (with trailing slashes and such)
       return new URL(url).href;
     } else {
-      throw new LHError(LHError.errors.INVALID_URL);
+      throw new LighthouseError(LighthouseError.errors.INVALID_URL);
     }
   }
 }

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -18,7 +18,7 @@ const fs = require('fs');
 const path = require('path');
 const Sentry = require('./lib/sentry.js');
 const generateReport = require('../report/generator/report-generator.js').generateReport;
-const LHError = require('./lib/lh-error.js');
+const LighthouseError = require('./lib/lh-error.js');
 const {version: lighthouseVersion} = require('../package.json');
 
 /** @typedef {import('./gather/connections/connection.js')} Connection */
@@ -357,7 +357,8 @@ class Runner {
         if (noArtifact || noRequiredTrace || noRequiredDevtoolsLog) {
           log.warn('Runner',
               `${artifactName} gatherer, required by audit ${audit.meta.id}, did not run.`);
-          throw new LHError(LHError.errors.MISSING_REQUIRED_ARTIFACT, {artifactName});
+          throw new LighthouseError(
+            LighthouseError.errors.MISSING_REQUIRED_ARTIFACT, {artifactName});
         }
 
         // If artifact was an error, output error result on behalf of audit.
@@ -375,7 +376,7 @@ class Runner {
             ` encountered an error: ${artifactError.message}`);
 
           // Create a friendlier display error and mark it as expected to avoid duplicates in Sentry
-          const error = new LHError(LHError.errors.ERRORED_REQUIRED_ARTIFACT,
+          const error = new LighthouseError(LighthouseError.errors.ERRORED_REQUIRED_ARTIFACT,
               {artifactName, errorMessage: artifactError.message});
           // @ts-expect-error Non-standard property added to Error
           error.expected = true;
@@ -435,7 +436,8 @@ class Runner {
     ];
 
     for (const possibleErrorArtifact of possibleErrorArtifacts) {
-      if (possibleErrorArtifact instanceof LHError && possibleErrorArtifact.lhrRuntimeError) {
+      // eslint-disable-next-line max-len
+      if (possibleErrorArtifact instanceof LighthouseError && possibleErrorArtifact.lhrRuntimeError) {
         const errorMessage = possibleErrorArtifact.friendlyMessage || possibleErrorArtifact.message;
 
         return {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -12,7 +12,7 @@ import jestMock from 'jest-mock';
 import Gatherer from '../../gather/gatherers/gatherer.js';
 // import GathererRunner_ from '../../gather/gather-runner.js';
 // import Config from '../../config/config.js';
-import LHError from '../../lib/lh-error.js';
+import LighthouseError from '../../lib/lh-error.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
 // import Driver from '../../gather/driver.js';
 import Connection from '../../gather/connections/connection.js';
@@ -208,7 +208,7 @@ describe('GatherRunner', function() {
 
   it('loads a page and returns a pageLoadError', async () => {
     const url = 'https://example.com';
-    const error = new LHError(LHError.errors.NO_FCP);
+    const error = new LighthouseError(LighthouseError.errors.NO_FCP);
     const driver = {};
     const {gotoURL} = requireMock('../../gather/driver/navigation.js', import.meta);
     gotoURL.mockRejectedValue(error);
@@ -481,7 +481,7 @@ describe('GatherRunner', function() {
     const requestedUrl = 'https://example.com';
     // This page load error should be overriden by ERRORED_DOCUMENT_REQUEST (for being
     // more specific) since the main document network request failed with a 500.
-    const navigationError = new LHError(LHError.errors.NO_FCP);
+    const navigationError = new LighthouseError(LighthouseError.errors.NO_FCP);
     const driver = Object.assign({}, fakeDriver, {
       online: true,
       /** @param {string} url */
@@ -516,7 +516,7 @@ describe('GatherRunner', function() {
   it('returns a pageLoadError and no artifacts when there is a navigation error', async () => {
     const requestedUrl = 'https://example.com';
     // This time, NO_FCP should win because it's the only error left.
-    const navigationError = new LHError(LHError.errors.NO_FCP);
+    const navigationError = new LighthouseError(LighthouseError.errors.NO_FCP);
     const driver = Object.assign({}, fakeDriver, {
       online: true,
       endDevtoolsLog() {
@@ -555,7 +555,7 @@ describe('GatherRunner', function() {
   it('succeeds when there is a navigation error but loadFailureMode was warn', async () => {
     const requestedUrl = 'https://example.com';
     // NO_FCP should be ignored because it's a warn pass.
-    const navigationError = new LHError(LHError.errors.NO_FCP);
+    const navigationError = new LighthouseError(LighthouseError.errors.NO_FCP);
 
     const gotoUrlForAboutBlank = fnAny().mockResolvedValue({});
     const gotoUrlForRealUrl = fnAny()
@@ -855,7 +855,7 @@ describe('GatherRunner', function() {
           firstLoad = false;
           return {mainDocumentUrl: requestedUrl, timedOut: false, warnings: []};
         } else {
-          throw new LHError(LHError.errors.NO_FCP);
+          throw new LighthouseError(LighthouseError.errors.NO_FCP);
         }
       });
     const options = {driver, requestedUrl, settings: config.settings, computedCache: new Map()};
@@ -875,7 +875,7 @@ describe('GatherRunner', function() {
     expect(artifacts.Test3).toBeUndefined();
 
     // PageLoadError artifact has the error.
-    expect(artifacts.PageLoadError).toBeInstanceOf(LHError);
+    expect(artifacts.PageLoadError).toBeInstanceOf(LighthouseError);
     expect(artifacts.PageLoadError).toMatchObject({code: 'NO_FCP'});
 
     // firstPass has a saved trace and devtoolsLog, secondPass has an error trace and log.

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -9,7 +9,7 @@ import fs from 'fs';
 
 import assetSaver from '../../lib/asset-saver.js';
 import Metrics from '../../lib/traces/pwmetrics-events.js';
-import LHError from '../../lib/lh-error.js';
+import LighthouseError from '../../lib/lh-error.js';
 import Audit from '../../audits/audit.js';
 import {getModuleDirectory} from '../../../esm-utils.mjs';
 import {LH_ROOT, readJson} from '../../../root.js';
@@ -290,10 +290,11 @@ describe('asset-saver helper', () => {
         /^Error: Connection refused by server.*test[\\/]lib[\\/]asset-saver-test\.js/s);
     });
 
-    it('round trips artifacts with an LHError member', async () => {
-      // Use an LHError that has an ICU replacement.
+    it('round trips artifacts with an LighthouseError member', async () => {
+      // Use an LighthouseError that has an ICU replacement.
       const protocolMethod = 'Page.getFastness';
-      const lhError = new LHError(LHError.errors.PROTOCOL_TIMEOUT, {protocolMethod});
+      const lhError = new LighthouseError(
+        LighthouseError.errors.PROTOCOL_TIMEOUT, {protocolMethod});
 
       const artifacts = {
         traces: {},
@@ -305,11 +306,11 @@ describe('asset-saver helper', () => {
       const roundTripArtifacts = await assetSaver.loadArtifacts(outputPath);
       expect(roundTripArtifacts).toStrictEqual(artifacts);
 
-      expect(roundTripArtifacts.ScriptElements).toBeInstanceOf(LHError);
+      expect(roundTripArtifacts.ScriptElements).toBeInstanceOf(LighthouseError);
       expect(roundTripArtifacts.ScriptElements.code).toEqual('PROTOCOL_TIMEOUT');
       expect(roundTripArtifacts.ScriptElements.protocolMethod).toEqual(protocolMethod);
       expect(roundTripArtifacts.ScriptElements.stack).toMatch(
-          /^LHError: PROTOCOL_TIMEOUT.*test[\\/]lib[\\/]asset-saver-test\.js/s);
+          /^LighthouseError: PROTOCOL_TIMEOUT.*test[\\/]lib[\\/]asset-saver-test\.js/s);
       expect(roundTripArtifacts.ScriptElements.friendlyMessage)
         .toBeDisplayString(/\(Method: Page\.getFastness\)/);
     });

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -19,7 +19,7 @@ import driverMock from './gather/fake-driver.js';
 import Audit from '../audits/audit.js';
 import Gatherer from '../gather/gatherers/gatherer.js';
 import assetSaver from '../lib/asset-saver.js';
-import LHError from '../lib/lh-error.js';
+import LighthouseError from '../lib/lh-error.js';
 import i18n from '../lib/i18n/i18n.js';
 import {importMock, makeMocksForGatherRunner} from './test-utils.js';
 import {getModuleDirectory, getModulePath} from '../../esm-utils.mjs';
@@ -208,7 +208,8 @@ describe('Runner', () => {
         afterPass(passContext) {
           const warning = str_(i18n.UIStrings.displayValueByteSavings, {wastedBytes: 2222});
           passContext.LighthouseRunWarnings.push(warning);
-          throw new LHError(LHError.errors.UNSUPPORTED_OLD_CHROME, {featureName: 'VRML'});
+          throw new LighthouseError(
+            LighthouseError.errors.UNSUPPORTED_OLD_CHROME, {featureName: 'VRML'});
         }
       }
       const gatherConfig = await Config.fromJson({
@@ -222,7 +223,7 @@ describe('Runner', () => {
       expect(artifacts.LighthouseRunWarnings[0]).not.toBe('string');
       expect(artifacts.LighthouseRunWarnings[0]).toBeDisplayString('Potential savings of 2 KiB');
       expect(artifacts.WarningAndErrorGatherer).toMatchObject({
-        name: 'LHError',
+        name: 'LighthouseError',
         code: 'UNSUPPORTED_OLD_CHROME',
         // eslint-disable-next-line max-len
         friendlyMessage: expect.toBeDisplayString(`This version of Chrome is too old to support 'VRML'. Use a newer version to see full results.`),
@@ -774,15 +775,15 @@ describe('Runner', () => {
   });
 
   describe('lhr.runtimeError', () => {
-    const NO_FCP = LHError.errors.NO_FCP;
+    const NO_FCP = LighthouseError.errors.NO_FCP;
     class RuntimeErrorGatherer extends Gatherer {
       afterPass() {
-        throw new LHError(NO_FCP);
+        throw new LighthouseError(NO_FCP);
       }
     }
     class RuntimeError2Gatherer extends Gatherer {
       afterPass() {
-        throw new LHError(LHError.errors.NO_SCREENSHOTS);
+        throw new LighthouseError(LighthouseError.errors.NO_SCREENSHOTS);
       }
     }
     class WarningAudit extends Audit {
@@ -836,7 +837,7 @@ describe('Runner', () => {
           firstLoad = false;
           return {mainDocumentUrl: url, warnings: []};
         } else {
-          throw new LHError(LHError.errors.PAGE_HUNG);
+          throw new LighthouseError(LighthouseError.errors.PAGE_HUNG);
         }
       });
 
@@ -851,7 +852,7 @@ describe('Runner', () => {
       expect(lhr.audits['test-audit'].errorMessage).toEqual(expect.stringContaining(NO_FCP.code));
 
       // But top-level runtimeError is the pageLoadError.
-      expect(lhr.runtimeError.code).toEqual(LHError.errors.PAGE_HUNG.code);
+      expect(lhr.runtimeError.code).toEqual(LighthouseError.errors.PAGE_HUNG.code);
       expect(lhr.runtimeError.message).toMatch(/because the page stopped responding/);
     });
   });
@@ -859,8 +860,8 @@ describe('Runner', () => {
   it('localized errors thrown from driver', async () => {
     const erroringDriver = {...driverMock,
       async connect() {
-        const err = new LHError(
-          LHError.errors.PROTOCOL_TIMEOUT,
+        const err = new LighthouseError(
+          LighthouseError.errors.PROTOCOL_TIMEOUT,
           {protocolMethod: 'Method.Failure'}
         );
         throw err;
@@ -871,7 +872,7 @@ describe('Runner', () => {
       await runGatherAndAudit(createGatherFn('https://example.com/'), {driverMock: erroringDriver, config: await Config.fromJson()});
       assert.fail('should have thrown');
     } catch (err) {
-      assert.equal(err.code, LHError.errors.PROTOCOL_TIMEOUT.code);
+      assert.equal(err.code, LighthouseError.errors.PROTOCOL_TIMEOUT.code);
       assert.ok(/^Waiting for DevTools protocol.*Method: Method.Failure/.test(err.friendlyMessage),
         'did not localize error message');
     }

--- a/shared/localization/format.js
+++ b/shared/localization/format.js
@@ -147,7 +147,7 @@ function _preformatValues(messageFormatter, values = {}, lhlMessage) {
   for (const valueId of Object.keys(values)) {
     if (valueId in formattedValues) continue;
 
-    // errorCode is a special case always allowed to help LHError ease-of-use.
+    // errorCode is a special case always allowed to help LighthouseError ease-of-use.
     if (valueId === 'errorCode') {
       formattedValues.errorCode = values.errorCode;
       continue;

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -14,7 +14,7 @@ import _CrdpMappings from 'devtools-protocol/types/protocol-mapping';
 import * as Externs from './externs';
 import Gatherer_ from './gatherer';
 import * as I18n from './lhr/i18n';
-import LHError = require('../lighthouse-core/lib/lh-error.js');
+import LighthouseError_ = require('../lighthouse-core/lib/lh-error.js');
 import LHResult from './lhr/lhr';
 import FlowResult_ from './lhr/flow';
 import Protocol_ from './protocol';
@@ -59,7 +59,7 @@ declare global {
     export import DevToolsJsonTarget = Externs.DevToolsJsonTarget;
 
     export import Gatherer = Gatherer_;
-    export import LighthouseError = LHError;
+    export import LighthouseError = LighthouseError_;
     export import Result = LHResult;
     export import FlowResult = FlowResult_;
 


### PR DESCRIPTION
While converting core to ESM (ref #12689) I changed `lh-error.js` to export the `LighthouseError` class as a named property. It's odd to export a class under a different name (`LHError`), so I've updated all usages of LHError to LighthouseError. This PR is to make the upcoming core PR _slightly_ less big.

Potentially breaking is the change of `name`. Could revert if someone feels strongly about it.

Of course, an alternative is to rename the class to `LHError`. No strong preference, just leaning towards spelling out our classes as a default.