### PR TITLE
core(trace-elements): include LCP type in artifact

### DIFF
--- a/cli/test/smokehouse/test-definitions/perf-trace-elements.js
+++ b/cli/test/smokehouse/test-definitions/perf-trace-elements.js
@@ -74,6 +74,7 @@ const expectations = {
             height: 318,
           },
         },
+        type: 'image',
       },
       {
         traceEventType: 'layout-shift',

--- a/core/audits/lcp-lazy-loaded.js
+++ b/core/audits/lcp-lazy-loaded.js
@@ -50,8 +50,9 @@ class LargestContentfulPaintLazyLoaded extends Audit {
    * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
-    const lcpElement = artifacts.TraceElements
-      .find(element => element.traceEventType === 'largest-contentful-paint');
+    const lcpElement = artifacts.TraceElements.find(element => {
+      return element.traceEventType === 'largest-contentful-paint' && element.type === 'image';
+    });
     const lcpElementImage = lcpElement ? artifacts.ImageElements.find(elem => {
       return elem.node.devtoolsNodePath === lcpElement.node.devtoolsNodePath;
     }) : undefined;
@@ -59,7 +60,7 @@ class LargestContentfulPaintLazyLoaded extends Audit {
 
     if (!lcpElementImage ||
       !this.isImageInViewport(lcpElementImage, artifacts.ViewportDimensions)) {
-      return {score: 1, notApplicable: true};
+      return {score: null, notApplicable: true};
     }
 
     /** @type {LH.Audit.Details.Table['headings']} */

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -25,7 +25,7 @@ import ProcessedNavigation from '../../computed/processed-navigation.js';
 import {LighthouseError} from '../../lib/lh-error.js';
 import ComputedResponsiveness from '../../computed/metrics/responsiveness.js';
 
-/** @typedef {{nodeId: number, score?: number, animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[]}} TraceElementData */
+/** @typedef {{nodeId: number, score?: number, animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[], type?: string}} TraceElementData */
 
 /**
  * @this {HTMLElement}
@@ -215,6 +215,34 @@ class TraceElements extends FRGatherer {
   }
 
   /**
+   * @param {LH.Artifacts.ProcessedTrace} processedTrace
+   * @param {LH.Gatherer.FRTransitionalContext} context
+   * @return {Promise<{nodeId: number, type: string} | undefined>}
+   */
+  static async getLcpElement(processedTrace, context) {
+    let processedNavigation;
+    try {
+      processedNavigation = await ProcessedNavigation.request(processedTrace, context);
+    } catch (err) {
+      // If we were running in timespan mode and there was no paint, treat LCP as missing.
+      if (context.gatherMode === 'timespan' && err.code === LighthouseError.errors.NO_FCP.code) {
+        return;
+      }
+
+      throw err;
+    }
+
+    // These should exist, but trace types are loose.
+    const lcpData = processedNavigation.largestContentfulPaintEvt?.args?.data;
+    if (lcpData?.nodeId === undefined || !lcpData.type) return;
+
+    return {
+      nodeId: lcpData.nodeId,
+      type: lcpData.type,
+    };
+  }
+
+  /**
    * @param {LH.Gatherer.FRTransitionalContext} context
    */
   async startInstrumentation(context) {
@@ -242,26 +270,16 @@ class TraceElements extends FRGatherer {
     }
 
     const processedTrace = await ProcessedTrace.request(trace, context);
-    const {largestContentfulPaintEvt} = await ProcessedNavigation
-      .request(processedTrace, context)
-      .catch(err => {
-        // If we were running in timespan mode and there was no paint, treat LCP as missing.
-        if (context.gatherMode === 'timespan' && err.code === LighthouseError.errors.NO_FCP.code) {
-          return {largestContentfulPaintEvt: undefined};
-        }
-
-        throw err;
-      });
     const {mainThreadEvents} = processedTrace;
 
-    const lcpNodeId = largestContentfulPaintEvt?.args?.data?.nodeId;
+    const lcpNodeData = await TraceElements.getLcpElement(processedTrace, context);
     const clsNodeData = TraceElements.getTopLayoutShiftElements(mainThreadEvents);
     const animatedElementData = await this.getAnimatedElements(mainThreadEvents);
     const responsivenessElementData = await TraceElements.getResponsivenessElement(trace, context);
 
     /** @type {Map<string, TraceElementData[]>} */
     const backendNodeDataMap = new Map([
-      ['largest-contentful-paint', lcpNodeId ? [{nodeId: lcpNodeId}] : []],
+      ['largest-contentful-paint', lcpNodeData ? [lcpNodeData] : []],
       ['layout-shift', clsNodeData],
       ['animation', animatedElementData],
       ['responsiveness', responsivenessElementData ? [responsivenessElementData] : []],
@@ -300,6 +318,7 @@ class TraceElements extends FRGatherer {
             score: backendNodeData[i].score,
             animations: backendNodeData[i].animations,
             nodeId: backendNodeId,
+            type: backendNodeData[i].type,
           });
         }
       }

--- a/core/test/audits/largest-contentful-paint-element-test.js
+++ b/core/test/audits/largest-contentful-paint-element-test.js
@@ -16,6 +16,7 @@ describe('Performance: largest-contentful-paint-element audit', () => {
           nodeLabel: 'My Test Label',
           snippet: '<h1 class="test-class">',
         },
+        type: 'text',
       }],
     };
 

--- a/core/test/audits/lcp-lazy-loaded-test.js
+++ b/core/test/audits/lcp-lazy-loaded-test.js
@@ -96,7 +96,29 @@ describe('Performance: lcp-lazy-loaded audit', () => {
     };
 
     const auditResult = await LargestContentfulPaintLazyLoaded.audit(artifacts);
-    expect(auditResult.score).toEqual(1);
+    expect(auditResult.score).toEqual(null);
     expect(auditResult.notApplicable).toEqual(true);
+  });
+
+  it('is not applicable when LCP was text', async () => {
+    const artifacts = {
+      TraceElements: [{
+        traceEventType: 'largest-contentful-paint',
+        node: SAMPLE_NODE,
+        type: 'text',
+      }],
+      ImageElements: [
+        generateImage('lazy', 700),
+      ],
+      ViewportDimensions: {
+        innerHeight: 500,
+        innerWidth: 300,
+      },
+    };
+    const auditResult = await LargestContentfulPaintLazyLoaded.audit(artifacts);
+    expect(auditResult).toEqual({
+      score: null,
+      notApplicable: true,
+    });
   });
 });

--- a/core/test/audits/lcp-lazy-loaded-test.js
+++ b/core/test/audits/lcp-lazy-loaded-test.js
@@ -31,6 +31,7 @@ describe('Performance: lcp-lazy-loaded audit', () => {
       TraceElements: [{
         traceEventType: 'largest-contentful-paint',
         node: SAMPLE_NODE,
+        type: 'image',
       }],
       ImageElements: [
         generateImage('lazy', 0),
@@ -54,6 +55,7 @@ describe('Performance: lcp-lazy-loaded audit', () => {
       TraceElements: [{
         traceEventType: 'largest-contentful-paint',
         node: SAMPLE_NODE,
+        type: 'image',
       }],
       ImageElements: [
         generateImage('eager', 0),
@@ -73,6 +75,7 @@ describe('Performance: lcp-lazy-loaded audit', () => {
       TraceElements: [{
         traceEventType: 'largest-contentful-paint',
         node: SAMPLE_NODE,
+        type: 'image',
       }],
       ImageElements: [
         generateImage('lazy', 700),

--- a/core/test/audits/preload-lcp-image-test.js
+++ b/core/test/audits/preload-lcp-image-test.js
@@ -34,7 +34,9 @@ describe('Performance: preload-lcp audit', () => {
         {
           traceEventType: 'largest-contentful-paint',
           node: {
-            devtoolsNodePath: '1,HTML,1,BODY,3,DIV,2,IMG'},
+            devtoolsNodePath: '1,HTML,1,BODY,3,DIV,2,IMG',
+          },
+          type: 'image',
         },
       ],
       ImageElements: [
@@ -93,7 +95,31 @@ describe('Performance: preload-lcp audit', () => {
     ];
   };
 
-  it('shouldn\'t be applicable if lcp image is not found', async () => {
+  it('is not applicable if TraceElements does not include LCP', async () => {
+    const networkRecords = mockNetworkRecords();
+    const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl, imageUrl);
+    artifacts.TraceElements = [];
+    const context = {settings: {}, computedCache: new Map()};
+    const result = await PreloadLCPImage.audit(artifacts, context);
+    expect(result).toEqual({
+      score: null,
+      notApplicable: true,
+    });
+  });
+
+  it('is not applicable if LCP was not an image', async () => {
+    const networkRecords = mockNetworkRecords();
+    const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl, imageUrl);
+    artifacts.TraceElements[0].type = 'text';
+    const context = {settings: {}, computedCache: new Map()};
+    const result = await PreloadLCPImage.audit(artifacts, context);
+    expect(result).toEqual({
+      score: null,
+      notApplicable: true,
+    });
+  });
+
+  it('shouldn\'t be applicable if lcp image element is not found', async () => {
     const networkRecords = mockNetworkRecords();
     const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl, imageUrl);
     artifacts.ImageElements = [];

--- a/core/test/gather/gatherers/trace-elements-test.js
+++ b/core/test/gather/gatherers/trace-elements-test.js
@@ -449,6 +449,7 @@ describe('Trace Elements gatherer - Animated Elements', () => {
         width: 30,
         height: 130,
       },
+      type: 'text',
     };
     const connectionStub = new Connection();
     connectionStub.sendCommand = createMockSendCommandFn()
@@ -525,6 +526,7 @@ describe('Trace Elements gatherer - Animated Elements', () => {
         width: 964,
         height: 18,
       },
+      type: 'text',
     };
     const animationNodeData = {
       traceEventType: 'animation',
@@ -630,6 +632,7 @@ describe('Trace Elements gatherer - Animated Elements', () => {
         width: 30,
         height: 130,
       },
+      type: 'text',
     };
     const connectionStub = new Connection();
     connectionStub.sendCommand = createMockSendCommandFn()

--- a/core/test/results/artifacts/artifacts.json
+++ b/core/test/results/artifacts/artifacts.json
@@ -11528,7 +11528,8 @@
         "snippet": "<h2>",
         "nodeLabel": "Do better web tester page"
       },
-      "nodeId": 6
+      "nodeId": 6,
+      "type": "text"
     },
     {
       "traceEventType": "layout-shift",

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -2583,17 +2583,8 @@
       "id": "preload-lcp-image",
       "title": "Preload Largest Contentful Paint image",
       "description": "If the LCP element is dynamically added to the page, you should preload the image in order to improve LCP. [Learn more about preloading LCP elements](https://web.dev/optimize-lcp/#preload-important-resources).",
-      "score": 1,
-      "scoreDisplayMode": "numeric",
-      "numericValue": 0,
-      "numericUnit": "millisecond",
-      "displayValue": "",
-      "details": {
-        "type": "opportunity",
-        "headings": [],
-        "items": [],
-        "overallSavingsMs": 0
-      }
+      "score": null,
+      "scoreDisplayMode": "notApplicable"
     },
     "csp-xss": {
       "id": "csp-xss",
@@ -7569,12 +7560,6 @@
       {
         "startTime": 0,
         "name": "lh:audit:preload-lcp-image",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:computed:LanternLargestContentfulPaint",
         "duration": 100,
         "entryType": "measure"
       },

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -578,6 +578,7 @@ declare module Artifacts {
     node: NodeDetails;
     nodeId?: number;
     animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[];
+    type?: string;
   }
 
   interface ViewportDimensions {


### PR DESCRIPTION
The LCP trace event reports if it was text or an image, which we can use to make tricky image cases easy.

This updates the two LCP image debug audits to use the LCP `type` information to mark themselves `notApplicable` if the LCP was text, even when `ImageElements` says otherwise due to url matching issues (#13338).

The change should be straightforward, but the commits separate the gatherer and audit changes to make it a little easier to review.