### PR TITLE
core: add priority to network-requests debug audit

### DIFF
--- a/core/audits/network-requests.js
+++ b/core/audits/network-requests.js
@@ -73,6 +73,7 @@ class NetworkRequests extends Audit {
         statusCode: record.statusCode,
         mimeType: record.mimeType,
         resourceType: record.resourceType,
+        priority: record.priority,
         isLinkPreload,
         experimentalFromMainFrame,
         lrEndTimeDeltaMs: endTimeDeltaMs, // Only exists on Lightrider runs

--- a/core/test/audits/network-requests-test.js
+++ b/core/test/audits/network-requests-test.js
@@ -35,6 +35,7 @@ describe('Network requests audit', () => {
       statusCode: 200,
       mimeType: 'text/html',
       resourceType: 'Document',
+      priority: 'VeryHigh',
     });
     expect(output.details.items[2]).toMatchObject({
       startTime: expect.toBeApproximately(711, 0),
@@ -45,6 +46,7 @@ describe('Network requests audit', () => {
       statusCode: 200,
       mimeType: 'image/png',
       resourceType: 'Image',
+      priority: 'Low',
     });
     expect(output.details.items[5]).toMatchObject({
       startTime: expect.toBeApproximately(717, 0),
@@ -55,6 +57,7 @@ describe('Network requests audit', () => {
       statusCode: 200,
       mimeType: 'application/javascript',
       resourceType: 'Script',
+      priority: 'Medium',
     });
 
     expect(output.details.debugData).toStrictEqual({

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -758,6 +758,7 @@
                   "statusCode": 200,
                   "mimeType": "text/html",
                   "resourceType": "Document",
+                  "priority": "VeryHigh",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -771,6 +772,7 @@
                   "statusCode": 200,
                   "mimeType": "font/woff2",
                   "resourceType": "Font",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -785,6 +787,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "Low",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -798,6 +801,7 @@
                   "statusCode": 200,
                   "mimeType": "text/css",
                   "resourceType": "Stylesheet",
+                  "priority": "VeryHigh",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -812,6 +816,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -826,6 +831,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -840,6 +846,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -854,6 +861,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -868,6 +876,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -882,6 +891,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -896,6 +906,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -910,6 +921,7 @@
                   "statusCode": 200,
                   "mimeType": "image/svg+xml",
                   "resourceType": "Image",
+                  "priority": "High",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -923,6 +935,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "Low",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -936,6 +949,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "Low",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -949,6 +963,7 @@
                   "statusCode": 200,
                   "mimeType": "text/css",
                   "resourceType": "Stylesheet",
+                  "priority": "VeryLow",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -962,6 +977,7 @@
                   "statusCode": 200,
                   "mimeType": "font/woff2",
                   "resourceType": "Font",
+                  "priority": "VeryHigh",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -975,6 +991,7 @@
                   "statusCode": 200,
                   "mimeType": "font/woff2",
                   "resourceType": "Font",
+                  "priority": "VeryHigh",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -988,6 +1005,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Other",
+                  "priority": "VeryLow",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -1001,6 +1019,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Other",
+                  "priority": "VeryLow",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -1014,6 +1033,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Other",
+                  "priority": "VeryLow",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -1027,6 +1047,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "Low",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -1040,6 +1061,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "Low",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -1053,6 +1075,7 @@
                   "statusCode": 200,
                   "mimeType": "image/png",
                   "resourceType": "Other",
+                  "priority": "High",
                   "experimentalFromMainFrame": true
                 }
               ],
@@ -7941,7 +7964,8 @@
                   "resourceSize": 6631,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "priority": "Low"
                 },
                 {
                   "url": "https://www.mikescerealshack.co/logo-text.svg",
@@ -7953,7 +7977,8 @@
                   "resourceSize": 53947,
                   "statusCode": 200,
                   "mimeType": "image/svg+xml",
-                  "resourceType": "Image"
+                  "resourceType": "Image",
+                  "priority": "High"
                 },
                 {
                   "url": "https://mnl4bjjsnz-dsn.algolia.net/1/indexes/dev_OFFICE_SCENES/query",
@@ -7965,7 +7990,8 @@
                   "resourceSize": 0,
                   "statusCode": 200,
                   "mimeType": "text/plain",
-                  "resourceType": "Preflight"
+                  "resourceType": "Preflight",
+                  "priority": "High"
                 },
                 {
                   "url": "https://mnl4bjjsnz-dsn.algolia.net/1/indexes/dev_OFFICE_SCENES/query",
@@ -7977,7 +8003,8 @@
                   "resourceSize": 16577,
                   "statusCode": 200,
                   "mimeType": "application/json",
-                  "resourceType": "Fetch"
+                  "resourceType": "Fetch",
+                  "priority": "High"
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/index-37980adf97404e76e41a.js",
@@ -7989,7 +8016,8 @@
                   "resourceSize": 0,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Other"
+                  "resourceType": "Other",
+                  "priority": "VeryLow"
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/terms-0236318e86139dd7d7f2.js",
@@ -8001,7 +8029,8 @@
                   "resourceSize": 0,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Other"
+                  "resourceType": "Other",
+                  "priority": "VeryLow"
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/privacy-864d3895f3c3722acef2.js",
@@ -8013,7 +8042,8 @@
                   "resourceSize": 0,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Other"
+                  "resourceType": "Other",
+                  "priority": "VeryLow"
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/privacy-864d3895f3c3722acef2.js",
@@ -8025,7 +8055,8 @@
                   "resourceSize": 720,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "priority": "Low"
                 },
                 {
                   "url": "https://www.mikescerealshack.co/_next/static/chunks/pages/terms-0236318e86139dd7d7f2.js",
@@ -8037,7 +8068,8 @@
                   "resourceSize": 11002,
                   "statusCode": 200,
                   "mimeType": "application/javascript",
-                  "resourceType": "Script"
+                  "resourceType": "Script",
+                  "priority": "Low"
                 },
                 {
                   "url": "https://cdn.mikescerealshack.co/frames/s8/e13/128w/81d89db1bf3d43b5b21f813d2f2a9777.jpg",
@@ -8049,7 +8081,8 @@
                   "resourceSize": 2379,
                   "statusCode": 200,
                   "mimeType": "image/jpeg",
-                  "resourceType": "Image"
+                  "resourceType": "Image",
+                  "priority": "Low"
                 },
                 {
                   "url": "https://cdn.mikescerealshack.co/frames/s3/e3/128w/9b3031eb3988ba363fe946929a79e016.jpg",
@@ -8061,7 +8094,8 @@
                   "resourceSize": 2865,
                   "statusCode": 200,
                   "mimeType": "image/jpeg",
-                  "resourceType": "Image"
+                  "resourceType": "Image",
+                  "priority": "Low"
                 },
                 {
                   "url": "https://cdn.mikescerealshack.co/frames/s3/e3/128w/793a408ca63a660b5d7aa1a41ac126ca.jpg",
@@ -8073,7 +8107,8 @@
                   "resourceSize": 1758,
                   "statusCode": 200,
                   "mimeType": "image/jpeg",
-                  "resourceType": "Image"
+                  "resourceType": "Image",
+                  "priority": "Low"
                 }
               ],
               "debugData": {
@@ -14874,6 +14909,7 @@
                   "statusCode": 200,
                   "mimeType": "text/html",
                   "resourceType": "Document",
+                  "priority": "VeryHigh",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -14887,6 +14923,7 @@
                   "statusCode": 200,
                   "mimeType": "font/woff2",
                   "resourceType": "Font",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -14901,6 +14938,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "Low",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -14914,6 +14952,7 @@
                   "statusCode": 200,
                   "mimeType": "text/css",
                   "resourceType": "Stylesheet",
+                  "priority": "VeryHigh",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -14928,6 +14967,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -14942,6 +14982,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -14956,6 +14997,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -14970,6 +15012,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -14984,6 +15027,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -14998,6 +15042,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -15012,6 +15057,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "High",
                   "isLinkPreload": true,
                   "experimentalFromMainFrame": true
                 },
@@ -15026,6 +15072,7 @@
                   "statusCode": 200,
                   "mimeType": "image/svg+xml",
                   "resourceType": "Image",
+                  "priority": "High",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -15039,6 +15086,7 @@
                   "statusCode": 200,
                   "mimeType": "image/jpeg",
                   "resourceType": "Image",
+                  "priority": "High",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -15052,6 +15100,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "Low",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -15065,6 +15114,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "Low",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -15078,6 +15128,7 @@
                   "statusCode": 200,
                   "mimeType": "text/css",
                   "resourceType": "Stylesheet",
+                  "priority": "VeryLow",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -15091,6 +15142,7 @@
                   "statusCode": 200,
                   "mimeType": "font/woff2",
                   "resourceType": "Font",
+                  "priority": "VeryHigh",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -15104,6 +15156,7 @@
                   "statusCode": 200,
                   "mimeType": "font/woff2",
                   "resourceType": "Font",
+                  "priority": "VeryHigh",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -15117,6 +15170,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Other",
+                  "priority": "VeryLow",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -15130,6 +15184,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Other",
+                  "priority": "VeryLow",
                   "experimentalFromMainFrame": true
                 },
                 {
@@ -15143,6 +15198,7 @@
                   "statusCode": 200,
                   "mimeType": "application/javascript",
                   "resourceType": "Script",
+                  "priority": "Low",
                   "experimentalFromMainFrame": true
                 }
               ],

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -1302,6 +1302,7 @@
             "statusCode": 200,
             "mimeType": "text/html",
             "resourceType": "Document",
+            "priority": "VeryHigh",
             "experimentalFromMainFrame": true
           },
           {
@@ -1315,6 +1316,7 @@
             "statusCode": 200,
             "mimeType": "text/css",
             "resourceType": "Stylesheet",
+            "priority": "VeryHigh",
             "experimentalFromMainFrame": true
           },
           {
@@ -1328,6 +1330,7 @@
             "statusCode": 404,
             "mimeType": "text/css",
             "resourceType": "Stylesheet",
+            "priority": "VeryHigh",
             "experimentalFromMainFrame": true
           },
           {
@@ -1341,6 +1344,7 @@
             "statusCode": 200,
             "mimeType": "text/css",
             "resourceType": "Stylesheet",
+            "priority": "VeryHigh",
             "experimentalFromMainFrame": true
           },
           {
@@ -1354,6 +1358,7 @@
             "statusCode": 200,
             "mimeType": "text/css",
             "resourceType": "Stylesheet",
+            "priority": "VeryHigh",
             "experimentalFromMainFrame": true
           },
           {
@@ -1367,6 +1372,7 @@
             "statusCode": 200,
             "mimeType": "text/css",
             "resourceType": "Stylesheet",
+            "priority": "VeryHigh",
             "experimentalFromMainFrame": true
           },
           {
@@ -1380,6 +1386,7 @@
             "statusCode": 200,
             "mimeType": "text/css",
             "resourceType": "Stylesheet",
+            "priority": "VeryHigh",
             "isLinkPreload": true,
             "experimentalFromMainFrame": true
           },
@@ -1394,6 +1401,7 @@
             "statusCode": 200,
             "mimeType": "text/css",
             "resourceType": "Stylesheet",
+            "priority": "VeryHigh",
             "experimentalFromMainFrame": true
           },
           {
@@ -1407,6 +1415,7 @@
             "statusCode": 200,
             "mimeType": "application/javascript",
             "resourceType": "Script",
+            "priority": "High",
             "experimentalFromMainFrame": true
           },
           {
@@ -1420,6 +1429,7 @@
             "statusCode": 200,
             "mimeType": "application/javascript",
             "resourceType": "Script",
+            "priority": "High",
             "experimentalFromMainFrame": true
           },
           {
@@ -1433,6 +1443,7 @@
             "statusCode": 200,
             "mimeType": "text/css",
             "resourceType": "Stylesheet",
+            "priority": "VeryLow",
             "experimentalFromMainFrame": true
           },
           {
@@ -1446,6 +1457,7 @@
             "statusCode": 404,
             "mimeType": "application/javascript",
             "resourceType": "Script",
+            "priority": "High",
             "experimentalFromMainFrame": true
           },
           {
@@ -1459,6 +1471,7 @@
             "statusCode": 200,
             "mimeType": "image/jpeg",
             "resourceType": "Image",
+            "priority": "Low",
             "experimentalFromMainFrame": true
           },
           {
@@ -1472,6 +1485,7 @@
             "statusCode": 200,
             "mimeType": "image/jpeg",
             "resourceType": "Image",
+            "priority": "High",
             "experimentalFromMainFrame": true
           },
           {
@@ -1485,6 +1499,7 @@
             "statusCode": 200,
             "mimeType": "image/jpeg",
             "resourceType": "Image",
+            "priority": "High",
             "experimentalFromMainFrame": true
           },
           {
@@ -1498,6 +1513,7 @@
             "statusCode": 200,
             "mimeType": "image/jpeg",
             "resourceType": "Image",
+            "priority": "High",
             "experimentalFromMainFrame": true
           },
           {
@@ -1511,6 +1527,7 @@
             "statusCode": 200,
             "mimeType": "image/jpeg",
             "resourceType": "Image",
+            "priority": "High",
             "experimentalFromMainFrame": true
           },
           {
@@ -1524,6 +1541,7 @@
             "statusCode": 200,
             "mimeType": "image/gif",
             "resourceType": "Image",
+            "priority": "Low",
             "experimentalFromMainFrame": true
           },
           {
@@ -1537,6 +1555,7 @@
             "statusCode": 200,
             "mimeType": "application/javascript",
             "resourceType": "Script",
+            "priority": "Medium",
             "experimentalFromMainFrame": true
           },
           {
@@ -1550,6 +1569,7 @@
             "statusCode": 200,
             "mimeType": "text/javascript",
             "resourceType": "Script",
+            "priority": "Medium",
             "experimentalFromMainFrame": true
           },
           {
@@ -1563,6 +1583,7 @@
             "statusCode": 200,
             "mimeType": "image/jpeg",
             "resourceType": "Image",
+            "priority": "High",
             "experimentalFromMainFrame": true
           },
           {
@@ -1576,6 +1597,7 @@
             "statusCode": 200,
             "mimeType": "text/css",
             "resourceType": "Stylesheet",
+            "priority": "VeryHigh",
             "experimentalFromMainFrame": true
           },
           {
@@ -1589,6 +1611,7 @@
             "statusCode": 200,
             "mimeType": "text/html",
             "resourceType": "XHR",
+            "priority": "VeryHigh",
             "experimentalFromMainFrame": true
           },
           {
@@ -1602,6 +1625,7 @@
             "statusCode": 200,
             "mimeType": "text/plain",
             "resourceType": "Image",
+            "priority": "Low",
             "experimentalFromMainFrame": true
           },
           {
@@ -1615,6 +1639,7 @@
             "statusCode": 200,
             "mimeType": "text/html",
             "resourceType": "Image",
+            "priority": "Low",
             "experimentalFromMainFrame": true
           },
           {
@@ -1628,6 +1653,7 @@
             "statusCode": 404,
             "mimeType": "image/vnd.microsoft.icon",
             "resourceType": "Other",
+            "priority": "High",
             "experimentalFromMainFrame": true
           }
         ],


### PR DESCRIPTION
this is one last major missing piece for analyzing loads from LHRs for preload opportunities. Priority can sometimes be inferred, and critical-request-chains has some of this information, but in practice inference isn't reliable and the crc data format is a nightmare for joining in SQL environments.