### PR TITLE
tests(smoke): use DevTools runner through node directly

### DIFF
--- a/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
+++ b/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
@@ -184,7 +184,7 @@ async function begin() {
   if (argv.runner === 'bundle') {
     console.log('\n✨ Be sure to have recently run this: yarn build-all');
   }
-  const {runLighthouse} = await import(runnerPath);
+  const {runLighthouse, setup} = await import(runnerPath);
   runLighthouse.runnerName = argv.runner;
 
   // Find test definition file and filter by requestedTestIds.
@@ -219,6 +219,7 @@ async function begin() {
       useLegacyNavigation: argv.legacyNavigation,
       lighthouseRunner: runLighthouse,
       takeNetworkRequestUrls,
+      setup,
     };
 
     smokehouseResult = (await runSmokehouse(prunedTestDefns, options));

--- a/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
+++ b/lighthouse-cli/test/smokehouse/frontends/smokehouse-bin.js
@@ -206,8 +206,8 @@ async function begin() {
     // If running the core tests, spin up the test server.
     if (testDefnPath === coreTestDefnsPath) {
       ({server, serverForOffline} = await import('../../fixtures/static-server.js'));
-      server.listen(10200, 'localhost');
-      serverForOffline.listen(10503, 'localhost');
+      await server.listen(10200, 'localhost');
+      await serverForOffline.listen(10503, 'localhost');
       takeNetworkRequestUrls = server.takeRequestUrls.bind(server);
     }
 

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -15,15 +15,13 @@ import {execFileSync} from 'child_process';
 import {LH_ROOT} from '../../../../root.js';
 import {testUrlFromDevtools} from '../../../../lighthouse-core/scripts/pptr-run-devtools.js';
 
-/** @type {Promise<void>} */
-let buildDevtoolsPromise;
 const devtoolsDir =
   process.env.DEVTOOLS_PATH || `${LH_ROOT}/.tmp/chromium-web-tests/devtools/devtools-frontend`;
 
 /**
  * Download/pull latest DevTools, build Lighthouse for DevTools, roll to DevTools, and build DevTools.
  */
-async function buildDevtools() {
+async function setup() {
   if (process.env.CI) return;
 
   process.env.DEVTOOLS_PATH = devtoolsDir;
@@ -48,9 +46,6 @@ async function buildDevtools() {
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>}
  */
 async function runLighthouse(url, configJson, testRunnerOptions = {}) {
-  if (!buildDevtoolsPromise) buildDevtoolsPromise = buildDevtools();
-  await buildDevtoolsPromise;
-
   const chromeFlags = [
     `--custom-devtools-frontend=file://${devtoolsDir}/out/Default/gen/front_end`,
   ];
@@ -69,4 +64,5 @@ async function runLighthouse(url, configJson, testRunnerOptions = {}) {
 
 export {
   runLighthouse,
+  setup,
 };

--- a/lighthouse-cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/lighthouse-cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -10,7 +10,7 @@
 
 import fs from 'fs';
 import os from 'os';
-import {execFile} from 'child_process';
+import {execFileSync} from 'child_process';
 
 import {LH_ROOT} from '../../../../root.js';
 import {testUrlFromDevtools} from '../../../../lighthouse-core/scripts/pptr-run-devtools.js';
@@ -21,33 +21,20 @@ const devtoolsDir =
   process.env.DEVTOOLS_PATH || `${LH_ROOT}/.tmp/chromium-web-tests/devtools/devtools-frontend`;
 
 /**
- * @param {string} command
- * @param {string[]} args
- * @return {Promise<void>}
- */
-function execAndLog(command, args) {
-  return new Promise((resolve, reject) => {
-    const handle = execFile(command, args, (error) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
-    });
-    handle.stdout?.pipe(process.stdout);
-    handle.stderr?.pipe(process.stderr);
-  });
-}
-
-/**
  * Download/pull latest DevTools, build Lighthouse for DevTools, roll to DevTools, and build DevTools.
  */
 async function buildDevtools() {
   if (process.env.CI) return;
 
   process.env.DEVTOOLS_PATH = devtoolsDir;
-  await execAndLog('bash', ['lighthouse-core/test/devtools-tests/download-devtools.sh']);
-  await execAndLog('bash', ['lighthouse-core/test/devtools-tests/roll-devtools.sh']);
+  execFileSync('bash',
+    ['lighthouse-core/test/devtools-tests/download-devtools.sh'],
+    {stdio: 'inherit'}
+  );
+  execFileSync('bash',
+    ['lighthouse-core/test/devtools-tests/roll-devtools.sh'],
+    {stdio: 'inherit'}
+  );
 }
 
 /**

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -58,9 +58,12 @@ async function runSmokehouse(smokeTestDefns, smokehouseOptions) {
     retries = DEFAULT_RETRIES,
     lighthouseRunner = Object.assign(cliLighthouseRunner, {runnerName: 'cli'}),
     takeNetworkRequestUrls,
+    setup,
   } = smokehouseOptions;
   assertPositiveInteger('jobs', jobs);
   assertNonNegativeInteger('retries', retries);
+
+  await setup?.();
 
   // Run each testDefn in parallel based on the concurrencyLimit.
   const concurrentMapper = new ConcurrentMapper();

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -63,7 +63,13 @@ async function runSmokehouse(smokeTestDefns, smokehouseOptions) {
   assertPositiveInteger('jobs', jobs);
   assertNonNegativeInteger('retries', retries);
 
-  await setup?.();
+  try {
+    await setup?.();
+  } catch (err) {
+    console.error(log.redify('\nERROR DURING SETUP:'));
+    console.error(log.redify(err.stack || err));
+    return {success: false, testResults: []};
+  }
 
   // Run each testDefn in parallel based on the concurrencyLimit.
   const concurrentMapper = new ConcurrentMapper();

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -251,7 +251,7 @@ function logChildProcessError(localConsole, err) {
     localConsole.adoptStdStrings(err);
   }
 
-  localConsole.log(log.redify('Error: ') + err + '\n' + err.stack);
+  localConsole.log(log.redify(err.stack || err.message));
 }
 
 /**

--- a/lighthouse-core/scripts/pptr-run-devtools.js
+++ b/lighthouse-core/scripts/pptr-run-devtools.js
@@ -222,6 +222,9 @@ async function runLighthouse() {
  * @param {LH.Config.Json} config
  */
 async function installCustomLighthouseConfig(browser, inspectorSession, config) {
+  // Prevent modification for tests that are retried.
+  config = JSON.parse(JSON.stringify(config));
+
   // Screen emulation is handled by DevTools, so we should avoid adding our own.
   if (config.settings?.screenEmulation) {
     throw new Error(

--- a/lighthouse-core/scripts/pptr-run-devtools.js
+++ b/lighthouse-core/scripts/pptr-run-devtools.js
@@ -57,6 +57,54 @@ const argv = /** @type {Awaited<typeof argv_>} */ (argv_);
 const config = argv.config ? JSON.parse(argv.config) : undefined;
 
 /**
+ * @template R [unknown]
+ * @param {puppeteer.CDPSession} session
+ * @param {string|(() => (R|Promise<R>))} fn
+ * @param {Function[]} [deps]
+ * @return {Promise<R>}
+ */
+async function evaluateInSession(session, fn, deps) {
+  const depsSerialized = deps ? deps.join('\n') : '';
+
+  const expression = `(() => {
+    ${depsSerialized}
+    return (${fn.toString()})();
+  })()`;
+  const {result, exceptionDetails} = await session.send('Runtime.evaluate', {
+    awaitPromise: true,
+    returnByValue: true,
+    expression,
+  });
+
+  if (exceptionDetails) {
+    const text = exceptionDetails.exception?.description || exceptionDetails.text;
+    const name = typeof fn === 'string' ? '<stringified>' : fn.name;
+    throw new Error(`Evaluation exception: ${text}\n    at ${name} (Runtime.evaluate)`);
+  }
+
+  return result.value;
+}
+
+/**
+ * @template R [unknown]
+ * @param {puppeteer.CDPSession} session
+ * @param {() => (R|Promise<R>)} fn
+ * @param {Function[]} [deps]
+ * @return {Promise<R>}
+ */
+async function waitForFunction(session, fn, deps) {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await evaluateInSession(session, fn, deps);
+    } catch {
+      await new Promise(r => setTimeout(r, 500));
+    }
+  }
+}
+
+/* eslint-disable */
+/**
  * https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/test_runner/TestRunner.js;l=170;drc=f59e6de269f4f50bca824f8ca678d5906c7d3dc8
  * @param {Record<string, function>} receiver
  * @param {string} methodName
@@ -89,57 +137,33 @@ function addSniffer(receiver, methodName, override) {
   };
 }
 
-const sniffLhr = `
-new Promise(resolve => {
-  const panel = UI.panels.lighthouse || UI.panels.audits;
-  const methodName = panel.__proto__.buildReportUI ?
-    'buildReportUI' : '_buildReportUI';
-  (${addSniffer.toString()})(
-    panel.__proto__,
-    methodName,
-    (lhr, artifacts) => resolve({lhr, artifacts})
-  );
-});
-`;
-
-const sniffLighthouseStarted = `
-new Promise(resolve => {
-  const panel = UI.panels.lighthouse || UI.panels.audits;
-  const protocolService = panel.protocolService || panel._protocolService;
-  const functionName = protocolService.__proto__.startLighthouse ?
-    'startLighthouse' :
-    'collectLighthouseResults';
-  (${addSniffer.toString()})(
-    protocolService.__proto__,
-    functionName,
-    (inspectedURL) => resolve(inspectedURL)
-  );
-});
-`;
-
-const startLighthouse = `
-(async () => {
+async function waitForLighthouseReady() {
+  // @ts-expect-error global
   const viewManager = UI.viewManager || (UI.ViewManager.ViewManager || UI.ViewManager).instance();
   const views = viewManager.views || viewManager._views;
   const panelName = views.has('lighthouse') ? 'lighthouse' : 'audits';
   await viewManager.showView(panelName);
 
+  // @ts-expect-error global
   const panel = UI.panels.lighthouse || UI.panels.audits;
   const button = panel.contentElement.querySelector('button');
   if (button.disabled) throw new Error('Start button disabled');
 
+  // @ts-expect-error global
   UI.dockController.setDockSide('undocked');
 
   // Give the main target model a moment to be available.
   // Otherwise, 'SDK.TargetManager.TargetManager.instance().mainTarget()' is null.
+  // @ts-expect-error global
   if (self.runtime && self.runtime.loadLegacyModule) {
     // This exposes TargetManager via self.SDK.
     try {
+    // @ts-expect-error global
       await self.runtime.loadLegacyModule('core/sdk/sdk-legacy.js');
     } catch {}
   }
-  const targetManager =
-    SDK.targetManager || (SDK.TargetManager.TargetManager || SDK.TargetManager).instance();
+  // @ts-expect-error global
+  const targetManager = SDK.targetManager || (SDK.TargetManager.TargetManager || SDK.TargetManager).instance();
   if (targetManager.mainTarget() === null) {
     if (targetManager?.observeTargets) {
       await new Promise(resolve => targetManager.observeTargets({
@@ -152,122 +176,146 @@ const startLighthouse = `
       }
     }
   }
+}
 
+async function runLighthouse() {
+  // @ts-expect-error global
+  const panel = UI.panels.lighthouse || UI.panels.audits;
+
+  /** @type {Promise<{lhr: LH.Result, artifacts: LH.Artifacts}>} */
+  const resultPromise = new Promise((resolve, reject) => {
+    const methodName = panel.__proto__.buildReportUI ?
+      'buildReportUI' : '_buildReportUI';
+    addSniffer(
+      panel.__proto__,
+      methodName,
+      // @ts-expect-error implicit any
+      (lhr, artifacts) => resolve({lhr, artifacts})
+    );
+
+    addSniffer(
+      panel.statusView.__proto__,
+      'renderBugReport',
+      // @ts-expect-error implicit any
+      (err) => reject(err)
+    );
+  });
+
+  const button = panel.contentElement.querySelector('button');
   button.click();
-})()
-`;
+
+  return resultPromise;
+}
+/* eslint-enable */
 
 /**
- * @param {string} url
+ * @param {puppeteer.Browser} browser
+ * @param {puppeteer.CDPSession} inspectorSession
+ * @param {LH.Config.Json} config
  */
-function isValidUrl(url) {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
+async function installCustomConfig(browser, inspectorSession, config) {
+  // Screen emulation is handled by DevTools, so we should avoid adding our own.
+  if (config.settings?.screenEmulation) {
+    throw new Error('Configs that modify device emulation are unsupported in DevTools');
   }
+  if (!config.settings) config.settings = {};
+  config.settings.screenEmulation = {disabled: true};
+
+  const workerTarget = await browser.waitForTarget(t => t.url().includes('lighthouse_worker'));
+
+  // Ensure the inspector is paused once the worker is initialized so Lighthouse doesn't start prematurely.
+  await Promise.all([
+    inspectorSession.send('Runtime.enable'),
+    inspectorSession.send('Debugger.enable'),
+  ]);
+  await inspectorSession.send('Debugger.pause');
+
+  const workerSession = await workerTarget.createCDPSession();
+  await Promise.all([
+    workerSession.send('Runtime.enable'),
+    workerSession.send('Debugger.enable'),
+    workerSession.send('Runtime.runIfWaitingForDebugger'),
+    new Promise(resolve => {
+      workerSession.once('Debugger.scriptParsed', resolve);
+    }),
+  ]);
+  await evaluateInSession(workerSession,
+    `self.createConfig = () => (${JSON.stringify(config)})`
+  );
+
+  await inspectorSession.send('Debugger.resume');
 }
 
 /**
- * @param {LH.Puppeteer.Page} page
- * @param {LH.Puppeteer.Browser} browser
+ * @param {puppeteer.CDPSession} inspectorSession
+ * @param {string[]} logs
+ */
+async function installConsoleListener(inspectorSession, logs) {
+  inspectorSession.on('Log.entryAdded', ({entry}) => {
+    if (entry.level === 'verbose') return;
+    logs.push(`LOG[${entry.level}]: ${entry.text}\n`);
+  });
+  inspectorSession.on('Runtime.exceptionThrown', ({exceptionDetails}) => {
+    const text = exceptionDetails.exception?.description || exceptionDetails.text;
+    logs.push(`EXCEPTION: ${text}\n`);
+  });
+  await inspectorSession.send('Log.enable');
+}
+
+/**
  * @param {string} url
  * @param {LH.Config.Json=} config
- * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts}>}
+ * @param {string[]=} chromeFlags
+ * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, logs: string[]}>}
  */
-async function testPage(page, browser, url, config) {
-  const targets = await browser.targets();
-  const inspectorTarget = targets.filter(t => t.url().includes('devtools'))[1];
-  if (!inspectorTarget) throw new Error('No inspector found.');
-
-  const session = await inspectorTarget.createCDPSession();
-  await session.send('Runtime.enable');
-
-  // Navigate to page and wait for initial HTML to be parsed before trying to start LH.
-  await new Promise((resolve, reject) => {
-    page.target().createCDPSession()
-      .then(session => {
-        session.send('Page.enable').then(() => {
-          session.once('Page.domContentEventFired', resolve);
-          page.goto(url);
-        });
-      })
-      .catch(reject);
+async function testUrlFromDevtools(url, config, chromeFlags) {
+  const browser = await puppeteer.launch({
+    executablePath: getChromePath(),
+    args: chromeFlags,
+    devtools: true,
   });
 
-  if (config) {
-    // Must attach to the Lighthouse worker target and override the `self.createConfig`
-    // function, allowing us to use any config we want.
-    session.send('Target.setAutoAttach', {
-      autoAttach: true, flatten: true, waitForDebuggerOnStart: false,
-    });
-    session.once('Target.attachedToTarget', async (event) => {
-      if (event.targetInfo.type !== 'worker') throw new Error('expected lighthouse worker');
+  try {
+    if ((await browser.version()).startsWith('Headless')) {
+      throw new Error('You cannot use headless');
+    }
 
-      const targets = await browser.targets();
-      const workerTarget = targets.find(t => t._targetId === event.targetInfo.targetId);
-      if (!workerTarget) throw new Error('No lighthouse worker target found.');
+    const page = (await browser.pages())[0];
 
-      const workerSession = await workerTarget.createCDPSession();
-      await Promise.all([
-        workerSession.send('Runtime.enable'),
-        workerSession.send('Debugger.enable'),
-        new Promise(resolve => {
-          workerSession.once('Debugger.scriptParsed', resolve);
-        }),
-      ]);
-      await workerSession.send('Debugger.pause');
-      await workerSession.send('Runtime.evaluate', {
-        expression: `self.createConfig = () => (${JSON.stringify(config)});`,
+    const inspectorTarget = await browser.waitForTarget(t => t.url().includes('devtools'));
+    const inspectorSession = await inspectorTarget.createCDPSession();
+
+    /** @type {string[]} */
+    const logs = [];
+    await installConsoleListener(inspectorSession, logs);
+
+    await page.goto(url, {waitUntil: ['domcontentloaded']});
+
+    await waitForFunction(inspectorSession, waitForLighthouseReady);
+
+    let configPromise = Promise.resolve();
+    if (config) {
+      // Must attach to the Lighthouse worker target and override the `self.createConfig`
+      // function, allowing us to use any config we want.
+      // This needs to be done *before* starting Lighthouse, otherwise the config may not be installed in time.
+      await inspectorSession.send('Target.setAutoAttach', {
+        autoAttach: true,
+        flatten: true,
+        waitForDebuggerOnStart: true,
       });
-      await workerSession.send('Debugger.resume');
-    });
-  }
 
-  /** @type {Omit<LH.Puppeteer.Protocol.Runtime.EvaluateResponse, 'result'>|undefined} */
-  let startLHResponse;
-  while (!startLHResponse || startLHResponse.exceptionDetails) {
-    if (startLHResponse) await new Promise(resolve => setTimeout(resolve, 1000));
-    startLHResponse = await session.send('Runtime.evaluate', {
-      expression: startLighthouse,
-      awaitPromise: true,
-    }).catch(err => ({exceptionDetails: err}));
-  }
+      configPromise = installCustomConfig(browser, inspectorSession, config);
+    }
 
-  /** @type {LH.Puppeteer.Protocol.Runtime.EvaluateResponse} */
-  const lhStartedResponse = await session.send('Runtime.evaluate', {
-    expression: sniffLighthouseStarted,
-    awaitPromise: true,
-    returnByValue: true,
-  }).catch(err => err);
-  // Verify the first parameter to `startLighthouse`, which should be a url.
-  // In M100 the LHR is returned on `collectLighthouseResults` which has just 1 options parameter containing `inspectedUrl`.
-  // Don't try to check the exact value (because of redirects and such), just
-  // make sure it exists.
-  if (
-    !isValidUrl(lhStartedResponse.result.value) &&
-    !isValidUrl(lhStartedResponse.result.value.inspectedURL)
-  ) {
-    throw new Error(`Lighthouse did not start correctly. Got unexpected value for url: ${
-      JSON.stringify(lhStartedResponse.result.value)}`);
-  }
+    const [result] = await Promise.all([
+      evaluateInSession(inspectorSession, runLighthouse, [addSniffer]),
+      configPromise,
+    ]);
 
-  /** @type {LH.Puppeteer.Protocol.Runtime.EvaluateResponse} */
-  const remoteLhrResponse = await session.send('Runtime.evaluate', {
-    expression: sniffLhr,
-    awaitPromise: true,
-    returnByValue: true,
-  }).catch(err => err);
-
-  if (!remoteLhrResponse.result?.value?.lhr) {
-    throw new Error('Problem sniffing LHR.');
+    return {...result, logs};
+  } finally {
+    await browser.close();
   }
-  if (!remoteLhrResponse.result?.value?.artifacts) {
-    throw new Error('Problem sniffing artifacts.');
-  }
-
-  return remoteLhrResponse.result.value;
 }
 
 /**
@@ -316,20 +364,9 @@ async function run() {
     }
   }
 
-  const browser = await puppeteer.launch({
-    executablePath: getChromePath(),
-    args: chromeFlags,
-    devtools: true,
-  });
-
-  if ((await browser.version()).startsWith('Headless')) {
-    throw new Error('You cannot use headless');
-  }
-
   let errorCount = 0;
   const urlList = await readUrlList();
   for (let i = 0; i < urlList.length; ++i) {
-    const page = await browser.newPage();
     try {
       /** @type {NodeJS.Timeout} */
       let timeout;
@@ -337,7 +374,7 @@ async function run() {
         timeout = setTimeout(reject, 100_000, new Error('Timed out waiting for Lighthouse to run'));
       });
       const {lhr, artifacts} = await Promise.race([
-        testPage(page, browser, urlList[i], config),
+        testUrlFromDevtools(urlList[i], config, chromeFlags),
         timeoutPromise,
       ]).finally(() => {
         clearTimeout(timeout);
@@ -349,17 +386,16 @@ async function run() {
       errorCount += 1;
       console.error(error.message);
       fs.writeFileSync(`${argv.o}/lhr-${i}.json`, JSON.stringify({error: error.message}, null, 2));
-    } finally {
-      try {
-        await page.close();
-      } catch {}
     }
   }
   console.log(`${urlList.length - errorCount} / ${urlList.length} urls run successfully.`);
   console.log(`Results saved to ${argv.o}`);
 
-  await browser.close();
-
   if (errorCount) process.exit(1);
 }
-run();
+
+if (process.argv.includes(import.meta.url.replace('file://', ''))) {
+  run();
+}
+
+export {testUrlFromDevtools};

--- a/lighthouse-core/scripts/pptr-run-devtools.js
+++ b/lighthouse-core/scripts/pptr-run-devtools.js
@@ -224,7 +224,10 @@ async function runLighthouse() {
 async function installCustomLighthouseConfig(browser, inspectorSession, config) {
   // Screen emulation is handled by DevTools, so we should avoid adding our own.
   if (config.settings?.screenEmulation) {
-    throw new Error('Configs that modify device emulation are unsupported in DevTools');
+    throw new Error(
+      'Configs that modify device emulation are unsupported in DevTools:\n' +
+      JSON.stringify(config, null, 2)
+    );
   }
   if (!config.settings) config.settings = {};
   config.settings.screenEmulation = {disabled: true};

--- a/lighthouse-core/scripts/pptr-run-devtools.js
+++ b/lighthouse-core/scripts/pptr-run-devtools.js
@@ -189,15 +189,17 @@ async function runLighthouse() {
     addSniffer(
       panel.__proto__,
       methodName,
-      // @ts-expect-error implicit any
+      /**
+       * @param {LH.Result} lhr
+       * @param {LH.Artifacts} artifacts
+       */
       (lhr, artifacts) => resolve({lhr, artifacts})
     );
 
     addSniffer(
       panel.statusView.__proto__,
       'renderBugReport',
-      // @ts-expect-error implicit any
-      (err) => reject(err)
+      reject,
     );
   });
 

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -67,6 +67,8 @@ declare global {
       lighthouseRunner?: LighthouseRunner;
       /** A function that gets a list of URLs requested to the server since the last fetch. */
       takeNetworkRequestUrls?: () => string[];
+      /** A function run once before all smoke tests. */
+      setup?: () => Promise<void>;
     }
 
     export interface SmokehouseLibOptions extends SmokehouseOptions {


### PR DESCRIPTION
Split out from https://github.com/GoogleChrome/lighthouse/pull/14199 since this should benefit our smokes on macos as well.

See my comments in https://github.com/GoogleChrome/lighthouse/pull/14199#pullrequestreview-1034763811 for the highlights.
