### PR TITLE
Fixed 🐛 Improper Neutralization of Special Elements used in a Command in Shell-quote

### DIFF
--- a/core/scripts/legacy-javascript/yarn.lock
+++ b/core/scripts/legacy-javascript/yarn.lock
@@ -2269,7 +2269,7 @@ shasum@^1.0.0:
     json-stable-stringify "~0.0.0"
     sha.js "~2.4.4"
 
-shell-quote@^1.6.1:
+shell-quote@^1.7.3:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==


### PR DESCRIPTION

**Summary**
The shell-quote package before 1.7.3 for Node.js allows command injection. An attacker can inject unescaped shell metacharacters through a regex designed to support Windows drive letters. If the output of this package is passed to a real shell as a quoted argument to a command with exec(), an attacker can inject arbitrary commands. This is because the Windows drive letter regex character class is {A-z] instead of the correct {A-Za-z]. Several shell metacharacters exist in the space between capital letter Z and lower case letter a, such as the backtick character.

<!-- Describe the need for this change -->
on shell-quote in [core/scripts/legacy-javascript/yarn.lock](https://github.com/imhunterand/lighthouse/blob/-/core/scripts/legacy-javascript/yarn.lock).
upgrade shell-quote to version 1.7.3.

**CVE-2021-42740**
`9.8 / 10`
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`