### PR TITLE
core(network-requests): include starting timestamp as debug data

### DIFF
--- a/core/audits/network-requests.js
+++ b/core/audits/network-requests.js
@@ -110,6 +110,14 @@ class NetworkRequests extends Audit {
 
     const tableDetails = Audit.makeTableDetails(headings, results);
 
+    // Include starting timestamp to allow syncing requests with navStart/metric timestamps.
+    const networkStartTimeTs = Number.isFinite(earliestStartTime) ?
+        earliestStartTime * 1_000_000 : undefined;
+    tableDetails.debugData = {
+      type: 'debugdata',
+      networkStartTimeTs,
+    };
+
     return {
       score: 1,
       details: tableDetails,

--- a/core/test/audits/network-requests-test.js
+++ b/core/test/audits/network-requests-test.js
@@ -57,7 +57,7 @@ describe('Network requests audit', () => {
       resourceType: 'Script',
     });
 
-    expect(output.details.debugData).toBe({
+    expect(output.details.debugData).toStrictEqual({
       type: 'debugdata',
       networkStartTimeTs: 360725781425,
     });

--- a/core/test/audits/network-requests-test.js
+++ b/core/test/audits/network-requests-test.js
@@ -56,6 +56,11 @@ describe('Network requests audit', () => {
       mimeType: 'application/javascript',
       resourceType: 'Script',
     });
+
+    expect(output.details.debugData).toBe({
+      type: 'debugdata',
+      networkStartTimeTs: 360725781425,
+    });
   });
 
   it('should handle times correctly', async () => {

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -1055,7 +1055,11 @@
                   "resourceType": "Other",
                   "experimentalFromMainFrame": true
                 }
-              ]
+              ],
+              "debugData": {
+                "type": "debugdata",
+                "networkStartTimeTs": 49208077236
+              }
             }
           },
           "network-rtt": {
@@ -8142,7 +8146,11 @@
                   "mimeType": "image/jpeg",
                   "resourceType": "Image"
                 }
-              ]
+              ],
+              "debugData": {
+                "type": "debugdata",
+                "networkStartTimeTs": 49220053647
+              }
             }
           },
           "network-rtt": {
@@ -15273,7 +15281,11 @@
                   "resourceType": "Script",
                   "experimentalFromMainFrame": true
                 }
-              ]
+              ],
+              "debugData": {
+                "type": "debugdata",
+                "networkStartTimeTs": 49241053294
+              }
             }
           },
           "network-rtt": {

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -1630,7 +1630,11 @@
             "resourceType": "Other",
             "experimentalFromMainFrame": true
           }
-        ]
+        ],
+        "debugData": {
+          "type": "debugdata",
+          "networkStartTimeTs": 8696703416
+        }
       }
     },
     "network-rtt": {


### PR DESCRIPTION
Like #14252, this allows comparing two hidden debug audits with slightly different time origins.

The `network-requests` hidden audit uses the first network request start time as time zero, and [emits all network timestamps relative to that point](https://github.com/GoogleChrome/lighthouse/blob/6786a5931903ee2ee63e3c9f9799b6097e999e2d/core/audits/network-requests.js#L51-L52) in the LHR.

This is fine for most purposes, unless you want to compare network request times to metric timestamps, which use navStart as a time origin. navStart and the first networkRequest are usually very close (a few milliseconds...trace events are `navigationStart` and the following `ResourceWillSendRequest` with the same `requestId` as the navStart's `navigationId`), but not simultaneous.

Rather than add the trace as a required artifact to the `network-requests` audit (complicating it and increasing the chances the audit will error or not be able to run), this PR just adds the raw request timestamp to the debugData since this is primarily for debugging. When comparing to e.g. [`observedLargestContentfulPaintAllFramesTs` over in metrics](https://github.com/GoogleChrome/lighthouse/blob/6786a5931903ee2ee63e3c9f9799b6097e999e2d/core/test/results/sample_v2.json#L1844), this base timestamp can be added to the network requests startTimes and the numbers can be compared directly.