### PR TITLE
tests(devtools): increase expected error count

### DIFF
--- a/third-party/devtools-tests/e2e/lighthouse/navigation_test.ts
+++ b/third-party/devtools-tests/e2e/lighthouse/navigation_test.ts
@@ -58,6 +58,9 @@ describe('Navigation', async function() {
           // TODO: Figure out why these are emitted in FR.
           expectError(/Protocol Error: the message with wrong session id/);
           expectError(/Protocol Error: the message with wrong session id/);
+          expectError(/Protocol Error: the message with wrong session id/);
+          expectError(/Protocol Error: the message with wrong session id/);
+          expectError(/Protocol Error: the message with wrong session id/);
         }
       });
 


### PR DESCRIPTION
The e2e tests have been flaky because sometimes more than 2 of these errors get surfaced.