### PR TITLE
core(replay): fix stringify extension

### DIFF
--- a/core/fraggle-rock/replay/stringify-extension.js
+++ b/core/fraggle-rock/replay/stringify-extension.js
@@ -37,14 +37,12 @@ class LighthouseStringifyExtension extends PuppeteerReplay.PuppeteerStringifyExt
 
     await super.beforeAllSteps(out, flow);
 
-    const configContext = {
-      settingsOverrides: {
-        screenEmulation: {
-          disabled: true,
-        },
+    const flags = {
+      screenEmulation: {
+        disabled: true,
       },
     };
-    out.appendLine(`const configContext = ${JSON.stringify(configContext)}`);
+    out.appendLine(`const flags = ${JSON.stringify(flags)}`);
     if (isMobile) {
       out.appendLine(`const config = undefined;`);
     } else {
@@ -54,7 +52,7 @@ class LighthouseStringifyExtension extends PuppeteerReplay.PuppeteerStringifyExt
 
     out.appendLine(`const lhApi = await import('lighthouse/core/fraggle-rock/api.js');`);
     // eslint-disable-next-line max-len
-    out.appendLine(`const lhFlow = await lhApi.startFlow(page, {name: ${JSON.stringify(flow.title)}, config, configContext});`);
+    out.appendLine(`const lhFlow = await lhApi.startFlow(page, {name: ${JSON.stringify(flow.title)}, config, flags});`);
   }
 
   /**

--- a/core/test/fraggle-rock/replay/__snapshots__/stringify-extension-test.js.snap
+++ b/core/test/fraggle-rock/replay/__snapshots__/stringify-extension-test.js.snap
@@ -10,10 +10,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
-  const configContext = {\\"settingsOverrides\\":{\\"screenEmulation\\":{\\"disabled\\":true}}}
+  const flags = {\\"screenEmulation\\":{\\"disabled\\":true}}
   const config = undefined;
   const lhApi = await import('lighthouse/core/fraggle-rock/api.js');
-  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow\\", config, configContext});
+  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow\\", config, flags});
   {
     const targetPage = page;
     await targetPage.setViewport({\\"width\\":757,\\"height\\":988})
@@ -65,10 +65,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
-  const configContext = {\\"settingsOverrides\\":{\\"screenEmulation\\":{\\"disabled\\":true}}}
+  const flags = {\\"screenEmulation\\":{\\"disabled\\":true}}
   const config = undefined;
   const lhApi = await import('lighthouse/core/fraggle-rock/api.js');
-  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow\\", config, configContext});
+  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow\\", config, flags});
   {
     const targetPage = page;
     await targetPage.setViewport({\\"width\\":757,\\"height\\":988})
@@ -111,10 +111,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
-  const configContext = {\\"settingsOverrides\\":{\\"screenEmulation\\":{\\"disabled\\":true}}}
+  const flags = {\\"screenEmulation\\":{\\"disabled\\":true}}
   const config = undefined;
   const lhApi = await import('lighthouse/core/fraggle-rock/api.js');
-  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow\\", config, configContext});
+  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow\\", config, flags});
   {
     const targetPage = page;
     await targetPage.setViewport({\\"width\\":757,\\"height\\":988})

--- a/core/test/fraggle-rock/scenarios/__snapshots__/stringified-replay-test-pptr.js.snap
+++ b/core/test/fraggle-rock/scenarios/__snapshots__/stringified-replay-test-pptr.js.snap
@@ -10,10 +10,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
-  const configContext = {\\"settingsOverrides\\":{\\"screenEmulation\\":{\\"disabled\\":true}}}
+  const flags = {\\"screenEmulation\\":{\\"disabled\\":true}}
   const config = (await import('lighthouse/core/config/desktop-config.js')).default;
   const lhApi = await import('lighthouse/core/fraggle-rock/api.js');
-  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow on Desktop\\", config, configContext});
+  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow on Desktop\\", config, flags});
   {
     const targetPage = page;
     await targetPage.setViewport({\\"width\\":757,\\"height\\":988})
@@ -252,10 +252,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
-  const configContext = {\\"settingsOverrides\\":{\\"screenEmulation\\":{\\"disabled\\":true}}}
+  const flags = {\\"screenEmulation\\":{\\"disabled\\":true}}
   const config = undefined;
   const lhApi = await import('lighthouse/core/fraggle-rock/api.js');
-  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow on Mobile\\", config, configContext});
+  const lhFlow = await lhApi.startFlow(page, {name: \\"Test Flow on Mobile\\", config, flags});
   {
     const targetPage = page;
     await targetPage.setViewport({\\"width\\":300,\\"height\\":600})


### PR DESCRIPTION
Kinda shot myself in the foot by merging #14146 and #14050 at the same time. Anyway unit tests started failing at this should be the fix.
