### PR TITLE
v9.6.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+<a name="9.6.5"></a>
+# 9.6.5 (2022-08-01)
+[Full Changelog](https://github.com/compare/v9.6.4...v9.6.5)
+
+This is an npm-only release and affects only the raw JSON report. We have no plans to release this specific version to DevTools or PSI, but the changes will be rolled up into the next release in those clients.
+
+## Core
+
+* core(network-requests): include starting timestamp as debug data ([#14253](https://github.com/GoogleChrome/lighthouse/pull/14253))
+* core: use trace time origin for main-thread-task time origin ([#14252](https://github.com/GoogleChrome/lighthouse/pull/14252))
+
 <a name="9.6.4"></a>
 # 9.6.4 (2022-07-26)
 [Full Changelog](https://github.com/compare/v9.6.3...v9.6.4)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -60,10 +60,10 @@ A Lighthouse plugin is just a node module with a name that starts with `lighthou
   "name": "lighthouse-plugin-cats",
   "main": "plugin.js",
   "peerDependencies": {
-    "lighthouse": "^9.6.4"
+    "lighthouse": "^9.6.5"
   },
   "devDependencies": {
-    "lighthouse": "^9.6.4"
+    "lighthouse": "^9.6.5"
   }
 }
 ```

--- a/docs/recipes/custom-audit/package.json
+++ b/docs/recipes/custom-audit/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "lighthouse": "^9.6.4"
+    "lighthouse": "^9.6.5"
   }
 }

--- a/docs/recipes/gulp/package.json
+++ b/docs/recipes/gulp/package.json
@@ -7,6 +7,6 @@
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-connect": "^5.0.0",
-    "lighthouse": "^9.6.4"
+    "lighthouse": "^9.6.5"
   }
 }

--- a/docs/recipes/lighthouse-plugin-example/package.json
+++ b/docs/recipes/lighthouse-plugin-example/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "main": "./plugin.js",
   "peerDependencies": {
-    "lighthouse": "^9.6.4"
+    "lighthouse": "^9.6.5"
   },
   "devDependencies": {
     "lighthouse": "^8.6.0"

--- a/lighthouse-core/audits/network-requests.js
+++ b/lighthouse-core/audits/network-requests.js
@@ -110,6 +110,14 @@ class NetworkRequests extends Audit {
 
     const tableDetails = Audit.makeTableDetails(headings, results);
 
+    // Include starting timestamp to allow syncing requests with navStart/metric timestamps.
+    const networkStartTimeTs = Number.isFinite(earliestStartTime) ?
+        earliestStartTime * 1_000_000 : undefined;
+    tableDetails.debugData = {
+      type: 'debugdata',
+      networkStartTimeTs,
+    };
+
     return {
       score: 1,
       details: tableDetails,

--- a/lighthouse-core/computed/main-thread-tasks.js
+++ b/lighthouse-core/computed/main-thread-tasks.js
@@ -17,7 +17,8 @@ class MainThreadTasks {
    */
   static async compute_(trace, context) {
     const {mainThreadEvents, frames, timestamps} = await ProcessedTrace.request(trace, context);
-    return MainThreadTasks_.getMainThreadTasks(mainThreadEvents, frames, timestamps.traceEnd);
+    return MainThreadTasks_.getMainThreadTasks(mainThreadEvents, frames, timestamps.traceEnd,
+        timestamps.timeOrigin);
   }
 }
 

--- a/lighthouse-core/lib/tracehouse/main-thread-tasks.js
+++ b/lighthouse-core/lib/tracehouse/main-thread-tasks.js
@@ -561,9 +561,10 @@ class MainThreadTasks {
    * @param {LH.TraceEvent[]} mainThreadEvents
    * @param {Array<{id: string, url: string}>} frames
    * @param {number} traceEndTs
+   * @param {number} [traceStartTs] Optional time-0 ts for tasks. Tasks before this point will have negative start/end times. Defaults to the first task found.
    * @return {TaskNode[]}
    */
-  static getMainThreadTasks(mainThreadEvents, frames, traceEndTs) {
+  static getMainThreadTasks(mainThreadEvents, frames, traceEndTs, traceStartTs) {
     const timers = new Map();
     const xhrs = new Map();
     const frameURLsById = new Map();
@@ -587,8 +588,8 @@ class MainThreadTasks {
       priorTaskData.lastTaskURLs = task.attributableURLs;
     }
 
-    // Rebase all the times to be relative to start of trace in ms
-    const firstTs = (tasks[0] || {startTime: 0}).startTime;
+    // Rebase all the times to be relative to start of trace and covert to ms.
+    const firstTs = traceStartTs ?? tasks[0].startTime;
     for (const task of tasks) {
       task.startTime = (task.startTime - firstTs) / 1000;
       task.endTime = (task.endTime - firstTs) / 1000;

--- a/lighthouse-core/test/audits/network-requests-test.js
+++ b/lighthouse-core/test/audits/network-requests-test.js
@@ -57,6 +57,11 @@ describe('Network requests audit', () => {
       mimeType: 'application/javascript',
       resourceType: 'Script',
     });
+
+    expect(output.details.debugData).toStrictEqual({
+      type: 'debugdata',
+      networkStartTimeTs: 360725781425,
+    });
   });
 
   it('should handle times correctly', async () => {

--- a/lighthouse-core/test/computed/main-thread-tasks-test.js
+++ b/lighthouse-core/test/computed/main-thread-tasks-test.js
@@ -16,4 +16,17 @@ describe('MainThreadTasksComputed', () => {
     const tasks = await MainThreadTasks.request(pwaTrace, context);
     expect(tasks.length).toEqual(4784);
   });
+
+  it('uses negative timestamps for tasks before navStart', async () => {
+    const context = {computedCache: new Map()};
+    const tasks = await MainThreadTasks.request(pwaTrace, context);
+    expect(tasks[0]).toMatchObject({
+      startTime: expect.toBeApproximately(-3, 1),
+      endTime: expect.toBeApproximately(-3, 1),
+    });
+    expect(tasks[1]).toMatchObject({
+      startTime: expect.toBeApproximately(-3, 1),
+      endTime: expect.toBeApproximately(-2.8, 1),
+    });
+  });
 });

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -2,7 +2,7 @@
   "steps": [
     {
       "lhr": {
-        "lighthouseVersion": "9.6.4",
+        "lighthouseVersion": "9.6.5",
         "requestedUrl": "https://www.mikescerealshack.co/",
         "finalUrl": "https://www.mikescerealshack.co/",
         "fetchTime": "2022-03-08T15:35:57.356Z",
@@ -7599,7 +7599,7 @@
     },
     {
       "lhr": {
-        "lighthouseVersion": "9.6.4",
+        "lighthouseVersion": "9.6.5",
         "requestedUrl": "https://www.mikescerealshack.co/",
         "finalUrl": "https://www.mikescerealshack.co/search?q=call+of+duty",
         "fetchTime": "2022-03-08T15:36:08.267Z",
@@ -11065,7 +11065,7 @@
     },
     {
       "lhr": {
-        "lighthouseVersion": "9.6.4",
+        "lighthouseVersion": "9.6.5",
         "requestedUrl": "https://www.mikescerealshack.co/search?q=call+of+duty",
         "finalUrl": "https://www.mikescerealshack.co/search?q=call+of+duty",
         "fetchTime": "2022-03-08T15:36:22.894Z",
@@ -15873,7 +15873,7 @@
     },
     {
       "lhr": {
-        "lighthouseVersion": "9.6.4",
+        "lighthouseVersion": "9.6.5",
         "requestedUrl": "https://www.mikescerealshack.co/corrections",
         "finalUrl": "https://www.mikescerealshack.co/corrections",
         "fetchTime": "2022-03-08T15:36:29.745Z",

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -2,7 +2,7 @@
   "steps": [
     {
       "lhr": {
-        "lighthouseVersion": "9.6.1",
+        "lighthouseVersion": "9.6.4",
         "requestedUrl": "https://www.mikescerealshack.co/",
         "finalUrl": "https://www.mikescerealshack.co/",
         "fetchTime": "2022-03-08T15:35:57.356Z",
@@ -1173,43 +1173,43 @@
               "items": [
                 {
                   "duration": 9.06,
-                  "startTime": 212.665
+                  "startTime": 203.866
                 },
                 {
                   "duration": 5.668,
-                  "startTime": 221.909
+                  "startTime": 213.11
                 },
                 {
                   "duration": 6.24,
-                  "startTime": 227.679
+                  "startTime": 218.88
                 },
                 {
                   "duration": 35.001,
-                  "startTime": 285.755
+                  "startTime": 276.956
                 },
                 {
                   "duration": 16.457,
-                  "startTime": 321.262
+                  "startTime": 312.463
                 },
                 {
                   "duration": 9.424,
-                  "startTime": 357.426
+                  "startTime": 348.627
                 },
                 {
                   "duration": 23.147,
-                  "startTime": 392.512
+                  "startTime": 383.713
                 },
                 {
                   "duration": 10.796,
-                  "startTime": 2973.653
+                  "startTime": 2964.854
                 },
                 {
                   "duration": 6.275,
-                  "startTime": 3011.559
+                  "startTime": 3002.76
                 },
                 {
                   "duration": 30.474,
-                  "startTime": 3211.47
+                  "startTime": 3202.671
                 }
               ]
             }
@@ -7595,7 +7595,7 @@
     },
     {
       "lhr": {
-        "lighthouseVersion": "9.6.1",
+        "lighthouseVersion": "9.6.4",
         "requestedUrl": "https://www.mikescerealshack.co/",
         "finalUrl": "https://www.mikescerealshack.co/search?q=call+of+duty",
         "fetchTime": "2022-03-08T15:36:08.267Z",
@@ -8485,103 +8485,103 @@
               "items": [
                 {
                   "duration": 22.89,
-                  "startTime": 11.794
+                  "startTime": 10.796
                 },
                 {
                   "duration": 11.346,
-                  "startTime": 34.882
+                  "startTime": 33.884
                 },
                 {
                   "duration": 14.707,
-                  "startTime": 47.712
+                  "startTime": 46.714
                 },
                 {
                   "duration": 11.476,
-                  "startTime": 64.964
+                  "startTime": 63.966
                 },
                 {
                   "duration": 10.211,
-                  "startTime": 77.887
+                  "startTime": 76.889
                 },
                 {
                   "duration": 7.878,
-                  "startTime": 90.234
+                  "startTime": 89.236
                 },
                 {
                   "duration": 12.607,
-                  "startTime": 101.631
+                  "startTime": 100.633
                 },
                 {
                   "duration": 9.346,
-                  "startTime": 116.441
+                  "startTime": 115.443
                 },
                 {
                   "duration": 11.39,
-                  "startTime": 126.968
+                  "startTime": 125.97
                 },
                 {
                   "duration": 11.435,
-                  "startTime": 140.423
+                  "startTime": 139.425
                 },
                 {
                   "duration": 10.084,
-                  "startTime": 152.953
+                  "startTime": 151.955
                 },
                 {
                   "duration": 10.9,
-                  "startTime": 164.298
+                  "startTime": 163.3
                 },
                 {
                   "duration": 6.346,
-                  "startTime": 206.944
+                  "startTime": 205.946
                 },
                 {
                   "duration": 6.642,
-                  "startTime": 214.45
+                  "startTime": 213.452
                 },
                 {
                   "duration": 16.871,
-                  "startTime": 222.556
+                  "startTime": 221.558
                 },
                 {
                   "duration": 35.881,
-                  "startTime": 821.648
+                  "startTime": 820.65
                 },
                 {
                   "duration": 15.437,
-                  "startTime": 857.584
+                  "startTime": 856.586
                 },
                 {
                   "duration": 9.331,
-                  "startTime": 873.028
+                  "startTime": 872.03
                 },
                 {
                   "duration": 7.848,
-                  "startTime": 887.532
+                  "startTime": 886.534
                 },
                 {
                   "duration": 6.696,
-                  "startTime": 897.886
+                  "startTime": 896.888
                 },
                 {
                   "duration": 18.004,
-                  "startTime": 1423.407
+                  "startTime": 1422.409
                 },
                 {
                   "duration": 6.862,
-                  "startTime": 2249.903
+                  "startTime": 2248.905
                 },
                 {
                   "duration": 194.901,
-                  "startTime": 2256.773
+                  "startTime": 2255.775
                 },
                 {
                   "duration": 14.028,
-                  "startTime": 2451.719
+                  "startTime": 2450.721
                 },
                 {
                   "duration": 8.949,
-                  "startTime": 2467.956
+                  "startTime": 2466.958
                 }
               ]
             }
@@ -8814,7 +8814,7 @@
                 {
                   "url": "https://www.mikescerealshack.co/",
                   "duration": 194.901,
-                  "startTime": 2256.773
+                  "startTime": 2255.775
                 }
               ]
             }
@@ -11057,7 +11057,7 @@
     },
     {
       "lhr": {
-        "lighthouseVersion": "9.6.1",
+        "lighthouseVersion": "9.6.4",
         "requestedUrl": "https://www.mikescerealshack.co/search?q=call+of+duty",
         "finalUrl": "https://www.mikescerealshack.co/search?q=call+of+duty",
         "fetchTime": "2022-03-08T15:36:22.894Z",
@@ -15865,7 +15865,7 @@
     },
     {
       "lhr": {
-        "lighthouseVersion": "9.6.1",
+        "lighthouseVersion": "9.6.4",
         "requestedUrl": "https://www.mikescerealshack.co/corrections",
         "finalUrl": "https://www.mikescerealshack.co/corrections",
         "fetchTime": "2022-03-08T15:36:29.745Z",
@@ -17022,19 +17022,19 @@
               "items": [
                 {
                   "duration": 14.962,
-                  "startTime": 151.327
+                  "startTime": 138.885
                 },
                 {
                   "duration": 10.715,
-                  "startTime": 188.398
+                  "startTime": 175.956
                 },
                 {
                   "duration": 12.041,
-                  "startTime": 213.628
+                  "startTime": 201.186
                 },
                 {
                   "duration": 19.568,
-                  "startTime": 284.111
+                  "startTime": 271.669
                 }
               ]
             }

--- a/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/lighthouse-core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -1057,7 +1057,11 @@
                   "resourceType": "Other",
                   "experimentalFromMainFrame": true
                 }
-              ]
+              ],
+              "debugData": {
+                "type": "debugdata",
+                "networkStartTimeTs": 28621648277
+              }
             }
           },
           "network-rtt": {
@@ -8377,7 +8381,11 @@
                   "mimeType": "image/jpeg",
                   "resourceType": "Image"
                 }
-              ]
+              ],
+              "debugData": {
+                "type": "debugdata",
+                "networkStartTimeTs": 28632353955
+              }
             }
           },
           "network-rtt": {
@@ -16906,7 +16914,11 @@
                   "resourceType": "Script",
                   "experimentalFromMainFrame": true
                 }
-              ]
+              ],
+              "debugData": {
+                "type": "debugdata",
+                "networkStartTimeTs": 28653584680
+              }
             }
           },
           "network-rtt": {

--- a/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
+++ b/lighthouse-core/test/lib/tracehouse/main-thread-tasks-test.js
@@ -70,6 +70,37 @@ describe('Main Thread Tasks', () => {
     expect(tasks).toHaveLength(425);
   });
 
+  it('should use the first task as time origin if no traceStartTs is given', () => {
+    const {mainThreadEvents, frames, timestamps} =
+        TraceProcessor.processTrace({traceEvents: pwaTrace});
+    const tasks = MainThreadTasks.getMainThreadTasks(mainThreadEvents, frames, timestamps.traceEnd);
+
+    expect(tasks[0]).toMatchObject({
+      startTime: 0,
+      endTime: expect.toBeApproximately(0.02),
+    });
+    expect(tasks[1]).toMatchObject({
+      startTime: expect.toBeApproximately(0.02),
+      endTime: expect.toBeApproximately(0.03),
+    });
+  });
+
+  it('should use traceStartTs as time origin if given', () => {
+    const {mainThreadEvents, frames, timestamps} =
+        TraceProcessor.processTrace({traceEvents: pwaTrace});
+    const tasks = MainThreadTasks.getMainThreadTasks(mainThreadEvents, frames, timestamps.traceEnd,
+        timestamps.timeOrigin);
+
+    expect(tasks[0]).toMatchObject({
+      startTime: expect.toBeApproximately(-15.02),
+      endTime: expect.toBeApproximately(-15),
+    });
+    expect(tasks[1]).toMatchObject({
+      startTime: expect.toBeApproximately(-15),
+      endTime: expect.toBeApproximately(-14.99),
+    });
+  });
+
   it('should compute parent/child correctly', () => {
     /*
     An artistic rendering of the below trace:

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1,5 +1,5 @@
 {
-  "lighthouseVersion": "9.6.4",
+  "lighthouseVersion": "9.6.5",
   "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
   "finalUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
   "fetchTime": "2021-09-07T20:11:11.853Z",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1638,7 +1638,11 @@
             "resourceType": "Other",
             "experimentalFromMainFrame": true
           }
-        ]
+        ],
+        "debugData": {
+          "type": "debugdata",
+          "networkStartTimeTs": 8696703416
+        }
       }
     },
     "network-rtt": {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1738,67 +1738,67 @@
         "items": [
           {
             "duration": 18.205,
-            "startTime": 577.894
+            "startTime": 575.062
           },
           {
             "duration": 13.115,
-            "startTime": 604.987
+            "startTime": 602.155
           },
           {
             "duration": 7.754,
-            "startTime": 618.358
+            "startTime": 615.526
           },
           {
             "duration": 6.866,
-            "startTime": 663.052
+            "startTime": 660.22
           },
           {
             "duration": 8.315,
-            "startTime": 2818.076
+            "startTime": 2815.244
           },
           {
             "duration": 49.24,
-            "startTime": 6769.397
+            "startTime": 6766.565
           },
           {
             "duration": 28.923,
-            "startTime": 6818.645
+            "startTime": 6815.813
           },
           {
             "duration": 1174.877,
-            "startTime": 6848.627
+            "startTime": 6845.795
           },
           {
             "duration": 6.514,
-            "startTime": 8023.518
+            "startTime": 8020.686
           },
           {
             "duration": 145.815,
-            "startTime": 8047.587
+            "startTime": 8044.755
           },
           {
             "duration": 8.377,
-            "startTime": 8193.425
+            "startTime": 8190.593
           },
           {
             "duration": 8.436,
-            "startTime": 8211.514
+            "startTime": 8208.682
           },
           {
             "duration": 5.248,
-            "startTime": 8531.242
+            "startTime": 8528.41
           },
           {
             "duration": 5.931,
-            "startTime": 8780.548
+            "startTime": 8777.716
           },
           {
             "duration": 11.936,
-            "startTime": 18938.384
+            "startTime": 18935.552
           },
           {
             "duration": 5.837,
-            "startTime": 24358.667
+            "startTime": 24355.835
           }
         ]
       }
@@ -2385,12 +2385,12 @@
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "duration": 1174.877,
-            "startTime": 6848.627
+            "startTime": 6845.795
           },
           {
             "url": "http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js",
             "duration": 145.815,
-            "startTime": 8047.587
+            "startTime": 8044.755
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "9.6.4",
+  "version": "9.6.5",
   "description": "Automated auditing, performance metrics, and best practices for the web.",
   "main": "./lighthouse-core/index.js",
   "bin": {

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-emulate-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-emulate-run-expected.txt
@@ -15,7 +15,7 @@ Analyze page load: enabled visible
 
 =============== Lighthouse Results ===============
 URL: http://127.0.0.1:8000/devtools/lighthouse/resources/lighthouse-emulate-pass.html
-Version: 9.6.4
+Version: 9.6.5
 formFactor: mobile
 screenEmulation: {
   "mobile": true,

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-navigation-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-navigation-expected.txt
@@ -262,7 +262,7 @@ Generating results...
 
 =============== Lighthouse Results ===============
 URL: http://127.0.0.1:8000/devtools/lighthouse/resources/lighthouse-basic.html
-Version: 9.6.4
+Version: 9.6.5
 ViewportDimensions: {
   "innerWidth": 980,
   "innerHeight": 1743,

--- a/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
+++ b/third-party/chromium-webtests/webtests/http/tests/devtools/lighthouse/lighthouse-successful-run-expected.txt
@@ -373,7 +373,7 @@ Generating results...
 
 =============== Lighthouse Results ===============
 URL: http://127.0.0.1:8000/devtools/lighthouse/resources/lighthouse-basic.html
-Version: 9.6.4
+Version: 9.6.5
 ViewportDimensions: {
   "innerWidth": 980,
   "innerHeight": 1743,


### PR DESCRIPTION
Patch release to include data to sync debug audits for the August 1st HTTP Archive run.

- [x] https://github.com/GoogleChrome/lighthouse/commit/6786a5931903ee2ee63e3c9f9799b6097e999e2d https://github.com/GoogleChrome/lighthouse/pull/14252
- [x] https://github.com/GoogleChrome/lighthouse/commit/c31a92a2224b8d491f22a95278f1b7a4f87acdc3 https://github.com/GoogleChrome/lighthouse/pull/14253

cherry-picking is harder now :/