### PR TITLE
deps: downgrade dev puppeteer

### DIFF
--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -25,7 +25,7 @@ import fs from 'fs';
 import readline from 'readline';
 import {fileURLToPath} from 'url';
 
-import puppeteer from 'puppeteer-core';
+import puppeteer from 'puppeteer';
 import yargs from 'yargs';
 import * as yargsHelpers from 'yargs/helpers';
 import {getChromePath} from 'chrome-launcher';

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -25,6 +25,9 @@ import fs from 'fs';
 import readline from 'readline';
 import {fileURLToPath} from 'url';
 
+// Puppeteer 16 can unpause worker targets prematurely so we use an older version just for this script.
+// https://bugs.chromium.org/p/chromium/issues/detail?id=1352175
+// TODO: Bump dev Puppeteer to latest.
 import puppeteer from 'puppeteer';
 import yargs from 'yargs';
 import * as yargsHelpers from 'yargs/helpers';

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "pako": "^2.0.3",
     "preact": "^10.7.2",
     "pretty-json-stringify": "^0.0.2",
-    "puppeteer": "^16.1.0",
+    "puppeteer": "^15.5.0",
     "resolve": "^1.20.0",
     "rollup": "^2.52.7",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6090,10 +6090,10 @@ puppeteer-core@^16.1.0:
     unbzip2-stream "1.4.3"
     ws "8.8.1"
 
-puppeteer@^16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-16.1.0.tgz#06a32dc347c94642601017fbf83e1d37379b9651"
-  integrity sha512-lhykJLbH2bbBaP3NfYI2Vj0T4ctrdfVdEVf8glZITPnLfqrJ0nfUzAYuIz5YcA79k5lmFKANIhEXex+jQChU3g==
+puppeteer@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-15.5.0.tgz#446e01547ba0f47c37ac2148e5333433b4ecb371"
+  integrity sha512-+vZPU8iBSdCx1Kn5hHas80fyo0TiVyMeqLGv/1dygX2HKhAZjO9YThadbRTCoTYq0yWw+w/CysldPsEekDtjDQ==
   dependencies:
     cross-fetch "3.1.5"
     debug "4.3.4"
@@ -6106,7 +6106,7 @@ puppeteer@^16.1.0:
     rimraf "3.0.2"
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
-    ws "8.8.1"
+    ws "8.8.0"
 
 q@^1.5.1:
   version "1.5.1"
@@ -7513,6 +7513,11 @@ write-file-atomic@^4.0.1:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+ws@8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.0.tgz#8e71c75e2f6348dbf8d78005107297056cb77769"
+  integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==
 
 ws@8.8.1:
   version "8.8.1"


### PR DESCRIPTION
Puppeteer 16 started pausing and resuming targets which shouldn't affect normal Lighthouse execution, but it will be a problem if we want to attach to worker targets https://github.com/GoogleChrome/lighthouse/issues/14211.

Our DT smokes attach to the LH worker to inject the config, and Puppeteer was resuming the the worker target before we inject the config.

This downgrade should only affect our DT smoke runner script and not anything actually shipped with Lighthouse.


