### PR TITLE
core: use trace time origin for main-thread-task time origin

### DIFF
--- a/core/computed/main-thread-tasks.js
+++ b/core/computed/main-thread-tasks.js
@@ -17,7 +17,8 @@ class MainThreadTasks {
    */
   static async compute_(trace, context) {
     const {mainThreadEvents, frames, timestamps} = await ProcessedTrace.request(trace, context);
-    return MainThreadTasks_.getMainThreadTasks(mainThreadEvents, frames, timestamps.traceEnd);
+    return MainThreadTasks_.getMainThreadTasks(mainThreadEvents, frames, timestamps.traceEnd,
+        timestamps.timeOrigin);
   }
 }
 

--- a/core/lib/tracehouse/main-thread-tasks.js
+++ b/core/lib/tracehouse/main-thread-tasks.js
@@ -561,9 +561,10 @@ class MainThreadTasks {
    * @param {LH.TraceEvent[]} mainThreadEvents
    * @param {Array<{id: string, url: string}>} frames
    * @param {number} traceEndTs
+   * @param {number} [traceStartTs] Optional time-0 ts for tasks. Tasks before this point will have negative start/end times. Defaults to the first task found.
    * @return {TaskNode[]}
    */
-  static getMainThreadTasks(mainThreadEvents, frames, traceEndTs) {
+  static getMainThreadTasks(mainThreadEvents, frames, traceEndTs, traceStartTs) {
     const timers = new Map();
     const xhrs = new Map();
     const frameURLsById = new Map();
@@ -587,8 +588,8 @@ class MainThreadTasks {
       priorTaskData.lastTaskURLs = task.attributableURLs;
     }
 
-    // Rebase all the times to be relative to start of trace in ms
-    const firstTs = (tasks[0] || {startTime: 0}).startTime;
+    // Rebase all the times to be relative to start of trace and covert to ms.
+    const firstTs = traceStartTs ?? tasks[0].startTime;
     for (const task of tasks) {
       task.startTime = (task.startTime - firstTs) / 1000;
       task.endTime = (task.endTime - firstTs) / 1000;

--- a/core/test/computed/main-thread-tasks-test.js
+++ b/core/test/computed/main-thread-tasks-test.js
@@ -4,6 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import {expect} from 'expect';
+
 import MainThreadTasks from '../../computed/main-thread-tasks.js';
 import {readJson} from '../test-utils.js';
 
@@ -14,5 +16,18 @@ describe('MainThreadTasksComputed', () => {
     const context = {computedCache: new Map()};
     const tasks = await MainThreadTasks.request(pwaTrace, context);
     expect(tasks.length).toEqual(4784);
+  });
+
+  it('uses negative timestamps for tasks before navStart', async () => {
+    const context = {computedCache: new Map()};
+    const tasks = await MainThreadTasks.request(pwaTrace, context);
+    expect(tasks[0]).toMatchObject({
+      startTime: expect.toBeApproximately(-3, 1),
+      endTime: expect.toBeApproximately(-3, 1),
+    });
+    expect(tasks[1]).toMatchObject({
+      startTime: expect.toBeApproximately(-3, 1),
+      endTime: expect.toBeApproximately(-2.8, 1),
+    });
   });
 });

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -1171,35 +1171,35 @@
               "items": [
                 {
                   "duration": 9.057,
-                  "startTime": 748.485
+                  "startTime": 739.383
                 },
                 {
                   "duration": 5.516,
-                  "startTime": 757.682
+                  "startTime": 748.58
                 },
                 {
                   "duration": 5.176,
-                  "startTime": 763.285
+                  "startTime": 754.183
                 },
                 {
                   "duration": 36.813,
-                  "startTime": 906.673
+                  "startTime": 897.571
                 },
                 {
                   "duration": 10.155,
-                  "startTime": 972.313
+                  "startTime": 963.211
                 },
                 {
                   "duration": 15.789,
-                  "startTime": 1003.996
+                  "startTime": 994.894
                 },
                 {
                   "duration": 28.247,
-                  "startTime": 1115.8
+                  "startTime": 1106.698
                 },
                 {
                   "duration": 5.311,
-                  "startTime": 1191.301
+                  "startTime": 1182.199
                 }
               ]
             }
@@ -8250,107 +8250,107 @@
               "items": [
                 {
                   "duration": 55.073,
-                  "startTime": 11.328
+                  "startTime": 10.63
                 },
                 {
                   "duration": 10.795,
-                  "startTime": 72.701
+                  "startTime": 72.003
                 },
                 {
                   "duration": 8.441,
-                  "startTime": 85.749
+                  "startTime": 85.051
                 },
                 {
                   "duration": 8.48,
-                  "startTime": 96.294
+                  "startTime": 95.596
                 },
                 {
                   "duration": 13.941,
-                  "startTime": 107.64
+                  "startTime": 106.942
                 },
                 {
                   "duration": 8.502,
-                  "startTime": 122.72
+                  "startTime": 122.022
                 },
                 {
                   "duration": 9.046,
-                  "startTime": 133.192
+                  "startTime": 132.494
                 },
                 {
                   "duration": 8.882,
-                  "startTime": 146.061
+                  "startTime": 145.363
                 },
                 {
                   "duration": 7.095,
-                  "startTime": 156.508
+                  "startTime": 155.81
                 },
                 {
                   "duration": 10.088,
-                  "startTime": 167.398
+                  "startTime": 166.7
                 },
                 {
                   "duration": 9.653,
-                  "startTime": 180.47
+                  "startTime": 179.772
                 },
                 {
                   "duration": 8.539,
-                  "startTime": 192.018
+                  "startTime": 191.32
                 },
                 {
                   "duration": 7.717,
-                  "startTime": 236.437
+                  "startTime": 235.739
                 },
                 {
                   "duration": 9.973,
-                  "startTime": 244.165
+                  "startTime": 243.467
                 },
                 {
                   "duration": 16.563,
-                  "startTime": 255.058
+                  "startTime": 254.36
                 },
                 {
                   "duration": 35.152,
-                  "startTime": 853.004
+                  "startTime": 852.306
                 },
                 {
                   "duration": 13.307,
-                  "startTime": 888.596
+                  "startTime": 887.898
                 },
                 {
                   "duration": 8.093,
-                  "startTime": 902.596
+                  "startTime": 901.898
                 },
                 {
                   "duration": 5.438,
-                  "startTime": 911.958
+                  "startTime": 911.26
                 },
                 {
                   "duration": 8.586,
-                  "startTime": 917.434
+                  "startTime": 916.736
                 },
                 {
                   "duration": 5.453,
-                  "startTime": 926.691
+                  "startTime": 925.993
                 },
                 {
                   "duration": 14.123,
-                  "startTime": 1454.129
+                  "startTime": 1453.431
                 },
                 {
                   "duration": 5.701,
-                  "startTime": 1747.959
+                  "startTime": 1747.261
                 },
                 {
                   "duration": 75.734,
-                  "startTime": 1765.511
+                  "startTime": 1764.813
                 },
                 {
                   "duration": 9.896,
-                  "startTime": 1841.774
+                  "startTime": 1841.076
                 },
                 {
                   "duration": 6.119,
-                  "startTime": 1854.003
+                  "startTime": 1853.305
                 }
               ]
             }
@@ -8576,12 +8576,12 @@
                 {
                   "url": "https://www.mikescerealshack.co/",
                   "duration": 75.734,
-                  "startTime": 1765.511
+                  "startTime": 1764.813
                 },
                 {
                   "url": "https://www.mikescerealshack.co/",
                   "duration": 55.073,
-                  "startTime": 11.328
+                  "startTime": 10.63
                 }
               ]
             }
@@ -15389,19 +15389,19 @@
               "items": [
                 {
                   "duration": 11.62,
-                  "startTime": 129.762
+                  "startTime": 120.628
                 },
                 {
                   "duration": 10.402,
-                  "startTime": 166.603
+                  "startTime": 157.469
                 },
                 {
                   "duration": 9.63,
-                  "startTime": 182.736
+                  "startTime": 173.602
                 },
                 {
                   "duration": 22.974,
-                  "startTime": 273.238
+                  "startTime": 264.104
                 }
               ]
             }

--- a/core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -69,6 +69,37 @@ describe('Main Thread Tasks', () => {
     expect(tasks).toHaveLength(425);
   });
 
+  it('should use the first task as time origin if no traceStartTs is given', () => {
+    const {mainThreadEvents, frames, timestamps} =
+        TraceProcessor.processTrace({traceEvents: pwaTrace});
+    const tasks = MainThreadTasks.getMainThreadTasks(mainThreadEvents, frames, timestamps.traceEnd);
+
+    expect(tasks[0]).toMatchObject({
+      startTime: 0,
+      endTime: expect.toBeApproximately(0.02),
+    });
+    expect(tasks[1]).toMatchObject({
+      startTime: expect.toBeApproximately(0.02),
+      endTime: expect.toBeApproximately(0.03),
+    });
+  });
+
+  it('should use traceStartTs as time origin if given', () => {
+    const {mainThreadEvents, frames, timestamps} =
+        TraceProcessor.processTrace({traceEvents: pwaTrace});
+    const tasks = MainThreadTasks.getMainThreadTasks(mainThreadEvents, frames, timestamps.traceEnd,
+        timestamps.timeOrigin);
+
+    expect(tasks[0]).toMatchObject({
+      startTime: expect.toBeApproximately(-15.02),
+      endTime: expect.toBeApproximately(-15),
+    });
+    expect(tasks[1]).toMatchObject({
+      startTime: expect.toBeApproximately(-15),
+      endTime: expect.toBeApproximately(-14.99),
+    });
+  });
+
   it('should compute parent/child correctly', () => {
     /*
     An artistic rendering of the below trace:

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -1730,67 +1730,67 @@
         "items": [
           {
             "duration": 18.205,
-            "startTime": 577.894
+            "startTime": 575.062
           },
           {
             "duration": 13.115,
-            "startTime": 604.987
+            "startTime": 602.155
           },
           {
             "duration": 7.754,
-            "startTime": 618.358
+            "startTime": 615.526
           },
           {
             "duration": 6.866,
-            "startTime": 663.052
+            "startTime": 660.22
           },
           {
             "duration": 8.315,
-            "startTime": 2818.076
+            "startTime": 2815.244
           },
           {
             "duration": 49.24,
-            "startTime": 6769.397
+            "startTime": 6766.565
           },
           {
             "duration": 28.923,
-            "startTime": 6818.645
+            "startTime": 6815.813
           },
           {
             "duration": 1174.877,
-            "startTime": 6848.627
+            "startTime": 6845.795
           },
           {
             "duration": 6.514,
-            "startTime": 8023.518
+            "startTime": 8020.686
           },
           {
             "duration": 145.815,
-            "startTime": 8047.587
+            "startTime": 8044.755
           },
           {
             "duration": 8.377,
-            "startTime": 8193.425
+            "startTime": 8190.593
           },
           {
             "duration": 8.436,
-            "startTime": 8211.514
+            "startTime": 8208.682
           },
           {
             "duration": 5.248,
-            "startTime": 8531.242
+            "startTime": 8528.41
           },
           {
             "duration": 5.931,
-            "startTime": 8780.548
+            "startTime": 8777.716
           },
           {
             "duration": 11.936,
-            "startTime": 18938.384
+            "startTime": 18935.552
           },
           {
             "duration": 5.837,
-            "startTime": 24358.667
+            "startTime": 24355.835
           }
         ]
       }
@@ -2377,12 +2377,12 @@
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "duration": 1174.877,
-            "startTime": 6848.627
+            "startTime": 6845.795
           },
           {
             "url": "http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js",
             "duration": 145.815,
-            "startTime": 8047.587
+            "startTime": 8044.755
           }
         ]
       }


### PR DESCRIPTION
addresses the first half of #14226, putting the hidden `main-thread-tasks` audit start times on the same timeline as e.g. the hidden `metrics` diagnostic audit timestamps.

After this change there will be tasks with negative start/endTimes returned from `getMainThreadTasks()`. There's no larger effect because no code touches the task start/endTimes except for the hidden `main-thread-tasks` diagnostic audit. All other audits that use `getMainThreadTasks()` just use the task durations.

A full fix for #14226 will (probably) remove any tasks happening before the time origin from those summary audits, but this change has no effect on those audits.