### PR TITLE
core(full-page-screenshot): make lhId less dependant on chrome internals

### DIFF
--- a/core/gather/driver/execution-context.js
+++ b/core/gather/driver/execution-context.js
@@ -82,6 +82,9 @@ class ExecutionContext {
       this._session.getNextProtocolTimeout() :
       60000;
 
+    // This is only used by the fullpage screenshot gatherer. See `getNodeDetails` in page-functions.
+    const uniqueExecutionContextIdentifier = (contextId || 0) - (this._executionContextId || 0);
+
     const evaluationParams = {
       // We need to explicitly wrap the raw expression for several purposes:
       // 1. Ensure that the expression will be a native Promise and not a polyfill/non-Promise.
@@ -90,7 +93,7 @@ class ExecutionContext {
       //    so that they can be serialized properly b/c JSON.stringify(new Error('foo')) === '{}'
       expression: `(function wrapInNativePromise() {
         ${ExecutionContext._cachedNativesPreamble};
-        globalThis.__lighthouseExecutionContextId = ${contextId};
+        globalThis.__lighthouseMainExecutionContextId = ${uniqueExecutionContextIdentifier};
         return new Promise(function (resolve) {
           return Promise.resolve()
             .then(_ => ${expression})

--- a/core/gather/driver/execution-context.js
+++ b/core/gather/driver/execution-context.js
@@ -16,6 +16,12 @@ class ExecutionContext {
 
     /** @type {number|undefined} */
     this._executionContextId = undefined;
+    /**
+     * Marks the order that execution context ids are used, for purposes of having a unique
+     * value (that doesn't expose the actual execution context id) to use for __lighthouseMainExecutionContextId.
+     * @type {number[]}
+     */
+    this._executionContextIdentifiersUsed = [];
 
     // We use isolated execution contexts for `evaluateAsync` that can be destroyed through navigation
     // and other page actions. Cleanup our relevant bookkeeping as we see those events.
@@ -82,8 +88,13 @@ class ExecutionContext {
       this._session.getNextProtocolTimeout() :
       60000;
 
-    // This is only used by the fullpage screenshot gatherer. See `getNodeDetails` in page-functions.
-    const uniqueExecutionContextIdentifier = (contextId || 0) - (this._executionContextId || 0);
+    // `__lighthouseMainExecutionContextId` is only used by the FullPageScreenshot gatherer.
+    // See `getNodeDetails` in page-functions.
+    if (!this._executionContextIdentifiersUsed.includes(contextId || 0)) {
+      this._executionContextIdentifiersUsed.push(contextId || 0);
+    }
+    const uniqueExecutionContextIdentifier =
+      this._executionContextIdentifiersUsed.indexOf(contextId || 0);
 
     const evaluationParams = {
       // We need to explicitly wrap the raw expression for several purposes:

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -498,6 +498,12 @@ function getNodeDetails(element) {
   const selector = getNodeSelector(element);
 
   // Create an id that will be unique across all execution contexts.
+  //
+  // Made up of 3 components:
+  //   - number unique to specific execution context
+  //   - nth unique node seen by this function for this execution context
+  //   - node tagName
+  //
   // The id could be any arbitrary string, the exact value is not important.
   // For example, tagName is added only because it might be useful for debugging.
   // But execution id and map size are added to ensure uniqueness.
@@ -507,9 +513,7 @@ function getNodeDetails(element) {
   let lhId = window.__lighthouseNodesDontTouchOrAllVarianceGoesAway.get(element);
   if (!lhId) {
     lhId = [
-      window.__lighthouseExecutionContextId !== undefined ?
-        window.__lighthouseExecutionContextId :
-        'page',
+      window.__lighthouseExecutionContextUniqueIdentifier ?? '?',
       window.__lighthouseNodesDontTouchOrAllVarianceGoesAway.size,
       element.tagName,
     ].join('-');

--- a/core/test/gather/driver/execution-context-test.js
+++ b/core/test/gather/driver/execution-context-test.js
@@ -218,7 +218,7 @@ describe('.evaluate', () => {
 const URL = globalThis.__nativeURL || globalThis.URL;
 const performance = globalThis.__nativePerformance || globalThis.performance;
 const fetch = globalThis.__nativeFetch || globalThis.fetch;
-        globalThis.__lighthouseExecutionContextId = undefined;
+        globalThis.__lighthouseMainExecutionContextId = 0;
         return new Promise(function (resolve) {
           return Promise.resolve()
             .then(_ => (() => {

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -30,7 +30,7 @@ declare global {
 
     /** Used by FullPageScreenshot gatherer. */
     __lighthouseNodesDontTouchOrAllVarianceGoesAway: Map<Element, string>;
-    __lighthouseExecutionContextId?: number;
+    __lighthouseExecutionContextUniqueIdentifier?: number;
 
     /** Injected into the page when the `--debug` flag is used. */
     continueLighthouseRun(): void;


### PR DESCRIPTION
The specific id for the execution context varies as Chrome internals do different things, and has already changed twice recently. Instead of using the exact id value, instead log the context ids we've used and use the indexOf from that array as the new execution-context specific position of the lhId.

These values should now only depend on the order in which we run our code (or whatever variance exists on the page that changes what elements our code inspects).