### PR TITLE
tests(unit): fix node to 16.16

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,7 +10,7 @@ jobs:
   unit:
     strategy:
       matrix:
-        node: ['14', '16', '17']
+        node: ['14', '16.16', '17']
       fail-fast: false
     runs-on: ubuntu-latest
     name: node ${{ matrix.node }}


### PR DESCRIPTION
Changes in node 16.17 broke sentry-test.js. I think this has to do with the mocking situation there but this should work as a temporary fix to unblock CI.