### PR TITLE
core(i18n): delete `i18n.createMessageInstanceIdFn`

### DIFF
--- a/build/build-cdt-strings.js
+++ b/build/build-cdt-strings.js
@@ -68,7 +68,7 @@ import * as i18n from '../lib/i18n/i18n.js';
 
 ${uiStringsDeclare}
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @param {LH.Crdp.Audits.DeprecationIssueDetails} issueDetails

--- a/core/audits/accessibility/accesskeys.js
+++ b/core/audits/accessibility/accesskeys.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn more about access keys](https://dequeuniversity.com/rules/axe/4.4/accesskeys).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class Accesskeys extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-allowed-attr.js
+++ b/core/audits/accessibility/aria-allowed-attr.js
@@ -25,7 +25,7 @@ const UIStrings = {
       'how to match ARIA attributes to their roles](https://dequeuniversity.com/rules/axe/4.4/aria-allowed-attr).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ARIAAllowedAttr extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-command-name.js
+++ b/core/audits/accessibility/aria-command-name.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn how to make command elements more accessible](https://dequeuniversity.com/rules/axe/4.4/aria-command-name).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaCommandName extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-hidden-body.js
+++ b/core/audits/accessibility/aria-hidden-body.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'Assistive technologies, like screen readers, work inconsistently when `aria-hidden="true"` is set on the document `<body>`. [Learn how `aria-hidden` affects the document body](https://dequeuniversity.com/rules/axe/4.4/aria-hidden-body).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaHiddenBody extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-hidden-focus.js
+++ b/core/audits/accessibility/aria-hidden-focus.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'Focusable descendents within an `[aria-hidden="true"]` element prevent those interactive elements from being available to users of assistive technologies like screen readers. [Learn how `aria-hidden` affects focusable elements](https://dequeuniversity.com/rules/axe/4.4/aria-hidden-focus).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaHiddenFocus extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-input-field-name.js
+++ b/core/audits/accessibility/aria-input-field-name.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'When an input field doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more about input field labels](https://dequeuniversity.com/rules/axe/4.4/aria-input-field-name).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaInputFieldName extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-meter-name.js
+++ b/core/audits/accessibility/aria-meter-name.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn how to name `meter` elements](https://dequeuniversity.com/rules/axe/4.4/aria-meter-name).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaMeterName extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-progressbar-name.js
+++ b/core/audits/accessibility/aria-progressbar-name.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'When a `progressbar` element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn how to label `progressbar` elements](https://dequeuniversity.com/rules/axe/4.4/aria-progressbar-name).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaProgressbarName extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-required-attr.js
+++ b/core/audits/accessibility/aria-required-attr.js
@@ -24,7 +24,7 @@ const UIStrings = {
       'of the element to screen readers. [Learn more about roles and required attributes](https://dequeuniversity.com/rules/axe/4.4/aria-required-attr).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ARIARequiredAttr extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-required-children.js
+++ b/core/audits/accessibility/aria-required-children.js
@@ -28,7 +28,7 @@ const UIStrings = {
       '[Learn more about roles and required children elements](https://dequeuniversity.com/rules/axe/4.4/aria-required-children).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaRequiredChildren extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-required-parent.js
+++ b/core/audits/accessibility/aria-required-parent.js
@@ -26,7 +26,7 @@ const UIStrings = {
       '[Learn more about ARIA roles and required parent element](https://dequeuniversity.com/rules/axe/4.4/aria-required-parent).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaRequiredParent extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-roles.js
+++ b/core/audits/accessibility/aria-roles.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn more about valid ARIA roles](https://dequeuniversity.com/rules/axe/4.4/aria-roles).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaRoles extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-toggle-field-name.js
+++ b/core/audits/accessibility/aria-toggle-field-name.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'When a toggle field doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more about toggle fields](https://dequeuniversity.com/rules/axe/4.4/aria-toggle-field-name).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaToggleFieldName extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-tooltip-name.js
+++ b/core/audits/accessibility/aria-tooltip-name.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn how to name `tooltip` elements](https://dequeuniversity.com/rules/axe/4.4/aria-tooltip-name).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaTooltipName extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-treeitem-name.js
+++ b/core/audits/accessibility/aria-treeitem-name.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'When a `treeitem` element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more about labeling `treeitem` elements](https://dequeuniversity.com/rules/axe/4.4/aria-treeitem-name).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AriaTreeitemName extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-valid-attr-value.js
+++ b/core/audits/accessibility/aria-valid-attr-value.js
@@ -25,7 +25,7 @@ const UIStrings = {
       'more about valid values for ARIA attributes](https://dequeuniversity.com/rules/axe/4.4/aria-valid-attr-value).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ARIAValidAttr extends AxeAudit {
   /**

--- a/core/audits/accessibility/aria-valid-attr.js
+++ b/core/audits/accessibility/aria-valid-attr.js
@@ -25,7 +25,7 @@ const UIStrings = {
       'more about valid ARIA attributes](https://dequeuniversity.com/rules/axe/4.4/aria-valid-attr).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ARIAValidAttr extends AxeAudit {
   /**

--- a/core/audits/accessibility/axe-audit.js
+++ b/core/audits/accessibility/axe-audit.js
@@ -19,7 +19,7 @@ const UIStrings = {
   failingElementsHeader: 'Failing Elements',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class AxeAudit extends Audit {
   /**

--- a/core/audits/accessibility/button-name.js
+++ b/core/audits/accessibility/button-name.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn how to make buttons more accessible](https://dequeuniversity.com/rules/axe/4.4/button-name).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ButtonName extends AxeAudit {
   /**

--- a/core/audits/accessibility/bypass.js
+++ b/core/audits/accessibility/bypass.js
@@ -26,7 +26,7 @@ const UIStrings = {
       '[Learn more about bypass blocks](https://dequeuniversity.com/rules/axe/4.4/bypass).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class Bypass extends AxeAudit {
   /**

--- a/core/audits/accessibility/color-contrast.js
+++ b/core/audits/accessibility/color-contrast.js
@@ -26,7 +26,7 @@ const UIStrings = {
       '[Learn how to provide sufficient color contrast](https://dequeuniversity.com/rules/axe/4.4/color-contrast).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ColorContrast extends AxeAudit {
   /**

--- a/core/audits/accessibility/definition-list.js
+++ b/core/audits/accessibility/definition-list.js
@@ -27,7 +27,7 @@ const UIStrings = {
       '[Learn how to structure definition lists correctly](https://dequeuniversity.com/rules/axe/4.4/definition-list).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class DefinitionList extends AxeAudit {
   /**

--- a/core/audits/accessibility/dlitem.js
+++ b/core/audits/accessibility/dlitem.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn how to structure definition lists correctly](https://dequeuniversity.com/rules/axe/4.4/dlitem).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class DLItem extends AxeAudit {
   /**

--- a/core/audits/accessibility/document-title.js
+++ b/core/audits/accessibility/document-title.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn more about document titles](https://dequeuniversity.com/rules/axe/4.4/document-title).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class DocumentTitle extends AxeAudit {
   /**

--- a/core/audits/accessibility/duplicate-id-active.js
+++ b/core/audits/accessibility/duplicate-id-active.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'All focusable elements must have a unique `id` to ensure that they\'re visible to assistive technologies. [Learn how to fix duplicate `id`s](https://dequeuniversity.com/rules/axe/4.4/duplicate-id-active).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class DuplicateIdActive extends AxeAudit {
   /**

--- a/core/audits/accessibility/duplicate-id-aria.js
+++ b/core/audits/accessibility/duplicate-id-aria.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'The value of an ARIA ID must be unique to prevent other instances from being overlooked by assistive technologies. [Learn how to fix duplicate ARIA IDs](https://dequeuniversity.com/rules/axe/4.4/duplicate-id-aria).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class DuplicateIdAria extends AxeAudit {
   /**

--- a/core/audits/accessibility/form-field-multiple-labels.js
+++ b/core/audits/accessibility/form-field-multiple-labels.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'Form fields with multiple labels can be confusingly announced by assistive technologies like screen readers which use either the first, the last, or all of the labels. [Learn how to use form labels](https://dequeuniversity.com/rules/axe/4.4/form-field-multiple-labels).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class FormFieldMultipleLabels extends AxeAudit {
   /**

--- a/core/audits/accessibility/frame-title.js
+++ b/core/audits/accessibility/frame-title.js
@@ -24,7 +24,7 @@ const UIStrings = {
       '[Learn more about frame titles](https://dequeuniversity.com/rules/axe/4.4/frame-title).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class FrameTitle extends AxeAudit {
   /**

--- a/core/audits/accessibility/heading-order.js
+++ b/core/audits/accessibility/heading-order.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'Properly ordered headings that do not skip levels convey the semantic structure of the page, making it easier to navigate and understand when using assistive technologies. [Learn more about heading order](https://dequeuniversity.com/rules/axe/4.4/heading-order).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class HeadingOrder extends AxeAudit {
   /**

--- a/core/audits/accessibility/html-has-lang.js
+++ b/core/audits/accessibility/html-has-lang.js
@@ -27,7 +27,7 @@ const UIStrings = {
       '[Learn more about the `lang` attribute](https://dequeuniversity.com/rules/axe/4.4/html-has-lang).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class HTMLHasLang extends AxeAudit {
   /**

--- a/core/audits/accessibility/html-lang-valid.js
+++ b/core/audits/accessibility/html-lang-valid.js
@@ -26,7 +26,7 @@ const UIStrings = {
       '[Learn how to use the `lang` attribute](https://dequeuniversity.com/rules/axe/4.4/html-lang-valid).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class HTMLLangValid extends AxeAudit {
   /**

--- a/core/audits/accessibility/image-alt.js
+++ b/core/audits/accessibility/image-alt.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn more about the `alt` attribute](https://dequeuniversity.com/rules/axe/4.4/image-alt).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ImageAlt extends AxeAudit {
   /**

--- a/core/audits/accessibility/input-image-alt.js
+++ b/core/audits/accessibility/input-image-alt.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn about input image alt text](https://dequeuniversity.com/rules/axe/4.4/input-image-alt).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class InputImageAlt extends AxeAudit {
   /**

--- a/core/audits/accessibility/label.js
+++ b/core/audits/accessibility/label.js
@@ -25,7 +25,7 @@ const UIStrings = {
       'more about form element labels](https://dequeuniversity.com/rules/axe/4.4/label).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class Label extends AxeAudit {
   /**

--- a/core/audits/accessibility/link-name.js
+++ b/core/audits/accessibility/link-name.js
@@ -26,7 +26,7 @@ const UIStrings = {
       '[Learn how to make links accessible](https://dequeuniversity.com/rules/axe/4.4/link-name).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class LinkName extends AxeAudit {
   /**

--- a/core/audits/accessibility/list.js
+++ b/core/audits/accessibility/list.js
@@ -27,7 +27,7 @@ const UIStrings = {
       '[Learn more about proper list structure](https://dequeuniversity.com/rules/axe/4.4/list).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class List extends AxeAudit {
   /**

--- a/core/audits/accessibility/listitem.js
+++ b/core/audits/accessibility/listitem.js
@@ -26,7 +26,7 @@ const UIStrings = {
       '[Learn more about proper list structure](https://dequeuniversity.com/rules/axe/4.4/listitem).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ListItem extends AxeAudit {
   /**

--- a/core/audits/accessibility/meta-refresh.js
+++ b/core/audits/accessibility/meta-refresh.js
@@ -26,7 +26,7 @@ const UIStrings = {
       '[Learn more about the refresh meta tag](https://dequeuniversity.com/rules/axe/4.4/meta-refresh).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class MetaRefresh extends AxeAudit {
   /**

--- a/core/audits/accessibility/meta-viewport.js
+++ b/core/audits/accessibility/meta-viewport.js
@@ -27,7 +27,7 @@ const UIStrings = {
       '[Learn more about the viewport meta tag](https://dequeuniversity.com/rules/axe/4.4/meta-viewport).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class MetaViewport extends AxeAudit {
   /**

--- a/core/audits/accessibility/object-alt.js
+++ b/core/audits/accessibility/object-alt.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn more about alt text for `object` elements](https://dequeuniversity.com/rules/axe/4.4/object-alt).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ObjectAlt extends AxeAudit {
   /**

--- a/core/audits/accessibility/tabindex.js
+++ b/core/audits/accessibility/tabindex.js
@@ -25,7 +25,7 @@ const UIStrings = {
       'for users who rely on assistive technologies. [Learn more about the `tabindex` attribute](https://dequeuniversity.com/rules/axe/4.4/tabindex).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class TabIndex extends AxeAudit {
   /**

--- a/core/audits/accessibility/td-headers-attr.js
+++ b/core/audits/accessibility/td-headers-attr.js
@@ -29,7 +29,7 @@ const UIStrings = {
       '[Learn more about the `headers` attribute](https://dequeuniversity.com/rules/axe/4.4/td-headers-attr).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class TDHeadersAttr extends AxeAudit {
   /**

--- a/core/audits/accessibility/th-has-data-cells.js
+++ b/core/audits/accessibility/th-has-data-cells.js
@@ -28,7 +28,7 @@ const UIStrings = {
       '[Learn more about table headers](https://dequeuniversity.com/rules/axe/4.4/th-has-data-cells).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class THHasDataCells extends AxeAudit {
   /**

--- a/core/audits/accessibility/valid-lang.js
+++ b/core/audits/accessibility/valid-lang.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn how to use the `lang` attribute](https://dequeuniversity.com/rules/axe/4.4/valid-lang).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ValidLang extends AxeAudit {
   /**

--- a/core/audits/accessibility/video-caption.js
+++ b/core/audits/accessibility/video-caption.js
@@ -26,7 +26,7 @@ const UIStrings = {
       '[Learn more about video captions](https://dequeuniversity.com/rules/axe/4.4/video-caption).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class VideoCaption extends AxeAudit {
   /**

--- a/core/audits/autocomplete.js
+++ b/core/audits/autocomplete.js
@@ -48,7 +48,7 @@ const UIStrings = {
   manualReview: 'Requires manual review',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /** @type {string[]} This array contains all acceptable autocomplete attributes from the WHATWG standard. More found at https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill */
 const validAutocompleteTokens = ['name', 'honorific-prefix', 'given-name',

--- a/core/audits/bootup-time.js
+++ b/core/audits/bootup-time.js
@@ -32,7 +32,7 @@ const UIStrings = {
     'Try auditing the page in incognito mode or from a Chrome profile without extensions.',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class BootupTime extends Audit {
   /**

--- a/core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -13,7 +13,7 @@ import NetworkRecords from '../../computed/network-records.js';
 import LoadSimulator from '../../computed/load-simulator.js';
 import PageDependencyGraph from '../../computed/page-dependency-graph.js';
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, {});
+const str_ = i18n.createIcuMessageFn(import.meta.url, {});
 
 /** @typedef {import('../../lib/dependency-graph/simulator/simulator').Simulator} Simulator */
 /** @typedef {import('../../lib/dependency-graph/base-node.js').Node} Node */

--- a/core/audits/byte-efficiency/duplicated-javascript.js
+++ b/core/audits/byte-efficiency/duplicated-javascript.js
@@ -25,7 +25,7 @@ const UIStrings = {
   // '[Learn more](https://web.dev/duplicated-javascript/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const IGNORE_THRESHOLD_IN_BYTES = 1024;
 

--- a/core/audits/byte-efficiency/efficient-animated-content.js
+++ b/core/audits/byte-efficiency/efficient-animated-content.js
@@ -21,7 +21,7 @@ const UIStrings = {
     'network bytes. [Learn more about efficient video formats](https://web.dev/efficient-animated-content/)',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // If GIFs are above this size, we'll flag them
 // See https://github.com/GoogleChrome/lighthouse/pull/4885#discussion_r178406623 and https://github.com/GoogleChrome/lighthouse/issues/4696#issuecomment-370979920

--- a/core/audits/byte-efficiency/legacy-javascript.js
+++ b/core/audits/byte-efficiency/legacy-javascript.js
@@ -43,7 +43,7 @@ const UIStrings = {
   description: 'Polyfills and transforms enable legacy browsers to use new JavaScript features. However, many aren\'t necessary for modern browsers. For your bundled JavaScript, adopt a modern script deployment strategy using module/nomodule feature detection to reduce the amount of code shipped to modern browsers, while retaining support for legacy browsers. [Learn how to use modern JavaScript](https://web.dev/publish-modern-javascript/)',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * Takes a list of patterns (consisting of a name identifier and a RegExp expression string)

--- a/core/audits/byte-efficiency/modern-image-formats.js
+++ b/core/audits/byte-efficiency/modern-image-formats.js
@@ -21,7 +21,7 @@ const UIStrings = {
     '[Learn more about modern image formats](https://web.dev/uses-webp-images/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const IGNORE_THRESHOLD_IN_BYTES = 8192;
 

--- a/core/audits/byte-efficiency/offscreen-images.js
+++ b/core/audits/byte-efficiency/offscreen-images.js
@@ -27,7 +27,7 @@ const UIStrings = {
     '[Learn how to defer offscreen images](https://web.dev/offscreen-images/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // See https://github.com/GoogleChrome/lighthouse/issues/10471 for discussion about the thresholds here.
 const ALLOWABLE_OFFSCREEN_IN_PX = 100;

--- a/core/audits/byte-efficiency/render-blocking-resources.js
+++ b/core/audits/byte-efficiency/render-blocking-resources.js
@@ -39,7 +39,7 @@ const UIStrings = {
     'JS/styles. [Learn how to eliminate render-blocking resources](https://web.dev/render-blocking-resources/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * Given a simulation's nodeTimings, return an object with the nodes/timing keyed by network URL

--- a/core/audits/byte-efficiency/total-byte-weight.js
+++ b/core/audits/byte-efficiency/total-byte-weight.js
@@ -23,7 +23,7 @@ const UIStrings = {
   displayValue: 'Total size was {totalBytes, number, bytes}\xa0KiB',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class TotalByteWeight extends Audit {
   /**

--- a/core/audits/byte-efficiency/unminified-css.js
+++ b/core/audits/byte-efficiency/unminified-css.js
@@ -18,7 +18,7 @@ const UIStrings = {
     '[Learn how to minify CSS](https://web.dev/unminified-css/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const IGNORE_THRESHOLD_IN_PERCENT = 5;
 const IGNORE_THRESHOLD_IN_BYTES = 2048;

--- a/core/audits/byte-efficiency/unminified-javascript.js
+++ b/core/audits/byte-efficiency/unminified-javascript.js
@@ -18,7 +18,7 @@ const UIStrings = {
     '[Learn how to minify JavaScript](https://web.dev/unminified-javascript/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const IGNORE_THRESHOLD_IN_PERCENT = 10;
 const IGNORE_THRESHOLD_IN_BYTES = 2048;

--- a/core/audits/byte-efficiency/unused-css-rules.js
+++ b/core/audits/byte-efficiency/unused-css-rules.js
@@ -18,7 +18,7 @@ const UIStrings = {
     '[Learn how to reduce unused CSS](https://web.dev/unused-css-rules/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // Allow 10KiB of unused CSS to permit `:hover` and other styles not used on a non-interactive load.
 // @see https://github.com/GoogleChrome/lighthouse/issues/9353 for more discussion.

--- a/core/audits/byte-efficiency/unused-javascript.js
+++ b/core/audits/byte-efficiency/unused-javascript.js
@@ -19,7 +19,7 @@ const UIStrings = {
     'decrease bytes consumed by network activity. [Learn how to reduce unused JavaScript](https://web.dev/unused-javascript/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const UNUSED_BYTES_IGNORE_THRESHOLD = 20 * 1024;
 const UNUSED_BYTES_IGNORE_BUNDLE_SOURCE_THRESHOLD = 512;

--- a/core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -29,7 +29,7 @@ const UIStrings = {
     }`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // Ignore assets that have very high likelihood of cache hit
 const IGNORE_THRESHOLD_IN_PERCENT = 0.925;

--- a/core/audits/byte-efficiency/uses-optimized-images.js
+++ b/core/audits/byte-efficiency/uses-optimized-images.js
@@ -21,7 +21,7 @@ const UIStrings = {
   '[Learn how to efficiently encode images](https://web.dev/uses-optimized-images/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const IGNORE_THRESHOLD_IN_BYTES = 4096;
 

--- a/core/audits/byte-efficiency/uses-responsive-images-snapshot.js
+++ b/core/audits/byte-efficiency/uses-responsive-images-snapshot.js
@@ -27,7 +27,7 @@ const UIStrings = {
   columnActualDimensions: 'Actual dimensions',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // Based on byte threshold of 4096, with 3 bytes per pixel.
 const IGNORE_THRESHOLD_IN_PIXELS = 1365;

--- a/core/audits/byte-efficiency/uses-responsive-images.js
+++ b/core/audits/byte-efficiency/uses-responsive-images.js
@@ -29,7 +29,7 @@ const UIStrings = {
   '[Learn how to size images](https://web.dev/uses-responsive-images/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const IGNORE_THRESHOLD_IN_BYTES = 4096;
 

--- a/core/audits/byte-efficiency/uses-text-compression.js
+++ b/core/audits/byte-efficiency/uses-text-compression.js
@@ -22,7 +22,7 @@ const UIStrings = {
     ' [Learn more about text compression](https://web.dev/uses-text-compression/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const IGNORE_THRESHOLD_IN_BYTES = 1400;
 const IGNORE_THRESHOLD_IN_PERCENT = 0.1;

--- a/core/audits/content-width.js
+++ b/core/audits/content-width.js
@@ -26,7 +26,7 @@ const UIStrings = {
     'size of {outerWidth}px.',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ContentWidth extends Audit {
   /**

--- a/core/audits/critical-request-chains.js
+++ b/core/audits/critical-request-chains.js
@@ -25,7 +25,7 @@ const UIStrings = {
     }`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class CriticalRequestChains extends Audit {
   /**

--- a/core/audits/csp-xss.js
+++ b/core/audits/csp-xss.js
@@ -32,7 +32,7 @@ const UIStrings = {
   itemSeveritySyntax: 'Syntax',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class CspXss extends Audit {
   /**

--- a/core/audits/deprecations.js
+++ b/core/audits/deprecations.js
@@ -36,7 +36,7 @@ const UIStrings = {
 };
 /* eslint-enable max-len */
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class Deprecations extends Audit {
   /**

--- a/core/audits/dobetterweb/charset.js
+++ b/core/audits/dobetterweb/charset.js
@@ -27,7 +27,7 @@ const UIStrings = {
     '[Learn more about declaring the character encoding](https://web.dev/charset/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const CONTENT_TYPE_HEADER = 'content-type';
 // /^[a-zA-Z0-9-_:.()]{2,}$/ matches all known IANA charset names (https://www.iana.org/assignments/character-sets/character-sets.xhtml)

--- a/core/audits/dobetterweb/doctype.js
+++ b/core/audits/dobetterweb/doctype.js
@@ -29,7 +29,7 @@ const UIStrings = {
   explanationBadDoctype: 'Doctype name must be the string `html`',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class Doctype extends Audit {
   /**

--- a/core/audits/dobetterweb/dom-size.js
+++ b/core/audits/dobetterweb/dom-size.js
@@ -41,7 +41,7 @@ const UIStrings = {
   statisticDOMWidth: 'Maximum Child Elements',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class DOMSize extends Audit {
   /**

--- a/core/audits/dobetterweb/geolocation-on-start.js
+++ b/core/audits/dobetterweb/geolocation-on-start.js
@@ -25,7 +25,7 @@ const UIStrings = {
     '[Learn more about the geolocation permission](https://web.dev/geolocation-on-start/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class GeolocationOnStart extends ViolationAudit {
   /**

--- a/core/audits/dobetterweb/inspector-issues.js
+++ b/core/audits/dobetterweb/inspector-issues.js
@@ -36,7 +36,7 @@ const UIStrings = {
   issueTypeHeavyAds: 'Heavy resource usage by ads',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class IssuesPanelEntries extends Audit {
   /**

--- a/core/audits/dobetterweb/js-libraries.js
+++ b/core/audits/dobetterweb/js-libraries.js
@@ -22,7 +22,7 @@ const UIStrings = {
   columnVersion: 'Version',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class JsLibrariesAudit extends Audit {
   /**

--- a/core/audits/dobetterweb/no-document-write.js
+++ b/core/audits/dobetterweb/no-document-write.js
@@ -42,7 +42,7 @@ const UIStrings = {
       '[Learn how to avoid document.write()](https://web.dev/no-document-write/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class NoDocWriteAudit extends ViolationAudit {
   /**

--- a/core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -46,7 +46,7 @@ const UIStrings = {
   columnSeverity: 'Highest Severity',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const SEMVER_REGEX = /^(\d+\.\d+\.\d+)[^-0-9]+/;
 

--- a/core/audits/dobetterweb/notification-on-start.js
+++ b/core/audits/dobetterweb/notification-on-start.js
@@ -25,7 +25,7 @@ const UIStrings = {
       'instead. [Learn more about responsibly getting permission for notifications](https://web.dev/notification-on-start/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class NotificationOnStart extends ViolationAudit {
   /**

--- a/core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
+++ b/core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
@@ -18,7 +18,7 @@ const UIStrings = {
       '[Learn more about user-friendly password fields](https://web.dev/password-inputs-can-be-pasted-into/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class PasswordInputsCanBePastedIntoAudit extends Audit {
   /**

--- a/core/audits/dobetterweb/uses-http2.js
+++ b/core/audits/dobetterweb/uses-http2.js
@@ -40,7 +40,7 @@ const UIStrings = {
   columnProtocol: 'Protocol',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /** @type {Set<LH.Artifacts.NetworkRequest['resourceType']>} */
 const STATIC_RESOURCE_TYPES = new Set([

--- a/core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -25,7 +25,7 @@ const UIStrings = {
       '[Learn more about adopting passive event listeners](https://web.dev/uses-passive-event-listeners/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class PassiveEventsAudit extends ViolationAudit {
   /**

--- a/core/audits/errors-in-console.js
+++ b/core/audits/errors-in-console.js
@@ -27,7 +27,7 @@ const UIStrings = {
     '[Learn more about this errors in console diagnostic audit](https://web.dev/errors-in-console/)',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /** @typedef {{ignoredPatterns?: Array<RegExp|string>}} AuditOptions */
 

--- a/core/audits/font-display.js
+++ b/core/audits/font-display.js
@@ -36,7 +36,7 @@ const UIStrings = {
     'other {Lighthouse was unable to automatically check the `font-display` values for the origin {fontOrigin}.}}',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class FontDisplay extends Audit {
   /**

--- a/core/audits/image-aspect-ratio.js
+++ b/core/audits/image-aspect-ratio.js
@@ -29,7 +29,7 @@ const UIStrings = {
   columnActual: 'Aspect Ratio (Actual)',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const THRESHOLD_PX = 2;
 

--- a/core/audits/image-size-responsive.js
+++ b/core/audits/image-size-responsive.js
@@ -33,7 +33,7 @@ const UIStrings = {
   columnExpected: 'Expected size',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // Factors used to allow for smaller effective density.
 // A factor of 1 means the actual device pixel density will be used.

--- a/core/audits/installable-manifest.js
+++ b/core/audits/installable-manifest.js
@@ -106,7 +106,7 @@ const UIStrings = {
 };
 /* eslint-enable max-len */
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview

--- a/core/audits/is-on-https.js
+++ b/core/audits/is-on-https.js
@@ -49,7 +49,7 @@ const resolutionToString = {
   MixedContentWarning: UIStrings.warning,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 
 class HTTPS extends Audit {

--- a/core/audits/largest-contentful-paint-element.js
+++ b/core/audits/largest-contentful-paint-element.js
@@ -16,7 +16,7 @@ const UIStrings = {
     '[Learn more about the Largest Contentful Paint element](https://web.dev/lighthouse-largest-contentful-paint/)',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class LargestContentfulPaintElement extends Audit {
   /**

--- a/core/audits/layout-shift-elements.js
+++ b/core/audits/layout-shift-elements.js
@@ -17,7 +17,7 @@ const UIStrings = {
   columnContribution: 'CLS Contribution',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class LayoutShiftElements extends Audit {
   /**

--- a/core/audits/lcp-lazy-loaded.js
+++ b/core/audits/lcp-lazy-loaded.js
@@ -17,7 +17,7 @@ const UIStrings = {
   description: 'Above-the-fold images that are lazily loaded render later in the page lifecycle, which can delay the largest contentful paint. [Learn more about optimal lazy loading](https://web.dev/lcp-lazy-loading/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class LargestContentfulPaintLazyLoaded extends Audit {
   /**

--- a/core/audits/long-tasks.js
+++ b/core/audits/long-tasks.js
@@ -30,7 +30,7 @@ const UIStrings = {
   }`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class LongTasks extends Audit {
   /**

--- a/core/audits/mainthread-work-breakdown.js
+++ b/core/audits/mainthread-work-breakdown.js
@@ -28,7 +28,7 @@ const UIStrings = {
   columnCategory: 'Category',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /** @typedef {import('../lib/tracehouse/task-groups.js').TaskGroupIds} TaskGroupIds */
 

--- a/core/audits/manual/pwa-cross-browser.js
+++ b/core/audits/manual/pwa-cross-browser.js
@@ -17,7 +17,7 @@ const UIStrings = {
   'every major browser. [Learn about cross-browser compatibility](https://web.dev/pwa-cross-browser/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview Manual PWA audit for cross browser support.

--- a/core/audits/manual/pwa-each-page-has-url.js
+++ b/core/audits/manual/pwa-each-page-has-url.js
@@ -16,7 +16,7 @@ const UIStrings = {
       'unique for the purpose of shareability on social media. [Learn more about providing deep links](https://web.dev/pwa-each-page-has-url/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview Manual PWA audit to ensure every page has a deep link.

--- a/core/audits/manual/pwa-page-transitions.js
+++ b/core/audits/manual/pwa-page-transitions.js
@@ -16,7 +16,7 @@ const UIStrings = {
     'This experience is key to a user\'s perception of performance. [Learn more about page transitions](https://web.dev/pwa-page-transitions/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview Manual PWA audit for janky-free page transitions.

--- a/core/audits/maskable-icon.js
+++ b/core/audits/maskable-icon.js
@@ -20,7 +20,7 @@ const UIStrings = {
     'the app on a device. [Learn about maskable manifest icons](https://web.dev/maskable-icon-audit/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview

--- a/core/audits/metrics/cumulative-layout-shift.js
+++ b/core/audits/metrics/cumulative-layout-shift.js
@@ -16,7 +16,7 @@ const UIStrings = {
                '[Learn more about the Cumulative Layout Shift metric](https://web.dev/cls/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview This metric represents the amount of visual shifting of DOM elements during page load.

--- a/core/audits/metrics/experimental-interaction-to-next-paint.js
+++ b/core/audits/metrics/experimental-interaction-to-next-paint.js
@@ -16,7 +16,7 @@ const UIStrings = {
                '[Learn more about the Interaction to Next Paint metric](https://web.dev/inp/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview This metric gives a high-percentile measure of responsiveness to input.

--- a/core/audits/metrics/first-contentful-paint.js
+++ b/core/audits/metrics/first-contentful-paint.js
@@ -15,7 +15,7 @@ const UIStrings = {
       'painted. [Learn more about the First Contentful Paint metric](https://web.dev/first-contentful-paint/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class FirstContentfulPaint extends Audit {
   /**

--- a/core/audits/metrics/first-meaningful-paint.js
+++ b/core/audits/metrics/first-meaningful-paint.js
@@ -15,7 +15,7 @@ const UIStrings = {
       'visible. [Learn more about the First Meaningful Paint metric](https://web.dev/first-meaningful-paint/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class FirstMeaningfulPaint extends Audit {
   /**

--- a/core/audits/metrics/interactive.js
+++ b/core/audits/metrics/interactive.js
@@ -15,7 +15,7 @@ const UIStrings = {
     'interactive. [Learn more about the Time to Interactive metric](https://web.dev/interactive/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview This audit identifies the time the page is "consistently interactive".

--- a/core/audits/metrics/largest-contentful-paint.js
+++ b/core/audits/metrics/largest-contentful-paint.js
@@ -15,7 +15,7 @@ const UIStrings = {
       `painted. [Learn more about the Largest Contentful Paint metric](https://web.dev/lighthouse-largest-contentful-paint/)`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class LargestContentfulPaint extends Audit {
   /**

--- a/core/audits/metrics/max-potential-fid.js
+++ b/core/audits/metrics/max-potential-fid.js
@@ -16,7 +16,7 @@ const UIStrings = {
       '[Learn more about the Maximum Potential First Input Delay metric](https://web.dev/lighthouse-max-potential-fid/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview This metric is the duration of the longest task after FCP. It is meant to capture

--- a/core/audits/metrics/speed-index.js
+++ b/core/audits/metrics/speed-index.js
@@ -15,7 +15,7 @@ const UIStrings = {
       '[Learn more about the Speed Index metric](https://web.dev/speed-index/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class SpeedIndex extends Audit {
   /**

--- a/core/audits/metrics/total-blocking-time.js
+++ b/core/audits/metrics/total-blocking-time.js
@@ -16,7 +16,7 @@ const UIStrings = {
       '[Learn more about the Total Blocking Time metric](https://web.dev/lighthouse-total-blocking-time/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class TotalBlockingTime extends Audit {
   /**

--- a/core/audits/network-rtt.js
+++ b/core/audits/network-rtt.js
@@ -19,7 +19,7 @@ const UIStrings = {
     'improve performance. [Learn more about the Round Trip Time](https://hpbn.co/primer-on-latency-and-bandwidth/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class NetworkRTT extends Audit {
   /**

--- a/core/audits/network-server-latency.js
+++ b/core/audits/network-server-latency.js
@@ -19,7 +19,7 @@ const UIStrings = {
     'or has poor backend performance. [Learn more about server response time](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class NetworkServerLatency extends Audit {
   /**

--- a/core/audits/no-unload-listeners.js
+++ b/core/audits/no-unload-listeners.js
@@ -18,7 +18,7 @@ const UIStrings = {
   description: 'The `unload` event does not fire reliably and listening for it can prevent browser optimizations like the Back-Forward Cache. Use `pagehide` or `visibilitychange` events instead. [Learn more about unload event listeners](https://web.dev/bfcache/#never-use-the-unload-event)',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class NoUnloadListeners extends Audit {
   /**

--- a/core/audits/non-composited-animations.js
+++ b/core/audits/non-composited-animations.js
@@ -46,7 +46,7 @@ const UIStrings = {
   unsupportedTimingParameters: 'Effect has unsupported timing parameters',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * Each failure reason is represented by a bit flag. The bit shift operator '<<' is used to define which bit corresponds to each failure reason.

--- a/core/audits/performance-budget.js
+++ b/core/audits/performance-budget.js
@@ -25,7 +25,7 @@ const UIStrings = {
    }`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /** @typedef {import('../computed/resource-summary.js').ResourceEntry} ResourceEntry */
 /** @typedef {{resourceType: LH.Budget.ResourceType, label: LH.IcuMessage, requestCount: number, transferSize: number, sizeOverBudget: number | undefined, countOverBudget: LH.IcuMessage | undefined}} BudgetItem */

--- a/core/audits/predictive-perf.js
+++ b/core/audits/predictive-perf.js
@@ -18,7 +18,7 @@ import LanternLcp from '../computed/metrics/lantern-largest-contentful-paint.js'
 const SCORING_P10 = 3651;
 const SCORING_MEDIAN = 10000;
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, {});
+const str_ = i18n.createIcuMessageFn(import.meta.url, {});
 
 class PredictivePerf extends Audit {
   /**

--- a/core/audits/preload-fonts.js
+++ b/core/audits/preload-fonts.js
@@ -26,7 +26,7 @@ const UIStrings = {
   description: 'Preload `optional` fonts so first-time visitors may use them. [Learn more about preloading fonts](https://web.dev/preload-optional-fonts/)',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class PreloadFontsAudit extends Audit {
   /**

--- a/core/audits/preload-lcp-image.js
+++ b/core/audits/preload-lcp-image.js
@@ -21,7 +21,7 @@ const UIStrings = {
     'image in order to improve LCP. [Learn more about preloading LCP elements](https://web.dev/optimize-lcp/#preload-important-resources).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @typedef {Array<{url: string, initiatorType: string}>} InitiatorPath

--- a/core/audits/redirects.js
+++ b/core/audits/redirects.js
@@ -20,7 +20,7 @@ const UIStrings = {
   description: 'Redirects introduce additional delays before the page can be loaded. [Learn how to avoid page redirects](https://web.dev/redirects/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class Redirects extends Audit {
   /**

--- a/core/audits/resource-summary.js
+++ b/core/audits/resource-summary.js
@@ -22,7 +22,7 @@ const UIStrings = {
     `other {# requests • {byteCount, number, bytes} KiB}}`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ResourceSummary extends Audit {
   /**

--- a/core/audits/seo/canonical.js
+++ b/core/audits/seo/canonical.js
@@ -43,7 +43,7 @@ const UIStrings = {
     'instead of an equivalent page of content',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @typedef CanonicalURLData

--- a/core/audits/seo/crawlable-anchors.js
+++ b/core/audits/seo/crawlable-anchors.js
@@ -19,7 +19,7 @@ const UIStrings = {
   columnFailingLink: 'Uncrawlable Link',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class CrawlableAnchors extends Audit {
   /**

--- a/core/audits/seo/font-size.js
+++ b/core/audits/seo/font-size.js
@@ -38,7 +38,7 @@ const UIStrings = {
   columnFontSize: 'Font Size',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @param {Array<FailingNodeData>} fontSizeArtifact

--- a/core/audits/seo/hreflang.js
+++ b/core/audits/seo/hreflang.js
@@ -31,7 +31,7 @@ const UIStrings = {
   notFullyQualified: 'Relative href value',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @param {string} href

--- a/core/audits/seo/http-status-code.js
+++ b/core/audits/seo/http-status-code.js
@@ -22,7 +22,7 @@ const UIStrings = {
   '[Learn more about HTTP status codes](https://web.dev/http-status-code/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class HTTPStatusCode extends Audit {
   /**

--- a/core/audits/seo/is-crawlable.js
+++ b/core/audits/seo/is-crawlable.js
@@ -30,7 +30,7 @@ const UIStrings = {
       'if they don\'t have permission to crawl them. [Learn more about crawler directives](https://web.dev/is-crawable/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * Checks if given directive is a valid unavailable_after directive with a date in the past

--- a/core/audits/seo/link-text.js
+++ b/core/audits/seo/link-text.js
@@ -92,7 +92,7 @@ const UIStrings = {
     }`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class LinkText extends Audit {
   /**

--- a/core/audits/seo/manual/structured-data.js
+++ b/core/audits/seo/manual/structured-data.js
@@ -15,7 +15,7 @@ const UIStrings = {
   title: 'Structured data is valid',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview Manual SEO audit to check if structured data on page is valid.

--- a/core/audits/seo/meta-description.js
+++ b/core/audits/seo/meta-description.js
@@ -21,7 +21,7 @@ const UIStrings = {
   explanation: 'Description text is empty.',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class Description extends Audit {
   /**

--- a/core/audits/seo/plugins.js
+++ b/core/audits/seo/plugins.js
@@ -44,7 +44,7 @@ const UIStrings = {
     '[Learn more about avoiding plugins](https://web.dev/plugins/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * Verifies if given MIME type matches any known plugin MIME type

--- a/core/audits/seo/robots-txt.js
+++ b/core/audits/seo/robots-txt.js
@@ -57,7 +57,7 @@ const UIStrings = {
   explanation: 'Lighthouse was unable to download a robots.txt file',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @param {string} directiveName

--- a/core/audits/seo/tap-targets.js
+++ b/core/audits/seo/tap-targets.js
@@ -43,7 +43,7 @@ const UIStrings = {
   displayValue: '{decimalProportion, number, percent} appropriately sized tap targets',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const FINGER_SIZE_PX = 48;
 // Ratio of the finger area tapping on an unintended element

--- a/core/audits/server-response-time.js
+++ b/core/audits/server-response-time.js
@@ -20,7 +20,7 @@ const UIStrings = {
   displayValue: `Root document took {timeInMs, number, milliseconds}\xa0ms`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // Due to the way that DevTools throttling works we cannot see if server response took less than ~570ms.
 // We set our failure threshold to 600ms to avoid those false positives but we want devs to shoot for 100ms.

--- a/core/audits/service-worker.js
+++ b/core/audits/service-worker.js
@@ -39,7 +39,7 @@ const UIStrings = {
     'the `start_url` ({startUrl}) is not in the service worker\'s scope ({scopeUrl})',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class ServiceWorker extends Audit {
   /**

--- a/core/audits/splash-screen.js
+++ b/core/audits/splash-screen.js
@@ -20,7 +20,7 @@ const UIStrings = {
     '[Learn more about splash screens](https://web.dev/splash-screen/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview

--- a/core/audits/themed-omnibox.js
+++ b/core/audits/themed-omnibox.js
@@ -20,7 +20,7 @@ const UIStrings = {
     '[Learn more about theming the address bar](https://web.dev/themed-omnibox/).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview

--- a/core/audits/third-party-facades.js
+++ b/core/audits/third-party-facades.js
@@ -67,7 +67,7 @@ const UIStrings = {
   categorySocial: '{productName} (Social)',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /** @type {Record<string, string>} */
 const CATEGORY_UI_MAP = {

--- a/core/audits/third-party-summary.js
+++ b/core/audits/third-party-summary.js
@@ -29,7 +29,7 @@ const UIStrings = {
     `{timeInMs, number, milliseconds}\xa0ms`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // A page passes when all third-party code blocks for less than 250 ms.
 const PASS_THRESHOLD_IN_MS = 250;

--- a/core/audits/timing-budget.js
+++ b/core/audits/timing-budget.js
@@ -22,7 +22,7 @@ const UIStrings = {
   columnMeasurement: 'Measurement',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /** @typedef {{metric: LH.Budget.TimingMetric, label: LH.IcuMessage, measurement?: LH.Audit.Details.NumericValue|number, overBudget?: LH.Audit.Details.NumericValue|number}} BudgetItem */
 

--- a/core/audits/unsized-images.js
+++ b/core/audits/unsized-images.js
@@ -23,7 +23,7 @@ const UIStrings = {
   description: 'Set an explicit width and height on image elements to reduce layout shifts and improve CLS. [Learn how to set image dimensions](https://web.dev/optimize-cls/#images-without-dimensions)',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class UnsizedImages extends Audit {
   /**

--- a/core/audits/user-timings.js
+++ b/core/audits/user-timings.js
@@ -25,7 +25,7 @@ const UIStrings = {
   columnType: 'Type',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /** @typedef {{name: string, isMark: true, args: LH.TraceEvent['args'], startTime: number}} MarkEvent */
 /** @typedef {{name: string, isMark: false, args: LH.TraceEvent['args'], startTime: number, endTime: number, duration: number}} MeasureEvent */

--- a/core/audits/uses-rel-preconnect.js
+++ b/core/audits/uses-rel-preconnect.js
@@ -52,7 +52,7 @@ const UIStrings = {
    'These should be used sparingly and only to the most important origins.',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class UsesRelPreconnectAudit extends Audit {
   /**

--- a/core/audits/uses-rel-preload.js
+++ b/core/audits/uses-rel-preload.js
@@ -30,7 +30,7 @@ const UIStrings = {
     'by the browser. Check that you are using the `crossorigin` attribute properly.',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const THRESHOLD_IN_MS = 100;
 

--- a/core/audits/valid-source-maps.js
+++ b/core/audits/valid-source-maps.js
@@ -30,7 +30,7 @@ const UIStrings = {
     }`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 const LARGE_JS_BYTE_THRESHOLD = 500 * 1024;
 

--- a/core/audits/viewport.js
+++ b/core/audits/viewport.js
@@ -23,7 +23,7 @@ const UIStrings = {
   explanationNoTag: 'No `<meta name="viewport">` tag found',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class Viewport extends Audit {
   /**

--- a/core/audits/work-during-interaction.js
+++ b/core/audits/work-during-interaction.js
@@ -44,7 +44,7 @@ const UIStrings = {
   eventTarget: 'Event target',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview This metric gives a high-percentile measure of responsiveness to input.

--- a/core/config/default-config.js
+++ b/core/config/default-config.js
@@ -121,7 +121,7 @@ const UIStrings = {
   pwaOptimizedGroupTitle: 'PWA Optimized',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // Ensure all artifact IDs match the typedefs.
 /** @type {Record<keyof LH.FRArtifacts, string>} */

--- a/core/gather/driver/environment.js
+++ b/core/gather/driver/environment.js
@@ -27,7 +27,7 @@ const UIStrings = {
  */
 const SLOW_CPU_BENCHMARK_INDEX_THRESHOLD = 1000;
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @param {LH.Gatherer.FRProtocolSession} session

--- a/core/gather/driver/navigation.js
+++ b/core/gather/driver/navigation.js
@@ -28,7 +28,7 @@ const UIStrings = {
   'Results may be incomplete.',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 
 // Controls how long to wait after FCP before continuing

--- a/core/gather/driver/storage.js
+++ b/core/gather/driver/storage.js
@@ -24,7 +24,7 @@ const UIStrings = {
   }`,
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 
 /**

--- a/core/lib/csp-evaluator.js
+++ b/core/lib/csp-evaluator.js
@@ -88,7 +88,7 @@ const UIStrings = {
     'Plain URL schemes allow scripts to be sourced from an unsafe domain.',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /** @type {Record<number, string|LH.IcuMessage|Record<string, LH.IcuMessage>>} */
 const FINDING_TO_UI_STRING = {

--- a/core/lib/deprecations-strings.js
+++ b/core/lib/deprecations-strings.js
@@ -269,7 +269,7 @@ const UIStrings = {
       '`supportsSession()` is deprecated. Please use `isSessionSupported()` and check the resolved boolean value instead.',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @param {LH.Crdp.Audits.DeprecationIssueDetails} issueDetails

--- a/core/lib/i18n/i18n.js
+++ b/core/lib/i18n/i18n.js
@@ -217,6 +217,4 @@ export {
   lookupLocale,
   createIcuMessageFn,
   isStringOrIcuMessage,
-  // TODO: exported for backwards compatibility. Consider removing on future breaking change.
-  createIcuMessageFn as createMessageInstanceIdFn,
 };

--- a/core/lib/lh-error.js
+++ b/core/lib/lh-error.js
@@ -89,7 +89,7 @@ const UIStrings = {
   oldChromeDoesNotSupportFeature: 'This version of Chrome is too old to support \'{featureName}\'. Use a newer version to see full results.',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 
 /**

--- a/core/lib/navigation-error.js
+++ b/core/lib/navigation-error.js
@@ -19,7 +19,7 @@ const UIStrings = {
     'The page MIME type is XHTML: Lighthouse does not explicitly support this document type',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 // MIME types are case-insensitive but Chrome normalizes MIME types to be lowercase.
 const HTML_MIME_TYPE = 'text/html';

--- a/core/lib/stack-packs.js
+++ b/core/lib/stack-packs.js
@@ -86,7 +86,7 @@ function getStackPacks(pageStacks) {
     }
 
     // Create i18n handler to get translated strings.
-    const str_ = i18n.createMessageInstanceIdFn(
+    const str_ = i18n.createIcuMessageFn(
       `node_modules/lighthouse-stack-packs/packs/${matchedPack.id}.js`,
       matchedPack.UIStrings
     );

--- a/core/test/config/config-plugin-test.js
+++ b/core/test/config/config-plugin-test.js
@@ -70,7 +70,7 @@ describe('ConfigPlugin', () => {
       title: 'this is a title',
       description: 'this is a description',
     };
-    const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
+    const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
     const localizedPlugin = {
       groups: {

--- a/core/test/lib/i18n/i18n-test.js
+++ b/core/test/lib/i18n/i18n-test.js
@@ -15,11 +15,11 @@ import {getModuleDirectory} from '../../../../esm-utils.js';
 const moduleDir = getModuleDirectory(import.meta);
 
 describe('i18n', () => {
-  describe('#createMessageInstanceIdFn', () => {
+  describe('#createIcuMessageFn', () => {
     it('returns an IcuMessage reference', () => {
       const fakeFile = path.join(moduleDir, 'fake-file.js');
       const templates = {daString: 'use {x} me!'};
-      const formatter = i18n.createMessageInstanceIdFn(fakeFile, templates);
+      const formatter = i18n.createIcuMessageFn(fakeFile, templates);
 
       expect(formatter(templates.daString, {x: 1})).toStrictEqual({
         i18nId: 'core/test/lib/i18n/fake-file.js | daString',

--- a/core/test/runner-test.js
+++ b/core/test/runner-test.js
@@ -201,7 +201,7 @@ describe('Runner', () => {
     it('serializes IcuMessages in gatherMode and is able to use them in auditMode', async () => {
       // Can use this to access shared UIStrings in i18n.js.
       // For future changes: exact messages aren't important, just choose ones with replacements.
-      const str_ = i18n.createMessageInstanceIdFn(import.meta.url, {});
+      const str_ = i18n.createIcuMessageFn(import.meta.url, {});
 
       // A gatherer that produces an IcuMessage runWarning and LighthouseError artifact.
       class WarningAndErrorGatherer extends Gatherer {

--- a/shared/test/localization/format-test.js
+++ b/shared/test/localization/format-test.js
@@ -85,7 +85,7 @@ describe('format', () => {
     it('replaces the references in the LHR', () => {
       const fakeFile = path.join(__dirname, 'fake-file-number-2.js');
       const UIStrings = {aString: 'different {x}!'};
-      const formatter = i18n.createMessageInstanceIdFn(fakeFile, UIStrings);
+      const formatter = i18n.createIcuMessageFn(fakeFile, UIStrings);
 
       const title = formatter(UIStrings.aString, {x: 1});
       const lhr = {audits: {'fake-audit': {title}}};
@@ -115,14 +115,14 @@ describe('format', () => {
   describe('#getFormatted', () => {
     it('returns the formatted string', () => {
       const UIStrings = {testMessage: 'happy test'};
-      const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+      const str_ = i18n.createIcuMessageFn(__filename, UIStrings);
       const formattedStr = format.getFormatted(str_(UIStrings.testMessage), 'en');
       expect(formattedStr).toEqual('happy test');
     });
 
     it('returns the formatted string with replacements', () => {
       const UIStrings = {testMessage: 'replacement test ({errorCode})'};
-      const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+      const str_ = i18n.createIcuMessageFn(__filename, UIStrings);
       const formattedStr = format.getFormatted(str_(UIStrings.testMessage,
           {errorCode: 'BOO'}), 'en');
       expect(formattedStr).toEqual('replacement test (BOO)');
@@ -131,7 +131,7 @@ describe('format', () => {
     it('throws an error for invalid locales', () => {
       // Populate a string to try to localize to a bad locale.
       const UIStrings = {testMessage: 'testy test'};
-      const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+      const str_ = i18n.createIcuMessageFn(__filename, UIStrings);
 
       expect(_ => format.getFormatted(str_(UIStrings.testMessage), 'still-not-a-locale'))
         .toThrow(`Unsupported locale 'still-not-a-locale'`);
@@ -141,7 +141,7 @@ describe('format', () => {
       const UIStrings = {
         testMessage: 'needs {count, number, bytes}KB test {str} in {timeInMs, number, seconds}s',
       };
-      const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+      const str_ = i18n.createIcuMessageFn(__filename, UIStrings);
 
       const replacements = {
         count: 2555,
@@ -184,7 +184,7 @@ describe('format', () => {
       format.registerLocaleData('en-XZ', localeData);
 
       const UIStrings = {testString: 'en-US string!'};
-      const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+      const str_ = i18n.createIcuMessageFn(__filename, UIStrings);
       const formattedStr = format.getFormatted(str_(UIStrings.testString), 'en-XZ');
       expect(formattedStr).toEqual('en-XZ cuerda!');
     });
@@ -192,7 +192,7 @@ describe('format', () => {
     it('overwrites existing locale strings', async () => {
       const filename = 'core/audits/is-on-https.js';
       const {UIStrings} = await import('../../../core/audits/is-on-https.js');
-      const str_ = i18n.createMessageInstanceIdFn(filename, UIStrings);
+      const str_ = i18n.createIcuMessageFn(filename, UIStrings);
 
       // To start with, we get back the intended string..
       const origTitle = format.getFormatted(str_(UIStrings.title), 'es-419');
@@ -324,7 +324,7 @@ describe('format', () => {
 
     let str_;
     before(() => {
-      str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+      str_ = i18n.createIcuMessageFn(__filename, UIStrings);
     });
 
     it('formats a basic message', () => {


### PR DESCRIPTION
Deprecate the legacy `i18n.createMessageInstanceIdFn` method in favor of the new `createIcuMessageFn` introduced in [#10630](https://github.com/GoogleChrome/lighthouse/pull/10630#discussion_r488288199). 

If we have external dependencies that rely on this method, they will have to be updated.

Fixes #13993.