### PR TITLE
tests: sync BUILD.gn files for devtools e2e tests

### DIFF
--- a/lighthouse-core/scripts/roll-to-devtools.sh
+++ b/lighthouse-core/scripts/roll-to-devtools.sh
@@ -84,10 +84,10 @@ rsync -avh "$lh_webtests_exp_dir" "$fe_webtests_exp_dir" --exclude="OWNERS" --de
 # copy e2e tests
 lh_e2e_dir="third-party/devtools-tests/e2e/lighthouse/"
 fe_e2e_dir="$dt_dir/test/e2e/lighthouse"
-rsync -avh "$lh_e2e_dir" "$fe_e2e_dir" --exclude="OWNERS" --exclude="BUILD.gn" --delete
+rsync -avh "$lh_e2e_dir" "$fe_e2e_dir" --exclude="OWNERS" --delete
 lh_e2e_res_dir="third-party/devtools-tests/e2e/resources/lighthouse/"
 fe_e2e_res_dir="$dt_dir/test/e2e/resources/lighthouse"
-rsync -avh "$lh_e2e_res_dir" "$fe_e2e_res_dir" --exclude="OWNERS" --exclude="BUILD.gn" --delete
+rsync -avh "$lh_e2e_res_dir" "$fe_e2e_res_dir" --exclude="OWNERS" --delete
 
 echo ""
 echo "Done. To run the webtests: "

--- a/third-party/devtools-tests/README.md
+++ b/third-party/devtools-tests/README.md
@@ -9,6 +9,6 @@ See `lighthouse-core/test/chromium-web-tests/README.md` for more.
 ## Sync
 
 ```sh
-rsync -ahvz --exclude='OWNERS' --exclude='BUILD.gn' ~/src/devtools/devtools-frontend/test/e2e/lighthouse/ third-party/devtools-tests/e2e/lighthouse/
-rsync -ahvz --exclude='OWNERS' --exclude='BUILD.gn' ~/src/devtools/devtools-frontend/test/e2e/resources/lighthouse/ third-party/devtools-tests/e2e/resources/lighthouse/
+rsync -ahvz --exclude='OWNERS' ~/src/devtools/devtools-frontend/test/e2e/lighthouse/ third-party/devtools-tests/e2e/lighthouse/
+rsync -ahvz --exclude='OWNERS' ~/src/devtools/devtools-frontend/test/e2e/resources/lighthouse/ third-party/devtools-tests/e2e/resources/lighthouse/
 ```

--- a/third-party/devtools-tests/e2e/lighthouse/BUILD.gn
+++ b/third-party/devtools-tests/e2e/lighthouse/BUILD.gn
@@ -1,0 +1,17 @@
+# Copyright 2020 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("../../../third_party/typescript/typescript.gni")
+
+node_ts_library("lighthouse") {
+  sources = [
+    "generate-report_test.ts",
+    "indexeddb-warning_test.ts",
+  ]
+
+  deps = [
+    "../../shared",
+    "../helpers",
+  ]
+}

--- a/third-party/devtools-tests/e2e/resources/lighthouse/BUILD.gn
+++ b/third-party/devtools-tests/e2e/resources/lighthouse/BUILD.gn
@@ -1,0 +1,9 @@
+# Copyright 2022 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("../../../../scripts/build/ninja/copy.gni")
+
+copy_to_gen("lighthouse") {
+  sources = [ "lighthouse-storage.html" ]
+}


### PR DESCRIPTION
Unlike with webtests, e2e tests specify each test file in `BUILD.gn` for devtools build system. So we'll need to sync these files otherwise a mismatch in test files will result in build errors / tests not running.