### PR TITLE
tests(smoke): check lhr.environment exists in version check

### DIFF
--- a/cli/test/smokehouse/report-assert.js
+++ b/cli/test/smokehouse/report-assert.js
@@ -259,6 +259,10 @@ function pruneExpectations(localConsole, lhr, expected, reportOptions) {
    * @param {*} obj
    */
   function failsChromeVersionCheck(obj) {
+    // LHR never actually run, so we can't know. Better to not prune
+    // things than to fail loudly when accessing lhr.environment.
+    if (!lhr.environment) return false;
+
     return !chromiumVersionCheck({
       version: getChromeVersionString(),
       min: obj._minChromiumVersion,


### PR DESCRIPTION
if LH failed to run and only produced a runtimeError, then this function errors during assertion report creation, and prevents the LHR from being printed.

with this change the LHR will actually be printed when it's seen to fail the assertions.