### PR TITLE
tests: move readJson from root.js to test-utils.js

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -21,7 +21,8 @@ import PubAdsPlugin from 'lighthouse-plugin-publisher-ads/plugin.js';
 
 import * as rollupPlugins from './rollup-plugins.js';
 import Runner from '../lighthouse-core/runner.js';
-import {LH_ROOT, readJson} from '../root.js';
+import {LH_ROOT} from '../root.js';
+import {readJson} from '../lighthouse-core/test/test-utils.js';
 
 const require = createRequire(import.meta.url);
 

--- a/build/build-extension.js
+++ b/build/build-extension.js
@@ -11,7 +11,8 @@ import cpy from 'cpy';
 import {rollup} from 'rollup';
 
 import * as rollupPlugins from './rollup-plugins.js';
-import {LH_ROOT, readJson} from '../root.js';
+import {LH_ROOT} from '../root.js';
+import {readJson} from '../lighthouse-core/test/test-utils.js';
 
 const argv = process.argv.slice(2);
 const browserBrand = argv[0];

--- a/build/build-sample-reports.js
+++ b/build/build-sample-reports.js
@@ -15,7 +15,8 @@ import swapFlowLocale from '../shared/localization/swap-flow-locale.js';
 import ReportGenerator from '../report/generator/report-generator.js';
 import {defaultSettings} from '../lighthouse-core/config/constants.js';
 import lighthouse from '../lighthouse-core/index.js';
-import {LH_ROOT, readJson} from '../root.js';
+import {LH_ROOT} from '../root.js';
+import {readJson} from '../lighthouse-core/test/test-utils.js';
 
 /** @type {LH.Result} */
 const lhr = readJson(`${LH_ROOT}/lighthouse-core/test/results/sample_v2.json`);

--- a/build/gh-pages-app.js
+++ b/build/gh-pages-app.js
@@ -14,7 +14,8 @@ import glob from 'glob';
 import * as terser from 'terser';
 
 import * as rollupPlugins from './rollup-plugins.js';
-import {LH_ROOT, readJson} from '../root.js';
+import {LH_ROOT} from '../root.js';
+import {readJson} from '../lighthouse-core/test/test-utils.js';
 
 const ghPagesDistDir = `${LH_ROOT}/dist/gh-pages`;
 const lighthousePackage = readJson(`${LH_ROOT}/package.json`);

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -9,7 +9,8 @@ import fs from 'fs';
 import * as td from 'testdouble';
 import jestMock from 'jest-mock';
 
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 
 const mockRunLighthouse = jestMock.fn();
 const mockGetFlags = jestMock.fn();

--- a/lighthouse-cli/test/cli/printer-test.js
+++ b/lighthouse-cli/test/cli/printer-test.js
@@ -7,7 +7,7 @@
 import {strict as assert} from 'assert';
 import fs from 'fs';
 
-import {readJson} from '../../../root.js';
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 import * as Printer from '../../printer.js';
 
 const sampleResults = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);

--- a/lighthouse-cli/test/smokehouse/report-assert-test.js
+++ b/lighthouse-cli/test/smokehouse/report-assert-test.js
@@ -6,8 +6,8 @@
 
 /* eslint-disable no-control-regex */
 
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 import {findDifferences, getAssertionReport} from './report-assert.js';
-import {readJson} from '../../../root.js';
 
 describe('findDiffersences', () => {
   const testCases = {

--- a/lighthouse-core/scripts/build-test-flow-report.js
+++ b/lighthouse-core/scripts/build-test-flow-report.js
@@ -11,7 +11,8 @@ import fs from 'fs';
 import open from 'open';
 
 import reportGenerator from '../../report/generator/report-generator.js';
-import {LH_ROOT, readJson} from '../../root.js';
+import {LH_ROOT} from '../../root.js';
+import {readJson} from '../test/test-utils.js';
 
 const flow = readJson('lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json');
 const htmlReport = reportGenerator.generateFlowReportHtml(flow);

--- a/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
+++ b/lighthouse-core/scripts/i18n/bake-ctc-to-lhl.js
@@ -10,7 +10,8 @@
 import fs from 'fs';
 import path from 'path';
 
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 /**
  * @typedef CtcMessage

--- a/lighthouse-core/scripts/i18n/count-translated.js
+++ b/lighthouse-core/scripts/i18n/count-translated.js
@@ -8,7 +8,8 @@
 
 import glob from 'glob';
 
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 /** @type {LhlMessages} */
 const enUsLhl = readJson('shared/localization/locales/en-US.json');

--- a/lighthouse-core/scripts/i18n/prune-obsolete-lhl-messages.js
+++ b/lighthouse-core/scripts/i18n/prune-obsolete-lhl-messages.js
@@ -11,7 +11,8 @@ import glob from 'glob';
 import MessageParser from 'intl-messageformat-parser';
 
 import {collectAllCustomElementsFromICU} from '../../../shared/localization/format.js';
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 /** @typedef {Record<string, {message: string}>} LhlMessages */
 

--- a/lighthouse-core/scripts/internal-analysis/analyze-issues.js
+++ b/lighthouse-core/scripts/internal-analysis/analyze-issues.js
@@ -17,7 +17,7 @@
 
 import log from 'lighthouse-logger';
 
-import {readJson} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 /** @typedef {import('./download-issues.js').AugmentedGitHubIssue} AugmentedGitHubIssue */
 

--- a/lighthouse-core/scripts/lantern/assert-baseline-lantern-values-unchanged.js
+++ b/lighthouse-core/scripts/lantern/assert-baseline-lantern-values-unchanged.js
@@ -14,7 +14,7 @@ import path from 'path';
 import chalk from 'chalk';
 
 import constants from './constants.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 const INPUT_PATH = process.argv[2] || constants.SITE_INDEX_WITH_GOLDEN_WITH_COMPUTED_PATH;
 const HEAD_PATH = path.resolve(process.cwd(), INPUT_PATH);

--- a/lighthouse-core/scripts/lantern/debug-url.js
+++ b/lighthouse-core/scripts/lantern/debug-url.js
@@ -11,7 +11,8 @@ import path from 'path';
 import {execFileSync} from 'child_process';
 
 import constants from './constants.js';
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 const INPUT_URL = process.argv[2];
 if (!INPUT_URL) throw new Error('Usage $0: <url>');

--- a/lighthouse-core/scripts/lantern/print-correlations.js
+++ b/lighthouse-core/scripts/lantern/print-correlations.js
@@ -19,7 +19,7 @@ import path from 'path';
 import chalk from 'chalk';
 
 import constants from './constants.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 const GOOD_DIFF_AS_PERCENT_THRESHOLD = 0.2;
 const OK_DIFF_AS_PERCENT_THRESHOLD = 0.5;

--- a/lighthouse-core/scripts/lantern/run-on-all-assets.js
+++ b/lighthouse-core/scripts/lantern/run-on-all-assets.js
@@ -25,7 +25,8 @@ import path from 'path';
 import {execFileSync} from 'child_process';
 
 import constants from './constants.js';
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 const INPUT_PATH = process.argv[2] || constants.SITE_INDEX_WITH_GOLDEN_PATH;
 const SITE_INDEX_PATH = path.resolve(process.cwd(), INPUT_PATH);

--- a/lighthouse-core/scripts/lantern/run-once.js
+++ b/lighthouse-core/scripts/lantern/run-once.js
@@ -11,7 +11,8 @@ import path from 'path';
 import PredictivePerf from '../../audits/predictive-perf.js';
 import Simulator from '../../lib/dependency-graph/simulator/simulator.js';
 import traceSaver from '../../lib/lantern-trace-saver.js';
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 if (process.argv.length !== 4) throw new Error('Usage $0 <trace file> <devtools file>');
 

--- a/lighthouse-core/scripts/lantern/update-baseline-lantern-values.js
+++ b/lighthouse-core/scripts/lantern/update-baseline-lantern-values.js
@@ -14,7 +14,8 @@ import {execFileSync} from 'child_process';
 import prettyJSONStringify from 'pretty-json-stringify';
 
 import constants from './constants.js';
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 const INPUT_PATH = process.argv[2] || constants.SITE_INDEX_WITH_GOLDEN_PATH;
 const SITE_INDEX_PATH = path.resolve(process.cwd(), INPUT_PATH);

--- a/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
+++ b/lighthouse-core/scripts/legacy-javascript/examine-latest-run.js
@@ -22,7 +22,8 @@ import colors from 'colors';
 
 import LegacyJavascript from '../../audits/byte-efficiency/legacy-javascript.js';
 import format from '../../../shared/localization/format.js';
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 const LATEST_RUN_DIR = path.join(LH_ROOT, 'latest-run');
 

--- a/lighthouse-core/scripts/legacy-javascript/run.js
+++ b/lighthouse-core/scripts/legacy-javascript/run.js
@@ -15,7 +15,8 @@ import glob from 'glob';
 import {makeHash} from './hash.js';
 import LegacyJavascript from '../../audits/byte-efficiency/legacy-javascript.js';
 import networkRecordsToDevtoolsLog from '../../test/network-records-to-devtools-log.js';
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 const scriptDir = `${LH_ROOT}/lighthouse-core/scripts/legacy-javascript`;
 

--- a/lighthouse-core/scripts/release/bump-versions.js
+++ b/lighthouse-core/scripts/release/bump-versions.js
@@ -8,7 +8,7 @@ import fs from 'fs';
 
 import glob from 'glob';
 
-import {readJson} from '../../../root.js';
+import {readJson} from '../../test/test-utils.js';
 
 const NEW_VERSION = process.argv[2];
 if (!/^\d+\.\d+\.\d+(-dev\.\d{8})?$/.test(NEW_VERSION)) {

--- a/lighthouse-core/test/audits/bootup-time-test.js
+++ b/lighthouse-core/test/audits/bootup-time-test.js
@@ -6,8 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import BootupTime from '../../audits/bootup-time.js';
+import {readJson} from '../test-utils.js';
 
 const acceptableTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const acceptableDevtoolsLogs = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -12,8 +12,7 @@ import CPUNode from '../../../lib/dependency-graph/cpu-node.js';
 import Simulator from '../../../lib/dependency-graph/simulator/simulator.js';
 import PageDependencyGraph from '../../../computed/page-dependency-graph.js';
 import LoadSimulator from '../../../computed/load-simulator.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
-import {readJson} from '../../../../root.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/duplicated-javascript-test.js
@@ -4,12 +4,12 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import DuplicatedJavascript from '../../../audits/byte-efficiency/duplicated-javascript.js';
 import {
   loadSourceMapFixture,
   createScript,
   getURLArtifactFromDevtoolsLog,
+  readJson,
 } from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);

--- a/lighthouse-core/test/audits/byte-efficiency/legacy-javascript-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/legacy-javascript-test.js
@@ -4,9 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import LegacyJavascript from '../../../audits/byte-efficiency/legacy-javascript.js';
 import networkRecordsToDevtoolsLog from '../../network-records-to-devtools-log.js';
+import {readJson} from '../../test-utils.js';
 
 /**
  * @param {Array<{url: string, code: string, map?: LH.Artifacts.RawSourceMap}>} scripts

--- a/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
@@ -12,8 +12,7 @@ import NetworkNode from '../../../lib/dependency-graph/network-node.js';
 import CPUNode from '../../../lib/dependency-graph/cpu-node.js';
 import Simulator from '../../../lib/dependency-graph/simulator/simulator.js';
 import NetworkRequest from '../../../lib/network-request.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
-import {readJson} from '../../../../root.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/critical-request-chains-test.js
+++ b/lighthouse-core/test/audits/critical-request-chains-test.js
@@ -6,10 +6,10 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import CriticalRequestChains from '../../audits/critical-request-chains.js';
 import createTestTrace from '../create-test-trace.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
+import {readJson} from '../test-utils.js';
 
 const redditDevtoolsLog = readJson('../fixtures/artifacts/perflog/defaultPass.devtoolslog.json', import.meta);
 

--- a/lighthouse-core/test/audits/diagnostics-test.js
+++ b/lighthouse-core/test/audits/diagnostics-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import Diagnostics from '../../audits/diagnostics.js';
+import {readJson} from '../test-utils.js';
 
 const acceptableTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const acceptableDevToolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
@@ -4,11 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import UsesHTTP2Audit from '../../../audits/dobetterweb/uses-http2.js';
 import NetworkRecords from '../../../computed/network-records.js';
 import networkRecordsToDevtoolsLog from '../../network-records-to-devtools-log.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/final-screenshot-test.js
+++ b/lighthouse-core/test/audits/final-screenshot-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import FinalScreenshotAudit from '../../audits/final-screenshot.js';
+import {readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 

--- a/lighthouse-core/test/audits/installable-manifest-test.js
+++ b/lighthouse-core/test/audits/installable-manifest-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import InstallableManifestAudit from '../../audits/installable-manifest.js';
 import manifestParser from '../../lib/manifest-parser.js';
+import {readJson} from '../test-utils.js';
 
 const manifest = readJson('../fixtures/manifest.json', import.meta);
 const manifestDirtyJpg = readJson('../fixtures/manifest-dirty-jpg.json', import.meta);

--- a/lighthouse-core/test/audits/main-thread-tasks-test.js
+++ b/lighthouse-core/test/audits/main-thread-tasks-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import MainThreadTasks from '../../audits/main-thread-tasks.js';
+import {readJson} from '../test-utils.js';
 
 const acceptableTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 

--- a/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
+++ b/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
@@ -6,8 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import PageExecutionTimings from '../../audits/mainthread-work-breakdown.js';
+import {readJson} from '../test-utils.js';
 
 const acceptableTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const siteWithRedirectTrace = readJson('../fixtures/traces/site-with-redirect.json', import.meta);

--- a/lighthouse-core/test/audits/maskable-icon-test.js
+++ b/lighthouse-core/test/audits/maskable-icon-test.js
@@ -4,9 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import MaskableIconAudit from '../../audits/maskable-icon.js';
 import manifestParser from '../../lib/manifest-parser.js';
+import {readJson} from '../test-utils.js';
 
 const manifest = readJson('../fixtures/manifest.json', import.meta);
 const manifestWithoutMaskable = readJson('../fixtures/manifest-no-maskable-icon.json', import.meta);

--- a/lighthouse-core/test/audits/metrics-test.js
+++ b/lighthouse-core/test/audits/metrics-test.js
@@ -6,10 +6,9 @@
 
 import jestMock from 'jest-mock';
 
-import {readJson} from '../../../root.js';
 import MetricsAudit from '../../audits/metrics.js';
 import TTIComputed from '../../computed/metrics/interactive.js';
-import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/metrics/cumulative-layout-shift-test.js
+++ b/lighthouse-core/test/audits/metrics/cumulative-layout-shift-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import CumulativeLayoutShift from '../../../audits/metrics/cumulative-layout-shift.js';
+import {readJson} from '../../test-utils.js';
 
 const jumpyClsTrace = readJson('../../fixtures/traces/jumpy-cls-m90.json', import.meta);
 

--- a/lighthouse-core/test/audits/metrics/experimental-interaction-to-next-paint-test.js
+++ b/lighthouse-core/test/audits/metrics/experimental-interaction-to-next-paint-test.js
@@ -4,9 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import ExperimentalInteractionToNextPaint from
   '../../../audits/metrics/experimental-interaction-to-next-paint.js';
+import {readJson} from '../../test-utils.js';
 
 const interactionTrace = readJson('../../fixtures/traces/timespan-responsiveness-m103.trace.json', import.meta);
 const noInteractionTrace = readJson('../../fixtures/traces/jumpy-cls-m90.json', import.meta);

--- a/lighthouse-core/test/audits/metrics/first-contentful-paint-3g-test.js
+++ b/lighthouse-core/test/audits/metrics/first-contentful-paint-3g-test.js
@@ -4,9 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import FCP3G from '../../../audits/metrics/first-contentful-paint-3g.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const pwaTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/metrics/first-contentful-paint-test.js
+++ b/lighthouse-core/test/audits/metrics/first-contentful-paint-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import FcpAudit from '../../../audits/metrics/first-contentful-paint.js';
 import constants from '../../../config/constants.js';
+import {readJson} from '../../test-utils.js';
 
 const pwaTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/metrics/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/metrics/first-meaningful-paint-test.js
@@ -9,8 +9,7 @@ import {strict as assert} from 'assert';
 import FMPAudit from '../../../audits/metrics/first-meaningful-paint.js';
 import Audit from '../../../audits/audit.js';
 import constants from '../../../config/constants.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
-import {readJson} from '../../../../root.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLogs = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/metrics/interactive-test.js
+++ b/lighthouse-core/test/audits/metrics/interactive-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import Interactive from '../../../audits/metrics/interactive.js';
 import constants from '../../../config/constants.js';
+import {readJson} from '../../test-utils.js';
 
 const acceptableTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const acceptableDevToolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/metrics/largest-contentful-paint-test.js
+++ b/lighthouse-core/test/audits/metrics/largest-contentful-paint-test.js
@@ -4,9 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import LCPAudit from '../../../audits/metrics/largest-contentful-paint.js';
 import constants from '../../../config/constants.js';
+import {readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/metrics/speed-index-test.js
+++ b/lighthouse-core/test/audits/metrics/speed-index-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import Audit from '../../../audits/metrics/speed-index.js';
 import constants from '../../../config/constants.js';
+import {readJson} from '../../test-utils.js';
 
 const pwaTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/metrics/total-blocking-time-test.js
+++ b/lighthouse-core/test/audits/metrics/total-blocking-time-test.js
@@ -4,10 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import TBTAudit from '../../../audits/metrics/total-blocking-time.js';
 import constants from '../../../config/constants.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/network-requests-test.js
+++ b/lighthouse-core/test/audits/network-requests-test.js
@@ -4,9 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import NetworkRequests from '../../audits/network-requests.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
+import {readJson} from '../test-utils.js';
 
 const cutoffLoadDevtoolsLog = readJson('../fixtures/traces/cutoff-load-m83.devtoolslog.json', import.meta);
 

--- a/lighthouse-core/test/audits/network-rtt-test.js
+++ b/lighthouse-core/test/audits/network-rtt-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import NetworkRTT from '../../audits/network-rtt.js';
+import {readJson} from '../test-utils.js';
 
 const acceptableDevToolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 

--- a/lighthouse-core/test/audits/network-server-latency-test.js
+++ b/lighthouse-core/test/audits/network-server-latency-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import ServerLatency from '../../audits/network-server-latency.js';
+import {readJson} from '../test-utils.js';
 
 const acceptableDevToolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -4,9 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import PredictivePerf from '../../audits/predictive-perf.js';
-import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../test-utils.js';
 
 const acceptableTrace = readJson('../fixtures/traces/lcp-m78.json', import.meta);
 const acceptableDevToolsLog = readJson('../fixtures/traces/lcp-m78.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/screenshot-thumbnails-test.js
+++ b/lighthouse-core/test/audits/screenshot-thumbnails-test.js
@@ -9,7 +9,8 @@ import path from 'path';
 import {strict as assert} from 'assert';
 
 import ScreenshotThumbnailsAudit from '../../audits/screenshot-thumbnails.js';
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/splash-screen-test.js
+++ b/lighthouse-core/test/audits/splash-screen-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import SplashScreenAudit from '../../audits/splash-screen.js';
 import manifestParser from '../../lib/manifest-parser.js';
+import {readJson} from '../test-utils.js';
 
 const manifest = readJson('../fixtures/manifest.json', import.meta);
 const manifestDirtyJpg = readJson('../fixtures/manifest-dirty-jpg.json', import.meta);

--- a/lighthouse-core/test/audits/themed-omnibox-test.js
+++ b/lighthouse-core/test/audits/themed-omnibox-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import ThemedOmniboxAudit from '../../audits/themed-omnibox.js';
 import manifestParser from '../../lib/manifest-parser.js';
+import {readJson} from '../test-utils.js';
 
 const manifest = readJson('../fixtures/manifest.json', import.meta);
 

--- a/lighthouse-core/test/audits/third-party-facades-test.js
+++ b/lighthouse-core/test/audits/third-party-facades-test.js
@@ -7,8 +7,7 @@
 import ThirdPartyFacades from '../../audits/third-party-facades.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
 import createTestTrace from '../create-test-trace.js';
-import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
-import {readJson} from '../../../root.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/third-party-summary-test.js
+++ b/lighthouse-core/test/audits/third-party-summary-test.js
@@ -4,9 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import ThirdPartySummary from '../../audits/third-party-summary.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
+import {readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/timing-budget-test.js
+++ b/lighthouse-core/test/audits/timing-budget-test.js
@@ -4,9 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import TimingBudgetAudit from '../../audits/timing-budget.js';
-import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../test-utils.js';
 
 const trace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/user-timing-test.js
+++ b/lighthouse-core/test/audits/user-timing-test.js
@@ -6,8 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import UserTimingsAudit from '../../audits/user-timings.js';
+import {readJson} from '../test-utils.js';
 
 const traceEvents = readJson('../fixtures/traces/trace-user-timings.json', import.meta);
 

--- a/lighthouse-core/test/audits/uses-rel-preload-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preload-test.js
@@ -9,8 +9,7 @@ import {strict as assert} from 'assert';
 import UsesRelPreload from '../../audits/uses-rel-preload.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
 import createTestTrace from '../create-test-trace.js';
-import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
-import {readJson} from '../../../root.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/audits/work-during-interaction-test.js
+++ b/lighthouse-core/test/audits/work-during-interaction-test.js
@@ -6,8 +6,8 @@
 
 /* eslint-disable no-irregular-whitespace */
 
-import {readJson} from '../../../root.js';
 import WorkDuringInteraction from '../../audits/work-during-interaction.js';
+import {readJson} from '../test-utils.js';
 
 const interactionTrace = readJson('../fixtures/traces/timespan-responsiveness-m103.trace.json', import.meta);
 const noInteractionTrace = readJson('../fixtures/traces/jumpy-cls-m90.json', import.meta);

--- a/lighthouse-core/test/computed/critical-request-chains-test.js
+++ b/lighthouse-core/test/computed/critical-request-chains-test.js
@@ -6,12 +6,11 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import CriticalRequestChains from '../../computed/critical-request-chains.js';
 import NetworkRequest from '../../lib/network-request.js';
 import createTestTrace from '../create-test-trace.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
-import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../test-utils.js';
 
 const wikipediaDevtoolsLog = readJson('../fixtures/wikipedia-redirect.devtoolslog.json', import.meta);
 

--- a/lighthouse-core/test/computed/load-simulator-test.js
+++ b/lighthouse-core/test/computed/load-simulator-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import LoadSimulator from '../../computed/load-simulator.js';
 import NetworkNode from '../../lib/dependency-graph/network-node.js';
+import {readJson} from '../test-utils.js';
 
 const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 

--- a/lighthouse-core/test/computed/main-resource-test.js
+++ b/lighthouse-core/test/computed/main-resource-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import MainResource from '../../computed/main-resource.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
+import {readJson} from '../test-utils.js';
 
 const wikipediaDevtoolsLog = readJson('../fixtures/wikipedia-redirect.devtoolslog.json', import.meta);
 

--- a/lighthouse-core/test/computed/main-thread-tasks-test.js
+++ b/lighthouse-core/test/computed/main-thread-tasks-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import MainThreadTasks from '../../computed/main-thread-tasks.js';
+import {readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 

--- a/lighthouse-core/test/computed/manifest-values-test.js
+++ b/lighthouse-core/test/computed/manifest-values-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import ManifestValues from '../../computed/manifest-values.js';
 import manifestParser from '../../lib/manifest-parser.js';
+import {readJson} from '../test-utils.js';
 
 const manifest = readJson('../fixtures/manifest.json', import.meta);
 

--- a/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
+++ b/lighthouse-core/test/computed/metrics/cumulative-layout-shift-test.js
@@ -4,9 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import CumulativeLayoutShift from '../../../computed/metrics/cumulative-layout-shift.js';
 import createTestTrace from '../../create-test-trace.js';
+import {readJson} from '../../test-utils.js';
 
 const jumpyClsTrace = readJson('../../fixtures/traces/jumpy-cls-m90.json', import.meta);
 const oldMetricsTrace = readJson('../../fixtures/traces/frame-metrics-m89.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/first-contentful-paint-all-frames-test.js
+++ b/lighthouse-core/test/computed/metrics/first-contentful-paint-all-frames-test.js
@@ -4,9 +4,9 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import FirstContentfulPaintAllFrames from '../../../computed/metrics/first-contentful-paint-all-frames.js'; // eslint-disable-line max-len
 import FirstContentfulPaint from '../../../computed/metrics/first-contentful-paint.js'; // eslint-disable-line max-len
+import {readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/frame-metrics-m89.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/frame-metrics-m89.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/first-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/first-contentful-paint-test.js
@@ -6,9 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import FirstContentfulPaint from '../../../computed/metrics/first-contentful-paint.js'; // eslint-disable-line max-len
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/first-meaningful-paint-test.js
@@ -6,9 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import FirstMeaningfulPaint from '../../../computed/metrics/first-meaningful-paint.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const pwaTrace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/interactive-test.js
+++ b/lighthouse-core/test/computed/metrics/interactive-test.js
@@ -6,9 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import Interactive from '../../../computed/metrics/interactive.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/lantern-first-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-first-contentful-paint-test.js
@@ -7,10 +7,9 @@
 import {strict as assert} from 'assert';
 
 import LanternFirstContentfulPaint from '../../../computed/metrics/lantern-first-contentful-paint.js'; // eslint-disable-line max-len
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 import networkRecordsToDevtoolsLog from '../../network-records-to-devtools-log.js';
 import createTestTrace from '../../create-test-trace.js';
-import {readJson} from '../../../../root.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/lantern-first-meaningful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-first-meaningful-paint-test.js
@@ -6,10 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import LanternFirstMeaningfulPaint from
   '../../../computed/metrics/lantern-first-meaningful-paint.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/lantern-interactive-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-interactive-test.js
@@ -6,9 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import LanternInteractive from '../../../computed/metrics/lantern-interactive.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/lantern-largest-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-largest-contentful-paint-test.js
@@ -6,9 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import LanternLargestContentfulPaint from '../../../computed/metrics/lantern-largest-contentful-paint.js'; // eslint-disable-line max-len
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/lantern-speed-index-test.js
+++ b/lighthouse-core/test/computed/metrics/lantern-speed-index-test.js
@@ -6,8 +6,7 @@
 
 import constants from '../../../config/constants.js';
 import LanternSpeedIndex from '../../../computed/metrics/lantern-speed-index.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
-import {readJson} from '../../../../root.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/largest-contentful-paint-all-frames-test.js
+++ b/lighthouse-core/test/computed/metrics/largest-contentful-paint-all-frames-test.js
@@ -6,8 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import LargestContentfulPaintAllFrames from '../../../computed/metrics/largest-contentful-paint-all-frames.js'; // eslint-disable-line max-len
+import {readJson} from '../../test-utils.js';
 
 const traceAllFrames = readJson('../../fixtures/traces/frame-metrics-m89.json', import.meta);
 const devtoolsLogAllFrames = readJson('../../fixtures/traces/frame-metrics-m89.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/largest-contentful-paint-test.js
+++ b/lighthouse-core/test/computed/metrics/largest-contentful-paint-test.js
@@ -6,9 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import LargestContentfulPaint from '../../../computed/metrics/largest-contentful-paint.js'; // eslint-disable-line max-len
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/lcp-m78.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/max-potential-fid-test.js
+++ b/lighthouse-core/test/computed/metrics/max-potential-fid-test.js
@@ -6,9 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import MaxPotentialFID from '../../../computed/metrics/max-potential-fid.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/responsiveness-test.js
+++ b/lighthouse-core/test/computed/metrics/responsiveness-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import Responsiveness from '../../../computed/metrics/responsiveness.js';
 import createTestTrace from '../../create-test-trace.js';
+import {readJson} from '../../test-utils.js';
 
 const interactionTrace = readJson('../../fixtures/traces/timespan-responsiveness-m103.trace.json', import.meta);
 const noInteractionTrace = readJson('../../fixtures/traces/frame-metrics-m89.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/speed-index-test.js
+++ b/lighthouse-core/test/computed/metrics/speed-index-test.js
@@ -6,9 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import SpeedIndex from '../../../computed/metrics/speed-index.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/timing-summary-test.js
+++ b/lighthouse-core/test/computed/metrics/timing-summary-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import TimingSummary from '../../../computed/metrics/timing-summary.js';
+import {readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/frame-metrics-m90.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/frame-metrics-m90.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/metrics/total-blocking-time-test.js
+++ b/lighthouse-core/test/computed/metrics/total-blocking-time-test.js
@@ -6,8 +6,7 @@
 
 import TotalBlockingTime from '../../../computed/metrics/total-blocking-time.js';
 import {calculateSumOfBlockingTime} from '../../../computed/metrics/tbt-utils.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
-import {readJson} from '../../../../root.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/computed/network-analysis-test.js
+++ b/lighthouse-core/test/computed/network-analysis-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import NetworkAnalysis from '../../computed/network-analysis.js';
+import {readJson} from '../test-utils.js';
 
 const acceptableDevToolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 

--- a/lighthouse-core/test/computed/page-dependency-graph-test.js
+++ b/lighthouse-core/test/computed/page-dependency-graph-test.js
@@ -9,10 +9,9 @@ import {strict as assert} from 'assert';
 import PageDependencyGraph from '../../computed/page-dependency-graph.js';
 import BaseNode from '../../lib/dependency-graph/base-node.js';
 import NetworkRequest from '../../lib/network-request.js';
-import {getURLArtifactFromDevtoolsLog} from '../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../test-utils.js';
 import NetworkRecorder from '../../lib/network-recorder.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
-import {readJson} from '../../../root.js';
 
 const sampleTrace = readJson('../fixtures/traces/iframe-m79.trace.json', import.meta);
 const sampleDevtoolsLog = readJson('../fixtures/traces/iframe-m79.devtoolslog.json', import.meta);

--- a/lighthouse-core/test/computed/processed-navigation-test.js
+++ b/lighthouse-core/test/computed/processed-navigation-test.js
@@ -6,7 +6,7 @@
 
 import ProcessedTrace from '../../computed/processed-trace.js';
 import ProcessedNavigation from '../../computed/processed-navigation.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const noFCPtrace = readJson('../fixtures/traces/airhorner_no_fcp.json', import.meta);

--- a/lighthouse-core/test/computed/processed-trace-test.js
+++ b/lighthouse-core/test/computed/processed-trace-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import ProcessedTrace from '../../computed/processed-trace.js';
+import {readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 

--- a/lighthouse-core/test/computed/screenshots-test.js
+++ b/lighthouse-core/test/computed/screenshots-test.js
@@ -6,8 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import Screenshots from '../../computed/screenshots.js';
+import {readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app.json', import.meta);
 

--- a/lighthouse-core/test/computed/speedline-test.js
+++ b/lighthouse-core/test/computed/speedline-test.js
@@ -7,7 +7,7 @@
 import {strict as assert} from 'assert';
 
 import Speedline from '../../computed/speedline.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app.json', import.meta);
 const threeFrameTrace = readJson('../fixtures/traces/threeframes-blank_content_more.json', import.meta);

--- a/lighthouse-core/test/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/computed/trace-of-tab-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
 import TraceOfTab from '../../computed/trace-of-tab.js';
+import {readJson} from '../test-utils.js';
 
 const pwaTrace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -4,8 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../root.js';
-import {fnAny} from '../test-utils.js';
+import {fnAny, readJson} from '../test-utils.js';
 
 /**
  * @param {{protocolGetVersionResponse: LH.CrdpCommands['Browser.getVersion']['returnType']}} param0

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -25,9 +25,9 @@ import {
   fnAny,
   timers,
   requireMock,
+  readJson,
 } from '../test-utils.js';
 import fakeDriver from './fake-driver.js';
-import {readJson} from '../../../root.js';
 
 const unresolvedPerfLog = readJson('./../fixtures/unresolved-perflog.json', import.meta);
 

--- a/lighthouse-core/test/gather/gatherers/image-elements-test.js
+++ b/lighthouse-core/test/gather/gatherers/image-elements-test.js
@@ -6,12 +6,11 @@
 
 import jestMock from 'jest-mock';
 
-import {readJson} from '../../../../root.js';
 import ImageElements from '../../../gather/gatherers/image-elements.js';
 import NetworkRecorder from '../../../lib/network-recorder.js';
 import {createMockContext, createMockDriver, createMockSession} from
   '../../fraggle-rock/gather/mock-driver.js';
-import {fnAny, timers} from '../../test-utils.js';
+import {fnAny, readJson, timers} from '../../test-utils.js';
 
 const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 

--- a/lighthouse-core/test/gather/gatherers/main-document-content-test.js
+++ b/lighthouse-core/test/gather/gatherers/main-document-content-test.js
@@ -4,11 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import MainDocumentContent from '../../../gather/gatherers/main-document-content.js';
 import NetworkRecorder from '../../../lib/network-recorder.js';
 import {createMockContext} from '../../fraggle-rock/gather/mock-driver.js';
-import {getURLArtifactFromDevtoolsLog} from '../../test-utils.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 

--- a/lighthouse-core/test/gather/gatherers/network-user-agent-test.js
+++ b/lighthouse-core/test/gather/gatherers/network-user-agent-test.js
@@ -4,8 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../../../root.js';
 import NetworkUserAgent from '../../../gather/gatherers/network-user-agent.js';
+import {readJson} from '../../test-utils.js';
 
 const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 

--- a/lighthouse-core/test/gather/gatherers/trace-elements-test.js
+++ b/lighthouse-core/test/gather/gatherers/trace-elements-test.js
@@ -9,8 +9,7 @@ import Driver from '../../../gather/driver.js';
 import Connection from '../../../gather/connections/connection.js';
 import createTestTrace from '../../create-test-trace.js';
 import {createMockSendCommandFn, createMockOnFn} from '../mock-commands.js';
-import {flushAllTimersAndMicrotasks, fnAny, timers} from '../../test-utils.js';
-import {readJson} from '../../../../root.js';
+import {flushAllTimersAndMicrotasks, fnAny, readJson, timers} from '../../test-utils.js';
 
 const animationTrace = readJson('../../fixtures/traces/animation.json', import.meta);
 

--- a/lighthouse-core/test/index-test.js
+++ b/lighthouse-core/test/index-test.js
@@ -7,7 +7,8 @@
 import {strict as assert} from 'assert';
 
 import lighthouse from '../index.js';
-import {LH_ROOT, readJson} from '../../root.js';
+import {LH_ROOT} from '../../root.js';
+import {readJson} from './test-utils.js';
 
 const pkg = readJson('package.json');
 

--- a/lighthouse-core/test/lib/arbitrary-equality-map-test.js
+++ b/lighthouse-core/test/lib/arbitrary-equality-map-test.js
@@ -6,8 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import ArbitraryEqualityMap from '../../lib/arbitrary-equality-map.js';
+import {readJson} from '../test-utils.js';
 
 const trace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -12,7 +12,8 @@ import Metrics from '../../lib/traces/pwmetrics-events.js';
 import LHError from '../../lib/lh-error.js';
 import Audit from '../../audits/audit.js';
 import {getModuleDirectory} from '../../../esm-utils.mjs';
-import {LH_ROOT, readJson} from '../../../root.js';
+import {LH_ROOT} from '../../../root.js';
+import {readJson} from '../test-utils.js';
 
 const traceEvents = readJson('../fixtures/traces/progressive-app.json', import.meta);
 const dbwTrace = readJson('../results/artifacts/defaultPass.trace.json', import.meta);

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -8,7 +8,7 @@ import {strict as assert} from 'assert';
 
 import NetworkAnalyzer from '../../../../lib/dependency-graph/simulator/network-analyzer.js';
 import NetworkRecords from '../../../../computed/network-records.js';
-import {readJson} from '../../../../../root.js';
+import {readJson} from '../../../test-utils.js';
 
 const devtoolsLog = readJson('../../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 const devtoolsLogWithRedirect = readJson('../../../fixtures/traces/site-with-redirect.devtools.log.json', import.meta);

--- a/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
@@ -11,8 +11,7 @@ import CpuNode from '../../../../lib/dependency-graph/cpu-node.js';
 import Simulator from '../../../../lib/dependency-graph/simulator/simulator.js';
 import DNSCache from '../../../../lib/dependency-graph/simulator/dns-cache.js';
 import PageDependencyGraph from '../../../../computed/page-dependency-graph.js';
-import {getURLArtifactFromDevtoolsLog} from '../../../test-utils.js';
-import {readJson} from '../../../../../root.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../../../test-utils.js';
 
 const pwaTrace = readJson('../../../fixtures/traces/progressive-app-m60.json', import.meta);
 const pwaDevtoolsLog = readJson('../../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/lib/manifest-parser-test.js
+++ b/lighthouse-core/test/lib/manifest-parser-test.js
@@ -6,8 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import manifestParser from '../../lib/manifest-parser.js';
+import {readJson} from '../test-utils.js';
 
 const manifestStub = readJson('../fixtures/manifest.json', import.meta);
 

--- a/lighthouse-core/test/lib/minify-devtoolslog-test.js
+++ b/lighthouse-core/test/lib/minify-devtoolslog-test.js
@@ -6,7 +6,7 @@
 
 import {minifyDevtoolsLog} from '../../lib/minify-devtoolslog.js';
 import MetricsAudit from '../../audits/metrics.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../test-utils.js';
 
 const trace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/lib/minify-trace-test.js
+++ b/lighthouse-core/test/lib/minify-trace-test.js
@@ -6,7 +6,7 @@
 
 import {minifyTrace} from '../../lib/minify-trace.js';
 import MetricsAudit from '../../audits/metrics.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../test-utils.js';
 
 const trace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
 const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);

--- a/lighthouse-core/test/lib/network-recorder-test.js
+++ b/lighthouse-core/test/lib/network-recorder-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../root.js';
 import NetworkRecorder from '../../lib/network-recorder.js';
 import networkRecordsToDevtoolsLog from '../network-records-to-devtools-log.js';
+import {readJson} from '../test-utils.js';
 
 const devtoolsLogItems = readJson('../fixtures/artifacts/perflog/defaultPass.devtoolslog.json', import.meta);
 const prefetchedScriptDevtoolsLog = readJson('../fixtures/prefetched-script.devtoolslog.json', import.meta);

--- a/lighthouse-core/test/lib/proto-preprocessor-test.js
+++ b/lighthouse-core/test/lib/proto-preprocessor-test.js
@@ -4,9 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {getProtoRoundTrip} from '../test-utils.js';
+import {getProtoRoundTrip, readJson} from '../test-utils.js';
 import {processForProto} from '../../lib/proto-preprocessor.js';
-import {readJson} from '../../../root.js';
 
 const sampleJson = readJson('../results/sample_v2.json', import.meta);
 

--- a/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
+++ b/lighthouse-core/test/lib/tracehouse/cpu-profile-model-test.js
@@ -8,7 +8,7 @@ import CpuProfileModel from '../../../lib/tracehouse/cpu-profile-model.js';
 import TraceProcessor from '../../../lib/tracehouse/trace-processor.js';
 import MainThreadTasks from '../../../lib/tracehouse/main-thread-tasks.js';
 import CpuProfilerModel from '../../../lib/tracehouse/cpu-profile-model.js';
-import {readJson} from '../../../../root.js';
+import {readJson} from '../../test-utils.js';
 
 const profilerTrace = readJson('../../fixtures/traces/cpu-profiler-m86.trace.json', import.meta);
 

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -10,7 +10,7 @@ import MainThreadTasks from '../../../lib/tracehouse/main-thread-tasks.js';
 import TraceProcessor from '../../../lib/tracehouse/trace-processor.js';
 import {taskGroups} from '../../../lib/tracehouse/task-groups.js';
 import TracingProcessor from '../../../lib/tracehouse/trace-processor.js';
-import {readJson} from '../../../../root.js';
+import {readJson} from '../../test-utils.js';
 
 const pwaTrace = readJson('../../fixtures/traces/progressive-app.json', import.meta);
 const noTracingStartedTrace = readJson('../../fixtures/traces/no-tracingstarted-m74.json', import.meta);

--- a/lighthouse-core/test/lib/tracehouse/task-summary-test.js
+++ b/lighthouse-core/test/lib/tracehouse/task-summary-test.js
@@ -14,7 +14,7 @@ import MainThreadTasks from '../../../lib/tracehouse/main-thread-tasks.js';
 import TraceProcessor from '../../../lib/tracehouse/trace-processor.js';
 import networkRecordsToDevtoolsLog from '../../network-records-to-devtools-log.js';
 import {taskGroups} from '../../../lib/tracehouse/task-groups.js';
-import {readJson} from '../../../../root.js';
+import {readJson} from '../../test-utils.js';
 
 const ampTrace = readJson('../../fixtures/traces/amp-m86.trace.json', import.meta);
 const ampDevtoolsLog = readJson('../../fixtures/traces/amp-m86.devtoolslog.json', import.meta);

--- a/lighthouse-core/test/lib/tracehouse/trace-processor-test.js
+++ b/lighthouse-core/test/lib/tracehouse/trace-processor-test.js
@@ -6,9 +6,9 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import TraceProcessor from '../../../lib/tracehouse/trace-processor.js';
 import createTestTrace from '../../create-test-trace.js';
+import {readJson} from '../../test-utils.js';
 
 const pwaTrace = readJson('../../fixtures/traces/progressive-app.json', import.meta);
 const badNavStartTrace = readJson('../../fixtures/traces/bad-nav-start-ts.json', import.meta);

--- a/lighthouse-core/test/lib/traces/pwmetrics-events-test.js
+++ b/lighthouse-core/test/lib/traces/pwmetrics-events-test.js
@@ -6,8 +6,8 @@
 
 import {strict as assert} from 'assert';
 
-import {readJson} from '../../../../root.js';
 import Metrics from '../../../lib/traces/pwmetrics-events.js';
+import {readJson} from '../../test-utils.js';
 
 const dbwTrace = readJson('../../results/artifacts/defaultPass.trace.json', import.meta);
 const dbwResults = readJson('../../results/sample_v2.json', import.meta);

--- a/lighthouse-core/test/network-records-to-devtools-log-test.js
+++ b/lighthouse-core/test/network-records-to-devtools-log-test.js
@@ -5,8 +5,8 @@
  */
 
 import NetworkRecorder from '../../lighthouse-core/lib/network-recorder.js';
-import {readJson} from '../../root.js';
 import networkRecordsToDevtoolsLog from './network-records-to-devtools-log.js';
+import {readJson} from './test-utils.js';
 
 const lcpDevtoolsLog = readJson('./fixtures/traces/lcp-m78.devtools.log.json', import.meta);
 

--- a/lighthouse-core/test/sample-json-test.js
+++ b/lighthouse-core/test/sample-json-test.js
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {readJson} from '../../root.js';
+import {readJson} from './test-utils.js';
 
 const sampleJson = readJson('./results/sample_v2.json', import.meta);
 

--- a/lighthouse-core/test/test-utils.js
+++ b/lighthouse-core/test/test-utils.js
@@ -16,6 +16,7 @@ import {LH_ROOT} from '../../root.js';
 import * as mockCommands from './gather/mock-commands.js';
 import NetworkRecorder from '../lib/network-recorder.js';
 import {timers} from './test-env/fake-timers.js';
+import {getModuleDirectory} from '../../esm-utils.mjs';
 
 const require = createRequire(import.meta.url);
 
@@ -308,6 +309,22 @@ function requireMock(modulePath, importMeta) {
   return mock;
 }
 
+/**
+ * Return parsed json object.
+ * Resolves path relative to importMeta.url (if provided) or LH_ROOT (if not provided).
+ *
+ * Note: Do not use this in lighthouse-core/ outside tests or scripts, as it
+ * will not be inlined when bundled. Instead, use `fs.readFileSync`.
+ *
+ * @param {string} filePath Can be an absolute or relative path.
+ * @param {ImportMeta=} importMeta
+ */
+function readJson(filePath, importMeta) {
+  const dir = importMeta ? getModuleDirectory(importMeta) : LH_ROOT;
+  filePath = path.resolve(dir, filePath);
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
 export {
   timers,
   getProtoRoundTrip,
@@ -324,4 +341,5 @@ export {
   getURLArtifactFromDevtoolsLog,
   importMock,
   requireMock,
+  readJson,
 };

--- a/report/test/renderer/category-renderer-test.js
+++ b/report/test/renderer/category-renderer-test.js
@@ -13,7 +13,7 @@ import {I18n} from '../../renderer/i18n.js';
 import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {CategoryRenderer} from '../../renderer/category-renderer.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 
 const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 

--- a/report/test/renderer/performance-category-renderer-test.js
+++ b/report/test/renderer/performance-category-renderer-test.js
@@ -14,7 +14,7 @@ import URL from '../../../lighthouse-core/lib/url-shim.js';
 import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {PerformanceCategoryRenderer} from '../../renderer/performance-category-renderer.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 
 const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 

--- a/report/test/renderer/pwa-category-renderer-test.js
+++ b/report/test/renderer/pwa-category-renderer-test.js
@@ -13,7 +13,7 @@ import {I18n} from '../../renderer/i18n.js';
 import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {PwaCategoryRenderer} from '../../renderer/pwa-category-renderer.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 
 const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 

--- a/report/test/renderer/report-renderer-axe-test.js
+++ b/report/test/renderer/report-renderer-axe-test.js
@@ -8,7 +8,7 @@ import puppeteer from 'puppeteer';
 
 import reportGenerator from '../../generator/report-generator.js';
 import axeLib from '../../../lighthouse-core/lib/axe.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 
 const sampleResults = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 

--- a/report/test/renderer/report-renderer-test.js
+++ b/report/test/renderer/report-renderer-test.js
@@ -15,7 +15,7 @@ import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {CategoryRenderer} from '../../renderer/category-renderer.js';
 import {ReportRenderer} from '../../renderer/report-renderer.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 
 const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 

--- a/report/test/renderer/report-ui-features-test.js
+++ b/report/test/renderer/report-ui-features-test.js
@@ -16,7 +16,7 @@ import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {ReportUIFeatures} from '../../renderer/report-ui-features.js';
 import {CategoryRenderer} from '../../renderer/category-renderer.js';
 import {ReportRenderer} from '../../renderer/report-renderer.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 
 const sampleResultsOrig = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 

--- a/report/test/renderer/util-test.js
+++ b/report/test/renderer/util-test.js
@@ -8,7 +8,7 @@ import {strict as assert} from 'assert';
 
 import {Util} from '../../renderer/util.js';
 import {I18n} from '../../renderer/i18n.js';
-import {readJson} from '../../../root.js';
+import {readJson} from '../../../lighthouse-core/test/test-utils.js';
 
 const sampleResult = readJson('../../../lighthouse-core/test/results/sample_v2.json', import.meta);
 

--- a/root.js
+++ b/root.js
@@ -5,24 +5,6 @@
  */
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const url = require('url');
-
-// import {dirname} from 'path';
-// import {fileURLToPath} from 'url';
-
 module.exports = {
   LH_ROOT: __dirname,
-  /**
-   * Return parsed json object.
-   * Resolves path relative to importMeta.url (if provided) or LH_ROOT (if not provided).
-   * @param {string} filePath Can be an absolute or relative path.
-   * @param {ImportMeta=} importMeta
-   */
-  readJson(filePath, importMeta) {
-    const dir = importMeta ? path.dirname(url.fileURLToPath(importMeta.url)) : __dirname;
-    filePath = path.resolve(dir, filePath);
-    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  },
 };


### PR DESCRIPTION
While converting core to ESM I came across a footgun where I used `readJson` inside core/, resulting in the bundled Lighthouse code being wrong (because we don't inline those calls). This large refactor is very simple: move readJson from root.js to test-utils.js, and update 70+ imports 👀 

This is intended to make it very obvious that this function should not be used outside tests or scripts.