### PR TITLE
cli: throw error if running x64 node on mac arm64

### DIFF
--- a/cli/run.js
+++ b/cli/run.js
@@ -77,7 +77,9 @@ function getDebuggableChrome(flags) {
       throw new Error(
         'Launching Chrome on Mac Silicon (arm64) from an x64 Node installation results in ' +
         'Rosetta translating the Chrome binary, even if Chrome is already arm64. This would ' +
-        'result in huge performance issues.');
+        'result in huge performance issues. To resolve this, you must run Lighthouse CLI with ' +
+        'a version of Node built for arm64. You should also confirm that your Chrome install ' +
+        'says arm64 in chrome://version');
     }
   }
 

--- a/cli/run.js
+++ b/cli/run.js
@@ -7,6 +7,7 @@
 /* eslint-disable no-console */
 
 import path from 'path';
+import os from 'os';
 
 import psList from 'ps-list';
 import * as ChromeLauncher from 'chrome-launcher';
@@ -70,6 +71,16 @@ function parseChromeFlags(flags = '') {
  * @return {Promise<ChromeLauncher.LaunchedChrome>}
  */
 function getDebuggableChrome(flags) {
+  if (process.platform === 'darwin' && process.arch === 'x64') {
+    const cpus = os.cpus();
+    if (cpus[0].model.includes('Apple')) {
+      throw new Error(
+        'Launching Chrome on Mac Silicon (arm64) from an x64 Node installation results in ' +
+        'Rosetta translating the Chrome binary, even if Chrome is already arm64. This would ' +
+        'result in huge performance issues.');
+    }
+  }
+
   return ChromeLauncher.launch({
     port: flags.port,
     ignoreDefaultFlags: flags.chromeIgnoreDefaultFlags,


### PR DESCRIPTION
https://docs.google.com/document/d/1hEt6q0BlZ1c50UNhm9ejXNKLvcOX8pStspCY6hAKwDI/edit# (can just read the most recent update, pasted below).

> The issue was my Node was built for x64 and when you spawn a process from x64, apparently Apple just assumes that it needs to be translated so it uses its Rosetta tech to do that. In chrome://version I see x86_64 translated when that happens, and get ~10x perf regressions.

![image](https://user-images.githubusercontent.com/4071474/184458810-8c94a5e4-927d-44bf-a174-81173f8142d8.png)

______

This PR fixes (well, at least warns about) `yarn smoke perf-preload` on my machine.

For pretty much any CLI invocation – (spawning chrome from my x64 Node install...apparently 14.20 is only distributed as x64 via nvm. arm64 only became a thing sometime in 15.x) – Chrome would get "translated" to some weird hybrid x64->arm64 binary (even tho the Chrome install is already arm64?!). That resulted in ~10x perf regressions all throughout Chrome. Any test that was perf-sensitive ... like `perf-preload` ... was bound to fail.

Initially I sought to grab the arch from Browser.getVersion, but it isn't exposed there. And what chrome://version uses is not easily exposable to CDP. So let's just detect the case where we know Rosetta would kick in - from an x64 node binary running on mac arm64.