### PR TITLE
misc(lantern-trace-saver): fix request finishTime

### DIFF
--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -154,7 +154,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
       ...requestData,
       decodedBodyLength: record.resourceSize,
       didFail: !!record.failed,
-      finishTime: endTime,
+      finishTime: toMicroseconds(endTime) / (1000 * 1000),
     };
 
     /** @type {LH.TraceEvent[]} */


### PR DESCRIPTION
Incidental to #14166. `finishTime` needs to both start at `baseTs` and to be in seconds.

before
<img width="440" alt="Information about a network request, showing 'Duration 6.31 s (4.7 hrs network transfer + -17010144827 μs resource loading)'" src="https://user-images.githubusercontent.com/316891/176305786-d3e908df-acd0-4f93-9f79-2635393ab803.png">

after
<img width="352" alt="Information about a network request, showing 'Duration 6.31 s (6.31 s network transfer + 0 resource loading)'" src="https://user-images.githubusercontent.com/316891/177870160-043cac39-5935-4efc-a4e5-02896e1f4ef8.png">
