### PR TITLE
i18n: fix collect-strings on windows with pathToFileURL

### DIFF
--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -38,7 +38,7 @@ const foldersWithStrings = [
   `${LH_ROOT}/report/renderer`,
   `${LH_ROOT}/treemap`,
   `${LH_ROOT}/flow-report`,
-  path.join(path.dirname(resolveModulePath('lighthouse-stack-packs')), 'packs'),
+  path.dirname(resolveModulePath('lighthouse-stack-packs')) + '/packs',
 ];
 
 const ignoredPathComponents = [

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -9,6 +9,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import {pathToFileURL} from 'url';
 
 import glob from 'glob';
 import {expect} from 'expect';
@@ -22,7 +23,6 @@ import {pruneObsoleteLhlMessages} from './prune-obsolete-lhl-messages.js';
 import {countTranslatedMessages} from './count-translated.js';
 import {LH_ROOT} from '../../../root.js';
 import {resolveModulePath} from '../../../esm-utils.mjs';
-import {pathToFileURL} from 'url';
 
 // Match declarations of UIStrings, terminating in either a `};\n` (very likely to always be right)
 // or `}\n\n` (allowing semicolon to be optional, but insisting on a double newline so that an

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -22,6 +22,7 @@ import {pruneObsoleteLhlMessages} from './prune-obsolete-lhl-messages.js';
 import {countTranslatedMessages} from './count-translated.js';
 import {LH_ROOT} from '../../../root.js';
 import {resolveModulePath} from '../../../esm-utils.mjs';
+import {pathToFileURL} from 'url';
 
 // Match declarations of UIStrings, terminating in either a `};\n` (very likely to always be right)
 // or `}\n\n` (allowing semicolon to be optional, but insisting on a double newline so that an
@@ -37,7 +38,7 @@ const foldersWithStrings = [
   `${LH_ROOT}/report/renderer`,
   `${LH_ROOT}/treemap`,
   `${LH_ROOT}/flow-report`,
-  path.dirname(resolveModulePath('lighthouse-stack-packs')) + '/packs',
+  path.join(path.dirname(resolveModulePath('lighthouse-stack-packs')), 'packs'),
 ];
 
 const ignoredPathComponents = [
@@ -552,7 +553,7 @@ async function collectAllStringsInDir(dir) {
     if (!process.env.CI) console.log('Collecting from', relativeToRootPath);
 
     const content = fs.readFileSync(absolutePath, 'utf8');
-    const exportVars = await import(absolutePath);
+    const exportVars = await import(pathToFileURL(absolutePath).href);
     const regexMatch = content.match(UISTRINGS_REGEX);
     const exportedUIStrings = exportVars.UIStrings || exportVars.default?.UIStrings;
 


### PR DESCRIPTION
Fixes this error on master:

```
====
Collecting strings from C:\Users\cjamc\code\lighthouse/lighthouse-core
====
Collecting from lighthouse-core/audits/accessibility/accesskeys.js
Waiting for the debugger to disconnect...
node:internal/errors:465
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at new NodeError (node:internal/errors:372:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1120:11)
    at defaultResolve (node:internal/modules/esm/resolve:1200:3)
    at ESMLoader.resolve (node:internal/modules/esm/loader:580:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:294:18)
    at ESMLoader.import (node:internal/modules/esm/loader:380:22)
    at importModuleDynamically (node:internal/modules/esm/translators:106:35)
    at importModuleDynamicallyCallback (node:internal/process/esm_loader:35:14)
    at collectAllStringsInDir (file:///C:/Users/cjamc/code/lighthouse/lighthouse-core/scripts/i18n/collect-strings.js:555:24)
    at main (file:///C:/Users/cjamc/code/lighthouse/lighthouse-core/scripts/i18n/collect-strings.js:693:31) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
```